### PR TITLE
Make the click-redirector responsive

### DIFF
--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -31,7 +31,8 @@
 .edit-post-visual-editor .editor-writing-flow__click-redirect {
 	// Collapse to minimum height of 50px, to fully occupy editor bottom pad.
 	height: 50px;
-	width: $content-width;
+	width: 100%;
+	max-width: $content-width;
 	// Offset for: Visual editor padding, block (default appender) margin.
 	margin: #{ -1 * $block-spacing } auto -50px;
 }


### PR DESCRIPTION
The click-redirect that sits below an empty page to redirect you to the first text appender was not responsive. It is in this PR.

Before:

<img width="1097" alt="screen shot 2018-04-03 at 10 25 11" src="https://user-images.githubusercontent.com/1204802/38238269-a128f708-3729-11e8-9a0b-0ab73348c226.png">

After:

<img width="874" alt="screen shot 2018-04-03 at 10 26 08" src="https://user-images.githubusercontent.com/1204802/38238275-a4e983da-3729-11e8-9571-77fd2c6f0e81.png">
