### PR TITLE
Try to avoid triggering modsec rules

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -121,6 +121,9 @@ function gutenberg_shim_api_request_emulate_http( $scripts ) {
 				}
 				options.headers['X-HTTP-Method-Override'] = options.method;
 				options.method = 'POST';
+
+				options.contentType = 'application/json';
+				options.data = JSON.stringify( options.data );
 			}
 		}
 


### PR DESCRIPTION
## Description

Since Gutenberg 2.3 (probably #5253), API requests have been triggering modsec rules.

Unfortunately, there isn't much to go on, so this PR is for trying out some techniques to potentially fix it.

See #5867.