### PR TITLE
E2e testing: Add test for splitting/merging paragraph blocks with Enter/Backspace

### DIFF
--- a/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`splitting and merging blocks Should split and merge paragraph blocks using Enter and Backspace 1`] = `
+"<!-- wp:paragraph -->
+<p>First</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`splitting and merging blocks Should split and merge paragraph blocks using Enter and Backspace 2`] = `
+"<!-- wp:paragraph -->
+<p>FirstSecond</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -10,46 +10,46 @@ describe( 'splitting and merging blocks', () => {
 		await newPost();
 	} );
 
-    it ( 'Should split and merge paragraph blocks using Enter and Backspace', async () => {
-        //Use regular inserter to add paragraph block and text
-        await page.click( '.edit-post-header [aria-label="Add block"]' );
-        await page.keyboard.type( 'paragraph' );
-        await page.keyboard.press( 'Tab' );
-        await page.keyboard.press( 'Enter' );
-        await page.keyboard.type( 'FirstSecond' );
+	it ( 'Should split and merge paragraph blocks using Enter and Backspace', async () => {
+		//Use regular inserter to add paragraph block and text
+		await page.click( '.edit-post-header [aria-label="Add block"]' );
+		await page.keyboard.type( 'paragraph' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'FirstSecond' );
 
-        //Move caret between 'First' and 'Second' and press Enter to split paragraph blocks
-        for ( let i = 0; i < 6; i++ ) {
-            await page.keyboard.press( 'ArrowLeft' );
-        }
-        await page.keyboard.press( 'Enter' );
+		//Move caret between 'First' and 'Second' and press Enter to split paragraph blocks
+		for ( let i = 0; i < 6; i++ ) {
+			await page.keyboard.press( 'ArrowLeft' );
+		}
+		await page.keyboard.press( 'Enter' );
 
-        //Switch to Code Editor to check HTML output
-        await page.click( '.edit-post-more-menu [aria-label="More"]' );
-        let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-        await codeEditorButton.click( 'button' );
+		//Switch to Code Editor to check HTML output
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		await codeEditorButton.click( 'button' );
 
-        //Assert that there are now two paragraph blocks with correct content
-        let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-        expect( textEditorContent ).toMatchSnapshot();
+		//Assert that there are now two paragraph blocks with correct content
+		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toMatchSnapshot();
 
-        //Switch to Visual Editor to continue testing
-        await page.click( '.edit-post-more-menu [aria-label="More"]' );
-        let visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
-        await visualEditorButton.click( 'button' );
+		//Switch to Visual Editor to continue testing
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
+		await visualEditorButton.click( 'button' );
 
-        //Press Backspace to merge paragraph blocks
-        await page.click( '.is-selected' );
-        await page.keyboard.press( 'Home' );
-        await page.keyboard.press( 'Backspace' );
+		//Press Backspace to merge paragraph blocks
+		await page.click( '.is-selected' );
+		await page.keyboard.press( 'Home' );
+		await page.keyboard.press( 'Backspace' );
 
-        //Switch to Code Editor to check HTML output
-        await page.click( '.edit-post-more-menu [aria-label="More"]' );
-        codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-        await codeEditorButton.click( 'button' );
+		//Switch to Code Editor to check HTML output
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		await codeEditorButton.click( 'button' );
 
-        //Assert that there is now one paragraph with correct content
-        textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-        expect( textEditorContent ).toMatchSnapshot();
-    } );
+		//Assert that there is now one paragraph with correct content
+		textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toMatchSnapshot();
+	} );
 } );

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -35,7 +35,7 @@ describe( 'splitting and merging blocks', () => {
 
 		//Switch to Visual Editor to continue testing
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
+		const visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
 		await visualEditorButton.click( 'button' );
 
 		//Press Backspace to merge paragraph blocks

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -1,0 +1,55 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage } from '../support/utils';
+
+describe( 'splitting and merging blocks', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+	} );
+
+    it ( 'Should split and merge paragraph blocks using Enter and Backspace', async () => {
+        //Use regular inserter to add paragraph block and text
+        await page.click( '.edit-post-header [aria-label="Add block"]' );
+        await page.keyboard.type( 'paragraph' );
+        await page.keyboard.press( 'Tab' );
+        await page.keyboard.press( 'Enter' );
+        await page.keyboard.type( 'FirstSecond' );
+
+        //Move caret between 'First' and 'Second' and press Enter to split paragraph blocks
+        for ( let i = 0; i < 6; i++ ) {
+            await page.keyboard.press( 'ArrowLeft' );
+        }
+        await page.keyboard.press( 'Enter' );
+
+        //Switch to Code Editor to check HTML output
+        await page.click( '.edit-post-more-menu [aria-label="More"]' );
+        let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+        await codeEditorButton.click( 'button' );
+
+        //Assert that there are now two paragraph blocks with correct content
+        let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+        expect( textEditorContent ).toMatchSnapshot();
+
+        //Switch to Visual Editor to continue testing
+        await page.click( '.edit-post-more-menu [aria-label="More"]' );
+        let visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
+        await visualEditorButton.click( 'button' );
+
+        //Press Backspace to merge paragraph blocks
+        await page.click( '.is-selected' );
+        await page.keyboard.press( 'Home' );
+        await page.keyboard.press( 'Backspace' );
+
+        //Switch to Code Editor to check HTML output
+        await page.click( '.edit-post-more-menu [aria-label="More"]' );
+        codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+        await codeEditorButton.click( 'button' );
+
+        //Assert that there is now one paragraph with correct content
+        textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+        expect( textEditorContent ).toMatchSnapshot();
+    } );
+} );

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -10,7 +10,7 @@ describe( 'splitting and merging blocks', () => {
 		await newPost();
 	} );
 
-	it ( 'Should split and merge paragraph blocks using Enter and Backspace', async () => {
+	it( 'Should split and merge paragraph blocks using Enter and Backspace', async () => {
 		//Use regular inserter to add paragraph block and text
 		await page.click( '.edit-post-header [aria-label="Add block"]' );
 		await page.keyboard.type( 'paragraph' );


### PR DESCRIPTION
## Description
Added 005-splitting-merging.js, which currently performs an e2e test to ensure that Enter correctly splits paragraph blocks, and Backspace correctly merges them.

## How Has This Been Tested?
This script was tested using Jest and a version of Gutenberg running on localhost. The test was performed by running the command 'npx jest splitting-merging.test.js --watch'.  I compared the test's results to the results from manually splitting and merging paragraph blocks, and they were the same.

## Types of changes
This is a non-breaking change that adds an e2e test of basic functionality.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code has proper inline documentation.
