### PR TITLE
E2E Tests: Adding a test to check CPT templates initialization.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - wordpress:/var/www/html
       - .:/var/www/html/wp-content/plugins/gutenberg
+      - ./test/e2e/test-plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
 
   cli:
     image: wordpress:cli

--- a/test/e2e/specs/__snapshots__/templates.test.js.snap
+++ b/test/e2e/specs/__snapshots__/templates.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Using a CPT with a predefined template Should add a custom post types with a predefined template 1`] = `
+"<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\" /></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {\\"placeholder\\":\\"Add a book description\\"} -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:columns -->
+<div class=\\"wp-block-columns has-2-columns\\">
+    <!-- wp:image {\\"layout\\":\\"column-1\\"} -->
+    <figure class=\\"wp-block-image layout-column-1\\"><img alt=\\"\\" /></figure>
+    <!-- /wp:image -->
+
+    <!-- wp:paragraph {\\"placeholder\\":\\"Add a inner paragraph\\",\\"layout\\":\\"column-2\\"} -->
+    <p class=\\"layout-column-2\\"></p>
+    <!-- /wp:paragraph -->
+</div>
+<!-- /wp:columns -->"
+`;

--- a/test/e2e/specs/templates.test.js
+++ b/test/e2e/specs/templates.test.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage } from '../support/utils';
+import { activatePlugin, deactivatePlugin } from '../support/plugins';
+
+describe( 'Using a CPT with a predefined template', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await activatePlugin( 'gutenberg-test-plugin-templates' );
+		await newPost( 'book' );
+	} );
+
+	afterAll( async () => {
+		await newDesktopBrowserPage();
+		await deactivatePlugin( 'gutenberg-test-plugin-templates' );
+	} );
+
+	it( 'Should add a custom post types with a predefined template', async () => {
+		//Switch to Code Editor to check HTML output
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		await codeEditorButton.click( 'button' );
+
+		// Assert that the post already contains the template defined blocks
+		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toMatchSnapshot();
+	} );
+} );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -62,8 +62,8 @@ export async function visitAdmin( adminPath ) {
 	}
 }
 
-export async function newPost() {
-	await visitAdmin( 'post-new.php' );
+export async function newPost( postType ) {
+	await visitAdmin( 'post-new.php' + ( postType ? '?post_type=' + postType : '' ) );
 }
 
 export async function newDesktopBrowserPage() {

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -70,39 +70,3 @@ export async function newDesktopBrowserPage() {
 	global.page = await browser.newPage();
 	await page.setViewport( { width: 1000, height: 700 } );
 }
-
-/**
- * Wait for all XHR request to finish before continuing.
- *
- * @param {number} minDelay minimum delay in milliseconds to wait for before returning
- * @param {number} maxDelay maximum delay in milliseconds to wait for before returning
- *
- * @return {Promise}        Promise.
- */
-export async function waitForRequests( minDelay = 1000, maxDelay = 20000 ) {
-	const requests = [];
-	let canResolve = false;
-
-	return new Promise( ( resolve ) => {
-		setTimeout( resolve, maxDelay );
-		setTimeout( () => {
-			canResolve = true;
-			maybeResolve();
-		}, minDelay );
-		const maybeResolve = () => {
-			if ( canResolve && requests.length === 0 ) {
-				resolve();
-			}
-		};
-		page.on( 'request', ( request ) => {
-			requests.push( request );
-		} );
-		page.on( 'requestfinished', ( request ) => {
-			const index = requests.indexOf( request );
-			if ( index !== -1 ) {
-				requests.splice( index, 1 );
-				maybeResolve();
-			}
-		} );
-	} );
-}

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -70,3 +70,39 @@ export async function newDesktopBrowserPage() {
 	global.page = await browser.newPage();
 	await page.setViewport( { width: 1000, height: 700 } );
 }
+
+/**
+ * Wait for all XHR request to finish before continuing.
+ *
+ * @param {number} minDelay minimum delay in milliseconds to wait for before returning
+ * @param {number} maxDelay maximum delay in milliseconds to wait for before returning
+ *
+ * @return {Promise}        Promise.
+ */
+export async function waitForRequests( minDelay = 1000, maxDelay = 20000 ) {
+	const requests = [];
+	let canResolve = false;
+
+	return new Promise( ( resolve ) => {
+		setTimeout( resolve, maxDelay );
+		setTimeout( () => {
+			canResolve = true;
+			maybeResolve();
+		}, minDelay );
+		const maybeResolve = () => {
+			if ( canResolve && requests.length === 0 ) {
+				resolve();
+			}
+		};
+		page.on( 'request', ( request ) => {
+			requests.push( request );
+		} );
+		page.on( 'requestfinished', ( request ) => {
+			const index = requests.indexOf( request );
+			if ( index !== -1 ) {
+				requests.splice( index, 1 );
+				maybeResolve();
+			}
+		} );
+	} );
+}

--- a/test/e2e/test-plugins/templates.php
+++ b/test/e2e/test-plugins/templates.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Templates
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-templates
+ */
+
+/**
+ * Registers a book CPT with a template
+ */
+function register_book_type() {
+	$args = array(
+		'public' => true,
+		'label'  => 'Books',
+		'show_in_rest' => true,
+		'template' => array(
+			array( 'core/image' ),
+			array(
+				'core/paragraph',
+				array(
+					'placeholder' => 'Add a book description',
+				),
+			),
+			array( 'core/quote' ),
+			array(
+				'core/columns',
+				array(),
+				array(
+					array( 'core/image', array( 'layout' => 'column-1' ) ),
+					array(
+						'core/paragraph',
+						array(
+							'placeholder' => 'Add a inner paragraph',
+							'layout' => 'column-2',
+						),
+					),
+				),
+			),
+		),
+	);
+	register_post_type( 'book', $args );
+}
+
+add_action( 'init', 'register_book_type' );


### PR DESCRIPTION
blocked by #5906

This PR adds test plugins to Gutenberg, these plugins can be used in E2E tests. The test plugins folders includes a single plugin for now to test CPT templates. 

This pattern could be used to fix this #5909