### PR TITLE
State: Prevent unnecessary state updates to edit-post preferences

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -92,12 +92,12 @@ const effects = {
 	INIT( _, store ) {
 		// Select the block settings tab when the selected block changes
 		subscribe( onChangeListener(
-			() => select( 'core/editor' ).getBlockSelectionStart(),
-			( selectionStart ) => {
+			() => !! select( 'core/editor' ).getBlockSelectionStart(),
+			( hasBlockSelection ) => {
 				if ( ! select( 'core/edit-post' ).isEditorSidebarOpened() ) {
 					return;
 				}
-				if ( selectionStart ) {
+				if ( hasBlockSelection ) {
 					store.dispatch( openGeneralSidebar( 'edit-post/block' ) );
 				} else {
 					store.dispatch( openGeneralSidebar( 'edit-post/document' ) );

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -24,45 +19,46 @@ import { PREFERENCES_DEFAULTS } from './defaults';
  *
  * @return {string} Updated state.
  */
-export function preferences( state = PREFERENCES_DEFAULTS, action ) {
-	switch ( action.type ) {
-		case 'OPEN_GENERAL_SIDEBAR':
-			return {
-				...state,
-				activeGeneralSidebar: action.name,
-			};
-		case 'CLOSE_GENERAL_SIDEBAR':
-			return {
-				...state,
-				activeGeneralSidebar: null,
-			};
-		case 'TOGGLE_GENERAL_SIDEBAR_EDITOR_PANEL':
-			return {
-				...state,
-				panels: {
-					...state.panels,
-					[ action.panel ]: ! get( state, [ 'panels', action.panel ], false ),
-				},
-			};
-		case 'SWITCH_MODE':
-			return {
-				...state,
-				editorMode: action.mode,
-			};
-		case 'TOGGLE_FEATURE':
-			return {
-				...state,
-				features: {
-					...state.features,
-					[ action.feature ]: ! state.features[ action.feature ],
-				},
-			};
-		case 'SERIALIZE':
-			return state;
-	}
+export const preferences = combineReducers( {
+	activeGeneralSidebar( state = PREFERENCES_DEFAULTS.activeGeneralSidebar, action ) {
+		switch ( action.type ) {
+			case 'OPEN_GENERAL_SIDEBAR':
+				return action.name;
 
-	return state;
-}
+			case 'CLOSE_GENERAL_SIDEBAR':
+				return null;
+		}
+
+		return state;
+	},
+	panels( state = PREFERENCES_DEFAULTS.panels, action ) {
+		if ( action.type === 'TOGGLE_GENERAL_SIDEBAR_EDITOR_PANEL' ) {
+			return {
+				...state,
+				[ action.panel ]: ! state[ action.panel ],
+			};
+		}
+
+		return state;
+	},
+	features( state = PREFERENCES_DEFAULTS.features, action ) {
+		if ( action.type === 'TOGGLE_FEATURE' ) {
+			return {
+				...state,
+				[ action.feature ]: ! state[ action.feature ],
+			};
+		}
+
+		return state;
+	},
+	editorMode( state = PREFERENCES_DEFAULTS.editorMode, action ) {
+		if ( action.type === 'SWITCH_MODE' ) {
+			return action.mode;
+		}
+
+		return state;
+	},
+} );
 
 export function panel( state = 'document', action ) {
 	switch ( action.type ) {

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -25,25 +25,48 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should set the general sidebar active panel', () => {
-			const state = preferences( deepFreeze( {
-				activeGeneralSidebar: 'editor',
-			} ), {
-				type: 'SET_GENERAL_SIDEBAR_ACTIVE_PANEL',
+		it( 'should set the general sidebar', () => {
+			const original = deepFreeze( preferences( undefined, {} ) );
+			const state = preferences( original, {
+				type: 'OPEN_GENERAL_SIDEBAR',
 				name: 'edit-post/document',
 			} );
-			expect( state ).toEqual( {
-				activeGeneralSidebar: 'editor',
+
+			expect( state.activeGeneralSidebar ).toBe( 'edit-post/document' );
+		} );
+
+		it( 'should does not update if sidebar is already set to value', () => {
+			const original = deepFreeze( preferences( undefined, {
+				type: 'OPEN_GENERAL_SIDEBAR',
+				name: 'edit-post/document',
+			} ) );
+			const state = preferences( original, {
+				type: 'OPEN_GENERAL_SIDEBAR',
+				name: 'edit-post/document',
 			} );
+
+			expect( original ).toBe( state );
+		} );
+
+		it( 'should unset the general sidebar', () => {
+			const original = deepFreeze( preferences( undefined, {
+				type: 'OPEN_GENERAL_SIDEBAR',
+				name: 'edit-post/document',
+			} ) );
+			const state = preferences( original, {
+				type: 'CLOSE_GENERAL_SIDEBAR',
+			} );
+
+			expect( state.activeGeneralSidebar ).toBe( null );
 		} );
 
 		it( 'should set the sidebar panel open flag to true if unset', () => {
-			const state = preferences( deepFreeze( {} ), {
+			const state = preferences( deepFreeze( { panels: {} } ), {
 				type: 'TOGGLE_GENERAL_SIDEBAR_EDITOR_PANEL',
 				panel: 'post-taxonomies',
 			} );
 
-			expect( state ).toEqual( { panels: { 'post-taxonomies': true } } );
+			expect( state.panels ).toEqual( { 'post-taxonomies': true } );
 		} );
 
 		it( 'should toggle the sidebar panel open flag', () => {
@@ -52,16 +75,16 @@ describe( 'state', () => {
 				panel: 'post-taxonomies',
 			} );
 
-			expect( state ).toEqual( { panels: { 'post-taxonomies': false } } );
+			expect( state.panels ).toEqual( { 'post-taxonomies': false } );
 		} );
 
 		it( 'should return switched mode', () => {
-			const state = preferences( deepFreeze( {} ), {
+			const state = preferences( deepFreeze( { editorMode: 'visual' } ), {
 				type: 'SWITCH_MODE',
 				mode: 'text',
 			} );
 
-			expect( state ).toEqual( { editorMode: 'text' } );
+			expect( state.editorMode ).toBe( 'text' );
 		} );
 
 		it( 'should toggle a feature flag', () => {
@@ -69,7 +92,8 @@ describe( 'state', () => {
 				type: 'TOGGLE_FEATURE',
 				feature: 'chicken',
 			} );
-			expect( state ).toEqual( { features: { chicken: false } } );
+
+			expect( state.features ).toEqual( { chicken: false } );
 		} );
 	} );
 


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/5974#issuecomment-378775560

This pull request seeks to resolve two issues with unnecessary state updates and dispatching to the edit post store:

1. Most preferences values were not comparing to the current state, merging into the state object and creating a new reference even if the new preference was the same. By returning a new object reference, all state subscribers were being invoked. With these changes, leveraging `combineReducers` has the benefit of avoiding state updates when each key of preferences is strictly equal.
2. The store subscriptions introduced in #5882 were dispatching in response to a change in the UID of the selected block, when it was sufficient to listen for a change in plainly whether or not there is a selected block (only having two states `true` and `false`, rather than unlimited states of possible set of block UIDs). With these changes, the subscribe listener will only dispatch when going from a state of cleared selection to having a selection, but not when changing selection from one block to another.

__Testing instructions:__

Verify that there are no regressions in the behaviors of preferences (toggled panels, active sidebar, editor mode).

Repeat testing instructions from #5882, verifying no regressions.