### PR TITLE
Fix Safari flashing a white screen just before the editor is loaded.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -148,7 +148,8 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-element',
 		gutenberg_url( 'element/build/index.js' ),
 		array( 'react', 'react-dom', 'wp-utils' ),
-		filemtime( gutenberg_dir_path() . 'element/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'element/build/index.js' ),
+		true
 	);
 	wp_register_script(
 		'wp-components',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -986,22 +986,8 @@ JS;
  * @return string The <script> tag with the defer property added.
  */
 function gutenberg_editor_defer( $tag, $handle ) {
-	$async_handles = array(
-		'wp-blocks',
-		'wp-components',
-		'wp-core-data',
-		'wp-data',
-		'wp-edit-post',
-		'wp-editor',
-		'wp-element',
-		'wp-hooks',
-		'wp-plugins',
-		'wp-utils',
-		'wp-viewport',
-	);
-
-	if ( in_array( $handle, $async_handles, true ) ) {
-		return str_replace( ' src', ' defer src', $tag );
+	if ( 'wp-edit-post' === $handle ) {
+		return str_replace( ' src', ' defer="defer" src', $tag );
 	}
 
 	return $tag;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -80,31 +80,36 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-data',
 		gutenberg_url( 'data/build/index.js' ),
 		array( 'wp-element', 'wp-utils' ),
-		filemtime( gutenberg_dir_path() . 'data/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'data/build/index.js' ),
+		true
 	);
 	wp_register_script(
 		'wp-core-data',
 		gutenberg_url( 'core-data/build/index.js' ),
 		array( 'wp-data', 'wp-api-request' ),
-		filemtime( gutenberg_dir_path() . 'core-data/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'core-data/build/index.js' ),
+		true
 	);
 	wp_register_script(
 		'wp-utils',
 		gutenberg_url( 'utils/build/index.js' ),
 		array( 'tinymce-latest' ),
-		filemtime( gutenberg_dir_path() . 'utils/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'utils/build/index.js' ),
+		true
 	);
 	wp_register_script(
 		'wp-hooks',
 		gutenberg_url( 'hooks/build/index.js' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'hooks/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'hooks/build/index.js' ),
+		true
 	);
 	wp_register_script(
 		'wp-date',
 		gutenberg_url( 'date/build/index.js' ),
 		array( 'moment' ),
-		filemtime( gutenberg_dir_path() . 'date/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'date/build/index.js' ),
+		true
 	);
 	global $wp_locale;
 	wp_add_inline_script( 'wp-date', 'window._wpDateSettings = ' . wp_json_encode( array(
@@ -136,7 +141,8 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-i18n',
 		gutenberg_url( 'i18n/build/index.js' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'i18n/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'i18n/build/index.js' ),
+		true
 	);
 	wp_register_script(
 		'wp-element',
@@ -148,13 +154,15 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-components',
 		gutenberg_url( 'components/build/index.js' ),
 		array( 'wp-element', 'wp-i18n', 'wp-utils', 'wp-hooks', 'wp-api-request', 'moment' ),
-		filemtime( gutenberg_dir_path() . 'components/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'components/build/index.js' ),
+		true
 	);
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
 		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-hooks', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'shortcode', 'editor', 'wp-core-data' ),
-		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' ),
+		true
 	);
 	wp_add_inline_script(
 		'wp-blocks',
@@ -168,7 +176,8 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-viewport',
 		gutenberg_url( 'viewport/build/index.js' ),
 		array( 'wp-element', 'wp-data', 'wp-components' ),
-		filemtime( gutenberg_dir_path() . 'viewport/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'viewport/build/index.js' ),
+		true
 	);
 	// Loading the old editor and its config to ensure the classic block works as expected.
 	wp_add_inline_script(
@@ -259,7 +268,8 @@ function gutenberg_register_scripts_and_styles() {
 			'word-count',
 			'editor',
 		),
-		filemtime( gutenberg_dir_path() . 'editor/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
+		true
 	);
 
 	wp_register_script(

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -986,8 +986,22 @@ JS;
  * @return string The <script> tag with the defer property added.
  */
 function gutenberg_editor_defer( $tag, $handle ) {
-	if ( 'wp-edit-post' === $handle ) {
-		return str_replace( ' src', ' defer="defer" src', $tag );
+	$async_handles = array(
+		'wp-blocks',
+		'wp-components',
+		'wp-core-data',
+		'wp-data',
+		'wp-edit-post',
+		'wp-editor',
+		'wp-element',
+		'wp-hooks',
+		'wp-plugins',
+		'wp-utils',
+		'wp-viewport',
+	);
+
+	if ( in_array( $handle, $async_handles, true ) ) {
+		return str_replace( ' src', ' defer src', $tag );
 	}
 
 	return $tag;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -940,9 +940,11 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$script  = '( function() {';
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
 	$script .= <<<JS
-		window._wpLoadGutenbergEditor = wp.api.init().then( function() {
-			wp.blocks.registerCoreBlocks();
-			return wp.editPost.initializeEditor( 'editor', window._wpGutenbergPost, editorSettings );
+		window.addEventListener( 'DOMContentLoaded', function() {
+			window._wpLoadGutenbergEditor = wp.api.init().then( function() {
+				wp.blocks.registerCoreBlocks();
+				return wp.editPost.initializeEditor( 'editor', window._wpGutenbergPost, editorSettings );
+			} );
 		} );
 JS;
 	$script .= '} )();';
@@ -973,3 +975,21 @@ JS;
 	 */
 	do_action( 'enqueue_block_editor_assets' );
 }
+
+/**
+ * Adds the "defer" property to the wp-edit-post script, so that it doesn't block rendering while loading.
+ *
+ * @since 2.6.0
+ *
+ * @param string $tag    The <script> tag being printed.
+ * @param string $handle The script handle for the <script>.
+ * @return string The <script> tag with the defer property added.
+ */
+function gutenberg_editor_defer( $tag, $handle ) {
+	if ( 'wp-edit-post' === $handle ) {
+		return str_replace( ' src', ' defer="defer" src', $tag );
+	}
+
+	return $tag;
+}
+add_filter( 'script_loader_tag', 'gutenberg_editor_defer', 10, 2 );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -940,11 +940,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$script  = '( function() {';
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
 	$script .= <<<JS
-		window.addEventListener( 'DOMContentLoaded', function() {
-			window._wpLoadGutenbergEditor = wp.api.init().then( function() {
-				wp.blocks.registerCoreBlocks();
-				return wp.editPost.initializeEditor( 'editor', window._wpGutenbergPost, editorSettings );
-			} );
+		window._wpLoadGutenbergEditor = wp.api.init().then( function() {
+			wp.blocks.registerCoreBlocks();
+			return wp.editPost.initializeEditor( 'editor', window._wpGutenbergPost, editorSettings );
 		} );
 JS;
 	$script .= '} )();';
@@ -975,21 +973,3 @@ JS;
 	 */
 	do_action( 'enqueue_block_editor_assets' );
 }
-
-/**
- * Adds the "defer" property to the wp-edit-post script, so that it doesn't block rendering while loading.
- *
- * @since 2.6.0
- *
- * @param string $tag    The <script> tag being printed.
- * @param string $handle The script handle for the <script>.
- * @return string The <script> tag with the defer property added.
- */
-function gutenberg_editor_defer( $tag, $handle ) {
-	if ( 'wp-edit-post' === $handle ) {
-		return str_replace( ' src', ' defer="defer" src', $tag );
-	}
-
-	return $tag;
-}
-add_filter( 'script_loader_tag', 'gutenberg_editor_defer', 10, 2 );

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -326,7 +326,7 @@ function the_gutenberg_metaboxes() {
 	 */
 	wp_add_inline_script(
 		'wp-edit-post',
-		'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
+		'window.addEventListener( "DOMContentLoaded", function() { window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } ); } );'
 	);
 
 	// Reset meta box data.

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -326,7 +326,7 @@ function the_gutenberg_metaboxes() {
 	 */
 	wp_add_inline_script(
 		'wp-edit-post',
-		'window.addEventListener( "DOMContentLoaded", function() { window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } ); } );'
+		'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
 	);
 
 	// Reset meta box data.


### PR DESCRIPTION
## Description

Safari appears to block rendering of the entire page while our scripts are being parsed and executed. To prevent that, we can load them in the footer, so the don't block rendering.

This doesn't appear to cause any difference in rendering in other browsers.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
