### PR TITLE
i18n: Use `wp-components` script handle to pass locale data to `wp.i18n`

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -866,9 +866,8 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Prepare Jed locale data.
 	$locale_data = gutenberg_get_jed_locale_data( 'gutenberg' );
 	wp_add_inline_script(
-		'wp-components',
-		'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ' );',
-		'before'
+		'wp-i18n',
+		'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ' );'
 	);
 
 	// Preload server-registered block schemas.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -866,7 +866,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Prepare Jed locale data.
 	$locale_data = gutenberg_get_jed_locale_data( 'gutenberg' );
 	wp_add_inline_script(
-		'wp-edit-post',
+		'wp-components',
 		'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ' );',
 		'before'
 	);


### PR DESCRIPTION
This changes the script handle from `wp-edit-post` to `wp-components` for the `wp_add_inline_script()` call that passes the locale data to `wp.i18n`.

Fixes #5898.

**Testing instructions:**

Change language of your WordPress install and check that all components are translated.