### PR TITLE
Performance: Avoid rerendering all blocks while drag and dropping

### DIFF
--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -11,7 +11,7 @@ import {
 	BlockSelectionClearer,
 	MultiSelectScrollIntoView,
 } from '@wordpress/editor';
-import { Fragment, compose, Component } from '@wordpress/element';
+import { Fragment, compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 
@@ -21,40 +21,32 @@ import { withViewportMatch } from '@wordpress/viewport';
 import './style.scss';
 import BlockInspectorButton from './block-inspector-button';
 
-class VisualEditor extends Component {
-	constructor() {
-		super( ...arguments );
-		this.renderBlockMenu = this.renderBlockMenu.bind( this );
-	}
+function VisualEditorBlockMenu( { children, onClose } ) {
+	return (
+		<Fragment>
+			<BlockInspectorButton onClick={ onClose } />
+			{ children }
+		</Fragment>
+	);
+}
 
-	renderBlockMenu( { children, onClose } ) {
-		return (
-			<Fragment>
-				<BlockInspectorButton onClick={ onClose } />
-				{ children }
-			</Fragment>
-		);
-	}
-
-	render() {
-		const { hasFixedToolbar, isLargeViewport } = this.props;
-		return (
-			<BlockSelectionClearer className="edit-post-visual-editor">
-				<EditorGlobalKeyboardShortcuts />
-				<CopyHandler />
-				<MultiSelectScrollIntoView />
-				<WritingFlow>
-					<ObserveTyping>
-						<PostTitle />
-						<BlockList
-							showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
-							renderBlockMenu={ this.renderBlockMenu }
-						/>
-					</ObserveTyping>
-				</WritingFlow>
-			</BlockSelectionClearer>
-		);
-	}
+function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
+	return (
+		<BlockSelectionClearer className="edit-post-visual-editor">
+			<EditorGlobalKeyboardShortcuts />
+			<CopyHandler />
+			<MultiSelectScrollIntoView />
+			<WritingFlow>
+				<ObserveTyping>
+					<PostTitle />
+					<BlockList
+						showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
+						renderBlockMenu={ VisualEditorBlockMenu }
+					/>
+				</ObserveTyping>
+			</WritingFlow>
+		</BlockSelectionClearer>
+	);
 }
 
 export default compose( [

--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -11,7 +11,7 @@ import {
 	BlockSelectionClearer,
 	MultiSelectScrollIntoView,
 } from '@wordpress/editor';
-import { Fragment, compose } from '@wordpress/element';
+import { Fragment, compose, Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 
@@ -21,28 +21,40 @@ import { withViewportMatch } from '@wordpress/viewport';
 import './style.scss';
 import BlockInspectorButton from './block-inspector-button';
 
-function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
-	return (
-		<BlockSelectionClearer className="edit-post-visual-editor">
-			<EditorGlobalKeyboardShortcuts />
-			<CopyHandler />
-			<MultiSelectScrollIntoView />
-			<WritingFlow>
-				<ObserveTyping>
-					<PostTitle />
-					<BlockList
-						showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
-						renderBlockMenu={ ( { children, onClose } ) => (
-							<Fragment>
-								<BlockInspectorButton onClick={ onClose } />
-								{ children }
-							</Fragment>
-						) }
-					/>
-				</ObserveTyping>
-			</WritingFlow>
-		</BlockSelectionClearer>
-	);
+class VisualEditor extends Component {
+	constructor() {
+		super( ...arguments );
+		this.renderBlockMenu = this.renderBlockMenu.bind( this );
+	}
+
+	renderBlockMenu( { children, onClose } ) {
+		return (
+			<Fragment>
+				<BlockInspectorButton onClick={ onClose } />
+				{ children }
+			</Fragment>
+		);
+	}
+
+	render() {
+		const { hasFixedToolbar, isLargeViewport } = this.props;
+		return (
+			<BlockSelectionClearer className="edit-post-visual-editor">
+				<EditorGlobalKeyboardShortcuts />
+				<CopyHandler />
+				<MultiSelectScrollIntoView />
+				<WritingFlow>
+					<ObserveTyping>
+						<PostTitle />
+						<BlockList
+							showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
+							renderBlockMenu={ this.renderBlockMenu }
+						/>
+					</ObserveTyping>
+				</WritingFlow>
+			</BlockSelectionClearer>
+		);
+	}
 }
 
 export default compose( [

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -619,7 +619,7 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		isMultiSelected: isBlockMultiSelected( uid ),
 		isFirstMultiSelected: isFirstMultiSelectedBlock( uid ),
 		isMultiSelecting: isMultiSelecting(),
-		isLastInSelection: getBlockSelectionEnd() === uid, // todo
+		isLastInSelection: getBlockSelectionEnd() === uid,
 		// We only care about this prop when the block is selected
 		// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
 		isTypingWithinBlock: isSelected && isTyping(),

--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import {
 	reduce,
 	get,
@@ -12,23 +11,23 @@ import {
  * WordPress dependencies
  */
 import { createElement } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import BlockListLayout from './layout';
-import { getBlocks, getBlockOrder } from '../../store/selectors';
 
-const UngroupedLayoutBlockList = connect(
-	( state, ownProps ) => ( {
-		blockUIDs: getBlockOrder( state, ownProps.rootUID ),
+const UngroupedLayoutBlockList = withSelect(
+	( select, ownProps ) => ( {
+		blockUIDs: select( 'core/editor' ).getBlockOrder( ownProps.rootUID ),
 	} )
 )( BlockListLayout );
 
-const GroupedLayoutBlockList = connect(
-	( state, ownProps ) => ( {
-		blocks: getBlocks( state, ownProps.rootUID ),
+const GroupedLayoutBlockList = withSelect(
+	( select, ownProps ) => ( {
+		blocks: select( 'core/editor' ).getBlocks( ownProps.rootUID ),
 	} ),
 )( ( {
 	blocks,


### PR DESCRIPTION
While drag and dropping blocks, `mapDispatchToProps` was being executed for each block generating new props. This was causing rerenders of the whole tree.

In this PR, I'm updating this to use `withDispatch` instead which is more optimized.

**Testing instructions**

 - Enable "Hughlight updates" in the React dev tools
 - Drag a block
 - While dragging, notice that blocks are not rerendering
