### PR TITLE
i18n: Correctly translate FormTokenField placeholder

### DIFF
--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -504,7 +504,7 @@ class FormTokenField extends Component {
 	render() {
 		const {
 			disabled,
-			placeholder = _( 'Add item.' ),
+			placeholder = __( 'Add item.' ),
 			instanceId,
 		} = this.props;
 		const classes = classnames( 'components-form-token-field', {


### PR DESCRIPTION
Related: #1141

This pull request seeks to use the correct `__` translation function, not `_` (presumably Underscore.js global) for the default value of the `FormTokenField` placeholder.
