### PR TITLE
Add possibility to manage innerBlocks while migrating deprecated blocks. 

### DIFF
--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -6,7 +6,7 @@ import {
 	getBlockAttributes,
 	asType,
 	createBlockWithFallback,
-	getAttributesFromDeprecatedVersion,
+	getAttributesAndInnerBlocksFromDeprecatedVersion,
 	default as parse,
 	parseWithAttributeSchema,
 } from '../parser';
@@ -185,18 +185,18 @@ describe( 'block parser', () => {
 		} );
 	} );
 
-	describe( 'getAttributesFromDeprecatedVersion', () => {
+	describe( 'getAttributesAndInnerBlocksFromDeprecatedVersion', () => {
 		it( 'should return undefined if the block has no deprecated versions', () => {
-			const attributes = getAttributesFromDeprecatedVersion(
+			const attributesAndInnerBlocks = getAttributesAndInnerBlocksFromDeprecatedVersion(
 				defaultBlockSettings,
 				'<span class="wp-block-test-block">Bananas</span>',
 				{},
 			);
-			expect( attributes ).toBeUndefined();
+			expect( attributesAndInnerBlocks ).toBeUndefined();
 		} );
 
 		it( 'should return undefined if no valid deprecated version found', () => {
-			const attributes = getAttributesFromDeprecatedVersion(
+			const attributesAndInnerBlocks = getAttributesAndInnerBlocksFromDeprecatedVersion(
 				{
 					name: 'core/test-block',
 					...defaultBlockSettings,
@@ -211,13 +211,13 @@ describe( 'block parser', () => {
 				'<span class="wp-block-test-block">Bananas</span>',
 				{},
 			);
-			expect( attributes ).toBeUndefined();
+			expect( attributesAndInnerBlocks ).toBeUndefined();
 			expect( console ).toHaveErrored();
 			expect( console ).toHaveWarned();
 		} );
 
 		it( 'should return the attributes parsed by the deprecated version', () => {
-			const attributes = getAttributesFromDeprecatedVersion(
+			const attributesAndInnerBlocks = getAttributesAndInnerBlocksFromDeprecatedVersion(
 				{
 					name: 'core/test-block',
 					...defaultBlockSettings,
@@ -238,7 +238,77 @@ describe( 'block parser', () => {
 				'<span class="wp-block-test-block">Bananas</span>',
 				{},
 			);
-			expect( attributes ).toEqual( { fruit: 'Bananas' } );
+			expect( attributesAndInnerBlocks.attributes ).toEqual( { fruit: 'Bananas' } );
+		} );
+
+		it( 'should return the innerBlocks if they are passed', () => {
+			const attributesAndInnerBlocks = getAttributesAndInnerBlocksFromDeprecatedVersion(
+				{
+					name: 'core/test-block',
+					...defaultBlockSettings,
+					save: ( props ) => <div>{ props.attributes.fruit }</div>,
+					deprecated: [
+						{
+							attributes: {
+								fruit: {
+									type: 'string',
+									source: 'text',
+									selector: 'span',
+								},
+							},
+							save: ( props ) => <span>{ props.attributes.fruit }</span>,
+						},
+					],
+				},
+				'<span class="wp-block-test-block">Bananas</span>',
+				{},
+				[ {
+					name: 'core/test-block',
+					attributes: { aaa: 'bbb' },
+				} ]
+			);
+
+			expect( attributesAndInnerBlocks.innerBlocks ).toHaveLength( 1 );
+			expect( attributesAndInnerBlocks.innerBlocks[ 0 ].name ).toEqual( 'core/test-block' );
+			expect( attributesAndInnerBlocks.innerBlocks[ 0 ].attributes ).toEqual( { aaa: 'bbb' } );
+		} );
+
+		it( 'should be able to migrate attributes and innerBlocks', () => {
+			const attributesAndInnerBlocks = getAttributesAndInnerBlocksFromDeprecatedVersion(
+				{
+					name: 'core/test-block',
+					...defaultBlockSettings,
+					save: ( props ) => <div>{ props.attributes.fruit }</div>,
+					deprecated: [
+						{
+							attributes: {
+								fruit: {
+									type: 'string',
+									source: 'text',
+									selector: 'span',
+								},
+							},
+							save: ( props ) => <span>{ props.attributes.fruit }</span>,
+							migrate: ( attributes ) => {
+								return [
+									{ newFruit: attributes.fruit },
+									[ {
+										name: 'core/test-block',
+										attributes: { aaa: 'bbb' },
+									} ],
+								];
+							},
+						},
+					],
+				},
+				'<span class="wp-block-test-block">Bananas</span>',
+				{},
+			);
+
+			expect( attributesAndInnerBlocks.attributes ).toEqual( { newFruit: 'Bananas' } );
+			expect( attributesAndInnerBlocks.innerBlocks ).toHaveLength( 1 );
+			expect( attributesAndInnerBlocks.innerBlocks[ 0 ].name ).toEqual( 'core/test-block' );
+			expect( attributesAndInnerBlocks.innerBlocks[ 0 ].attributes ).toEqual( { aaa: 'bbb' } );
 		} );
 	} );
 

--- a/docs/deprecated-blocks.md
+++ b/docs/deprecated-blocks.md
@@ -173,3 +173,96 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 {% end %}
 
 In the example above we updated the markup of the block to use a `div` instead of `p` and rename the `text` attribute to `content`.
+
+
+## Changing the innerBlocks
+
+Situations may exist where when migrating the block we may need to add or remove innerBlocks.
+E.g: a block wants to migrate a title attribute to a paragraph innerBlock.
+
+### Example:
+
+{% codetabs %}
+{% ES5 %}
+```js
+var el = wp.element.createElement,
+	registerBlockType = wp.blocks.registerBlockType;
+
+registerBlockType( 'gutenberg/block-with-deprecated-version', {
+
+	// ... block properties go here
+
+	deprecated: [
+		{
+			attributes: {
+				title: {
+					type: 'array',
+					source: 'children',
+					selector: 'p',
+				},
+			},
+
+			migrate: function( attributes, innerBlocks ) {
+				return [
+					omit( attributes, 'title' ),
+					[
+						createBlock( 'core/paragraph', {
+							content: attributes.title,
+							fontSize: 'large',
+						} ),
+					].concat( innerBlocks ),
+				];
+			},
+
+			save: function( props ) {
+				return el( 'p', {}, props.attributes.title );
+			},
+		}
+	]
+} );
+```
+{% ESNext %}
+```js
+const { registerBlockType } = wp.blocks;
+
+registerBlockType( 'gutenberg/block-with-deprecated-version', {
+
+	// ... block properties go here
+
+	save( props ) {
+		return <p>{ props.attributes.title }</div>;
+	},
+
+	deprecated: [
+		{
+			attributes: {
+				title: {
+					type: 'array',
+					source: 'children',
+					selector: 'p',
+				},
+			},
+
+			migrate( attributes, innerBlocks  ) {
+				return [
+					omit( attributes, 'title' ),
+					[
+						createBlock( 'core/paragraph', {
+							content: attributes.title,
+							fontSize: 'large',
+						} ),
+						...innerBlocks,
+					],
+				];
+			},
+
+			save( props ) {
+				return <p>{ props.attributes.title }</div>;
+			},
+		}
+	]
+} );
+```
+{% end %}
+
+In the example above we updated the block to use an inner paragraph block with a title instead of a title attribute.


### PR DESCRIPTION
This PR was extracted from https://github.com/WordPress/gutenberg/pull/5452, to make reviewing easier as this ones just focus on changes to the blocks API.

## Description
Before the migrate function received the existing attributes and returned the new attributes now, migrate receives an object with attributes and innerBlocks and returns another object with the migrated attributes & innerBlocks.
This allows, for example, to migrate an attribute to an innerBlock, or the contrary move an inner block to be an attribute.
These changes were used to migrate existing cover image blocks to the nested version.

## How Has This Been Tested?
To test the cover image migration merge this changes in a temporary branch with the nesting in cover image PR.

Add a post with following code:
```
<!-- wp:cover-image {"url":"http://via.placeholder.com/350x150","contentAlign":"right","id":14,"dimRatio":0} -->
<div class="wp-block-cover-image has-right-content" style="background-image:url(http://via.placeholder.com/350x150)">
    <p class="wp-block-cover-image-text">aaaaa</p>
</div>
<!-- /wp:cover-image -->

<!-- wp:cover-image {"url":"http://via.placeholder.com/350x150","id":14} -->
<div class="wp-block-cover-image has-background-dim" style="background-image:url(http://via.placeholder.com/350x150)">
    <p class="wp-block-cover-image-text">aaaaa</p>
</div>
<!-- /wp:cover-image -->

<!-- wp:paragraph {"fontSize":56} -->
<p style="font-size:56px">dsfdsfs</p>
<!-- /wp:paragraph -->
```
Open the post in the visual editor and verify no invalid block error appears and the cover image blocks and paragraphs were migrated.
