### PR TITLE
Removed background color from paragraph. Fixed contrast checker on transparent colors.

### DIFF
--- a/blocks/contrast-checker/index.js
+++ b/blocks/contrast-checker/index.js
@@ -20,7 +20,9 @@ function ContrastChecker( { backgroundColor, textColor, isLargeText, fallbackBac
 	}
 	const tinyBackgroundColor = tinycolor( backgroundColor || fallbackBackgroundColor );
 	const tinyTextColor = tinycolor( textColor || fallbackTextColor );
-	if ( tinycolor.isReadable(
+	const hasTransparency = tinyBackgroundColor.getAlpha() !== 1 || tinyTextColor.getAlpha() !== 1;
+
+	if ( hasTransparency || tinycolor.isReadable(
 		tinyBackgroundColor,
 		tinyTextColor,
 		{ level: 'AA', size: ( isLargeText ? 'large' : 'small' ) }

--- a/blocks/contrast-checker/test/index.js
+++ b/blocks/contrast-checker/test/index.js
@@ -15,6 +15,7 @@ describe( 'ContrastChecker', () => {
 	const fallbackBackgroundColor = '#fff';
 	const fallbackTextColor = '#000';
 	const sameShade = '#666';
+	const colorWithTransparency = 'rgba(102,102,102,0.5)';
 
 	const wrapper = mount(
 		<ContrastChecker
@@ -44,6 +45,32 @@ describe( 'ContrastChecker', () => {
 		);
 
 		expect( componentWrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should render render null if background color contains a transparency', () => {
+		const componentWrapper = mount(
+			<ContrastChecker
+				backgroundColor={ colorWithTransparency }
+				textColor={ sameShade }
+				isLargeText={ isLargeText }
+				fallbackBackgroundColor={ fallbackBackgroundColor }
+				fallbackTextColor={ fallbackTextColor } />
+		);
+
+		expect( componentWrapper.html() ).toBeNull();
+	} );
+
+	test( 'should render render null if text color contains a transparency', () => {
+		const componentWrapper = mount(
+			<ContrastChecker
+				backgroundColor={ sameShade }
+				textColor={ colorWithTransparency }
+				isLargeText={ isLargeText }
+				fallbackBackgroundColor={ fallbackBackgroundColor }
+				fallbackTextColor={ fallbackTextColor } />
+		);
+
+		expect( componentWrapper.html() ).toBeNull();
 	} );
 
 	test( 'should render different message matching snapshot when background color has less brightness than text color.', () => {

--- a/blocks/library/paragraph/editor.scss
+++ b/blocks/library/paragraph/editor.scss
@@ -1,12 +1,3 @@
-.editor-block-list__block:not( .is-multi-selected ) .wp-block-paragraph {
-	background: white;
-}
-
-// Don't show white background when a nesting parent is selected
-.editor-block-list__layout .editor-block-list__layout .editor-block-list__block .wp-block-paragraph {
-	background: inherit;
-}
-
 .blocks-font-size__main {
 	display: flex;
 	justify-content: space-between;


### PR DESCRIPTION
Until now, the paragraph block had a background set to white.
With the recent nesting addition, this is causing us some problems. As noted in the discussions in https://github.com/WordPress/gutenberg/pull/5658. In the cover image nesting PR https://github.com/WordPress/gutenberg/pull/5452 the background rule is also problematic so this PR removes this rule.

This PR also fixes the contrast checking mechanism to not display an error if the colors we are dealing with contain transparencies. Because if the colors contain transparency we don't know what is below them (it can even be an image) with a big contrast.


## How Has This Been Tested?
No noticeable changes should be seen in the paragraph.
If no background is set for a paragraph the contrast checker should never display errors (as in this case the background is transparent) and the theme may have a color with high contrast. If set a background color for the paragraph the contrast checker should work as expected.
If we set a background color for a paragraph using a CSS rule the contrast checking should work as expected in accordance with the background rule set with CSS.
Example css rule.
```
.wp-block-paragraph {
	background: red;
}