### PR TITLE
E2E Tests: Adding helpers to install/activate/deactivate and remove plugins

### DIFF
--- a/test/e2e/support/plugins.js
+++ b/test/e2e/support/plugins.js
@@ -1,0 +1,43 @@
+/**
+ * Node dependencies
+ */
+import { visitAdmin, waitForRequests } from './utils';
+
+export async function installPlugin( name, searchTerm ) {
+	await visitAdmin( 'plugin-install.php?s=' + encodeURIComponent( searchTerm || name ) + '&tab=search&type=term' );
+	const promise = waitForRequests();
+	await page.click( '.install-now[data-slug="' + name + '"]' );
+	await promise;
+}
+
+export async function activatePlugin( name ) {
+	await visitAdmin( 'plugins.php' );
+	const promise = waitForRequests();
+	await page.click( 'tr[data-slug="' + name + '"] .activate a' );
+	await promise;
+}
+
+export async function deactivatePlugin( name ) {
+	await visitAdmin( 'plugins.php' );
+	const promise = waitForRequests();
+	await page.click( 'tr[data-slug="' + name + '"] .deactivate a' );
+	await promise;
+}
+
+export async function uninstallPlugin( name ) {
+	await visitAdmin( 'plugins.php' );
+	const confirmPromise = new Promise( resolve => {
+		const confirmDialog = ( dialog ) => {
+			dialog.accept();
+			page.removeListener( 'dialog', confirmDialog );
+			resolve();
+		};
+		page.on( 'dialog', confirmDialog );
+	} );
+	const promise = waitForRequests();
+	await Promise.all( [
+		page.click( 'tr[data-slug="' + name + '"] .delete a' ),
+		confirmPromise,
+	] );
+	await promise;
+}

--- a/test/e2e/support/plugins.js
+++ b/test/e2e/support/plugins.js
@@ -1,27 +1,24 @@
 /**
  * Node dependencies
  */
-import { visitAdmin, waitForRequests } from './utils';
+import { visitAdmin } from './utils';
 
 export async function installPlugin( name, searchTerm ) {
 	await visitAdmin( 'plugin-install.php?s=' + encodeURIComponent( searchTerm || name ) + '&tab=search&type=term' );
-	const promise = waitForRequests();
 	await page.click( '.install-now[data-slug="' + name + '"]' );
-	await promise;
+	await page.waitForSelector( '.activate-now[data-slug="' + name + '"]' );
 }
 
 export async function activatePlugin( name ) {
 	await visitAdmin( 'plugins.php' );
-	const promise = waitForRequests();
 	await page.click( 'tr[data-slug="' + name + '"] .activate a' );
-	await promise;
+	await page.waitForSelector( 'tr[data-slug="' + name + '"] .deactivate a' );
 }
 
 export async function deactivatePlugin( name ) {
 	await visitAdmin( 'plugins.php' );
-	const promise = waitForRequests();
 	await page.click( 'tr[data-slug="' + name + '"] .deactivate a' );
-	await promise;
+	await page.waitForSelector( 'tr[data-slug="' + name + '"] .delete a' );
 }
 
 export async function uninstallPlugin( name ) {
@@ -34,10 +31,9 @@ export async function uninstallPlugin( name ) {
 		};
 		page.on( 'dialog', confirmDialog );
 	} );
-	const promise = waitForRequests();
 	await Promise.all( [
 		page.click( 'tr[data-slug="' + name + '"] .delete a' ),
 		confirmPromise,
 	] );
-	await promise;
+	await page.waitForSelector( 'tr[data-slug="' + name + '"].deleted' );
 }

--- a/test/e2e/support/plugins.js
+++ b/test/e2e/support/plugins.js
@@ -3,25 +3,46 @@
  */
 import { visitAdmin } from './utils';
 
