### PR TITLE
Writing Flow: Restore click below to focus last field

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -70,6 +70,7 @@ class WritingFlow extends Component {
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
 		this.clearVerticalRect = this.clearVerticalRect.bind( this );
+		this.focusLastTextField = this.focusLastTextField.bind( this );
 
 		/**
 		 * Here a rectangle is stored while moving the caret vertically so


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/pull/5411#discussion_r179318380

This pull request seeks to restore the _click redirector_ behavior which was inadvertently removed in #5411. It also adds to the existing `add-blocks` E2E test to verify this behavior to prevent future regressions.

__Testing instructions:__

Verify you can focus the last field of the post by clicking below the editor.

Ensure end-to-end tests pass:

```
npm run test-e2e
```