### PR TITLE
Data Module: Refactor the Post Type Capabilities fetching to use the data module

### DIFF
--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -64,3 +64,19 @@ export function receivePostTypes( postTypes ) {
 		postTypes: castArray( postTypes ),
 	};
 }
+
+/**
+ * Returns an action object used in signalling that the user capabilties fora post type have been received.
+ *
+ * @param {string} postTypeSlug Post Type
+ * @param {Object} capabilities Capabilities received.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveUserPostTypeCapabilities( postTypeSlug, capabilities ) {
+	return {
+		type: 'RECEIVE_USER_POST_TYPE_CAPABILITIES',
+		postTypeSlug,
+		capabilities,
+	};
+}

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -82,8 +82,29 @@ export function postTypes( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Reducer managing user post types capabilties state. Keyed by post type.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function userPostTypeCapabilities( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_USER_POST_TYPE_CAPABILITIES':
+			return {
+				...state,
+				[ action.postTypeSlug ]: action.capabilities,
+			};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	terms,
 	media,
 	postTypes,
+	userPostTypeCapabilities,
 } );

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -11,6 +11,7 @@ import {
 	receiveTerms,
 	receiveMedia,
 	receivePostTypes,
+	receiveUserPostTypeCapabilities,
 } from './actions';
 
 /**
@@ -38,9 +39,21 @@ export async function* getMedia( state, id ) {
  * Requests a post type element from the REST API.
  *
  * @param {Object} state State tree
- * @param {number} slug  Post Type slug
+ * @param {string} slug  Post Type slug
  */
 export async function* getPostType( state, slug ) {
 	const postType = await apiRequest( { path: `/wp/v2/types/${ slug }?context=edit` } );
 	yield receivePostTypes( postType );
 }
+
+/**
+ * Request user capabilities for a given post type from the REST API.
+ * @param {Object} state         State tree
+ * @param {string} postTypeSlug  Post Type slug
+ */
+export async function* getUserPostTypeCapabilities( state, postTypeSlug ) {
+	const userWithCapabilities = await apiRequest( { path: `/wp/v2/users/me?post_type=${ postTypeSlug }&context=edit` } );
+	yield receiveUserPostTypeCapabilities( postTypeSlug, userWithCapabilities.post_type_capabilities );
+}
+
+export const getUserPostTypeCapability = getUserPostTypeCapabilities;

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -62,10 +62,27 @@ export function getMedia( state, id ) {
  * Returns the Post Type object by slug.
  *
  * @param {Object} state Data state.
- * @param {number} slug  Post Type slug.
+ * @param {string} slug  Post Type slug.
  *
  * @return {Object?}     Post Type object.
  */
 export function getPostType( state, slug ) {
 	return state.postTypes[ slug ];
+}
+
+/**
+ * Returns whether a user has a capability per post type.
+ *
+ * @param {Object} state        Data state.
+ * @param {string} postTypeSlug Post Type slug.
+ * @param {string} capability   Capability.
+ *
+ * @return {boolean}            Whether the user has the give cabability.
+ */
+export function getUserPostTypeCapability( state, postTypeSlug, capability ) {
+	const capabilities = state.userPostTypeCapabilities[ postTypeSlug ];
+
+	// If the capabilities are not loaded return undefined
+	// If the capabilities are loaded but the capability not set return false
+	return capabilities ? capabilities[ capability ] || false : undefined;
 }

--- a/core-data/test/reducer.js
+++ b/core-data/test/reducer.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { terms, media, postTypes } from '../reducer';
+import { terms, media, postTypes, userPostTypeCapabilities } from '../reducer';
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -106,6 +106,34 @@ describe( 'postTypes', () => {
 		expect( state ).toEqual( {
 			b: { slug: 'b', title: 'beach' },
 			s: { slug: 's', title: 'sun' },
+		} );
+	} );
+} );
+
+describe( 'userPostTypeCapabilities', () => {
+	it( 'returns an empty object by default', () => {
+		const state = userPostTypeCapabilities( undefined, {} );
+
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns with received capabilities by slug', () => {
+		const originalState = deepFreeze( {
+			page: {
+				editPost: false,
+			},
+		} );
+		const state = userPostTypeCapabilities( originalState, {
+			type: 'RECEIVE_USER_POST_TYPE_CAPABILITIES',
+			postTypeSlug: 'post',
+			capabilities: {
+				publishPost: true,
+			},
+		} );
+
+		expect( state ).toEqual( {
+			page: { editPost: false },
+			post: { publishPost: true },
 		} );
 	} );
 } );

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -6,8 +6,19 @@ import apiRequest from '@wordpress/api-request';
 /**
  * Internal dependencies
  */
