### PR TITLE
Plugins: Re-render plugin area on registration / unregistration

### DIFF
--- a/plugins/api/index.js
+++ b/plugins/api/index.js
@@ -3,7 +3,7 @@
 /**
  * WordPress dependencies
  */
-import { applyFilters } from '@wordpress/hooks';
+import { applyFilters, doAction } from '@wordpress/hooks';
 
 /**
  * External dependencies
@@ -61,7 +61,11 @@ export function registerPlugin( name, settings ) {
 
 	settings = applyFilters( 'plugins.registerPlugin', settings, name );
 
-	return plugins[ settings.name ] = settings;
+	plugins[ settings.name ] = settings;
+
+	doAction( 'plugins.pluginRegistered', settings, name );
+
+	return settings;
 }
 
 /**
@@ -81,6 +85,9 @@ export function unregisterPlugin( name ) {
 	}
 	const oldPlugin = plugins[ name ];
 	delete plugins[ name ];
+
+	doAction( 'plugins.pluginUnregistered', oldPlugin, name );
+
 	return oldPlugin;
 }
 

--- a/plugins/components/plugin-area/index.js
+++ b/plugins/components/plugin-area/index.js
@@ -33,12 +33,12 @@ class PluginArea extends Component {
 
 	componentDidMount() {
 		addAction( 'plugins.pluginRegistered', 'core/plugins/plugin-area-plugins-registered', this.setPlugins );
-		addAction( 'plugins.pluginRegistered', 'core/plugins/plugin-area-plugins-unregistered', this.setPlugins );
+		addAction( 'plugins.pluginUnregistered', 'core/plugins/plugin-area-plugins-unregistered', this.setPlugins );
 	}
 
 	componentWillUnmount() {
 		removeAction( 'plugins.pluginRegistered', 'core/plugins/plugin-area-plugins-registered' );
-		removeAction( 'plugins.pluginRegistered', 'core/plugins/plugin-area-plugins-unregistered' );
+		removeAction( 'plugins.pluginUnregistered', 'core/plugins/plugin-area-plugins-unregistered' );
 	}
 
 	setPlugins() {


### PR DESCRIPTION
Fixes #5759
Related: #5819, #5849, #5773

This pull request seeks to resolve the issue described in #5759 by ensuring that the plugin area re-renders when a plugin is registered or unregistered, via newly added action hooks.

__Testing instructions:__

Repeat steps to reproduce from #5759, verifying that the expected behavior is present.