### PR TITLE
Use nested blocks for quotes

### DIFF
--- a/blocks/inner-blocks/index.js
+++ b/blocks/inner-blocks/index.js
@@ -4,13 +4,13 @@
 import { withContext } from '@wordpress/components';
 
 function InnerBlocks( { BlockList, layouts } ) {
-	return <BlockList layouts={ layouts } />;
+	return BlockList ? <BlockList layouts={ layouts } /> : null;
 }
 
 InnerBlocks = withContext( 'BlockList' )()( InnerBlocks );
 
 InnerBlocks.Content = ( { BlockContent } ) => {
-	return <BlockContent />;
+	return BlockContent ? <BlockContent /> : null;
 };
 
 InnerBlocks.Content = withContext( 'BlockContent' )()( InnerBlocks.Content );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -148,8 +148,7 @@ export const settings = {
 					onMerge={ mergeBlocks }
 					onSplit={
 						insertBlocksAfter ?
-							( before, after, ...blocks ) => {
-								setAttributes( { content: before } );
+							( unused, after, ...blocks ) => {
 								insertBlocksAfter( [
 									...blocks,
 									createBlock( 'core/paragraph', { content: after } ),

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, compact, get, initial, last, isEmpty } from 'lodash';
+import { find, compact, get, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -62,21 +62,6 @@ export const settings = {
 				},
 			},
 			{
-				type: 'block',
-				blocks: [ 'core/quote' ],
-				transform: ( { value, citation } ) => {
-					const items = value.map( ( p ) => get( p, 'children.props.children' ) );
-					if ( ! isEmpty( citation ) ) {
-						items.push( citation );
-					}
-					const hasItems = ! items.every( isEmpty );
-					return createBlock( 'core/list', {
-						nodeName: 'UL',
-						values: hasItems ? items.map( ( content, index ) => <li key={ index }>{ content }</li> ) : [],
-					} );
-				},
-			},
-			{
 				type: 'raw',
 				isMatch: ( node ) => node.nodeName === 'OL' || node.nodeName === 'UL',
 			},
@@ -110,18 +95,6 @@ export const settings = {
 						.map( ( content ) => createBlock( 'core/paragraph', {
 							content: [ content ],
 						} ) ),
-			},
-			{
-				type: 'block',
-				blocks: [ 'core/quote' ],
-				transform: ( { values } ) => {
-					return createBlock( 'core/quote', {
-						value: compact( ( values.length === 1 ? values : initial( values ) )
-							.map( ( value ) => get( value, 'props.children', null ) ) )
-							.map( ( children ) => ( { children: <p>{ children }</p> } ) ),
-						citation: ( values.length === 1 ? undefined : [ get( last( values ), 'props.children' ) ] ),
-					} );
-				},
 			},
 		],
 	},
@@ -230,7 +203,6 @@ export const settings = {
 			const {
 				attributes,
 				insertBlocksAfter,
-				setAttributes,
 				mergeBlocks,
 				onReplace,
 				className,
@@ -278,7 +250,7 @@ export const settings = {
 						onMerge={ mergeBlocks }
 						onSplit={
 							insertBlocksAfter ?
-								( before, after, ...blocks ) => {
+								( unused, after, ...blocks ) => {
 									if ( ! blocks.length ) {
 										blocks.push( createBlock( 'core/paragraph' ) );
 									}
@@ -290,7 +262,6 @@ export const settings = {
 										} ) );
 									}
 
-									setAttributes( { values: before } );
 									insertBlocksAfter( blocks );
 								} :
 								undefined

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -246,8 +246,7 @@ class ParagraphBlock extends Component {
 							} );
 						} }
 						onSplit={ insertBlocksAfter ?
-							( before, after, ...blocks ) => {
-								setAttributes( { content: before } );
+							( unused, after, ...blocks ) => {
 								insertBlocksAfter( [
 									...blocks,
 									createBlock( 'core/paragraph', { content: after } ),

--- a/blocks/library/pullquote/test/__snapshots__/index.js.snap
+++ b/blocks/library/pullquote/test/__snapshots__/index.js.snap
@@ -3,35 +3,5 @@
 exports[`core/pullquote block edit matches snapshot 1`] = `
 <blockquote
   class="wp-block-pullquote"
->
-  <div
-    class="blocks-pullquote__content blocks-rich-text"
-  >
-    <div>
-      <div>
-        <div
-          class="components-autocomplete"
-        >
-          <div
-            aria-autocomplete="list"
-            aria-expanded="false"
-            aria-label="Write quote…"
-            aria-multiline="true"
-            class="blocks-rich-text__tinymce"
-            contenteditable="true"
-            data-is-placeholder-visible="true"
-            role="textbox"
-          />
-          <div
-            class="blocks-rich-text__tinymce"
-          >
-            <p>
-              Write quote…
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</blockquote>
+/>
 `;

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { castArray, get, isString } from 'lodash';
 import classnames from 'classnames';
+import { castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,28 +16,13 @@ import { Fragment } from '@wordpress/element';
  */
 import './style.scss';
 import './editor.scss';
-import { createBlock } from '../../api';
+import { createBlock, rawHandler } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import RichText from '../../rich-text';
-
-const toRichTextValue = ( value ) => value.map( ( ( subValue ) => subValue.children ) );
-const fromRichTextValue = ( value ) => value.map( ( subValue ) => ( {
-	children: subValue,
-} ) );
+import InnerBlocks from '../../inner-blocks';
 
 const blockAttributes = {
-	value: {
-		type: 'array',
-		source: 'query',
-		selector: 'blockquote > p',
-		query: {
-			children: {
-				source: 'node',
-			},
-		},
-		default: [],
-	},
 	citation: {
 		type: 'array',
 		source: 'children',
@@ -64,100 +49,28 @@ export const settings = {
 
 	transforms: {
 		from: [
-			{
+			...[ 'core/paragraph', 'core/heading' ].map( ( fromName ) => ( {
 				type: 'block',
-				blocks: [ 'core/paragraph' ],
-				transform: ( { content } ) => {
-					return createBlock( 'core/quote', {
-						value: [
-							{ children: <p key="1">{ content }</p> },
-						],
-					} );
-				},
-			},
-			{
-				type: 'block',
-				blocks: [ 'core/heading' ],
-				transform: ( { content } ) => {
-					return createBlock( 'core/quote', {
-						value: [
-							{ children: <p key="1">{ content }</p> },
-						],
-					} );
-				},
-			},
+				blocks: [ fromName ],
+				transform: ( attributes ) => createBlock( name, {}, [
+					createBlock( fromName, attributes ),
+				] ),
+			} ) ),
 			{
 				type: 'pattern',
 				regExp: /^>\s/,
-				transform: ( { content } ) => {
-					return createBlock( 'core/quote', {
-						value: [
-							{ children: <p key="1">{ content }</p> },
-						],
-					} );
-				},
+				transform: ( attributes ) => createBlock( name, {}, [
+					createBlock( 'core/paragraph', attributes ),
+				] ),
 			},
 			{
 				type: 'raw',
 				isMatch: ( node ) => node.nodeName === 'BLOCKQUOTE',
-			},
-		],
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/paragraph' ],
-				transform: ( { value, citation } ) => {
-					// transforming an empty quote
-					if ( ( ! value || ! value.length ) && ! citation ) {
-						return createBlock( 'core/paragraph' );
-					}
-					// transforming a quote with content
-					return ( value || [] ).map( ( item ) => createBlock( 'core/paragraph', {
-						content: [ get( item, 'children.props.children', '' ) ],
-					} ) ).concat( citation ? createBlock( 'core/paragraph', {
-						content: citation,
-					} ) : [] );
-				},
-			},
-			{
-				type: 'block',
-				blocks: [ 'core/heading' ],
-				transform: ( { value, citation, ...attrs } ) => {
-					// if no text content exist just transform the quote into an heading block
-					// using citation as the content, it may be empty creating an empty heading block.
-					if ( ( ! value || ! value.length ) ) {
-						return createBlock( 'core/heading', {
-							content: citation,
-						} );
-					}
-
-					const firstValue = get( value, [ 0, 'children' ] );
-					const headingContent = castArray( isString( firstValue ) ?
-						firstValue :
-						get( firstValue, [ 'props', 'children' ], '' )
-					);
-
-					// if the quote content just contains a paragraph and no citation exist
-					// convert the quote content into and heading block.
-					if ( ! citation && value.length === 1 ) {
-						return createBlock( 'core/heading', {
-							content: headingContent,
-						} );
-					}
-
-					// In the normal case convert the first paragraph of quote into an heading
-					// and create a new quote block equal tl what we had excluding the first paragraph
-					const heading = createBlock( 'core/heading', {
-						content: headingContent,
-					} );
-
-					const quote = createBlock( 'core/quote', {
-						...attrs,
-						citation,
-						value: value.slice( 1 ),
-					} );
-
-					return [ heading, quote ];
+				transform( node ) {
+					return createBlock( name, {}, rawHandler( {
+						HTML: node.innerHTML,
+						mode: 'BLOCKS',
+					} ) );
 				},
 			},
 		],
@@ -165,8 +78,8 @@ export const settings = {
 
 	edit: withState( {
 		editable: 'content',
-	} )( ( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className, editable, setState } ) => {
-		const { align, value, citation, style } = attributes;
+	} )( ( { attributes, setAttributes, isSelected, className, editable, setState } ) => {
+		const { align, citation, style } = attributes;
 		const containerClassname = classnames( className, style === 2 ? 'is-large' : '' );
 		const onSetActiveEditable = ( newEditable ) => () => {
 			setState( { editable: newEditable } );
@@ -194,26 +107,7 @@ export const settings = {
 					className={ containerClassname }
 					style={ { textAlign: align } }
 				>
-					<RichText
-						multiline="p"
-						value={ toRichTextValue( value ) }
-						onChange={
-							( nextValue ) => setAttributes( {
-								value: fromRichTextValue( nextValue ),
-							} )
-						}
-						onMerge={ mergeBlocks }
-						onRemove={ ( forward ) => {
-							const hasEmptyCitation = ! citation || citation.length === 0;
-							if ( ! forward && hasEmptyCitation ) {
-								onReplace( [] );
-							}
-						} }
-						/* translators: the text of the quotation */
-						placeholder={ __( 'Write quote…' ) }
-						isSelected={ isSelected && editable === 'content' }
-						onFocus={ onSetActiveEditable( 'content' ) }
-					/>
+					<InnerBlocks />
 					{ ( ( citation && citation.length > 0 ) || isSelected ) && (
 						<RichText
 							tagName="cite"
@@ -235,14 +129,14 @@ export const settings = {
 	} ),
 
 	save( { attributes } ) {
-		const { align, value, citation, style } = attributes;
+		const { align, citation, style } = attributes;
 
 		return (
 			<blockquote
 				className={ style === 2 ? 'is-large' : '' }
 				style={ { textAlign: align ? align : null } }
 			>
-				<RichText.Content value={ toRichTextValue( value ) } />
+				<InnerBlocks.Content />
 				{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>
 		);
@@ -252,6 +146,60 @@ export const settings = {
 		{
 			attributes: {
 				...blockAttributes,
+				value: {
+					type: 'array',
+					source: 'query',
+					selector: 'blockquote > p',
+					query: {
+						children: {
+							source: 'node',
+						},
+					},
+					default: [],
+				},
+			},
+
+			migrate( { value = [], ...attributes } ) {
+				return [
+					attributes,
+					value.map( ( { children: paragraph } ) =>
+						createBlock( 'core/paragraph', {
+							content: castArray( paragraph.props.children ),
+						} )
+					),
+				];
+			},
+
+			save( { attributes } ) {
+				const { align, value, citation, style } = attributes;
+
+				return (
+					<blockquote
+						className={ style === 2 ? 'is-large' : '' }
+						style={ { textAlign: align ? align : null } }
+					>
+						{ value.map( ( paragraph, i ) => (
+							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
+						) ) }
+						{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				);
+			},
+		},
+		{
+			attributes: {
+				...blockAttributes,
+				value: {
+					type: 'array',
+					source: 'query',
+					selector: 'blockquote > p',
+					query: {
+						children: {
+							source: 'node',
+						},
+					},
+					default: [],
+				},
 				citation: {
 					type: 'array',
 					source: 'children',
@@ -267,7 +215,9 @@ export const settings = {
 						className={ `blocks-quote-style-${ style }` }
 						style={ { textAlign: align ? align : null } }
 					>
-						<RichText.Content value={ toRichTextValue( value ) } />
+						{ value.map( ( paragraph, i ) => (
+							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
+						) ) }
 						{ citation && citation.length > 0 && <RichText.Content tagName="footer" value={ citation } /> }
 					</blockquote>
 				);

--- a/blocks/library/quote/test/__snapshots__/index.js.snap
+++ b/blocks/library/quote/test/__snapshots__/index.js.snap
@@ -3,35 +3,5 @@
 exports[`core/quote block edit matches snapshot 1`] = `
 <blockquote
   class="wp-block-quote"
->
-  <div
-    class="blocks-rich-text"
-  >
-    <div>
-      <div>
-        <div
-          class="components-autocomplete"
-        >
-          <div
-            aria-autocomplete="list"
-            aria-expanded="false"
-            aria-label="Write quote…"
-            aria-multiline="true"
-            class="blocks-rich-text__tinymce"
-            contenteditable="true"
-            data-is-placeholder-visible="true"
-            role="textbox"
-          />
-          <div
-            class="blocks-rich-text__tinymce"
-          >
-            <p>
-              Write quote…
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</blockquote>
+/>
 `;

--- a/blocks/rich-text/README.md
+++ b/blocks/rich-text/README.md
@@ -39,7 +39,7 @@ a traditional `input` field, usually when the user exits the field.
 
 ### `onSplit( before: Array|String, after: Array|String, ...blocks: Object ): Function`
 
-*Optional.* Called when the content can be split with `before` and `after`. There might be blocks present, which should be inserted in between.
+*Optional.* Called when the content can be split with `after` as the split off value. There might be blocks present, which should be inserted before the `after` value. Note: the `before` value should no longer be used.
 
 ### `onReplace( blocks: Array ): Function`
 

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -38,6 +38,11 @@ import { EVENTS } from './constants';
 import { withBlockEditContext } from '../block-edit/context';
 import { domToFormat, valueToString, isEmpty } from './format';
 
+/**
+ * Browser dependencies
+ */
+const { console } = window;
+
 const { BACKSPACE, DELETE, ENTER } = keycodes;
 
 /**
@@ -121,6 +126,7 @@ export class RichText extends Component {
 		};
 
 		this.isEmpty = ! value || ! value.length;
+		this.savedContent = value;
 	}
 
 	/**
@@ -272,7 +278,7 @@ export class RichText extends Component {
 			} );
 
 			// Allows us to ask for this information when we get a report.
-			window.console.log( 'Received item:\n\n', blob );
+			console.log( 'Received item:\n\n', blob );
 
 			if ( isEmptyEditor && this.props.onReplace ) {
 				// Necessary to allow the paste bin to be removed without errors.
@@ -303,8 +309,8 @@ export class RichText extends Component {
 	onPastePreProcess( event ) {
 		const HTML = this.isPlainTextPaste ? '' : event.content;
 		// Allows us to ask for this information when we get a report.
-		window.console.log( 'Received HTML:\n\n', HTML );
-		window.console.log( 'Received plain text:\n\n', this.pastedPlainText );
+		console.log( 'Received HTML:\n\n', HTML );
+		console.log( 'Received plain text:\n\n', this.pastedPlainText );
 
 		// There is a selection, check if a link is pasted.
 		if ( ! this.editor.selection.isCollapsed() ) {
@@ -319,7 +325,7 @@ export class RichText extends Component {
 				} );
 
 				// Allows us to ask for this information when we get a report.
-				window.console.log( 'Created link:\n\n', pastedText );
+				console.log( 'Created link:\n\n', pastedText );
 
 				event.preventDefault();
 
@@ -487,6 +493,10 @@ export class RichText extends Component {
 				if ( event.shiftKey || ! this.props.onSplit ) {
 					this.editor.execCommand( 'InsertLineBreak', false, event );
 				} else {
+					// Splitting the content might destroy the editor, so it's
+					// important that we stop other handlers (e.g. ones
+					// registered by TinyMCE) from also handling this event.
+					event.stopImmediatePropagation();
 					this.splitContent();
 				}
 			}
@@ -619,10 +629,8 @@ export class RichText extends Component {
 			return memo;
 		}, [] );
 
-		// Splitting into two blocks
-		this.setContent( this.props.value );
-
 		const { format } = this.props;
+
 		this.restoreContentAndSplit(
 			domToFormat( before, format, this.editor ),
 			domToFormat( after, format, this.editor )
@@ -701,15 +709,16 @@ export class RichText extends Component {
 			!! this.editor &&
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
-			this.props.value !== this.savedContent &&
-
-			// Comparing using isEqual is necessary especially to avoid unnecessary updateContent calls
-			// This fixes issues in multi richText blocks like quotes when moving the focus between
-			// the different editables.
-			! isEqual( this.props.value, prevProps.value ) &&
-			! isEqual( this.props.value, this.savedContent )
+			this.props.value !== this.savedContent
 		) {
 			this.updateContent();
+
+			if (
+				'development' === process.env.NODE_ENV &&
+				isEqual( this.props.value, prevProps.value )
+			) {
+				console.warn( 'The current and previous value props are not strictly equal but the contents are the same. Please ensure the value prop reference does not change.' );
+			}
 		}
 	}
 
@@ -765,14 +774,15 @@ export class RichText extends Component {
 
 	/**
 	 * Calling onSplit means we need to abort the change done by TinyMCE.
-	 * we need to call updateContent to restore the initial content before calling onSplit.
+	 * we need to call setContent to restore the initial content before calling onSplit.
 	 *
 	 * @param {Array}  before content before the split position
 	 * @param {Array}  after  content after the split position
 	 * @param {?Array} blocks blocks to insert at the split position
 	 */
 	restoreContentAndSplit( before, after, blocks = [] ) {
-		this.updateContent();
+		this.setContent( before );
+		this.onChange();
 		this.props.onSplit( before, after, ...blocks );
 	}
 

--- a/blocks/test/fixtures/core__pullquote.html
+++ b/blocks/test/fixtures/core__pullquote.html
@@ -1,5 +1,8 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-<p>Testing pullquote block...</p><cite>...with a caption</cite>
+	<!-- wp:core/paragraph -->
+	<p>Testing pullquote block...</p>
+	<!-- /wp:core/paragraph -->
+	<cite>...with a caption</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote.json
+++ b/blocks/test/fixtures/core__pullquote.json
@@ -4,26 +4,26 @@
         "name": "core/pullquote",
         "isValid": true,
         "attributes": {
-            "value": [
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "Testing pullquote block..."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                }
-            ],
             "citation": [
                 "...with a caption"
             ],
             "align": "none"
         },
-        "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>"
+        "innerBlocks": [
+            {
+                "name": "core/paragraph",
+                "uid": "_uid_0",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Testing pullquote block..."
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Testing pullquote block...</p>"
+            }
+        ],
+        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n\t\n\t<cite>...with a caption</cite>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote.parsed.json
+++ b/blocks/test/fixtures/core__pullquote.parsed.json
@@ -2,8 +2,15 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>Testing pullquote block...</p>\n\t"
+            }
+        ],
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n\t\n\t<cite>...with a caption</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__pullquote.serialized.html
+++ b/blocks/test/fixtures/core__pullquote.serialized.html
@@ -1,4 +1,6 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-	<p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote>
+	<!-- wp:paragraph -->
+	<p>Testing pullquote block...</p>
+	<!-- /wp:paragraph --><cite>...with a caption</cite></blockquote>
 <!-- /wp:pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.html
@@ -1,7 +1,11 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
+	<!-- wp:core/paragraph -->
     <p>Paragraph <strong>one</strong></p>
+    <!-- /wp:core/paragraph -->
+    <!-- wp:core/paragraph -->
     <p>Paragraph two</p>
+    <!-- /wp:core/paragraph -->
     <cite>by whomever</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -4,50 +4,43 @@
         "name": "core/pullquote",
         "isValid": true,
         "attributes": {
-            "value": [
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": [
-                                "Paragraph ",
-                                {
-                                    "type": "strong",
-                                    "key": "_domReact71",
-                                    "ref": null,
-                                    "props": {
-                                        "children": "one"
-                                    },
-                                    "_owner": null,
-                                    "_store": {}
-                                }
-                            ]
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                },
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "Paragraph two"
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                }
-            ],
             "citation": [
                 "by whomever"
             ],
             "align": "none"
         },
-        "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>"
+        "innerBlocks": [
+            {
+                "uid": "_uid_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Paragraph ",
+                        {
+                            "type": "strong",
+                            "children": "one"
+                        }
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Paragraph <strong>one</strong></p>"
+            },
+            {
+                "uid": "_uid_1",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Paragraph two"
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Paragraph two</p>"
+            }
+        ],
+        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n\t\n    \n    <cite>by whomever</cite>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -2,8 +2,21 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n    <p>Paragraph <strong>one</strong></p>\n    "
+            },
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n    <p>Paragraph two</p>\n    "
+            }
+        ],
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n\t\n    \n    <cite>by whomever</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,5 +1,10 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
+	<!-- wp:paragraph -->
 	<p>Paragraph <strong>one</strong></p>
-	<p>Paragraph two</p><cite>by whomever</cite></blockquote>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Paragraph two</p>
+	<!-- /wp:paragraph --><cite>by whomever</cite></blockquote>
 <!-- /wp:pullquote -->

--- a/blocks/test/fixtures/core__quote__style-1.html
+++ b/blocks/test/fixtures/core__quote__style-1.html
@@ -1,3 +1,8 @@
 <!-- wp:core/quote {"style":"1"} -->
-<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote">
+	<!-- wp:core/paragraph -->
+	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
+	<!-- /wp:core/paragraph -->
+	<cite>Matt Mullenweg, 2017</cite>
+</blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -4,26 +4,26 @@
         "name": "core/quote",
         "isValid": true,
         "attributes": {
-            "value": [
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                }
-            ],
             "citation": [
                 "Matt Mullenweg, 2017"
             ],
             "style": 1
         },
-        "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
+        "innerBlocks": [
+            {
+                "uid": "_uid_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>"
+            }
+        ],
+        "originalContent": "<blockquote class=\"wp-block-quote\">\n\t\n\t<cite>Matt Mullenweg, 2017</cite>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -4,8 +4,15 @@
         "attrs": {
             "style": "1"
         },
-        "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>\n\t"
+            }
+        ],
+        "innerHTML": "\n<blockquote class=\"wp-block-quote\">\n\t\n\t<cite>Matt Mullenweg, 2017</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,4 +1,6 @@
 <!-- wp:quote -->
 <blockquote class="wp-block-quote">
-	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+	<!-- wp:paragraph -->
+	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
+	<!-- /wp:paragraph --><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:quote -->

--- a/blocks/test/fixtures/core__quote__style-2.html
+++ b/blocks/test/fixtures/core__quote__style-2.html
@@ -1,3 +1,8 @@
 <!-- wp:core/quote {"style":"2"} -->
-<blockquote class="wp-block-quote is-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-large">
+	<!-- wp:core/paragraph -->
+	<p>There is no greater agony than bearing an untold story inside you.</p>
+	<!-- /wp:core/paragraph -->
+	<cite>Maya Angelou</cite>
+</blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -4,26 +4,26 @@
         "name": "core/quote",
         "isValid": true,
         "attributes": {
-            "value": [
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "There is no greater agony than bearing an untold story inside you."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                }
-            ],
             "citation": [
                 "Maya Angelou"
             ],
             "style": 2
         },
-        "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote is-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
+        "innerBlocks": [
+            {
+                "uid": "_uid_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "There is no greater agony than bearing an untold story inside you."
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>There is no greater agony than bearing an untold story inside you.</p>"
+            }
+        ],
+        "originalContent": "<blockquote class=\"wp-block-quote is-large\">\n\t\n\t<cite>Maya Angelou</cite>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -4,8 +4,15 @@
         "attrs": {
             "style": "2"
         },
-        "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote is-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>There is no greater agony than bearing an untold story inside you.</p>\n\t"
+            }
+        ],
+        "innerHTML": "\n<blockquote class=\"wp-block-quote is-large\">\n\t\n\t<cite>Maya Angelou</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,4 +1,6 @@
 <!-- wp:quote {"style":2} -->
 <blockquote class="wp-block-quote is-large">
-	<p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+	<!-- wp:paragraph -->
+	<p>There is no greater agony than bearing an untold story inside you.</p>
+	<!-- /wp:paragraph --><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:quote -->

--- a/post-content.js
+++ b/post-content.js
@@ -72,7 +72,12 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:quote {"style":1} -->',
-		'<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>',
+		'<blockquote class="wp-block-quote">',
+		'<!-- wp:paragraph -->',
+		'<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>',
+		'<!-- /wp:paragraph -->',
+		'<cite>Matt Mullenweg, 2017</cite>',
+		'</blockquote>',
 		'<!-- /wp:quote -->',
 
 		'<!-- wp:paragraph -->',
@@ -135,7 +140,12 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:pullquote -->',
-		'<blockquote class="wp-block-pullquote alignnone"><p>Code is Poetry</p><cite>The WordPress community</cite></blockquote>',
+		'<blockquote class="wp-block-pullquote alignnone">',
+		'<!-- wp:paragraph -->',
+		'<p>Code is Poetry</p>',
+		'<!-- /wp:paragraph -->',
+		'<cite>The WordPress community</cite>',
+		'</blockquote>',
 		'<!-- /wp:pullquote -->',
 
 		'<!-- wp:paragraph {"align":"center"} -->',

--- a/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
@@ -11,11 +11,13 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 
 <!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\">
+	<!-- wp:paragraph -->
 	<p>Quote block</p>
-</blockquote>
-<!-- /wp:quote -->
+	<!-- /wp:paragraph -->
 
-<!-- wp:code -->
-<pre class=\\"wp-block-code\\"><code>Code block</code></pre>
-<!-- /wp:code -->"
+	<!-- wp:code -->
+	<pre class=\\"wp-block-code\\"><code>Code block</code></pre>
+	<!-- /wp:code -->
+</blockquote>
+<!-- /wp:quote -->"
 `;

--- a/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
@@ -15,3 +15,17 @@ exports[`splitting and merging blocks Should split and merge paragraph blocks us
 <p>FirstSecond</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`splitting and merging blocks should split out of quote block using enter 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\">
+	<!-- wp:paragraph -->
+	<p>test</p>
+	<!-- /wp:paragraph -->
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage } from '../support/utils';
+import { newPost, newDesktopBrowserPage, getHTMLFromCodeEditor } from '../support/utils';
 
 describe( 'adding blocks', () => {
 	beforeAll( async () => {
@@ -85,14 +85,6 @@ describe( 'adding blocks', () => {
 		await clickAtRightish( inserter );
 		await page.keyboard.type( 'Second paragraph' );
 
-		// Switch to Text Mode to check HTML Output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
-
-		// Assertions
-		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-
-		expect( textEditorContent ).toMatchSnapshot();
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/multi-block-selection.test.js
+++ b/test/e2e/specs/multi-block-selection.test.js
@@ -13,7 +13,7 @@ describe( 'Multi-block selection', () => {
 	it( 'Should select/unselect multiple blocks', async () => {
 		const firstBlockSelector = '[data-type="core/paragraph"]';
 		const secondBlockSelector = '[data-type="core/image"]';
-		const thirdBlockSelector = '[data-type="core/quote"]';
+		const thirdBlockSelector = '[data-type="core/list"]';
 		const multiSelectedCssClass = 'is-multi-selected';
 
 		// Creating test blocks
@@ -24,10 +24,10 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 		await page.click( '.edit-post-header [aria-label="Add block"]' );
-		await page.keyboard.type( 'Quote' );
+		await page.keyboard.type( 'List' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Quote Block' );
+		await page.keyboard.type( 'List Block' );
 
 		const blocks = [ firstBlockSelector, secondBlockSelector, thirdBlockSelector ];
 		const expectMultiSelected = ( selectors, areMultiSelected ) => {

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage } from '../support/utils';
+import { newPost, newDesktopBrowserPage, getHTMLFromCodeEditor } from '../support/utils';
 
 describe( 'splitting and merging blocks', () => {
-	beforeAll( async () => {
+	beforeEach( async () => {
 		await newDesktopBrowserPage();
 		await newPost();
 	} );
@@ -24,32 +24,26 @@ describe( 'splitting and merging blocks', () => {
 		}
 		await page.keyboard.press( 'Enter' );
 
-		//Switch to Code Editor to check HTML output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
-
-		//Assert that there are now two paragraph blocks with correct content
-		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-		expect( textEditorContent ).toMatchSnapshot();
-
-		//Switch to Visual Editor to continue testing
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		const visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
-		await visualEditorButton.click( 'button' );
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
 
 		//Press Backspace to merge paragraph blocks
 		await page.click( '.is-selected' );
 		await page.keyboard.press( 'Home' );
 		await page.keyboard.press( 'Backspace' );
 
-		//Switch to Code Editor to check HTML output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
+	} );
 
-		//Assert that there is now one paragraph with correct content
-		textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-		expect( textEditorContent ).toMatchSnapshot();
+	it( 'should split out of quote block using enter', async () => {
+		//Use regular inserter to add paragraph block and text
+		await page.click( '.edit-post-header [aria-label="Add block"]' );
+		await page.keyboard.type( 'quote' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'test' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/templates.test.js
+++ b/test/e2e/specs/templates.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage } from '../support/utils';
+import { newPost, newDesktopBrowserPage, getHTMLFromCodeEditor } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
 describe( 'Using a CPT with a predefined template', () => {
@@ -18,13 +18,6 @@ describe( 'Using a CPT with a predefined template', () => {
 	} );
 
 	it( 'Should add a custom post types with a predefined template', async () => {
-		//Switch to Code Editor to check HTML output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
-
-		// Assert that the post already contains the template defined blocks
-		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-		expect( textEditorContent ).toMatchSnapshot();
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -58,3 +58,16 @@ export async function newDesktopBrowserPage() {
 	global.page = await browser.newPage();
 	await page.setViewport( { width: 1000, height: 700 } );
 }
+
+export async function switchToEditor( mode ) {
+	await page.click( '.edit-post-more-menu [aria-label="More"]' );
+	const [ button ] = await page.$x( `//button[contains(text(), \'${ mode } Editor\')]` );
+	await button.click( 'button' );
+}
+
+export async function getHTMLFromCodeEditor() {
+	await switchToEditor( 'Code' );
+	const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+	await switchToEditor( 'Visual' );
+	return textEditorContent;
+}


### PR DESCRIPTION
## Description

Related: #5265.

This branch changes both quotes block so that they use nested blocks for the content. This enables the user to add content other than paragraphs and simplifies the block registration.

~~WIP, to do:~~

* ~~Preserve citation when unwrapping the blocks.~~
* ~~Make paste work.~~
* ~~Double enter should exit the quote.~~ Should this be a general nested block behaviour?
* ~~Update demo content.~~

## How Has This Been Tested?
* Ensure old quotes still work (try demo content).
* Ensure transformations work.
* Try the shortcut: `> + SPACE` both with and without existing content.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.