### PR TITLE
Fixes the nested blocks contextual toolbar preference

### DIFF
--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Toolbar, withContext } from '@wordpress/components';
+import { Toolbar } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { withEditorSettings } from '../editor-settings';
 
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	left: {
@@ -54,7 +59,7 @@ export function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CON
 	);
 }
 
-export default withContext( 'editor' )(
+export default withEditorSettings(
 	( settings ) => ( {
 		wideControlsEnabled: settings.alignWide,
 	} )

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -8,13 +8,14 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Dropdown, withContext } from '@wordpress/components';
+import { Dropdown } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import { withEditorSettings } from '../editor-settings';
 
 export function ColorPalette( { colors, disableCustomColors = false, value, onChange } ) {
 	function applyOrUnset( color ) {
@@ -78,7 +79,7 @@ export function ColorPalette( { colors, disableCustomColors = false, value, onCh
 	);
 }
 
-export default withContext( 'editor' )(
+export default withEditorSettings(
 	( settings, props ) => ( {
 		colors: props.colors || settings.colors,
 		disableCustomColors: props.disableCustomColors !== undefined ?

--- a/blocks/editor-settings/index.js
+++ b/blocks/editor-settings/index.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+/**
+ * The default editor settings
+ * You can override any default settings when calling initializeEditor
+ *
+ *  alignWide   boolean   Enable/Disable Wide/Full Alignments
+ *
+ * @var {Object} DEFAULT_SETTINGS
+ */
+const DEFAULT_SETTINGS = {
+	alignWide: false,
+	colors: [
+		'#f78da7',
+		'#cf2e2e',
+		'#ff6900',
+		'#fcb900',
+		'#7bdcb5',
+		'#00d084',
+		'#8ed1fc',
+		'#0693e3',
+		'#eee',
+		'#abb8c3',
+		'#313131',
+	],
+
+	// This is current max width of the block inner area
+	// It's used to constraint image resizing and this value could be overriden later by themes
+	maxWidth: 608,
+
+	// Allowed block types for the editor, defaulting to true (all supported).
+	allowedBlockTypes: true,
+};
+
+const EditorSettings = createContext( DEFAULT_SETTINGS );
+EditorSettings.defaultSettings = DEFAULT_SETTINGS;
+
+export default EditorSettings;
+
+export const withEditorSettings = ( mapSettingsToProps ) => ( Component ) => {
+	return function WithSettingsComponent( props ) {
+		return (
+			<EditorSettings.Consumer>
+				{ settings => (
+					<Component
+						{ ...props }
+						{ ...( mapSettingsToProps ? mapSettingsToProps( settings, props ) : { settings } ) }
+					/>
+				) }
+			</EditorSettings.Consumer>
+		);
+	};
+};

--- a/blocks/editor-settings/index.js
+++ b/blocks/editor-settings/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createContext } from '@wordpress/element';
+import { createContext, createHigherOrderComponent } from '@wordpress/element';
 
 /**
  * The default editor settings
@@ -41,17 +41,20 @@ EditorSettings.defaultSettings = DEFAULT_SETTINGS;
 
 export default EditorSettings;
 
-export const withEditorSettings = ( mapSettingsToProps ) => ( Component ) => {
-	return function WithSettingsComponent( props ) {
-		return (
-			<EditorSettings.Consumer>
-				{ settings => (
-					<Component
-						{ ...props }
-						{ ...( mapSettingsToProps ? mapSettingsToProps( settings, props ) : { settings } ) }
-					/>
-				) }
-			</EditorSettings.Consumer>
-		);
-	};
-};
+export const withEditorSettings = ( mapSettingsToProps ) => createHigherOrderComponent(
+	( Component ) => {
+		return function WithSettingsComponent( props ) {
+			return (
+				<EditorSettings.Consumer>
+					{ settings => (
+						<Component
+							{ ...props }
+							{ ...( mapSettingsToProps ? mapSettingsToProps( settings, props ) : { settings } ) }
+						/>
+					) }
+				</EditorSettings.Consumer>
+			);
+		};
+	},
+	'withEditorSettings'
+);

--- a/blocks/editor-settings/index.js
+++ b/blocks/editor-settings/index.js
@@ -5,11 +5,12 @@ import { createContext } from '@wordpress/element';
 
 /**
  * The default editor settings
- * You can override any default settings when calling initializeEditor
  *
- *  alignWide   boolean   Enable/Disable Wide/Full Alignments
- *
- * @var {Object} DEFAULT_SETTINGS
+ *  alignWide         boolean        Enable/Disable Wide/Full Alignments
+ *  colors            Array          Palette colors
+ *  maxWidth          number         Max width to constraint resizing
+ *  blockTypes        boolean|Array  Allowed block types
+ *  hasFixedToolbar   boolean        Whether or not the editor toolbar is fixed
  */
 const DEFAULT_SETTINGS = {
 	alignWide: false,

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -31,3 +31,4 @@ export { default as RichText } from './rich-text';
 export { default as RichTextProvider } from './rich-text/provider';
 export { default as UrlInput } from './url-input';
 export { default as UrlInputButton } from './url-input/button';
+export { default as EditorSettings, withEditorSettings } from './editor-settings';

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -23,7 +23,6 @@ import {
 	SelectControl,
 	TextareaControl,
 	Toolbar,
-	withContext,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
@@ -39,6 +38,7 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import UrlInputButton from '../../url-input/button';
 import ImageSize from './image-size';
 import { mediaUpload } from '../../../utils/mediaupload';
+import { withEditorSettings } from '../../editor-settings';
 
 /**
  * Module constants
@@ -301,9 +301,7 @@ class ImageBlock extends Component {
 }
 
 export default compose( [
-	withContext( 'editor' )( ( settings ) => {
-		return { settings };
-	} ),
+	withEditorSettings(),
 	withSelect( ( select, props ) => {
 		const { getMedia } = select( 'core' );
 		const { id } = props.attributes;

--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -11,7 +11,7 @@ import {
 	BlockSelectionClearer,
 	MultiSelectScrollIntoView,
 } from '@wordpress/editor';
-import { Fragment, compose } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -44,5 +44,4 @@ function VisualEditor() {
 	);
 }
 
-export default compose( [
-] )( VisualEditor );
+export default VisualEditor;

--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -12,8 +12,6 @@ import {
 	MultiSelectScrollIntoView,
 } from '@wordpress/editor';
 import { Fragment, compose } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
-import { withViewportMatch } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -30,7 +28,7 @@ function VisualEditorBlockMenu( { children, onClose } ) {
 	);
 }
 
-function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
+function VisualEditor() {
 	return (
 		<BlockSelectionClearer className="edit-post-visual-editor">
 			<EditorGlobalKeyboardShortcuts />
@@ -39,10 +37,7 @@ function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
 			<WritingFlow>
 				<ObserveTyping>
 					<PostTitle />
-					<BlockList
-						showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
-						renderBlockMenu={ VisualEditorBlockMenu }
-					/>
+					<BlockList renderBlockMenu={ VisualEditorBlockMenu } />
 				</ObserveTyping>
 			</WritingFlow>
 		</BlockSelectionClearer>
@@ -50,8 +45,4 @@ function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
 }
 
 export default compose( [
-	withSelect( ( select ) => ( {
-		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
-	} ) ),
-	withViewportMatch( { isLargeViewport: 'medium' } ),
 ] )( VisualEditor );

--- a/edit-post/editor.js
+++ b/edit-post/editor.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+import { EditorProvider, ErrorBoundary } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import Layout from './components/layout';
+
+function Editor( { settings, hasFixedToolbar, onError, ...props } ) {
+	return (
+		<EditorProvider settings={ { ...settings, hasFixedToolbar } } { ...props }>
+			<ErrorBoundary onError={ onError }>
+				<Layout />
+			</ErrorBoundary>
+		</EditorProvider>
+	);
+}
+
+export default withSelect( select => ( {
+	hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+} ) )( Editor );

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -2,17 +2,15 @@
  * WordPress dependencies
  */
 import { render, unmountComponentAtNode } from '@wordpress/element';
-import { EditorProvider, ErrorBoundary } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import './assets/stylesheets/main.scss';
 import './hooks';
-import Layout from './components/layout';
 import store from './store';
 import { initializeMetaBoxState } from './store/actions';
-
+import Editor from './editor';
 import PluginMoreMenuItem from './components/plugin-more-menu-item';
 
 /**
@@ -35,15 +33,10 @@ window.jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
  */
 export function reinitializeEditor( target, settings ) {
 	unmountComponentAtNode( target );
-
 	const reboot = reinitializeEditor.bind( null, target, settings );
 
 	render(
-		<EditorProvider settings={ settings } recovery>
-			<ErrorBoundary onError={ reboot }>
-				<Layout />
-			</ErrorBoundary>
-		</EditorProvider>,
+		<Editor settings={ settings } onError={ reboot } recovery />,
 		target
 	);
 }
@@ -65,11 +58,7 @@ export function initializeEditor( id, post, settings ) {
 	const reboot = reinitializeEditor.bind( null, target, settings );
 
 	render(
-		<EditorProvider settings={ settings } post={ post }>
-			<ErrorBoundary onError={ reboot }>
-				<Layout />
-			</ErrorBoundary>
-		</EditorProvider>,
+		<Editor settings={ settings } onError={ reboot } post={ post } />,
 		target
 	);
 

--- a/editor/components/block-drop-zone/index.js
+++ b/editor/components/block-drop-zone/index.js
@@ -7,12 +7,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { DropZone, withContext } from '@wordpress/components';
+import { DropZone } from '@wordpress/components';
 import {
 	rawHandler,
 	cloneBlock,
 	getBlockTransforms,
 	findTransform,
+	withEditorSettings,
 } from '@wordpress/blocks';
 import { compose, Component } from '@wordpress/element';
 import { withDispatch } from '@wordpress/data';
@@ -137,7 +138,7 @@ export default compose(
 			},
 		};
 	} ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -24,8 +24,9 @@ import {
 	getSaveElement,
 	isSharedBlock,
 	isUnmodifiedDefaultBlock,
+	withEditorSettings,
 } from '@wordpress/blocks';
-import { withFilters, withContext } from '@wordpress/components';
+import { withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 
@@ -691,7 +692,7 @@ BlockListBlock.childContextTypes = {
 export default compose(
 	applyWithSelect,
 	applyWithDispatch,
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -29,6 +29,7 @@ import {
 import { withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { withViewportMatch } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -96,8 +97,8 @@ export class BlockListBlock extends Component {
 		// we inject this function via context.
 		return {
 			createInnerBlockList: ( uid ) => {
-				const { renderBlockMenu, showContextualToolbar } = this.props;
-				return createInnerBlockList( uid, renderBlockMenu, showContextualToolbar );
+				const { renderBlockMenu } = this.props;
+				return createInnerBlockList( uid, renderBlockMenu );
 			},
 		};
 	}
@@ -393,7 +394,7 @@ export class BlockListBlock extends Component {
 			block,
 			order,
 			mode,
-			showContextualToolbar,
+			hasFixedToolbar,
 			isLocked,
 			isFirst,
 			isLast,
@@ -408,6 +409,7 @@ export class BlockListBlock extends Component {
 			isTypingWithinBlock,
 			isMultiSelecting,
 			hoverArea,
+			isLargeViewport,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -427,7 +429,7 @@ export class BlockListBlock extends Component {
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
 		const shouldShowBreadcrumb = isHovered;
-		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
+		const shouldShowContextualToolbar = shouldAppearSelected && isValid && ( ! hasFixedToolbar || ! isLargeViewport );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
 
@@ -692,11 +694,13 @@ BlockListBlock.childContextTypes = {
 export default compose(
 	applyWithSelect,
 	applyWithDispatch,
+	withViewportMatch( { isLargeViewport: 'medium' } ),
 	withEditorSettings( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {
 			isLocked: !! templateLock,
+			hasFixedToolbar: settings.hasFixedToolbar,
 		};
 	} ),
 	withFilters( 'editor.BlockListBlock' ),

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -2,9 +2,9 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { isUnmodifiedDefaultBlock, withEditorSettings } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
-import { ifCondition, withContext } from '@wordpress/components';
+import { ifCondition } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 class BlockInsertionPoint extends Component {
@@ -37,7 +37,7 @@ class BlockInsertionPoint extends Component {
 	}
 }
 export default compose(
-	withContext( 'editor' )( ( { templateLock } ) => ( { templateLock } ) ),
+	withEditorSettings( ( { templateLock } ) => ( { templateLock } ) ),
 	ifCondition( ( { templateLock } ) => ! templateLock ),
 	withSelect( ( select, { uid, rootUID } ) => {
 		const {

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -190,7 +190,6 @@ class BlockListLayout extends Component {
 	render() {
 		const {
 			blockUIDs,
-			showContextualToolbar,
 			layout,
 			isGroupedByLayout,
 			rootUID,
@@ -216,7 +215,6 @@ class BlockListLayout extends Component {
 						blockRef={ this.setBlockRef }
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
-						showContextualToolbar={ showContextualToolbar }
 						rootUID={ rootUID }
 						layout={ defaultLayout }
 						isFirst={ blockIndex === 0 }

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -8,8 +8,8 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, withContext, withInstanceId } from '@wordpress/components';
-import { getBlockType } from '@wordpress/blocks';
+import { IconButton, withInstanceId } from '@wordpress/components';
+import { getBlockType, withEditorSettings } from '@wordpress/blocks';
 import { compose, Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -121,7 +121,7 @@ export default compose(
 			onMoveUp: partial( moveBlocksUp, uids, rootUID ),
 		};
 	} ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {

--- a/editor/components/block-preview/index.js
+++ b/editor/components/block-preview/index.js
@@ -30,7 +30,7 @@ class BlockPreview extends Component {
 		// we inject this function via context.
 		return {
 			createInnerBlockList: ( uid ) => {
-				return createInnerBlockList( uid, noop );
+				return createInnerBlockList( uid );
 			},
 		};
 	}

--- a/editor/components/block-preview/index.js
+++ b/editor/components/block-preview/index.js
@@ -30,7 +30,7 @@ class BlockPreview extends Component {
 		// we inject this function via context.
 		return {
 			createInnerBlockList: ( uid ) => {
-				return createInnerBlockList( uid, noop, noop );
+				return createInnerBlockList( uid, noop );
 			},
 		};
 	}

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -7,10 +7,10 @@ import { flow, noop, last, every, first } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, withContext } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { cloneBlock, getBlockType } from '@wordpress/blocks';
+import { cloneBlock, getBlockType, withEditorSettings } from '@wordpress/blocks';
 
 export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, role } ) {
 	const canDuplicate = every( blocks, block => {
@@ -54,7 +54,7 @@ export default compose(
 			}
 		},
 	} ) ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -7,9 +7,10 @@ import { flow, noop } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, withContext } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withDispatch } from '@wordpress/data';
+import { withEditorSettings } from '@wordpress/blocks';
 
 export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false, role } ) {
 	if ( isLocked ) {
@@ -37,7 +38,7 @@ export default compose(
 			dispatch( 'core/editor' ).removeBlocks( uids );
 		},
 	} ) ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {

--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -7,8 +7,8 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, withContext } from '@wordpress/components';
-import { getPossibleBlockTransformations, switchToBlockType } from '@wordpress/blocks';
+import { IconButton } from '@wordpress/components';
+import { getPossibleBlockTransformations, switchToBlockType, withEditorSettings } from '@wordpress/blocks';
 import { compose, Fragment } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -64,7 +64,7 @@ export default compose(
 			);
 		},
 	} ) ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu, withContext } from '@wordpress/components';
-import { getBlockType, getPossibleBlockTransformations, switchToBlockType, BlockIcon } from '@wordpress/blocks';
+import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu } from '@wordpress/components';
+import { getBlockType, getPossibleBlockTransformations, switchToBlockType, BlockIcon, withEditorSettings } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -109,7 +109,7 @@ export default compose(
 			);
 		},
 	} ) ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {

--- a/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
+++ b/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MultiBlocksSwitcher should return a BlockSwitcher element matching the snapshot. 1`] = `
-<WithSelect(WithDispatch(WrappedComponent))
+<WithSelect(WithDispatch(WithSettingsComponent))
   key="switcher"
   uids={
     Array [

--- a/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
+++ b/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MultiBlocksSwitcher should return a BlockSwitcher element matching the snapshot. 1`] = `
-<WithSelect(WithDispatch(WithSettingsComponent))
+<WithSelect(WithDispatch(WithEditorSettings(BlockSwitcher)))
   key="switcher"
   uids={
     Array [

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -8,8 +8,7 @@ import { get } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/element';
-import { getDefaultBlockName } from '@wordpress/blocks';
-import { withContext } from '@wordpress/components';
+import { getDefaultBlockName, withEditorSettings } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -91,7 +90,7 @@ export default compose(
 			},
 		};
 	} ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock, bodyPlaceholder } = settings;
 
 		return {

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WrappedComponent) />
+  <WithDispatch(WithSettingsComponent) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -35,8 +35,8 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     type="text"
     value="Write your story"
   />
-  <WrappedComponent />
-  <WithSelect(WithDispatch(WrappedComponent))
+  <WithSettingsComponent />
+  <WithSelect(WithDispatch(WithSettingsComponent))
     position="top right"
   />
 </div>
@@ -47,7 +47,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WrappedComponent) />
+  <WithDispatch(WithSettingsComponent) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -59,8 +59,8 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     type="text"
     value="Write your story"
   />
-  <WrappedComponent />
-  <WithSelect(WithDispatch(WrappedComponent))
+  <WithSettingsComponent />
+  <WithSelect(WithDispatch(WithSettingsComponent))
     position="top right"
   />
 </div>
@@ -71,7 +71,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WrappedComponent) />
+  <WithDispatch(WithSettingsComponent) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -83,8 +83,8 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     type="text"
     value=""
   />
-  <WrappedComponent />
-  <WithSelect(WithDispatch(WrappedComponent))
+  <WithSettingsComponent />
+  <WithSelect(WithDispatch(WithSettingsComponent))
     position="top right"
   />
 </div>

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSettingsComponent) />
+  <WithDispatch(WithEditorSettings(BlockDropZone)) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -35,8 +35,8 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     type="text"
     value="Write your story"
   />
-  <WithSettingsComponent />
-  <WithSelect(WithDispatch(WithSettingsComponent))
+  <WithEditorSettings(Connect(WithDispatch(InserterWithShortcuts))) />
+  <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
     position="top right"
   />
 </div>
@@ -47,7 +47,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSettingsComponent) />
+  <WithDispatch(WithEditorSettings(BlockDropZone)) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -59,8 +59,8 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     type="text"
     value="Write your story"
   />
-  <WithSettingsComponent />
-  <WithSelect(WithDispatch(WithSettingsComponent))
+  <WithEditorSettings(Connect(WithDispatch(InserterWithShortcuts))) />
+  <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
     position="top right"
   />
 </div>
@@ -71,7 +71,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSettingsComponent) />
+  <WithDispatch(WithEditorSettings(BlockDropZone)) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -83,8 +83,8 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     type="text"
     value=""
   />
-  <WithSettingsComponent />
-  <WithSelect(WithDispatch(WithSettingsComponent))
+  <WithEditorSettings(Connect(WithDispatch(InserterWithShortcuts))) />
+  <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
     position="top right"
   />
 </div>

--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -7,8 +7,9 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { Component, Fragment, compose } from '@wordpress/element';
-import { KeyboardShortcuts, withContext } from '@wordpress/components';
+import { KeyboardShortcuts } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { withEditorSettings } from '@wordpress/blocks';
 
 class EditorGlobalKeyboardShortcuts extends Component {
 	constructor() {
@@ -120,7 +121,7 @@ export default compose( [
 			onSave: autosave,
 		};
 	} ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -7,9 +7,9 @@ import { filter, isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { BlockIcon, createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { BlockIcon, createBlock, getDefaultBlockName, withEditorSettings } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
-import { IconButton, withContext } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch } from '@wordpress/data';
 
@@ -46,7 +46,7 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 }
 
 export default compose(
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { templateLock, allowedBlockTypes } = settings;
 
 		return {

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -7,8 +7,8 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton, withContext } from '@wordpress/components';
-import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { Dropdown, IconButton } from '@wordpress/components';
+import { createBlock, isUnmodifiedDefaultBlock, withEditorSettings } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -106,7 +106,7 @@ export default compose( [
 			return dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootUID );
 		},
 	} ) ),
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { allowedBlockTypes, templateLock } = settings;
 
 		return {

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -24,9 +24,8 @@ import {
 	TabbableContainer,
 	withInstanceId,
 	withSpokenMessages,
-	withContext,
 } from '@wordpress/components';
-import { getCategories, isSharedBlock } from '@wordpress/blocks';
+import { getCategories, isSharedBlock, withEditorSettings } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -340,7 +339,7 @@ export class InserterMenu extends Component {
 }
 
 export default compose(
-	withContext( 'editor' )( ( settings ) => {
+	withEditorSettings( ( settings ) => {
 		const { allowedBlockTypes } = settings;
 
 		return {

--- a/editor/components/page-attributes/check.js
+++ b/editor/components/page-attributes/check.js
@@ -6,7 +6,7 @@ import { get, isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withContext } from '@wordpress/components';
+import { withEditorSettings } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
@@ -29,7 +29,7 @@ const applyWithSelect = withSelect( ( select ) => {
 	};
 } );
 
-const applyWithContext = withContext( 'editor' )(
+const applyWithEditorSettings = withEditorSettings(
 	( settings ) => ( {
 		availableTemplates: settings.availableTemplates,
 	} )
@@ -37,5 +37,5 @@ const applyWithContext = withContext( 'editor' )(
 
 export default compose( [
 	applyWithSelect,
-	applyWithContext,
+	applyWithEditorSettings,
 ] )( PageAttributesCheck );

--- a/editor/components/page-attributes/template.js
+++ b/editor/components/page-attributes/template.js
@@ -8,8 +8,9 @@ import { isEmpty, map } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withContext, withInstanceId } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/components';
 import { compose } from '@wordpress/element';
+import { withEditorSettings } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -54,7 +55,7 @@ const applyConnect = connect(
 	}
 );
 
-const applyWithContext = withContext( 'editor' )(
+const applyWithEditorSettings = withEditorSettings(
 	( settings ) => ( {
 		availableTemplates: settings.availableTemplates,
 	} )
@@ -62,6 +63,6 @@ const applyWithContext = withContext( 'editor' )(
 
 export default compose(
 	applyConnect,
-	applyWithContext,
+	applyWithEditorSettings,
 	withInstanceId,
 )( PageTemplate );

--- a/editor/components/post-format/check.js
+++ b/editor/components/post-format/check.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withContext } from '@wordpress/components';
+import { withEditorSettings } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ function PostFormatCheck( { disablePostFormats, ...props } ) {
 		<PostTypeSupportCheck { ...props } supportKeys="post-formats" />;
 }
 
-export default withContext( 'editor' )(
+export default withEditorSettings(
 	( { disablePostFormats } ) => ( { disablePostFormats } )
 )( PostFormatCheck );
 

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -11,7 +11,8 @@ import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { keycodes, decodeEntities } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { KeyboardShortcuts, withContext, withInstanceId, withFocusOutside } from '@wordpress/components';
+import { KeyboardShortcuts, withInstanceId, withFocusOutside } from '@wordpress/components';
+import { withEditorSettings } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -152,7 +153,7 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 	};
 } );
 
-const applyEditorSettings = withContext( 'editor' )(
+const applyEditorSettings = withEditorSettings(
 	( settings ) => ( {
 		placeholder: settings.titlePlaceholder,
 	} )

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -28,33 +28,29 @@ class EditorProvider extends Component {
 
 		this.store = store;
 
-		this.settings = {
-			...EditorSettings.defaultSettings,
-			...props.settings,
-		};
-
 		// Assume that we don't need to initialize in the case of an error recovery.
 		if ( ! props.recovery ) {
-			this.store.dispatch( setupEditor( props.post, this.settings ) );
-		}
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if (
-			nextProps.settings !== this.props.settings
-		) {
-			// eslint-disable-next-line no-console
-			console.error( 'The Editor Provider Props are immutable.' );
+			this.store.dispatch(
+				setupEditor( props.post, {
+					...EditorSettings.defaultSettings,
+					...this.props.settings,
+				} )
+			);
 		}
 	}
 
 	render() {
-		const { children } = this.props;
+		const { children, settings } = this.props;
 		const providers = [
 			// Editor settings provider
 			[
 				EditorSettings.Provider,
-				{ value: this.settings },
+				{
+					value: {
+						...EditorSettings.defaultSettings,
+						...settings,
+					},
+				},
 			],
 
 			// Redux provider:

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -3,13 +3,13 @@
  */
 import { bindActionCreators } from 'redux';
 import { Provider as ReduxProvider } from 'react-redux';
-import { flow, pick, noop } from 'lodash';
+import { flow, pick } from 'lodash';
 
 /**
  * WordPress Dependencies
  */
 import { createElement, Component } from '@wordpress/element';
-import { RichTextProvider } from '@wordpress/blocks';
+import { RichTextProvider, EditorSettings } from '@wordpress/blocks';
 import {
 	APIProvider,
 	DropZoneProvider,
@@ -22,38 +22,6 @@ import {
 import { setupEditor, undo, redo, createUndoLevel } from '../../store/actions';
 import store from '../../store';
 
-/**
- * The default editor settings
- * You can override any default settings when calling initializeEditor
- *
- *  alignWide   boolean   Enable/Disable Wide/Full Alignments
- *
- * @var {Object} DEFAULT_SETTINGS
- */
-const DEFAULT_SETTINGS = {
-	alignWide: false,
-	colors: [
-		'#f78da7',
-		'#cf2e2e',
-		'#ff6900',
-		'#fcb900',
-		'#7bdcb5',
-		'#00d084',
-		'#8ed1fc',
-		'#0693e3',
-		'#eee',
-		'#abb8c3',
-		'#313131',
-	],
-
-	// This is current max width of the block inner area
-	// It's used to constraint image resizing and this value could be overriden later by themes
-	maxWidth: 608,
-
-	// Allowed block types for the editor, defaulting to true (all supported).
-	allowedBlockTypes: true,
-};
-
 class EditorProvider extends Component {
 	constructor( props ) {
 		super( ...arguments );
@@ -61,7 +29,7 @@ class EditorProvider extends Component {
 		this.store = store;
 
 		this.settings = {
-			...DEFAULT_SETTINGS,
+			...EditorSettings.defaultSettings,
 			...props.settings,
 		};
 
@@ -69,12 +37,6 @@ class EditorProvider extends Component {
 		if ( ! props.recovery ) {
 			this.store.dispatch( setupEditor( props.post, this.settings ) );
 		}
-	}
-
-	getChildContext() {
-		return {
-			editor: this.settings,
-		};
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -89,6 +51,12 @@ class EditorProvider extends Component {
 	render() {
 		const { children } = this.props;
 		const providers = [
+			// Editor settings provider
+			[
+				EditorSettings.Provider,
+				{ value: this.settings },
+			],
+
 			// Redux provider:
 			//
 			//  - context.store
@@ -151,9 +119,5 @@ class EditorProvider extends Component {
 		return createEditorElement( children );
 	}
 }
-
-EditorProvider.childContextTypes = {
-	editor: noop,
-};
 
 export default EditorProvider;

--- a/editor/utils/block-list.js
+++ b/editor/utils/block-list.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -28,7 +33,7 @@ const INNER_BLOCK_LIST_CACHE = {};
  *
  * @return {Component} Pre-bound BlockList component
  */
-export function createInnerBlockList( uid, renderBlockMenu ) {
+export function createInnerBlockList( uid, renderBlockMenu = noop ) {
 	if ( ! INNER_BLOCK_LIST_CACHE[ uid ] ) {
 		INNER_BLOCK_LIST_CACHE[ uid ] = [
 			// The component class:

--- a/editor/utils/block-list.js
+++ b/editor/utils/block-list.js
@@ -25,12 +25,10 @@ const INNER_BLOCK_LIST_CACHE = {};
  *                                         BlockList component.
  * @param {Function} renderBlockMenu       Render function for block menu of
  *                                         nested BlockList.
- * @param {boolean}  showContextualToolbar Whether contextual toolbar is to be
- *                                         used.
  *
  * @return {Component} Pre-bound BlockList component
  */
-export function createInnerBlockList( uid, renderBlockMenu, showContextualToolbar ) {
+export function createInnerBlockList( uid, renderBlockMenu ) {
 	if ( ! INNER_BLOCK_LIST_CACHE[ uid ] ) {
 		INNER_BLOCK_LIST_CACHE[ uid ] = [
 			// The component class:
@@ -52,7 +50,6 @@ export function createInnerBlockList( uid, renderBlockMenu, showContextualToolba
 						<BlockList
 							rootUID={ uid }
 							renderBlockMenu={ renderBlockMenu }
-							showContextualToolbar={ showContextualToolbar }
 							{ ...this.props } />
 					);
 				}


### PR DESCRIPTION
closes #6047

On nested blocks, when we switch the "Fixed toolbar" preference, the UI was not being updated because the `InnerBlocks` component is cached and doesn't change on prop change.

So solve this issue, this does two things:

 - Move the `hasFixedToolbar` preference to the editor settings object to avoid having to pass it down as a prop to all the needed components and rely on context instead.

 - Since this preference can change over time, the old implementation of React context is not possible, so I'm also updating the editorSettings to rely on the new React context API.

This PR surfaces several things:

1 - The `blocks` module needs to know about the `editorSettings` (`editor` module). Previously, it was implicit because we we're just grabbing a context value, with the next React API, it's explicit (better IMO) because we need to import the `Consumer` component. In this first implementation, I implemented the `EditorSettings` context in the `blocks` module to avoid circular dependencies. But This is just one other thing proving that the distinction we have right now between blocks and editor is not correct and should be rethought separately.

2 - The new Editor Settings Object can change over time (it used to be immutable). This is already handled properly everywhere using the Context API. Aside one place, the `setupEditor` action is being triggered using the settings object. I think this is used to check the post against its template (which is available in the settings). I think it's fine for now because the template config can't be changed yet, but we could imagine rechecking again if the settings change. (retrigger a `setupEditor` action).

3 - Also this raises the question on the difference between the `data` module and the new React context API. And the response is simple, there's no difference conceptually :). So why I didn't use the data module instead of the React context API here? Because I didn't want to introduce a `blocks` store yet while the distinction between `editor` and `blocks` is not clear yet (see point 1). We should probably be using the `editor` store to hold these settings instead of a newly created `blocks` store. Bur for this to happen we need to merge these two modules first. So the tradeoff here is to use the React API and we'd be able to replace it easily with the data module once the point 1 is fixed.

**Testing instructionos**

 - Add a columns block
 - Switch the "Fixed toolbar preference"
 - The toolbar should show up at the right place depending on the value of the preference.