### PR TITLE
Modify endpoint path to match routes that exist in schema

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -176,6 +176,9 @@ export default ( mapPropsToData ) => createHigherOrderComponent( ( WrappedCompon
 
 				result[ propName ] = {};
 
+				if ( window._apiEndpointMap ) {
+					path = path.replace( 'wp/v2/', window._apiEndpointMap );
+				}
 				const route = getRoute( this.schema, path );
 				if ( ! route ) {
 					return result;


### PR DESCRIPTION
## Description

Due to the way schemas and endpoints match in our case, specifying the endpoints do not match directory to the routes needed, due to requiring a blog id.

I can set a global variable in an wp-inline-script prior to loading Gutenberg, but need to do something like this change to match up the endpoint to route requests.

This is the most basic of what we need, I realize this is not an ideal solution, but we need some way to achieve something similar. Open to suggestions on others ways.

Fixes #5453 

## How Has This Been Tested?

Yes, if the global variable is not defined there is no change.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
