### PR TITLE
Allow overriding webpack's devtool setting

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -207,7 +207,7 @@ const config = {
 };
 
 if ( config.mode !== 'production' ) {
-	config.devtool = 'source-map';
+	config.devtool = process.env.SOURCEMAP || 'source-map';
 }
 
 module.exports = config;


### PR DESCRIPTION
I've noticed that incremental builds are starting to get slow again which is a drain on (my) productivity. 

Changing webpack's `devtool` setting from `source-map` to `cheap-module-eval-source-map` brings down the time for an incremental build on my machine from ~1500 ms to < 500 ms.

This PR allows one to override this setting with an environment variable so that folks that want to trade sourcemap quality for build speed can go ahead and do that.

I chose `SOURCEMAP` as the name of this variable so as to match Calypso, but it could just as easily be named `DEVTOOL`.

Useful reading: https://webpack.js.org/configuration/devtool/
Related PRs: https://github.com/WordPress/gutenberg/pull/4537 https://github.com/WordPress/gutenberg/pull/5931

#### How to test

Fire up your terminal and run this:

```
SOURCEMAP=eval npm run dev
```

Then, make some code changes. Notice that incremental builds are quick.

#### Questions

1. Should we change the default? [This page](https://webpack.js.org/configuration/devtool/#development) documents which options are ideal for development. I think we should move to `eval-source-map` since it produces source maps that are of the same quality as what we currently have, but with a faster incremental build time.
2. Should we document this? I fear that mentioning this in `CONTRIBUTING.md` might be too intimidating. 