### PR TITLE
Fix auto completer on IE

### DIFF
--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -215,7 +215,7 @@ describe( 'Autocomplete', () => {
 		it( 'renders children', () => {
 			const wrapper = makeAutocompleter( [] );
 			expect( wrapper.state().open ).toBeUndefined();
-			expect( wrapper.childAt( 0 ).hasClass( 'components-autocomplete' ) ).toBe( true );
+			expect( wrapper.find( '.components-autocomplete' ) ).toHaveLength( 1 );
 			expect( wrapper.find( '.fake-editor' ) ).toHaveLength( 1 );
 		} );
 

--- a/components/back-compatible-on-input/index.js
+++ b/components/back-compatible-on-input/index.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+export default class BackCompatibleOnInput extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onInput = this.onInput.bind( this );
+		this.onKeyUp = this.onKeyUp.bind( this );
+
+		this.state = {
+			isOnInputSupported: false,
+		};
+	}
+
+	onInput( event ) {
+		this.setState( {
+			onInputSupported: true,
+		} );
+		this.props.onInput( event );
+	}
+
+	onKeyUp( event ) {
+		if ( this.state.isOnInputSupported ) {
+			return;
+		}
+		this.props.onInput( event );
+	}
+
+	render() {
+		const { isOnInputSupported } = this.state;
+		const { onInput, children, ...props } = this.props;
+		return (
+			<div
+				onInput={ isOnInputSupported ? onInput : this.onInput }
+				onKeyUp={ isOnInputSupported ? undefined : this.onKeyUp }
+				{ ...props }
+			>
+				{ children }
+			</div>
+		);
+	}
+}

--- a/core-blocks/button/test/__snapshots__/index.js.snap
+++ b/core-blocks/button/test/__snapshots__/index.js.snap
@@ -9,24 +9,26 @@ exports[`core/button block edit matches snapshot 1`] = `
   >
     <div>
       <div>
-        <div
-          class="components-autocomplete"
-        >
-          <span
-            aria-autocomplete="list"
-            aria-expanded="false"
-            aria-label="Add text…"
-            aria-multiline="false"
-            class="wp-block-button__link blocks-rich-text__tinymce"
-            contenteditable="true"
-            data-is-placeholder-visible="true"
-            role="textbox"
-          />
-          <span
-            class="blocks-rich-text__tinymce wp-block-button__link"
+        <div>
+          <div
+            class="components-autocomplete"
           >
-            Add text…
-          </span>
+            <span
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-label="Add text…"
+              aria-multiline="false"
+              class="wp-block-button__link blocks-rich-text__tinymce"
+              contenteditable="true"
+              data-is-placeholder-visible="true"
+              role="textbox"
+            />
+            <span
+              class="blocks-rich-text__tinymce wp-block-button__link"
+            >
+              Add text…
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/core-blocks/heading/test/__snapshots__/index.js.snap
+++ b/core-blocks/heading/test/__snapshots__/index.js.snap
@@ -6,24 +6,26 @@ exports[`core/heading block edit matches snapshot 1`] = `
 >
   <div>
     <div>
-      <div
-        class="components-autocomplete"
-      >
-        <h2
-          aria-autocomplete="list"
-          aria-expanded="false"
-          aria-label="Write heading…"
-          aria-multiline="false"
-          class="blocks-rich-text__tinymce"
-          contenteditable="true"
-          data-is-placeholder-visible="true"
-          role="textbox"
-        />
-        <h2
-          class="blocks-rich-text__tinymce"
+      <div>
+        <div
+          class="components-autocomplete"
         >
-          Write heading…
-        </h2>
+          <h2
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Write heading…"
+            aria-multiline="false"
+            class="blocks-rich-text__tinymce"
+            contenteditable="true"
+            data-is-placeholder-visible="true"
+            role="textbox"
+          />
+          <h2
+            class="blocks-rich-text__tinymce"
+          >
+            Write heading…
+          </h2>
+        </div>
       </div>
     </div>
   </div>

