### PR TITLE
Used fallBack styles to compute font size slider initial value.

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -37,17 +37,17 @@ import ContrastChecker from '../../contrast-checker';
 
 const { getComputedStyle } = window;
 
-const ContrastCheckerWithFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
-	const { textColor, backgroundColor } = ownProps;
-	//avoid the use of querySelector if both colors are known and verify if node is available.
-	const editableNode = ( ! textColor || ! backgroundColor ) && node ? node.querySelector( '[contenteditable="true"]' ) : null;
+const FallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textColor, backgroundColor, fontSize, customFontSize } = ownProps.attributes;
+	const editableNode = node.querySelector( '[contenteditable="true"]' );
 	//verify if editableNode is available, before using getComputedStyle.
 	const computedStyles = editableNode ? getComputedStyle( editableNode ) : null;
 	return {
 		fallbackBackgroundColor: backgroundColor || ! computedStyles ? undefined : computedStyles.backgroundColor,
 		fallbackTextColor: textColor || ! computedStyles ? undefined : computedStyles.color,
+		fallbackFontSize: fontSize || customFontSize || ! computedStyles ? undefined : parseInt( computedStyles.fontSize ) || undefined,
 	};
-} )( ContrastChecker );
+} );
 
 const FONT_SIZES = {
 	small: 14,
@@ -61,8 +61,6 @@ const autocompleters = [ blockAutocompleter, ...defaultAutocompleters ];
 class ParagraphBlock extends Component {
 	constructor() {
 		super( ...arguments );
-		this.nodeRef = null;
-		this.bindRef = this.bindRef.bind( this );
 		this.onReplace = this.onReplace.bind( this );
 		this.toggleDropCap = this.toggleDropCap.bind( this );
 		this.getFontSize = this.getFontSize.bind( this );
@@ -86,13 +84,6 @@ class ParagraphBlock extends Component {
 	toggleDropCap() {
 		const { attributes, setAttributes } = this.props;
 		setAttributes( { dropCap: ! attributes.dropCap } );
-	}
-
-	bindRef( node ) {
-		if ( ! node ) {
-			return;
-		}
-		this.nodeRef = node;
 	}
 
 	getFontSize() {
@@ -131,6 +122,9 @@ class ParagraphBlock extends Component {
 			mergeBlocks,
 			onReplace,
 			className,
+			fallbackBackgroundColor,
+			fallbackTextColor,
+			fallbackFontSize,
 		} = this.props;
 
 		const {
@@ -189,6 +183,7 @@ class ParagraphBlock extends Component {
 							className="blocks-paragraph__custom-size-slider"
 							label={ __( 'Custom Size' ) }
 							value={ fontSize || '' }
+							initialPosition={ fallbackFontSize }
 							onChange={ ( value ) => this.setFontSize( value ) }
 							min={ 12 }
 							max={ 100 }
@@ -213,12 +208,15 @@ class ParagraphBlock extends Component {
 							onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
 						/>
 					</PanelColor>
-					{ this.nodeRef && <ContrastCheckerWithFallbackStyles
-						node={ this.nodeRef }
-						textColor={ textColor }
-						backgroundColor={ backgroundColor }
+					<ContrastChecker
+						{ ...{
+							textColor,
+							backgroundColor,
+							fallbackBackgroundColor,
+							fallbackTextColor,
+						} }
 						isLargeText={ fontSize >= 18 }
-					/> }
+					/>
 					<PanelBody title={ __( 'Block Alignment' ) }>
 						<BlockAlignmentToolbar
 							value={ width }
@@ -227,7 +225,7 @@ class ParagraphBlock extends Component {
 					</PanelBody>
 				</InspectorControls>
 			),
-			<div key="editable" ref={ this.bindRef }>
+			<div key="editable">
 				<RichText
 					tagName="p"
 					className={ classnames( 'wp-block-paragraph', className, {
@@ -408,7 +406,7 @@ export const settings = {
 		}
 	},
 
-	edit: ParagraphBlock,
+	edit: FallbackStyles( ParagraphBlock ),
 
 	save( { attributes } ) {
 		const {

--- a/blocks/library/paragraph/test/__snapshots__/index.js.snap
+++ b/blocks/library/paragraph/test/__snapshots__/index.js.snap
@@ -2,32 +2,36 @@
 
 exports[`core/paragraph block edit matches snapshot 1`] = `
 <div>
-  <div
-    class="blocks-rich-text"
-  >
-    <div>
+   
+  <div>
+    <div
+      class="blocks-rich-text"
+    >
       <div>
-        <div
-          class="components-autocomplete"
-        >
-          <p
-            aria-autocomplete="list"
-            aria-expanded="false"
-            aria-label="Add text or type / to add content"
-            aria-multiline="false"
-            class="wp-block-paragraph blocks-rich-text__tinymce"
-            contenteditable="true"
-            data-is-placeholder-visible="true"
-            role="textbox"
-          />
-          <p
-            class="blocks-rich-text__tinymce wp-block-paragraph"
+        <div>
+          <div
+            class="components-autocomplete"
           >
-            Add text or type / to add content
-          </p>
+            <p
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-label="Add text or type / to add content"
+              aria-multiline="false"
+              class="wp-block-paragraph blocks-rich-text__tinymce"
+              contenteditable="true"
+              data-is-placeholder-visible="true"
+              role="textbox"
+            />
+            <p
+              class="blocks-rich-text__tinymce wp-block-paragraph"
+            >
+              Add text or type / to add content
+            </p>
+          </div>
         </div>
       </div>
     </div>
   </div>
+   
 </div>
 `;

--- a/components/range-control/README.md
+++ b/components/range-control/README.md
@@ -58,6 +58,13 @@ If this property is true, a button to reset the the slider is rendered.
 - Type: `Boolean`
 - Required: No
 
+### initialPosition
+
+In no value exists this prop contains the slider starting position.
+
+- Type: `Number`
+- Required: No
+
 ### value
 
 The current value of the range slider.

--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -11,9 +11,22 @@ import { BaseControl, Button, Dashicon } from '../';
 import withInstanceId from '../higher-order/with-instance-id';
 import './style.scss';
 
-function RangeControl( { className, label, value, instanceId, onChange, beforeIcon, afterIcon, help, allowReset, ...props } ) {
+function RangeControl( {
+	className,
+	label,
+	value,
+	instanceId,
+	onChange,
+	beforeIcon,
+	afterIcon,
+	help,
+	allowReset,
+	initialPosition,
+	...props
+} ) {
 	const id = `inspector-range-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
+	const initialSliderValue = value || initialPosition || '';
 
 	return (
 		<BaseControl
@@ -27,7 +40,7 @@ function RangeControl( { className, label, value, instanceId, onChange, beforeIc
 				className="components-range-control__slider"
 				id={ id }
 				type="range"
-				value={ value }
+				value={ initialSliderValue }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props } />


### PR DESCRIPTION
## Description
This PR changes the RangeSlider to have a new prop called initialPosition. If this prop is set, when no value is passed to the slider, the slider appears with the given start value.
withFallbackStyles is used to get the font size of the paragraph if it is not known. Fallback value is used as the initial position in the slider.
As we use compute styles, even if the paragraph is nested and a CSS rule changes the size of the nested paragraph, the default value in the slider should be right.

Before the slider was in the middle so when the user changed the slider it would make the size very big and different from what it was. Now the slider starts at the correct size so when the user slides the behavior looks more correct.



## How Has This Been Tested?
Add paragraph verify the slider starting position corresponds to the actual font size of the paragraph.

## Screenshots (jpeg or gifs if applicable):
After:
![apr-09-2018 18-31-11](https://user-images.githubusercontent.com/11271197/38513201-5ab0d1dc-3c25-11e8-9dc2-ed33fde76411.gif)
Before:
![apr-09-2018 18-38-12](https://user-images.githubusercontent.com/11271197/38513202-5ad9e072-3c25-11e8-9464-c9d53cbc320d.gif)


