### PR TITLE
Reset margin and padding values for gallery

### DIFF
--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -1,4 +1,4 @@
-.wp-block-gallery:not( .components-placeholder ):not( .alignfull ) {
+.gutenberg .wp-block-gallery:not( .components-placeholder ) {
 	// allow gallery items to go edge to edge
 	margin-left: -8px;
 	margin-right: -8px;

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -5,6 +5,8 @@
 	display: flex;
 	flex-wrap: wrap;
 	list-style-type: none;
+	margin: 0px;
+	padding: 0px;
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {


### PR DESCRIPTION
This PR resets margins and paddings for the gallery so the values themes set as margin and/or padding for normal lists (ul) do not interfere with the margins set in the gallery.

Fixes: https://github.com/WordPress/gutenberg/issues/5890

The design changes depend on the theme but they should not be easy to notice and when noticed is to solve a problem where gallery used list margin of the theme.


## How Has This Been Tested?
Use a theme like Twenty Fourteen that sets margin for ul's, verify the margin set by the theme is not used and the margin set in Gutenberg is used.

