### PR TITLE
Opens the block inspector automatically when the block is selected

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { reduce, values, some, get } from 'lodash';
+import { reduce, values, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -92,10 +92,15 @@ const effects = {
 	INIT( _, store ) {
 		// Select the block settings tab when the selected block changes
 		subscribe( onChangeListener(
-			() => get( select( 'core/editor' ).getSelectedBlock(), 'uid' ),
-			( selectedBlockUid ) => {
-				if ( selectedBlockUid && select( 'core/edit-post' ).isEditorSidebarOpened() ) {
+			() => select( 'core/editor' ).getBlockSelectionStart(),
+			( selectionStart ) => {
+				if ( ! select( 'core/edit-post' ).isEditorSidebarOpened() ) {
+					return;
+				}
+				if ( selectionStart ) {
 					store.dispatch( openGeneralSidebar( 'edit-post/block' ) );
+				} else {
+					store.dispatch( openGeneralSidebar( 'edit-post/document' ) );
 				}
 			} )
 		);

--- a/edit-post/store/index.js
+++ b/edit-post/store/index.js
@@ -5,9 +5,6 @@ import {
 	registerStore,
 	withRehydratation,
 	loadAndPersist,
-	subscribe,
-	dispatch,
-	select,
 } from '@wordpress/data';
 
 /**
@@ -31,17 +28,6 @@ const store = registerStore( 'core/edit-post', {
 
 applyMiddlewares( store );
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
-
-let lastIsSmall;
-subscribe( () => {
-	const isSmall = select( 'core/viewport' ).isViewportMatch( '< medium' );
-	const hasViewportShrunk = isSmall && ! lastIsSmall;
-	lastIsSmall = isSmall;
-
-	// Collapse sidebar when viewport shrinks.
-	if ( hasViewportShrunk ) {
-		dispatch( 'core/edit-post' ).closeGeneralSidebar();
-	}
-} );
+store.dispatch( { type: 'INIT' } );
 
 export default store;

--- a/edit-post/store/utils.js
+++ b/edit-post/store/utils.js
@@ -1,0 +1,18 @@
+/**
+ * Given a selector returns a functions that returns the listener only
+ * if the returned value from the selector changes.
+ *
+ * @param  {function} selector Selector.
+ * @param  {function} listener Listener.
+ * @return {function}          Listener creator.
+ */
+export const onChangeListener = ( selector, listener ) => {
+	let previousValue = selector();
+	return () => {
+		const selectedValue = selector();
+		if ( selectedValue !== previousValue ) {
+			previousValue = selectedValue;
+			listener( selectedValue );
+		}
+	};
+};


### PR DESCRIPTION
closes #5764

This PR adds the following behavior: It automatically opens the block inspector when a new block is selected.

**Testing instructions**

 - Open the sidebar on the "document" panel
 - Select a block
 - The block inspector should show up.