### PR TITLE
Extract map for i18n strings to use for directed load of i18n strings per view.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 gutenberg.zip
 languages/gutenberg.pot
 /languages/gutenberg-translations.php
+translation-map.json
 
 # Directories/files that may appear in your environment
 .DS_Store
@@ -13,4 +14,4 @@ languages/gutenberg.pot
 phpcs.xml
 yarn.lock
 docker-compose.override.yml
-translation-map.json
+*.mo

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ languages/gutenberg.pot
 phpcs.xml
 yarn.lock
 docker-compose.override.yml
+translation-map.json

--- a/bin/i18n-map-extractor.js
+++ b/bin/i18n-map-extractor.js
@@ -22,14 +22,15 @@ class wpi18nExtractor {
 		const strings = [];
 		switch ( functionName ) {
 			case '__':
-			case '_x':
 			case 'sprintf':
+			case '_n':
 				strings.push( args[ 0 ].value );
 				break;
-			case '_n':
-			case '_nx':
-				strings.push( args[ 0 ].value, args[ 1 ].value );
+			case '_x':
+				strings.push( args[ 1 ].value + '\u0004' + args[ 0 ].value );
 				break;
+			case '_nx':
+				strings.push( args[ 3 ].value + '\u0004' + args[ 0 ].value );
 		}
 		return strings;
 	}

--- a/bin/i18n-map-extractor.js
+++ b/bin/i18n-map-extractor.js
@@ -1,6 +1,6 @@
 const recast = require( 'recast' );
 const { forEach, reduce, includes, isEmpty, isFunction } = require( 'lodash' );
-const { writeFileSync } = require( 'fs' );
+const { readFileSync, writeFileSync } = require( 'fs' );
 const NormalModule = require( 'webpack/lib/NormalModule' );
 
 class wpi18nExtractor {
@@ -101,7 +101,7 @@ class wpi18nExtractor {
 					processChunks( chunks, extractor );
 				} );
 			} );
