### PR TITLE
Issue/5924 - Provide empty array if no caption exists

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -280,7 +280,7 @@ class ImageBlock extends Component {
 					<RichText
 						tagName="figcaption"
 						placeholder={ __( 'Write caption…' ) }
-						value={ caption }
+						value={ caption || [] }
 						onFocus={ this.onFocusCaption }
 						onChange={ ( value ) => setAttributes( { caption: value } ) }
 						isSelected={ this.state.captionFocused }


### PR DESCRIPTION
#5924 

## Description
Provides an empty array if no caption exists.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
