### PR TITLE
Build: Re-incorporate Webpack devtool into development build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -207,4 +207,8 @@ const config = {
 	},
 };
 
+if ( config.mode !== 'production' ) {
+	config.devtool = 'source-map';
+}
+
 module.exports = config;


### PR DESCRIPTION
Related: #5267

This pull request seeks to reincorporate the Webpack `devtool` configuration option into the development build, enabling improved debugging through the browser developer tools. Without this option, the quality of the code will appear as transformed, making it difficult to trace through code in the source tab.

See: https://webpack.js.org/configuration/devtool/#devtool

**These changes merely restore the value that existed prior to Webpack 4 upgrade.**

If performance is a concern, we may consider another option, though ideally it is one of equivalent quality, particularly on the more challenging points of source maps: breakpoints set where intended, including in-line statements, and step-through and step-into with expected behavior.

We may also consider easier overrides, such as an environment variable. Though in this case, I might suggest it as a case for encouraging source debugging.

__Testing instructions:__

Verify source maps present if and only if development build `npm run dev` (`.map` files, visible in sources tab of decent browser).