### PR TITLE
Conditionally load the FormData polyfill

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -284,7 +284,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_add_inline_script(
 		'wp-edit-post',
-		gutenberg_get_script_polyfill( array( 'false' => 'formdata' ) ),
+		gutenberg_get_script_polyfill( array( 'window.FormData && window.FormData.prototype.keys' => 'formdata' ) ),
 		'before'
 	);
 


### PR DESCRIPTION
This PR updates the formdata polyfill to load it conditionally depending on whether the `FormData.prototype.keys` is defined or not.

**Testing instructions**

 - Verify that the polyfill is loading in Safari but not in Chrome