### PR TITLE
Paste: Inject missing spaces

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -27,6 +27,7 @@ import embeddedContentReducer from './embedded-content-reducer';
 import { deepFilterHTML, isInvalidInline, isNotWhitelisted, isPlain, isInline } from './utils';
 import shortcodeConverter from './shortcode-converter';
 import slackMarkdownVariantCorrector from './slack-markdown-variant-corrector';
+import injectMissingSpaces from './inject-missing-spaces';
 
 /**
  * Converts an HTML string to known blocks. Strips everything else.
@@ -103,6 +104,8 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 			createUnwrapper( ( node ) => ! isInline( node, tagName ) ),
 		] );
 
+		HTML = injectMissingSpaces( HTML, plainText );
+
 		// Allows us to ask for this information when we get a report.
 		window.console.log( 'Processed inline HTML:\n\n', HTML );
 
@@ -142,6 +145,8 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 		] );
 
 		piece = normaliseBlocks( piece );
+
+		piece = injectMissingSpaces( piece, plainText );
 
 		// Allows us to ask for this information when we get a report.
 		window.console.log( 'Processed HTML piece:\n\n', piece );

--- a/blocks/api/raw-handling/inject-missing-spaces.js
+++ b/blocks/api/raw-handling/inject-missing-spaces.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import diff from 'fast-diff';
+
+/**
+ * Based on the plain text version, inject any missing spaces into the HTML.
+ * Some browsers omit spaces at the edges of text nodes which can result in
+ * words being pressed together.
+ *
+ * @param {string} HTML      HTML with potentially missing spaces.
+ * @param {string} plainText Plain text version.
+ *
+ * @return {string} HTML including any missing spaces.
+ */
+export default function( HTML, plainText ) {
+	return diff( HTML, plainText ).map( ( [ operation, content ] ) => {
+		// Pieces of text that appear in the plain text but not in the HTML.
+		if ( operation === diff.INSERT ) {
+			// Leave any extra spaces that appear in plain text.
+			return /^ +$/.test( content ) ? content : '';
+		}
+
+		return content;
+	} ).join( '' );
+}

--- a/blocks/api/raw-handling/test/inject-missing-spaces.js
+++ b/blocks/api/raw-handling/test/inject-missing-spaces.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { equal } from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import injectMissingSpaces from '../inject-missing-spaces';
+
+describe( 'injectMissingSpaces', () => {
+	it( 'should inject missing spaces', () => {
+		equal( injectMissingSpaces( '<p>sometext</p>', 'some text' ), '<p>some text</p>' );
+		equal( injectMissingSpaces( '<p><em>some</em>text</p>', 'some text' ), '<p><em>some</em> text</p>' );
+		equal( injectMissingSpaces( '<p>some<em>text</em></p>', 'some text' ), '<p>some<em> text</em></p>' );
+	} );
+} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2413,7 +2413,7 @@
 			"dev": true,
 			"requires": {
 				"browserslist": "1.7.7",
-				"caniuse-db": "1.0.30000804",
+				"caniuse-db": "1.0.30000823",
 				"lodash.memoize": "4.1.2",
 				"lodash.uniq": "4.5.0"
 			},
@@ -2424,16 +2424,16 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000804",
+						"caniuse-db": "1.0.30000823",
 						"electron-to-chromium": "1.3.33"
 					}
 				}
 			}
 		},
 		"caniuse-db": {
-			"version": "1.0.30000804",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000804.tgz",
-			"integrity": "sha1-hP60IBj8ZM9q/2Nx5DEV8pLAAXk=",
+			"version": "1.0.30000823",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000823.tgz",
+			"integrity": "sha1-5o5fjHB4PvQFnS6g3oH1UWUdpvw=",
 			"dev": true
 		},
 		"caniuse-lite": {
@@ -3856,7 +3856,7 @@
 					"dev": true,
 					"requires": {
 						"browserslist": "1.7.7",
-						"caniuse-db": "1.0.30000804",
+						"caniuse-db": "1.0.30000823",
 						"normalize-range": "0.1.2",
 						"num2fraction": "1.2.2",
 						"postcss": "5.2.18",
@@ -3869,7 +3869,7 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000804",
+						"caniuse-db": "1.0.30000823",
 						"electron-to-chromium": "1.3.33"
 					}
 				}
@@ -5099,6 +5099,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
 			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
 			"dev": true
+		},
+		"fast-diff": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -11369,7 +11374,7 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000804",
+						"caniuse-db": "1.0.30000823",
 						"electron-to-chromium": "1.3.33"
 					}
 				}
@@ -12579,53 +12584,48 @@
 			"integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.0",
+				"chalk": "2.3.2",
 				"findup": "0.1.5",
 				"mkdirp": "0.5.1",
-				"postcss": "6.0.17",
+				"postcss": "6.0.21",
 				"strip-json-comments": "2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
+						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"supports-color": "5.3.0"
 					}
 				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
 				"postcss": {
-					"version": "6.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"version": "6.0.21",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+					"integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
+						"chalk": "2.3.2",
 						"source-map": "0.6.1",
-						"supports-color": "5.1.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-							"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-							"dev": true,
-							"requires": {
-								"has-flag": "2.0.0"
-							}
-						}
+						"supports-color": "5.3.0"
 					}
 				},
 				"source-map": {
@@ -12635,12 +12635,12 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"element-closest": "2.0.2",
 		"escape-string-regexp": "1.0.5",
 		"eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
+		"fast-diff": "1.1.2",
 		"hpq": "1.2.0",
 		"jed": "1.1.1",
 		"jquery": "3.2.1",


### PR DESCRIPTION
## Description
This branch tries to fix a browser issue where spaces at the edges of text nodes are omitted from the HTML version in the clipboard. Interestingly the plain text version still has these spaces, so we can create a diff and them to the HTML version. I've tested this a bit and I haven't stumbled upon any side effects so far. In the worst case this could inject unwanted spaces into very complex HTML content (when a diff is quite choppy).

## How Has This Been Tested?
Paste the poem from https://www.nytimes.com/2018/03/28/magazine/poem-the-nod.html.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.