### PR TITLE
State: Reset block selection when replacing with empty set

### DIFF
--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -17,6 +17,7 @@ import {
 	isEqual,
 	includes,
 	overSome,
+	get,
 } from 'lodash';
 
 /**
@@ -663,13 +664,18 @@ export function blockSelection( state = {
 				isMultiSelecting: false,
 			};
 		case 'REPLACE_BLOCKS':
-			if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.start ) === -1 ) {
+			if ( action.uids.indexOf( state.start ) === -1 ) {
 				return state;
 			}
+
+			// If there is replacement block(s), assign first's UID as the next
+			// selected block. If empty replacement, reset to null.
+			const nextSelectedBlockUID = get( action.blocks, [ 0, 'uid' ], null );
+
 			return {
 				...state,
-				start: action.blocks[ 0 ].uid,
-				end: action.blocks[ 0 ].uid,
+				start: nextSelectedBlockUID,
+				end: nextSelectedBlockUID,
 				initialPosition: null,
 				isMultiSelecting: false,
 			};

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1508,6 +1508,22 @@ describe( 'state', () => {
 			} );
 		} );
 
+		it( 'should reset if replacing with empty set', () => {
+			const original = deepFreeze( { start: 'chicken', end: 'chicken' } );
+			const state = blockSelection( original, {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'chicken' ],
+				blocks: [],
+			} );
+
+			expect( state ).toEqual( {
+				start: null,
+				end: null,
+				initialPosition: null,
+				isMultiSelecting: false,
+			} );
+		} );
+
 		it( 'should keep the selected block', () => {
 			const original = deepFreeze( { start: 'chicken', end: 'chicken' } );
 			const state = blockSelection( original, {


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/5974#issuecomment-378775560

This pull request seeks to change the behavior of the editor `blockSelection` state to properly reset block selection to initial state when the selected block is replaced, even when there are no blocks replacing the removed block. This currently occurs when inserting the first default block in a new post and immediately pressing backspace. It may be that this should be an explicit `removeBlock`; all the same, the behavior here should be expected anyways. We should not have a lingering block selection for a block which no longer exists.

__Testing instructions:__

Verify unit tests pass:

```
npm run test-unit editor/store/test/reducer.js
```

With [Redux DevTools](https://github.com/gaearon/redux-devtools), ensure that there is a `null` `blockSelection.start` and `blockSelection.end` after removing a newly inserted default block.

1. Start a new post
2. Focus the writing prompt
3. Press backspace