### PR TITLE
Terms: Include only known terms in rendered selector

### DIFF
--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -46,7 +46,7 @@ class FlatTermSelector extends Component {
 	componentDidMount() {
 		if ( this.props.terms ) {
 			this.setState( { loading: false } );
-			this.initRequest = this.fetchTerms( { include: this.props.terms } );
+			this.initRequest = this.fetchTerms( { include: this.props.terms, per_page: 100 } );
 			this.initRequest.then(
 				() => {
 					this.setState( { loading: false } );

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -46,7 +46,10 @@ class FlatTermSelector extends Component {
 	componentDidMount() {
 		if ( this.props.terms ) {
 			this.setState( { loading: false } );
-			this.initRequest = this.fetchTerms( { include: this.props.terms, per_page: 100 } );
+			this.initRequest = this.fetchTerms( {
+				include: this.props.terms.join( ',' ),
+				per_page: 100,
+			} );
 			this.initRequest.then(
 				() => {
 					this.setState( { loading: false } );

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -94,10 +94,14 @@ class FlatTermSelector extends Component {
 	}
 
 	updateSelectedTerms( terms = [] ) {
-		const selectedTerms = terms.map( ( termId ) => {
+		const selectedTerms = terms.reduce( ( result, termId ) => {
 			const termObject = find( this.state.availableTerms, ( term ) => term.id === termId );
-			return termObject ? termObject.name : '';
-		} );
+			if ( termObject ) {
+				result.push( termObject.name );
+			}
+
+			return result;
+		}, [] );
 		this.setState( {
 			selectedTerms,
 		} );


### PR DESCRIPTION
This pull request seeks to resolve an issue where posts with multiple non-hierarchical terms assigned will display empty term values in the term selector. Previously, we would render a term even if its name could not be determined (because it had not yet been fetched), resulting in an issue of conflicting `key` assignments, since the `key` is derived from the value, an empty string when not yet known.

With these changes, we only include the term in the selector if it's known. Since we [explicitly request terms assigned to the post](https://github.com/WordPress/gutenberg/blob/d78163dedcdb38cbb98cb94dc16908f35e7d1115/editor/components/post-taxonomies/flat-term-selector.js#L49), this should work well enough, though by default this request would only return 10 terms. Therefore, it is possible that a post with more than 10 terms assigned would not display all terms in the selector. With these changes, I have increased this to 100, though this is still not a perfect solution since more than 100 terms for a post is technically possible. A more thorough solution would paginate results as necessary.

Since this component needs to be refactored with consideration of data module improvements (related: #5826), I am inclined to defer this to a future improvement.

__Testing instructions:__

Verify that with multiple tags assigned to a post, no empty tags appear in tag selector.