### PR TITLE
 Blocks: Improve UI for all Inspector Controls

### DIFF
--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -3,7 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Dashicon, IconButton, PanelColor, ToggleControl, withFallbackStyles } from '@wordpress/components';
+import {
+	Dashicon,
+	IconButton,
+	PanelBody,
+	PanelColor,
+	ToggleControl,
+	withFallbackStyles,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -96,29 +103,31 @@ class ButtonBlock extends Component {
 				/>
 				{ isSelected &&
 					<InspectorControls key="inspector">
-						<ToggleControl
-							label={ __( 'Wrap text' ) }
-							checked={ !! clear }
-							onChange={ this.toggleClear }
-						/>
-						<PanelColor title={ __( 'Background Color' ) } colorValue={ color } >
-							<ColorPalette
-								value={ color }
-								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
+						<PanelBody>
+							<ToggleControl
+								label={ __( 'Wrap text' ) }
+								checked={ !! clear }
+								onChange={ this.toggleClear }
 							/>
-						</PanelColor>
-						<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } >
-							<ColorPalette
-								value={ textColor }
-								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
-							/>
-						</PanelColor>
-						{ this.nodeRef && <ContrastCheckerWithFallbackStyles
-							node={ this.nodeRef }
-							textColor={ textColor }
-							backgroundColor={ color }
-							isLargeText={ true }
-						/> }
+							<PanelColor title={ __( 'Background Color' ) } colorValue={ color } >
+								<ColorPalette
+									value={ color }
+									onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
+								/>
+							</PanelColor>
+							<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } >
+								<ColorPalette
+									value={ textColor }
+									onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
+								/>
+							</PanelColor>
+							{ this.nodeRef && <ContrastCheckerWithFallbackStyles
+								node={ this.nodeRef }
+								textColor={ textColor }
+								backgroundColor={ color }
+								isLargeText={ true }
+							/> }
+						</PanelBody>
 					</InspectorControls>
 				}
 			</span>,

