### PR TITLE
Add role=menuitem to the More Options menu items

### DIFF
--- a/edit-post/components/visual-editor/block-inspector-button.js
+++ b/edit-post/components/visual-editor/block-inspector-button.js
@@ -29,7 +29,6 @@ export function BlockInspectorButton( {
 	};
 
 	const label = areAdvancedSettingsOpened ? __( 'Hide Advanced Settings' ) : __( 'Show Advanced Settings' );
-	const { ariaRole } = props;
 
 	return (
 		<IconButton
@@ -37,7 +36,7 @@ export function BlockInspectorButton( {
 			onClick={ flow( areAdvancedSettingsOpened ? closeSidebar : openEditorSidebar, speakMessage, onClick ) }
 			icon="admin-generic"
 			label={ small ? label : undefined }
-			role={ ariaRole }
+			{ ...props }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/edit-post/components/visual-editor/block-inspector-button.js
+++ b/edit-post/components/visual-editor/block-inspector-button.js
@@ -18,6 +18,7 @@ export function BlockInspectorButton( {
 	onClick = noop,
 	small = false,
 	speak,
+	ariaRole,
 } ) {
 	const speakMessage = () => {
 		if ( areAdvancedSettingsOpened ) {
@@ -35,7 +36,7 @@ export function BlockInspectorButton( {
 			onClick={ flow( areAdvancedSettingsOpened ? closeSidebar : openEditorSidebar, speakMessage, onClick ) }
 			icon="admin-generic"
 			label={ small ? label : undefined }
-			role="menuitem"
+			role={ ariaRole }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/edit-post/components/visual-editor/block-inspector-button.js
+++ b/edit-post/components/visual-editor/block-inspector-button.js
@@ -18,7 +18,7 @@ export function BlockInspectorButton( {
 	onClick = noop,
 	small = false,
 	speak,
-	ariaRole,
+	...props
 } ) {
 	const speakMessage = () => {
 		if ( areAdvancedSettingsOpened ) {
@@ -29,6 +29,7 @@ export function BlockInspectorButton( {
 	};
 
 	const label = areAdvancedSettingsOpened ? __( 'Hide Advanced Settings' ) : __( 'Show Advanced Settings' );
+	const { ariaRole } = props;
 
 	return (
 		<IconButton

--- a/edit-post/components/visual-editor/block-inspector-button.js
+++ b/edit-post/components/visual-editor/block-inspector-button.js
@@ -35,6 +35,7 @@ export function BlockInspectorButton( {
 			onClick={ flow( areAdvancedSettingsOpened ? closeSidebar : openEditorSidebar, speakMessage, onClick ) }
 			icon="admin-generic"
 			label={ small ? label : undefined }
+			role="menuitem"
 		>
 			{ ! small && label }
 		</IconButton>

--- a/edit-post/components/visual-editor/block-inspector-button.js
+++ b/edit-post/components/visual-editor/block-inspector-button.js
@@ -18,7 +18,7 @@ export function BlockInspectorButton( {
 	onClick = noop,
 	small = false,
 	speak,
-	...props
+	role,
 } ) {
 	const speakMessage = () => {
 		if ( areAdvancedSettingsOpened ) {
@@ -36,7 +36,7 @@ export function BlockInspectorButton( {
 			onClick={ flow( areAdvancedSettingsOpened ? closeSidebar : openEditorSidebar, speakMessage, onClick ) }
 			icon="admin-generic"
 			label={ small ? label : undefined }
-			{ ...props }
+			role={ role }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -24,7 +24,7 @@ import BlockInspectorButton from './block-inspector-button';
 function VisualEditorBlockMenu( { children, onClose } ) {
 	return (
 		<Fragment>
-			<BlockInspectorButton onClick={ onClose } ariaRole="menuitem" />
+			<BlockInspectorButton onClick={ onClose } role="menuitem" />
 			{ children }
 		</Fragment>
 	);

--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -24,7 +24,7 @@ import BlockInspectorButton from './block-inspector-button';
 function VisualEditorBlockMenu( { children, onClose } ) {
 	return (
 		<Fragment>
-			<BlockInspectorButton onClick={ onClose } />
+			<BlockInspectorButton onClick={ onClose } ariaRole="menuitem" />
 			{ children }
 		</Fragment>
 	);

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -12,7 +12,7 @@ import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { cloneBlock, getBlockType } from '@wordpress/blocks';
 
-export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, ariaRole } ) {
+export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, ...props } ) {
 	const canDuplicate = every( blocks, block => {
 		const type = getBlockType( block.name );
 		return ! type.useOnce;
@@ -22,6 +22,7 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 	}
 
 	const label = __( 'Duplicate' );
+	const { ariaRole } = props;
 
 	return (
 		<IconButton

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -29,6 +29,7 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 			onClick={ flow( onDuplicate, onClick ) }
 			icon="admin-page"
 			label={ small ? label : undefined }
+			role="menuitem"
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -22,7 +22,6 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 	}
 
 	const label = __( 'Duplicate' );
-	const { ariaRole } = props;
 
 	return (
 		<IconButton
@@ -30,7 +29,7 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 			onClick={ flow( onDuplicate, onClick ) }
 			icon="admin-page"
 			label={ small ? label : undefined }
-			role={ ariaRole }
+			{ ...props }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -12,7 +12,7 @@ import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { cloneBlock, getBlockType } from '@wordpress/blocks';
 
-export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false } ) {
+export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, ariaRole } ) {
 	const canDuplicate = every( blocks, block => {
 		const type = getBlockType( block.name );
 		return ! type.useOnce;
@@ -29,7 +29,7 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 			onClick={ flow( onDuplicate, onClick ) }
 			icon="admin-page"
 			label={ small ? label : undefined }
-			role="menuitem"
+			role={ ariaRole }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -12,7 +12,7 @@ import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { cloneBlock, getBlockType } from '@wordpress/blocks';
 
-export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, ...props } ) {
+export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, role } ) {
 	const canDuplicate = every( blocks, block => {
 		const type = getBlockType( block.name );
 		return ! type.useOnce;
@@ -29,7 +29,7 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 			onClick={ flow( onDuplicate, onClick ) }
 			icon="admin-page"
 			label={ small ? label : undefined }
-			{ ...props }
+			role={ role }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-mode-toggle.js
+++ b/editor/components/block-settings-menu/block-mode-toggle.js
@@ -17,7 +17,7 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { getBlockMode, getBlock } from '../../store/selectors';
 import { toggleBlockMode } from '../../store/actions';
 
-export function BlockModeToggle( { blockType, mode, onToggleMode, small = false } ) {
+export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, ariaRole } ) {
 	if ( ! hasBlockSupport( blockType, 'html', true ) ) {
 		return null;
 	}
@@ -32,7 +32,7 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false 
 			onClick={ onToggleMode }
 			icon="html"
 			label={ small ? label : undefined }
-			role="menuitem"
+			role={ ariaRole }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-mode-toggle.js
+++ b/editor/components/block-settings-menu/block-mode-toggle.js
@@ -32,6 +32,7 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false 
 			onClick={ onToggleMode }
 			icon="html"
 			label={ small ? label : undefined }
+			role="menuitem"
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-mode-toggle.js
+++ b/editor/components/block-settings-menu/block-mode-toggle.js
@@ -22,7 +22,6 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false,
 		return null;
 	}
 
-	const { ariaRole } = props;
 	const label = mode === 'visual' ?
 		__( 'Edit as HTML' ) :
 		__( 'Edit visually' );
@@ -33,7 +32,7 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false,
 			onClick={ onToggleMode }
 			icon="html"
 			label={ small ? label : undefined }
-			role={ ariaRole }
+			{ ...props }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-mode-toggle.js
+++ b/editor/components/block-settings-menu/block-mode-toggle.js
@@ -17,11 +17,12 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { getBlockMode, getBlock } from '../../store/selectors';
 import { toggleBlockMode } from '../../store/actions';
 
-export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, ariaRole } ) {
+export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, ...props } ) {
 	if ( ! hasBlockSupport( blockType, 'html', true ) ) {
 		return null;
 	}
 
+	const { ariaRole } = props;
 	const label = mode === 'visual' ?
 		__( 'Edit as HTML' ) :
 		__( 'Edit visually' );

--- a/editor/components/block-settings-menu/block-mode-toggle.js
+++ b/editor/components/block-settings-menu/block-mode-toggle.js
@@ -17,7 +17,7 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { getBlockMode, getBlock } from '../../store/selectors';
 import { toggleBlockMode } from '../../store/actions';
 
-export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, ...props } ) {
+export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, role } ) {
 	if ( ! hasBlockSupport( blockType, 'html', true ) ) {
 		return null;
 	}
@@ -32,7 +32,7 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false,
 			onClick={ onToggleMode }
 			icon="html"
 			label={ small ? label : undefined }
-			{ ...props }
+			role={ role }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -29,6 +29,7 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small =
 			onClick={ flow( onRemove, onClick ) }
 			icon="trash"
 			label={ small ? label : undefined }
+			role="menuitem"
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -16,12 +16,13 @@ import { compose } from '@wordpress/element';
  */
 import { removeBlocks } from '../../store/actions';
 
-export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false, ariaRole } ) {
+export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false, ...props } ) {
 	if ( isLocked ) {
 		return null;
 	}
 
 	const label = __( 'Remove' );
+	const { ariaRole } = props;
 
 	return (
 		<IconButton

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -16,7 +16,7 @@ import { compose } from '@wordpress/element';
  */
 import { removeBlocks } from '../../store/actions';
 
-export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false } ) {
+export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false, ariaRole } ) {
 	if ( isLocked ) {
 		return null;
 	}
@@ -29,7 +29,7 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small =
 			onClick={ flow( onRemove, onClick ) }
 			icon="trash"
 			label={ small ? label : undefined }
-			role="menuitem"
+			role={ ariaRole }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -22,7 +22,6 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small =
 	}
 
 	const label = __( 'Remove' );
-	const { ariaRole } = props;
 
 	return (
 		<IconButton
@@ -30,7 +29,7 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small =
 			onClick={ flow( onRemove, onClick ) }
 			icon="trash"
 			label={ small ? label : undefined }
-			role={ ariaRole }
+			{ ...props }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -16,7 +16,7 @@ import { compose } from '@wordpress/element';
  */
 import { removeBlocks } from '../../store/actions';
 
-export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false, ...props } ) {
+export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false, role } ) {
 	if ( isLocked ) {
 		return null;
 	}
@@ -29,7 +29,7 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small =
 			onClick={ flow( onRemove, onClick ) }
 			icon="trash"
 			label={ small ? label : undefined }
-			{ ...props }
+			role={ role }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -43,6 +43,7 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 						} }
 						icon={ icon }
 						label={ small ? title : undefined }
+						role="menuitem"
 					>
 						{ ! small && title }
 					</IconButton>

--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -19,7 +19,7 @@ import './style.scss';
 import { getBlock } from '../../store/selectors';
 import { replaceBlocks } from '../../store/actions';
 
-function BlockTransformations( { blocks, small = false, onTransform, onClick = noop, isLocked } ) {
+function BlockTransformations( { blocks, small = false, onTransform, onClick = noop, isLocked, itemsAriaRole } ) {
 	const possibleBlockTransformations = getPossibleBlockTransformations( blocks );
 	if ( isLocked || ! possibleBlockTransformations.length ) {
 		return null;
@@ -43,7 +43,7 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 						} }
 						icon={ icon }
 						label={ small ? title : undefined }
-						role="menuitem"
+						role={ itemsAriaRole }
 					>
 						{ ! small && title }
 					</IconButton>

--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -19,7 +19,7 @@ import './style.scss';
 import { getBlock } from '../../store/selectors';
 import { replaceBlocks } from '../../store/actions';
 
-function BlockTransformations( { blocks, small = false, onTransform, onClick = noop, isLocked, itemsAriaRole } ) {
+function BlockTransformations( { blocks, small = false, onTransform, onClick = noop, isLocked, itemsRole } ) {
 	const possibleBlockTransformations = getPossibleBlockTransformations( blocks );
 	if ( isLocked || ! possibleBlockTransformations.length ) {
 		return null;
@@ -43,7 +43,7 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 						} }
 						icon={ icon }
 						label={ small ? title : undefined }
-						role={ itemsAriaRole }
+						role={ itemsRole }
 					>
 						{ ! small && title }
 					</IconButton>

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -61,12 +61,12 @@ function BlockSettingsMenu( {
 				// Should this just use a DropdownMenu instead of a DropDown ?
 				<NavigableMenu className="editor-block-settings-menu__content">
 					{ renderBlockMenu( { onClose, children: [
-						count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } ariaRole="menuitem" />,
-						count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } ariaRole="menuitem" />,
-						<BlockRemoveButton key="remove" uids={ uids } ariaRole="menuitem" />,
-						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } ariaRole="menuitem" />,
-						count === 1 && <ReusableBlockSettings key="reusable-block" uid={ uids[ 0 ] } onToggle={ onClose } ariaRole="menuitem" />,
-						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsAriaRole="menuitem" />,
+						count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } role="menuitem" />,
+						count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } role="menuitem" />,
+						<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />,
+						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } role="menuitem" />,
+						count === 1 && <ReusableBlockSettings key="reusable-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
+						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsRole="menuitem" />,
 					] } ) }
 				</NavigableMenu>
 			) }

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -61,12 +61,12 @@ function BlockSettingsMenu( {
 				// Should this just use a DropdownMenu instead of a DropDown ?
 				<NavigableMenu className="editor-block-settings-menu__content">
 					{ renderBlockMenu( { onClose, children: [
-						count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } />,
-						count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } />,
-						<BlockRemoveButton key="remove" uids={ uids } />,
-						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } />,
-						count === 1 && <ReusableBlockSettings key="reusable-block" uid={ uids[ 0 ] } onToggle={ onClose } />,
-						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } />,
+						count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } ariaRole="menuitem" />,
+						count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } ariaRole="menuitem" />,
+						<BlockRemoveButton key="remove" uids={ uids } ariaRole="menuitem" />,
+						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } ariaRole="menuitem" />,
+						count === 1 && <ReusableBlockSettings key="reusable-block" uid={ uids[ 0 ] } onToggle={ onClose } ariaRole="menuitem" />,
+						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsAriaRole="menuitem" />,
 					] } ) }
 				</NavigableMenu>
 			) }

