### PR TITLE
Removed an invalid test case from isCurrentPostScheduled.

### DIFF
--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -663,16 +663,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isCurrentPostScheduled', () => {
-		it( 'should return true for posts with status future', () => {
-			const state = {
-				currentPost: {
-					status: 'future',
-				},
-			};
-
-			expect( isCurrentPostScheduled( state ) ).toBe( true );
-		} );
-
 		it( 'should return true for future scheduled posts', () => {
 			const state = {
 				currentPost: {


### PR DESCRIPTION
The test case "should return true for posts with status future" was invalid as besides the status being future the scheduled date needs also to be in the future otherwise the post is not "scheduled" but "published".
During the development of the selector, I missed to removal of test case as it should have been replaced by "should return true for future scheduled posts".

## How Has This Been Tested?
Execute the automated sometimes and verify the tests pass. 
