### PR TITLE
Inserter: Rename Frequent → Suggested

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -60,7 +60,7 @@ export class InserterMenu extends Component {
 		this.nodes = {};
 		this.state = {
 			filterValue: '',
-			tab: 'frequent',
+			tab: 'suggested',
 			selectedItem: null,
 		};
 		this.filter = this.filter.bind( this );
@@ -69,7 +69,7 @@ export class InserterMenu extends Component {
 		this.sortItems = this.sortItems.bind( this );
 		this.selectItem = this.selectItem.bind( this );
 
-		this.tabScrollTop = { frequent: 0, blocks: 0, embeds: 0 };
+		this.tabScrollTop = { suggested: 0, blocks: 0, embeds: 0 };
 		this.switchTab = this.switchTab.bind( this );
 		this.previewItem = this.previewItem.bind( this );
 	}
@@ -127,7 +127,7 @@ export class InserterMenu extends Component {
 
 		let predicate;
 		switch ( tab ) {
-			case 'frequent':
+			case 'suggested':
 				return frecentItems;
 
 			case 'blocks':
@@ -147,7 +147,7 @@ export class InserterMenu extends Component {
 	}
 
 	sortItems( items ) {
-		if ( 'frequent' === this.state.tab && ! this.state.filterValue ) {
+		if ( 'suggested' === this.state.tab && ! this.state.filterValue ) {
 			return items;
 		}
 
@@ -220,8 +220,8 @@ export class InserterMenu extends Component {
 	renderTabView( tab ) {
 		const itemsForTab = this.getItemsForTab( tab );
 
-		// If the Frequent tab is selected, don't render category headers
-		if ( 'frequent' === tab ) {
+		// If the Suggested tab is selected, don't render category headers
+		if ( 'suggested' === tab ) {
 			return this.renderItems( itemsForTab );
 		}
 
@@ -248,7 +248,7 @@ export class InserterMenu extends Component {
 
 	// Passed to TabbableContainer, extending its event-handling logic
 	eventToOffset( event ) {
-		// If a tab (Frequent, Blocks, …) is focused, pressing the down arrow
+		// If a tab (Suggested, Blocks, …) is focused, pressing the down arrow
 		// moves focus to the selected panel below.
 		if (
 			event.keyCode === keycodes.DOWN &&
@@ -297,8 +297,8 @@ export class InserterMenu extends Component {
 						onSelect={ this.switchTab }
 						tabs={ [
 							{
-								name: 'frequent',
-								title: __( 'Frequent' ),
+								name: 'suggested',
+								title: __( 'Suggested' ),
 								className: 'editor-inserter__tab',
 							},
 							{

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -88,7 +88,7 @@ describe( 'InserterMenu', () => {
 	// wrapper.find have had to be strengthened (and the filterWhere strengthened also), otherwise two
 	// results would be returned even though only one was in the DOM.
 
-	it( 'should show the frequent tab by default', () => {
+	it( 'should show the suggested tab by default', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
@@ -102,7 +102,7 @@ describe( 'InserterMenu', () => {
 		);
 
 		const activeCategory = wrapper.find( '.editor-inserter__tab button.is-active' );
-		expect( activeCategory.text() ).toBe( 'Frequent' );
+		expect( activeCategory.text() ).toBe( 'Suggested' );
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
 		expect( visibleBlocks ).toHaveLength( 0 );
@@ -124,7 +124,7 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 0 );
 	} );
 
-	it( 'should show the frequently used items in the frequent tab', () => {
+	it( 'should show frecently used items in the suggested tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }


### PR DESCRIPTION
## Description

There's been some confusion (https://github.com/WordPress/gutenberg/issues/5956, https://github.com/WordPress/gutenberg/issues/5627) about why blocks that have never been used appear under the _Frequent_ tab.

A simple short term fix is to rename the tab to _Suggested_, which better indicates that Gutenberg is trying to be intelligent about which blocks it displays in the default inserter tab.

Closes #5627.

## How Has This Been Tested?
1. Open the inserter
2. Note that the first tab is now called _Suggested_

## Screenshots 

<img width="373" alt="screen shot 2018-04-04 at 10 16 01" src="https://user-images.githubusercontent.com/612155/38282125-c6ccd470-37f1-11e8-9f24-a3ca74aadd94.png">