--- a/editor/components/block-settings-menu/reusable-block-settings.js
+++ b/editor/components/block-settings-menu/reusable-block-settings.js
@@ -18,9 +18,7 @@ import { isReusableBlock } from '@wordpress/blocks';
 import { getBlock, getReusableBlock } from '../../store/selectors';
 import { convertBlockToStatic, convertBlockToReusable, deleteReusableBlock } from '../../store/actions';
 
-export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onConvertToReusable, onDelete, ...props } ) {
-	const { ariaRole } = props;
-
+export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onConvertToReusable, onDelete, itemsRole } ) {
 	return (
 		<Fragment>
 			{ ! reusableBlock && (
@@ -28,7 +26,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 					className="editor-block-settings-menu__control"
 					icon="controls-repeat"
 					onClick={ onConvertToReusable }
-					role={ ariaRole }
+					role={ itemsRole }
 				>
 					{ __( 'Convert to Shared Block' ) }
 				</IconButton>
@@ -39,7 +37,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 						className="editor-block-settings-menu__control"
 						icon="controls-repeat"
 						onClick={ onConvertToStatic }
-						role={ ariaRole }
+						role={ itemsRole }
 					>
 						{ __( 'Convert to Regular Block' ) }
 					</IconButton>
@@ -48,7 +46,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 						icon="no"
 						disabled={ reusableBlock.isTemporary }
 						onClick={ () => onDelete( reusableBlock.id ) }
-						role={ ariaRole }
+						role={ itemsRole }
 					>
 						{ __( 'Delete Shared Block' ) }
 					</IconButton>

--- a/editor/components/block-settings-menu/reusable-block-settings.js
+++ b/editor/components/block-settings-menu/reusable-block-settings.js
@@ -26,6 +26,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 					className="editor-block-settings-menu__control"
 					icon="controls-repeat"
 					onClick={ onConvertToReusable }
+					role="menuitem"
 				>
 					{ __( 'Convert to Shared Block' ) }
 				</IconButton>
@@ -36,6 +37,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 						className="editor-block-settings-menu__control"
 						icon="controls-repeat"
 						onClick={ onConvertToStatic }
+						role="menuitem"
 					>
 						{ __( 'Convert to Regular Block' ) }
 					</IconButton>
@@ -44,6 +46,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 						icon="no"
 						disabled={ reusableBlock.isTemporary }
 						onClick={ () => onDelete( reusableBlock.id ) }
+						role="menuitem"
 					>
 						{ __( 'Delete Shared Block' ) }
 					</IconButton>

--- a/editor/components/block-settings-menu/reusable-block-settings.js
+++ b/editor/components/block-settings-menu/reusable-block-settings.js
@@ -18,7 +18,7 @@ import { isReusableBlock } from '@wordpress/blocks';
 import { getBlock, getReusableBlock } from '../../store/selectors';
 import { convertBlockToStatic, convertBlockToReusable, deleteReusableBlock } from '../../store/actions';
 
-export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onConvertToReusable, onDelete } ) {
+export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onConvertToReusable, onDelete, ariaRole } ) {
 	return (
 		<Fragment>
 			{ ! reusableBlock && (
@@ -26,7 +26,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 					className="editor-block-settings-menu__control"
 					icon="controls-repeat"
 					onClick={ onConvertToReusable }
-					role="menuitem"
+					role={ ariaRole }
 				>
 					{ __( 'Convert to Shared Block' ) }
 				</IconButton>
@@ -37,7 +37,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 						className="editor-block-settings-menu__control"
 						icon="controls-repeat"
 						onClick={ onConvertToStatic }
-						role="menuitem"
+						role={ ariaRole }
 					>
 						{ __( 'Convert to Regular Block' ) }
 					</IconButton>
@@ -46,7 +46,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 						icon="no"
 						disabled={ reusableBlock.isTemporary }
 						onClick={ () => onDelete( reusableBlock.id ) }
-						role="menuitem"
+						role={ ariaRole }
 					>
 						{ __( 'Delete Shared Block' ) }
 					</IconButton>

--- a/editor/components/block-settings-menu/reusable-block-settings.js
+++ b/editor/components/block-settings-menu/reusable-block-settings.js
@@ -18,7 +18,9 @@ import { isReusableBlock } from '@wordpress/blocks';
 import { getBlock, getReusableBlock } from '../../store/selectors';
 import { convertBlockToStatic, convertBlockToReusable, deleteReusableBlock } from '../../store/actions';
 
-export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onConvertToReusable, onDelete, ariaRole } ) {
+export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onConvertToReusable, onDelete, ...props } ) {
+	const { ariaRole } = props;
+
 	return (
 		<Fragment>
 			{ ! reusableBlock && (

--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -18,12 +18,13 @@ import { compose } from '@wordpress/element';
 import { getBlock, getCurrentPostType } from '../../store/selectors';
 import { replaceBlocks } from '../../store/actions';
 
-export function UnknownConverter( { block, onReplace, small, user, ariaRole } ) {
+export function UnknownConverter( { block, onReplace, small, user, ...props } ) {
 	if ( ! block || getUnknownTypeHandlerName() !== block.name ) {
 		return null;
 	}
 
 	const label = __( 'Convert to blocks' );
+	const { ariaRole } = props;
 
 	const convertToBlocks = () => {
 		onReplace( block.uid, rawHandler( {

--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -18,7 +18,7 @@ import { compose } from '@wordpress/element';
 import { getBlock, getCurrentPostType } from '../../store/selectors';
 import { replaceBlocks } from '../../store/actions';
 
-export function UnknownConverter( { block, onReplace, small, user } ) {
+export function UnknownConverter( { block, onReplace, small, user, ariaRole } ) {
 	if ( ! block || getUnknownTypeHandlerName() !== block.name ) {
 		return null;
 	}
@@ -39,7 +39,7 @@ export function UnknownConverter( { block, onReplace, small, user } ) {
 			onClick={ convertToBlocks }
 			icon="screenoptions"
 			label={ small ? label : undefined }
-			role="menuitem"
+			role={ ariaRole }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -24,7 +24,6 @@ export function UnknownConverter( { block, onReplace, small, user, ...props } ) 
 	}
 
 	const label = __( 'Convert to blocks' );
-	const { ariaRole } = props;
 
 	const convertToBlocks = () => {
 		onReplace( block.uid, rawHandler( {
@@ -40,7 +39,7 @@ export function UnknownConverter( { block, onReplace, small, user, ...props } ) 
 			onClick={ convertToBlocks }
 			icon="screenoptions"
 			label={ small ? label : undefined }
-			role={ ariaRole }
+			{ ...props }
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -39,6 +39,7 @@ export function UnknownConverter( { block, onReplace, small, user } ) {
 			onClick={ convertToBlocks }
 			icon="screenoptions"
 			label={ small ? label : undefined }
+			role="menuitem"
 		>
 			{ ! small && label }
 		</IconButton>

--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -18,7 +18,7 @@ import { compose } from '@wordpress/element';
 import { getBlock, getCurrentPostType } from '../../store/selectors';
 import { replaceBlocks } from '../../store/actions';
 
-export function UnknownConverter( { block, onReplace, small, user, ...props } ) {
+export function UnknownConverter( { block, onReplace, small, user, role } ) {
 	if ( ! block || getUnknownTypeHandlerName() !== block.name ) {
 		return null;
 	}
@@ -39,7 +39,7 @@ export function UnknownConverter( { block, onReplace, small, user, ...props } ) 
 			onClick={ convertToBlocks }
 			icon="screenoptions"
 			label={ small ? label : undefined }
-			{ ...props }
+			role={ role }
 		>
 			{ ! small && label }
 		</IconButton>


### PR DESCRIPTION
Adds `role="menuitem"` to the "More Options" menu items.

This menu already uses a `role="menu"`, so its children are required to use `role="menuitem"`.

Fixes #5953 