### PR TITLE
Data Module: Add isFulfilled API for advanced resolver use cases

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -3,7 +3,7 @@
  */
 import isShallowEqual from 'shallowequal';
 import { combineReducers, createStore } from 'redux';
-import { flowRight, without, mapValues, isPlainObject } from 'lodash';
+import { flowRight, without, mapValues } from 'lodash';
 import memoize from 'memize';
 
 /**
@@ -137,17 +137,15 @@ export function registerResolvers( reducerKey, newResolvers ) {
 		}
 
 		const store = stores[ reducerKey ];
-		let resolver = newResolvers[ key ];
-		if ( ! isPlainObject( resolver ) ) {
-			resolver = { fulfill: resolver };
-		}
+		const resolver = newResolvers[ key ];
 
 		const rawFulfill = async ( ...args ) => {
 			// At this point, selectors have already been pre-bound to inject
 			// state, it would not be otherwise provided to fulfill.
 			const state = store.getState();
 
-			let fulfillment = resolver.fulfill( state, ...args );
+			const fulfill = resolver.fulfill ? resolver.fulfill : resolver;
+			let fulfillment = fulfill( state, ...args );
 
 			// Attempt to normalize fulfillment as async iterable.
 			fulfillment = toAsyncIterable( fulfillment );

--- a/data/index.js
+++ b/data/index.js
@@ -3,7 +3,7 @@
  */
 import isShallowEqual from 'shallowequal';
 import { combineReducers, createStore } from 'redux';
-import { flowRight, without, mapValues } from 'lodash';
+import { flowRight, without, mapValues, isPlainObject } from 'lodash';
 import memoize from 'memize';
 
 /**
@@ -136,15 +136,15 @@ export function registerResolvers( reducerKey, newResolvers ) {
 			return selector;
 		}
 
-		// Ensure single invocation per argument set via memoization.
-		const fulfill = memoize( async ( ...args ) => {
-			const store = stores[ reducerKey ];
+		const store = stores[ reducerKey ];
+		const resolver = isPlainObject( newResolvers[ key ] ) ? newResolvers[ key ] : { fulfill: newResolvers[ key ] };
 
+		const rawFullfill = async ( ...args ) => {
 			// At this point, selectors have already been pre-bound to inject
 			// state, it would not be otherwise provided to fulfill.
 			const state = store.getState();
 
-			let fulfillment = newResolvers[ key ]( state, ...args );
+			let fulfillment = resolver.fulfill( state, ...args );
 
 			// Attempt to normalize fulfillment as async iterable.
 			fulfillment = toAsyncIterable( fulfillment );
@@ -158,7 +158,16 @@ export function registerResolvers( reducerKey, newResolvers ) {
 					store.dispatch( maybeAction );
 				}
 			}
-		} );
+		};
+
+		// Ensure single invocation per argument set via memoization
+		// or via isFulfilled call if provided.
+		const fulfill = resolver.isFulfilled ? ( ...args ) => {
+			const state = store.getState();
+			if ( ! resolver.isFulfilled( state, ...args ) ) {
+				rawFullfill( ...args );
+			}
+		} : memoize( rawFullfill );
 
 		return ( ...args ) => {
 			fulfill( ...args );

--- a/data/index.js
+++ b/data/index.js
@@ -137,9 +137,12 @@ export function registerResolvers( reducerKey, newResolvers ) {
 		}
 
 		const store = stores[ reducerKey ];
-		const resolver = isPlainObject( newResolvers[ key ] ) ? newResolvers[ key ] : { fulfill: newResolvers[ key ] };
+		let resolver = newResolvers[ key ];
+		if ( ! isPlainObject( resolver ) ) {
+			resolver = { fulfill: resolver };
+		}
 
-		const rawFullfill = async ( ...args ) => {
+		const rawFulfill = async ( ...args ) => {
 			// At this point, selectors have already been pre-bound to inject
 			// state, it would not be otherwise provided to fulfill.
 			const state = store.getState();
@@ -165,9 +168,9 @@ export function registerResolvers( reducerKey, newResolvers ) {
 		const fulfill = resolver.isFulfilled ? ( ...args ) => {
 			const state = store.getState();
 			if ( ! resolver.isFulfilled( state, ...args ) ) {
-				rawFullfill( ...args );
+				rawFulfill( ...args );
 			}
-		} : memoize( rawFullfill );
+		} : memoize( rawFulfill );
 
 		return ( ...args ) => {
 			fulfill( ...args );


### PR DESCRIPTION
In some advanced use cases, the memoization of the resolvers is not enough to avoid similar requests to be triggered multiple times:

 - When using complex args (new instance of objects)
 - Multiple generators dealing with the same data.

To solve this, I'm introducing an `isFulfilled` API to the resolvers.

We can now write resolvers like this:

```js
const myResolver: { 
  fulfill: ( state, ...args ) => // do something.
  isFulfilled: ( state, ...args ) => // returns a boolean. 
},
```

This resolver will be triggered each time we call the selector unless `isFulfilled` returns true.

**Testing instructions**

Nothing is changing for now, I'm planning to use this in #5875