### PR TITLE
API Request: Add preloading support to wp.apiRequest

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -844,6 +844,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	// Preload common data.
 	$preload_paths = array(
+		sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
 		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
 		'/wp/v2/taxonomies?context=edit',
 		gutenberg_get_rest_link( $post_to_edit, 'about', 'edit' ),

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -133,7 +133,7 @@ function gutenberg_shim_fix_api_request_plain_permalinks( $scripts ) {
 			return deferred.promise();
 		}
 
-		return previousApiRequest(request);
+		return previousApiRequest.call( previousApiRequest, request );
 	}
 	wp.apiRequest.transport = previousApiRequest.transport;
 	wp.apiRequest.buildAjaxOptions = previousApiRequest.buildAjaxOptions;

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -134,8 +134,11 @@ function gutenberg_shim_api_request( $scripts ) {
 
 		return previousApiRequest.call( previousApiRequest, request );
 	}
-	wp.apiRequest.transport = previousApiRequest.transport;
-	wp.apiRequest.buildAjaxOptions = previousApiRequest.buildAjaxOptions;
+	for ( var name in previousApiRequest ) {
+		if ( previousApiRequest.hasOwnProperty( name ) ) {
+			wp.apiRequest[ name ] = previousApiRequest[ name ];
+		}
+	}
 
 } )( window.wp, window.wpApiSettings );
 JS;

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -101,11 +101,17 @@ function gutenberg_shim_fix_api_request_plain_permalinks( $scripts ) {
 			// [ 'b=1', 'c=2', 'a=5' ]
 			.split( '&' )
 			// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
-			.map( ( entry ) => entry.split( '=' ) )
+			.map( function ( entry ) {
+				return entry.split( '=' );
+			 } )
 			// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
-			.sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) )
+			.sort( function ( a, b ) {
+				return a[ 0 ].localeCompare( b[ 0 ] );
+			 } )
 			// [ 'a=5', 'b=1', 'c=2' ]
-			.map( ( pair ) => pair.join( '=' ) )
+			.map( function ( pair ) {
+				return pair.join( '=' );
+			 } )
 			// 'a=5&b=1&c=2'
 			.join( '&' );
 	};
@@ -122,7 +128,9 @@ function gutenberg_shim_fix_api_request_plain_permalinks( $scripts ) {
 		var method = request.method || 'GET';
 		var path = getStablePath( request.path )
 		if ( 'GET' === method && window._wpAPIDataPreload[ path ] ) {
-			return Promise.resolve( window._wpAPIDataPreload[ path ].body );
+			var deferred = jQuery.Deferred();
+			deferred.resolve( window._wpAPIDataPreload[ path ].body );
+			return deferred.promise();
 		}
 
 		return previousApiRequest(request);


### PR DESCRIPTION
Since we're moving more stuff to use the Data Module instead of `withAPIData` we need a way to prefetch data the same way we used to do with `withAPIData`. This PR adds preloading support using the same mechanism used in `withAPIData` but built-in into the low level `apiRequest`.

I'm not removing the caching support from `withAPIData` yet because it has more features, it also caches new requests as they're performed, and this is not needed in the Data Module since the data module is a cache in itself.

**Testing instructions**

 - Check that when loading Gutenberg for a new post, there's no XHR request triggered. Specifically the `/wp/v2/types/post?context=edit` request.