### PR TITLE
Fix menu z-index, reposition menu on scroll & resize

### DIFF
--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -54,6 +54,8 @@ class Popover extends Component {
 		this.getAnchorRect = this.getAnchorRect.bind( this );
 		this.setOffset = this.setOffset.bind( this );
 		this.throttledSetOffset = this.throttledSetOffset.bind( this );
+		this.setForcedPositions = this.setForcedPositions.bind( this );
+		this.throttledSetPosition = this.throttledSetPosition.bind( this );
 		this.maybeClose = this.maybeClose.bind( this );
 
 		this.nodes = {};
@@ -104,6 +106,10 @@ class Popover extends Component {
 		window.cancelAnimationFrame( this.rafHandle );
 		window[ handler ]( 'resize', this.throttledSetOffset );
 		window[ handler ]( 'scroll', this.throttledSetOffset, true );
+
+		window.cancelAnimationFrame( this.positionHandle );
+		window[ handler ]( 'resize', this.throttledSetPosition );
+		window[ handler ]( 'scroll', this.throttledSetPosition, true );
 	}
 
 	focus() {
@@ -129,6 +135,10 @@ class Popover extends Component {
 
 	throttledSetOffset() {
 		this.rafHandle = window.requestAnimationFrame( this.setOffset );
+	}
+
+	throttledSetPosition() {
+		this.positionHandle = window.requestAnimationFrame( this.setForcedPositions );
 	}
 
 	getAnchorRect() {

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -22,11 +22,15 @@
 
 // Popout menu
 .editor-block-settings-menu__popover {
-	z-index: z-index( '.editor-block-settings-menu__popover' );
 
 	&:before,
 	&:after {
 		margin-left: 2px;
+	}
+
+	// Lower z-index for bottom block setting menu.
+	&:not(.is-mobile).is-bottom {
+		z-index: z-index('.editor-block-settings-menu__popover');
 	}
 
 	.components-popover__content {


### PR DESCRIPTION
## Description
When opening the ellipsis menu on a block early in the page, and if that ellipsis menu contains a long list of options, it renders below the toolbar.

## Screenshots (jpeg or gifs if applicable):
![4519-block ellipsis menu opens below the toolbar](https://user-images.githubusercontent.com/1633818/38493407-b8f67ed8-3c0f-11e8-90a9-7a0d7daeea83.gif)

## Types of changes
Bug fixes, Change z-index for menu to push over toolbar, reposition menu on scroll and resize.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

Fixes : #4519 & #6026