### PR TITLE
Remove redundant z-index

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -22,7 +22,6 @@ $z-layers: (
 	'.components-popover__close': 5,
 	'.editor-block-list__insertion-point': 5,
 	'.blocks-format-toolbar__link-modal': 6,
-	'.editor-block-mover': 1,
 	'.blocks-gallery-item__inline-menu': 20,
 	'.editor-block-settings-menu__popover': 20, // Below the header
 	'.blocks-url-input__suggestions': 30,

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -369,7 +369,6 @@
 	// Left side UI
 	> .editor-block-mover {
 		left: -$block-side-ui-width;
-		z-index: z-index( '.editor-block-mover' );
 
 		// Mobile
 		display: none;


### PR DESCRIPTION
Per https://github.com/WordPress/gutenberg/pull/5658#issuecomment-378003015, this removes a no-longer-necessary z-index from the map.

It is replaced by a different z-index that applies both for the left and right side UI.

Test that the movers work in nested, normal, and floated contexts.