### PR TITLE
Drag And Drop: Fix nested blocks ghost

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -1,5 +1,5 @@
 .components-draggable__clone {
-	.editor-block-list__block-draggable {
+	& > .editor-block-list__block > .editor-block-list__block-draggable {
 		background: white;
 		box-shadow: $shadow-popover;
 


### PR DESCRIPTION
closes #6037 

This PR applies the ghost styling (background white with shadow) to the root block being dragged only.

**Testing instructions**

Repeat instructions in #6037, nested blocks shouldn't have the ghost styling when dragging the parent block.