### PR TITLE
Added filter for request path

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -7,6 +7,7 @@ import { mapValues, reduce, forEach, noop } from 'lodash';
  * WordPress dependencies
  */
 import { Component, createHigherOrderComponent } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -135,6 +136,9 @@ export default ( mapPropsToData ) => createHigherOrderComponent( ( WrappedCompon
 		}
 
 		request( propName, method, path ) {
+
+			path = applyFilters( 'request.path', path, propName, method );
+
 			this.setIntoDataProp( propName, {
 				[ this.getPendingKey( method ) ]: true,
 			} );


### PR DESCRIPTION
## Description
This fix is needed so third party plugins will be able to append URL arguments on internal requests, as Gutenberg concatenate the rest_url avoiding us to filter it on PHP side.

## Types of changes
New feature (non-breaking change which adds functionality) 

Issue: https://github.com/WordPress/gutenberg/issues/5958