### PR TITLE
Reopen sidebar when going to viewport sizes larger than medium.

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -20,7 +20,7 @@ import {
 	openGeneralSidebar,
 	closeGeneralSidebar,
 } from './actions';
-import { getMetaBoxes } from './selectors';
+import { getMetaBoxes, getActiveGeneralSidebarName } from './selectors';
 import { getMetaBoxContainer } from '../utils/meta-boxes';
 import { onChangeListener } from './utils';
 
@@ -108,11 +108,21 @@ const effects = {
 		// Collapse sidebar when viewport shrinks.
 		subscribe( onChangeListener(
 			() => select( 'core/viewport' ).isViewportMatch( '< medium' ),
-			( isSmall ) => {
-				if ( isSmall ) {
-					store.dispatch( closeGeneralSidebar() );
-				}
-			}
+			( () => {
+				// contains the sidebar we close when going to viewport sizes lower than medium.
+				// This allows to reopen it when going again to viewport sizes greater than medium.
+				let sidebarToReOpenOnExpand = null;
+				return ( isSmall ) => {
+					if ( isSmall ) {
+						sidebarToReOpenOnExpand = getActiveGeneralSidebarName( store.getState() );
+						if ( sidebarToReOpenOnExpand ) {
+							store.dispatch( closeGeneralSidebar() );
+						}
+					} else if ( sidebarToReOpenOnExpand && ! getActiveGeneralSidebarName( store.getState() ) ) {
+						store.dispatch( openGeneralSidebar( sidebarToReOpenOnExpand ) );
+					}
+				};
+			} )()
 		) );
 	},
 


### PR DESCRIPTION
This PR adds logic to reopen sidebar when going to viewport sizes larger than medium if it was closed because of resizing to viewport sizes lower than medium.

Fixes: https://github.com/WordPress/gutenberg/issues/5586

## How Has This Been Tested?
Start with a big screen size and the sidebar closed, resize the window to a small size see the sidebar was closed. Resize again to a big size and see the sidebar reopens was it was before we did any of the resize operations.

