### PR TITLE
Keyboard accessibility: Add a "Skip link" to jump back from the inspector to the selected block

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -68,6 +68,8 @@ $z-layers: (
 	'.components-popover.is-bottom': 99990,
 
 	'.components-autocomplete__results': 1000000,
+
+	'.skip-to-selected-block': 100000,
 );
 
 @function z-index( $key ) {

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -81,6 +81,13 @@
 	p + div.components-toolbar {
 		margin-top: -1em;
 	}
+
+	.editor-skip-to-selected-block:focus {
+		top: auto;
+		right: 10px;
+		bottom: 10px;
+		left: auto;
+	}
 }
 
 /* Visual and Text editor both */

--- a/editor/components/block-inspector/index.js
+++ b/editor/components/block-inspector/index.js
@@ -20,6 +20,7 @@ import { PanelBody } from '@wordpress/components';
  * Internal Dependencies
  */
 import './style.scss';
+import SkipToSelectedBlock from '../skip-to-selected-block';
 import { getSelectedBlock, getSelectedBlockCount } from '../../store/selectors';
 
 const BlockInspector = ( { selectedBlock, count } ) => {
@@ -55,6 +56,7 @@ const BlockInspector = ( { selectedBlock, count } ) => {
 				</PanelBody>
 			) }
 		</InspectorAdvancedControls.Slot>,
+		<SkipToSelectedBlock key="back" />,
 	];
 };
 

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -68,6 +68,7 @@ export { default as MultiSelectScrollIntoView } from './multi-select-scroll-into
 export { default as NavigableToolbar } from './navigable-toolbar';
 export { default as ObserveTyping } from './observe-typing';
 export { default as PreserveScrollInReorder } from './preserve-scroll-in-reorder';
+export { default as SkipToSelectedBlock } from './skip-to-selected-block';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
 

--- a/editor/components/skip-to-selected-block/index.js
+++ b/editor/components/skip-to-selected-block/index.js
@@ -1,18 +1,13 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
+import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
-import { getSelectedBlock } from '../../store/selectors';
 import { getBlockWrapperDOMNode } from '../../utils/dom';
 
 const SkipToSelectedBlock = ( { selectedBlock } ) => {
@@ -35,10 +30,8 @@ const SkipToSelectedBlock = ( { selectedBlock } ) => {
 	);
 };
 
-export default connect(
-	( state ) => {
-		return {
-			selectedBlock: getSelectedBlock( state ),
-		};
-	}
-)( SkipToSelectedBlock );
+export default withSelect( ( select ) => {
+	return {
+		selectedBlock: select( 'core/editor' ).getSelectedBlock(),
+	};
+} )( SkipToSelectedBlock );

--- a/editor/components/skip-to-selected-block/index.js
+++ b/editor/components/skip-to-selected-block/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal Dependencies
+ */
+import './style.scss';
+import { getSelectedBlock } from '../../store/selectors';
+import { getBlockWrapperDOMNode } from '../../utils/dom';
+
+const SkipToSelectedBlock = ( { selectedBlock } ) => {
+	if ( ! selectedBlock ) {
+		return <span className="editor-skip-to-selected-block__no-blocks">{ __( 'No block selected.' ) }</span>;
+	}
+
+	const { uid } = selectedBlock;
+
+	const onClick = () => {
+		const selectedBlockElement = getBlockWrapperDOMNode( uid );
+		selectedBlockElement.focus();
+	};
+
+	return (
+		uid &&
+		<button type="button" className="button editor-skip-to-selected-block screen-reader-shortcut" onClick={ onClick }>
+			{ __( 'Skip to the selected block' ) }
+		</button>
+	);
+};
+
+export default connect(
+	( state ) => {
+		return {
+			selectedBlock: getSelectedBlock( state ),
+		};
+	}
+)( SkipToSelectedBlock );

