### PR TITLE
Data Module: Adding a generic Requests state

### DIFF
--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -4,19 +4,41 @@
 import { castArray } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { getRequestId } from './utils';
+
+/**
  * Returns an action object used in signalling that the request for a given
  * data type has been made.
  *
  * @param {string}  dataType Data type requested.
- * @param {?string} subType  Optional data sub-type.
+ * @param {*} query          Optional request args.
  *
  * @return {Object} Action object.
  */
-export function setRequested( dataType, subType ) {
+export function setRequested( dataType, query ) {
 	return {
 		type: 'SET_REQUESTED',
+		id: getRequestId( query ),
 		dataType,
-		subType,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the request for a given
+ * data type has been triggered.
+ *
+ * @param {string}  dataType Data type requested.
+ * @param {*} query          Optional request args.
+ *
+ * @return {Object} Action object.
+ */
+export function setRequesting( dataType, query ) {
+	return {
+		type: 'SET_REQUESTING',
+		id: getRequestId( query ),
+		dataType,
 	};
 }
 

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -9,6 +9,38 @@ import { keyBy } from 'lodash';
 import { combineReducers } from '@wordpress/data';
 
 /**
+ * Reducer managing the state of async requests keyed by request type and request id
+ * The request id is in general a unique identifier generated based on the request args.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function requests( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SET_REQUESTING':
+			return {
+				...state,
+				[ action.dataType ]: {
+					...state[ action.dataType ],
+					[ action.id ]: { isRequesting: true },
+				},
+			};
+		case 'SET_REQUESTED':
+			return {
+				...state,
+				[ action.dataType ]: {
+					...state[ action.dataType ],
+					[ action.id ]: { isRequested: true, isRequesting: false },
+				},
+			};
+	}
+
+	return state;
+}
+
+/**
  * Reducer managing terms state. Keyed by taxonomy slug, the value is either
  * undefined (if no request has been made for given taxonomy), null (if a
  * request is in-flight for given taxonomy), or the array of terms for the
@@ -25,17 +57,6 @@ export function terms( state = {}, action ) {
 			return {
 				...state,
 				[ action.taxonomy ]: action.terms,
-			};
-
-		case 'SET_REQUESTED':
-			const { dataType, subType: taxonomy } = action;
-			if ( dataType !== 'terms' || state.hasOwnProperty( taxonomy ) ) {
-				return state;
-			}
-
-			return {
-				...state,
-				[ taxonomy ]: null,
 			};
 	}
 
@@ -86,4 +107,5 @@ export default combineReducers( {
 	terms,
 	media,
 	postTypes,
+	requests,
 } );

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -8,6 +8,7 @@ import apiRequest from '@wordpress/api-request';
  */
 import {
 	setRequested,
+	setRequesting,
 	receiveTerms,
 	receiveMedia,
 	receivePostTypes,
@@ -18,9 +19,10 @@ import {
  * progress.
  */
 export async function* getCategories() {
-	yield setRequested( 'terms', 'categories' );
+	yield setRequesting( 'terms', 'categories' );
 	const categories = await apiRequest( { path: '/wp/v2/categories' } );
 	yield receiveTerms( 'categories', categories );
+	yield setRequested( 'terms', 'categories' );
 }
 
 /**

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -1,4 +1,44 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getRequestId } from './utils';
+
+/**
+ * Returns whether a request for a given
+ * data type has been made.
+ *
+ * @param {Object} state    Data state.
+ * @param {string}  dataType Data type requested.
+ * @param {*} query          Optional request args.
+ *
+ * @return {boolean}         Request made or not.
+ */
+export function isRequested( state, dataType, query ) {
+	const id = getRequestId( query );
+	return get( state.requests, [ dataType, id, 'isRequested' ], false );
+}
+
+/**
+ * Returns whether a request for a given
+ * data type is in flight.
+ *
+ * @param {Object} state    Data state.
+ * @param {string}  dataType Data type requested.
+ * @param {*} query          Optional request args.
+ *
+ * @return {boolean}         Request made or not.
+ */
+export function isRequesting( state, dataType, query ) {
+	const id = getRequestId( query );
+	return get( state.requests, [ dataType, id, 'isRequesting' ], false );
+}
+
+/**
  * Returns all the available terms for the given taxonomy.
  *
  * @param {Object} state    Data state.
@@ -31,7 +71,7 @@ export function getCategories( state ) {
  * @return {boolean} Whether a request is in progress for taxonomy's terms.
  */
 export function isRequestingTerms( state, taxonomy ) {
-	return state.terms[ taxonomy ] === null;
+	return isRequesting( state, 'terms', taxonomy );
 }
 
 /**

--- a/core-data/test/reducer.js
+++ b/core-data/test/reducer.js
@@ -6,7 +6,49 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { terms, media, postTypes } from '../reducer';
+import { requests, terms, media, postTypes } from '../reducer';
+
+describe( 'requests', () => {
+	it( 'returns an empty object by default', () => {
+		const state = requests( undefined, {} );
+
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns an object with isRequesting to true', () => {
+		const originalState = deepFreeze( {} );
+		const state = requests( originalState, {
+			type: 'SET_REQUESTING',
+			dataType: 'terms',
+			id: 'categories',
+		} );
+
+		expect( state ).toEqual( {
+			terms: { categories: { isRequesting: true } },
+		} );
+	} );
+
+	it( 'returns an object with isRequested to true', () => {
+		const originalState = deepFreeze( {
+			terms: {
+				tag: { isRequesting: true },
+				categories: { isRequesting: true },
+			},
+		} );
+		const state = requests( originalState, {
+			type: 'SET_REQUESTED',
+			dataType: 'terms',
+			id: 'categories',
+		} );
+
+		expect( state ).toEqual( {
+			terms: {
+				tag: { isRequesting: true },
+				categories: { isRequesting: false, isRequested: true },
+			},
+		} );
+	} );
+} );
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -26,45 +68,6 @@ describe( 'terms()', () => {
 		expect( state ).toEqual( {
 			categories: [ { id: 1 } ],
 		} );
-	} );
-
-	it( 'assigns requested taxonomy to null', () => {
-		const originalState = deepFreeze( {} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'terms',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {
-			categories: null,
-		} );
-	} );
-
-	it( 'does not assign requested taxonomy to null if received', () => {
-		const originalState = deepFreeze( {
-			categories: [ { id: 1 } ],
-		} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'terms',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {
-			categories: [ { id: 1 } ],
-		} );
-	} );
-
-	it( 'does not assign requested taxonomy if not terms data type', () => {
-		const originalState = deepFreeze( {} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'foo',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {} );
 	} );
 } );
 

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -7,7 +7,7 @@ import apiRequest from '@wordpress/api-request';
  * Internal dependencies
  */
 import { getCategories, getMedia, getPostType } from '../resolvers';
-import { setRequested, receiveTerms, receiveMedia, receivePostTypes } from '../actions';
+import { setRequested, receiveTerms, receiveMedia, receivePostTypes, setRequesting } from '../actions';
 
 jest.mock( '@wordpress/api-request' );
 
@@ -24,10 +24,12 @@ describe( 'getCategories', () => {
 
 	it( 'yields with requested terms', async () => {
 		const fulfillment = getCategories();
-		const requested = ( await fulfillment.next() ).value;
-		expect( requested.type ).toBe( setRequested().type );
+		const requesting = ( await fulfillment.next() ).value;
+		expect( requesting.type ).toBe( setRequesting().type );
 		const received = ( await fulfillment.next() ).value;
 		expect( received ).toEqual( receiveTerms( 'categories', CATEGORIES ) );
+		const requested = ( await fulfillment.next() ).value;
+		expect( requested.type ).toBe( setRequested().type );
 	} );
 } );
 

--- a/core-data/test/selectors.js
+++ b/core-data/test/selectors.js
@@ -6,7 +6,90 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getTerms, isRequestingTerms, getMedia, getPostType } from '../selectors';
+import {
+	isRequested,
+	isRequesting,
+	getTerms,
+	isRequestingTerms,
+	getMedia,
+	getPostType,
+} from '../selectors';
+
+describe( 'isRequesting', () => {
+	it( 'returns false if never requested', () => {
+		const state = deepFreeze( {
+			requests: { terms: {} },
+		} );
+
+		const result = isRequesting( state, 'terms', 'categories' );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false if requested', () => {
+		const state = deepFreeze( {
+			requests: { terms: {
+				categories: {
+					isRequested: true,
+					isRequesting: false,
+				},
+			} },
+		} );
+
+		const result = isRequesting( state, 'terms', 'categories' );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if requesting', () => {
+		const state = deepFreeze( {
+			requests: { terms: {
+				categories: {
+					isRequesting: true,
+				},
+			} },
+		} );
+
+		const result = isRequesting( state, 'terms', 'categories' );
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'isRequested', () => {
+	it( 'returns false if never requested', () => {
+		const state = deepFreeze( {
+			requests: { terms: {} },
+		} );
+
+		const result = isRequested( state, 'terms', 'categories' );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if requested', () => {
+		const state = deepFreeze( {
+			requests: { terms: {
+				categories: {
+					isRequested: true,
+					isRequesting: false,
+				},
+			} },
+		} );
+
+		const result = isRequested( state, 'terms', 'categories' );
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false if requesting', () => {
+		const state = deepFreeze( {
+			requests: { terms: {
+				categories: {
+					isRequesting: true,
+				},
+			} },
+		} );
+
+		const result = isRequested( state, 'terms', 'categories' );
+		expect( result ).toBe( false );
+	} );
+} );
 
 describe( 'getTerms()', () => {
 	it( 'returns value of terms by taxonomy', () => {
@@ -25,31 +108,13 @@ describe( 'getTerms()', () => {
 } );
 
 describe( 'isRequestingTerms()', () => {
-	it( 'returns false if never requested', () => {
-		const state = deepFreeze( {
-			terms: {},
-		} );
-
-		const result = isRequestingTerms( state, 'categories' );
-		expect( result ).toBe( false );
-	} );
-
-	it( 'returns false if terms received', () => {
-		const state = deepFreeze( {
-			terms: {
-				categories: [ { id: 1 } ],
-			},
-		} );
-
-		const result = isRequestingTerms( state, 'categories' );
-		expect( result ).toBe( false );
-	} );
-
 	it( 'returns true if requesting', () => {
 		const state = deepFreeze( {
-			terms: {
-				categories: null,
-			},
+			requests: { terms: {
+				categories: {
+					isRequesting: true,
+				},
+			} },
 		} );
 
 		const result = isRequestingTerms( state, 'categories' );

--- a/core-data/test/utils.js
+++ b/core-data/test/utils.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { getRequestId } from '../utils';
+
+describe( 'getRequestId', () => {
+	it( 'returns the default id if no args', () => {
+		expect( getRequestId() ).toBe( '[[default]]' );
+	} );
+
+	it( 'returns the scalar if scalar', () => {
+		expect( getRequestId( 'myId' ) ).toBe( 'myId' );
+	} );
+
+	it( 'returns a JSON encoded object if object', () => {
+		expect( getRequestId( { id: 'myId' } ) ).toBe( '{"id":"myId"}' );
+	} );
+} );

--- a/core-data/utils.js
+++ b/core-data/utils.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { isPlainObject } from 'lodash';
+
+/**
+ * Module constants
+ */
+const DEFAULT_ID = '[[default]]';
+
+/**
+ * Generates a unique identifier based on an object/scalar query arg.
+ *
+ * @param  {*}      query
+ *
+ * @return {string}       Request ID.
+ */
+export function getRequestId( query = DEFAULT_ID ) {
+	return isPlainObject( query ) ? JSON.stringify( query ) : query;
+}


### PR DESCRIPTION
This PR adds a generic requests state to the data module to keep track of the REST API requests. This state could also be useful when dealing with the fulfilled API ( see #6084 )

Also, tracking requests is something we'd have to deal with anyway so instead of solving it per request type, a generic way is better to avoid duplication.

I'm also planning to use this in #5875

**Testing instructions**

 - Check that the categories blocks behaves properly (loading and then showing the categories)