--- a/core-blocks/list/test/__snapshots__/index.js.snap
+++ b/core-blocks/list/test/__snapshots__/index.js.snap
@@ -6,25 +6,27 @@ exports[`core/list block edit matches snapshot 1`] = `
 >
   <div>
     <div>
-      <div
-        class="components-autocomplete"
-      >
-        <ul
-          aria-autocomplete="list"
-          aria-expanded="false"
-          aria-label="Write list…"
-          aria-multiline="true"
-          class="blocks-rich-text__tinymce"
-          contenteditable="true"
-          data-is-placeholder-visible="true"
-        />
-        <ul
-          class="blocks-rich-text__tinymce"
+      <div>
+        <div
+          class="components-autocomplete"
         >
-          <li>
-            Write list…
-          </li>
-        </ul>
+          <ul
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Write list…"
+            aria-multiline="true"
+            class="blocks-rich-text__tinymce"
+            contenteditable="true"
+            data-is-placeholder-visible="true"
+          />
+          <ul
+            class="blocks-rich-text__tinymce"
+          >
+            <li>
+              Write list…
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/core-blocks/paragraph/test/__snapshots__/index.js.snap
+++ b/core-blocks/paragraph/test/__snapshots__/index.js.snap
@@ -9,24 +9,26 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
     >
       <div>
         <div>
-          <div
-            class="components-autocomplete"
-          >
-            <p
-              aria-autocomplete="list"
-              aria-expanded="false"
-              aria-label="Add text or type / to add content"
-              aria-multiline="false"
-              class="wp-block-paragraph blocks-rich-text__tinymce"
-              contenteditable="true"
-              data-is-placeholder-visible="true"
-              role="textbox"
-            />
-            <p
-              class="blocks-rich-text__tinymce wp-block-paragraph"
+          <div>
+            <div
+              class="components-autocomplete"
             >
-              Add text or type / to add content
-            </p>
+              <p
+                aria-autocomplete="list"
+                aria-expanded="false"
+                aria-label="Add text or type / to add content"
+                aria-multiline="false"
+                class="wp-block-paragraph blocks-rich-text__tinymce"
+                contenteditable="true"
+                data-is-placeholder-visible="true"
+                role="textbox"
+              />
+              <p
+                class="blocks-rich-text__tinymce wp-block-paragraph"
+              >
+                Add text or type / to add content
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/core-blocks/preformatted/test/__snapshots__/index.js.snap
+++ b/core-blocks/preformatted/test/__snapshots__/index.js.snap
@@ -6,24 +6,26 @@ exports[`core/preformatted block edit matches snapshot 1`] = `
 >
   <div>
     <div>
-      <div
-        class="components-autocomplete"
-      >
-        <pre
-          aria-autocomplete="list"
-          aria-expanded="false"
-          aria-label="Write preformatted text…"
-          aria-multiline="false"
-          class="blocks-rich-text__tinymce"
-          contenteditable="true"
-          data-is-placeholder-visible="true"
-          role="textbox"
-        />
-        <pre
-          class="blocks-rich-text__tinymce"
+      <div>
+        <div
+          class="components-autocomplete"
         >
-          Write preformatted text…
-        </pre>
+          <pre
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Write preformatted text…"
+            aria-multiline="false"
+            class="blocks-rich-text__tinymce"
+            contenteditable="true"
+            data-is-placeholder-visible="true"
+            role="textbox"
+          />
+          <pre
+            class="blocks-rich-text__tinymce"
+          >
+            Write preformatted text…
+          </pre>
+        </div>
       </div>
     </div>
   </div>

