### PR TITLE
Fix issue with block more button when multi selected

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -434,6 +434,7 @@
 	}
 
 	// Elevate when selected or hovered
+	&.is-multi-selected,
 	&.is-selected,
 	&.is-hovered {
 		.editor-block-settings-menu,


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/pull/5658#issuecomment-378585882.

The More button when selecting multiple blocks inside a column wasn't elevated as it should be. This PR addresses that.

Screenshot:

<img width="496" alt="screen shot 2018-04-05 at 10 49 52" src="https://user-images.githubusercontent.com/1204802/38356200-6068bdf6-38bf-11e8-9ee4-ce88d6b70eb6.png">
