### PR TITLE
Fix 'unary operator expected' error when DOCKER is not defined

### DIFF
--- a/bin/run-wp-unit-tests.sh
+++ b/bin/run-wp-unit-tests.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")/../"
 
 export PATH="$HOME/.composer/vendor/bin:$PATH"
-if [ ${DOCKER} = "true" ]; then
+if [[ $DOCKER = "true" ]]; then
 	bin/setup-local-env.sh
 else
 	bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
@@ -28,7 +28,7 @@ if ! git diff --quiet --exit-code lib/parser.php; then
 fi
 
 echo Running with the following versions:
-if [ ${DOCKER} = "true" ]; then
+if [[ $DOCKER = "true" ]]; then
 	docker-compose run --rm wordpress_phpunit php -v
 	docker-compose run --rm wordpress_phpunit phpunit --version
 else
@@ -40,7 +40,7 @@ fi
 php lib/parser.php || exit 1
 
 # Run PHPUnit tests
-if [ ${DOCKER} = "true" ]; then
+if [[ $DOCKER = "true" ]]; then
 	npm run test-php || exit 1
 	npm run test-unit-php-multisite || exit 1
 else


### PR DESCRIPTION
I noticed this error in the Travis CI logs for every job where we **don't** set `DOCKER=true`:

```
./bin/run-wp-unit-tests.sh: line 6: [: =: unary operator expected
```

It's caused by that classic bash gotcha where variable substitutions happen _before_ the `[` program runs. The simplest fix is to use the native `[[ .. ]]` bash construct instead of the `[` program.