### PR TITLE
Fix color picker width

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -60,7 +60,6 @@ export function ColorPalette( { colors, disableCustomColors = false, value, onCh
 						<ChromePicker
 							color={ value }
 							onChangeComplete={ ( color ) => onChange( color.hex ) }
-							style={ { width: '100%' } }
 							disableAlpha
 						/>
 					) }

--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -144,3 +144,9 @@ $color-palette-circle-spacing: 14px;
 
 	background-clip: content-box, content-box, content-box, content-box, content-box, content-box, padding-box, padding-box, padding-box, padding-box, padding-box, padding-box;
 }
+
+.blocks-color-palette__picker{
+	.chrome-picker{
+		width: 100% !important;
+	}
+}


### PR DESCRIPTION
## Description
Current inline 100% width on chromepicker component doesn't work & picker doesn't fill the popover container.
Width override is moved to the corresponding style.scss not sure if its the best way but CSS rule uses `!important` 

## How Has This Been Tested?
Manually on laptop & mobile browser

## Screenshots (jpeg or gifs if applicable):
![picker_width](https://user-images.githubusercontent.com/1039236/38275988-48f270ae-37b1-11e8-8bf6-43a5577e09b2.jpg)


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
