### PR TITLE
Hide 'Advanced' options by default.

### DIFF
--- a/editor/components/block-inspector/index.js
+++ b/editor/components/block-inspector/index.js
@@ -49,6 +49,7 @@ const BlockInspector = ( { selectedBlock, count } ) => {
 				<PanelBody
 					className="editor-block-inspector__advanced"
 					title={ __( 'Advanced' ) }
+					initialOpen={ false }
 				>
 					{ fills }
 				</PanelBody>


### PR DESCRIPTION
## Description
Hide the 'Advanced' options in the Inspector by default.

By definition 'Advanced' options won't be used by most of the time so it makes sense to hide them behind a toggle.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