-export async function installPlugin( name, searchTerm ) {
-	await visitAdmin( 'plugin-install.php?s=' + encodeURIComponent( searchTerm || name ) + '&tab=search&type=term' );
-	await page.click( '.install-now[data-slug="' + name + '"]' );
-	await page.waitForSelector( '.activate-now[data-slug="' + name + '"]' );
+/**
+ * Install a plugin from the WP.org repository.
+ *
+ * @param {string} slug        Plugin slug.
+ * @param {string?} searchTerm If the plugin is not findable by its slug use an alternative term to search.
+ */
+export async function installPlugin( slug, searchTerm ) {
+	await visitAdmin( 'plugin-install.php?s=' + encodeURIComponent( searchTerm || slug ) + '&tab=search&type=term' );
+	await page.click( '.install-now[data-slug="' + slug + '"]' );
+	await page.waitForSelector( '.activate-now[data-slug="' + slug + '"]' );
 }
 
-export async function activatePlugin( name ) {
+/**
+ * Activates an installed plugin.
+ *
+ * @param {string} slug Plugin slug.
+ */
+export async function activatePlugin( slug ) {
 	await visitAdmin( 'plugins.php' );
-	await page.click( 'tr[data-slug="' + name + '"] .activate a' );
-	await page.waitForSelector( 'tr[data-slug="' + name + '"] .deactivate a' );
+	await page.click( 'tr[data-slug="' + slug + '"] .activate a' );
+	await page.waitForSelector( 'tr[data-slug="' + slug + '"] .deactivate a' );
 }
 
-export async function deactivatePlugin( name ) {
+/**
+ * Dectivates an active plugin.
+ *
+ * @param {string} slug Plugin slug.
+ */
+export async function deactivatePlugin( slug ) {
 	await visitAdmin( 'plugins.php' );
-	await page.click( 'tr[data-slug="' + name + '"] .deactivate a' );
-	await page.waitForSelector( 'tr[data-slug="' + name + '"] .delete a' );
+	await page.click( 'tr[data-slug="' + slug + '"] .deactivate a' );
+	await page.waitForSelector( 'tr[data-slug="' + slug + '"] .delete a' );
 }
 
-export async function uninstallPlugin( name ) {
+/**
+ * Uninstall a plugin.
+ *
+ * @param {string} slug Plugin slug.
+ */
+export async function uninstallPlugin( slug ) {
 	await visitAdmin( 'plugins.php' );
 	const confirmPromise = new Promise( resolve => {
 		const confirmDialog = ( dialog ) => {
@@ -32,8 +53,8 @@ export async function uninstallPlugin( name ) {
 		page.on( 'dialog', confirmDialog );
 	} );
 	await Promise.all( [
-		page.click( 'tr[data-slug="' + name + '"] .delete a' ),
 		confirmPromise,
+		page.click( 'tr[data-slug="' + slug + '"] .delete a' ),
 	] );
-	await page.waitForSelector( 'tr[data-slug="' + name + '"].deleted' );
+	await page.waitForSelector( 'tr[data-slug="' + slug + '"].deleted' );
 }

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -70,39 +70,3 @@ export async function newDesktopBrowserPage() {
 	global.page = await browser.newPage();
 	await page.setViewport( { width: 1000, height: 700 } );
 }
-
-/**
- * Wait for all XHR request to finish before continuing.
- *
- * @param {number} minDelay minimum delay in milliseconds to wait for before returning
- * @param {number} maxDelay maximum delay in milliseconds to wait for before returning
- *
- * @return {Promise}        Promise.
- */
-export async function waitForRequests( minDelay = 1000, maxDelay = 20000 ) {
-	const requests = [];
-	let canResolve = false;
-
-	return new Promise( ( resolve ) => {
-		setTimeout( resolve, maxDelay );
-		setTimeout( () => {
-			canResolve = true;
-			maybeResolve();
-		}, minDelay );
-		const maybeResolve = () => {
-			if ( canResolve && requests.length === 0 ) {
-				resolve();
-			}
-		};
-		page.on( 'request', ( request ) => {
-			requests.push( request );
-		} );
-		page.on( 'requestfinished', ( request ) => {
-			const index = requests.indexOf( request );
-			if ( index !== -1 ) {
-				requests.splice( index, 1 );
-				maybeResolve();
-			}
-		} );
-	} );
-}

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -70,3 +70,39 @@ export async function newDesktopBrowserPage() {
 	global.page = await browser.newPage();
 	await page.setViewport( { width: 1000, height: 700 } );
 }
+
+/**
+ * Wait for all XHR request to finish before continuing.
+ *
+ * @param {number} minDelay minimum delay in milliseconds to wait for before returning
+ * @param {number} maxDelay maximum delay in milliseconds to wait for before returning
+ *
+ * @return {Promise}        Promise.
+ */
+export async function waitForRequests( minDelay = 1000, maxDelay = 20000 ) {
+	const requests = [];
+	let canResolve = false;
+
+	return new Promise( ( resolve ) => {
+		setTimeout( resolve, maxDelay );
+		setTimeout( () => {
+			canResolve = true;
+			maybeResolve();
+		}, minDelay );
+		const maybeResolve = () => {
+			if ( canResolve && requests.length === 0 ) {
+				resolve();
+			}
+		};
+		page.on( 'request', ( request ) => {
+			requests.push( request );
+		} );
+		page.on( 'requestfinished', ( request ) => {
+			const index = requests.indexOf( request );
+			if ( index !== -1 ) {
+				requests.splice( index, 1 );
+				maybeResolve();
+			}
+		} );
+	} );
+}


### PR DESCRIPTION
In order to test extensibility APIs (meta boxes, templates etc...) we need a way to install and uninstall plugins.

This PR adds these helpers. I'm planning to use these in #5902 

**Testing instructions**

You can add something like this to any e2e test

```
import { installPlugin, uninstallPlugin, activatePlugin, deactivatePlugin } from '../support/plugins';
await installPlugin( 'edit-flow', 'Edit Flow' );
await activatePlugin( 'edit-flow' );
await deactivatePlugin( 'edit-flow' );
await uninstallPlugin( 'edit-flow' );
```