### PR TITLE
MetaBoxes: Fix meta boxes toggling

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -31,6 +31,8 @@ const effects = {
 		// Allow toggling metaboxes panels
 		// We need to wait for all scripts to load
 		// If the meta box loads the post script, it will already trigger this.
+		// After merge in Core, make sure to drop the timeout and update the postboxes script
+		// to avoid the double binding.
 		setTimeout( () => {
 			const postType = select( 'core/editor' ).getCurrentPostType();
 			if ( window.postboxes.page !== postType ) {

--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -29,7 +29,14 @@ const effects = {
 		}
 
 		// Allow toggling metaboxes panels
-		window.postboxes.add_postbox_toggles( select( 'core/editor' ).getCurrentPostType() );
+		// We need to wait for all scripts to load
+		// If the meta box loads the post script, it will already trigger this.
+		setTimeout( () => {
+			const postType = select( 'core/editor' ).getCurrentPostType();
+			if ( window.postboxes.page !== postType ) {
+				window.postboxes.add_postbox_toggles( postType );
+			}
+		} );
 
 		// Initialize metaboxes state
 		const dataPerLocation = reduce( action.metaBoxes, ( memo, isActive, location ) => {


### PR DESCRIPTION
Some MetaBoxes depend on the post script which will have the side effect of calling `window.postboxes.add_postbox_toggles( postType )` twice. This breaks meta boxes collapsing.

In this PR, I only init the postboxes if it hasn't been done yet.

**Testing instructions**

 - Install the EditFlow plugin
 - Collapse/Uncollapse the meta boxes
 - It should work as intended.