-import { getCategories, getMedia, getPostType } from '../resolvers';
-import { setRequested, receiveTerms, receiveMedia, receivePostTypes } from '../actions';
+import {
+	getCategories,
+	getMedia,
+	getPostType,
+	getUserPostTypeCapabilities,
+} from '../resolvers';
+import {
+	setRequested,
+	receiveTerms,
+	receiveMedia,
+	receivePostTypes,
+	receiveUserPostTypeCapabilities,
+} from '../actions';
 
 jest.mock( '@wordpress/api-request' );
 
@@ -66,3 +77,22 @@ describe( 'getPostType', () => {
 		expect( received ).toEqual( receivePostTypes( POST_TYPE ) );
 	} );
 } );
+
+describe( 'getUserPostTypeCapabilities', () => {
+	const USER = { post_type_capabilities: { publishPost: true } };
+
+	beforeAll( () => {
+		apiRequest.mockImplementation( ( options ) => {
+			if ( options.path === '/wp/v2/users/me?post_type=post&context=edit' ) {
+				return Promise.resolve( USER );
+			}
+		} );
+	} );
+
+	it( 'yields with received capabilties', async () => {
+		const fulfillment = getUserPostTypeCapabilities( {}, 'post' );
+		const received = ( await fulfillment.next() ).value;
+		expect( received ).toEqual( receiveUserPostTypeCapabilities( 'post', { publishPost: true } ) );
+	} );
+} );
+

--- a/core-data/test/selectors.js
+++ b/core-data/test/selectors.js
@@ -6,7 +6,13 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getTerms, isRequestingTerms, getMedia, getPostType } from '../selectors';
+import {
+	getTerms,
+	isRequestingTerms,
+	getMedia,
+	getPostType,
+	getUserPostTypeCapability,
+} from '../selectors';
 
 describe( 'getTerms()', () => {
 	it( 'returns value of terms by taxonomy', () => {
@@ -90,5 +96,36 @@ describe( 'getPostType', () => {
 			},
 		} );
 		expect( getPostType( state, 'post' ) ).toEqual( { slug: 'post' } );
+	} );
+} );
+
+describe( 'getUserPostTypeCapability', () => {
+	it( 'should return undefined for unknown post type', () => {
+		const state = deepFreeze( {
+			userPostTypeCapabilities: {},
+		} );
+		expect( getUserPostTypeCapability( state, 'post', 'publishPost' ) ).toBe( undefined );
+	} );
+
+	it( 'should return false for unknown capability', () => {
+		const state = deepFreeze( {
+			userPostTypeCapabilities: {
+				post: {
+					hasPost: false,
+				},
+			},
+		} );
+		expect( getUserPostTypeCapability( state, 'post', 'publishPost' ) ).toBe( false );
+	} );
+
+	it( 'should return the capability value', () => {
+		const state = deepFreeze( {
+			userPostTypeCapabilities: {
+				post: {
+					publishPost: true,
+				},
+			},
+		} );
+		expect( getUserPostTypeCapability( state, 'post', 'publishPost' ) ).toBe( true );
 	} );
 } );

--- a/editor/components/post-author/test/check.js
+++ b/editor/components/post-author/test/check.js
@@ -35,21 +35,11 @@ describe( 'PostAuthorCheck', () => {
 		],
 	};
 
