### PR TITLE
Fix expander padding and outline

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -447,7 +447,7 @@ function gutenberg_replace_default_add_new_button() {
 			position: relative;
 			vertical-align: top;
 			text-decoration: none !important;
-			padding: 3px 5px 3px 3px;
+			padding: 4px 5px 4px 3px;
 		}
 
 		.split-page-title-action .dropdown {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -447,7 +447,7 @@ function gutenberg_replace_default_add_new_button() {
 			position: relative;
 			vertical-align: top;
 			text-decoration: none !important;
-			padding: 4px 5px 4px 3px;
+			padding: 3px 5px 3px 3px;
 		}
 
 		.split-page-title-action .dropdown {
@@ -470,6 +470,10 @@ function gutenberg_replace_default_add_new_button() {
 			<?php else : ?>
 			padding-right: 9px;
 			<?php endif; ?>
+		}
+
+		.expander {
+			outline: none;
 		}
 
 	</style>

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -472,7 +472,7 @@ function gutenberg_replace_default_add_new_button() {
 			<?php endif; ?>
 		}
 
-		.expander {
+		.split-page-title-action .expander {
 			outline: none;
 		}
 


### PR DESCRIPTION
## Description
The expander select box has extra `top` and `bottom` padding and small yellow outline below expander button which does not look good.   

## How Has This Been Tested?
Click on `All Posts` and check the expander select box. You will find that there is extra `top` and `bottom` padding and check small yellow outline below expander button.
 
## Screenshots (jpeg or gifs if applicable):
![expander-padding](https://user-images.githubusercontent.com/26354653/38469245-0a974962-3b6f-11e8-8ee5-cf80af934901.png)

## Types of changes
It's just little `enhancement` in CSS.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
