### PR TITLE
Update/gallery block caption scrolling

### DIFF
--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -18,6 +18,8 @@
 	.blocks-rich-text {
 		position: absolute;
 		width: 100%;
+        max-height: 100%;
+        overflow: auto;
 	}
 
 	.blocks-rich-text figcaption:not( [data-is-placeholder-visible="true"] ) {

--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -18,8 +18,8 @@
 	.blocks-rich-text {
 		position: absolute;
 		width: 100%;
-        max-height: 100%;
-        overflow: auto;
+		max-height: 100%;
+		overflow: auto;
 	}
 
 	.blocks-rich-text figcaption:not( [data-is-placeholder-visible="true"] ) {

--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -19,11 +19,12 @@
 		position: absolute;
 		width: 100%;
 		max-height: 100%;
-		overflow: auto;
+		overflow-y: auto;
 	}
 
 	.blocks-rich-text figcaption:not( [data-is-placeholder-visible="true"] ) {
 		position: relative;
+		overflow: hidden;
 	}
 
 	.is-selected .blocks-rich-text {

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -39,8 +39,8 @@
 			background-color: rgba($color: $black, $alpha: 0.7);
 			position: absolute;
 			width: 100%;
-            max-height: 100%;
-            overflow: auto;
+			max-height: 100%;
+			overflow: auto;
 		}
 	}
 

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -39,6 +39,8 @@
 			background-color: rgba($color: $black, $alpha: 0.7);
 			position: absolute;
 			width: 100%;
+            max-height: 100%;
+            overflow: auto;
 		}
 	}
 


### PR DESCRIPTION
Fixes #5831 

## Types of changes
Adds scrolling to really long captions for Gallery block images. 

![capture](https://user-images.githubusercontent.com/5658814/38439819-164a72fc-39ad-11e8-9cd7-ad4a08e20a1d.JPG)

Tested in latest versions of Opera, Firefox, IE and Chrome on Windows 7
