### PR TITLE
Code clean-up: Rename 'reusable blocks' to 'shared blocks'

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -32,7 +32,7 @@ export {
 	getBlockTypes,
 	getBlockSupport,
 	hasBlockSupport,
-	isReusableBlock,
+	isSharedBlock,
 } from './registration';
 export {
 	isUnmodifiedDefaultBlock,

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -290,14 +290,14 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
 }
 
 /**
- * Determines whether or not the given block is a reusable block. This is a
- * special block type that is used to point to a global block stored via
- * the API.
+ * Determines whether or not the given block is a shared block. This is a
+ * special block type that is used to point to a global block stored via the
+ * API.
  *
  * @param {Object} blockOrType Block or Block Type to test.
  *
- * @return {boolean} Whether the given block is a reusable block.
+ * @return {boolean} Whether the given block is a shared block.
  */
-export function isReusableBlock( blockOrType ) {
+export function isSharedBlock( blockOrType ) {
 	return blockOrType.name === 'core/block';
 }

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -22,7 +22,7 @@ import {
 	getBlockTypes,
 	getBlockSupport,
 	hasBlockSupport,
-	isReusableBlock,
+	isSharedBlock,
 } from '../registration';
 
 describe( 'blocks', () => {
@@ -491,15 +491,15 @@ describe( 'blocks', () => {
 		} );
 	} );
 
-	describe( 'isReusableBlock', () => {
-		it( 'should return true for a reusable block', () => {
+	describe( 'isSharedBlock', () => {
+		it( 'should return true for a shared block', () => {
 			const block = { name: 'core/block' };
-			expect( isReusableBlock( block ) ).toBe( true );
+			expect( isSharedBlock( block ) ).toBe( true );
 		} );
 
 		it( 'should return false for other blocks', () => {
 			const block = { name: 'core/paragraph' };
-			expect( isReusableBlock( block ) ).toBe( false );
+			expect( isSharedBlock( block ) ).toBe( false );
 		} );
 	} );
 } );

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -16,7 +16,7 @@ import './style.scss';
  */
 const { ESCAPE } = keycodes;
 
-class ReusableBlockEditPanel extends Component {
+class SharedBlockEditPanel extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -58,22 +58,22 @@ class ReusableBlockEditPanel extends Component {
 		return (
 			<Fragment>
 				{ ( ! isEditing && ! isSaving ) && (
-					<div className="reusable-block-edit-panel">
-						<b className="reusable-block-edit-panel__info">
+					<div className="shared-block-edit-panel">
+						<b className="shared-block-edit-panel__info">
 							{ title }
 						</b>
-						<Button isLarge className="reusable-block-edit-panel__button" onClick={ onEdit }>
+						<Button isLarge className="shared-block-edit-panel__button" onClick={ onEdit }>
 							{ __( 'Edit' ) }
 						</Button>
 					</div>
 				) }
 				{ ( isEditing || isSaving ) && (
-					<form className="reusable-block-edit-panel" onSubmit={ this.handleFormSubmit }>
+					<form className="shared-block-edit-panel" onSubmit={ this.handleFormSubmit }>
 						<input
 							ref={ this.bindTitleRef }
 							type="text"
 							disabled={ isSaving }
-							className="reusable-block-edit-panel__title"
+							className="shared-block-edit-panel__title"
 							value={ title }
 							onChange={ this.handleTitleChange }
 							onKeyDown={ this.handleTitleKeyDown }
@@ -84,7 +84,7 @@ class ReusableBlockEditPanel extends Component {
 							isLarge
 							isBusy={ isSaving }
 							disabled={ ! title || isSaving }
-							className="reusable-block-edit-panel__button"
+							className="shared-block-edit-panel__button"
 							onClick={ onSave }
 						>
 							{ __( 'Save' ) }
@@ -92,7 +92,7 @@ class ReusableBlockEditPanel extends Component {
 						<Button
 							isLarge
 							disabled={ isSaving }
-							className="reusable-block-edit-panel__button"
+							className="shared-block-edit-panel__button"
 							onClick={ onCancel }
 						>
 							{ __( 'Cancel' ) }
@@ -104,4 +104,4 @@ class ReusableBlockEditPanel extends Component {
 	}
 }
 
-export default ReusableBlockEditPanel;
+export default SharedBlockEditPanel;

--- a/blocks/library/block/edit-panel/style.scss
+++ b/blocks/library/block/edit-panel/style.scss
@@ -1,4 +1,4 @@
-.reusable-block-edit-panel {
+.shared-block-edit-panel {
 	align-items: center;
 	background: $light-gray-100;
 	color: $dark-gray-500;
@@ -11,15 +11,15 @@
 	position: relative;
 	top: $block-padding;
 
-	.reusable-block-edit-panel__spinner {
+	.shared-block-edit-panel__spinner {
 		margin: 0 5px;
 	}
 
-	.reusable-block-edit-panel__info {
+	.shared-block-edit-panel__info {
 		margin-right: auto;
 	}
 
-	.reusable-block-edit-panel__title {
+	.shared-block-edit-panel__title {
 		flex-grow: 1;
 		font-size: 14px;
 		height: 30px;
@@ -28,7 +28,7 @@
 	}
 
 	// Needs specificity to override the margin-bottom set by .button
-	.wp-core-ui & .reusable-block-edit-panel__button {
+	.wp-core-ui & .shared-block-edit-panel__button {
 		margin: 0 0 0 5px;
 	}
 }

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -15,11 +15,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockEdit from '../../block-edit';
-import ReusableBlockEditPanel from './edit-panel';
-import ReusableBlockIndicator from './indicator';
+import SharedBlockEditPanel from './edit-panel';
+import SharedBlockIndicator from './indicator';
 
-class ReusableBlockEdit extends Component {
-	constructor( { reusableBlock } ) {
+class SharedBlockEdit extends Component {
+	constructor( { sharedBlock } ) {
 		super( ...arguments );
 
 		this.startEditing = this.startEditing.bind( this );
@@ -29,24 +29,24 @@ class ReusableBlockEdit extends Component {
 		this.save = this.save.bind( this );
 
 		this.state = {
-			isEditing: !! ( reusableBlock && reusableBlock.isTemporary ),
+			isEditing: !! ( sharedBlock && sharedBlock.isTemporary ),
 			title: null,
 			changedAttributes: null,
 		};
 	}
 
 	componentDidMount() {
-		if ( ! this.props.reusableBlock ) {
-			this.props.fetchReusableBlock();
+		if ( ! this.props.sharedBlock ) {
+			this.props.fetchSharedBlock();
 		}
 	}
 
 	startEditing() {
-		const { reusableBlock } = this.props;
+		const { sharedBlock } = this.props;
 
 		this.setState( {
 			isEditing: true,
-			title: reusableBlock.title,
+			title: sharedBlock.title,
 			changedAttributes: {},
 		} );
 	}
@@ -72,10 +72,10 @@ class ReusableBlockEdit extends Component {
 	}
 
 	save() {
-		const { reusableBlock, onUpdateTitle, updateAttributes, block, onSave } = this.props;
+		const { sharedBlock, onUpdateTitle, updateAttributes, block, onSave } = this.props;
 		const { title, changedAttributes } = this.state;
 
-		if ( title !== reusableBlock.title ) {
+		if ( title !== sharedBlock.title ) {
 			onUpdateTitle( title );
 		}
 
@@ -86,14 +86,14 @@ class ReusableBlockEdit extends Component {
 	}
 
 	render() {
-		const { isSelected, reusableBlock, block, isFetching, isSaving } = this.props;
+		const { isSelected, sharedBlock, block, isFetching, isSaving } = this.props;
 		const { isEditing, title, changedAttributes } = this.state;
 
-		if ( ! reusableBlock && isFetching ) {
+		if ( ! sharedBlock && isFetching ) {
 			return <Placeholder><Spinner /></Placeholder>;
 		}
 
-		if ( ! reusableBlock || ! block ) {
+		if ( ! sharedBlock || ! block ) {
 			return <Placeholder>{ __( 'Block has been deleted or is unavailable.' ) }</Placeholder>;
 		}
 
@@ -116,57 +116,57 @@ class ReusableBlockEdit extends Component {
 			<Fragment>
 				{ element }
 				{ ( isSelected || isEditing ) && (
-					<ReusableBlockEditPanel
+					<SharedBlockEditPanel
 						isEditing={ isEditing }
-						title={ title !== null ? title : reusableBlock.title }
-						isSaving={ isSaving && ! reusableBlock.isTemporary }
+						title={ title !== null ? title : sharedBlock.title }
+						isSaving={ isSaving && ! sharedBlock.isTemporary }
 						onEdit={ this.startEditing }
 						onChangeTitle={ this.setTitle }
 						onSave={ this.save }
 						onCancel={ this.stopEditing }
 					/>
 				) }
-				{ ! isSelected && ! isEditing && <ReusableBlockIndicator title={ reusableBlock.title } /> }
+				{ ! isSelected && ! isEditing && <SharedBlockIndicator title={ sharedBlock.title } /> }
 			</Fragment>
 		);
 	}
 }
 
-const EnhancedReusableBlockEdit = compose( [
+const EnhancedSharedBlockEdit = compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
-			getReusableBlock,
-			isFetchingReusableBlock,
-			isSavingReusableBlock,
+			getSharedBlock,
+			isFetchingSharedBlock,
+			isSavingSharedBlock,
 			getBlock,
 		} = select( 'core/editor' );
 		const { ref } = ownProps.attributes;
-		const reusableBlock = getReusableBlock( ref );
+		const sharedBlock = getSharedBlock( ref );
 
 		return {
-			reusableBlock,
-			isFetching: isFetchingReusableBlock( ref ),
-			isSaving: isSavingReusableBlock( ref ),
-			block: reusableBlock ? getBlock( reusableBlock.uid ) : null,
+			sharedBlock,
+			isFetching: isFetchingSharedBlock( ref ),
+			isSaving: isSavingSharedBlock( ref ),
+			block: sharedBlock ? getBlock( sharedBlock.uid ) : null,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const {
-			fetchReusableBlocks,
+			fetchSharedBlocks,
 			updateBlockAttributes,
-			updateReusableBlockTitle,
-			saveReusableBlock,
+			updateSharedBlockTitle,
+			saveSharedBlock,
 		} = dispatch( 'core/editor' );
 		const { ref } = ownProps.attributes;
 
 		return {
-			fetchReusableBlock: partial( fetchReusableBlocks, ref ),
+			fetchSharedBlock: partial( fetchSharedBlocks, ref ),
 			updateAttributes: updateBlockAttributes,
-			onUpdateTitle: partial( updateReusableBlockTitle, ref ),
-			onSave: partial( saveReusableBlock, ref ),
+			onUpdateTitle: partial( updateSharedBlockTitle, ref ),
+			onSave: partial( saveSharedBlock, ref ),
 		};
 	} ),
-] )( ReusableBlockEdit );
+] )( SharedBlockEdit );
 
 export const name = 'core/block';
 
@@ -186,6 +186,6 @@ export const settings = {
 		html: false,
 	},
 
-	edit: EnhancedReusableBlockEdit,
+	edit: EnhancedSharedBlockEdit,
 	save: () => null,
 };

--- a/blocks/library/block/index.php
+++ b/blocks/library/block/index.php
@@ -12,17 +12,17 @@
  *
  * @return string Rendered HTML of the referenced block.
  */
-function gutenberg_render_block_core_reusable_block( $attributes ) {
+function render_block_core_block( $attributes ) {
 	if ( empty( $attributes['ref'] ) ) {
 		return '';
 	}
 
-	$reusable_block = get_post( $attributes['ref'] );
-	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
+	$shared_block = get_post( $attributes['ref'] );
+	if ( ! $shared_block || 'wp_block' !== $shared_block->post_type ) {
 		return '';
 	}
 
-	$blocks = gutenberg_parse_blocks( $reusable_block->post_content );
+	$blocks = gutenberg_parse_blocks( $shared_block->post_content );
 
 	$block = array_shift( $blocks );
 	if ( ! $block ) {
@@ -39,5 +39,5 @@ register_block_type( 'core/block', array(
 		),
 	),
 
-	'render_callback' => 'gutenberg_render_block_core_reusable_block',
+	'render_callback' => 'render_block_core_block',
 ) );

--- a/blocks/library/block/indicator/index.js
+++ b/blocks/library/block/indicator/index.js
@@ -9,14 +9,14 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import './style.scss';
 
-function ReusableBlockIndicator( { title } ) {
+function SharedBlockIndicator( { title } ) {
 	return (
 		<Tooltip text={ sprintf( __( 'Shared Block: %s' ), title ) }>
-			<span className="reusable-block-indicator">
+			<span className="shared-block-indicator">
 				<Dashicon icon="controls-repeat" />
 			</span>
 		</Tooltip>
 	);
 }
 
-export default ReusableBlockIndicator;
+export default SharedBlockIndicator;

--- a/blocks/library/block/indicator/style.scss
+++ b/blocks/library/block/indicator/style.scss
@@ -1,4 +1,4 @@
-.reusable-block-indicator {
+.shared-block-indicator {
 	background: $white;
 	border-left: 1px dashed $light-gray-500;
 	color: $dark-gray-500;

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -25,7 +25,7 @@ import * as list from './list';
 import * as more from './more';
 import * as preformatted from './preformatted';
 import * as pullquote from './pullquote';
-import * as reusableBlock from './block';
+import * as sharedBlock from './block';
 import * as separator from './separator';
 import * as shortcode from './shortcode';
 import * as subhead from './subhead';
@@ -62,8 +62,8 @@ export const registerCoreBlocks = () => {
 		more,
 		preformatted,
 		pullquote,
-		reusableBlock,
 		separator,
+		sharedBlock,
 		subhead,
 		table,
 		textColumns,

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -36,7 +36,7 @@ $z-layers: (
 
 	// Should have higher index than the inset/underlay used for dragging
 	'.components-placeholder__fieldset': 1,
-	'.editor-block-list__block-edit .reusable-block-edit-panel *': 1,
+	'.editor-block-list__block-edit .shared-block-edit-panel *': 1,
 
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -22,7 +22,7 @@ import {
 	cloneBlock,
 	getBlockType,
 	getSaveElement,
-	isReusableBlock,
+	isSharedBlock,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
 import { withFilters, withContext } from '@wordpress/components';
@@ -440,7 +440,7 @@ export class BlockListBlock extends Component {
 			'is-selected': shouldAppearSelected,
 			'is-multi-selected': isMultiSelected,
 			'is-hovered': isHovered,
-			'is-reusable': isReusableBlock( blockType ),
+			'is-shared': isSharedBlock( blockType ),
 			'is-hidden': dragging,
 			'is-typing': isTypingWithinBlock,
 		} );

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -78,8 +78,8 @@
 		visibility: hidden;
 	}
 
-	.editor-block-list__block-edit .reusable-block-edit-panel * {
-		z-index: z-index( '.editor-block-list__block-edit .reusable-block-edit-panel *' );
+	.editor-block-list__block-edit .shared-block-edit-panel * {
+		z-index: z-index( '.editor-block-list__block-edit .shared-block-edit-panel *' );
 	}
 }
 
@@ -239,18 +239,18 @@
 	}
 
 	/**
-	 * Reusable Block style
+	 * Shared blocks
 	 */
 
-	&.is-reusable > .editor-block-mover:before {
+	&.is-shared > .editor-block-mover:before {
 		border-right: none;
 	}
 
-	&.is-reusable > .editor-block-settings-menu:before {
+	&.is-shared > .editor-block-settings-menu:before {
 		border-left: none;
 	}
 
-	&.is-reusable > .editor-block-list__block-edit:before {
+	&.is-shared > .editor-block-list__block-edit:before {
 		outline: 1px dashed $light-gray-500;
 	}
 

--- a/editor/components/block-preview/style.scss
+++ b/editor/components/block-preview/style.scss
@@ -28,7 +28,7 @@
 		height: auto;
 	}
 
-	> .reusable-block-indicator {
+	> .shared-block-indicator {
 		display: none;
 	}
 }

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -18,7 +18,7 @@ import BlockModeToggle from './block-mode-toggle';
 import BlockRemoveButton from './block-remove-button';
 import BlockDuplicateButton from './block-duplicate-button';
 import BlockTransformations from './block-transformations';
-import ReusableBlockSettings from './reusable-block-settings';
+import SharedBlockSettings from './shared-block-settings';
 import UnknownConverter from './unknown-converter';
 import { selectBlock } from '../../store/actions';
 
@@ -65,7 +65,7 @@ function BlockSettingsMenu( {
 						count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } role="menuitem" />,
 						<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />,
 						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } role="menuitem" />,
-						count === 1 && <ReusableBlockSettings key="reusable-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
+						count === 1 && <SharedBlockSettings key="shared-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
 						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsRole="menuitem" />,
 					] } ) }
 				</NavigableMenu>

--- a/editor/components/block-settings-menu/shared-block-settings.js
+++ b/editor/components/block-settings-menu/shared-block-settings.js
@@ -10,28 +10,28 @@ import { noop } from 'lodash';
 import { Fragment } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { isReusableBlock } from '@wordpress/blocks';
+import { isSharedBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { getBlock, getReusableBlock } from '../../store/selectors';
-import { convertBlockToStatic, convertBlockToReusable, deleteReusableBlock } from '../../store/actions';
+import { getBlock, getSharedBlock } from '../../store/selectors';
+import { convertBlockToStatic, convertBlockToShared, deleteSharedBlock } from '../../store/actions';
 
-export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onConvertToReusable, onDelete, itemsRole } ) {
+export function SharedBlockSettings( { sharedBlock, onConvertToStatic, onConvertToShared, onDelete, itemsRole } ) {
 	return (
 		<Fragment>
-			{ ! reusableBlock && (
+			{ ! sharedBlock && (
 				<IconButton
 					className="editor-block-settings-menu__control"
 					icon="controls-repeat"
-					onClick={ onConvertToReusable }
+					onClick={ onConvertToShared }
 					role={ itemsRole }
 				>
 					{ __( 'Convert to Shared Block' ) }
 				</IconButton>
 			) }
-			{ reusableBlock && (
+			{ sharedBlock && (
 				<div className="editor-block-settings-menu__section">
 					<IconButton
 						className="editor-block-settings-menu__control"
@@ -44,8 +44,8 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 					<IconButton
 						className="editor-block-settings-menu__control"
 						icon="no"
-						disabled={ reusableBlock.isTemporary }
-						onClick={ () => onDelete( reusableBlock.id ) }
+						disabled={ sharedBlock.isTemporary }
+						onClick={ () => onDelete( sharedBlock.id ) }
 						role={ itemsRole }
 					>
 						{ __( 'Delete Shared Block' ) }
@@ -60,7 +60,7 @@ export default connect(
 	( state, { uid } ) => {
 		const block = getBlock( state, uid );
 		return {
-			reusableBlock: isReusableBlock( block ) ? getReusableBlock( state, block.attributes.ref ) : null,
+			sharedBlock: isSharedBlock( block ) ? getSharedBlock( state, block.attributes.ref ) : null,
 		};
 	},
 	( dispatch, { uid, onToggle = noop } ) => ( {
@@ -68,8 +68,8 @@ export default connect(
 			dispatch( convertBlockToStatic( uid ) );
 			onToggle();
 		},
-		onConvertToReusable() {
-			dispatch( convertBlockToReusable( uid ) );
+		onConvertToShared() {
+			dispatch( convertBlockToShared( uid ) );
 			onToggle();
 		},
 		onDelete( id ) {
@@ -81,9 +81,9 @@ export default connect(
 			) );
 
 			if ( hasConfirmed ) {
-				dispatch( deleteReusableBlock( id ) );
+				dispatch( deleteSharedBlock( id ) );
 				onToggle();
 			}
 		},
 	} )
-)( ReusableBlockSettings );
+)( SharedBlockSettings );

--- a/editor/components/block-settings-menu/test/shared-block-settings.js
+++ b/editor/components/block-settings-menu/test/shared-block-settings.js
@@ -6,15 +6,15 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { ReusableBlockSettings } from '../reusable-block-settings';
+import { SharedBlockSettings } from '../shared-block-settings';
 
-describe( 'ReusableBlockSettings', () => {
-	it( 'should allow converting a static block to reusable', () => {
+describe( 'SharedBlockSettings', () => {
+	it( 'should allow converting a static block to a shared block', () => {
 		const onConvert = jest.fn();
 		const wrapper = shallow(
-			<ReusableBlockSettings
-				reusableBlock={ null }
-				onConvertToReusable={ onConvert }
+			<SharedBlockSettings
+				sharedBlock={ null }
+				onConvertToShared={ onConvert }
 			/>
 		);
 
@@ -25,11 +25,11 @@ describe( 'ReusableBlockSettings', () => {
 		expect( onConvert ).toHaveBeenCalled();
 	} );
 
-	it( 'should allow converting a reusable block to static', () => {
+	it( 'should allow converting a shared block to static', () => {
 		const onConvert = jest.fn();
 		const wrapper = shallow(
-			<ReusableBlockSettings
-				reusableBlock={ {} }
+			<SharedBlockSettings
+				sharedBlock={ {} }
 				onConvertToStatic={ onConvert }
 			/>
 		);
@@ -41,11 +41,11 @@ describe( 'ReusableBlockSettings', () => {
 		expect( onConvert ).toHaveBeenCalled();
 	} );
 
-	it( 'should allow deleting a reusable block', () => {
+	it( 'should allow deleting a shared block', () => {
 		const onDelete = jest.fn();
 		const wrapper = shallow(
-			<ReusableBlockSettings
-				reusableBlock={ { id: 123 } }
+			<SharedBlockSettings
+				sharedBlock={ { id: 123 } }
 				onDelete={ onDelete }
 			/>
 		);

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -26,7 +26,7 @@ import {
 	withSpokenMessages,
 	withContext,
 } from '@wordpress/components';
-import { getCategories, isReusableBlock } from '@wordpress/blocks';
+import { getCategories, isSharedBlock } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -36,7 +36,7 @@ import './style.scss';
 import NoBlocks from './no-blocks';
 
 import { getInserterItems, getFrecentInserterItems } from '../../store/selectors';
-import { fetchReusableBlocks } from '../../store/actions';
+import { fetchSharedBlocks } from '../../store/actions';
 import { default as InserterGroup } from './group';
 import BlockPreview from '../block-preview';
 
@@ -75,7 +75,7 @@ export class InserterMenu extends Component {
 	}
 
 	componentDidMount() {
-		this.props.fetchReusableBlocks();
+		this.props.fetchSharedBlocks();
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
@@ -330,7 +330,7 @@ export class InserterMenu extends Component {
 						{ this.renderCategories( this.getVisibleItemsByCategory( items ) ) }
 					</div>
 				}
-				{ selectedItem && isReusableBlock( selectedItem ) &&
+				{ selectedItem && isSharedBlock( selectedItem ) &&
 					<BlockPreview name={ selectedItem.name } attributes={ selectedItem.initialAttributes } />
 				}
 			</TabbableContainer>
@@ -354,7 +354,7 @@ export default compose(
 				frecentItems: getFrecentInserterItems( state, ownProps.enabledBlockTypes ),
 			};
 		},
-		{ fetchReusableBlocks }
+		{ fetchSharedBlocks }
 	),
 	withSpokenMessages,
 	withInstanceId

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -64,11 +64,11 @@ const textEmbedItem = {
 	isDisabled: false,
 };
 
-const reusableItem = {
+const sharedItem = {
 	id: 'core/block/123',
 	name: 'core/block',
 	initialAttributes: { ref: 123 },
-	title: 'My reusable block',
+	title: 'My shared block',
 	category: 'shared',
 	isDisabled: false,
 };
@@ -80,7 +80,7 @@ const items = [
 	moreItem,
 	youtubeItem,
 	textEmbedItem,
-	reusableItem,
+	sharedItem,
 ];
 
 describe( 'InserterMenu', () => {
@@ -96,7 +96,7 @@ describe( 'InserterMenu', () => {
 				items={ [] }
 				frecentItems={ [] }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 				blockTypes
 			/>
 		);
@@ -116,7 +116,7 @@ describe( 'InserterMenu', () => {
 				items={ [] }
 				frecentItems={ [] }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 			/>
 		);
 
@@ -132,7 +132,7 @@ describe( 'InserterMenu', () => {
 				items={ items }
 				frecentItems={ [ advancedTextItem, textItem, someOtherItem ] }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 			/>
 		);
 
@@ -151,7 +151,7 @@ describe( 'InserterMenu', () => {
 				items={ items }
 				frecentItems={ [] }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 			/>
 		);
 		const embedTab = wrapper.find( '.editor-inserter__tab' )
@@ -167,7 +167,7 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'A Text Embed' );
 	} );
 
-	it( 'should show reusable items in the shared tab', () => {
+	it( 'should show shared items in the shared tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
@@ -175,7 +175,7 @@ describe( 'InserterMenu', () => {
 				items={ items }
 				frecentItems={ [] }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 			/>
 		);
 		const embedTab = wrapper.find( '.editor-inserter__tab' )
@@ -187,10 +187,10 @@ describe( 'InserterMenu', () => {
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
 		expect( visibleBlocks ).toHaveLength( 1 );
-		expect( visibleBlocks.at( 0 ).text() ).toBe( 'My reusable block' );
+		expect( visibleBlocks.at( 0 ).text() ).toBe( 'My shared block' );
 	} );
 
-	it( 'should show all items except embeds and reusable blocks in the blocks tab', () => {
+	it( 'should show all items except embeds and shared blocks in the blocks tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
@@ -198,7 +198,7 @@ describe( 'InserterMenu', () => {
 				items={ items }
 				frecentItems={ [] }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 			/>
 		);
 		const blocksTab = wrapper.find( '.editor-inserter__tab' )
@@ -224,7 +224,7 @@ describe( 'InserterMenu', () => {
 				items={ items }
 				frecentItems={ items }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 			/>
 		);
 
@@ -241,7 +241,7 @@ describe( 'InserterMenu', () => {
 				items={ items }
 				frecentItems={ [] }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 			/>
 		);
 		wrapper.setState( { filterValue: 'text' } );
@@ -264,7 +264,7 @@ describe( 'InserterMenu', () => {
 				items={ items }
 				frecentItems={ [] }
 				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
+				fetchSharedBlocks={ noop }
 			/>
 		);
 		wrapper.setState( { filterValue: ' text' } );

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -515,86 +515,86 @@ export const createErrorNotice = partial( createNotice, 'error' );
 export const createWarningNotice = partial( createNotice, 'warning' );
 
 /**
- * Returns an action object used to fetch a single reusable block or all
- * reusable blocks from the REST API into the store.
+ * Returns an action object used to fetch a single shared block or all shared
+ * blocks from the REST API into the store.
  *
- * @param {?string} id If given, only a single reusable block with this ID will
+ * @param {?string} id If given, only a single shared block with this ID will
  *                     be fetched.
  *
  * @return {Object} Action object.
  */
-export function fetchReusableBlocks( id ) {
+export function fetchSharedBlocks( id ) {
 	return {
-		type: 'FETCH_REUSABLE_BLOCKS',
+		type: 'FETCH_SHARED_BLOCKS',
 		id,
 	};
 }
 
 /**
- * Returns an action object used in signalling that reusable blocks have been
- * received. Results is an array of objects containing reusableBlock (details
- * about reusable persistence) and parsedBlock (the original block).
+ * Returns an action object used in signalling that shared blocks have been
+ * received. `results` is an array of objects containing:
+ *  - `sharedBlock` - Details about how the shared block is persisted.
+ *  - `parsedBlock` - The original block.
  *
- * @param {Object[]} results Reusable blocks received.
+ * @param {Object[]} results Shared blocks received.
  *
  * @return {Object} Action object.
  */
-export function receiveReusableBlocks( results ) {
+export function receiveSharedBlocks( results ) {
 	return {
-		type: 'RECEIVE_REUSABLE_BLOCKS',
+		type: 'RECEIVE_SHARED_BLOCKS',
 		results,
 	};
 }
 
 /**
- * Returns an action object used to save a reusable block that's in the store
- * to the REST API.
+ * Returns an action object used to save a shared block that's in the store to
+ * the REST API.
  *
- * @param {Object} id The ID of the reusable block to save.
+ * @param {Object} id The ID of the shared block to save.
  *
  * @return {Object} Action object.
  */
-export function saveReusableBlock( id ) {
+export function saveSharedBlock( id ) {
 	return {
-		type: 'SAVE_REUSABLE_BLOCK',
+		type: 'SAVE_SHARED_BLOCK',
 		id,
 	};
 }
 
 /**
- * Returns an action object used to delete a reusable block via the REST API.
+ * Returns an action object used to delete a shared block via the REST API.
  *
- * @param {number} id The ID of the reusable block to delete.
+ * @param {number} id The ID of the shared block to delete.
  *
  * @return {Object} Action object.
  */
-export function deleteReusableBlock( id ) {
+export function deleteSharedBlock( id ) {
 	return {
-		type: 'DELETE_REUSABLE_BLOCK',
+		type: 'DELETE_SHARED_BLOCK',
 		id,
 	};
 }
 
 /**
- * Returns an action object used in signalling that a reusable block's title is
+ * Returns an action object used in signalling that a shared block's title is
  * to be updated.
  *
- * @param {number} id    The ID of the reusable block to update.
+ * @param {number} id    The ID of the shared block to update.
  * @param {string} title The new title.
  *
  * @return {Object} Action object.
  */
-export function updateReusableBlockTitle( id, title ) {
+export function updateSharedBlockTitle( id, title ) {
 	return {
-		type: 'UPDATE_REUSABLE_BLOCK_TITLE',
+		type: 'UPDATE_SHARED_BLOCK_TITLE',
 		id,
 		title,
 	};
 }
 
 /**
- * Returns an action object used to convert a reusable block into a static
- * block.
+ * Returns an action object used to convert a shared block into a static block.
  *
  * @param {Object} uid The ID of the block to attach.
  *
@@ -608,16 +608,15 @@ export function convertBlockToStatic( uid ) {
 }
 
 /**
- * Returns an action object used to convert a static block into a reusable
- * block.
+ * Returns an action object used to convert a static block into a shared block.
  *
  * @param {Object} uid The ID of the block to detach.
  *
  * @return {Object} Action object.
  */
-export function convertBlockToReusable( uid ) {
+export function convertBlockToShared( uid ) {
 	return {
-		type: 'CONVERT_BLOCK_TO_REUSABLE',
+		type: 'CONVERT_BLOCK_TO_SHARED',
 		uid,
 	};
 }

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -23,7 +23,7 @@ import {
 /**
  * WordPress dependencies
  */
-import { isReusableBlock } from '@wordpress/blocks';
+import { isSharedBlock } from '@wordpress/blocks';
 import { combineReducers } from '@wordpress/data';
 
 /**
@@ -369,10 +369,10 @@ export const editor = flow( [
 			case 'REMOVE_BLOCKS':
 				return omit( state, action.uids );
 
-			case 'SAVE_REUSABLE_BLOCK_SUCCESS': {
+			case 'SAVE_SHARED_BLOCK_SUCCESS': {
 				const { id, updatedId } = action;
 
-				// If a temporary reusable block is saved, we swap the temporary id with the final one
+				// If a temporary shared block is saved, we swap the temporary id with the final one
 				if ( id === updatedId ) {
 					return state;
 				}
@@ -712,7 +712,7 @@ export function provisionalBlockUID( state = null, action ) {
 
 		case 'UPDATE_BLOCK_ATTRIBUTES':
 		case 'UPDATE_BLOCK':
-		case 'CONVERT_BLOCK_TO_REUSABLE':
+		case 'CONVERT_BLOCK_TO_SHARED':
 			const { uid } = action;
 			if ( uid === state ) {
 				return null;
@@ -808,7 +808,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 			return action.blocks.reduce( ( prevState, block ) => {
 				let id = block.name;
 				const insert = { name: block.name };
-				if ( isReusableBlock( block ) ) {
+				if ( isSharedBlock( block ) ) {
 					insert.ref = block.attributes.ref;
 					id += '/' + block.attributes.ref;
 				}
@@ -826,7 +826,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 				};
 			}, state );
 
-		case 'REMOVE_REUSABLE_BLOCK':
+		case 'REMOVE_SHARED_BLOCK':
 			return {
 				...state,
 				insertUsage: omitBy( state.insertUsage, ( { insert } ) => insert.ref === action.id ),
@@ -896,12 +896,12 @@ export function notices( state = [], action ) {
 	return state;
 }
 
-export const reusableBlocks = combineReducers( {
+export const sharedBlocks = combineReducers( {
 	data( state = {}, action ) {
 		switch ( action.type ) {
-			case 'RECEIVE_REUSABLE_BLOCKS': {
+			case 'RECEIVE_SHARED_BLOCKS': {
 				return reduce( action.results, ( nextState, result ) => {
-					const { id, title } = result.reusableBlock;
+					const { id, title } = result.sharedBlock;
 					const { uid } = result.parsedBlock;
 
 					const value = { uid, title };
@@ -918,7 +918,7 @@ export const reusableBlocks = combineReducers( {
 				}, state );
 			}
 
-			case 'UPDATE_REUSABLE_BLOCK_TITLE': {
+			case 'UPDATE_SHARED_BLOCK_TITLE': {
 				const { id, title } = action;
 
 				if ( ! state[ id ] || state[ id ].title === title ) {
@@ -934,10 +934,10 @@ export const reusableBlocks = combineReducers( {
 				};
 			}
 
-			case 'SAVE_REUSABLE_BLOCK_SUCCESS': {
+			case 'SAVE_SHARED_BLOCK_SUCCESS': {
 				const { id, updatedId } = action;
 
-				// If a temporary reusable block is saved, we swap the temporary id with the final one
+				// If a temporary shared block is saved, we swap the temporary id with the final one
 				if ( id === updatedId ) {
 					return state;
 				}
@@ -949,7 +949,7 @@ export const reusableBlocks = combineReducers( {
 				};
 			}
 
-			case 'REMOVE_REUSABLE_BLOCK': {
+			case 'REMOVE_SHARED_BLOCK': {
 				const { id } = action;
 				return omit( state, id );
 			}
@@ -960,7 +960,7 @@ export const reusableBlocks = combineReducers( {
 
 	isFetching( state = {}, action ) {
 		switch ( action.type ) {
-			case 'FETCH_REUSABLE_BLOCKS': {
+			case 'FETCH_SHARED_BLOCKS': {
 				const { id } = action;
 				if ( ! id ) {
 					return state;
@@ -972,8 +972,8 @@ export const reusableBlocks = combineReducers( {
 				};
 			}
 
-			case 'FETCH_REUSABLE_BLOCKS_SUCCESS':
-			case 'FETCH_REUSABLE_BLOCKS_FAILURE': {
+			case 'FETCH_SHARED_BLOCKS_SUCCESS':
+			case 'FETCH_SHARED_BLOCKS_FAILURE': {
 				const { id } = action;
 				return omit( state, id );
 			}
@@ -984,14 +984,14 @@ export const reusableBlocks = combineReducers( {
 
 	isSaving( state = {}, action ) {
 		switch ( action.type ) {
-			case 'SAVE_REUSABLE_BLOCK':
+			case 'SAVE_SHARED_BLOCK':
 				return {
 					...state,
 					[ action.id ]: true,
 				};
 
-			case 'SAVE_REUSABLE_BLOCK_SUCCESS':
-			case 'SAVE_REUSABLE_BLOCK_FAILURE': {
+			case 'SAVE_SHARED_BLOCK_SUCCESS':
+			case 'SAVE_SHARED_BLOCK_FAILURE': {
 				const { id } = action;
 				return omit( state, id );
 			}
@@ -1012,6 +1012,6 @@ export default optimist( combineReducers( {
 	preferences,
 	saving,
 	notices,
-	reusableBlocks,
+	sharedBlocks,
 	template,
 } ) );

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1165,7 +1165,7 @@ export function getNotices( state ) {
 
 /**
  * An item that appears in the inserter. Inserting this item will create a new
- * block. Inserter items encapsulate both regular blocks and reusable blocks.
+ * block. Inserter items encapsulate both regular blocks and shared blocks.
  *
  * @typedef {Object} Editor.InserterItem
  * @property {string}   id                Unique identifier for the item.
@@ -1214,16 +1214,16 @@ function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
 }
 
 /**
- * Given a reusable block, constructs an item that appears in the inserter.
+ * Given a shared block, constructs an item that appears in the inserter.
  *
  * @param {Object}           state             Global application state.
  * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
- * @param {Object}           reusableBlock     Reusable block, likely from getReusableBlock().
+ * @param {Object}           sharedBlock       Shared block, likely from getSharedBlock().
  *
  * @return {Editor.InserterItem} Item that appears in inserter.
  */
-function buildInserterItemFromReusableBlock( state, enabledBlockTypes, reusableBlock ) {
-	if ( ! enabledBlockTypes || ! reusableBlock ) {
+function buildInserterItemFromSharedBlock( state, enabledBlockTypes, sharedBlock ) {
+	if ( ! enabledBlockTypes || ! sharedBlock ) {
 		return null;
 	}
 
@@ -1232,7 +1232,7 @@ function buildInserterItemFromReusableBlock( state, enabledBlockTypes, reusableB
 		return null;
 	}
 
-	const referencedBlock = getBlock( state, reusableBlock.uid );
+	const referencedBlock = getBlock( state, sharedBlock.uid );
 	if ( ! referencedBlock ) {
 		return null;
 	}
@@ -1243,10 +1243,10 @@ function buildInserterItemFromReusableBlock( state, enabledBlockTypes, reusableB
 	}
 
 	return {
-		id: `core/block/${ reusableBlock.id }`,
+		id: `core/block/${ sharedBlock.id }`,
 		name: 'core/block',
-		initialAttributes: { ref: reusableBlock.id },
-		title: reusableBlock.title,
+		initialAttributes: { ref: sharedBlock.id },
+		title: sharedBlock.title,
 		icon: referencedBlockType.icon,
 		category: 'shared',
 		keywords: [],
@@ -1256,7 +1256,7 @@ function buildInserterItemFromReusableBlock( state, enabledBlockTypes, reusableB
 
 /**
  * Determines the items that appear in the the inserter. Includes both static
- * items (e.g. a regular block type) and dynamic items (e.g. a reusable block).
+ * items (e.g. a regular block type) and dynamic items (e.g. a shared block).
  *
  * @param {Object}           state             Global application state.
  * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
@@ -1272,8 +1272,8 @@ export function getInserterItems( state, enabledBlockTypes = true ) {
 		buildInserterItemFromBlockType( state, enabledBlockTypes, blockType )
 	);
 
-	const dynamicItems = getReusableBlocks( state ).map( reusableBlock =>
-		buildInserterItemFromReusableBlock( state, enabledBlockTypes, reusableBlock )
+	const dynamicItems = getSharedBlocks( state ).map( sharedBlock =>
+		buildInserterItemFromSharedBlock( state, enabledBlockTypes, sharedBlock )
 	);
 
 	const items = [ ...staticItems, ...dynamicItems ];
@@ -1300,8 +1300,8 @@ function getItemsFromInserts( state, inserts, enabledBlockTypes = true, maximum 
 
 	const items = fillWithCommonBlocks( inserts ).map( insert => {
 		if ( insert.ref ) {
-			const reusableBlock = getReusableBlock( state, insert.ref );
-			return buildInserterItemFromReusableBlock( state, enabledBlockTypes, reusableBlock );
+			const sharedBlock = getSharedBlock( state, insert.ref );
+			return buildInserterItemFromSharedBlock( state, enabledBlockTypes, sharedBlock );
 		}
 
 		const blockType = getBlockType( insert.name );
@@ -1350,16 +1350,16 @@ export function getFrecentInserterItems( state, enabledBlockTypes = true, maximu
 }
 
 /**
- * Returns the reusable block with the given ID.
+ * Returns the shared block with the given ID.
  *
  * @param {Object}        state Global application state.
- * @param {number|string} ref   The reusable block's ID.
+ * @param {number|string} ref   The shared block's ID.
  *
- * @return {Object} The reusable block, or null if none exists.
+ * @return {Object} The shared block, or null if none exists.
  */
-export const getReusableBlock = createSelector(
+export const getSharedBlock = createSelector(
 	( state, ref ) => {
-		const block = state.reusableBlocks.data[ ref ];
+		const block = state.sharedBlocks.data[ ref ];
 		if ( ! block ) {
 			return null;
 		}
@@ -1373,44 +1373,44 @@ export const getReusableBlock = createSelector(
 		};
 	},
 	( state, ref ) => [
-		state.reusableBlocks.data[ ref ],
+		state.sharedBlocks.data[ ref ],
 	],
 );
 
 /**
- * Returns whether or not the reusable block with the given ID is being saved.
+ * Returns whether or not the shared block with the given ID is being saved.
  *
  * @param {Object} state Global application state.
- * @param {string} ref   The reusable block's ID.
+ * @param {string} ref   The shared block's ID.
  *
- * @return {boolean} Whether or not the reusable block is being saved.
+ * @return {boolean} Whether or not the shared block is being saved.
  */
-export function isSavingReusableBlock( state, ref ) {
-	return state.reusableBlocks.isSaving[ ref ] || false;
+export function isSavingSharedBlock( state, ref ) {
+	return state.sharedBlocks.isSaving[ ref ] || false;
 }
 
 /**
- * Returns true if the reusable block with the given ID is being fetched, or
+ * Returns true if the shared block with the given ID is being fetched, or
  * false otherwise.
  *
  * @param {Object} state Global application state.
- * @param {string} ref   The reusable block's ID.
+ * @param {string} ref   The shared block's ID.
  *
- * @return {boolean} Whether the reusable block is being fetched.
+ * @return {boolean} Whether the shared block is being fetched.
  */
-export function isFetchingReusableBlock( state, ref ) {
-	return !! state.reusableBlocks.isFetching[ ref ];
+export function isFetchingSharedBlock( state, ref ) {
+	return !! state.sharedBlocks.isFetching[ ref ];
 }
 
 /**
- * Returns an array of all reusable blocks.
+ * Returns an array of all shared blocks.
  *
  * @param {Object} state Global application state.
  *
- * @return {Array} An array of all reusable blocks.
+ * @return {Array} An array of all shared blocks.
  */
-export function getReusableBlocks( state ) {
-	return map( state.reusableBlocks.data, ( value, ref ) => getReusableBlock( state, ref ) );
+export function getSharedBlocks( state ) {
+	return map( state.sharedBlocks.data, ( value, ref ) => getSharedBlock( state, ref ) );
 }
 
 /**

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -5,11 +5,11 @@ import {
 	replaceBlocks,
 	startTyping,
 	stopTyping,
-	fetchReusableBlocks,
-	saveReusableBlock,
-	deleteReusableBlock,
+	fetchSharedBlocks,
+	saveSharedBlock,
+	deleteSharedBlock,
 	convertBlockToStatic,
-	convertBlockToReusable,
+	convertBlockToShared,
 	toggleSelection,
 	setupEditor,
 	resetPost,
@@ -460,34 +460,34 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'fetchReusableBlocks', () => {
-		it( 'should return the FETCH_REUSABLE_BLOCKS action', () => {
-			expect( fetchReusableBlocks() ).toEqual( {
-				type: 'FETCH_REUSABLE_BLOCKS',
+	describe( 'fetchSharedBlocks', () => {
+		it( 'should return the FETCH_SHARED_BLOCKS action', () => {
+			expect( fetchSharedBlocks() ).toEqual( {
+				type: 'FETCH_SHARED_BLOCKS',
 			} );
 		} );
 
 		it( 'should take an optional id argument', () => {
 			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
-			expect( fetchReusableBlocks( id ) ).toEqual( {
-				type: 'FETCH_REUSABLE_BLOCKS',
+			expect( fetchSharedBlocks( id ) ).toEqual( {
+				type: 'FETCH_SHARED_BLOCKS',
 				id,
 			} );
 		} );
 	} );
 
-	describe( 'saveReusableBlock', () => {
+	describe( 'saveSharedBlock', () => {
 		const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
-		expect( saveReusableBlock( id ) ).toEqual( {
-			type: 'SAVE_REUSABLE_BLOCK',
+		expect( saveSharedBlock( id ) ).toEqual( {
+			type: 'SAVE_SHARED_BLOCK',
 			id,
 		} );
 	} );
 
-	describe( 'deleteReusableBlock', () => {
+	describe( 'deleteSharedBlock', () => {
 		const id = 123;
-		expect( deleteReusableBlock( id ) ).toEqual( {
-			type: 'DELETE_REUSABLE_BLOCK',
+		expect( deleteSharedBlock( id ) ).toEqual( {
+			type: 'DELETE_SHARED_BLOCK',
 			id,
 		} );
 	} );
@@ -500,10 +500,10 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'convertBlockToReusable', () => {
+	describe( 'convertBlockToShared', () => {
 		const uid = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
-		expect( convertBlockToReusable( uid ) ).toEqual( {
-			type: 'CONVERT_BLOCK_TO_REUSABLE',
+		expect( convertBlockToShared( uid ) ).toEqual( {
+			type: 'CONVERT_BLOCK_TO_SHARED',
 			uid,
 		} );
 	} );

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -24,15 +24,15 @@ import {
 	selectBlock,
 	removeBlock,
 	createErrorNotice,
-	fetchReusableBlocks,
-	receiveReusableBlocks,
+	fetchSharedBlocks,
+	receiveSharedBlocks,
 	receiveBlocks,
-	saveReusableBlock,
-	deleteReusableBlock,
+	saveSharedBlock,
+	deleteSharedBlock,
 	removeBlocks,
 	resetBlocks,
 	convertBlockToStatic,
-	convertBlockToReusable,
+	convertBlockToShared,
 	setTemplateValidity,
 } from '../actions';
 import effects, {
@@ -570,7 +570,7 @@ describe( 'effects', () => {
 		} );
 	} );
 
-	describe( 'reusable block effects', () => {
+	describe( 'shared block effects', () => {
 		beforeAll( () => {
 			registerBlockType( 'core/test-block', {
 				title: 'Test block',
@@ -581,7 +581,7 @@ describe( 'effects', () => {
 				},
 			} );
 			registerBlockType( 'core/block', {
-				title: 'Reusable Block',
+				title: 'Shared Block',
 				category: 'common',
 				save: () => null,
 				attributes: {
@@ -595,10 +595,10 @@ describe( 'effects', () => {
 			unregisterBlockType( 'core/block' );
 		} );
 
-		describe( '.FETCH_REUSABLE_BLOCKS', () => {
-			const handler = effects.FETCH_REUSABLE_BLOCKS;
+		describe( '.FETCH_SHARED_BLOCKS', () => {
+			const handler = effects.FETCH_SHARED_BLOCKS;
 
-			it( 'should fetch multiple reusable blocks', () => {
+			it( 'should fetch multiple shared blocks', () => {
 				const promise = Promise.resolve( [
 					{
 						id: 123,
@@ -613,13 +613,13 @@ describe( 'effects', () => {
 				const dispatch = jest.fn();
 				const store = { getState: noop, dispatch };
 
-				handler( fetchReusableBlocks(), store );
+				handler( fetchSharedBlocks(), store );
 
 				return promise.then( () => {
 					expect( dispatch ).toHaveBeenCalledWith(
-						receiveReusableBlocks( [
+						receiveSharedBlocks( [
 							{
-								reusableBlock: {
+								sharedBlock: {
 									id: 123,
 									title: 'My cool block',
 									content: '<!-- wp:test-block {"name":"Big Bird"} /-->',
@@ -632,13 +632,13 @@ describe( 'effects', () => {
 						] )
 					);
 					expect( dispatch ).toHaveBeenCalledWith( {
-						type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
+						type: 'FETCH_SHARED_BLOCKS_SUCCESS',
 						id: undefined,
 					} );
 				} );
 			} );
 
-			it( 'should fetch a single reusable block', () => {
+			it( 'should fetch a single shared block', () => {
 				const promise = Promise.resolve( {
 					id: 123,
 					title: 'My cool block',
@@ -651,13 +651,13 @@ describe( 'effects', () => {
 				const dispatch = jest.fn();
 				const store = { getState: noop, dispatch };
 
-				handler( fetchReusableBlocks( 123 ), store );
+				handler( fetchSharedBlocks( 123 ), store );
 
 				return promise.then( () => {
 					expect( dispatch ).toHaveBeenCalledWith(
-						receiveReusableBlocks( [
+						receiveSharedBlocks( [
 							{
-								reusableBlock: {
+								sharedBlock: {
 									id: 123,
 									title: 'My cool block',
 									content: '<!-- wp:test-block {"name":"Big Bird"} /-->',
@@ -670,7 +670,7 @@ describe( 'effects', () => {
 						] )
 					);
 					expect( dispatch ).toHaveBeenCalledWith( {
-						type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
+						type: 'FETCH_SHARED_BLOCKS_SUCCESS',
 						id: 123,
 					} );
 				} );
@@ -685,11 +685,11 @@ describe( 'effects', () => {
 				const dispatch = jest.fn();
 				const store = { getState: noop, dispatch };
 
-				handler( fetchReusableBlocks(), store );
+				handler( fetchSharedBlocks(), store );
 
 				return promise.catch( () => {
 					expect( dispatch ).toHaveBeenCalledWith( {
-						type: 'FETCH_REUSABLE_BLOCKS_FAILURE',
+						type: 'FETCH_SHARED_BLOCKS_FAILURE',
 						error: {
 							code: 'unknown_error',
 							message: 'An unknown error occurred.',
@@ -699,11 +699,11 @@ describe( 'effects', () => {
 			} );
 		} );
 
-		describe( '.RECEIVE_REUSABLE_BLOCKS', () => {
-			const handler = effects.RECEIVE_REUSABLE_BLOCKS;
+		describe( '.RECEIVE_SHARED_BLOCKS', () => {
+			const handler = effects.RECEIVE_SHARED_BLOCKS;
 
 			it( 'should receive parsed blocks', () => {
-				const action = receiveReusableBlocks( [
+				const action = receiveSharedBlocks( [
 					{
 						parsedBlock: { uid: 'broccoli' },
 					},
@@ -715,10 +715,10 @@ describe( 'effects', () => {
 			} );
 		} );
 
-		describe( '.SAVE_REUSABLE_BLOCK', () => {
-			const handler = effects.SAVE_REUSABLE_BLOCK;
+		describe( '.SAVE_SHARED_BLOCK', () => {
+			const handler = effects.SAVE_SHARED_BLOCK;
 
-			it( 'should save a reusable block and swap its id', () => {
+			it( 'should save a shared block and swap its id', () => {
 				let modelAttributes;
 				const promise = Promise.resolve( { id: 456 } );
 
@@ -728,18 +728,18 @@ describe( 'effects', () => {
 					return promise;
 				} );
 
-				const reusableBlock = { id: 123, title: 'My cool block' };
+				const sharedBlock = { id: 123, title: 'My cool block' };
 				const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 				const state = reduce( [
-					receiveReusableBlocks( [ { reusableBlock, parsedBlock } ] ),
+					receiveSharedBlocks( [ { sharedBlock, parsedBlock } ] ),
 					receiveBlocks( [ parsedBlock ] ),
 				], reducer, undefined );
 
 				const dispatch = jest.fn();
 				const store = { getState: () => state, dispatch };
 
-				handler( saveReusableBlock( 123 ), store );
+				handler( saveSharedBlock( 123 ), store );
 
 				expect( modelAttributes ).toEqual( {
 					id: 123,
@@ -749,7 +749,7 @@ describe( 'effects', () => {
 
 				return promise.then( () => {
 					expect( dispatch ).toHaveBeenCalledWith( {
-						type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
+						type: 'SAVE_SHARED_BLOCK_SUCCESS',
 						id: 123,
 						updatedId: 456,
 					} );
@@ -762,54 +762,54 @@ describe( 'effects', () => {
 				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
 				set( global, 'wp.apiRequest', () => promise );
 
-				const reusableBlock = { id: 123, title: 'My cool block' };
+				const sharedBlock = { id: 123, title: 'My cool block' };
 				const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 				const state = reduce( [
-					receiveReusableBlocks( [ { reusableBlock, parsedBlock } ] ),
+					receiveSharedBlocks( [ { sharedBlock, parsedBlock } ] ),
 					receiveBlocks( [ parsedBlock ] ),
 				], reducer, undefined );
 
 				const dispatch = jest.fn();
 				const store = { getState: () => state, dispatch };
 
-				handler( saveReusableBlock( 123 ), store );
+				handler( saveSharedBlock( 123 ), store );
 
 				return promise.catch( () => {
 					expect( dispatch ).toHaveBeenCalledWith( {
-						type: 'SAVE_REUSABLE_BLOCK_FAILURE',
+						type: 'SAVE_SHARED_BLOCK_FAILURE',
 						id: 123,
 					} );
 				} );
 			} );
 		} );
 
-		describe( '.DELETE_REUSABLE_BLOCK', () => {
-			const handler = effects.DELETE_REUSABLE_BLOCK;
+		describe( '.DELETE_SHARED_BLOCK', () => {
+			const handler = effects.DELETE_SHARED_BLOCK;
 
-			it( 'should delete a reusable block', () => {
+			it( 'should delete a shared block', () => {
 				const promise = Promise.resolve( {} );
 
 				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
 				set( global, 'wp.apiRequest', () => promise );
 
 				const associatedBlock = createBlock( 'core/block', { ref: 123 } );
-				const reusableBlock = { id: 123, title: 'My cool block' };
+				const sharedBlock = { id: 123, title: 'My cool block' };
 				const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 				const state = reduce( [
 					resetBlocks( [ associatedBlock ] ),
-					receiveReusableBlocks( [ { reusableBlock, parsedBlock } ] ),
+					receiveSharedBlocks( [ { sharedBlock, parsedBlock } ] ),
 					receiveBlocks( [ parsedBlock ] ),
 				], reducer, undefined );
 
 				const dispatch = jest.fn();
 				const store = { getState: () => state, dispatch };
 
-				handler( deleteReusableBlock( 123 ), store );
+				handler( deleteSharedBlock( 123 ), store );
 
 				expect( dispatch ).toHaveBeenCalledWith( {
-					type: 'REMOVE_REUSABLE_BLOCK',
+					type: 'REMOVE_SHARED_BLOCK',
 					id: 123,
 					optimist: expect.any( Object ),
 				} );
@@ -820,7 +820,7 @@ describe( 'effects', () => {
 
 				return promise.then( () => {
 					expect( dispatch ).toHaveBeenCalledWith( {
-						type: 'DELETE_REUSABLE_BLOCK_SUCCESS',
+						type: 'DELETE_SHARED_BLOCK_SUCCESS',
 						id: 123,
 						optimist: expect.any( Object ),
 					} );
@@ -833,41 +833,41 @@ describe( 'effects', () => {
 				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
 				set( global, 'wp.apiRequest', () => promise );
 
-				const reusableBlock = { id: 123, title: 'My cool block' };
+				const sharedBlock = { id: 123, title: 'My cool block' };
 				const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 				const state = reduce( [
-					receiveReusableBlocks( [ { reusableBlock, parsedBlock } ] ),
+					receiveSharedBlocks( [ { sharedBlock, parsedBlock } ] ),
 					receiveBlocks( [ parsedBlock ] ),
 				], reducer, undefined );
 
 				const dispatch = jest.fn();
 				const store = { getState: () => state, dispatch };
 
-				handler( deleteReusableBlock( 123 ), store );
+				handler( deleteSharedBlock( 123 ), store );
 
 				return promise.catch( () => {
 					expect( dispatch ).toHaveBeenCalledWith( {
-						type: 'DELETE_REUSABLE_BLOCK_FAILURE',
+						type: 'DELETE_SHARED_BLOCK_FAILURE',
 						id: 123,
 						optimist: expect.any( Object ),
 					} );
 				} );
 			} );
 
-			it( 'should not save reusable blocks with temporary IDs', () => {
-				const reusableBlock = { id: 'reusable1', title: 'My cool block' };
+			it( 'should not save shared blocks with temporary IDs', () => {
+				const sharedBlock = { id: 'shared1', title: 'My cool block' };
 				const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 				const state = reduce( [
-					receiveReusableBlocks( [ { reusableBlock, parsedBlock } ] ),
+					receiveSharedBlocks( [ { sharedBlock, parsedBlock } ] ),
 					receiveBlocks( [ parsedBlock ] ),
 				], reducer, undefined );
 
 				const dispatch = jest.fn();
 				const store = { getState: () => state, dispatch };
 
-				handler( deleteReusableBlock( 'reusable1' ), store );
+				handler( deleteSharedBlock( 'shared1' ), store );
 
 				expect( dispatch ).not.toHaveBeenCalled();
 			} );
@@ -876,14 +876,14 @@ describe( 'effects', () => {
 		describe( '.CONVERT_BLOCK_TO_STATIC', () => {
 			const handler = effects.CONVERT_BLOCK_TO_STATIC;
 
-			it( 'should convert a reusable block into a static block', () => {
+			it( 'should convert a shared block into a static block', () => {
 				const associatedBlock = createBlock( 'core/block', { ref: 123 } );
-				const reusableBlock = { id: 123, title: 'My cool block' };
+				const sharedBlock = { id: 123, title: 'My cool block' };
 				const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 				const state = reduce( [
 					resetBlocks( [ associatedBlock ] ),
-					receiveReusableBlocks( [ { reusableBlock, parsedBlock } ] ),
+					receiveSharedBlocks( [ { sharedBlock, parsedBlock } ] ),
 					receiveBlocks( [ parsedBlock ] ),
 				], reducer, undefined );
 
@@ -906,22 +906,22 @@ describe( 'effects', () => {
 			} );
 		} );
 
-		describe( '.CONVERT_BLOCK_TO_REUSABLE', () => {
-			const handler = effects.CONVERT_BLOCK_TO_REUSABLE;
+		describe( '.CONVERT_BLOCK_TO_SHARED', () => {
+			const handler = effects.CONVERT_BLOCK_TO_SHARED;
 
-			it( 'should convert a static block into a reusable block', () => {
+			it( 'should convert a static block into a shared block', () => {
 				const staticBlock = createBlock( 'core/block', { ref: 123 } );
 				const state = reducer( undefined, resetBlocks( [ staticBlock ] ) );
 
 				const dispatch = jest.fn();
 				const store = { getState: () => state, dispatch };
 
-				handler( convertBlockToReusable( staticBlock.uid ), store );
+				handler( convertBlockToShared( staticBlock.uid ), store );
 
 				expect( dispatch ).toHaveBeenCalledWith(
-					receiveReusableBlocks( [ {
-						reusableBlock: {
-							id: expect.stringMatching( /^reusable/ ),
+					receiveSharedBlocks( [ {
+						sharedBlock: {
+							id: expect.stringMatching( /^shared/ ),
 							uid: staticBlock.uid,
 							title: 'Untitled block',
 						},
@@ -930,7 +930,7 @@ describe( 'effects', () => {
 				);
 
 				expect( dispatch ).toHaveBeenCalledWith(
-					saveReusableBlock( expect.stringMatching( /^reusable/ ) ),
+					saveSharedBlock( expect.stringMatching( /^shared/ ) ),
 				);
 
 				expect( dispatch ).toHaveBeenCalledWith( {
@@ -939,7 +939,7 @@ describe( 'effects', () => {
 					blocks: [
 						expect.objectContaining( {
 							name: 'core/block',
-							attributes: { ref: expect.stringMatching( /^reusable/ ) },
+							attributes: { ref: expect.stringMatching( /^shared/ ) },
 						} ),
 					],
 					time: expect.any( Number ),

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -33,7 +33,7 @@ import {
 	provisionalBlockUID,
 	blocksMode,
 	isInsertionPointVisible,
-	reusableBlocks,
+	sharedBlocks,
 	template,
 } from '../reducer';
 
@@ -491,7 +491,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should update the reusable block reference if the temporary id is swapped', () => {
+		it( 'should update the shared block reference if the temporary id is swapped', () => {
 			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
@@ -506,7 +506,7 @@ describe( 'state', () => {
 			} );
 
 			const state = editor( deepFreeze( original ), {
-				type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
+				type: 'SAVE_SHARED_BLOCK_SUCCESS',
 				id: 'random-uid',
 				updatedId: 3,
 			} );
@@ -1644,7 +1644,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should remove recorded reusable blocks that are deleted', () => {
+		it( 'should remove recorded shared blocks that are deleted', () => {
 			const initialState = {
 				insertUsage: {
 					'core/block/123': {
@@ -1656,7 +1656,7 @@ describe( 'state', () => {
 			};
 
 			const state = preferences( deepFreeze( initialState ), {
-				type: 'REMOVE_REUSABLE_BLOCK',
+				type: 'REMOVE_SHARED_BLOCK',
 				id: 123,
 			} );
 
@@ -1797,7 +1797,7 @@ describe( 'state', () => {
 		const PROVISIONAL_UPDATE_ACTION_TYPES = [
 			'UPDATE_BLOCK_ATTRIBUTES',
 			'UPDATE_BLOCK',
-			'CONVERT_BLOCK_TO_REUSABLE',
+			'CONVERT_BLOCK_TO_SHARED',
 		];
 
 		const PROVISIONAL_REPLACE_ACTION_TYPES = [
@@ -1909,9 +1909,9 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'reusableBlocks()', () => {
+	describe( 'sharedBlocks()', () => {
 		it( 'should start out empty', () => {
-			const state = reusableBlocks( undefined, {} );
+			const state = sharedBlocks( undefined, {} );
 			expect( state ).toEqual( {
 				data: {},
 				isFetching: {},
@@ -1919,11 +1919,11 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should add received reusable blocks', () => {
-			const state = reusableBlocks( {}, {
-				type: 'RECEIVE_REUSABLE_BLOCKS',
+		it( 'should add received shared blocks', () => {
+			const state = sharedBlocks( {}, {
+				type: 'RECEIVE_SHARED_BLOCKS',
 				results: [ {
-					reusableBlock: {
+					sharedBlock: {
 						id: 123,
 						title: 'My cool block',
 					},
@@ -1942,7 +1942,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should update a reusable block', () => {
+		it( 'should update a shared block', () => {
 			const initialState = {
 				data: {
 					123: { uid: '', title: '' },
@@ -1951,8 +1951,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = reusableBlocks( initialState, {
-				type: 'UPDATE_REUSABLE_BLOCK_TITLE',
+			const state = sharedBlocks( initialState, {
+				type: 'UPDATE_SHARED_BLOCK_TITLE',
 				id: 123,
 				title: 'My block',
 			} );
@@ -1966,17 +1966,17 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should update the reusable block\'s id if it was temporary', () => {
+		it( 'should update the shared block\'s id if it was temporary', () => {
 			const initialState = {
 				data: {
-					reusable1: { uid: '', title: '' },
+					shared1: { uid: '', title: '' },
 				},
 				isSaving: {},
 			};
 
-			const state = reusableBlocks( initialState, {
-				type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
-				id: 'reusable1',
+			const state = sharedBlocks( initialState, {
+				type: 'SAVE_SHARED_BLOCK_SUCCESS',
+				id: 'shared1',
 				updatedId: 123,
 			} );
 
@@ -1989,7 +1989,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should remove a reusable block', () => {
+		it( 'should remove a shared block', () => {
 			const id = 123;
 			const initialState = {
 				data: {
@@ -2007,8 +2007,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = reusableBlocks( deepFreeze( initialState ), {
-				type: 'REMOVE_REUSABLE_BLOCK',
+			const state = sharedBlocks( deepFreeze( initialState ), {
+				type: 'REMOVE_SHARED_BLOCK',
 				id,
 			} );
 
@@ -2019,7 +2019,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should indicate that a reusable block is fetching', () => {
+		it( 'should indicate that a shared block is fetching', () => {
 			const id = 123;
 			const initialState = {
 				data: {},
@@ -2027,8 +2027,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = reusableBlocks( initialState, {
-				type: 'FETCH_REUSABLE_BLOCKS',
+			const state = sharedBlocks( initialState, {
+				type: 'FETCH_SHARED_BLOCKS',
 				id,
 			} );
 
@@ -2041,7 +2041,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should stop indicating that a reusable block is saving when the fetch succeeded', () => {
+		it( 'should stop indicating that a shared block is saving when the fetch succeeded', () => {
 			const id = 123;
 			const initialState = {
 				data: {
@@ -2053,8 +2053,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = reusableBlocks( initialState, {
-				type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
+			const state = sharedBlocks( initialState, {
+				type: 'FETCH_SHARED_BLOCKS_SUCCESS',
 				id,
 				updatedId: id,
 			} );
@@ -2068,7 +2068,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should stop indicating that a reusable block is fetching when there is an error', () => {
+		it( 'should stop indicating that a shared block is fetching when there is an error', () => {
 			const id = 123;
 			const initialState = {
 				data: {},
@@ -2078,8 +2078,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = reusableBlocks( initialState, {
-				type: 'FETCH_REUSABLE_BLOCKS_FAILURE',
+			const state = sharedBlocks( initialState, {
+				type: 'FETCH_SHARED_BLOCKS_FAILURE',
 				id,
 			} );
 
@@ -2090,7 +2090,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should indicate that a reusable block is saving', () => {
+		it( 'should indicate that a shared block is saving', () => {
 			const id = 123;
 			const initialState = {
 				data: {},
@@ -2098,8 +2098,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = reusableBlocks( initialState, {
-				type: 'SAVE_REUSABLE_BLOCK',
+			const state = sharedBlocks( initialState, {
+				type: 'SAVE_SHARED_BLOCK',
 				id,
 			} );
 
@@ -2112,7 +2112,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should stop indicating that a reusable block is saving when the save succeeded', () => {
+		it( 'should stop indicating that a shared block is saving when the save succeeded', () => {
 			const id = 123;
 			const initialState = {
 				data: {
@@ -2124,8 +2124,8 @@ describe( 'state', () => {
 				},
 			};
 
-			const state = reusableBlocks( initialState, {
-				type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
+			const state = sharedBlocks( initialState, {
+				type: 'SAVE_SHARED_BLOCK_SUCCESS',
 				id,
 				updatedId: id,
 			} );
@@ -2139,7 +2139,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should stop indicating that a reusable block is saving when there is an error', () => {
+		it( 'should stop indicating that a shared block is saving when there is an error', () => {
 			const id = 123;
 			const initialState = {
 				data: {},
@@ -2149,8 +2149,8 @@ describe( 'state', () => {
 				},
 			};
 
-			const state = reusableBlocks( initialState, {
-				type: 'SAVE_REUSABLE_BLOCK_FAILURE',
+			const state = sharedBlocks( initialState, {
+				type: 'SAVE_SHARED_BLOCK_FAILURE',
 				id,
 			} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -69,11 +69,11 @@ const {
 	didPostSaveRequestFail,
 	getSuggestedPostFormat,
 	getNotices,
-	getReusableBlock,
-	isSavingReusableBlock,
-	isFetchingReusableBlock,
+	getSharedBlock,
+	isSavingSharedBlock,
+	isFetchingSharedBlock,
 	isSelectionEnabled,
-	getReusableBlocks,
+	getSharedBlocks,
 	getStateBeforeOptimisticTransaction,
 	isPublishingPost,
 	getInserterItems,
@@ -2474,7 +2474,7 @@ describe( 'selectors', () => {
 					},
 				},
 				currentPost: {},
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {},
 				},
 			};
@@ -2493,7 +2493,7 @@ describe( 'selectors', () => {
 					},
 				},
 				currentPost: {},
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {},
 				},
 			};
@@ -2526,7 +2526,7 @@ describe( 'selectors', () => {
 					},
 				},
 				currentPost: {},
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {},
 				},
 			};
@@ -2535,7 +2535,7 @@ describe( 'selectors', () => {
 			expect( items[ 0 ].isDisabled ).toBe( true );
 		} );
 
-		it( 'should properly list reusable blocks', () => {
+		it( 'should properly list shared blocks', () => {
 			const state = {
 				editor: {
 					present: {
@@ -2547,9 +2547,9 @@ describe( 'selectors', () => {
 					},
 				},
 				currentPost: {},
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {
-						123: { uid: 'carrot', title: 'My reusable block' },
+						123: { uid: 'carrot', title: 'My shared block' },
 					},
 				},
 			};
@@ -2559,7 +2559,7 @@ describe( 'selectors', () => {
 					id: 'core/block/123',
 					name: 'core/block',
 					initialAttributes: { ref: 123 },
-					title: 'My reusable block',
+					title: 'My shared block',
 					icon: 'test',
 					category: 'shared',
 					keywords: [],
@@ -2583,7 +2583,7 @@ describe( 'selectors', () => {
 				preferences: {
 					insertUsage: {
 						'core/deleted-block': { time: 1000, count: 10, insert: { name: 'core/deleted-block' } }, // Deleted blocks should be filtered out
-						'core/block/456': { time: 1000, count: 4, insert: { name: 'core/block', ref: 456 } }, // Deleted reusable blocks should be filtered out
+						'core/block/456': { time: 1000, count: 4, insert: { name: 'core/block', ref: 456 } }, // Deleted shared blocks should be filtered out
 						'core/image': { time: 1000, count: 3, insert: { name: 'core/image' } },
 						'core/block/123': { time: 1000, count: 5, insert: { name: 'core/block', ref: 123 } },
 						'core/paragraph': { time: 1000, count: 2, insert: { name: 'core/paragraph' } },
@@ -2598,7 +2598,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {
 						123: { uid: 'carrot' },
 					},
@@ -2626,7 +2626,7 @@ describe( 'selectors', () => {
 						blockOrder: [],
 					},
 				},
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {},
 				},
 			};
@@ -2650,7 +2650,7 @@ describe( 'selectors', () => {
 						blockOrder: [],
 					},
 				},
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {},
 				},
 			};
@@ -2682,10 +2682,10 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getReusableBlock', () => {
-		it( 'should return a reusable block', () => {
+	describe( 'getSharedBlock', () => {
+		it( 'should return a shared block', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {
 						8109: {
 							uid: 'foo',
@@ -2695,8 +2695,8 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const actualReusableBlock = getReusableBlock( state, 8109 );
-			expect( actualReusableBlock ).toEqual( {
+			const actualSharedBlock = getSharedBlock( state, 8109 );
+			expect( actualSharedBlock ).toEqual( {
 				id: 8109,
 				isTemporary: false,
 				uid: 'foo',
@@ -2704,11 +2704,11 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		it( 'should return a temporary reusable block', () => {
+		it( 'should return a temporary shared block', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {
-						reusable1: {
+						shared1: {
 							uid: 'foo',
 							title: 'My cool block',
 						},
@@ -2716,106 +2716,106 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const actualReusableBlock = getReusableBlock( state, 'reusable1' );
-			expect( actualReusableBlock ).toEqual( {
-				id: 'reusable1',
+			const actualSharedBlock = getSharedBlock( state, 'shared1' );
+			expect( actualSharedBlock ).toEqual( {
+				id: 'shared1',
 				isTemporary: true,
 				uid: 'foo',
 				title: 'My cool block',
 			} );
 		} );
 
-		it( 'should return null when no reusable block exists', () => {
+		it( 'should return null when no shared block exists', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {},
 				},
 			};
 
-			const reusableBlock = getReusableBlock( state, '358b59ee-bab3-4d6f-8445-e8c6971a5605' );
-			expect( reusableBlock ).toBeNull();
+			const sharedBlock = getSharedBlock( state, '358b59ee-bab3-4d6f-8445-e8c6971a5605' );
+			expect( sharedBlock ).toBeNull();
 		} );
 	} );
 
-	describe( 'isSavingReusableBlock', () => {
+	describe( 'isSavingSharedBlock', () => {
 		it( 'should return false when the block is not being saved', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					isSaving: {},
 				},
 			};
 
-			const isSaving = isSavingReusableBlock( state, 5187 );
+			const isSaving = isSavingSharedBlock( state, 5187 );
 			expect( isSaving ).toBe( false );
 		} );
 
 		it( 'should return true when the block is being saved', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					isSaving: {
 						5187: true,
 					},
 				},
 			};
 
-			const isSaving = isSavingReusableBlock( state, 5187 );
+			const isSaving = isSavingSharedBlock( state, 5187 );
 			expect( isSaving ).toBe( true );
 		} );
 	} );
 
-	describe( 'isFetchingReusableBlock', () => {
+	describe( 'isFetchingSharedBlock', () => {
 		it( 'should return false when the block is not being fetched', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					isFetching: {},
 				},
 			};
 
-			const isFetching = isFetchingReusableBlock( state, 5187 );
+			const isFetching = isFetchingSharedBlock( state, 5187 );
 			expect( isFetching ).toBe( false );
 		} );
 
 		it( 'should return true when the block is being fetched', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					isFetching: {
 						5187: true,
 					},
 				},
 			};
 
-			const isFetching = isFetchingReusableBlock( state, 5187 );
+			const isFetching = isFetchingSharedBlock( state, 5187 );
 			expect( isFetching ).toBe( true );
 		} );
 	} );
 
-	describe( 'getReusableBlocks', () => {
-		it( 'should return an array of reusable blocks', () => {
+	describe( 'getSharedBlocks', () => {
+		it( 'should return an array of shared blocks', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {
 						123: { uid: 'carrot' },
-						reusable1: { uid: 'broccoli' },
+						shared1: { uid: 'broccoli' },
 					},
 				},
 			};
 
-			const reusableBlocks = getReusableBlocks( state );
-			expect( reusableBlocks ).toEqual( [
+			const sharedBlocks = getSharedBlocks( state );
+			expect( sharedBlocks ).toEqual( [
 				{ id: 123, isTemporary: false, uid: 'carrot' },
-				{ id: 'reusable1', isTemporary: true, uid: 'broccoli' },
+				{ id: 'shared1', isTemporary: true, uid: 'broccoli' },
 			] );
 		} );
 
-		it( 'should return an empty array when no reusable blocks exist', () => {
+		it( 'should return an empty array when no shared blocks exist', () => {
 			const state = {
-				reusableBlocks: {
+				sharedBlocks: {
 					data: {},
 				},
 			};
 
-			const reusableBlocks = getReusableBlocks( state );
-			expect( reusableBlocks ).toEqual( [] );
+			const sharedBlocks = getSharedBlocks( state );
+			expect( sharedBlocks ).toEqual( [] );
 		} );
 	} );
 

--- a/lib/class-wp-rest-blocks-controller.php
+++ b/lib/class-wp-rest-blocks-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Reusable Blocks REST API: WP_REST_Blocks_Controller class
+ * Shared blocks REST API: WP_REST_Blocks_Controller class
  *
  * @package gutenberg
  * @since 0.10.0
@@ -8,8 +8,8 @@
 
 /**
  * Controller which provides a REST endpoint for Gutenberg to read, create,
- * edit and delete reusable blocks. Blocks are stored as posts with the
- * wp_block post type.
+ * edit and delete shared blocks. Blocks are stored as posts with the wp_block
+ * post type.
  *
  * @since 0.10.0
  *

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -225,7 +225,7 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 	/**
 	 * Exhaustively check that each role either can or cannot create, edit,
-	 * update, and delete reusable blocks.
+	 * update, and delete shared blocks.
 	 *
 	 * @dataProvider data_capabilities
 	 */

--- a/phpunit/class-reusable-blocks-render-test.php
+++ b/phpunit/class-reusable-blocks-render-test.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Reusable block rendering tests.
+ * Shared block rendering tests.
  *
  * @package Gutenberg
  */
 
 /**
- * Tests reusable block rendering.
+ * Tests shared block rendering.
  */
-class Reusable_Blocks_Render_Test extends WP_UnitTestCase {
+class Shared_Blocks_Render_Test extends WP_UnitTestCase {
 	/**
 	 * Fake user ID.
 	 *
@@ -67,7 +67,7 @@ class Reusable_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering of a reusable block.
+	 * Test rendering of a shared block.
 	 */
 	public function test_render() {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/block' );
@@ -76,7 +76,7 @@ class Reusable_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering of a reusable block when 'ref' is missing, which should fail by
+	 * Test rendering of a shared block when 'ref' is missing, which should fail by
 	 * rendering an empty string.
 	 */
 	public function test_ref_empty() {
@@ -86,7 +86,7 @@ class Reusable_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering of a reusable block when 'ref' points to wrong post type, which
+	 * Test rendering of a shared block when 'ref' points to wrong post type, which
 	 * should fail by rendering an empty string.
 	 */
 	public function test_ref_wrong_post_type() {


### PR DESCRIPTION
## Description

In https://github.com/WordPress/gutenberg/pull/5322, we renamed _reusable blocks_ to _shared blocks_ throughout the UI. 

Now that this feature has settled down, it's a good time to perform this change throughout the codebase and rename any function, variable or constant from e.g. `reusableBlock` to `sharedBlock`.

This was brought up in https://github.com/WordPress/gutenberg/pull/5322#discussion_r172831942.

To do this, I performed these changes automatically:

- s/reusableBlock/sharedBlock/
- s/ReusableBlock/SharedBlock/
- s/reusable-block/shared-block/
- s/reusable_block/shared_block/
- s/REUSABLE_BLOCK/SHARED_BLOCK/
- s/reusable block/shared block/
- s/is-reusable/is-shared/
- s/convertBlockToReusable/convertBlockToShared/
- s/CONVERT_BLOCK_TO_REUSABLE/CONVERT_BLOCK_TO_SHARED/

I then performed these changes manually:

- Replaced occurrences of /reusable block/i
- Renamed files that match /reusable/i
- Audit all occurrences of /reusable/I

I then spent two hours trying to get our PHP unit tests to run locally, but that's another story! 🙃

## How Has This Been Tested?
First, the automated ought to pass.

Then:

1. Create a shared block
2. Insert a shared block
3. Edit and save a shared block
4. Edit and cancel a shared block
5. Convert a shared block to a regular block
6. Delete a shared block