### PR TITLE
Add the ability for a block to opt-out of being made into a shared block

### DIFF
--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -30,6 +30,7 @@ export const settings = {
 	supports: {
 		className: false,
 		customClassName: false,
+		sharing: false,
 	},
 
 	edit,

--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -30,7 +30,7 @@ export const settings = {
 	supports: {
 		className: false,
 		customClassName: false,
-		sharing: false,
+		_sharing: false,
 	},
 
 	edit,

--- a/editor/components/block-settings-menu/shared-block-settings.js
+++ b/editor/components/block-settings-menu/shared-block-settings.js
@@ -9,10 +9,21 @@ import { noop } from 'lodash';
 import { Fragment, compose } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { isSharedBlock } from '@wordpress/blocks';
+import { isSharedBlock, hasBlockSupport } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-export function SharedBlockSettings( { sharedBlock, onConvertToStatic, onConvertToShared, onDelete, itemsRole } ) {
+export function SharedBlockSettings( {
+	block,
+	sharedBlock,
+	onConvertToStatic,
+	onConvertToShared,
+	onDelete,
+	itemsRole,
+} ) {
+	if ( ! hasBlockSupport( block.name, 'sharing', true ) ) {
+		return null;
+	}
+
 	return (
 		<Fragment>
 			{ ! sharedBlock && (
@@ -55,6 +66,7 @@ export default compose( [
 		const { getBlock, getSharedBlock } = select( 'core/editor' );
 		const block = getBlock( uid );
 		return {
+			block,
 			sharedBlock: block && isSharedBlock( block ) ? getSharedBlock( block.attributes.ref ) : null,
 		};
 	} ),

--- a/editor/components/block-settings-menu/shared-block-settings.js
+++ b/editor/components/block-settings-menu/shared-block-settings.js
@@ -20,7 +20,12 @@ export function SharedBlockSettings( {
 	onDelete,
 	itemsRole,
 } ) {
-	if ( ! hasBlockSupport( block.name, 'sharing', true ) ) {
+	/**
+	 * Allow blocks to indicate that they cannot be made into a shared block. This
+	 * is a non-public API since the user could work around it by e.g. nesting the
+	 * block within a container block and sharing the container block.
+	 */
+	if ( ! hasBlockSupport( block.name, '_sharing', true ) ) {
 		return null;
 	}
 

--- a/editor/components/block-settings-menu/test/shared-block-settings.js
+++ b/editor/components/block-settings-menu/test/shared-block-settings.js
@@ -23,7 +23,7 @@ describe( 'SharedBlockSettings', () => {
 		registerBlockType( 'test/unshareable', {
 			title: 'Don\'t You Dare Share Me',
 			category: 'common',
-			supports: { sharing: false },
+			supports: { _sharing: false },
 			save: () => null,
 		} );
 	} );

--- a/editor/components/block-settings-menu/test/shared-block-settings.js
+++ b/editor/components/block-settings-menu/test/shared-block-settings.js
@@ -4,15 +4,40 @@
 import { shallow } from 'enzyme';
 
 /**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import { SharedBlockSettings } from '../shared-block-settings';
 
 describe( 'SharedBlockSettings', () => {
+	beforeAll( () => {
+		registerBlockType( 'test/shareable', {
+			title: 'Consider Sharing Me',
+			category: 'common',
+			save: () => null,
+		} );
+		registerBlockType( 'test/unshareable', {
+			title: 'Don\'t You Dare Share Me',
+			category: 'common',
+			supports: { sharing: false },
+			save: () => null,
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( 'test/shareable' );
+		unregisterBlockType( 'test/unshareable' );
+	} );
+
 	it( 'should allow converting a static block to a shared block', () => {
 		const onConvert = jest.fn();
 		const wrapper = shallow(
 			<SharedBlockSettings
+				block={ { name: 'test/shareable ' } }
 				sharedBlock={ null }
 				onConvertToShared={ onConvert }
 			/>
@@ -29,6 +54,7 @@ describe( 'SharedBlockSettings', () => {
 		const onConvert = jest.fn();
 		const wrapper = shallow(
 			<SharedBlockSettings
+				block={ { name: 'core/block' } }
 				sharedBlock={ {} }
 				onConvertToStatic={ onConvert }
 			/>
@@ -45,6 +71,7 @@ describe( 'SharedBlockSettings', () => {
 		const onDelete = jest.fn();
 		const wrapper = shallow(
 			<SharedBlockSettings
+				block={ { name: 'core/block' } }
 				sharedBlock={ { id: 123 } }
 				onDelete={ onDelete }
 			/>
@@ -55,5 +82,16 @@ describe( 'SharedBlockSettings', () => {
 
 		wrapper.find( 'IconButton' ).last().simulate( 'click' );
 		expect( onDelete ).toHaveBeenCalledWith( 123 );
+	} );
+
+	it( 'should render null when block does not support sharing', () => {
+		const wrapper = shallow(
+			<SharedBlockSettings
+				block={ { name: 'test/unshareable' } }
+				sharedBlocks={ null }
+			/>
+		);
+
+		expect( wrapper.isEmptyRender() ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
## Description

Adds `supports.sharing` which allows a block to indicate that it cannot be made into a shared block. 

The Classic (AKA Freeform) block is one such example of a block that should not be made shareable, as it makes for a confusing UX (see https://github.com/WordPress/gutenberg/issues/5941) and only exists as a fallback block type.

This fixes #5941. The idea for allowing blocks to opt-out of this feature came up before in #4722.

## How Has This Been Tested?
1. Create a Classic block
2. Click on the More options kebab icon
3. Note that there is no _Convert to Shared Block_ button 

## Screenshots
<img width="731" alt="screen shot 2018-04-04 at 12 45 44" src="https://user-images.githubusercontent.com/612155/38286219-81c2b2f8-3807-11e8-9e88-e6b4aab26129.png">