-		// webpack 3 registration.
+			// webpack 3 registration.
 		} else {
 			compiler.plugin( 'this-compilation', ( compilation ) => {
 				compilation.plugin( [ 'optimize-chunks', 'optimize-extracted-chunks' ], ( chunks ) => {
@@ -117,7 +117,8 @@ class wpi18nExtractor {
 			translationMap,
 			parseSourcesToMap,
 		} = extractor;
-		let chunkName;
+		let chunkName,
+			finalMap;
 		forEach( chunks, function( chunk ) {
 			if ( chunk.name ) {
 				//get chunk.name from alias if it exists
@@ -127,8 +128,16 @@ class wpi18nExtractor {
 				parseSourcesToMap( chunk._modules, chunkName, extractor );
 			}
 		} );
+		//get existing json and merge
+		try {
+			finalMap = JSON.parse( readFileSync( './' + options.filename ) );
+		} catch ( e ) {
+			// if there is no existing file then lets just default to an empty object.
+			finalMap = {};
+		}
+		finalMap = Object.assign( {}, finalMap, translationMap );
 		writeFileSync( './' + options.filename,
-			JSON.stringify( translationMap, null, 2 ),
+			JSON.stringify( finalMap, null, 2 ),
 			'utf-8'
 		);
 	}

--- a/bin/i18n-map-extractor.js
+++ b/bin/i18n-map-extractor.js
@@ -38,13 +38,13 @@ class wpi18nExtractor {
 
 	getStringsFromModule( module, extractor ) {
 		const source = module.originalSource().source();
+		const { parse, types } = recast;
 		if ( isEmpty( source ) ) {
 			return [];
 		}
 		let strings = [];
 		try {
-			const ast = recast.parse( source );
-			const { types } = recast;
+			const ast = parse( source );
 			types.visit( ast, {
 				visitCallExpression: function( path ) {
 					const node = path.node;
@@ -132,7 +132,6 @@ class wpi18nExtractor {
 		try {
 			finalMap = JSON.parse( readFileSync( './' + options.filename ) );
 		} catch ( e ) {
-			// if there is no existing file then lets just default to an empty object.
 			finalMap = {};
 		}
 		finalMap = Object.assign( {}, finalMap, translationMap );

--- a/bin/i18n-map-extractor.js
+++ b/bin/i18n-map-extractor.js
@@ -1,7 +1,7 @@
-const recast = require('recast');
-const { forEach, reduce, includes, has, isEmpty, isFunction } = require('lodash');
-const { writeFileSync } = require('fs');
-const NormalModule = require('webpack/lib/NormalModule');
+const recast = require( 'recast' );
+const { forEach, reduce, includes, has, isEmpty, isFunction } = require( 'lodash' );
+const { writeFileSync } = require( 'fs' );
+const NormalModule = require( 'webpack/lib/NormalModule' );
 
 class wpi18nExtractor {
 	constructor( options ) {
@@ -10,6 +10,7 @@ class wpi18nExtractor {
 			'_n',
 			'_x',
 			'_nx',
+			'sprintf',
 		];
 		this.options = options || {};
 		this.options.filename = this.options.filename || 'translation-map.json';
@@ -43,19 +44,19 @@ class wpi18nExtractor {
 			const ast = recast.parse( source );
 			const { types } = recast;
 			types.visit( ast, {
-				visitCallExpression: function(path) {
+				visitCallExpression: function( path ) {
 					const node = path.node;
-					if (includes(extractor.functionNames, node.callee.name)
-						&& node.arguments
+					if ( includes( extractor.functionNames, node.callee.name ) &&
+						node.arguments
 					) {
 						strings = strings.concat(
 							extractor.extractStringFromFunctionCall(
-								types.getFieldValue(node, 'arguments'),
+								types.getFieldValue( node, 'arguments' ),
 								node.callee.name,
 							)
 						);
 					}
-					this.traverse(path);
+					this.traverse( path );
 				},
 			} );
 		} catch ( e ) {
@@ -69,8 +70,8 @@ class wpi18nExtractor {
 		reduce(
 			Array.from( modules ),
 			function( mapped, module ) {
-				if ( ! module instanceof NormalModule
-					|| ! isFunction( module.originalSource )
+				if ( ! module instanceof NormalModule ||
+					! isFunction( module.originalSource )
 				) {
 					return mapped;
 				}

--- a/bin/i18n-map-extractor.js
+++ b/bin/i18n-map-extractor.js
@@ -1,0 +1,112 @@
+const recast = require('recast');
+const { forEach, reduce, includes, has, isEmpty, isFunction } = require('lodash');
+const { writeFileSync } = require('fs');
+const NormalModule = require('webpack/lib/NormalModule');
+
+class wpi18nExtractor {
+	constructor( options ) {
+		const DEFAULT_FUNCTIONS = [
+			'__',
+			'_n',
+			'_x',
+			'_nx',
+		];
+		this.options = options || {};
+		this.options.filename = this.options.filename || 'translation-map.json';
+		this.translationMap = {};
+		this.functionNames = this.options.functionNames || DEFAULT_FUNCTIONS;
+	}
+
+	extractStringFromFunctionCall( args, functionName ) {
+		const strings = [];
+		switch ( functionName ) {
+			case '__':
+			case '_x':
+			case 'sprintf':
+				strings.push( args[ 0 ].value );
+				break;
+			case '_n':
+			case '_nx':
+				strings.push( args[ 0 ].value, args[ 1 ].value );
+				break;
+		}
+		return strings;
+	}
+
+	getStringsFromModule( module, extractor ) {
+		const source = module.originalSource().source();
+		if ( isEmpty( source ) ) {
+			return [];
+		}
+		let strings = [];
+		try {
+			const ast = recast.parse( source );
+			const { types } = recast;
+			types.visit( ast, {
+				visitCallExpression: function(path) {
+					const node = path.node;
+					if (includes(extractor.functionNames, node.callee.name)
+						&& node.arguments
+					) {
+						strings = strings.concat(
+							extractor.extractStringFromFunctionCall(
+								types.getFieldValue(node, 'arguments'),
+								node.callee.name,
+							)
+						);
+					}
+					this.traverse(path);
+				},
+			} );
+		} catch ( e ) {
+			//we just want to skip parsing errors.
+		}
+		return strings;
+	}
+
+	parseSourcesToMap( modules, chunkName, extractor ) {
+		const { getStringsFromModule } = extractor;
+		reduce(
+			Array.from( modules ),
+			function( mapped, module ) {
+				if ( ! module instanceof NormalModule
+					|| ! isFunction( module.originalSource )
+				) {
+					return mapped;
+				}
+				if ( ! has( mapped, chunkName ) ) {
+					mapped[ chunkName ] = [];
+				}
+				mapped[ chunkName ] = mapped[ chunkName ]
+					.concat( getStringsFromModule( module, extractor ) );
+				return mapped;
+			},
+			extractor.translationMap
+		);
+	}
+
+	apply( compiler ) {
+		const {
+			options,
+			translationMap,
+			parseSourcesToMap,
+		} = this;
+		const extractor = this;
+
+		compiler.plugin( 'this-compilation', ( compilation ) => {
+			compilation.plugin( [ 'optimize-chunks', 'optimize-extracted-chunks' ], ( chunks ) => {
+				forEach( chunks, function( chunk ) {
+					if ( chunk.name ) {
+						parseSourcesToMap( chunk._modules, chunk.name, extractor );
+					}
+				} );
+				writeFileSync( './' + options.filename,
+					JSON.stringify( translationMap, null, 2 ),
+					'utf-8'
+				);
+			} );
+		} );
+	}
+}
+
+module.exports = wpi18nExtractor;

--- a/bin/i18n-map-extractor.js
+++ b/bin/i18n-map-extractor.js
@@ -121,9 +121,9 @@ class wpi18nExtractor {
 		forEach( chunks, function( chunk ) {
 			if ( chunk.name ) {
 				//get chunk.name from alias if it exists
-				chunkName = options.aliases.hasOwnProperty(chunk.name)
-					? options.aliases[chunk.name]
-					: chunk.name;
+				chunkName = options.aliases.hasOwnProperty( chunk.name ) ?
+					options.aliases[ chunk.name ] :
+					chunk.name;
 				parseSourcesToMap( chunk._modules, chunkName, extractor );
 			}
 		} );

--- a/bin/i18n-map-extractor.js
+++ b/bin/i18n-map-extractor.js
@@ -13,6 +13,7 @@ class wpi18nExtractor {
 			'sprintf',
 		];
 		this.options = options || {};
+		this.options.aliases = this.options.aliases || {};
 		this.options.filename = this.options.filename || 'translation-map.json';
 		this.translationMap = {};
 		this.functionNames = this.options.functionNames || DEFAULT_FUNCTIONS;
@@ -116,9 +117,14 @@ class wpi18nExtractor {
 			translationMap,
 			parseSourcesToMap,
 		} = extractor;
+		let chunkName;
 		forEach( chunks, function( chunk ) {
 			if ( chunk.name ) {
-				parseSourcesToMap( chunk._modules, chunk.name, extractor );
+				//get chunk.name from alias if it exists
+				chunkName = options.aliases.hasOwnProperty(chunk.name)
+					? options.aliases[chunk.name]
+					: chunk.name;
+				parseSourcesToMap( chunk._modules, chunkName, extractor );
 			}
 		} );
 		writeFileSync( './' + options.filename,

--- a/bin/i18n-map-extractor.js
+++ b/bin/i18n-map-extractor.js
@@ -1,5 +1,5 @@
 const recast = require( 'recast' );
-const { forEach, reduce, includes, has, isEmpty, isFunction } = require( 'lodash' );
+const { forEach, reduce, includes, isEmpty, isFunction } = require( 'lodash' );
 const { writeFileSync } = require( 'fs' );
 const NormalModule = require( 'webpack/lib/NormalModule' );
 
@@ -76,7 +76,7 @@ class wpi18nExtractor {
 				) {
 					return mapped;
 				}
-				if ( ! has( mapped, chunkName ) ) {
+				if ( ! mapped.hasOwnProperty( chunkName ) ) {
 					mapped[ chunkName ] = [];
 				}
 				mapped[ chunkName ] = mapped[ chunkName ]
@@ -94,12 +94,13 @@ class wpi18nExtractor {
 		/**
 		 * webpack 4 registration
 		 */
-		if ( has( compiler, 'hooks' ) ) {
+		if ( compiler.hasOwnProperty( 'hooks' ) ) {
 			compiler.hooks.thisCompilation.tap( 'webpack-i18n-map-extractor', compilation => {
 				compilation.hooks.optimizeChunks.tap( 'webpack-i18n-map-extractor', chunks => {
 					processChunks( chunks, extractor );
 				} );
 			} );
+		// webpack 3 registration.
 		} else {
 			compiler.plugin( 'this-compilation', ( compilation ) => {
 				compilation.plugin( [ 'optimize-chunks', 'optimize-extracted-chunks' ], ( chunks ) => {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"composer/installers": "~1.0"
 	},
 	"scripts": {
-		"lint": "phpcs"
+		"lint": "phpcs",
+	  	"lint:fix": "phpcbf"
 	}
 }

--- a/lib/class-gb-scripts.php
+++ b/lib/class-gb-scripts.php
@@ -1,13 +1,16 @@
 <?php
-
-if ( ! defined( 'ABSPATH' ) ) {
-	die( 'Silence is golden.' );
-}
+/**
+ * This file includes the GB_Scripts class which handles automatic i81n string attachment to registered js scripts.
+ *
+ * @package gutenberg
+ * @since 2.6.x
+ */
 
 /**
  * This class handles queueing up only the translations for javascript files that have been enqueued for translation.
  *
- * @since   1.0.0
+ * @package gutenberg
+ * @since   2.6.x
  */
 class GB_Scripts {
 
@@ -51,9 +54,10 @@ class GB_Scripts {
 	/**
 	 * Used to register a script that has i18n strings for its $chunk_name
 	 *
-	 * @param string $handle
-	 * @param string $chunk_name
-	 * @param string $domain
+	 * @param string $handle    The script handle reference.
+	 * @param string $chunk_name The name used for the script chunk in the build process.  Should correspond to the an
+	 *                           index for strings in the translation-map.json.
+	 * @param string $domain    The i18n domain for the strings.
 	 */
 	public function register_script_i18n( $handle, $chunk_name, $domain ) {
 		$this->registered_i18n[ $handle ] = array( $chunk_name, $domain );
@@ -63,7 +67,7 @@ class GB_Scripts {
 	/**
 	 * Callback on print_scripts_array to listen for scripts enqueued and handle seting up the localized data.
 	 *
-	 * @param $handles
+	 * @param array $handles Array of registered script handles.
 	 *
 	 * @return array
 	 */
@@ -71,33 +75,33 @@ class GB_Scripts {
 		if ( empty( $this->registered_i18n ) || empty( $this->chunk_map ) ) {
 			return $handles;
 		}
-		foreach ( ( array ) $handles as $handle ) {
+		foreach ( (array) $handles as $handle ) {
 			$this->queue_i18n_chunk_for_handle( $handle );
 		}
 		if ( $this->queued_chunk_translations ) {
 			foreach ( $this->queued_chunk_translations as $handle => $translations_for_domain ) {
 				$this->register_inline_script(
 					$handle,
-					$translations_for_domain[ 'translations' ],
-					$translations_for_domain[ 'domain' ]
+					$translations_for_domain['translations'],
+					$translations_for_domain['domain']
 				);
 			}
 		}
 		return $handles;
 	}
-	
-	
+
+
 	/**
 	 * Registers inline script with translations for given handle and domain.
 	 *
-	 * @param string $handle  Handle used to register javascript file containing translations
-	 * @param array  $translations
+	 * @param string $handle  Handle used to register javascript file containing translations.
+	 * @param array  $translations  Array of string translations.
 	 * @param string $domain    Domain for translations.  If left empty then strings are registered with the default
 	 *                          domain for the javascript.
 	 */
 	private function register_inline_script( $handle, $translations, $domain = '' ) {
 		$script = $domain ?
-			'wp.i18n.setLocaleData( ' . json_encode( $translations ) . ', ' . $domain .  ' );' :
+			'wp.i18n.setLocaleData( ' . json_encode( $translations ) . ', ' . $domain . ' );' :
 			'wp.i18n.setLocaleData( ' . json_encode( $translations ) . ' );';
 		wp_add_inline_script(
 			$handle,
@@ -110,19 +114,19 @@ class GB_Scripts {
 	/**
 	 * Queues up the translation strings for the given handle.
 	 *
-	 * @param string $handle
+	 * @param string $handle  The script handle being queued up.
 	 */
 	private function queue_i18n_chunk_for_handle( $handle ) {
 		if ( isset( $this->registered_i18n[ $handle ] ) ) {
 			list( $chunk, $domain ) = $this->registered_i18n[ $handle ];
-			$translations = $this->get_jed_locale_data_for_domain_and_chunk( $chunk, $domain );
+			$translations           = $this->get_jed_locale_data_for_domain_and_chunk( $chunk, $domain );
 			if ( count( $translations ) > 1 ) {
 				$this->queued_chunk_translations[ $handle ] = array(
 					'domain'       => $domain,
-					'translations' => $this->get_jed_locale_data_for_domain_and_chunk( $chunk, $domain )
+					'translations' => $this->get_jed_locale_data_for_domain_and_chunk( $chunk, $domain ),
 				);
 			}
-			unset ( $this->registered_i18n[ $handle ] );
+			unset( $this->registered_i18n[ $handle ] );
 		}
 	}
 
@@ -132,10 +136,11 @@ class GB_Scripts {
 	 *
 	 * If $chunk_map is empty or not an array, will attempt to load a chunk map from a default named map.
 	 *
-	 * @param array $chunk_map
+	 * @param array $chunk_map If provided, an array of translation strings indexed by script chunk_names they
+	 *                         correspond to.
 	 */
 	private function set_chunk_map( $chunk_map ) {
-		if ( empty( $chunk_map ) || ! is_array( $chunk_map) ) {
+		if ( empty( $chunk_map ) || ! is_array( $chunk_map ) ) {
 			$chunk_map = json_decode(
 				file_get_contents( gutenberg_dir_path() . 'translation-map.json' ),
 				true
@@ -148,20 +153,20 @@ class GB_Scripts {
 	/**
 	 * Get the jed locale data for a given chunk and domain
 	 *
-	 * @param string $chunk
-	 * @param string $domain
+	 * @param string $chunk_name  The name for the script chunk we want strings returned from.
+	 * @param string $domain      The i18n domain.
 	 *
-	 * @return array()
+	 * @return array
 	 */
-	protected function get_jed_locale_data_for_domain_and_chunk( $chunk, $domain ) {
+	protected function get_jed_locale_data_for_domain_and_chunk( $chunk_name, $domain ) {
 		$translations = gutenberg_get_jed_locale_data( $domain );
-		//get index for adding back after extracting strings for this $chunk
-		$index = $translations[ '' ];
-		$translations = $this->get_locale_data_matching_map(
-			$this->get_original_strings_for_chunk_from_map( $chunk ),
+		// get index for adding back after extracting strings for this $chunk.
+		$index            = $translations[''];
+		$translations     = $this->get_locale_data_matching_map(
+			$this->get_original_strings_for_chunk_from_map( $chunk_name ),
 			$translations
 		);
-		$translations[ '' ] = $index;
+		$translations[''] = $index;
 		return $translations;
 	}
 
@@ -169,17 +174,17 @@ class GB_Scripts {
 	/**
 	 * Get locale data for given strings from given translations
 	 *
-	 * @param $string_set
-	 * @param $translations
+	 * @param array $string_set   This is the subset of strings (msgIds) we want to extract from the translations array.
+	 * @param array $translations  Translation data to extra strings from.
 	 *
 	 * @return array
 	 */
 	protected function get_locale_data_matching_map( $string_set, $translations ) {
-		if ( ! is_array( $string_set ) || ! is_array( $translations ) || empty ( $string_set ) ) {
+		if ( ! is_array( $string_set ) || ! is_array( $translations ) || empty( $string_set ) ) {
 			return array();
 		}
-		//some strings with quotes in them will break on the array_flip, so making sure quotes in the string are slashed
-		//also filter falsey values
+		// some strings with quotes in them will break on the array_flip, so making sure quotes in the string are
+		// slashed also filter falsey values.
 		$string_set = array_unique( array_filter( wp_slash( $string_set ) ) );
 		return array_intersect_key( $translations, array_flip( $string_set ) );
 	}
@@ -188,7 +193,7 @@ class GB_Scripts {
 	/**
 	 * Get original strings to translate for the given chunk from the map
 	 *
-	 * @param string $chunk_name
+	 * @param string $chunk_name    The script chunk name to get strings from the map for.
 	 *
 	 * @return array
 	 */

--- a/lib/class-gb-scripts.php
+++ b/lib/class-gb-scripts.php
@@ -102,11 +102,7 @@ class GB_Scripts {
 		$script = $domain ?
 			'wp.i18n.setLocaleData( ' . json_encode( $translations ) . ', ' . $domain . ' );' :
 			'wp.i18n.setLocaleData( ' . json_encode( $translations ) . ' );';
-		wp_add_inline_script(
-			$handle,
-			$script,
-			'before'
-		);
+		wp_add_inline_script( $handle, $script, 'before' );
 	}
 
 

--- a/lib/class-gb-scripts.php
+++ b/lib/class-gb-scripts.php
@@ -77,10 +77,15 @@ class GB_Scripts {
 		}
 		if ( $handle && ! empty( $this->queued_chunk_translations ) ) {
 			foreach ( $this->queued_chunk_translations as $domain => $translations ) {
+				$index_translation = isset( $translations[""] ) ?
+					$translations[""]
+					: '';
+				unset($translations[""]);
 				$translations = call_user_func_array( 'array_merge', $translations );
+				$translations[""] = $index_translation;
 				wp_add_inline_script(
-					$handle,
-					'wp.i18n.setLocaleData( ' . json_encode( $translations ) . ', "' . $domain . '" );'
+					'wp-i18n',
+					'wp.i18n.setLocaleData( ' . json_encode( $translations ) . ' );'
 				);
 			}
 		}

--- a/lib/class-gb-scripts.php
+++ b/lib/class-gb-scripts.php
@@ -37,8 +37,8 @@ class GB_Scripts {
 	 * @var array
 	 */
 	private $i18n_map;
-	
-	
+
+
 	/**
 	 * GB_Scripts constructor.
 	 *
@@ -50,8 +50,8 @@ class GB_Scripts {
 		$this->set_chunk_map( $i18n_map );
 		add_filter( 'print_scripts_array', array( $this, 'queue_i18n' ) );
 	}
-	
-	
+
+
 	/**
 	 * Used to register a script that has i18n strings for its $handle
 	 *
@@ -113,12 +113,12 @@ class GB_Scripts {
 	 */
 	private function queue_i18n_translations_for_handle( $handle ) {
 		if ( isset( $this->registered_i18n[ $handle ] ) ) {
-			$domain = $this->registered_i18n[ $handle ];
-			$translations           = $this->get_jed_locale_data_for_domain_and_chunk( $handle, $domain );
+			$domain       = $this->registered_i18n[ $handle ];
+			$translations = $this->get_jed_locale_data_for_domain_and_chunk( $handle, $domain );
 			if ( count( $translations ) > 1 ) {
 				$this->queued_chunk_translations[ $handle ] = array(
 					'domain'       => $domain,
-					'translations' => $translations
+					'translations' => $translations,
 				);
 			}
 			unset( $this->registered_i18n[ $handle ] );

--- a/lib/class-gb-scripts.php
+++ b/lib/class-gb-scripts.php
@@ -1,0 +1,186 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * This class handles queueing up only the translations for javascript files that have been enqueued for translation.
+ *
+ * @since   1.0.0
+ */
+class GB_Scripts {
+
+	/**
+	 * Will hold all registered i18n scripts.
+	 *
+	 * @var array
+	 */
+	private $registered_i18n = array();
+
+
+	/**
+	 * Used to hold queued translations for the chunks loading in a view.
+	 *
+	 * @var array
+	 */
+	private $queued_chunk_translations = array();
+
+
+	/**
+	 * Obtained from the generated json file from the all javascript using wp.i18n with a map of chunk names to
+	 * translation strings.
+	 *
+	 * @var array
+	 */
+	private $chunk_map;
+
+
+	/**
+	 * GB_Scripts constructor.
+	 *
+	 * @param array() $chunk_map  An array of chunks and the strings translated for those chunks.  If not provided class
+	 *                            will look for map in root of plugin with filename of 'translation-map.json'.
+	 */
+	public function __construct( $chunk_map = array() ) {
+		$this->set_chunk_map( $chunk_map );
+		add_filter( 'print_scripts_array', array( $this, 'queue_i18n' ) );
+	}
+
+
+	/**
+	 * Used to register a script that has i18n strings for its $chunk_name
+	 *
+	 * @param string $handle
+	 * @param string $chunk_name
+	 * @param string $domain
+	 */
+	public function register_script_i18n( $handle, $chunk_name, $domain ) {
+		$this->registered_i18n[ $handle ] = array( $chunk_name, $domain );
+	}
+
+
+	/**
+	 * Callback on print_scripts_array to listen for scripts enqueued and handle seting up the localized data.
+	 *
+	 * @param $handles
+	 *
+	 * @return array
+	 */
+	public function queue_i18n( $handles ) {
+		if ( empty( $this->registered_i18n ) || empty( $this->chunk_map ) ) {
+			return $handles;
+		}
+		$handle = '';
+		foreach ( (array) $handles as $handle ) {
+			$this->queue_i18n_chunk_for_handle( $handle );
+		}
+		if ( $handle && ! empty( $this->queued_chunk_translations ) ) {
+			foreach ( $this->queued_chunk_translations as $domain => $translations ) {
+				$translations = call_user_func_array( 'array_merge', $translations );
+				wp_add_inline_script(
+					$handle,
+					'wp.i18n.setLocaleData( ' . json_encode( $translations ) . ', "' . $domain . '" );'
+				);
+			}
+		}
+		return $handles;
+	}
+
+
+	/**
+	 * Queues up the translation strings for the given handle.
+	 *
+	 * @param string $handle
+	 */
+	private function queue_i18n_chunk_for_handle( $handle ) {
+		if ( isset( $this->registered_i18n[ $handle ] ) ) {
+			list( $chunk, $domain ) = $this->registered_i18n[ $handle ];
+			if ( ! isset( $this->queued_chunk_translations[ $domain ] ) ) {
+				$this->queued_chunk_translations[ $domain ][''] = $this->get_initial_jed_locale_data_for_domain( $domain );
+			}
+			$this->queued_chunk_translations[ $domain ][] = $this->get_jed_locale_data_for_domain_and_chunk( $chunk, $domain );
+			//make sure we only enqueue once
+			unset ( $this->registered_i18n[ $handle ] );
+		}
+	}
+
+
+	/**
+	 * Sets the internal chunk_map property.
+	 *
+	 * If $chunk_map is empty or not an array, will attempt to load a chunk map from a default named map.
+	 *
+	 * @param array $chunk_map
+	 */
+	private function set_chunk_map( $chunk_map ) {
+		if ( empty( $chunk_map ) || ! is_array( $chunk_map) ) {
+			$chunk_map = json_decode(
+				file_get_contents(gutenberg_dir_path() . 'translation-map.json' ),
+				true
+			);
+		}
+		$this->chunk_map = $chunk_map;
+	}
+
+
+	/**
+	 * Provides the base locale data for the domain.
+	 *
+	 * @param $domain
+	 * @return mixed
+	 */
+	protected function get_initial_jed_locale_data_for_domain( $domain ) {
+		$locale_data = gutenberg_get_jed_locale_data( $domain );
+		return $locale_data[''];
+	}
+
+
+	/**
+	 * Get the jed locale data for a given chunk and domain
+	 *
+	 * @param string $chunk
+	 * @param string $domain
+	 *
+	 * @return array()
+	 */
+	protected function get_jed_locale_data_for_domain_and_chunk( $chunk, $domain ) {
+		$translations = gutenberg_get_jed_locale_data( $domain );
+		//unset the empty string index because we've already taken care of that earlier
+		unset ( $translations[''] );
+		return $this->get_locale_data_matching_map(
+			$this->get_original_strings_for_chunk_from_map( $chunk ),
+			$translations
+		);
+	}
+
+
+	/**
+	 * Get locale data for given strings from given translations
+	 *
+	 * @param $string_set
+	 * @param $translations
+	 *
+	 * @return array
+	 */
+	protected function get_locale_data_matching_map( $string_set, $translations ) {
+		if ( ! is_array( $string_set ) || ! is_array( $translations ) || empty ( $string_set ) ) {
+			return array();
+		}
+		//some strings with quotes in them will break on the array_flip, so making sure quotes in the string are slashed
+		$string_set = wp_slash( $string_set );
+		return array_intersect_key( $translations, array_flip( $string_set ) );
+	}
+
+
+	/**
+	 * Get original strings to translate for the given chunk from the map
+	 *
+	 * @param string $chunk_name
+	 *
+	 * @return array
+	 */
+	protected function get_original_strings_for_chunk_from_map( $chunk_name ) {
+		return isset( $this->chunk_map[ $chunk_name ] ) ? $this->chunk_map[ $chunk_name ] : array();
+	}
+}

--- a/lib/class-gb-scripts.php
+++ b/lib/class-gb-scripts.php
@@ -179,7 +179,8 @@ class GB_Scripts {
 			return array();
 		}
 		//some strings with quotes in them will break on the array_flip, so making sure quotes in the string are slashed
-		$string_set = wp_slash( $string_set );
+		//also filter falsey values
+		$string_set = array_unique( array_filter( wp_slash( $string_set ) ) );
 		return array_intersect_key( $translations, array_flip( $string_set ) );
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -115,31 +115,35 @@ function gutenberg_register_scripts_and_styles() {
 		true
 	);
 	global $wp_locale;
-	wp_add_inline_script( 'wp-date', 'window._wpDateSettings = ' . wp_json_encode( array(
-		'l10n'     => array(
-			'locale'        => get_user_locale(),
-			'months'        => array_values( $wp_locale->month ),
-			'monthsShort'   => array_values( $wp_locale->month_abbrev ),
-			'weekdays'      => array_values( $wp_locale->weekday ),
-			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
-			'meridiem'      => (object) $wp_locale->meridiem,
-			'relative'      => array(
-				/* translators: %s: duration */
-				'future' => __( '%s from now', 'default' ),
-				/* translators: %s: duration */
-				'past'   => __( '%s ago', 'default' ),
-			),
-		),
-		'formats'  => array(
-			'time'     => get_option( 'time_format', __( 'g:i a', 'default' ) ),
-			'date'     => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
-			'datetime' => __( 'F j, Y g:i a', 'default' ),
-		),
-		'timezone' => array(
-			'offset' => get_option( 'gmt_offset', 0 ),
-			'string' => get_option( 'timezone_string', 'UTC' ),
-		),
-	) ), 'before' );
+	wp_add_inline_script(
+		'wp-date', 'window._wpDateSettings = ' . wp_json_encode(
+			array(
+				'l10n'     => array(
+					'locale'        => get_user_locale(),
+					'months'        => array_values( $wp_locale->month ),
+					'monthsShort'   => array_values( $wp_locale->month_abbrev ),
+					'weekdays'      => array_values( $wp_locale->weekday ),
+					'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+					'meridiem'      => (object) $wp_locale->meridiem,
+					'relative'      => array(
+						/* translators: %s: duration */
+						'future' => __( '%s from now', 'default' ),
+						/* translators: %s: duration */
+						'past'   => __( '%s ago', 'default' ),
+					),
+				),
+				'formats'  => array(
+					'time'     => get_option( 'time_format', __( 'g:i a', 'default' ) ),
+					'date'     => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
+					'datetime' => __( 'F j, Y g:i a', 'default' ),
+				),
+				'timezone' => array(
+					'offset' => get_option( 'gmt_offset', 0 ),
+					'string' => get_option( 'timezone_string', 'UTC' ),
+				),
+			)
+		), 'before'
+	);
 	wp_register_script(
 		'wp-i18n',
 		gutenberg_url( 'i18n/build/index.js' ),
@@ -170,10 +174,12 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_add_inline_script(
 		'wp-blocks',
-		gutenberg_get_script_polyfill( array(
-			'\'Promise\' in window' => 'promise',
-			'\'fetch\' in window'   => 'fetch',
-		) ),
+		gutenberg_get_script_polyfill(
+			array(
+				'\'Promise\' in window' => 'promise',
+				'\'fetch\' in window'   => 'fetch',
+			)
+		),
 		'before'
 	);
 	wp_register_script(
@@ -187,70 +193,90 @@ function gutenberg_register_scripts_and_styles() {
 	wp_add_inline_script(
 		'wp-blocks', 'window.wp.oldEditor = window.wp.editor;', 'before'
 	);
-	$tinymce_settings = apply_filters( 'tiny_mce_before_init', array(
-		'plugins'          => implode( ',', array_unique( apply_filters( 'tiny_mce_plugins', array(
-			'charmap',
-			'colorpicker',
-			'hr',
-			'lists',
-			'media',
-			'paste',
-			'tabfocus',
-			'textcolor',
-			'fullscreen',
-			'wordpress',
-			'wpautoresize',
-			'wpeditimage',
-			'wpemoji',
-			'wpgallery',
-			'wplink',
-			'wpdialogs',
-			'wptextpattern',
-			'wpview',
-		) ) ) ),
-		'toolbar1'         => implode( ',', array_merge( apply_filters( 'mce_buttons', array(
-			'formatselect',
-			'bold',
-			'italic',
-			'bullist',
-			'numlist',
-			'blockquote',
-			'alignleft',
-			'aligncenter',
-			'alignright',
-			'link',
-			'unlink',
-			'wp_more',
-			'spellchecker',
-		), 'editor' ), array( 'kitchensink' ) ) ),
-		'toolbar2'         => implode( ',', apply_filters( 'mce_buttons_2', array(
-			'strikethrough',
-			'hr',
-			'forecolor',
-			'pastetext',
-			'removeformat',
-			'charmap',
-			'outdent',
-			'indent',
-			'undo',
-			'redo',
-			'wp_help',
-		), 'editor' ) ),
-		'toolbar3'         => implode( ',', apply_filters( 'mce_buttons_3', array(), 'editor' ) ),
-		'toolbar4'         => implode( ',', apply_filters( 'mce_buttons_4', array(), 'editor' ) ),
-		'external_plugins' => apply_filters( 'mce_external_plugins', array() ),
-	), 'editor' );
+	$tinymce_settings = apply_filters(
+		'tiny_mce_before_init', array(
+			'plugins'          => implode(
+				',', array_unique(
+					apply_filters(
+						'tiny_mce_plugins', array(
+							'charmap',
+							'colorpicker',
+							'hr',
+							'lists',
+							'media',
+							'paste',
+							'tabfocus',
+							'textcolor',
+							'fullscreen',
+							'wordpress',
+							'wpautoresize',
+							'wpeditimage',
+							'wpemoji',
+							'wpgallery',
+							'wplink',
+							'wpdialogs',
+							'wptextpattern',
+							'wpview',
+						)
+					)
+				)
+			),
+			'toolbar1'         => implode(
+				',', array_merge(
+					apply_filters(
+						'mce_buttons', array(
+							'formatselect',
+							'bold',
+							'italic',
+							'bullist',
+							'numlist',
+							'blockquote',
+							'alignleft',
+							'aligncenter',
+							'alignright',
+							'link',
+							'unlink',
+							'wp_more',
+							'spellchecker',
+						), 'editor'
+					), array( 'kitchensink' )
+				)
+			),
+			'toolbar2'         => implode(
+				',', apply_filters(
+					'mce_buttons_2', array(
+						'strikethrough',
+						'hr',
+						'forecolor',
+						'pastetext',
+						'removeformat',
+						'charmap',
+						'outdent',
+						'indent',
+						'undo',
+						'redo',
+						'wp_help',
+					), 'editor'
+				)
+			),
+			'toolbar3'         => implode( ',', apply_filters( 'mce_buttons_3', array(), 'editor' ) ),
+			'toolbar4'         => implode( ',', apply_filters( 'mce_buttons_4', array(), 'editor' ) ),
+			'external_plugins' => apply_filters( 'mce_external_plugins', array() ),
+		), 'editor'
+	);
 	if ( isset( $tinymce_settings['style_formats'] ) && is_string( $tinymce_settings['style_formats'] ) ) {
 		// Decode the options as we used to recommende json_encoding the TinyMCE settings.
 		$tinymce_settings['style_formats'] = json_decode( $tinymce_settings['style_formats'] );
 	}
-	wp_localize_script( 'wp-blocks', 'wpEditorL10n', array(
-		'tinymce' => array(
-			'baseURL'  => includes_url( 'js/tinymce' ),
-			'suffix'   => SCRIPT_DEBUG ? '' : '.min',
-			'settings' => $tinymce_settings,
-		),
-	) );
+	wp_localize_script(
+		'wp-blocks', 'wpEditorL10n', array(
+			'tinymce' => array(
+				'baseURL'  => includes_url( 'js/tinymce' ),
+				'suffix'   => SCRIPT_DEBUG ? '' : '.min',
+				'settings' => $tinymce_settings,
+			),
+		)
+	);
 
 	wp_register_script(
 		'wp-editor',
@@ -634,10 +660,12 @@ JS;
 	// Localize the wp-api settings and schema.
 	$schema_response = rest_do_request( new WP_REST_Request( 'GET', '/' ) );
 	if ( ! $schema_response->is_error() ) {
-		wp_add_inline_script( 'wp-api', sprintf(
-			'wpApiSettings.cacheSchema = true; wpApiSettings.schema = %s;',
-			wp_json_encode( $schema_response->get_data() )
-		), 'before' );
+		wp_add_inline_script(
+			'wp-api', sprintf(
+				'wpApiSettings.cacheSchema = true; wpApiSettings.schema = %s;',
+				wp_json_encode( $schema_response->get_data() )
+			), 'before'
+		);
 	}
 }
 
@@ -802,20 +830,25 @@ function gutenberg_capture_code_editor_settings( $settings ) {
 }
 
 
+/**
+ * This takes care of registering script i18n strings with each handle and chunk for that handle
+ *
+ * @since 2.6.x
+ */
 function gutenberg_register_wpi18n_for_scripts() {
 	$handles_and_chunks = array(
-		'wp-data' => 'data',
-		'wp-core-data' => 'coreData',
-		'wp-utils' => 'utils',
-		'wp-hooks' => 'hooks',
-		'wp-date' => 'date',
-		'wp-element' => 'element',
+		'wp-data'       => 'data',
+		'wp-core-data'  => 'coreData',
+		'wp-utils'      => 'utils',
+		'wp-hooks'      => 'hooks',
+		'wp-date'       => 'date',
+		'wp-element'    => 'element',
 		'wp-components' => 'components',
-		'wp-blocks' => 'blocks',
-		'wp-viewport' => 'viewport',
-		'wp-editor' => 'editor',
-		'wp-edit-post' => 'editPost',
-		'wp-plugins' => 'plugins'
+		'wp-blocks'     => 'blocks',
+		'wp-viewport'   => 'viewport',
+		'wp-editor'     => 'editor',
+		'wp-edit-post'  => 'editPost',
+		'wp-plugins'    => 'plugins',
 	);
 	foreach ( $handles_and_chunks as $handle => $chunk ) {
 		gutenberg_register_script_i18n( $handle, $chunk );
@@ -909,12 +942,14 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	// Get admin url for handling meta boxes.
 	$meta_box_url = admin_url( 'post.php' );
-	$meta_box_url = add_query_arg( array(
-		'post'           => $post_to_edit['id'],
-		'action'         => 'edit',
-		'classic-editor' => true,
-		'meta_box'       => true,
-	), $meta_box_url );
+	$meta_box_url = add_query_arg(
+		array(
+			'post'           => $post_to_edit['id'],
+			'action'         => 'edit',
+			'classic-editor' => true,
+			'meta_box'       => true,
+		), $meta_box_url
+	);
 	wp_localize_script( 'wp-editor', '_wpMetaBoxUrl', $meta_box_url );
 
 	// Populate default code editor settings by short-circuiting wp_enqueue_code_editor.
@@ -922,10 +957,12 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	add_filter( 'wp_code_editor_settings', 'gutenberg_capture_code_editor_settings' );
 	wp_enqueue_code_editor( array( 'type' => 'text/html' ) );
 	remove_filter( 'wp_code_editor_settings', 'gutenberg_capture_code_editor_settings' );
-	wp_add_inline_script( 'wp-editor', sprintf(
-		'window._wpGutenbergCodeEditorSettings = %s;',
-		wp_json_encode( $gutenberg_captured_code_editor_settings )
-	) );
+	wp_add_inline_script(
+		'wp-editor', sprintf(
+			'window._wpGutenbergCodeEditorSettings = %s;',
+			wp_json_encode( $gutenberg_captured_code_editor_settings )
+		)
+	);
 
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
@@ -989,9 +1026,11 @@ JS;
 	/**
 	 * Scripts
 	 */
-	wp_enqueue_media( array(
-		'post' => $post_to_edit['id'],
-	) );
+	wp_enqueue_media(
+		array(
+			'post' => $post_to_edit['id'],
+		)
+	);
 	wp_enqueue_editor();
 
 	/**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -836,22 +836,22 @@ function gutenberg_capture_code_editor_settings( $settings ) {
  * @since 2.6.x
  */
 function gutenberg_register_wpi18n_for_scripts() {
-	$handles_and_chunks = array(
-		'wp-data'       => 'data',
-		'wp-core-data'  => 'coreData',
-		'wp-utils'      => 'utils',
-		'wp-hooks'      => 'hooks',
-		'wp-date'       => 'date',
-		'wp-element'    => 'element',
-		'wp-components' => 'components',
-		'wp-blocks'     => 'blocks',
-		'wp-viewport'   => 'viewport',
-		'wp-editor'     => 'editor',
-		'wp-edit-post'  => 'editPost',
-		'wp-plugins'    => 'plugins',
+	$handles = array(
+		'wp-data',
+		'wp-core-data',
+		'wp-utils',
+		'wp-hooks',
+		'wp-date',
+		'wp-element',
+		'wp-components',
+		'wp-blocks',
+		'wp-viewport',
+		'wp-editor',
+		'wp-edit-post',
+		'wp-plugins',
 	);
-	foreach ( $handles_and_chunks as $handle => $chunk ) {
-		gutenberg_register_script_i18n( $handle, $chunk );
+	foreach ( $handles as $handle ) {
+		gutenberg_register_script_i18n( $handle );
 	}
 }
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -904,13 +904,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		);
 	}
 
-	// Prepare Jed locale data.
-	// $locale_data = gutenberg_get_jed_locale_data( 'gutenberg' );
-	// 	// wp_add_inline_script(
-	// 	// 	'wp-i18n',
-	// 	// 	'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ' );'
-	// 	// );
-
 	// Preload server-registered block schemas.
 	wp_localize_script( 'wp-blocks', '_wpBlocks', gutenberg_prepare_blocks_for_js() );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -74,6 +74,7 @@ function gutenberg_get_script_polyfill( $tests ) {
  */
 function gutenberg_register_scripts_and_styles() {
 	gutenberg_register_vendor_scripts();
+	gutenberg_register_wpi18n_for_scripts();
 
 	// Editor Scripts.
 	wp_register_script(
@@ -800,6 +801,27 @@ function gutenberg_capture_code_editor_settings( $settings ) {
 	return false;
 }
 
+
+function gutenberg_register_wpi18n_for_scripts() {
+	$handles_and_chunks = array(
+		'wp-data' => 'data',
+		'wp-core-data' => 'coreData',
+		'wp-utils' => 'utils',
+		'wp-hooks' => 'hooks',
+		'wp-date' => 'date',
+		'wp-element' => 'element',
+		'wp-components' => 'components',
+		'wp-blocks' => 'blocks',
+		'wp-viewport' => 'viewport',
+		'wp-editor' => 'editor',
+		'wp-edit-post' => 'editPost',
+		'wp-plugins' => 'plugins'
+	);
+	foreach ( $handles_and_chunks as $handle => $chunk ) {
+		gutenberg_register_script_i18n( $handle, $chunk, 'gutenberg' );
+	}
+}
+
 /**
  * Scripts & Styles.
  *
@@ -883,11 +905,11 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	}
 
 	// Prepare Jed locale data.
-	$locale_data = gutenberg_get_jed_locale_data( 'gutenberg' );
-	wp_add_inline_script(
-		'wp-i18n',
-		'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ' );'
-	);
+	// $locale_data = gutenberg_get_jed_locale_data( 'gutenberg' );
+	// 	// wp_add_inline_script(
+	// 	// 	'wp-i18n',
+	// 	// 	'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ' );'
+	// 	// );
 
 	// Preload server-registered block schemas.
 	wp_localize_script( 'wp-blocks', '_wpBlocks', gutenberg_prepare_blocks_for_js() );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -818,7 +818,7 @@ function gutenberg_register_wpi18n_for_scripts() {
 		'wp-plugins' => 'plugins'
 	);
 	foreach ( $handles_and_chunks as $handle => $chunk ) {
-		gutenberg_register_script_i18n( $handle, $chunk, 'gutenberg' );
+		gutenberg_register_script_i18n( $handle, $chunk );
 	}
 }
 

--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -10,6 +10,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
+/**
+ * Register script handle and chunk name for the given domain
+ *
+ * Registered scripts will be matched against the generated `translation-map.json` for any i18n strings to be loaded
+ * when the script with the given handle is enqueued.
+ *
+ * @since 2.6.x
+ *
+ * @param string $handle     Name of the script being registered.
+ * @param string $chunk_name Name of the script chunk corresponding to the script handle.
+ * @param string $domain     i18n domain.
+ */
 function gutenberg_register_script_i18n( $handle, $chunk_name, $domain = '' ) {
 	static $gb_scripts;
 	if ( ! $gb_scripts instanceof GB_Scripts ) {
@@ -29,10 +41,10 @@ function gutenberg_register_script_i18n( $handle, $chunk_name, $domain = '' ) {
  * @return array
  */
 function gutenberg_get_jed_locale_data( $domain ) {
-	//gutenberg doesn't use domain in its js strings but has a domain set by virtue of being a plugin in the WordPress
-	//plugin repository.  So we need to use that to retrieve the gutenberg translations. When GB is merged to WordPress
-	//core this will be unnecessary.
-	$domain = $domain ? $domain : 'gutenberg';
+	// gutenberg doesn't use domain in its js strings but has a domain set by virtue of being a plugin in the WordPress
+	// plugin repository.  So we need to use that to retrieve the gutenberg translations. When GB is merged to WordPress
+	// core this will be unnecessary.
+	$domain       = $domain ? $domain : 'gutenberg';
 	$translations = get_translations_for_domain( $domain );
 
 	$locale = array(

--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -9,6 +9,54 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+
+/**
+ * Returns Jed-formatted localization data associated with the given chunk string.
+ *
+ * @param string $chunk
+ * @param string $domain
+ * @return array
+ */
+function gutenberg_get_jed_locale_data_for_domain_and_chunk( $chunk, $domain ) {
+	return gutenberg_get_locale_data_matching_map(
+		gutenberg_get_original_strings_for_chunk_from_map( $chunk ),
+		gutenberg_get_jed_locale_data( $domain )
+	);
+}
+
+
+/**
+ * Get original base strings for translations from a provided map of strings to chunk.
+ *
+ * @param string $chunk
+ * @param array $map  Optional. If not provided will attempt to get default map from a json file.
+ * @return array|mixed
+ */
+function gutenberg_get_original_strings_for_chunk_from_map( $chunk, $map = array() ) {
+	if ( empty( $map ) || ! is_array( $map ) ) {
+		$map = json_decode(
+			file_get_contents(gutenberg_dir_path() . 'translation-map.json' ),
+			true
+		);
+	}
+	return isset( $map[ $chunk ] ) ? $map[ $chunk ] : array();
+}
+
+
+/**
+ * Returns all translations matching those in the provided set of strings
+ *
+ * @param array  $string_set   (set of original strings to retrieve from the provided $translations.
+ * @param array  $translations
+ * @return array
+ */
+function gutenberg_get_locale_data_matching_map( $string_set, $translations ) {
+	if ( ! is_array( $string_set ) || ! is_array( $translations ) ) {
+		return array();
+	}
+	return array_intersect_key( $translations, array_flip( $string_set ) );
+}
+
 /**
  * Returns Jed-formatted localization data.
  *

--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -19,15 +19,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.6.x
  *
  * @param string $handle     Name of the script being registered.
- * @param string $chunk_name Name of the script chunk corresponding to the script handle.
  * @param string $domain     i18n domain.
  */
-function gutenberg_register_script_i18n( $handle, $chunk_name, $domain = '' ) {
+function gutenberg_register_script_i18n( $handle, $domain = '' ) {
 	static $gb_scripts;
 	if ( ! $gb_scripts instanceof GB_Scripts ) {
 		$gb_scripts = new GB_Scripts();
 	}
-	$gb_scripts->register_script_i18n( $handle, $chunk_name, $domain );
+	$gb_scripts->register_script_i18n( $handle, $domain );
 }
 
 

--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -10,52 +10,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-/**
- * Returns Jed-formatted localization data associated with the given chunk string.
- *
- * @param string $chunk
- * @param string $domain
- * @return array
- */
-function gutenberg_get_jed_locale_data_for_domain_and_chunk( $chunk, $domain ) {
-	return gutenberg_get_locale_data_matching_map(
-		gutenberg_get_original_strings_for_chunk_from_map( $chunk ),
-		gutenberg_get_jed_locale_data( $domain )
-	);
-}
-
-
-/**
- * Get original base strings for translations from a provided map of strings to chunk.
- *
- * @param string $chunk
- * @param array $map  Optional. If not provided will attempt to get default map from a json file.
- * @return array|mixed
- */
-function gutenberg_get_original_strings_for_chunk_from_map( $chunk, $map = array() ) {
-	if ( empty( $map ) || ! is_array( $map ) ) {
-		$map = json_decode(
-			file_get_contents(gutenberg_dir_path() . 'translation-map.json' ),
-			true
-		);
+function gutenberg_register_script_i18n( $handle, $chunk_name, $domain ) {
+	static $gb_scripts;
+	if ( ! $gb_scripts instanceof GB_Scripts ) {
+		$gb_scripts = new GB_Scripts();
 	}
-	return isset( $map[ $chunk ] ) ? $map[ $chunk ] : array();
+	$gb_scripts->register_script_i18n( $handle, $chunk_name, $domain );
 }
 
-
-/**
- * Returns all translations matching those in the provided set of strings
- *
- * @param array  $string_set   (set of original strings to retrieve from the provided $translations.
- * @param array  $translations
- * @return array
- */
-function gutenberg_get_locale_data_matching_map( $string_set, $translations ) {
-	if ( ! is_array( $string_set ) || ! is_array( $translations ) ) {
-		return array();
-	}
-	return array_intersect_key( $translations, array_flip( $string_set ) );
-}
 
 /**
  * Returns Jed-formatted localization data.

--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-function gutenberg_register_script_i18n( $handle, $chunk_name, $domain ) {
+function gutenberg_register_script_i18n( $handle, $chunk_name, $domain = '' ) {
 	static $gb_scripts;
 	if ( ! $gb_scripts instanceof GB_Scripts ) {
 		$gb_scripts = new GB_Scripts();
@@ -29,6 +29,10 @@ function gutenberg_register_script_i18n( $handle, $chunk_name, $domain ) {
  * @return array
  */
 function gutenberg_get_jed_locale_data( $domain ) {
+	//gutenberg doesn't use domain in its js strings but has a domain set by virtue of being a plugin in the WordPress
+	//plugin repository.  So we need to use that to retrieve the gutenberg translations. When GB is merged to WordPress
+	//core this will be unnecessary.
+	$domain = $domain ? $domain : 'gutenberg';
 	$translations = get_translations_for_domain( $domain );
 
 	$locale = array(

--- a/lib/load.php
+++ b/lib/load.php
@@ -20,6 +20,7 @@ require dirname( __FILE__ ) . '/plugin-compat.php';
 require dirname( __FILE__ ) . '/i18n.php';
 require dirname( __FILE__ ) . '/parser.php';
 require dirname( __FILE__ ) . '/register.php';
+require dirname( __FILE__ ) . '/class-gb-scripts.php';
 
 // Register server-side code for individual blocks.
 foreach ( glob( dirname( __FILE__ ) . '/../blocks/library/*/index.php' ) as $block_logic ) {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
 		"lint-php": "docker-compose run --rm composer run-script lint",
+	  	"lint-php:fix": "docker-compose run --rm composer run-script lint:fix",
 		"predev": "check-node-version --package",
 		"dev": "cross-env webpack --watch",
 		"test": "npm run lint && npm run test-unit",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 const { get } = require( 'lodash' );
 const { basename } = require( 'path' );
+const wpi18nExtractor = require( './bin/i18n-map-extractor.js' );
 
 /**
  * WordPress dependencies
@@ -178,6 +179,7 @@ const config = {
 		blocksCSSPlugin,
 		editBlocksCSSPlugin,
 		mainCSSExtractTextPlugin,
+		new wpi18nExtractor(),
 		// Create RTL files with a -rtl suffix
 		new WebpackRTLPlugin( {
 			suffix: '-rtl',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ const extractConfig = {
 };
 
 /**
- * Given a string, returns a new string with dash separators converedd to
+ * Given a string, returns a new string with dash separators converted to
  * camel-case equivalent. This is not as aggressive as `_.camelCase` in
  * converting to uppercase, where Lodash will convert letters following
  * numbers.
@@ -101,6 +101,8 @@ const externals = {
 	'lodash-es': 'lodash',
 };
 
+const aliases = {};
+
 [
 	...entryPointNames,
 	...packageNames,
@@ -109,6 +111,7 @@ const externals = {
 	externals[ `@wordpress/${ name }` ] = {
 		this: [ 'wp', camelCaseDash( name ) ],
 	};
+	aliases[ camelCaseDash( name ) ] = 'wp-' + name;
 } );
 
 const config = {
@@ -179,7 +182,7 @@ const config = {
 		blocksCSSPlugin,
 		editBlocksCSSPlugin,
 		mainCSSExtractTextPlugin,
-		new wpi18nExtractor(),
+		new wpi18nExtractor( { aliases } ),
 		// Create RTL files with a -rtl suffix
 		new WebpackRTLPlugin( {
 			suffix: '-rtl',


### PR DESCRIPTION
## Description
Ongoing work.  See #6015 for details.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
When complete this will:

- [x] introduce a new webpack plugin for building the map of i18n strings to chunk.  
- [x] introduce a mechanism server side for registering only the necessary locale strings for the scripts being loaded on page.

## Checklist:
- [x] My code is manually (user) tested.
- [ ] My code has unit tests.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
