### PR TITLE
Issue #6001 - remove label in the shortcode block

### DIFF
--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -3,7 +3,7 @@
  */
 import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { withInstanceId, Dashicon } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -66,10 +66,6 @@ export const settings = {
 
 			return (
 				<div className="wp-block-shortcode">
-					<label htmlFor={ inputId }>
-						<Dashicon icon="editor-code" />
-						{ __( 'Shortcode' ) }
-					</label>
 					<PlainText
 						id={ inputId }
 						value={ attributes.text }

--- a/blocks/library/shortcode/test/__snapshots__/index.js.snap
+++ b/blocks/library/shortcode/test/__snapshots__/index.js.snap
@@ -4,25 +4,6 @@ exports[`core/shortcode block edit matches snapshot 1`] = `
 <div
   class="wp-block-shortcode"
 >
-  <label
-    for="blocks-shortcode-input-0"
-  >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-editor-code"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M9 6l-4 4 4 4-1 2-6-6 6-6zm2 8l4-4-4-4 1-2 6 6-6 6z"
-      />
-    </svg>
-    Shortcode
-  </label>
   <textarea
     class="blocks-plain-text"
     id="blocks-shortcode-input-0"


### PR DESCRIPTION
## Description
Removes the Label from inside the shortcode block.
- The icon was wrong anyway ( code-editor rather than shortcode)
- The text label of Shortcode was unnecessary
- It used up space
- It was inconsistent
- Not required now that there's a new visual indicator for block names.
<!-- Please describe your changes -->

## How Has This Been Tested?
Manually. 
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/2474435/38418124-fb8712aa-3992-11e8-8db1-e6b5084bb904.png)


## Types of changes
I deleted some code.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
