### PR TITLE
Utils: Default to empty object for previous defined utils

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -97,7 +97,7 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'utils/build/index.js' ),
 		true
 	);
-	wp_add_inline_script( 'wp-utils', 'var originalUtils = wp.utils;', 'before' );
+	wp_add_inline_script( 'wp-utils', 'var originalUtils = window.wp && window.wp.utils ? window.wp.utils : {};', 'before' );
 	wp_add_inline_script( 'wp-utils', 'for ( var key in originalUtils ) wp.utils[ key ] = originalUtils[ key ];' );
 	wp_register_script(
 		'wp-hooks',


### PR DESCRIPTION
closes #6063

Depending on the order of the loaded scripts (which can change depending on the plugins used), we can see an error like this `ReferenceError: Can't find variable: wp` while depending on the `wp-utils` script because the global `wp` and `wp.utils` are not defined if this is the first script to be loaded.

This PR default to an empty object if one of these variables are not defined.