### PR TITLE
Demo Content: Changed caption for theme compatibility clarity

### DIFF
--- a/post-content.js
+++ b/post-content.js
@@ -36,7 +36,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:image {"align":"center"} -->',
-		'<figure class="wp-block-image aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>Give it a try. Press the "wide" button on the image toolbar.</figcaption></figure>',
+		'<figure class="wp-block-image aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>If your theme supports it, you\'ll see the "wide" button on the image toolbar. Give it a try.</figcaption></figure>',
 		'<!-- /wp:image -->',
 
 		'<!-- wp:paragraph -->',


### PR DESCRIPTION
## Description
Caption on the demo prompted user to click the "wide" button.

Wide button is an opt-in feature and we shouldn't assume the user will be able to click that button.

Reworded the caption so if the user doesn't see the "wide" button they know where to look to enable it. 

## How Has This Been Tested?
Tested on a local environment. It only affects that one line in the demo content.

## Screenshots (jpeg or gifs if applicable):
![2018-04-07_gutenberg_demo_text_issue](https://user-images.githubusercontent.com/9543581/38455378-d7fce4fa-3aa9-11e8-82c7-9ac077e0657a.jpg)

## Types of changes
Bug fix of issue identified in #6058 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation. (N/A)
