### PR TITLE
Terms: Avoid term request if term set is empty array

### DIFF
--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get, unescape as unescapeString, find, throttle, uniqBy } from 'lodash';
+import { isEmpty, get, unescape as unescapeString, find, throttle, uniqBy } from 'lodash';
 import { stringify } from 'querystring';
 
 /**
@@ -44,7 +44,7 @@ class FlatTermSelector extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.terms ) {
+		if ( ! isEmpty( this.props.terms ) ) {
 			this.setState( { loading: false } );
 			this.initRequest = this.fetchTerms( {
 				include: this.props.terms.join( ',' ),


### PR DESCRIPTION
This pull request seeks to avoid an unnecessary (and invalid) request for terms on a post which does not have terms assigned.

```
jquery.js?ver=1.12.4:4 GET http://editor.test/wp-json/wp/v2/tags?per_page=100&orderby=count&order=desc&_fields=id%2Cname&include= 400 (Bad Request)
```

This is caused by the condition in the `FlatTermSelector` component mount behavior which assumes to test for the existence of terms, but does so by a naive [truthy check](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), which is insufficient because an empty array is truthy. The changes proposed here use [Lodash's `_.isEmpty`](https://lodash.com/docs/4.17.5#isEmpty) instead which checks both for truthiness and a non-zero length.

__Testing instructions:__

1. Navigate to Posts > New Post
2. Open sidebar if not already open
3. Expand Tags panel if not already expanded
4. Note there are no invalid requests (either in network tab of your browser's developer tools, and/or via any console errors)