### PR TITLE
Fixed image add link input disappears issue

### DIFF
--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -113,3 +113,14 @@
 		}
 	}
 }
+
+.editor-block-list__block[data-type="core/image"] .blocks-format-toolbar__link-modal {
+	position: absolute;
+	left: 0;
+	right: 0;
+	margin: -1px 0;
+
+	@include break-small() {
+		margin: -1px;
+	}
+}

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -114,7 +114,7 @@
 	}
 }
 
-.editor-block-list__block[data-type="core/image"] .blocks-format-toolbar__link-modal {
+.editor-block-list__block[data-type="core/image"] .editor-block-toolbar .blocks-format-toolbar__link-modal {
 	position: absolute;
 	left: 0;
 	right: 0;

--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -16,6 +16,9 @@ import { IconButton } from '@wordpress/components';
  */
 import UrlInput from './';
 
+// Stop the key event propagating when start typing in URLInput.
+const stopKeyPropagation = ( event ) => event.stopPropagation();
+
 class UrlInputButton extends Component {
 	constructor() {
 		super( ...arguments );
@@ -51,8 +54,12 @@ class UrlInputButton extends Component {
 					} ) }
 				/>
 				{ expanded &&
+					// Disable reason: KeyPress & KeyDown must be suppressed so the input changes doesn't close the URLInput block.
+					/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 					<form
 						className="blocks-format-toolbar__link-modal"
+						onKeyPress={ stopKeyPropagation }
+						onKeyDown={ stopKeyPropagation }
 						onSubmit={ this.submitLink }>
 						<div className="blocks-format-toolbar__link-modal-line">
 							<IconButton

--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -16,9 +16,6 @@ import { IconButton } from '@wordpress/components';
  */
 import UrlInput from './';
 
-// Stop the key event propagating when start typing in URLInput.
-const stopKeyPropagation = ( event ) => event.stopPropagation();
-
 class UrlInputButton extends Component {
 	constructor() {
 		super( ...arguments );
@@ -54,12 +51,8 @@ class UrlInputButton extends Component {
 					} ) }
 				/>
 				{ expanded &&
-					// Disable reason: KeyPress & KeyDown must be suppressed so the input changes doesn't close the URLInput block.
-					/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 					<form
 						className="blocks-format-toolbar__link-modal"
-						onKeyPress={ stopKeyPropagation }
-						onKeyDown={ stopKeyPropagation }
 						onSubmit={ this.submitLink }>
 						<div className="blocks-format-toolbar__link-modal-line">
 							<IconButton

--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -42,6 +42,15 @@ $input-size: 230px;
 	width: $input-size + $icon-button-size * 2 + 2px; // add borders
 }
 
+// Hide suggestions on mobile until we @todo find a better way to show them
+.blocks-url-input__suggestions,
+.blocks-url-input .spinner {
+	display: none;
+	@include break-small() {
+		display: inherit;
+	}
+}
+
 .blocks-url-input__suggestion {
 	padding: 4px #{ $icon-button-size + $input-padding } 4px $input-padding;
 	color: $dark-gray-300; // lightest we can use for contrast

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -670,10 +670,6 @@
 		margin-left: -1px;
 	}
 
-	> .editor-block-switcher:first-child {
-		margin-left: -2px;
-	}
-
 	@include break-small() {
 		width: auto;
 	}

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -1,5 +1,9 @@
 .editor-block-switcher {
 	position: relative;
+
+	.components-toolbar {
+		border-left: none;
+	}
 }
 
 .editor-block-switcher__toggle {

--- a/editor/components/block-toolbar/style.scss
+++ b/editor/components/block-toolbar/style.scss
@@ -1,9 +1,14 @@
 .editor-block-toolbar {
 	display: inline-flex;
-	overflow: auto; // allow horizontal scrolling on mobile
 	flex-grow: 1;
 	width: 100%;
 	background: $white;
+	overflow: auto; // allow horizontal scrolling on mobile
+
+	// allow overflow on desktop
+	@include break-small() {
+		overflow: inherit;
+	}
 
 	.components-toolbar {
 		border: none;

--- a/editor/components/observe-typing/index.js
+++ b/editor/components/observe-typing/index.js
@@ -120,7 +120,8 @@ class ObserveTyping extends Component {
 
 		// Abort early if already typing, or key press is incurred outside a
 		// text field (e.g. arrow-ing through toolbar buttons).
-		if ( isTyping || ! isTextField( target ) ) {
+		// Ignore typing in a block toolbar
+		if ( isTyping || ! isTextField( target ) || target.closest( '.editor-block-toolbar' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #5894
Same as #3822

## Description
When you begin typing anything in the image link input, it simply just closes the UI due to key events propagation, changing the states and triggering updates.

## How Has This Been Tested?
Add image block and try to add a link from the toolbar. When you start typing, input should stay open.

## Types of changes
Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
