### PR TITLE
Avoid confusion around blockTypes/allowedBlockTypes/enabledBlockTypes setting

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -3,6 +3,8 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 ## 2.8.0
 
 - `Original autocompleter interface in wp.components.Autocomplete` updated. Please use `latest autocompleter interface` instead. See: https://github.com/WordPress/gutenberg/blob/master/components/autocomplete/README.md.
+- `getInserterItems`: the `allowedBlockTypes` argument is now mandatory.
+- `getFrecentInserterItems`: the `allowedBlockTypes` argument is now mandatory.
 
 ## 2.7.0
 

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -47,16 +47,16 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 
 export default compose(
 	withContext( 'editor' )( ( settings ) => {
-		const { templateLock, blockTypes } = settings;
+		const { templateLock, allowedBlockTypes } = settings;
 
 		return {
 			isLocked: !! templateLock,
-			enabledBlockTypes: blockTypes,
+			allowedBlockTypes,
 		};
 	} ),
 	connect(
-		( state, { enabledBlockTypes } ) => ( {
-			items: getFrecentInserterItems( state, enabledBlockTypes, 4 ),
+		( state, { allowedBlockTypes } ) => ( {
+			items: getFrecentInserterItems( state, allowedBlockTypes, 4 ),
 		} )
 	),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -107,10 +107,10 @@ export default compose( [
 		},
 	} ) ),
 	withContext( 'editor' )( ( settings ) => {
-		const { blockTypes, templateLock } = settings;
+		const { allowedBlockTypes, templateLock } = settings;
 
 		return {
-			hasSupportedBlocks: true === blockTypes || ! isEmpty( blockTypes ),
+			hasSupportedBlocks: true === allowedBlockTypes || ! isEmpty( allowedBlockTypes ),
 			isLocked: !! templateLock,
 		};
 	} ),

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -341,17 +341,17 @@ export class InserterMenu extends Component {
 
 export default compose(
 	withContext( 'editor' )( ( settings ) => {
-		const { blockTypes } = settings;
+		const { allowedBlockTypes } = settings;
 
 		return {
-			enabledBlockTypes: blockTypes,
+			allowedBlockTypes,
 		};
 	} ),
 	connect(
-		( state, ownProps ) => {
+		( state, { allowedBlockTypes } ) => {
 			return {
-				items: getInserterItems( state, ownProps.enabledBlockTypes ),
-				frecentItems: getFrecentInserterItems( state, ownProps.enabledBlockTypes ),
+				items: getInserterItems( state, allowedBlockTypes ),
+				frecentItems: getFrecentInserterItems( state, allowedBlockTypes ),
 			};
 		},
 		{ fetchSharedBlocks }

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -51,7 +51,7 @@ const DEFAULT_SETTINGS = {
 	maxWidth: 608,
 
 	// Allowed block types for the editor, defaulting to true (all supported).
-	blockTypes: true,
+	allowedBlockTypes: true,
 };
 
 class EditorProvider extends Component {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1209,17 +1209,17 @@ export function getNotices( state ) {
  * Given a regular block type, constructs an item that appears in the inserter.
  *
  * @param {Object}           state             Global application state.
- * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
+ * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
  * @param {Object}           blockType         Block type, likely from getBlockType().
  *
  * @return {Editor.InserterItem} Item that appears in inserter.
  */
-function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
-	if ( ! enabledBlockTypes || ! blockType ) {
+function buildInserterItemFromBlockType( state, allowedBlockTypes, blockType ) {
+	if ( ! allowedBlockTypes || ! blockType ) {
 		return null;
 	}
 
-	const blockTypeIsDisabled = Array.isArray( enabledBlockTypes ) && ! includes( enabledBlockTypes, blockType.name );
+	const blockTypeIsDisabled = Array.isArray( allowedBlockTypes ) && ! includes( allowedBlockTypes, blockType.name );
 	if ( blockTypeIsDisabled ) {
 		return null;
 	}
@@ -1244,17 +1244,17 @@ function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
  * Given a shared block, constructs an item that appears in the inserter.
  *
  * @param {Object}           state             Global application state.
- * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
+ * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
  * @param {Object}           sharedBlock       Shared block, likely from getSharedBlock().
  *
  * @return {Editor.InserterItem} Item that appears in inserter.
  */
-function buildInserterItemFromSharedBlock( state, enabledBlockTypes, sharedBlock ) {
-	if ( ! enabledBlockTypes || ! sharedBlock ) {
+function buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock ) {
+	if ( ! allowedBlockTypes || ! sharedBlock ) {
 		return null;
 	}
 
-	const blockTypeIsDisabled = Array.isArray( enabledBlockTypes ) && ! includes( enabledBlockTypes, 'core/block' );
+	const blockTypeIsDisabled = Array.isArray( allowedBlockTypes ) && ! includes( allowedBlockTypes, 'core/block' );
 	if ( blockTypeIsDisabled ) {
 		return null;
 	}
@@ -1286,30 +1286,30 @@ function buildInserterItemFromSharedBlock( state, enabledBlockTypes, sharedBlock
  * items (e.g. a regular block type) and dynamic items (e.g. a shared block).
  *
  * @param {Object}           state             Global application state.
- * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
+ * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
  *
  * @return {Editor.InserterItem[]} Items that appear in inserter.
  */
-export function getInserterItems( state, enabledBlockTypes ) {
-	if ( enabledBlockTypes === undefined ) {
-		enabledBlockTypes = true;
-		deprecated( 'getInserterItems with no enabledBlockTypes argument', {
+export function getInserterItems( state, allowedBlockTypes ) {
+	if ( allowedBlockTypes === undefined ) {
+		allowedBlockTypes = true;
+		deprecated( 'getInserterItems with no allowedBlockTypes argument', {
 			version: '2.8',
-			alternative: 'getInserterItems with an explcit enabledBlockTypes argument',
+			alternative: 'getInserterItems with an explcit allowedBlockTypes argument',
 			plugin: 'Gutenberg',
 		} );
 	}
 
-	if ( ! enabledBlockTypes ) {
+	if ( ! allowedBlockTypes ) {
 		return [];
 	}
 
 	const staticItems = getBlockTypes().map( blockType =>
-		buildInserterItemFromBlockType( state, enabledBlockTypes, blockType )
+		buildInserterItemFromBlockType( state, allowedBlockTypes, blockType )
 	);
 
 	const dynamicItems = getSharedBlocks( state ).map( sharedBlock =>
-		buildInserterItemFromSharedBlock( state, enabledBlockTypes, sharedBlock )
+		buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock )
 	);
 
 	const items = [ ...staticItems, ...dynamicItems ];
@@ -1329,19 +1329,19 @@ function fillWithCommonBlocks( inserts ) {
 	return unionWith( items, commonInserts, areInsertsEqual );
 }
 
-function getItemsFromInserts( state, inserts, enabledBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
-	if ( ! enabledBlockTypes ) {
+function getItemsFromInserts( state, inserts, allowedBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
+	if ( ! allowedBlockTypes ) {
 		return [];
 	}
 
 	const items = fillWithCommonBlocks( inserts ).map( insert => {
 		if ( insert.ref ) {
 			const sharedBlock = getSharedBlock( state, insert.ref );
-			return buildInserterItemFromSharedBlock( state, enabledBlockTypes, sharedBlock );
+			return buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock );
 		}
 
 		const blockType = getBlockType( insert.name );
-		return buildInserterItemFromBlockType( state, enabledBlockTypes, blockType );
+		return buildInserterItemFromBlockType( state, allowedBlockTypes, blockType );
 	} );
 
 	return compact( items ).slice( 0, maximum );
@@ -1355,17 +1355,17 @@ function getItemsFromInserts( state, inserts, enabledBlockTypes, maximum = MAX_R
  * https://en.wikipedia.org/wiki/Frecency
  *
  * @param {Object}           state             Global application state.
- * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
+ * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
  * @param {number}           maximum           Number of items to return.
  *
  * @return {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
  */
-export function getFrecentInserterItems( state, enabledBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
-	if ( enabledBlockTypes === undefined ) {
-		enabledBlockTypes = true;
-		deprecated( 'getFrecentInserterItems with no enabledBlockTypes argument', {
+export function getFrecentInserterItems( state, allowedBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
+	if ( allowedBlockTypes === undefined ) {
+		allowedBlockTypes = true;
+		deprecated( 'getFrecentInserterItems with no allowedBlockTypes argument', {
 			version: '2.8',
-			alternative: 'getFrecentInserterItems with an explcit enabledBlockTypes argument',
+			alternative: 'getFrecentInserterItems with an explcit allowedBlockTypes argument',
 			plugin: 'Gutenberg',
 		} );
 	}
@@ -1391,7 +1391,7 @@ export function getFrecentInserterItems( state, enabledBlockTypes, maximum = MAX
 	const sortedInserts = values( state.preferences.insertUsage )
 		.sort( ( a, b ) => calculateFrecency( b.time, b.count ) - calculateFrecency( a.time, a.count ) )
 		.map( ( { insert } ) => insert );
-	return getItemsFromInserts( state, sortedInserts, enabledBlockTypes, maximum );
+	return getItemsFromInserts( state, sortedInserts, allowedBlockTypes, maximum );
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -24,6 +24,7 @@ import { serialize, getBlockType, getBlockTypes } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { moment } from '@wordpress/date';
+import { deprecated } from '@wordpress/utils';
 
 /***
  * Module constants
@@ -1289,7 +1290,16 @@ function buildInserterItemFromSharedBlock( state, enabledBlockTypes, sharedBlock
  *
  * @return {Editor.InserterItem[]} Items that appear in inserter.
  */
-export function getInserterItems( state, enabledBlockTypes = true ) {
+export function getInserterItems( state, enabledBlockTypes ) {
+	if ( enabledBlockTypes === undefined ) {
+		enabledBlockTypes = true;
+		deprecated( 'getInserterItems with no enabledBlockTypes argument', {
+			version: '2.8',
+			alternative: 'getInserterItems with an explcit enabledBlockTypes argument',
+			plugin: 'Gutenberg',
+		} );
+	}
+
 	if ( ! enabledBlockTypes ) {
 		return [];
 	}
@@ -1319,7 +1329,7 @@ function fillWithCommonBlocks( inserts ) {
 	return unionWith( items, commonInserts, areInsertsEqual );
 }
 
-function getItemsFromInserts( state, inserts, enabledBlockTypes = true, maximum = MAX_RECENT_BLOCKS ) {
+function getItemsFromInserts( state, inserts, enabledBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
 	if ( ! enabledBlockTypes ) {
 		return [];
 	}
@@ -1350,7 +1360,16 @@ function getItemsFromInserts( state, inserts, enabledBlockTypes = true, maximum 
  *
  * @return {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
  */
-export function getFrecentInserterItems( state, enabledBlockTypes = true, maximum = MAX_RECENT_BLOCKS ) {
+export function getFrecentInserterItems( state, enabledBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
+	if ( enabledBlockTypes === undefined ) {
+		enabledBlockTypes = true;
+		deprecated( 'getFrecentInserterItems with no enabledBlockTypes argument', {
+			version: '2.8',
+			alternative: 'getFrecentInserterItems with an explcit enabledBlockTypes argument',
+			plugin: 'Gutenberg',
+		} );
+	}
+
 	const calculateFrecency = ( time, count ) => {
 		if ( ! time ) {
 			return count;

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2527,7 +2527,7 @@ describe( 'selectors', () => {
 			};
 
 			const blockTypes = getBlockTypes().filter( blockType => ! blockType.isPrivate );
-			expect( getInserterItems( state ) ).toHaveLength( blockTypes.length );
+			expect( getInserterItems( state, true ) ).toHaveLength( blockTypes.length );
 		} );
 
 		it( 'should properly list a regular block type', () => {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -936,7 +936,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$editor_settings = array(
 		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
 		'availableTemplates'  => wp_get_theme()->get_page_templates( get_post( $post_to_edit['id'] ) ),
-		'blockTypes'          => $allowed_block_types,
+		'allowedBlockTypes'   => $allowed_block_types,
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),


### PR DESCRIPTION
Quick cleanup that does two things.

First, it makes the `enabledBlockTypes` argument in `getInserterItems` and `getFrecentInserterItems` non-optional. [I regret making this optional](https://github.com/WordPress/gutenberg/pull/6067#discussion_r179983161) since it implies that not providing this argument is a sensible thing to do, when in reality it would cause subtle bugs, e.g. a user could insert a block that has been disabled via the `allowed_block_types` filter.

Since selectors are exposed publicly now, I added a deprecation warning so as to avoid breaking backwards compatibility. Let me know if you think that's overkill.

Secondly, I noticed that we refer to this array of allowed block types throughout the codebase as either `blockTypes`, `allowedBlockTypes` or `enabledBlockTypes`. I've renamed these variables so that we are always referring to this array as `allowedBlockTypes`, which matches [the name of the filter](https://github.com/WordPress/gutenberg/blob/master/lib/client-assets.php#L934).

#### How I tested this

1. Create a post, insert some regular and shared blocks. There should be no warnings in the console
2. Add the following to the top of `lib/load.php`:  
  ```php
  add_filter( 'allowed_block_types', function() {
  	return [ 'core/paragraph', 'core/image', 'core/quote' ];
  } );
  ```
3. Create a post. Test that only paragraphs, images and quotes can be inserted via the inserter and _quick inserter_ (the thing that appears to the right of _Write your story_). 