-	const user = {
-		data: {
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
 	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
 		let wrapper = shallow( <PostAuthorCheck users={ users } user={ {} }>authors</PostAuthorCheck> );
 		expect( wrapper.type() ).toBe( null );
 		wrapper = shallow(
-			<PostAuthorCheck users={ users } user={
-				{ data: { post_type_capabilities: { publish_posts: false } } }
-			}>
+			<PostAuthorCheck users={ users } canPublishPosts={ false }>
 				authors
 			</PostAuthorCheck>
 		);
@@ -57,13 +47,13 @@ describe( 'PostAuthorCheck', () => {
 	} );
 
 	it( 'should not render anything if users unknown', () => {
-		const wrapper = shallow( <PostAuthorCheck users={ {} } user={ user }>authors</PostAuthorCheck> );
+		const wrapper = shallow( <PostAuthorCheck users={ {} } canPublishPosts>authors</PostAuthorCheck> );
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'should not render anything if single user', () => {
 		const wrapper = shallow(
-			<PostAuthorCheck users={ { data: users.data.slice( 0, 1 ) } } user={ user }>
+			<PostAuthorCheck users={ { data: users.data.slice( 0, 1 ) } } canPublishPosts>
 				authors
 			</PostAuthorCheck>
 		);
@@ -72,7 +62,7 @@ describe( 'PostAuthorCheck', () => {
 
 	it( 'should not render anything if single filtered user', () => {
 		const wrapper = shallow(
-			<PostAuthorCheck users={ { data: users.data.slice( 0, 2 ) } } user={ user }>
+			<PostAuthorCheck users={ { data: users.data.slice( 0, 2 ) } } canPublishPosts>
 				authors
 			</PostAuthorCheck>
 		);
@@ -81,7 +71,7 @@ describe( 'PostAuthorCheck', () => {
 
 	it( 'should render  control', () => {
 		const wrapper = shallow(
-			<PostAuthorCheck users={ users } user={ user }>
+			<PostAuthorCheck users={ users } canPublishPosts>
 				authors
 			</PostAuthorCheck>
 		);

--- a/editor/components/post-pending-status/check.js
+++ b/editor/components/post-pending-status/check.js
@@ -1,46 +1,23 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
-import { compose } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { isCurrentPostPublished, getCurrentPostType } from '../../store/selectors';
-
-export function PostPendingStatusCheck( { isPublished, children, user } ) {
-	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-
-	if ( isPublished || ! userCanPublishPosts ) {
+export function PostPendingStatusCheck( { isPublished, children, canPublishPosts } ) {
+	if ( isPublished || ! canPublishPosts ) {
 		return null;
 	}
 
 	return children;
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		isPublished: isCurrentPostPublished( state ),
-		postType: getCurrentPostType( state ),
-	} ),
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
-export default compose(
-	applyConnect,
-	applyWithAPIData
+export default withSelect(
+	( select ) => {
+		const { getEditedPostAttribute, isCurrentPostPublished } = select( 'core/editor' );
+		const { getUserPostTypeCapability } = select( 'core' );
+		return {
+			isPublished: isCurrentPostPublished(),
+			canPublishPosts: getUserPostTypeCapability( getEditedPostAttribute( 'type' ), 'publish_posts' ),
+		};
+	},
 )( PostPendingStatusCheck );

--- a/editor/components/post-pending-status/test/check.js
+++ b/editor/components/post-pending-status/test/check.js
@@ -9,21 +9,11 @@ import { shallow } from 'enzyme';
 import { PostPendingStatusCheck } from '../check';
 
 describe( 'PostPendingStatusCheck', () => {
-	const user = {
-		data: {
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
 	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
 		let wrapper = shallow( <PostPendingStatusCheck user={ {} }>status</PostPendingStatusCheck> );
 		expect( wrapper.type() ).toBe( null );
 		wrapper = shallow(
-			<PostPendingStatusCheck user={
-				{ data: { post_type_capabilities: { publish_posts: false } } }
-			}>
+			<PostPendingStatusCheck canPublishPosts={ false }>
 				status
 			</PostPendingStatusCheck>
 		);
@@ -31,7 +21,7 @@ describe( 'PostPendingStatusCheck', () => {
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow( <PostPendingStatusCheck user={ user }>status</PostPendingStatusCheck> );
+		const wrapper = shallow( <PostPendingStatusCheck canPublishPosts>status</PostPendingStatusCheck> );
 		expect( wrapper.type() ).not.toBe( null );
 	} );
 } );

--- a/editor/components/post-publish-button/test/index.js
+++ b/editor/components/post-publish-button/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,23 +9,6 @@ import { merge } from 'lodash';
 import { PostPublishButton } from '../';
 
 describe( 'PostPublishButton', () => {
-	const user = {
-		data: {
-			id: 1,
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
-	const contributor = merge( {}, user, {
-		data: {
-			post_type_capabilities: {
-				publish_posts: false,
-			},
-		},
-	} );
-
 	describe( 'disabled', () => {
 		it( 'should be disabled if current user is unknown', () => {
 			const wrapper = shallow(
@@ -38,7 +20,7 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be disabled if post is currently saving', () => {
 			const wrapper = shallow(
-				<PostPublishButton user={ user } isSaving />
+				<PostPublishButton canPublishPosts isSaving />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
@@ -46,7 +28,7 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be disabled if post is not publishable', () => {
 			const wrapper = shallow(
-				<PostPublishButton user={ user } isPublishable={ false } />
+				<PostPublishButton canPublishPosts isPublishable={ false } />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
@@ -54,7 +36,7 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be disabled if post is not saveable', () => {
 			const wrapper = shallow(
-				<PostPublishButton user={ user } isSaveable={ false } />
+				<PostPublishButton canPublishPosts isSaveable={ false } />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
@@ -62,7 +44,7 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be enabled otherwise', () => {
 			const wrapper = shallow(
-				<PostPublishButton user={ user } isPublishable isSaveable />
+				<PostPublishButton canPublishPosts isPublishable isSaveable />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( false );
@@ -75,7 +57,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ contributor }
+					canPublishPosts={ false }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave } />
 			);
@@ -90,7 +72,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ user }
+					canPublishPosts
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
 					isBeingScheduled />
@@ -106,7 +88,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ user }
+					canPublishPosts
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
 					visibility="private" />
@@ -122,7 +104,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ user }
+					canPublishPosts
 					onStatusChange={ onStatusChange }
 					onSave={ onSave } />
 			);
@@ -139,7 +121,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ user }
+					canPublishPosts
 					onStatusChange={ onStatusChange }
 					onSave={ onSave } />
 			);
@@ -153,7 +135,7 @@ describe( 'PostPublishButton', () => {
 
 	it( 'should have save modifier class', () => {
 		const wrapper = shallow(
-			<PostPublishButton user={ user } isSaving />
+			<PostPublishButton canPublishPosts isSaving />
 		);
 
 		expect( wrapper.hasClass( 'is-saving' ) ).toBe( true );

--- a/editor/components/post-publish-button/test/label.js
+++ b/editor/components/post-publish-button/test/label.js
@@ -1,73 +1,51 @@
 /**
- * External dependencies
- */
-import { merge } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { PublishButtonLabel } from '../label';
 
 describe( 'PublishButtonLabel', () => {
-	const user = {
-		data: {
-			id: 1,
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
-	const contributor = merge( {}, user, {
-		data: {
-			post_type_capabilities: {
-				publish_posts: false,
-			},
-		},
-	} );
-
 	it( 'should show publishing if publishing in progress', () => {
-		const label = PublishButtonLabel( { user, isPublishing: true } );
+		const label = PublishButtonLabel( { canPublishPosts: true, isPublishing: true } );
 		expect( label ).toBe( 'Publishing…' );
 	} );
 
 	it( 'should show updating if published and saving in progress', () => {
-		const label = PublishButtonLabel( { user, isPublished: true, isSaving: true } );
+		const label = PublishButtonLabel( { canPublishPosts: true, isPublished: true, isSaving: true } );
 		expect( label ).toBe( 'Updating…' );
 	} );
 
 	it( 'should show scheduling if scheduled and saving in progress', () => {
-		const label = PublishButtonLabel( { user, isBeingScheduled: true, isSaving: true } );
+		const label = PublishButtonLabel( { canPublishPosts: true, isBeingScheduled: true, isSaving: true } );
 		expect( label ).toBe( 'Scheduling…' );
 	} );
 
 	it( 'should show publish if not published and saving in progress', () => {
-		const label = PublishButtonLabel( { user, isPublished: false, isSaving: true } );
+		const label = PublishButtonLabel( { canPublishPosts: true, isPublished: false, isSaving: true } );
 		expect( label ).toBe( 'Publish' );
 	} );
 
 	it( 'should show publish if user unknown', () => {
-		const label = PublishButtonLabel( { user: {} } );
+		const label = PublishButtonLabel( { canPublishPosts: undefined } );
 		expect( label ).toBe( 'Publish' );
 	} );
 
 	it( 'should show submit for review for contributor', () => {
-		const label = PublishButtonLabel( { user: contributor } );
+		const label = PublishButtonLabel( { canPublishPosts: false } );
 		expect( label ).toBe( 'Submit for Review' );
 	} );
 
 	it( 'should show update for already published', () => {
-		const label = PublishButtonLabel( { user, isPublished: true } );
+		const label = PublishButtonLabel( { canPublishPosts: true, isPublished: true } );
 		expect( label ).toBe( 'Update' );
 	} );
 
 	it( 'should show schedule for scheduled', () => {
-		const label = PublishButtonLabel( { user, isBeingScheduled: true } );
+		const label = PublishButtonLabel( { canPublishPosts: true, isBeingScheduled: true } );
 		expect( label ).toBe( 'Schedule' );
 	} );
 
 	it( 'should show publish otherwise', () => {
-		const label = PublishButtonLabel( { user } );
+		const label = PublishButtonLabel( { canPublishPosts: true } );
 		expect( label ).toBe( 'Publish' );
 	} );
 } );

--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -1,33 +1,16 @@
 /**
- * External Dependencies
- */
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
  * WordPress Dependencies
  */
-import { Button, withAPIData } from '@wordpress/components';
-import { compose } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal Dependencies
  */
 import PostPublishButton from '../post-publish-button';
-import {
-	isSavingPost,
-	isEditedPostSaveable,
-	isEditedPostPublishable,
-	isCurrentPostPending,
-	isCurrentPostPublished,
-	isEditedPostBeingScheduled,
-	isCurrentPostScheduled,
-	getCurrentPostType,
-} from '../../store/selectors';
 
 function PostPublishPanelToggle( {
-	user,
 	isSaving,
 	isPublishable,
 	isSaveable,
@@ -39,14 +22,13 @@ function PostPublishPanelToggle( {
 	isOpen,
 	forceIsDirty,
 	forceIsSaving,
+	canPublishPosts,
 } ) {
 	const isButtonEnabled = (
 		! isSaving && ! forceIsSaving && isPublishable && isSaveable
 	) || isPublished;
 
-	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-	const isContributor = user.data && ! userCanPublishPosts;
-	const showToggle = ! isPublished && ! ( isScheduled && isBeingScheduled ) && ! ( isPending && isContributor );
+	const showToggle = ! isPublished && ! ( isScheduled && isBeingScheduled ) && ! ( isPending && ! canPublishPosts );
 
 	if ( ! showToggle ) {
 		return <PostPublishButton forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />;
@@ -66,28 +48,28 @@ function PostPublishPanelToggle( {
 	);
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		isSaving: isSavingPost( state ),
-		isSaveable: isEditedPostSaveable( state ),
-		isPublishable: isEditedPostPublishable( state ),
-		isPending: isCurrentPostPending( state ),
-		isPublished: isCurrentPostPublished( state ),
-		isScheduled: isCurrentPostScheduled( state ),
-		isBeingScheduled: isEditedPostBeingScheduled( state ),
-		postType: getCurrentPostType( state ),
-	} ),
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
-export default compose( [
-	applyConnect,
-	applyWithAPIData,
-] )( PostPublishPanelToggle );
+export default withSelect(
+	( select ) => {
+		const {
+			getEditedPostAttribute,
+			isSavingPost,
+			isEditedPostSaveable,
+			isEditedPostPublishable,
+			isCurrentPostPending,
+			isCurrentPostPublished,
+			isCurrentPostScheduled,
+			isEditedPostBeingScheduled,
+		} = select( 'core/editor' );
+		const { getUserPostTypeCapability } = select( 'core' );
+		return {
+			isSaving: isSavingPost(),
+			isSaveable: isEditedPostSaveable(),
+			isPublishable: isEditedPostPublishable(),
+			isPending: isCurrentPostPending(),
+			isPublished: isCurrentPostPublished(),
+			isScheduled: isCurrentPostScheduled(),
+			isBeingScheduled: isEditedPostBeingScheduled(),
+			canPublishPosts: getUserPostTypeCapability( getEditedPostAttribute( 'type' ), 'publish_posts' ),
+		};
+	},
+)( PostPublishPanelToggle );

--- a/editor/components/post-schedule/check.js
+++ b/editor/components/post-schedule/check.js
@@ -1,47 +1,22 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
-import { compose } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { getCurrentPostType } from '../../store/selectors';
-
-export function PostScheduleCheck( { user, children } ) {
-	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-
-	if ( ! userCanPublishPosts ) {
+export function PostScheduleCheck( { canPublishPosts, children } ) {
+	if ( ! canPublishPosts ) {
 		return null;
 	}
 
 	return children;
 }
 
-const applyConnect = connect(
-	( state ) => {
+export default withSelect(
+	( select ) => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getUserPostTypeCapability } = select( 'core' );
 		return {
-			postType: getCurrentPostType( state ),
+			canPublishPosts: getUserPostTypeCapability( getEditedPostAttribute( 'type' ), 'publish_posts' ),
 		};
 	},
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
-export default compose( [
-	applyConnect,
-	applyWithAPIData,
-] )( PostScheduleCheck );
+)( PostScheduleCheck );

--- a/editor/components/post-schedule/test/check.js
+++ b/editor/components/post-schedule/test/check.js
@@ -9,25 +9,15 @@ import { shallow } from 'enzyme';
 import { PostScheduleCheck } from '../check';
 
 describe( 'PostScheduleCheck', () => {
-	const user = {
-		data: {
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
 	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
-		let wrapper = shallow( <PostScheduleCheck user={ {} } >yes</PostScheduleCheck> );
+		let wrapper = shallow( <PostScheduleCheck>yes</PostScheduleCheck> );
 		expect( wrapper.type() ).toBe( null );
-		wrapper = shallow( <PostScheduleCheck user={
-			{ data: { post_type_capabilities: { publish_posts: false } } }
-		}>yes</PostScheduleCheck> );
+		wrapper = shallow( <PostScheduleCheck canPublishPosts={ false }>yes</PostScheduleCheck> );
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow( <PostScheduleCheck user={ user }>yes</PostScheduleCheck> );
+		const wrapper = shallow( <PostScheduleCheck canPublishPosts>yes</PostScheduleCheck> );
 		expect( wrapper.type() ).not.toBe( null );
 	} );
 } );

--- a/editor/components/post-sticky/test/check.js
+++ b/editor/components/post-sticky/test/check.js
@@ -9,18 +9,9 @@ import { shallow } from 'enzyme';
 import { PostStickyCheck } from '../check';
 
 describe( 'PostSticky', () => {
-	const user = {
-		data: {
-			post_type_capabilities: {
-				edit_others_posts: true,
-				publish_posts: true,
-			},
-		},
-	};
-
 	it( 'should not render anything if the post type is not "post"', () => {
 		const wrapper = shallow(
-			<PostStickyCheck postType="page" user={ user }>
+			<PostStickyCheck postType="page" canPublishPosts canEditOtherPosts>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
@@ -29,25 +20,21 @@ describe( 'PostSticky', () => {
 
 	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
 		let wrapper = shallow(
-			<PostStickyCheck postType="post" user={ {} }>
+			<PostStickyCheck postType="post">
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
 		expect( wrapper.type() ).toBe( null );
 
 		wrapper = shallow(
-			<PostStickyCheck postType="post" user={
-				{ data: { post_type_capabilities: { edit_others_posts: false, publish_posts: true } } }
-			}>
+			<PostStickyCheck postType="post" canPublishPosts canEditOtherPosts={ false }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
 		expect( wrapper.type() ).toBe( null );
 
 		wrapper = shallow(
-			<PostStickyCheck postType="post" user={
-				{ data: { post_type_capabilities: { edit_others_posts: true, publish_posts: false } } }
-			}>
+			<PostStickyCheck postType="post" canPublishPosts={ false } canEditOtherPosts>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
@@ -56,7 +43,7 @@ describe( 'PostSticky', () => {
 
 	it( 'should render if the user has the correct capability', () => {
 		const wrapper = shallow(
-			<PostStickyCheck postType="post" user={ user }>
+			<PostStickyCheck postType="post" canPublishPosts canEditOtherPosts>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);

--- a/editor/components/post-visibility/check.js
+++ b/editor/components/post-visibility/check.js
@@ -1,43 +1,18 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
-import { compose } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
-/**
- * Internal Dependencies
- */
-import { getCurrentPostType } from '../../store/selectors';
-
-export function PostVisibilityCheck( { user, render } ) {
-	const canEdit = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-
-	return render( { canEdit } );
+export function PostVisibilityCheck( { canPublishPosts, render } ) {
+	return render( { canEdit: canPublishPosts } );
 }
 
-const applyConnect = connect(
-	( state ) => {
+export default withSelect(
+	( select ) => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getUserPostTypeCapability } = select( 'core' );
 		return {
-			postType: getCurrentPostType( state ),
+			canPublishPosts: getUserPostTypeCapability( getEditedPostAttribute( 'type' ), 'publish_posts' ),
 		};
 	},
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
-export default compose( [
-	applyConnect,
-	applyWithAPIData,
-] )( PostVisibilityCheck );
+)( PostVisibilityCheck );

--- a/editor/components/post-visibility/test/check.js
+++ b/editor/components/post-visibility/test/check.js
@@ -9,28 +9,18 @@ import { shallow } from 'enzyme';
 import { PostVisibilityCheck } from '../check';
 
 describe( 'PostVisibilityCheck', () => {
-	const user = {
-		data: {
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
 	const render = ( { canEdit } ) => ( canEdit ? 'yes' : 'no' );
 
 	it( 'should not render the edit link if the user doesn\'t have the right capability', () => {
-		let wrapper = shallow( <PostVisibilityCheck user={ {} } render={ render } /> );
+		let wrapper = shallow( <PostVisibilityCheck render={ render } /> );
 		expect( wrapper.text() ).toBe( 'no' );
 
-		wrapper = shallow( <PostVisibilityCheck postType="post" render={ render } user={
-			{ data: { post_type_capabilities: { publish_posts: false } } }
-		} /> );
+		wrapper = shallow( <PostVisibilityCheck postType="post" render={ render } canPublishPosts={ false } /> );
 		expect( wrapper.text() ).toBe( 'no' );
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow( <PostVisibilityCheck user={ user } render={ render } /> );
+		const wrapper = shallow( <PostVisibilityCheck canPublishPosts render={ render } /> );
 		expect( wrapper.text() ).toBe( 'yes' );
 	} );
 } );


### PR DESCRIPTION
This pull request is part of a series of pull request targeted at more complex use of selector resolvers introduced in #5219.

The current PR moves the fetching of the post type user capabilities to the data module.

**Testing instructions**

Check that you can publish properly and that the sidebar panels show up as expected.