### PR TITLE
Edit Post: Drop react-redux usage from the edit-post module replacing it with the data module

### DIFF
--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { isEqual, find, some, filter, noop, throttle } from 'lodash';
+import isShallowEqual from 'shallowequal';
 
 /**
  * WordPress dependencies
@@ -170,11 +171,14 @@ class DropZoneProvider extends Component {
 			} );
 		} );
 
-		this.setState( {
+		const newState = {
 			isDraggingOverDocument: true,
 			hoveredDropZone: hoveredDropZoneIndex,
 			position,
-		} );
+		};
+		if ( ! isShallowEqual( newState, this.state ) ) {
+			this.setState( newState );
+		}
 	}
 
 	isWithinZoneBounds( dropzone, x, y ) {

--- a/data/index.js
+++ b/data/index.js
@@ -241,6 +241,10 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			this.state = {};
 		}
 
+		shouldComponentUpdate( nextProps, nextState ) {
+			return ! isShallowEqual( nextProps, this.props ) || ! isShallowEqual( nextState, this.state );
+		}
+
 		componentWillMount() {
 			this.subscribe();
 

--- a/edit-post/components/header/mode-switcher/index.js
+++ b/edit-post/components/header/mode-switcher/index.js
@@ -1,21 +1,15 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
+import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import shortcuts from '../../../keyboard-shortcuts';
-import { getEditorMode } from '../../../store/selectors';
-import { switchEditorMode } from '../../../store/actions';
-
 /**
  * Set of available mode options.
  *
@@ -54,16 +48,14 @@ function ModeSwitcher( { onSwitch, mode } ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		mode: getEditorMode( state ),
-	} ),
-	( dispatch, ownProps ) => ( {
+export default compose( [
+	withSelect( ( select ) => ( {
+		mode: select( 'core/edit-post' ).getEditorMode(),
+	} ) ),
+	withDispatch( ( dispatch, ownProps ) => ( {
 		onSwitch( mode ) {
-			dispatch( switchEditorMode( mode ) );
+			dispatch( 'core/edit-post' ).switchEditorMode( mode );
 			ownProps.onSelect( mode );
 		},
-	} ),
-	undefined,
-	{ storeKey: 'edit-post' }
-)( ModeSwitcher );
+	} ) ),
+] )( ModeSwitcher );

--- a/edit-post/components/keyboard-shortcuts/index.js
+++ b/edit-post/components/keyboard-shortcuts/index.js
@@ -1,20 +1,14 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { KeyboardShortcuts } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import shortcuts from '../../keyboard-shortcuts';
-import { getEditorMode } from '../../store/selectors';
-import { switchEditorMode } from '../../store/actions';
 
 class EditorModeKeyboardShortcuts extends Component {
 	constructor() {
@@ -37,19 +31,17 @@ class EditorModeKeyboardShortcuts extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			mode: getEditorMode( state ),
+			mode: select( 'core/edit-post' ).getEditorMode(),
 		};
-	},
-	( dispatch ) => {
+	} ),
+	withDispatch( ( dispatch ) => {
 		return {
 			switchMode: ( mode ) => {
-				dispatch( switchEditorMode( mode ) );
+				dispatch( 'core/edit-post' ).switchEditorMode( mode );
 			},
 		};
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-)( EditorModeKeyboardShortcuts );
+	} ),
+] )( EditorModeKeyboardShortcuts );

--- a/edit-post/components/meta-boxes/index.js
+++ b/edit-post/components/meta-boxes/index.js
@@ -1,14 +1,13 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { connect } from 'react-redux';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import MetaBoxesArea from './meta-boxes-area';
 import MetaBoxesPanel from './meta-boxes-panel';
-import { getMetaBox } from '../../store/selectors';
 
 function MetaBoxes( { location, isActive, usePanel = false } ) {
 	if ( ! isActive ) {
@@ -28,11 +27,8 @@ function MetaBoxes( { location, isActive, usePanel = false } ) {
 	);
 }
 
-export default connect(
-	( state, ownProps ) => ( {
-		isActive: getMetaBox( state, ownProps.location ).isActive,
+export default withSelect(
+	( select, ownProps ) => ( {
+		isActive: select( 'core/edit-post' ).getMetaBox( ownProps.location ).isActive,
 	} ),
-	undefined,
-	undefined,
-	{ storeKey: 'edit-post' }
 )( MetaBoxes );

--- a/edit-post/components/meta-boxes/meta-boxes-area/index.js
+++ b/edit-post/components/meta-boxes/meta-boxes-area/index.js
@@ -2,19 +2,18 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { isSavingMetaBoxes } from '../../../store/selectors';
 
 class MetaBoxesArea extends Component {
 	/**
@@ -77,18 +76,8 @@ class MetaBoxesArea extends Component {
 	}
 }
 
-/**
- * @inheritdoc
- */
-function mapStateToProps( state ) {
+export default withSelect( ( select ) => {
 	return {
-		isSaving: isSavingMetaBoxes( state ),
+		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 	};
-}
-
-export default connect(
-	mapStateToProps,
-	undefined,
-	undefined,
-	{ storeKey: 'edit-post' }
-)( MetaBoxesArea );
+} )( MetaBoxesArea );

