### PR TITLE
replace any occurrence of bold with 600

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -82,7 +82,7 @@
 		font-size: 4.1em;
 		line-height: 0.7;
 		font-family: serif;
-		font-weight: bold;
+		font-weight: 600;
 		margin: .07em .23em 0 0;
 		text-transform: uppercase;
 		font-style: normal;

--- a/blocks/library/paragraph/style.scss
+++ b/blocks/library/paragraph/style.scss
@@ -4,7 +4,7 @@ p.has-drop-cap {
 		font-size: 4.1em;
 		line-height: 0.7;
 		font-family: serif;
-		font-weight: bold;
+		font-weight: 600;
 		margin: .07em .23em 0 0;
 		text-transform: uppercase;
 		font-style: normal;

--- a/components/placeholder/style.scss
+++ b/components/placeholder/style.scss
@@ -14,7 +14,7 @@
 .components-placeholder__label {
 	display: flex;
 	justify-content: center;
-	font-weight: bold;
+	font-weight: 600;
 	margin-bottom: 1em;
 
 	.dashicon {

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -98,7 +98,7 @@ div.components-toolbar {
 		content: attr( data-subscript );
 		font-family: $default-font;
 		font-size: $default-font-size;
-		font-weight: bold;
+		font-weight: 600;
 		position: absolute;
 		right: 6px;
 		bottom: 8px;

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -67,7 +67,7 @@
 }
 
 .editor-text-editor__formatting .editor-text-editor__bold {
-	font-weight: bold;
+	font-weight: 600;
 }
 
 .editor-text-editor__formatting .editor-text-editor__italic {


### PR DESCRIPTION
## Description
replaces any occurrence of font-weight: bold; with 600 https://github.com/WordPress/gutenberg/issues/5848

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
