### PR TITLE
Components: Reset drag state if component unmounts

### DIFF
--- a/components/draggable/index.js
+++ b/components/draggable/index.js
@@ -23,13 +23,15 @@ const clonePadding = 20;
 class Draggable extends Component {
 	constructor() {
 		super( ...arguments );
+
 		this.onDragStart = this.onDragStart.bind( this );
 		this.onDragOver = this.onDragOver.bind( this );
 		this.onDragEnd = this.onDragEnd.bind( this );
+		this.resetDragState = this.resetDragState.bind( this );
 	}
 
 	componentWillUnmount() {
-		this.removeDragClone();
+		this.resetDragState();
 	}
 
 	/**
@@ -38,10 +40,9 @@ class Draggable extends Component {
 	 */
 	onDragEnd( event ) {
 		const { onDragEnd = noop } = this.props;
-		this.removeDragClone();
-		// Reset cursor.
-		document.body.classList.remove( 'is-dragging-components-draggable' );
 		event.preventDefault();
+
+		this.resetDragState();
 
 		this.props.setTimeout( onDragEnd );
 	}
@@ -134,13 +135,20 @@ class Draggable extends Component {
 		this.props.setTimeout( onDragStart );
 	}
 
-	removeDragClone() {
+	/**
+	 * Cleans up drag state when drag has completed, or component unmounts
+	 * while dragging.
+	 */
+	resetDragState() {
+		// Remove drag clone
 		document.removeEventListener( 'dragover', this.onDragOver );
 		if ( this.cloneWrapper && this.cloneWrapper.parentNode ) {
-			// Remove clone.
 			this.cloneWrapper.parentNode.removeChild( this.cloneWrapper );
 			this.cloneWrapper = null;
 		}
+
+		// Reset cursor.
+		document.body.classList.remove( 'is-dragging-components-draggable' );
 	}
 
 	render() {


### PR DESCRIPTION
This pull request seeks to resolve an issue which can occur when the Draggable component is unmounted while a drag is in progress, leaving artifacts of the in-progress drag which are never reset. In particular, the cursor can be left as `grab` in perpetuity.

__Testing instructions:__

While others I have asked to test were not always able to reproduce, this issue had occurred for me consistently with the following steps:

1. New Post
2. Add Columns block
3. Add Text block
4. Drag Text block into Columns block

In any case, verify that the drag clone and drag cursor are reset after dropping a block.