### PR TITLE
Blocks: Media upload docs improvements

### DIFF
--- a/blocks/media-upload/README.md
+++ b/blocks/media-upload/README.md
@@ -3,6 +3,25 @@ MediaUpload
 
 MediaUpload is a React component used to render a button that opens a the WordPress media modal.
 
+## Setup
+
+This is a placeholder component necessary to make it possible to provide an integration with the core blocks that handle media files. By default it renders nothing but it provides a way to have it overridden with the `components.MediaUpload` filter.
+
+```jsx
+import { addFilter } from '@wordpress/hooks';
+import MediaUpload from './media-upload';
+
+const replaceMediaUpload = () => MediaUpload;
+
+addFilter(
+	'blocks.MediaUpload',
+	'core/edit-post/blocks/media-upload/replaceMediaUpload',
+	replaceMediaUpload
+);
+```
+
+You can check how this component is implemented for the edit post page using `wp.media` module in [edit-post](../../edit-post/hooks/blocks/media-upload/index.js).
+
 ## Usage
 
 

--- a/blocks/media-upload/index.js
+++ b/blocks/media-upload/index.js
@@ -3,6 +3,13 @@
  */
 import { withFilters } from '@wordpress/components';
 
+/**
+ * This is a placeholder for the media upload component necessary to make it possible to provide
+ * an integration with the core blocks that handle media files. By default it renders nothing but
+ * it provides a way to have it overridden with the `blocks.MediaUpload` filter.
+ *
+ * @return {WPElement} Media upload element.
+ */
 const MediaUpload = () => null;
 
 export default withFilters( 'blocks.MediaUpload' )( MediaUpload );


### PR DESCRIPTION
## Description
Follow-up for #5211:
> At the moment `MediaUpload` component depends on `wp.media`, which makes also `blocks` module dependent on `media` module.  This PR tries to move this dependency to the `edit-post` in Gutenberg and give more flexibility on how images are inserted into the post.

This PR adds missing documentation which explains how `MediaUpload` component can be overridden and explains why it is structured this way.

When working on the docs I came up to the conclusion that `MediaUpload` can be now moved to the `components` module. I added deprecation logic to make sure that there is proper feedback provided for the developers that decided to use this component.

## How Has This Been Tested?
Manually tested to confirm that there are no regressions. It should be still possible

Run `npm test` to make sure all tests still pass.