### PR TITLE
Travis CI: Cache `$HOME/.npm`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.phpbrew
+    - $HOME/.npm
 
 before_install:
   - nvm install && nvm use


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

The addition of Puppeteer in #5618 adds an ~75MB binary to `node_modules` as part of the `npm install` process, this PR adds `$HOME/.npm` to the Travis CI cache with the goal to improving subsequent Travis CI build/job times.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Testing this PR results to follow in comments from Travis CI test results

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Build tooling improvement to allow faster Travis CI build results

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