--- a/editor/components/skip-to-selected-block/index.js
+++ b/editor/components/skip-to-selected-block/index.js
@@ -24,7 +24,7 @@ const SkipToSelectedBlock = ( { selectedBlock } ) => {
 
 	return (
 		selectedBlock && uid &&
-		<button type="button" className="button skip-to-selected-block" onClick={ onClick }>
+		<button type="button" className="button editor-skip-to-selected-block" onClick={ onClick }>
 			{ __( 'Skip to the selected block' ) }
 		</button>
 	);

--- a/editor/components/skip-to-selected-block/index.js
+++ b/editor/components/skip-to-selected-block/index.js
@@ -12,7 +12,7 @@ import { getBlockWrapperDOMNode } from '../../utils/dom';
 
 const SkipToSelectedBlock = ( { selectedBlock } ) => {
 	if ( ! selectedBlock ) {
-		return <span className="editor-skip-to-selected-block__no-blocks">{ __( 'No block selected.' ) }</span>;
+		return null;
 	}
 
 	const { uid } = selectedBlock;
@@ -23,8 +23,8 @@ const SkipToSelectedBlock = ( { selectedBlock } ) => {
 	};
 
 	return (
-		uid &&
-		<button type="button" className="button editor-skip-to-selected-block screen-reader-shortcut" onClick={ onClick }>
+		selectedBlock && uid &&
+		<button type="button" className="button skip-to-selected-block" onClick={ onClick }>
 			{ __( 'Skip to the selected block' ) }
 		</button>
 	);

--- a/editor/components/skip-to-selected-block/index.js
+++ b/editor/components/skip-to-selected-block/index.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal Dependencies
  */
 import './style.scss';
-import { getBlockWrapperDOMNode } from '../../utils/dom';
+import { getBlockFocusableWrapper } from '../../utils/dom';
 
 const SkipToSelectedBlock = ( { selectedBlock } ) => {
 	if ( ! selectedBlock ) {
@@ -18,7 +18,7 @@ const SkipToSelectedBlock = ( { selectedBlock } ) => {
 	const { uid } = selectedBlock;
 
 	const onClick = () => {
-		const selectedBlockElement = getBlockWrapperDOMNode( uid );
+		const selectedBlockElement = getBlockFocusableWrapper( uid );
 		selectedBlockElement.focus();
 	};
 

--- a/editor/components/skip-to-selected-block/index.js
+++ b/editor/components/skip-to-selected-block/index.js
@@ -10,20 +10,14 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import { getBlockFocusableWrapper } from '../../utils/dom';
 
-const SkipToSelectedBlock = ( { selectedBlock } ) => {
-	if ( ! selectedBlock ) {
-		return null;
-	}
-
-	const { uid } = selectedBlock;
-
+const SkipToSelectedBlock = ( { selectedBlockUID } ) => {
 	const onClick = () => {
-		const selectedBlockElement = getBlockFocusableWrapper( uid );
+		const selectedBlockElement = getBlockFocusableWrapper( selectedBlockUID );
 		selectedBlockElement.focus();
 	};
 
 	return (
-		selectedBlock && uid &&
+		selectedBlockUID &&
 		<button type="button" className="button editor-skip-to-selected-block" onClick={ onClick }>
 			{ __( 'Skip to the selected block' ) }
 		</button>
@@ -32,6 +26,6 @@ const SkipToSelectedBlock = ( { selectedBlock } ) => {
 
 export default withSelect( ( select ) => {
 	return {
-		selectedBlock: select( 'core/editor' ).getSelectedBlock(),
+		selectedBlockUID: select( 'core/editor' ).getBlockSelectionStart(),
 	};
 } )( SkipToSelectedBlock );

--- a/editor/components/skip-to-selected-block/style.scss
+++ b/editor/components/skip-to-selected-block/style.scss
@@ -1,0 +1,27 @@
+.editor-skip-to-selected-block {
+	position: absolute;
+	top: -9999em;
+
+	&:focus {
+		height: auto;
+		width: auto;
+		display: block;
+		font-size: 14px;
+		font-weight: 600;
+		padding: 15px 23px 14px;
+		background: #f1f1f1;
+		color: $blue-wordpress;
+		line-height: normal;
+		box-shadow: 0 0 2px 2px rgba(0,0,0,.6);
+		text-decoration: none;
+		outline: none;
+		z-index: z-index( '.skip-to-selected-block' );
+	}
+}
+
+.edit-post-sidebar .editor-skip-to-selected-block:focus {
+	top: auto;
+	right: 10px;
+	bottom: 10px;
+	left: auto;
+}

--- a/editor/components/skip-to-selected-block/style.scss
+++ b/editor/components/skip-to-selected-block/style.scss
@@ -1,4 +1,4 @@
-.skip-to-selected-block {
+.editor-skip-to-selected-block {
 	position: absolute;
 	top: -9999em;
 
@@ -17,11 +17,4 @@
 		outline: none;
 		z-index: z-index( '.skip-to-selected-block' );
 	}
-}
-
-.edit-post-sidebar .skip-to-selected-block:focus {
-	top: auto;
-	right: 10px;
-	bottom: 10px;
-	left: auto;
 }

--- a/editor/components/skip-to-selected-block/style.scss
+++ b/editor/components/skip-to-selected-block/style.scss
@@ -1,4 +1,4 @@
-.editor-skip-to-selected-block {
+.skip-to-selected-block {
 	position: absolute;
 	top: -9999em;
 
@@ -19,7 +19,7 @@
 	}
 }
 
-.edit-post-sidebar .editor-skip-to-selected-block:focus {
+.edit-post-sidebar .skip-to-selected-block:focus {
 	top: auto;
 	right: 10px;
 	bottom: 10px;

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -16,6 +16,10 @@ export function getBlockDOMNode( uid ) {
 	return document.querySelector( '[data-block="' + uid + '"]' );
 }
 
+export function getBlockWrapperDOMNode( uid ) {
+	return getBlockDOMNode( uid ).closest( '.editor-block-list__block' );
+}
+
 /**
  * Returns true if the given HTMLElement is a block focus stop. Blocks without
  * their own text fields rely on the focus stop to be keyboard navigable.

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -16,7 +16,16 @@ export function getBlockDOMNode( uid ) {
 	return document.querySelector( '[data-block="' + uid + '"]' );
 }
 
-export function getBlockWrapperDOMNode( uid ) {
+/**
+ * Given a block UID, returns the corresponding DOM node for the block focusable
+ * wrapper, if exists. As much as possible, this helper should be avoided, and
+ * used only in cases where isolated behaviors need remote access to a block node.
+ *
+ * @param {string} uid Block UID.
+ *
+ * @return {Element} Block DOM node.
+ */
+export function getBlockFocusableWrapper( uid ) {
 	return getBlockDOMNode( uid ).closest( '.editor-block-list__block' );
 }
 


### PR DESCRIPTION
This PR adds a way for keyboard and assistive technologies users to jump back to the currently selected block.

Users can already use keyboard shortcuts to navigate the editor regions, see #3084 and screen reader users can use ARIA landmarks, see #2380. These tools can be used to jump from the block being edited to the Sidebar but there's no way to jump back from the sidebar to the block being edited.

This PR adds a reusable component that mimics the "skip links" already used in core. Actually, it's a button that gets revealed just when it receives keyboard focus and, when pressed, moves focus back to the currently selected block.

Related:
- coordination with #5709 
- investigation / resolution of #5847 

For now, it's placed in the block inspector in the sidebar (in the bottom right corner of the screen) but it could be useful also in the "post settings". I could see it also reused in the header toolbar and in the publishing flow, so I guess the best option would be to consider it as a generic component. In this regard, I'm not sure where the new files should be placed. For now they're in the `editor` directory. Any feedback welcome.

Screenshot:

<img width="419" alt="screen shot 2018-03-28 at 21 31 03" src="https://user-images.githubusercontent.com/1682452/38051821-b041e032-32cf-11e8-9687-dcee506e7eff.png">

Design-wise, I've made it look like the current "skip links" in core, any feedback welcome.

When a better, customizable, shortcut for `navigateRegions` will be available, see:
`Consider a mechanism to customize shortcuts, e.g. Ctrl + backtick` #3218
there will be a way for all keyboard users to jump from the selected block to the sidebar and back from the sidebar to the selected block, thus fixing #1182 