### PR TITLE
Fix findDOMNode lint warning

### DIFF
--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -48,6 +48,9 @@ class DropZoneProvider extends Component {
 		window.addEventListener( 'dragover', this.dragOverListener );
 		window.addEventListener( 'drop', this.onDrop );
 		window.addEventListener( 'mouseup', this.resetDragState );
+
+		// Disable reason: Can't use a ref since this component just renders its children
+		// eslint-disable-next-line react/no-find-dom-node
 		this.container = findDOMNode( this );
 	}
 

--- a/eslint/config.js
+++ b/eslint/config.js
@@ -114,7 +114,6 @@ module.exports = {
 		'react/jsx-key': 'error',
 		'react/jsx-tag-spacing': 'error',
 		'react/no-children-prop': 'off',
-		'react/no-find-dom-node': 'warn',
 		'react/prop-types': 'off',
 		semi: 'error',
 		'semi-spacing': 'error',


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/4115#discussion_r179185367.

- Ignore the warning we get for using `findDOMNode`
- Explain why we're using `findDOMNode`
- Make this lint rule an error instead of a warning so that, in the future, CI will force us to explain why we're using `findDOMNode`

🐶