### PR TITLE
Fix sticky post saving if we use metaboxes

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -75,6 +75,7 @@ const effects = {
 		const additionalData = [
 			post.comment_status ? [ 'comment_status', post.comment_status ] : false,
 			post.ping_status ? [ 'ping_status', post.ping_status ] : false,
+			post.sticky ? [ 'sticky', post.sticky ] : false,
 			[ 'post_author', post.author ],
 		].filter( Boolean );
 


### PR DESCRIPTION
closes #6062

When using meta boxes, the request triggered to save the meta boxes was resetting the sticky post flag, we need to send the flag as part of the request.

**Testing instructions**

 - Add meta boxes
 - Create a new sticky post
 - Save it
 - Refresh the page, the post should remain sticky