### PR TITLE
Add a few checks to confirm functions exists before calling

### DIFF
--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -17,7 +17,7 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import { getCurrentPostType } from '../../store/selectors';
 
 export function PostAuthorCheck( { user, users, children } ) {
-	const authors = filter( users.data, ( { capabilities } ) => capabilities.level_1 );
+	const authors = filter( users.data, ( { capabilities } ) => undefined !== capabilities && capabilities.level_1 );
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
 
 	if ( ! userCanPublishPosts || authors.length < 2 ) {

--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -17,7 +17,7 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import { getCurrentPostType } from '../../store/selectors';
 
 export function PostAuthorCheck( { user, users, children } ) {
-	const authors = filter( users.data, ( { capabilities } ) => undefined !== capabilities && capabilities.level_1 );
+	const authors = filter( users.data, ( { capabilities } ) => get( capabilities, 'level_1', false ) );
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
 
 	if ( ! userCanPublishPosts || authors.length < 2 ) {

--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -17,7 +17,7 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import { getCurrentPostType } from '../../store/selectors';
 
 export function PostAuthorCheck( { user, users, children } ) {
-	const authors = filter( users.data, ( { capabilities } ) => get( capabilities, 'level_1', false ) );
+	const authors = filter( users.data, ( { capabilities } ) => get( capabilities, [ 'level_1' ], false ) );
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
 
 	if ( ! userCanPublishPosts || authors.length < 2 ) {

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -39,7 +39,7 @@ export class PostAuthor extends Component {
 		// See: https://codex.wordpress.org/Roles_and_Capabilities#User_Levels
 		const { users } = this.props;
 		return filter( users.data, ( user ) => {
-			return user.capabilities.level_1;
+			return undefined !== user.capabilities && user.capabilities.level_1;
 		} );
 	}
 

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { filter } from 'lodash';
+import { get, filter } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -39,7 +39,7 @@ export class PostAuthor extends Component {
 		// See: https://codex.wordpress.org/Roles_and_Capabilities#User_Levels
 		const { users } = this.props;
 		return filter( users.data, ( user ) => {
-			return undefined !== user.capabilities && user.capabilities.level_1;
+			return get( user, [ 'capabilities', 'level_1' ], false );
 		} );
 	}
 

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -68,8 +68,11 @@ class FlatTermSelector extends Component {
 	}
 
 	componentWillUnmount() {
-		this.initRequest.abort();
-		if ( this.searchRequest ) {
+		if ( this.initRequest && typeof this.initRequest.abort !== 'undefined' ) {
+			this.initRequest.abort();
+		}
+
+		if ( this.searchRequest && typeof this.searchRequest.abort !== 'undefined' ) {
 			this.searchRequest.abort();
 		}
 	}
@@ -160,7 +163,7 @@ class FlatTermSelector extends Component {
 	}
 
 	searchTerms( search = '' ) {
-		if ( this.searchRequest ) {
+		if ( this.searchRequest && typeof this.searchRequest.abort !== 'undefined' ) {
 			this.searchRequest.abort();
 		}
 		this.searchRequest = this.fetchTerms( { search } );

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -68,13 +68,8 @@ class FlatTermSelector extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this.initRequest && typeof this.initRequest.abort !== 'undefined' ) {
-			this.initRequest.abort();
-		}
-
-		if ( this.searchRequest && typeof this.searchRequest.abort !== 'undefined' ) {
-			this.searchRequest.abort();
-		}
+		lodashResult( this.initRequest, 'abort' );
+		lodashResult( this.searchRequest, 'abort' );
 	}
 
 	componentWillReceiveProps( newProps ) {

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { isEmpty, get, unescape as unescapeString, find, throttle, uniqBy } from 'lodash';
+import { isEmpty, get, unescape as unescapeString, find, throttle, uniqBy, result as lodashResult } from 'lodash';
 import { stringify } from 'querystring';
 
 /**
@@ -163,9 +163,7 @@ class FlatTermSelector extends Component {
 	}
 
 	searchTerms( search = '' ) {
-		if ( this.searchRequest && typeof this.searchRequest.abort !== 'undefined' ) {
-			this.searchRequest.abort();
-		}
+		lodashResult( this.searchRequest, 'abort' );
 		this.searchRequest = this.fetchTerms( { search } );
 	}
 

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { isEmpty, get, unescape as unescapeString, find, throttle, uniqBy, result as lodashResult } from 'lodash';
+import { isEmpty, get, unescape as unescapeString, find, throttle, uniqBy, invoke } from 'lodash';
 import { stringify } from 'querystring';
 
 /**
@@ -68,8 +68,8 @@ class FlatTermSelector extends Component {
 	}
 
 	componentWillUnmount() {
-		lodashResult( this.initRequest, 'abort' );
-		lodashResult( this.searchRequest, 'abort' );
+		invoke( this.initRequest, [ 'abort' ] );
+		invoke( this.searchRequest, [ 'abort' ] );
 	}
 
 	componentWillReceiveProps( newProps ) {
@@ -158,7 +158,7 @@ class FlatTermSelector extends Component {
 	}
 
 	searchTerms( search = '' ) {
-		lodashResult( this.searchRequest, 'abort' );
+		invoke( this.searchRequest, [ 'abort' ] );
 		this.searchRequest = this.fetchTerms( { search } );
 	}
 

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -192,11 +192,11 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this.fetchRequest ) {
+		if ( this.fetchRequest && typeof this.fetchRequest.abort !== 'undefined' ) {
 			this.fetchRequest.abort();
 		}
 
-		if ( this.addRequest ) {
+		if ( this.addRequest && typeof this.addRequest.abort !== 'undefined' ) {
 			this.addRequest.abort();
 		}
 	}

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get, unescape as unescapeString, without, find, some } from 'lodash';
+import { get, unescape as unescapeString, without, find, some, result } from 'lodash';
 import { stringify } from 'querystring';
 
 /**
@@ -192,13 +192,8 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this.fetchRequest && typeof this.fetchRequest.abort !== 'undefined' ) {
-			this.fetchRequest.abort();
-		}
-
-		if ( this.addRequest && typeof this.addRequest.abort !== 'undefined' ) {
-			this.addRequest.abort();
-		}
+		result( this.fetchRequest, 'abort' );
+		result( this.addRequest, 'abort' );
 	}
 
 	renderTerms( renderedTerms ) {

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get, unescape as unescapeString, without, find, some, result } from 'lodash';
+import { get, unescape as unescapeString, without, find, some, invoke } from 'lodash';
 import { stringify } from 'querystring';
 
 /**
@@ -192,8 +192,8 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	componentWillUnmount() {
-		result( this.fetchRequest, 'abort' );
-		result( this.addRequest, 'abort' );
+		invoke( this.fetchRequest, [ 'abort' ] );
+		invoke( this.addRequest, [ 'abort' ] );
 	}
 
 	renderTerms( renderedTerms ) {


### PR DESCRIPTION
## Description

This simply adds a couple of checks to confirm functions exist before calling them.

The two scenarios are:

1. Around user capabilities was not defined in some cases for us, and thus throws an error.

2.  Requests for post taxonomies (hierarchial/flat) did not include .abort() function, it assumes an XHR requests, which may not always be the case

## How Has This Been Tested?

1. Verify user capabilities all works fine, usually happens around ability to Publish.

2. Confirm taxonomies are fine, categories and tags.


## Types of changes

The code is relatively simple and just checks for undefined and returns false or skips calling, which is a fine/expected behavior in both cases.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