--- a/edit-post/components/sidebar/discussion-panel/index.js
+++ b/edit-post/components/sidebar/discussion-panel/index.js
@@ -1,20 +1,11 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { PostComments, PostPingbacks, PostTypeSupportCheck } from '@wordpress/editor';
-
-/**
- * Internal Dependencies
- */
-import { isEditorSidebarPanelOpened } from '../../../store/selectors';
-import { toggleGeneralSidebarEditorPanel } from '../../../store/actions';
+import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Module Constants
@@ -41,18 +32,16 @@ function DiscussionPanel( { isOpened, onTogglePanel } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
+			isOpened: select( 'core/edit-post' ).isEditorSidebarPanelOpened( PANEL_NAME ),
 		};
-	},
-	{
+	} ),
+	withDispatch( ( dispatch ) => ( {
 		onTogglePanel() {
-			return toggleGeneralSidebarEditorPanel( PANEL_NAME );
+			return dispatch( 'core/edit-post' ).toggleGeneralSidebarEditorPanel( PANEL_NAME );
 		},
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-)( DiscussionPanel );
+	} ) ),
+] )( DiscussionPanel );
 

--- a/edit-post/components/sidebar/document-outline-panel/index.js
+++ b/edit-post/components/sidebar/document-outline-panel/index.js
@@ -1,20 +1,11 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
 import { DocumentOutline, DocumentOutlineCheck } from '@wordpress/editor';
-
-/**
- * Internal dependencies
- */
-import { isEditorSidebarPanelOpened } from '../../../store/selectors';
-import { toggleGeneralSidebarEditorPanel } from '../../../store/actions';
+import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Module constants
@@ -31,17 +22,15 @@ function DocumentOutlinePanel( { isOpened, onTogglePanel } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
+			isOpened: select( 'core/edit-post' ).isEditorSidebarPanelOpened( PANEL_NAME ),
 		};
-	},
-	{
+	} ),
+	withDispatch( ( dispatch ) => ( {
 		onTogglePanel() {
-			return toggleGeneralSidebarEditorPanel( PANEL_NAME );
+			return dispatch( 'core/edit-post' ).toggleGeneralSidebarEditorPanel( PANEL_NAME );
 		},
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-)( DocumentOutlinePanel );
+	} ) ),
+] )( DocumentOutlinePanel );

--- a/edit-post/components/sidebar/post-excerpt/index.js
+++ b/edit-post/components/sidebar/post-excerpt/index.js
@@ -1,20 +1,11 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
 import { PostExcerpt as PostExcerptForm, PostExcerptCheck } from '@wordpress/editor';
-
-/**
- * Internal Dependencies
- */
-import { isEditorSidebarPanelOpened } from '../../../store/selectors';
-import { toggleGeneralSidebarEditorPanel } from '../../../store/actions';
+import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Module Constants
@@ -31,18 +22,16 @@ function PostExcerpt( { isOpened, onTogglePanel } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
+			isOpened: select( 'core/edit-post' ).isEditorSidebarPanelOpened( PANEL_NAME ),
 		};
