### PR TITLE
Drag & Drop: Disable Drag & Drop into Empty Placeholders

### DIFF
--- a/components/drop-zone/index.js
+++ b/components/drop-zone/index.js
@@ -26,6 +26,7 @@ class DropZone extends Component {
 			isDraggingOverDocument: false,
 			isDraggingOverElement: false,
 			position: null,
+			type: null,
 		};
 	}
 
@@ -49,7 +50,7 @@ class DropZone extends Component {
 
 	render() {
 		const { className, label } = this.props;
-		const { isDraggingOverDocument, isDraggingOverElement, position } = this.state;
+		const { isDraggingOverDocument, isDraggingOverElement, position, type } = this.state;
 		const classes = classnames( 'components-drop-zone', className, {
 			'is-active': isDraggingOverDocument || isDraggingOverElement,
 			'is-dragging-over-document': isDraggingOverDocument,
@@ -58,6 +59,7 @@ class DropZone extends Component {
 			'is-close-to-bottom': position && position.y === 'bottom',
 			'is-close-to-left': position && position.x === 'left',
 			'is-close-to-right': position && position.x === 'right',
+			[ `is-dragging-${ type }` ]: !! type,
 		} );
 
 		return (

--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -81,6 +81,7 @@ class DropZoneProvider extends Component {
 				isDraggingOverDocument: false,
 				isDraggingOverElement: false,
 				position: null,
+				type: null,
 			} );
 		} );
 	}
@@ -164,10 +165,12 @@ class DropZoneProvider extends Component {
 		// Notifying the dropzones
 		dropzonesToUpdate.map( ( dropzone ) => {
 			const index = this.dropzones.indexOf( dropzone );
+			const isDraggingOverDropZone = index === hoveredDropZoneIndex;
 			dropzone.updateState( {
-				isDraggingOverElement: index === hoveredDropZoneIndex,
-				position: index === hoveredDropZoneIndex ? position : null,
+				isDraggingOverElement: isDraggingOverDropZone,
+				position: isDraggingOverDropZone ? position : null,
 				isDraggingOverDocument: this.doesDropzoneSupportType( dropzone, dragEventType ),
+				type: isDraggingOverDropZone ? dragEventType : null,
 			} );
 		} );
 

--- a/editor/components/block-drop-zone/style.scss
+++ b/editor/components/block-drop-zone/style.scss
@@ -1,22 +1,29 @@
 	// Dropzones
-	.editor-block-drop-zone {
-		border: none;
-		border-radius: 0;
+.editor-block-drop-zone {
+	border: none;
+	border-radius: 0;
 
+	.components-drop-zone__content {
+		display: none;
+	}
+
+	&.is-close-to-bottom {
+		background: none;
+		border-bottom: 3px solid $blue-medium-500;
+	}
+
+	&.is-close-to-top,
+	&.is-appender.is-close-to-top,
+	&.is-appender.is-close-to-bottom {
+		background: none;
+		border-top: 3px solid $blue-medium-500;
+		border-bottom: none;
+	}
+
+	&.is-dragging-html,
+	&.is-dragging-default {
 		.components-drop-zone__content {
 			display: none;
 		}
-
-		&.is-close-to-bottom {
-			background: none;
-			border-bottom: 3px solid $blue-medium-500;
-		}
-
-		&.is-close-to-top,
-		&.is-appender.is-close-to-top,
-		&.is-appender.is-close-to-bottom {
-			background: none;
-			border-top: 3px solid $blue-medium-500;
-			border-bottom: none;
-		}
 	}
+}

--- a/editor/components/block-drop-zone/style.scss
+++ b/editor/components/block-drop-zone/style.scss
@@ -1,0 +1,22 @@
+	// Dropzones
+	.editor-block-drop-zone {
+		border: none;
+		border-radius: 0;
+
+		.components-drop-zone__content {
+			display: none;
+		}
+
+		&.is-close-to-bottom {
+			background: none;
+			border-bottom: 3px solid $blue-medium-500;
+		}
+
+		&.is-close-to-top,
+		&.is-appender.is-close-to-top,
+		&.is-appender.is-close-to-bottom {
+			background: none;
+			border-top: 3px solid $blue-medium-500;
+			border-bottom: none;
+		}
+	}

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -389,26 +389,10 @@
 	}
 
 	// Dropzones
-	& > .components-drop-zone {
-		border: none;
+	.editor-block-drop-zone {
 		top: -4px;
 		bottom: -3px;
 		margin: 0 $block-padding;
-		border-radius: 0;
-
-		.components-drop-zone__content {
-			display: none;
-		}
-
-		&.is-close-to-top {
-			background: none;
-			border-top: 3px solid $blue-medium-500;
-		}
-
-		&.is-close-to-bottom {
-			background: none;
-			border-bottom: 3px solid $blue-medium-500;
-		}
 	}
 }
 

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <Connect(WrappedComponent) />
+  <WithDispatch(WrappedComponent) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -47,7 +47,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <Connect(WrappedComponent) />
+  <WithDispatch(WrappedComponent) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -71,7 +71,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <Connect(WrappedComponent) />
+  <WithDispatch(WrappedComponent) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"


### PR DESCRIPTION
closes #6035 

Allowing Drag & Drop into the empty placeholders is a bit confusing because their styling is different and their label is misleading.

In this PR, I'm updating the style of the default block appender dropzone to match the regular block's dropzone (just a single line).

**Testing instructions**

 - try drag and dropping a block
 - While dragging, the dropzone with the "Drop file to upload" label is not shown.