### PR TITLE
Framework: Optimize block validation attribute testing

### DIFF
--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -43,7 +43,7 @@ const REGEXP_STYLE_URL_TYPE = /^url\s*\(['"\s]*(.*?)['"\s]*\)$/;
  *
  * @type {Array}
  */
-const BOOLEAN_ATTRIBUTES = new Set( [
+const BOOLEAN_ATTRIBUTES = [
 	'allowfullscreen',
 	'allowpaymentrequest',
 	'allowusermedia',
@@ -72,7 +72,7 @@ const BOOLEAN_ATTRIBUTES = new Set( [
 	'reversed',
 	'selected',
 	'typemustmatch',
-] );
+];
 
 /**
  * Enumerated attributes are attributes which must be of a specific value form.
@@ -88,7 +88,7 @@ const BOOLEAN_ATTRIBUTES = new Set( [
  *
  * @type {Array}
  */
-const ENUMERATED_ATTRIBUTES = new Set( [
+const ENUMERATED_ATTRIBUTES = [
 	'autocomplete',
 	'contenteditable',
 	'crossorigin',
@@ -112,7 +112,7 @@ const ENUMERATED_ATTRIBUTES = new Set( [
 	'type',
 	'workertype',
 	'wrap',
-] );
+];
 
 /**
  * Meaningful attributes are those who cannot be safely ignored when omitted in

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { tokenize } from 'simple-html-tokenizer';
-import { xor, fromPairs, isEqual, includes } from 'lodash';
+import { xor, fromPairs, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,7 +43,7 @@ const REGEXP_STYLE_URL_TYPE = /^url\s*\(['"\s]*(.*?)['"\s]*\)$/;
  *
  * @type {Array}
  */
-const BOOLEAN_ATTRIBUTES = [
+const BOOLEAN_ATTRIBUTES = new Set( [
 	'allowfullscreen',
 	'allowpaymentrequest',
 	'allowusermedia',
@@ -72,7 +72,7 @@ const BOOLEAN_ATTRIBUTES = [
 	'reversed',
 	'selected',
 	'typemustmatch',
-];
+] );
 
 /**
  * Enumerated attributes are attributes which must be of a specific value form.
@@ -88,7 +88,7 @@ const BOOLEAN_ATTRIBUTES = [
  *
  * @type {Array}
  */
-const ENUMERATED_ATTRIBUTES = [
+const ENUMERATED_ATTRIBUTES = new Set( [
 	'autocomplete',
 	'contenteditable',
 	'crossorigin',
@@ -112,7 +112,7 @@ const ENUMERATED_ATTRIBUTES = [
 	'type',
 	'workertype',
 	'wrap',
-];
+] );
 
 /**
  * Meaningful attributes are those who cannot be safely ignored when omitted in
@@ -120,10 +120,10 @@ const ENUMERATED_ATTRIBUTES = [
  *
  * @type {Array}
  */
-const MEANINGFUL_ATTRIBUTES = [
+const MEANINGFUL_ATTRIBUTES = new Set( [
 	...BOOLEAN_ATTRIBUTES,
 	...ENUMERATED_ATTRIBUTES,
-];
+] );
 
 /**
  * Object of logger functions.
@@ -197,7 +197,7 @@ export function getMeaningfulAttributePairs( token ) {
 		return (
 			value ||
 			key.indexOf( 'data-' ) === 0 ||
-			includes( MEANINGFUL_ATTRIBUTES, key )
+			MEANINGFUL_ATTRIBUTES.has( key )
 		);
 	} );
 }


### PR DESCRIPTION
Related: #5897

This pull request seeks to optimize the block validator, specifically in its handling of attributes, replacing use of `Array` with `Set`, where lookup via `Set#has` is many magnitudes more performant than `Array#indexOf` ([~4x faster with CoreJS shim, ~9x faster natively](https://jsperf.com/array-indexof-vs-core-set-has)). To my surprise while testing, I was not aware that `Set` is supported in IE11. Our build process still applies CoreJS, though I'm unsure if it is applied as a proper shim (when not already present in environment). In any case, a further step may be to drop this, though this should probably already be handled via `babel-preset-env`.

__Testing instructions:__

Verify that tests pass, and there are no regressions in the behavior of block validation (including invalidation), particularly affecting "meaningful attributes" (boolean attributes like `disabled` or enumerated attributes like `contenteditable="true"`).