### PR TITLE
Fixed clone function to clone innerBlocks.

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -65,13 +65,13 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
  * Given a block object, returns a copy of the block object, optionally merging
  * new attributes and/or replacing its inner blocks.
  *
- * @param {Object} block           Block object.
- * @param {Object} mergeAttributes Block attributes.
- * @param {?Array} innerBlocks     Nested blocks.
+ * @param {Object} block              Block object.
+ * @param {Object} mergeAttributes    Block attributes.
+ * @param {?Array} newInnerBlocks     Nested blocks.
  *
  * @return {Object} A cloned block.
  */
-export function cloneBlock( block, mergeAttributes = {}, innerBlocks = block.innerBlocks ) {
+export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 	return {
 		...block,
 		uid: uuid(),
@@ -79,7 +79,8 @@ export function cloneBlock( block, mergeAttributes = {}, innerBlocks = block.inn
 			...block.attributes,
 			...mergeAttributes,
 		},
-		innerBlocks,
+		innerBlocks: newInnerBlocks ||
+			block.innerBlocks.map( ( innerBlock ) => cloneBlock( innerBlock ) ),
 	};
 }
 

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -186,6 +186,43 @@ describe( 'block factory', () => {
 			expect( clonedBlock.innerBlocks ).toHaveLength( 1 );
 			expect( clonedBlock.innerBlocks[ 0 ].attributes ).not.toHaveProperty( 'align' );
 		} );
+
+		it( 'should clone innerBlocks if innerBlocks are not passed', () => {
+			registerBlockType( 'core/test-block', {
+				attributes: {
+					align: {
+						type: 'string',
+					},
+					isDifferent: {
+						type: 'boolean',
+						default: false,
+					},
+				},
+				save: noop,
+				category: 'common',
+				title: 'test block',
+			} );
+			const block = deepFreeze(
+				createBlock(
+					'core/test-block',
+					{ align: 'left' },
+					[
+						createBlock( 'core/test-block', { align: 'right' } ),
+						createBlock( 'core/test-block', { align: 'left' } ),
+					],
+				)
+			);
+
+			const clonedBlock = cloneBlock( block );
+
+			expect( clonedBlock.innerBlocks ).toHaveLength( 2 );
+			expect( clonedBlock.innerBlocks[ 0 ].uid ).not.toBe( block.innerBlocks[ 0 ].uid );
+			expect( clonedBlock.innerBlocks[ 0 ].attributes ).not.toBe( block.innerBlocks[ 0 ].attributes );
+			expect( clonedBlock.innerBlocks[ 0 ].attributes ).toEqual( block.innerBlocks[ 0 ].attributes );
+			expect( clonedBlock.innerBlocks[ 1 ].uid ).not.toBe( block.innerBlocks[ 1 ].uid );
+			expect( clonedBlock.innerBlocks[ 1 ].attributes ).not.toBe( block.innerBlocks[ 1 ].attributes );
+			expect( clonedBlock.innerBlocks[ 1 ].attributes ).toEqual( block.innerBlocks[ 1 ].attributes );
+		} );
 	} );
 
 	describe( 'getPossibleBlockTransformations()', () => {


### PR DESCRIPTION
Clone function did not clone the inner blocks so if we clone a block e.g: a column with inner blocks both columns would reference the same inner blocks so changes applied to one inner block would also apply to the other.
Now if inner blocks are not passed explicitly to clone, all the inner blocks are recursively cloned.
Props to @mcsf for discovering this bug.

## How Has This Been Tested?
Add a column block, add a paragraph inside it, clone the column block, change the text of the cloned block and verify it does not changes the content of the original paragraph.

## Screenshot of the bug
![apr-04-2018 22-27-34](https://user-images.githubusercontent.com/11271197/38335782-76564d12-3857-11e8-8a38-62b215066ba2.gif)


