### PR TITLE
Blocks: Revert the default fonti size changes for Paragraph

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -104,8 +104,6 @@ class ParagraphBlock extends Component {
 		if ( customFontSize ) {
 			return customFontSize;
 		}
-
-		return FONT_SIZES.regular;
 	}
 
 	setFontSize( fontSizeValue ) {
@@ -190,7 +188,7 @@ class ParagraphBlock extends Component {
 						<RangeControl
 							className="blocks-paragraph__custom-size-slider"
 							label={ __( 'Custom Size' ) }
-							value={ fontSize }
+							value={ fontSize || '' }
 							onChange={ ( value ) => this.setFontSize( value ) }
 							min={ 12 }
 							max={ 100 }
@@ -239,7 +237,7 @@ class ParagraphBlock extends Component {
 					style={ {
 						backgroundColor: backgroundColor,
 						color: textColor,
-						fontSize: fontSize !== FONT_SIZES.regular ? fontSize + 'px' : undefined,
+						fontSize: fontSize ? fontSize + 'px' : undefined,
 						textAlign: align,
 					} }
 					value={ content }


### PR DESCRIPTION
## Description
As noted by @jorgefilipecosta in #5995:

> We are setting the default size for font Size as regular making the range control start in some value. But we don't apply the regular class.
> This may cause problems, imagine for example I set a CSS rule for paragraphs nested inside the cover image to have size 20px. These changes make the default size for paragraph appear as 16px but we don't set the class so the size will be in fact the one set with CSS for paragraphs inside cover image 20px.
> Essentially I think there is a difference of state between not having size specified, no class et all where we use the default css rules depending on the context, and having regular font size where we use the regular class.

This PR reverts this behavior. I tried a few different tricks, but they all have some flaws. The most promising one was to set 16px only when it matches the computed style, but it doesn't work properly when switching back from HTML mode. In addition, it isn't consistent when you set the value back to 16px. Then it adds class name which isn't perfect. We can tackle it later in a separate PR.

## How Has This Been Tested?
Manually. This is how font size setting should look like on the initial load for the default Paragraph block:

![screen shot 2018-04-09 at 11 44 07](https://user-images.githubusercontent.com/699132/38491157-5ebe4b36-3beb-11e8-8776-b945c86794ae.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
