### PR TITLE
Iterate on 'Insert link' interface

### DIFF
--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -194,6 +194,8 @@ class FormatToolbar extends Component {
 									onKeyDown={ this.onKeyDown }
 									onSubmit={ this.submitLink }>
 									<div className="blocks-format-toolbar__link-modal-line">
+										<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
+										<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 										<IconButton
 											className="blocks-format-toolbar__link-settings-toggle"
 											icon="ellipsis"
@@ -201,8 +203,6 @@ class FormatToolbar extends Component {
 											onClick={ this.toggleLinkSettingsVisibility }
 											aria-expanded={ settingsVisible }
 										/>
-										<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
-										<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 									</div>
 									{ linkSettings }
 								</form>
@@ -217,13 +217,6 @@ class FormatToolbar extends Component {
 									onKeyPress={ stopKeyPropagation }
 								>
 									<div className="blocks-format-toolbar__link-modal-line">
-										<IconButton
-											className="blocks-format-toolbar__link-settings-toggle"
-											icon="ellipsis"
-											label={ __( 'Link Settings' ) }
-											onClick={ this.toggleLinkSettingsVisibility }
-											aria-expanded={ settingsVisible }
-										/>
 										<a
 											className="blocks-format-toolbar__link-value"
 											href={ formats.link.value }
@@ -232,6 +225,13 @@ class FormatToolbar extends Component {
 											{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
 										</a>
 										<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
+										<IconButton
+											className="blocks-format-toolbar__link-settings-toggle"
+											icon="ellipsis"
+											label={ __( 'Link Settings' ) }
+											onClick={ this.toggleLinkSettingsVisibility }
+											aria-expanded={ settingsVisible }
+										/>
 									</div>
 									{ linkSettings }
 								</div>

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -111,7 +111,9 @@ class FormatToolbar extends Component {
 
 	setLinkTarget( opensInNewWindow ) {
 		this.setState( { opensInNewWindow } );
-		this.props.onChange( { link: { value: this.props.formats.link.value, target: opensInNewWindow ? '_blank' : '' } } );
+		if ( this.props.formats.link ) {
+			this.props.onChange( { link: { value: this.props.formats.link.value, target: opensInNewWindow ? '_blank' : '' } } );
+		}
 	}
 
 	addLink() {

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -3,7 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { IconButton, Toolbar, withSpokenMessages, Fill } from '@wordpress/components';
+import {
+	Fill,
+	IconButton,
+	ToggleControl,
+	Toolbar,
+	withSpokenMessages,
+} from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -12,7 +18,6 @@ import { keycodes } from '@wordpress/utils';
 import './style.scss';
 import UrlInput from '../../url-input';
 import { filterURLForDisplay } from '../../../editor/utils/url';
-import ToggleControl from '../../inspector-controls/toggle-control';
 
 const { ESCAPE, LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } = keycodes;
 
@@ -106,8 +111,7 @@ class FormatToolbar extends Component {
 		this.setState( ( state ) => ( { settingsVisible: ! state.settingsVisible } ) );
 	}
 
-	setLinkTarget( event ) {
-		const opensInNewWindow = event.target.checked;
+	setLinkTarget( opensInNewWindow ) {
 		this.setState( { opensInNewWindow } );
 		this.props.onChange( { link: { value: this.props.formats.link.value, target: opensInNewWindow ? '_blank' : '' } } );
 	}

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -184,14 +184,16 @@ class FormatToolbar extends Component {
 							onKeyDown={ this.onKeyDown }
 							onSubmit={ this.submitLink }>
 							<div className="blocks-format-toolbar__link-modal-line">
+								<IconButton
+									className="blocks-format-toolbar__link-settings-toggle"
+									icon="ellipsis"
+									label={ __( 'Link Settings' ) }
+									onClick={ this.toggleLinkSettingsVisibility }
+									aria-expanded={ settingsVisible }
+								/>
 								<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
 								<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 								<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
-								<IconButton
-									icon="admin-generic"
-									label={ __( 'Link Settings' ) }
-									onClick={ this.toggleLinkSettingsVisibility }
-									aria-expanded={ settingsVisible } />
 							</div>
 							{ linkSettings }
 						</form>
@@ -209,6 +211,13 @@ class FormatToolbar extends Component {
 							onKeyPress={ stopKeyPropagation }
 						>
 							<div className="blocks-format-toolbar__link-modal-line">
+								<IconButton
+									className="blocks-format-toolbar__link-settings-toggle"
+									icon="ellipsis"
+									label={ __( 'Link Settings' ) }
+									onClick={ this.toggleLinkSettingsVisibility }
+									aria-expanded={ settingsVisible }
+								/>
 								<a
 									className="blocks-format-toolbar__link-value"
 									href={ formats.link.value }
@@ -218,11 +227,6 @@ class FormatToolbar extends Component {
 								</a>
 								<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
 								<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
-								<IconButton
-									icon="admin-generic"
-									label={ __( 'Link Settings' ) }
-									onClick={ this.toggleLinkSettingsVisibility }
-									aria-expanded={ settingsVisible } />
 							</div>
 							{ linkSettings }
 						</div>

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -130,6 +130,7 @@ class FormatToolbar extends Component {
 
 	submitLink( event ) {
 		event.preventDefault();
+		this.setState( { isEditingLink: false, isAddingLink: false, newLinkValue: '' } );
 		this.props.onChange( { link: { value: this.state.newLinkValue, target: this.state.opensInNewWindow ? '_blank' : '' } } );
 		if ( this.state.isAddingLink ) {
 			this.props.speak( __( 'Link added.' ), 'assertive' );

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -146,9 +146,6 @@ class FormatToolbar extends Component {
 	render() {
 		const { formats, focusPosition, enabledControls = DEFAULT_CONTROLS, customControls = [] } = this.props;
 		const { isAddingLink, isEditingLink, newLinkValue, settingsVisible, opensInNewWindow } = this.state;
-		const linkStyle = focusPosition ?
-			{ position: 'absolute', ...focusPosition } :
-			null;
 
 		const toolbarControls = FORMATTING_CONTROLS.concat( customControls )
 			.filter( control => enabledControls.indexOf( control.format ) !== -1 )
@@ -185,64 +182,64 @@ class FormatToolbar extends Component {
 			<div className="blocks-format-toolbar">
 				<Toolbar controls={ toolbarControls } />
 
-				{ ( isAddingLink || isEditingLink ) &&
-					// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-					/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+				{ ( isAddingLink || isEditingLink || formats.link ) && (
 					<Fill name="RichText.Siblings">
-						<form
-							className="blocks-format-toolbar__link-modal"
-							style={ linkStyle }
-							onKeyPress={ stopKeyPropagation }
-							onKeyDown={ this.onKeyDown }
-							onSubmit={ this.submitLink }>
-							<div className="blocks-format-toolbar__link-modal-line">
-								<IconButton
-									className="blocks-format-toolbar__link-settings-toggle"
-									icon="ellipsis"
-									label={ __( 'Link Settings' ) }
-									onClick={ this.toggleLinkSettingsVisibility }
-									aria-expanded={ settingsVisible }
-								/>
-								<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
-								<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-							</div>
-							{ linkSettings }
-						</form>
-					</Fill>
-					/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
-				}
+						<div style={ { position: 'absolute', ...focusPosition } }>
+							{ ( isAddingLink || isEditingLink ) && (
+								// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+								<form
+									className="blocks-format-toolbar__link-modal"
+									onKeyPress={ stopKeyPropagation }
+									onKeyDown={ this.onKeyDown }
+									onSubmit={ this.submitLink }>
+									<div className="blocks-format-toolbar__link-modal-line">
+										<IconButton
+											className="blocks-format-toolbar__link-settings-toggle"
+											icon="ellipsis"
+											label={ __( 'Link Settings' ) }
+											onClick={ this.toggleLinkSettingsVisibility }
+											aria-expanded={ settingsVisible }
+										/>
+										<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
+										<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
+									</div>
+									{ linkSettings }
+								</form>
+								/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+							) }
 
-				{ !! formats.link && ! isAddingLink && ! isEditingLink &&
-					// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-					/* eslint-disable jsx-a11y/no-static-element-interactions */
-					<Fill name="RichText.Siblings">
-						<div
-							className="blocks-format-toolbar__link-modal"
-							style={ linkStyle }
-							onKeyPress={ stopKeyPropagation }
-						>
-							<div className="blocks-format-toolbar__link-modal-line">
-								<IconButton
-									className="blocks-format-toolbar__link-settings-toggle"
-									icon="ellipsis"
-									label={ __( 'Link Settings' ) }
-									onClick={ this.toggleLinkSettingsVisibility }
-									aria-expanded={ settingsVisible }
-								/>
-								<a
-									className="blocks-format-toolbar__link-value"
-									href={ formats.link.value }
-									target="_blank"
+							{ formats.link && ! isAddingLink && ! isEditingLink && (
+								// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+								/* eslint-disable jsx-a11y/no-static-element-interactions */
+								<div
+									className="blocks-format-toolbar__link-modal"
+									onKeyPress={ stopKeyPropagation }
 								>
-									{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
-								</a>
-								<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
-							</div>
-							{ linkSettings }
+									<div className="blocks-format-toolbar__link-modal-line">
+										<IconButton
+											className="blocks-format-toolbar__link-settings-toggle"
+											icon="ellipsis"
+											label={ __( 'Link Settings' ) }
+											onClick={ this.toggleLinkSettingsVisibility }
+											aria-expanded={ settingsVisible }
+										/>
+										<a
+											className="blocks-format-toolbar__link-value"
+											href={ formats.link.value }
+											target="_blank"
+										>
+											{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
+										</a>
+										<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
+									</div>
+									{ linkSettings }
+								</div>
+								/* eslint-enable jsx-a11y/no-static-element-interactions */
+							) }
 						</div>
 					</Fill>
-					/* eslint-enable jsx-a11y/no-static-element-interactions */
-				}
+				) }
 			</div>
 		);
 	}

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -38,8 +38,6 @@ const FORMATTING_CONTROLS = [
 		format: 'strikethrough',
 	},
 	{
-		icon: 'admin-links',
-		title: __( 'Link' ),
 		format: 'link',
 	},
 ];
@@ -152,11 +150,22 @@ class FormatToolbar extends Component {
 		const toolbarControls = FORMATTING_CONTROLS.concat( customControls )
 			.filter( control => enabledControls.indexOf( control.format ) !== -1 )
 			.map( ( control ) => {
-				const isLink = control.format === 'link';
+				if ( control.format === 'link' ) {
+					const isFormatActive = this.isFormatActive( 'link' );
+					const isActive = isFormatActive || isAddingLink;
+					return {
+						...control,
+						icon: isFormatActive ? 'editor-unlink' : 'admin-links', // TODO: Need proper unlink icon
+						title: isFormatActive ? __( 'Unlink' ) : __( 'Link' ),
+						onClick: isActive ? this.dropLink : this.addLink,
+						isActive,
+					};
+				}
+
 				return {
 					...control,
-					onClick: isLink ? this.addLink : this.toggleFormat( control.format ),
-					isActive: this.isFormatActive( control.format ) || ( isLink && isAddingLink ),
+					onClick: this.toggleFormat( control.format ),
+					isActive: this.isFormatActive( control.format ),
 				};
 			} );
 
@@ -193,7 +202,6 @@ class FormatToolbar extends Component {
 								/>
 								<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
 								<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-								<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
 							</div>
 							{ linkSettings }
 						</form>
@@ -226,7 +234,6 @@ class FormatToolbar extends Component {
 									{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
 								</a>
 								<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
-								<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
 							</div>
 							{ linkSettings }
 						</div>

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -14,22 +14,46 @@
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 	z-index: z-index( '.blocks-format-toolbar__link-modal' );
-
-	.blocks-url-input {
-		width: 230px;
-	}
 }
 
 .blocks-format-toolbar__link-modal-line {
+	$button-size: 36px;
+	$input-padding: 10px;
+	$input-size: 230px;
+
 	display: flex;
 	flex-direction: row;
 	flex-grow: 1;
 	flex-shrink: 1;
 	min-width: 0;
-	align-items: center;
+	align-items: flex-start;
 
 	.components-button {
 		flex-shrink: 0;
+		width: $button-size;
+		height: $button-size;
+	}
+
+	.blocks-url-input {
+		width: $input-size;
+
+		input {
+			padding: $input-padding;
+		}
+	}
+
+	.blocks-url-input__suggestions {
+		border-top: 1px solid $light-gray-500;
+		box-shadow: none;
+		left: -( $button-size );
+		padding: 4px 0;
+		position: relative;
+		width: $input-size + $button-size * 2;
+	}
+
+	.blocks-url-input__suggestion {
+		color: $dark-gray-100;
+		padding: 4px ( $button-size + $input-padding );
 	}
 }
 

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -45,7 +45,6 @@
 	.blocks-url-input__suggestions {
 		border-top: 1px solid $light-gray-500;
 		box-shadow: none;
-		left: -( $button-size );
 		padding: 4px 0;
 		position: relative;
 		width: $input-size + $button-size * 2;

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -52,7 +52,7 @@
 	border-top: 1px solid $light-gray-500;
 	padding-top: 8px; // add 1px for the border
 
-	.blocks-base-control {
+	.components-base-control {
 		margin: 0;
 		flex-grow: 1;
 		flex-shrink: 1;

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -7,13 +7,17 @@
 	box-shadow: 0 3px 20px rgba( 18, 24, 30, .1 ), 0 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
 	background: #fff;
-	width: 300px;
+	width: 305px;
 	display: flex;
 	flex-direction: column;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 	z-index: z-index( '.blocks-format-toolbar__link-modal' );
+
+	.blocks-url-input {
+		width: auto;
+	}
 }
 
 .blocks-format-toolbar__link-modal-line {
@@ -40,5 +44,17 @@
 
 	&:after {
 		@include long-content-fade( $size: 40% );
+	}
+}
+
+.blocks-format-toolbar__link-settings {
+	padding: 7px 8px;
+	border-top: 1px solid $light-gray-500;
+	padding-top: 8px; // add 1px for the border
+
+	.blocks-base-control {
+		margin: 0;
+		flex-grow: 1;
+		flex-shrink: 1;
 	}
 }

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -3,11 +3,11 @@
 }
 
 .blocks-format-toolbar__link-modal {
-	position: absolute;
+	position: relative;
+	left: -50%;
 	box-shadow: 0 3px 20px rgba( 18, 24, 30, .1 ), 0 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
 	background: #fff;
-	width: 305px;
 	display: flex;
 	flex-direction: column;
 	font-family: $default-font;
@@ -16,7 +16,7 @@
 	z-index: z-index( '.blocks-format-toolbar__link-modal' );
 
 	.blocks-url-input {
-		width: auto;
+		width: 230px;
 	}
 }
 
@@ -42,13 +42,11 @@
 	flex-grow: 1;
 	flex-shrink: 1;
 	overflow: hidden;
+	text-overflow: ellipsis;
 	position: relative;
 	white-space: nowrap;
-	min-width: 0;
-
-	&:after {
-		@include long-content-fade( $size: 40% );
-	}
+	min-width: 150px;
+	max-width: 500px;
 }
 
 .blocks-format-toolbar__link-settings {

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -33,6 +33,10 @@
 	}
 }
 
+.blocks-format-toolbar__link-settings-toggle .dashicon {
+	transform: rotate(90deg);
+}
+
 .blocks-format-toolbar__link-value {
 	margin: 10px;
 	flex-grow: 1;

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -103,7 +103,7 @@ export function getFormatProperties( formatName, parents ) {
 	switch ( formatName ) {
 		case 'link' : {
 			const anchor = find( parents, node => node.nodeName.toLowerCase() === 'a' );
-			return !! anchor ? { value: anchor.getAttribute( 'href' ) || '', node: anchor } : {};
+			return !! anchor ? { value: anchor.getAttribute( 'href' ) || '', target: anchor.getAttribute( 'target' ) || '', node: anchor } : {};
 		}
 		default:
 			return {};
@@ -753,7 +753,7 @@ export class RichText extends Component {
 					if ( ! anchor ) {
 						this.removeFormat( 'link' );
 					}
-					this.applyFormat( 'link', { href: formatValue.value }, anchor );
+					this.applyFormat( 'link', { href: formatValue.value, target: formatValue.target }, anchor );
 				} else {
 					this.editor.execCommand( 'Unlink' );
 				}

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -432,11 +432,10 @@ export class RichText extends Component {
 		const container = findRelativeParent( this.editor.getBody() );
 		const containerPosition = container.getBoundingClientRect();
 		const toolbarOffset = { top: 10, left: 0 };
-		const linkModalWidth = 298;
 
 		return {
 			top: position.top - containerPosition.top + ( position.height ) + toolbarOffset.top,
-			left: position.left - containerPosition.left - ( linkModalWidth / 2 ) + ( position.width / 2 ) + toolbarOffset.left,
+			left: position.left - containerPosition.left + ( position.width / 2 ) + toolbarOffset.left,
 		};
 	}
 

--- a/blocks/rich-text/test/index.js
+++ b/blocks/rich-text/test/index.js
@@ -145,6 +145,7 @@ describe( 'getFormatProperties', () => {
 		nodeName: 'A',
 		attributes: {
 			href: 'https://www.testing.com',
+			target: '_blank',
 		},
 	};
 
@@ -156,7 +157,7 @@ describe( 'getFormatProperties', () => {
 		expect( getFormatProperties( formatName, [ { ...node, nodeName: 'P' } ] ) ).toEqual( {} );
 	} );
 
-	test( 'should return an object of value and node for a link', () => {
+	test( 'should return a populated object', () => {
 		const mockNode = {
 			...node,
 			getAttribute: jest.fn().mockImplementation( ( attr ) => mockNode.attributes[ attr ] ),
@@ -168,11 +169,12 @@ describe( 'getFormatProperties', () => {
 
 		expect( getFormatProperties( formatName, parents ) ).toEqual( {
 			value: 'https://www.testing.com',
+			target: '_blank',
 			node: mockNode,
 		} );
 	} );
 
-	test( 'should return an object of value and node of empty values when no values are found.', () => {
+	test( 'should return an object with empty values when no link is found', () => {
 		const mockNode = {
 			...node,
 			attributes: {},
@@ -185,6 +187,7 @@ describe( 'getFormatProperties', () => {
 
 		expect( getFormatProperties( formatName, parents ) ).toEqual( {
 			value: '',
+			target: '',
 			node: mockNode,
 		} );
 	} );


### PR DESCRIPTION
Closes #4572.

![linky-links](https://user-images.githubusercontent.com/612155/38406719-bec60cdc-39b9-11e8-9da1-6bc912d294a7.gif)

- Restores the _Open in new window_ setting by reverting #4583.
- Removes the _Unlink_ button. Instead, links can be removed by toggling off the _Link_ button in the formatting toolbar.
- Styles the _Link Settings_ button to look like the mockup in https://github.com/WordPress/gutenberg/issues/4572.
- Styles the suggested links dropdown to look like the mockup in https://github.com/WordPress/gutenberg/issues/4572.
- Makes it so that the UI expands to fit long URLs when not in editing mode.
- Keeps the _Edit link_ and _Apply_ buttons because I agree with https://github.com/WordPress/gutenberg/issues/4572#issuecomment-360538437.
- Does **not** highlight the selected text while the user is inserting a link. I couldn't make it work—see https://github.com/WordPress/gutenberg/pull/4909#issuecomment-364360350 😢 

#### Testing

1. Create a paragraph block.
2. Highlight some text and click the _Link_ button in the formatting toolbar.
3. Create a link by searching for a page.
4. Create a link by typing in an URL.
5. Toggle on/off _Open in new window_ and check that the generated markup receives a `target="_blank"`.
7. Select an existing link and edit it by clicking on the _Edit_ button in the popup.
6. Select an existing link and remove it by clicking on the _Unlink_ button in the formatting toolbar.