### PR TITLE
Add custom placeholder icon

### DIFF
--- a/components/placeholder/index.js
+++ b/components/placeholder/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { isString } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ function Placeholder( { icon, children, label, instructions, className, ...addit
 	return (
 		<div { ...additionalProps } className={ classes }>
 			<div className="components-placeholder__label">
-				{ !! icon && <Dashicon icon={ icon } /> }
+				{ isString( icon ) ? <Dashicon icon={ icon } /> : icon }
 				{ label }
 			</div>
 			{ !! instructions && <div className="components-placeholder__instructions">{ instructions }</div> }


### PR DESCRIPTION
## Description
Currently `Placeholder` component does not support custom icon like `IconButton`.  Allowing custom icon will make the component more flexible. 

## How Has This Been Tested?
Manually 

## Screenshots (jpeg or gifs if applicable):
![placeholder-icon](https://user-images.githubusercontent.com/1039236/38278875-7ca4e4b8-37bb-11e8-831c-7773d2e03e98.jpg)


## Types of changes
Nonbreaking component change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
