### PR TITLE
Improve image figure widths, remove inline styles

### DIFF
--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -71,4 +71,12 @@
 		height: inherit;
 	}
 
+	// Apply max-width to floated items that have no intrinsic width
+	[data-align="left"] &,
+	[data-align="right"] &,
+	&.alignleft,
+	&.alignright {
+		max-width: $content-width / 2;
+		width: 100%;
+	}
 }

--- a/blocks/library/embed/style.scss
+++ b/blocks/library/embed/style.scss
@@ -4,3 +4,12 @@
 	text-align: center;
 	font-size: $default-font-size;
 }
+
+// Apply max-width to floated items that have no intrinsic width
+.editor-block-list__block[data-type="core/embed"][data-align="left"] .editor-block-list__block-edit,
+.editor-block-list__block[data-type="core/embed"][data-align="right"] .editor-block-list__block-edit,
+.wp-block-embed.alignleft,
+.wp-block-embed.alignright {
+	max-width: $content-width / 2;
+	width: 100%;
+}

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -1,7 +1,4 @@
-.wp-block-gallery,
-.wp-block-gallery.alignleft,
-.wp-block-gallery.alignright,
-.wp-block-gallery.aligncenter {
+.wp-block-gallery {
 	display: flex;
 	flex-wrap: wrap;
 	list-style-type: none;
@@ -77,5 +74,14 @@
 				width: calc(100% / #{ $i } - 16px );
 			}
 		}
+	}
+
+	// Apply max-width to floated items that have no intrinsic width
+	[data-align="left"] &,
+	[data-align="right"] &,
+	&.alignleft,
+	&.alignright {
+		max-width: $content-width / 2;
+		width: 100%;
 	}
 }

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -174,8 +174,6 @@ export const settings = {
 
 		if ( width ) {
 			figureStyle = { width };
-		} else if ( align === 'left' || align === 'right' ) {
-			figureStyle = { maxWidth: '50%' };
 		}
 
 		return (

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -170,14 +170,8 @@ export const settings = {
 			/>
 		);
 
-		let figureStyle = {};
-
-		if ( width ) {
-			figureStyle = { width };
-		}
-
 		return (
-			<figure className={ align ? `align${ align }` : null } style={ figureStyle }>
+			<figure className={ align ? `align${ align }` : null }>
 				{ href ? <a href={ href }>{ image }</a> : image }
 				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 			</figure>

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -1,4 +1,5 @@
 .wp-block-image {
+	width: fit-content;
 	figcaption {
 		margin-top: 0.5em;
 		color: $dark-gray-300;

--- a/components/placeholder/style.scss
+++ b/components/placeholder/style.scss
@@ -5,6 +5,7 @@
 	justify-content: center;
 	padding: 1em;
 	min-height: 200px;
+	width: 100%;
 	text-align: center;
 	font-family: $default-font;
 	font-size: $default-font-size;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -304,7 +304,7 @@
 
 	// Full-wide
 	&[data-align="full"] {
-
+		
 		// compensate for main container padding
 		@include break-small() {
 			margin-left: -$block-side-ui-padding;
@@ -318,6 +318,11 @@
 			@include break-small() {
 				margin-left: -$block-side-ui-padding - $block-padding;
 				margin-right: -$block-side-ui-padding - $block-padding;
+			}
+
+			// this explicitly sets the width of the block, to override the fit-content from the image block
+			figure {
+				width: 100%;
 			}
 		}
 

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -273,21 +273,6 @@
 		}
 	}
 
-	// Apply max-width to floated items that have no intrinsic width, like Cover Image or Gallery
-	&[data-align="left"],
-	&[data-align="right"] {
-		> .editor-block-list__block-edit {
-			max-width: 360px;
-			width: 100%;
-		}
-
-		// reset when data-resized
-		&[data-resized="true"] > .editor-block-list__block-edit {
-			max-width: none;
-			width: auto;
-		}
-	}
-
 	// Left
 	&[data-align="left"] {
 		.editor-block-list__block-edit {	// This is in the editor only, on the frontend, the img should be floated


### PR DESCRIPTION
As themes try to accommodate the new image figure syntax in Gutenberg, there are increasingly issues with the `figure` being a block element whereas `img` traditionally being an inline block. The bigger problem is that when we float things, and an image isn't explicitly resized, we set an inline max-width, which can only be overridden using `!important`, which you should never ever use.

GIF:

![images](https://user-images.githubusercontent.com/1204802/38301988-847df15c-3801-11e8-9cd8-c8f485e7a7dd.gif)


As such, this PR removes those inline styles. In a way, it is an almost identical copy to Gary's PR in #5209, which this is meant to replace (apologies, and you should have all the props). My concerns noted in https://github.com/WordPress/gutenberg/pull/5209#issuecomment-367936828 are not technically addressed, but in order to move on, these are perhaps best addressed separately.

Notably those issues are specific to _floats_. Specifically that if we use the float trick in https://codepen.io/joen/pen/oEYVXB to accommodate both floats and wide images in a fairly elegant way (the editor itself uses this also), we essentially need yet another wrapping element. In other words, merging in https://github.com/WordPress/gutenberg/pull/5460 would address those concerns — but we have to be okay with adding yet another wrapping element. This is also tracked in https://github.com/WordPress/gutenberg/issues/5292

This PR fixes #3945 and #5213. I think it also fixes #5567 by making that core issue moot.

CC: also @aduth and @samikeijonen, as I think you were working on a separate PR that accomplished some of the same as this. 

---

To summarize, what works well with this branch

- floats
- wide and fullwide alignments
- themes can handle floats better, and legacy themes mostly just work (though with some edgecases when captions are added)
- no need to use !important in themes

What sort of regresses in this branch is that if you insert a huge image, bigger than the main column, and float it, well it doesn't really look like it floats. You have to resize it first. This is because I removed the max-width. This is similar to how it's always worked, though perhaps not as elegant.