-	},
-	{
+	} ),
+	withDispatch( ( dispatch ) => ( {
 		onTogglePanel() {
-			return toggleGeneralSidebarEditorPanel( PANEL_NAME );
+			return dispatch( 'core/edit-post' ).toggleGeneralSidebarEditorPanel( PANEL_NAME );
 		},
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-)( PostExcerpt );
+	} ) ),
+] )( PostExcerpt );
 

--- a/edit-post/components/sidebar/post-status/index.js
+++ b/edit-post/components/sidebar/post-status/index.js
@@ -1,13 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
+import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal Dependencies
@@ -20,10 +17,6 @@ import PostSticky from '../post-sticky';
 import PostAuthor from '../post-author';
 import PostFormat from '../post-format';
 import PostPendingStatus from '../post-pending-status';
-import {
-	isEditorSidebarPanelOpened,
-} from '../../../store/selectors';
-import { toggleGeneralSidebarEditorPanel } from '../../../store/actions';
 
 /**
  * Module Constants
@@ -44,16 +37,14 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
-	} ),
-	{
+export default compose( [
+	withSelect( ( select ) => ( {
+		isOpened: select( 'core/edit-post' ).isEditorSidebarPanelOpened( PANEL_NAME ),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
 		onTogglePanel() {
-			return toggleGeneralSidebarEditorPanel( PANEL_NAME );
+			return dispatch( 'core/edit-post' ).toggleGeneralSidebarEditorPanel( PANEL_NAME );
 		},
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-)( PostStatus );
+	} ) ),
+] )( PostStatus );
 

--- a/edit-post/components/sidebar/post-taxonomies/index.js
+++ b/edit-post/components/sidebar/post-taxonomies/index.js
@@ -1,18 +1,13 @@
 /**
- * External Dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { PostTaxonomies as PostTaxonomiesForm, PostTaxonomiesCheck } from '@wordpress/editor';
+import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { isEditorSidebarPanelOpened } from '../../../store/selectors';
-import { toggleGeneralSidebarEditorPanel } from '../../../store/actions';
 import TaxonomyPanel from './taxonomy-panel';
 
 /**
@@ -36,18 +31,16 @@ function PostTaxonomies() {
 	);
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
+			isOpened: select( 'core/edit-post' ).isEditorSidebarPanelOpened( PANEL_NAME ),
 		};
-	},
-	{
+	} ),
+	withDispatch( ( dispatch ) => ( {
 		onTogglePanel() {
-			return toggleGeneralSidebarEditorPanel( PANEL_NAME );
+			return dispatch( 'core/edit-post' ).toggleGeneralSidebarEditorPanel( PANEL_NAME );
 		},
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-)( PostTaxonomies );
+	} ) ),
+] )( PostTaxonomies );
 

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { createProvider } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { render, unmountComponentAtNode } from '@wordpress/element';
@@ -43,14 +38,11 @@ export function reinitializeEditor( target, settings ) {
 	unmountComponentAtNode( target );
 
 	const reboot = reinitializeEditor.bind( null, target, settings );
-	const ReduxProvider = createProvider( 'edit-post' );
 
 	render(
 		<EditorProvider settings={ settings } recovery>
 			<ErrorBoundary onError={ reboot }>
-				<ReduxProvider store={ store }>
-					<Layout />
-				</ReduxProvider>
+				<Layout />
 			</ErrorBoundary>
 		</EditorProvider>,
 		target
@@ -72,14 +64,11 @@ export function reinitializeEditor( target, settings ) {
 export function initializeEditor( id, post, settings ) {
 	const target = document.getElementById( id );
 	const reboot = reinitializeEditor.bind( null, target, settings );
-	const ReduxProvider = createProvider( 'edit-post' );
 
 	render(
 		<EditorProvider settings={ settings } post={ post }>
 			<ErrorBoundary onError={ reboot }>
-				<ReduxProvider store={ store }>
-					<Layout />
-				</ReduxProvider>
+				<Layout />
 			</ErrorBoundary>
 		</EditorProvider>,
 		target


### PR DESCRIPTION
Also this PR contains an update to the `withSelect` Higher Order Component making it work like a pure component not updating if state or props didn't change.

**Testing instructions**

 - Just do a quick check that writing/publish posts work.
 - You can also open the React dev tools, check "highlight updates" and ensure that there's way less components rerendering compared to master while dragging.