### PR TITLE
Framework: Remove unused PrismJS dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11595,15 +11595,6 @@
 				}
 			}
 		},
-		"prismjs": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz",
-			"integrity": "sha1-EY2V+3pm26InLjQ7NF9SNmWds2U=",
-			"dev": true,
-			"requires": {
-				"clipboard": "1.7.1"
-			}
-		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
 		"pegjs-loader": "0.5.4",
 		"phpegjs": "1.0.0-beta7",
 		"postcss-loader": "2.1.3",
-		"prismjs": "1.6.0",
 		"puppeteer": "1.2.0",
 		"raw-loader": "0.5.1",
 		"react-test-renderer": "16.3.0",


### PR DESCRIPTION
Related: #1009, #1786

This pull request seeks to remove the `prismjs` dependency which, to my knowledge, is no longer in used. It was originally introduced for React Storybook (#1009), and then used by Docutron (#1786), both of which are now defunct.