### PR TITLE
Edit Post: Make sure block controls do not show up over sidebar on greater than small viewport

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -44,7 +44,7 @@ $z-layers: (
 
 	// Block controls, particularly in nested contexts, floats aside block and
 	// should overlap most block content.
-	'.editor-block-list__block.is-{selected,hovered} .editor-block-{settings-menu,mover}': 100,
+	'.editor-block-list__block.is-{selected,hovered} .editor-block-{settings-menu,mover}': 80,
 
 	// Show sidebar above wp-admin navigation bar for mobile viewports:
 	// #wpadminbar { z-index: 99999 }
@@ -53,7 +53,7 @@ $z-layers: (
 
 	// Show sidebar in greater than small viewports above editor related elements
 	// but bellow #adminmenuback { z-index: 100 }
-	'.edit-post-sidebar {greater than small}': 50,
+	'.edit-post-sidebar {greater than small}': 90,
 
 	// Show notices below expanded wp-admin submenus:
 	// #adminmenuwrap { z-index: 9990 }


### PR DESCRIPTION
## Description
This PR tries to fix regression introduced after release 2.6 went out. Editor movers and block settings are displayed over sidebar menu when browsing on greater than small screens (> 600px & < 780px).

_Sidenote:_ Honestly speaking I updated those values randomly to make it work. Let me know what is the proper way to fix it 🙇 

## How Has This Been Tested?
Manually.

* Need to set screen width between 600px and 780px.
* Select one of the blocks.
* Open advanced block settings.

## Screenshots (jpeg or gifs if applicable):

#### Before
![screen shot 2018-04-09 at 13 26 24](https://user-images.githubusercontent.com/699132/38496342-7d928092-3bfd-11e8-95d0-406b8a7b5b02.png)


#### After
![screen shot 2018-04-09 at 13 49 16](https://user-images.githubusercontent.com/699132/38496346-80f20870-3bfd-11e8-9575-d6a6341da106.png)