--- a/blocks/library/categories/block.js
+++ b/blocks/library/categories/block.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Placeholder, Spinner, ToggleControl } from '@wordpress/components';
+import { PanelBody, Placeholder, Spinner, ToggleControl } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { times, unescape } from 'lodash';
@@ -148,22 +148,23 @@ class CategoriesBlock extends Component {
 
 		const inspectorControls = focus && (
 			<InspectorControls key="inspector">
-				<h3>{ __( 'Categories Settings' ) }</h3>
-				<ToggleControl
-					label={ __( 'Display as dropdown' ) }
-					checked={ displayAsDropdown }
-					onChange={ this.toggleDisplayAsDropdown }
-				/>
-				<ToggleControl
-					label={ __( 'Show post counts' ) }
-					checked={ showPostCounts }
-					onChange={ this.toggleShowPostCounts }
-				/>
-				<ToggleControl
-					label={ __( 'Show hierarchy' ) }
-					checked={ showHierarchy }
-					onChange={ this.toggleShowHierarchy }
-				/>
+				<PanelBody title={ __( 'Categories Settings' ) }>
+					<ToggleControl
+						label={ __( 'Display as dropdown' ) }
+						checked={ displayAsDropdown }
+						onChange={ this.toggleDisplayAsDropdown }
+					/>
+					<ToggleControl
+						label={ __( 'Show post counts' ) }
+						checked={ showPostCounts }
+						onChange={ this.toggleShowPostCounts }
+					/>
+					<ToggleControl
+						label={ __( 'Show hierarchy' ) }
+						checked={ showHierarchy }
+						onChange={ this.toggleShowHierarchy }
+					/>
+				</PanelBody>
 			</InspectorControls>
 		);
 

--- a/blocks/library/columns/index.js
+++ b/blocks/library/columns/index.js
@@ -9,7 +9,7 @@ import memoize from 'memize';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { RangeControl } from '@wordpress/components';
+import { PanelBody, RangeControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -84,17 +84,19 @@ export const settings = {
 					/>
 				</BlockControls>,
 				<InspectorControls key="inspector">
-					<RangeControl
-						label={ __( 'Columns' ) }
-						value={ columns }
-						onChange={ ( nextColumns ) => {
-							setAttributes( {
-								columns: nextColumns,
-							} );
-						} }
-						min={ 2 }
-						max={ 6 }
-					/>
+					<PanelBody>
+						<RangeControl
+							label={ __( 'Columns' ) }
+							value={ columns }
+							onChange={ ( nextColumns ) => {
+								setAttributes( {
+									columns: nextColumns,
+								} );
+							} }
+							min={ 2 }
+							max={ 6 }
+						/>
+					</PanelBody>
 				</InspectorControls>,
 			] : [],
 			<div className={ classes } key="container">

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -147,20 +147,21 @@ export const settings = {
 				</Toolbar>
 			</BlockControls>,
 			<InspectorControls key="inspector">
-				<h2>{ __( 'Cover Image Settings' ) }</h2>
-				<ToggleControl
-					label={ __( 'Fixed Background' ) }
-					checked={ !! hasParallax }
-					onChange={ toggleParallax }
-				/>
-				<RangeControl
-					label={ __( 'Background Dimness' ) }
-					value={ dimRatio }
-					onChange={ setDimRatio }
-					min={ 0 }
-					max={ 100 }
-					step={ 10 }
-				/>
+				<PanelBody title={ __( 'Cover Image Settings' ) }>
+					<ToggleControl
+						label={ __( 'Fixed Background' ) }
+						checked={ !! hasParallax }
+						onChange={ toggleParallax }
+					/>
+					<RangeControl
+						label={ __( 'Background Dimness' ) }
+						value={ dimRatio }
+						onChange={ setDimRatio }
+						min={ 0 }
+						max={ 100 }
+						step={ 10 }
+					/>
+				</PanelBody>
 				<PanelBody title={ __( 'Text Alignment' ) }>
 					{ alignmentToolbar }
 				</PanelBody>

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -13,6 +13,7 @@ import {
 	IconButton,
 	DropZone,
 	FormFileUpload,
+	PanelBody,
 	RangeControl,
 	SelectControl,
 	ToggleControl,
@@ -206,25 +207,26 @@ class GalleryBlock extends Component {
 			controls,
 			isSelected && (
 				<InspectorControls key="inspector">
-					<h2>{ __( 'Gallery Settings' ) }</h2>
-					{ images.length > 1 && <RangeControl
-						label={ __( 'Columns' ) }
-						value={ columns }
-						onChange={ this.setColumnsNumber }
-						min={ 1 }
-						max={ Math.min( MAX_COLUMNS, images.length ) }
-					/> }
-					<ToggleControl
-						label={ __( 'Crop Images' ) }
-						checked={ !! imageCrop }
-						onChange={ this.toggleImageCrop }
-					/>
-					<SelectControl
-						label={ __( 'Link to' ) }
-						value={ linkTo }
-						onChange={ this.setLinkTo }
-						options={ linkOptions }
-					/>
+					<PanelBody title={ __( 'Gallery Settings' ) }>
+						{ images.length > 1 && <RangeControl
+							label={ __( 'Columns' ) }
+							value={ columns }
+							onChange={ this.setColumnsNumber }
+							min={ 1 }
+							max={ Math.min( MAX_COLUMNS, images.length ) }
+						/> }
+						<ToggleControl
+							label={ __( 'Crop Images' ) }
+							checked={ !! imageCrop }
+							onChange={ this.toggleImageCrop }
+						/>
+						<SelectControl
+							label={ __( 'Link to' ) }
+							value={ linkTo }
+							onChange={ this.setLinkTo }
+							options={ linkOptions }
+						/>
+					</PanelBody>
 				</InspectorControls>
 			),
 			<ul key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { concatChildren } from '@wordpress/element';
-import { Toolbar } from '@wordpress/components';
+import { PanelBody, Toolbar } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -121,26 +121,27 @@ export const settings = {
 			),
 			isSelected && (
 				<InspectorControls key="inspector">
-					<h3>{ __( 'Heading Settings' ) }</h3>
-					<p>{ __( 'Level' ) }</p>
-					<Toolbar
-						controls={
-							'123456'.split( '' ).map( ( level ) => ( {
-								icon: 'heading',
-								title: sprintf( __( 'Heading %s' ), level ),
-								isActive: 'H' + level === nodeName,
-								onClick: () => setAttributes( { nodeName: 'H' + level } ),
-								subscript: level,
-							} ) )
-						}
-					/>
-					<p>{ __( 'Text Alignment' ) }</p>
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-					/>
+					<PanelBody title={ __( 'Heading Settings' ) }>
+						<p>{ __( 'Level' ) }</p>
+						<Toolbar
+							controls={
+								'123456'.split( '' ).map( ( level ) => ( {
+									icon: 'heading',
+									title: sprintf( __( 'Heading %s' ), level ),
+									isActive: 'H' + level === nodeName,
+									onClick: () => setAttributes( { nodeName: 'H' + level } ),
+									subscript: level,
+								} ) )
+							}
+						/>
+						<p>{ __( 'Text Alignment' ) }</p>
+						<AlignmentToolbar
+							value={ align }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { align: nextAlign } );
+							} }
+						/>
+					</PanelBody>
 				</InspectorControls>
 			),
 			<RichText

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -19,6 +19,7 @@ import { Component, compose } from '@wordpress/element';
 import { getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
 import {
 	IconButton,
+	PanelBody,
 	SelectControl,
 	TextControl,
 	Toolbar,
@@ -201,19 +202,25 @@ class ImageBlock extends Component {
 			controls,
 			isSelected && (
 				<InspectorControls key="inspector">
-					<h2>{ __( 'Image Settings' ) }</h2>
-					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) } />
-					{ ! isEmpty( availableSizes ) && (
-						<SelectControl
-							label={ __( 'Size' ) }
-							value={ url }
-							options={ map( availableSizes, ( size, name ) => ( {
-								value: size.source_url,
-								label: startCase( name ),
-							} ) ) }
-							onChange={ this.updateImageURL }
+					<PanelBody title={ __( 'Image Settings' ) }>
+						<TextControl
+							label={ __( 'Textual Alternative' ) }
+							value={ alt }
+							onChange={ this.updateAlt }
+							help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) }
 						/>
-					) }
+						{ ! isEmpty( availableSizes ) && (
+							<SelectControl
+								label={ __( 'Size' ) }
+								value={ url }
+								options={ map( availableSizes, ( size, name ) => ( {
+									value: size.source_url,
+									label: startCase( name ),
+								} ) ) }
+								onChange={ this.updateImageURL }
+							/>
+						) }
+					</PanelBody>
 				</InspectorControls>
 			),
 			<figure key="image" className={ classes } style={ figureStyle }>

--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -11,6 +11,7 @@ import { stringify } from 'querystringify';
  */
 import { Component } from '@wordpress/element';
 import {
+	PanelBody,
 	Placeholder,
 	QueryControls,
 	RangeControl,
@@ -54,31 +55,32 @@ class LatestPostsBlock extends Component {
 
 		const inspectorControls = isSelected && (
 			<InspectorControls key="inspector">
-				<h3>{ __( 'Latest Posts Settings' ) }</h3>
-				<QueryControls
-					{ ...{ order, orderBy } }
-					numberOfItems={ postsToShow }
-					categoriesList={ get( categoriesList, 'data', {} ) }
-					selectedCategoryId={ categories }
-					onOrderChange={ ( value ) => setAttributes( { order: value } ) }
-					onOrderByChange={ ( value ) => setAttributes( { orderBy: value } ) }
-					onCategoryChange={ ( value ) => setAttributes( { categories: '' !== value ? value : undefined } ) }
-					onNumberOfItemsChange={ ( value ) => setAttributes( { postsToShow: value } ) }
-				/>
-				<ToggleControl
-					label={ __( 'Display post date' ) }
-					checked={ displayPostDate }
-					onChange={ this.toggleDisplayPostDate }
-				/>
-				{ layout === 'grid' &&
-					<RangeControl
-						label={ __( 'Columns' ) }
-						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ 2 }
-						max={ ! hasPosts ? MAX_POSTS_COLUMNS : Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
+				<PanelBody title={ __( 'Latest Posts Settings' ) }>
+					<QueryControls
+						{ ...{ order, orderBy } }
+						numberOfItems={ postsToShow }
+						categoriesList={ get( categoriesList, 'data', {} ) }
+						selectedCategoryId={ categories }
+						onOrderChange={ ( value ) => setAttributes( { order: value } ) }
+						onOrderByChange={ ( value ) => setAttributes( { orderBy: value } ) }
+						onCategoryChange={ ( value ) => setAttributes( { categories: '' !== value ? value : undefined } ) }
+						onNumberOfItemsChange={ ( value ) => setAttributes( { postsToShow: value } ) }
 					/>
-				}
+					<ToggleControl
+						label={ __( 'Display post date' ) }
+						checked={ displayPostDate }
+						onChange={ this.toggleDisplayPostDate }
+					/>
+					{ layout === 'grid' &&
+						<RangeControl
+							label={ __( 'Columns' ) }
+							value={ columns }
+							onChange={ ( value ) => setAttributes( { columns: value } ) }
+							min={ 2 }
+							max={ ! hasPosts ? MAX_POSTS_COLUMNS : Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
+						/>
+					}
+				</PanelBody>
 			</InspectorControls>
 		);
 

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -7,7 +7,7 @@ import { compact } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToggleControl } from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { Component, RawHTML } from '@wordpress/element';
 
 /**
@@ -100,11 +100,13 @@ export const settings = {
 			return [
 				isSelected && (
 					<InspectorControls key="inspector">
-						<ToggleControl
-							label={ __( 'Hide the teaser before the "More" tag' ) }
-							checked={ !! noTeaser }
-							onChange={ toggleNoTeaser }
-						/>
+						<PanelBody>
+							<ToggleControl
+								label={ __( 'Hide the teaser before the "More" tag' ) }
+								checked={ !! noTeaser }
+								onChange={ toggleNoTeaser }
+							/>
+						</PanelBody>
 					</InspectorControls>
 				),
 				<div key="more-tag" className="wp-block-more">

--- a/blocks/library/paragraph/editor.scss
+++ b/blocks/library/paragraph/editor.scss
@@ -3,7 +3,9 @@
 	justify-content: space-between;
 }
 
-.blocks-font-size .blocks-range-control__slider + .dashicon {
-	width: 30px;
-	height: 30px;
+.blocks-paragraph__custom-size-slider {
+	.components-range-control__slider + .dashicon {
+		width: 30px;
+		height: 30px;
+	}
 }

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -104,6 +104,8 @@ class ParagraphBlock extends Component {
 		if ( customFontSize ) {
 			return customFontSize;
 		}
+
+		return FONT_SIZES.regular;
 	}
 
 	setFontSize( fontSizeValue ) {
@@ -186,8 +188,9 @@ class ParagraphBlock extends Component {
 							</Button>
 						</div>
 						<RangeControl
+							className="blocks-paragraph__custom-size-slider"
 							label={ __( 'Custom Size' ) }
-							value={ fontSize || '' }
+							value={ fontSize }
 							onChange={ ( value ) => this.setFontSize( value ) }
 							min={ 12 }
 							max={ 100 }
@@ -236,7 +239,7 @@ class ParagraphBlock extends Component {
 					style={ {
 						backgroundColor: backgroundColor,
 						color: textColor,
-						fontSize: fontSize ? fontSize + 'px' : undefined,
+						fontSize: fontSize !== FONT_SIZES.regular ? fontSize + 'px' : undefined,
 						textAlign: align,
 					} }
 					value={ content }

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -7,7 +7,7 @@ import { times } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RangeControl } from '@wordpress/components';
+import { PanelBody, RangeControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -73,13 +73,15 @@ export const settings = {
 			),
 			isSelected && (
 				<InspectorControls key="inspector">
-					<RangeControl
-						label={ __( 'Columns' ) }
-						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ 2 }
-						max={ 4 }
-					/>
+					<PanelBody>
+						<RangeControl
+							label={ __( 'Columns' ) }
+							value={ columns }
+							onChange={ ( value ) => setAttributes( { columns: value } ) }
+							min={ 2 }
+							max={ 4 }
+						/>
+					</PanelBody>
 				</InspectorControls>
 			),
 			<div className={ `${ className } align${ width } columns-${ columns }` } key="block">

--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,13 +11,18 @@ import { BaseControl, Button, Dashicon } from '../';
 import withInstanceId from '../higher-order/with-instance-id';
 import './style.scss';
 
-function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIcon, help, allowReset, ...props } ) {
+function RangeControl( { className, label, value, instanceId, onChange, beforeIcon, afterIcon, help, allowReset, ...props } ) {
 	const id = `inspector-range-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 
 	return (
-		<BaseControl label={ label } id={ id } help={ help } className="components-range-control">
-			{ beforeIcon && <Dashicon icon={ beforeIcon } size={ 20 } /> }
+		<BaseControl
+			label={ label }
+			id={ id }
+			help={ help }
+			className={ classnames( 'components-range-control', className ) }
+		>
+			{ beforeIcon && <Dashicon icon={ beforeIcon } /> }
 			<input
 				className="components-range-control__slider"
 				id={ id }

--- a/edit-post/components/sidebar/block-inspector-panel/style.scss
+++ b/edit-post/components/sidebar/block-inspector-panel/style.scss
@@ -10,8 +10,12 @@
 		color: $dark-gray-500;
 	}
 
-	&.editor-block-inspector__advanced {
+	&:first-child {
 		border-top: 1px solid $light-gray-500;
+		margin-top: 16px;
+	}
+
+	&:last-child {
 		margin-bottom: -16px;
 	}
 }

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -14,9 +14,7 @@
 .editor-block-inspector__card {
 	display: flex;
 	align-items: flex-start;
-	border-bottom: 1px solid $light-gray-500;
 	margin: -16px;
-	margin-bottom: 16px;
 	padding: 16px;
 }
 


### PR DESCRIPTION
## Description
Follows up #5952.

> I just noticed a possible improvement, that in my option does not block the PR. When the block has advanced controls but hasn't normal controls we show two bars:
> ![image](https://user-images.githubusercontent.com/11271197/38305196-e1c231e6-3803-11e8-9282-3df8b84b9063.png).
> The fix for this is not easy because even when normal inspector controls and advanced ones are empty, we render empty container divs, so using nth-child or first/last is not possible. We can either remove this container divs if possible. Or add classes to them with empty/not empty state and we could add the border when advanced controls with content follow normal controls with content (using + selector).

This PR also improves the default view of the `Custom Size` slider:

**Before:**
<img width="281" alt="screen shot 2018-04-05 at 07 38 47" src="https://user-images.githubusercontent.com/699132/38348819-73705ba4-38a4-11e8-9873-17b8c8c13329.png">

**After:**
<img width="282" alt="screen shot 2018-04-05 at 07 39 27" src="https://user-images.githubusercontent.com/699132/38348840-87d0609e-38a4-11e8-8ed2-7af491db724e.png">

## How Has This Been Tested?
Manually.

Checking the diff of this PR is much easier without whitespace changes: https://github.com/WordPress/gutenberg/pull/5995/files?w=1.

## Screenshots (jpeg or gifs if applicable):

**Paragraph**
 
<img width="288" alt="screen shot 2018-04-05 at 07 43 11" src="https://user-images.githubusercontent.com/699132/38348947-11289c30-38a5-11e8-98d7-6cfcceb75fdf.png">

**Latest Posts**
<img width="286" alt="screen shot 2018-04-05 at 07 44 09" src="https://user-images.githubusercontent.com/699132/38348966-2cde0320-38a5-11e8-9fbd-03cdaebedc0f.png">

**Shortcode**
<img width="291" alt="screen shot 2018-04-05 at 07 44 39" src="https://user-images.githubusercontent.com/699132/38348982-3dc9d614-38a5-11e8-9cb9-cfb263187b09.png">

**List**
<img width="287" alt="screen shot 2018-04-05 at 07 45 17" src="https://user-images.githubusercontent.com/699132/38349006-523997f6-38a5-11e8-87b9-7d8bc134f9d0.png">


## Types of changes
UI improvements.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
