### PR TITLE
Fixed moment timezone configuration.

### DIFF
--- a/date/index.js
+++ b/date/index.js
@@ -5,14 +5,12 @@ import 'moment-timezone/moment-timezone-utils';
 export const settings = window._wpDateSettings;
 
 // Create WP timezone based off dateSettings.
-const offsets = ( settings.timezone.string ) ? momentLib.tz.zone( settings.timezone.string ).offsets : [ -settings.timezone.offset * 60 ];
-const momentTimezone = {
+momentLib.tz.add( momentLib.tz.pack( {
 	name: 'WP',
 	abbrs: [ 'WP' ],
 	untils: [ null ],
-	offsets: [ offsets ],
-};
-momentLib.tz.add( momentLib.tz.pack( momentTimezone ) );
+	offsets: [ -settings.timezone.offset * 60 || 0 ],
+} ) );
 
 // Create a new moment object which mirrors moment but includes
 // the attached timezone, instead of setting a default timezone on


### PR DESCRIPTION
When we use moment.tz.zone( settings.timezone.string ) moment returns us an object which contains the offsets property with a large array, but also returns arrays of the same sizes for untils and abbrs. When timezone was passed back to the moment (to configure it) we only passed the offsets array and we used an array with a null value for untils and an array with 'WP' for the abbrs. This made moment logic not work correctly. If besides offsets we also passback untils and abbrs arrays things work as expected.
Given that our logic worked correctly when the timezone contains just the offset  (a UTC value was set as timezone instead of a city), there is no need to maintain two logics because if we select a city as timezone we have access to offset anyway which was computed on the server using get_option( 'gmt_offset', 0 );
So we are changing the moment timezone configuration to rely just on the offset.

Fixes: https://github.com/WordPress/gutenberg/issues/5874

## How Has This Been Tested?
Set your wordpress timezone settings to a city e.g: "Lisbon".
Create a new post, write something and verify the Publish button says "Publish...", publish the post see the pre/pos publish panel works as expected.
Schedule a post to be posted after 3 minutes and after a long time verify we have now a "Schedule..." button and the schedule flow works as expected.