--- a/core-blocks/table/test/__snapshots__/index.js.snap
+++ b/core-blocks/table/test/__snapshots__/index.js.snap
@@ -6,35 +6,37 @@ exports[`core/embed block edit matches snapshot 1`] = `
 >
   <div>
     <div>
-      <div
-        class="components-autocomplete"
-      >
-        <table
-          aria-autocomplete="list"
-          aria-expanded="false"
-          aria-multiline="false"
-          class="blocks-rich-text__tinymce"
-          contenteditable="true"
+      <div>
+        <div
+          class="components-autocomplete"
         >
-          <tbody>
-            <tr>
-              <td>
-                <br />
-              </td>
-              <td>
-                <br />
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <br />
-              </td>
-              <td>
-                <br />
-              </td>
-            </tr>
-          </tbody>
-        </table>
+          <table
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-multiline="false"
+            class="blocks-rich-text__tinymce"
+            contenteditable="true"
+          >
+            <tbody>
+              <tr>
+                <td>
+                  <br />
+                </td>
+                <td>
+                  <br />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <br />
+                </td>
+                <td>
+                  <br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/core-blocks/text-columns/test/__snapshots__/index.js.snap
+++ b/core-blocks/text-columns/test/__snapshots__/index.js.snap
@@ -12,24 +12,26 @@ exports[`core/text-columns block edit matches snapshot 1`] = `
     >
       <div>
         <div>
-          <div
-            class="components-autocomplete"
-          >
-            <p
-              aria-autocomplete="list"
-              aria-expanded="false"
-              aria-label="New Column"
-              aria-multiline="false"
-              class="blocks-rich-text__tinymce"
-              contenteditable="true"
-              data-is-placeholder-visible="true"
-              role="textbox"
-            />
-            <p
-              class="blocks-rich-text__tinymce"
+          <div>
+            <div
+              class="components-autocomplete"
             >
-              New Column
-            </p>
+              <p
+                aria-autocomplete="list"
+                aria-expanded="false"
+                aria-label="New Column"
+                aria-multiline="false"
+                class="blocks-rich-text__tinymce"
+                contenteditable="true"
+                data-is-placeholder-visible="true"
+                role="textbox"
+              />
+              <p
+                class="blocks-rich-text__tinymce"
+              >
+                New Column
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -43,24 +45,26 @@ exports[`core/text-columns block edit matches snapshot 1`] = `
     >
       <div>
         <div>
-          <div
-            class="components-autocomplete"
-          >
-            <p
-              aria-autocomplete="list"
-              aria-expanded="false"
-              aria-label="New Column"
-              aria-multiline="false"
-              class="blocks-rich-text__tinymce"
-              contenteditable="true"
-              data-is-placeholder-visible="true"
-              role="textbox"
-            />
-            <p
-              class="blocks-rich-text__tinymce"
+          <div>
+            <div
+              class="components-autocomplete"
             >
-              New Column
-            </p>
+              <p
+                aria-autocomplete="list"
+                aria-expanded="false"
+                aria-label="New Column"
+                aria-multiline="false"
+                class="blocks-rich-text__tinymce"
+                contenteditable="true"
+                data-is-placeholder-visible="true"
+                role="textbox"
+              />
+              <p
+                class="blocks-rich-text__tinymce"
+              >
+                New Column
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/core-blocks/verse/test/__snapshots__/index.js.snap
+++ b/core-blocks/verse/test/__snapshots__/index.js.snap
@@ -6,24 +6,26 @@ exports[`core/verse block edit matches snapshot 1`] = `
 >
   <div>
     <div>
-      <div
-        class="components-autocomplete"
-      >
-        <pre
-          aria-autocomplete="list"
-          aria-expanded="false"
-          aria-label="Write…"
-          aria-multiline="false"
-          class="blocks-rich-text__tinymce"
-          contenteditable="true"
-          data-is-placeholder-visible="true"
-          role="textbox"
-        />
-        <pre
-          class="blocks-rich-text__tinymce"
+      <div>
+        <div
+          class="components-autocomplete"
         >
-          Write…
-        </pre>
+          <pre
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Write…"
+            aria-multiline="false"
+            class="blocks-rich-text__tinymce"
+            contenteditable="true"
+            data-is-placeholder-visible="true"
+            role="textbox"
+          />
+          <pre
+            class="blocks-rich-text__tinymce"
+          >
+            Write…
+          </pre>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Autocompleter did not work on IE mainly because IE does not handle onInput events on editables. We now make use of a newly implemented BackCompatibleOnInput component that falls back to key events when onInput is not supported.


Fixes: https://github.com/WordPress/gutenberg/issues/3409
## How Has This Been Tested?
Test auto-completer, in IE and other browsers, verify it works well.

