### PR TITLE
Widen dropzone indicator

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -393,7 +393,7 @@
 		border: none;
 		top: -4px;
 		bottom: -3px;
-		margin: 0 $block-side-ui-padding;
+		margin: 0 $block-padding;
 		border-radius: 0;
 
 		.components-drop-zone__content {


### PR DESCRIPTION
This is a subtle change to make the blue dropzone indicator wider, so it matches that of the text.

This probably used to work, but regressed in a rebase that included the side UI padding tweaks.

Before:

![dragondrop before](https://user-images.githubusercontent.com/1204802/38356961-876dd984-38c1-11e8-8842-1210aed18ca6.gif)

After:

![dragondrop after](https://user-images.githubusercontent.com/1204802/38356971-8d2809a8-38c1-11e8-83a8-066f5f0e52b1.gif)
