### PR TITLE
Block: Try adding the left/right block hover areas

### DIFF
--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -18,15 +18,6 @@
 }
 
 @mixin fade_in {
-	animation: fade-in 0.5s ease-out;
+	animation: fade-in 0.3s ease-out;
 	animation-fill-mode: forwards;
-}
-
-@keyframes fade-in {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
 }

--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -17,4 +17,16 @@
 	animation: slide_in_right 0.1s forwards;
 }
 
+@mixin fade_in {
+	animation: fade-in 0.5s ease-out;
+	animation-fill-mode: forwards;
+}
 
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -147,3 +147,12 @@ body.gutenberg-editor-page {
 		padding: 6px 10px;
 	}
 }
+
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -423,8 +423,8 @@ export class BlockListBlock extends Component {
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showSideInserter && isSelectedNotTyping;
 		// We render block movers and block settings to keep them tabbale even if hidden
-		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
-		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
+		const shouldRenderMovers = isHovered && ( isSelected || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
+		const shouldRenderBlockSettings = isHovered && ( isSelected || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
 		const shouldShowBreadcrumb = isHovered;
 		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
 		const shouldShowMobileToolbar = shouldAppearSelected;

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -423,8 +423,8 @@ export class BlockListBlock extends Component {
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showSideInserter && isSelectedNotTyping;
 		// We render block movers and block settings to keep them tabbale even if hidden
-		const shouldRenderMovers = isHovered && ( isSelected || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
-		const shouldRenderBlockSettings = isHovered && ( isSelected || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
+		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
+		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
 		const shouldShowBreadcrumb = isHovered;
 		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
 		const shouldShowMobileToolbar = shouldAppearSelected;
@@ -522,7 +522,7 @@ export class BlockListBlock extends Component {
 						layout={ layout }
 						isFirst={ isFirst }
 						isLast={ isLast }
-						isHidden={ hoverArea !== 'left' }
+						isHidden={ ! isHovered || hoverArea !== 'left' }
 					/>
 				) }
 				{ shouldRenderBlockSettings && (
@@ -530,7 +530,7 @@ export class BlockListBlock extends Component {
 						uids={ [ uid ] }
 						rootUID={ rootUID }
 						renderBlockMenu={ renderBlockMenu }
-						isHidden={ hoverArea !== 'right' }
+						isHidden={ ! isHovered || hoverArea !== 'right' }
 					/>
 				) }
 				{ shouldShowBreadcrumb && <BlockBreadcrumb uid={ uid } isHidden={ hoverArea !== 'left' } /> }

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -425,6 +425,7 @@ export class BlockListBlock extends Component {
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
+		const shouldShowBreadcrumb = isHovered;
 		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
@@ -532,7 +533,7 @@ export class BlockListBlock extends Component {
 						isHidden={ hoverArea !== 'right' }
 					/>
 				) }
-				{ isHovered && <BlockBreadcrumb uid={ uid } /> }
+				{ shouldShowBreadcrumb && <BlockBreadcrumb uid={ uid } isHidden={ hoverArea !== 'left' } /> }
 				{ shouldShowContextualToolbar && <BlockContextualToolbar /> }
 				{ isFirstMultiSelected && <BlockMultiControls rootUID={ rootUID } /> }
 				<IgnoreNestedEvents

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -422,8 +422,9 @@ export class BlockListBlock extends Component {
 		const isSelectedNotTyping = isSelected && ! isTypingWithinBlock;
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showSideInserter && isSelectedNotTyping;
-		const shouldShowMovers = ( isSelectedNotTyping || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
-		const shouldShowSettingsMenu = ( isSelectedNotTyping || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
+		// We render block movers and block settings to keep them tabbale even if hidden
+		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
+		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
 		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
@@ -513,20 +514,22 @@ export class BlockListBlock extends Component {
 					rootUID={ rootUID }
 					layout={ layout }
 				/>
-				{ shouldShowMovers && (
+				{ shouldRenderMovers && (
 					<BlockMover
 						uids={ [ uid ] }
 						rootUID={ rootUID }
 						layout={ layout }
 						isFirst={ isFirst }
 						isLast={ isLast }
+						isHidden={ hoverArea !== 'left' }
 					/>
 				) }
-				{ shouldShowSettingsMenu && ! showSideInserter && (
+				{ shouldRenderBlockSettings && (
 					<BlockSettingsMenu
 						uids={ [ uid ] }
 						rootUID={ rootUID }
 						renderBlockMenu={ renderBlockMenu }
+						isHidden={ hoverArea !== 'right' }
 					/>
 				) }
 				{ isHovered && <BlockBreadcrumb uid={ uid } /> }

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -48,6 +48,7 @@ import BlockDraggable from './block-draggable';
 import IgnoreNestedEvents from './ignore-nested-events';
 import InserterWithShortcuts from '../inserter-with-shortcuts';
 import Inserter from '../inserter';
+import withHoverAreas from './with-hover-areas';
 import { createInnerBlockList } from '../../utils/block-list';
 
 const { BACKSPACE, DELETE, ENTER } = keycodes;
@@ -404,8 +405,10 @@ export class BlockListBlock extends Component {
 			isFirstMultiSelected,
 			isLastInSelection,
 			isTypingWithinBlock,
+			isMultiSelecting,
+			hoverArea,
 		} = this.props;
-		const isHovered = this.state.isHovered && ! this.props.isMultiSelecting;
+		const isHovered = this.state.isHovered && ! isMultiSelecting;
 		const { name: blockName, isValid } = block;
 		const blockType = getBlockType( blockName );
 		// translators: %s: Type of block (i.e. Text, Image etc)
@@ -419,8 +422,8 @@ export class BlockListBlock extends Component {
 		const isSelectedNotTyping = isSelected && ! isTypingWithinBlock;
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showSideInserter && isSelectedNotTyping;
-		const shouldShowMovers = ( shouldAppearSelected || isHovered || ( isEmptyDefaultBlock && isSelectedNotTyping ) ) && ! showSideInserter;
-		const shouldShowSettingsMenu = shouldShowMovers;
+		const shouldShowMovers = ( isSelectedNotTyping || hoverArea === 'left' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
+		const shouldShowSettingsMenu = ( isSelectedNotTyping || hoverArea === 'right' ) && ! showSideInserter && ! isMultiSelecting && ! isMultiSelected;
 		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
@@ -692,4 +695,5 @@ export default compose(
 		};
 	} ),
 	withFilters( 'editor.BlockListBlock' ),
+	withHoverAreas
 )( BlockListBlock );

--- a/editor/components/block-list/breadcrumb.js
+++ b/editor/components/block-list/breadcrumb.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/element';
@@ -37,9 +42,11 @@ function stopPropagation( event ) {
  *
  * @return {WPElement} Breadcrumb element.
  */
-function BlockBreadcrumb( { uid, rootUID, selectRootBlock } ) {
+function BlockBreadcrumb( { uid, rootUID, selectRootBlock, isHidden } ) {
 	return (
-		<NavigableToolbar className="editor-block-breadcrumb">
+		<NavigableToolbar className={ classnames( 'editor-block-breadcrumb', {
+			'is-visible': ! isHidden,
+		} ) }>
 			<Toolbar>
 				{ rootUID && (
 					<Tooltip text={ __( 'Select parent block' ) }>

--- a/editor/components/block-list/breadcrumb.js
+++ b/editor/components/block-list/breadcrumb.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/element';
+import { compose, Component } from '@wordpress/element';
 import { Dashicon, Tooltip, Toolbar, Button } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -18,20 +18,6 @@ import NavigableToolbar from '../navigable-toolbar';
 import BlockTitle from '../block-title';
 
 /**
- * Stops propagation of the given event argument. Assumes that the event has
- * been completely handled and no other listeners should be informed.
- *
- * For the breadcrumb component, this is used for improved interoperability
- * with the block's `onFocus` handler which selects the block, thus conflicting
- * with the intention to select the root block.
- *
- * @param {Event} event Event for which propagation should be stopped.
- */
-function stopPropagation( event ) {
-	event.stopPropagation();
-}
-
-/**
  * Block breadcrumb component, displaying the label of the block. If the block
  * descends from a root block, a button is displayed enabling the user to select
  * the root block.
@@ -39,29 +25,59 @@ function stopPropagation( event ) {
  * @param {string}   props.uid             UID of block.
  * @param {string}   props.rootUID         UID of block's root.
  * @param {Function} props.selectRootBlock Callback to select root block.
- *
- * @return {WPElement} Breadcrumb element.
  */
-function BlockBreadcrumb( { uid, rootUID, selectRootBlock, isHidden } ) {
-	return (
-		<NavigableToolbar className={ classnames( 'editor-block-breadcrumb', {
-			'is-visible': ! isHidden,
-		} ) }>
-			<Toolbar>
-				{ rootUID && (
-					<Tooltip text={ __( 'Select parent block' ) }>
-						<Button
-							onClick={ selectRootBlock }
-							onFocus={ stopPropagation }
-						>
-							<Dashicon icon="arrow-left" uid={ uid } />
-						</Button>
-					</Tooltip>
-				) }
-				<BlockTitle uid={ uid } />
-			</Toolbar>
-		</NavigableToolbar>
-	);
+export class BlockBreadcrumb extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			isFocused: false,
+		};
+		this.onFocus = this.onFocus.bind( this );
+		this.onBlur = this.onBlur.bind( this );
+	}
+
+	onFocus( event ) {
+		this.setState( {
+			isFocused: true,
+		} );
+
+		// This is used for improved interoperability
+		// with the block's `onFocus` handler which selects the block, thus conflicting
+		// with the intention to select the root block.
+		event.stopPropagation();
+	}
+
+	onBlur() {
+		this.setState( {
+			isFocused: false,
+		} );
+	}
+
+	render( ) {
+		const { uid, rootUID, selectRootBlock, isHidden } = this.props;
+		const { isFocused } = this.state;
+
+		return (
+			<NavigableToolbar className={ classnames( 'editor-block-breadcrumb', {
+				'is-visible': ! isHidden || isFocused,
+			} ) }>
+				<Toolbar>
+					{ rootUID && (
+						<Tooltip text={ __( 'Select parent block' ) }>
+							<Button
+								onClick={ selectRootBlock }
+								onFocus={ this.onFocus }
+								onBlur={ this.onBlur }
+							>
+								<Dashicon icon="arrow-left" uid={ uid } />
+							</Button>
+						</Tooltip>
+					) }
+					<BlockTitle uid={ uid } />
+				</Toolbar>
+			</NavigableToolbar>
+		);
+	}
 }
 
 export default compose( [

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -699,3 +699,11 @@
 		padding-top: 6px;
 	}
 }
+
+.editor-block-breadcrumb {
+	opacity: 0;
+
+	&.is-visible {
+		@include fade_in;
+	}
+}

--- a/editor/components/block-list/with-hover-areas.js
+++ b/editor/components/block-list/with-hover-areas.js
@@ -3,11 +3,6 @@
  */
 import { Component, findDOMNode } from '@wordpress/element';
 
-/**
- * Module constants
- */
-const HOVER_AREA_SIZE = 120;
-
 const withHoverAreas = ( WrappedComponent ) => {
 	class WithHoverAreasComponent extends Component {
 		constructor() {
@@ -40,12 +35,11 @@ const withHoverAreas = ( WrappedComponent ) => {
 
 		onMouseMove( event ) {
 			const { width, left, right } = this.container.getBoundingClientRect();
-			const isSmall = width < ( HOVER_AREA_SIZE * 2 ) + 10;
 
 			let hoverArea = null;
-			if ( ( event.clientX - left ) < ( isSmall ? width / 2 : HOVER_AREA_SIZE ) ) {
+			if ( ( event.clientX - left ) < width / 3 ) {
 				hoverArea = 'left';
-			} else if ( ( right - event.clientX ) < ( isSmall ? width / 2 : HOVER_AREA_SIZE ) ) {
+			} else if ( ( right - event.clientX ) < width / 3 ) {
 				hoverArea = 'right';
 			}
 

--- a/editor/components/block-list/with-hover-areas.js
+++ b/editor/components/block-list/with-hover-areas.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { Component, findDOMNode } from '@wordpress/element';
+
+/**
+ * Module constants
+ */
+const HOVER_AREA_SIZE = 120;
+
+const withHoverAreas = ( WrappedComponent ) => {
+	class WithHoverAreasComponent extends Component {
+		constructor() {
+			super( ...arguments );
+			this.state = {
+				hoverArea: null,
+			};
+			this.onMouseLeave = this.onMouseLeave.bind( this );
+			this.onMouseMove = this.onMouseMove.bind( this );
+		}
+
+		componentDidMount() {
+			// Disable reason: We use findDOMNode to avoid unnecessary extra dom Nodes
+			// eslint-disable-next-line react/no-find-dom-node
+			this.container = findDOMNode( this );
+			this.container.addEventListener( 'mousemove', this.onMouseMove );
+			this.container.addEventListener( 'mouseleave', this.onMouseLeave );
+		}
+
+		componentWillUnmount() {
+			this.container.removeEventListener( 'mousemove', this.onMouseMove );
+			this.container.removeEventListener( 'mouseleave', this.onMouseLeave );
+		}
+
+		onMouseLeave() {
+			if ( this.state.hoverArea ) {
+				this.setState( { hoverArea: null } );
+			}
+		}
+
+		onMouseMove( event ) {
+			const { width, left, right } = this.container.getBoundingClientRect();
+			const isSmall = width < ( HOVER_AREA_SIZE * 2 ) + 10;
+
+			let hoverArea = null;
+			if ( ( event.clientX - left ) < ( isSmall ? width / 2 : HOVER_AREA_SIZE ) ) {
+				hoverArea = 'left';
+			} else if ( ( right - event.clientX ) < ( isSmall ? width / 2 : HOVER_AREA_SIZE ) ) {
+				hoverArea = 'right';
+			}
+
+			if ( hoverArea !== this.state.hoverArea ) {
+				this.setState( { hoverArea } );
+			}
+		}
+
+		render() {
+			const { hoverArea } = this.state;
+			return (
+				<WrappedComponent { ...this.props } hoverArea={ hoverArea } />
+			);
+		}
+	}
+
+	return WithHoverAreasComponent;
+};
+
+export default withHoverAreas;

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { first } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -10,7 +11,7 @@ import { first } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { IconButton, withContext, withInstanceId } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
-import { compose } from '@wordpress/element';
+import { compose, Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,59 +21,88 @@ import { getBlockMoverDescription } from './mover-description';
 import { getBlockIndex, getBlock } from '../../store/selectors';
 import { upArrow, downArrow } from './arrows';
 
-export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked, instanceId } ) {
-	if ( isLocked ) {
-		return null;
+export class BlockMover extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			isFocused: false,
+		};
+		this.onFocus = this.onFocus.bind( this );
+		this.onBlur = this.onBlur.bind( this );
 	}
 
-	// We emulate a disabled state because forcefully applying the `disabled`
-	// attribute on the button while it has focus causes the screen to change
-	// to an unfocused state (body as active element) without firing blur on,
-	// the rendering parent, leaving it unable to react to focus out.
-	return (
-		<div className="editor-block-mover">
-			<IconButton
-				className="editor-block-mover__control"
-				onClick={ isFirst ? null : onMoveUp }
-				icon={ upArrow }
-				label={ __( 'Move up' ) }
-				aria-describedby={ `editor-block-mover__up-description-${ instanceId }` }
-				aria-disabled={ isFirst }
-			/>
-			<IconButton
-				className="editor-block-mover__control"
-				onClick={ isLast ? null : onMoveDown }
-				icon={ downArrow }
-				label={ __( 'Move down' ) }
-				aria-describedby={ `editor-block-mover__down-description-${ instanceId }` }
-				aria-disabled={ isLast }
-			/>
-			<span id={ `editor-block-mover__up-description-${ instanceId }` } className="editor-block-mover__description">
-				{
-					getBlockMoverDescription(
-						uids.length,
-						blockType && blockType.title,
-						firstIndex,
-						isFirst,
-						isLast,
-						-1,
-					)
-				}
-			</span>
-			<span id={ `editor-block-mover__down-description-${ instanceId }` } className="editor-block-mover__description">
-				{
-					getBlockMoverDescription(
-						uids.length,
-						blockType && blockType.title,
-						firstIndex,
-						isFirst,
-						isLast,
-						1,
-					)
-				}
-			</span>
-		</div>
-	);
+	onFocus() {
+		this.setState( {
+			isFocused: true,
+		} );
+	}
+
+	onBlur() {
+		this.setState( {
+			isFocused: false,
+		} );
+	}
+
+	render() {
+		const { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked, instanceId, isHidden } = this.props;
+		const { isFocused } = this.state;
+		if ( isLocked ) {
+			return null;
+		}
+
+		// We emulate a disabled state because forcefully applying the `disabled`
+		// attribute on the button while it has focus causes the screen to change
+		// to an unfocused state (body as active element) without firing blur on,
+		// the rendering parent, leaving it unable to react to focus out.
+		return (
+			<div className={ classnames( 'editor-block-mover', { 'is-visible': isFocused || ! isHidden } ) }>
+				<IconButton
+					className="editor-block-mover__control"
+					onClick={ isFirst ? null : onMoveUp }
+					icon={ upArrow }
+					label={ __( 'Move up' ) }
+					aria-describedby={ `editor-block-mover__up-description-${ instanceId }` }
+					aria-disabled={ isFirst }
+					onFocus={ this.onFocus }
+					onBlur={ this.onBlur }
+				/>
+				<IconButton
+					className="editor-block-mover__control"
+					onClick={ isLast ? null : onMoveDown }
+					icon={ downArrow }
+					label={ __( 'Move down' ) }
+					aria-describedby={ `editor-block-mover__down-description-${ instanceId }` }
+					aria-disabled={ isLast }
+					onFocus={ this.onFocus }
+					onBlur={ this.onBlur }
+				/>
+				<span id={ `editor-block-mover__up-description-${ instanceId }` } className="editor-block-mover__description">
+					{
+						getBlockMoverDescription(
+							uids.length,
+							blockType && blockType.title,
+							firstIndex,
+							isFirst,
+							isLast,
+							-1,
+						)
+					}
+				</span>
+				<span id={ `editor-block-mover__down-description-${ instanceId }` } className="editor-block-mover__description">
+					{
+						getBlockMoverDescription(
+							uids.length,
+							blockType && blockType.title,
+							firstIndex,
+							isFirst,
+							isLast,
+							1,
+						)
+					}
+				</span>
+			</div>
+		);
+	}
 }
 
 /**

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -1,3 +1,11 @@
+.editor-block-mover {
+	opacity: 0;
+
+	&.is-visible {
+		@include fade_in;
+	}
+}
+
 // Mover icon buttons
 .editor-block-mover__control {
 	display: block;

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import { IconButton, Dropdown, NavigableMenu } from '@wordpress/components';
 
 /**
@@ -22,56 +23,86 @@ import SharedBlockSettings from './shared-block-settings';
 import UnknownConverter from './unknown-converter';
 import { selectBlock } from '../../store/actions';
 
-function BlockSettingsMenu( {
-	uids,
-	onSelect,
-	focus,
-	rootUID,
-	renderBlockMenu = ( { children } ) => children,
-} ) {
-	const count = uids.length;
+export class BlockSettingsMenu extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			isFocused: false,
+		};
+		this.onFocus = this.onFocus.bind( this );
+		this.onBlur = this.onBlur.bind( this );
+	}
 
-	return (
-		<Dropdown
-			className="editor-block-settings-menu"
-			contentClassName="editor-block-settings-menu__popover"
-			position="bottom left"
-			renderToggle={ ( { onToggle, isOpen } ) => {
-				const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
-					'is-opened': isOpen,
-				} );
+	onFocus() {
+		this.setState( {
+			isFocused: true,
+		} );
+	}
 
-				return (
-					<IconButton
-						className={ toggleClassname }
-						onClick={ () => {
-							if ( uids.length === 1 ) {
-								onSelect( uids[ 0 ] );
-							}
-							onToggle();
-						} }
-						icon="ellipsis"
-						label={ __( 'More Options' ) }
-						aria-expanded={ isOpen }
-						focus={ focus }
-					/>
-				);
-			} }
-			renderContent={ ( { onClose } ) => (
+	onBlur() {
+		this.setState( {
+			isFocused: false,
+		} );
+	}
+
+	render() {
+		const {
+			uids,
+			onSelect,
+			focus,
+			rootUID,
+			renderBlockMenu = ( { children } ) => children,
+			isHidden,
+		} = this.props;
+		const { isFocused } = this.state;
+		const count = uids.length;
+
+		return (
+			<Dropdown
+				className={ classnames( 'editor-block-settings-menu', {
+					'is-visible': isFocused || ! isHidden,
+				} ) }
+				contentClassName="editor-block-settings-menu__popover"
+				position="bottom left"
+				renderToggle={ ( { onToggle, isOpen } ) => {
+					const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
+						'is-opened': isOpen,
+					} );
+
+					return (
+						<IconButton
+							className={ toggleClassname }
+							onClick={ () => {
+								if ( uids.length === 1 ) {
+									onSelect( uids[ 0 ] );
+								}
+								onToggle();
+							} }
+							icon="ellipsis"
+							label={ __( 'More Options' ) }
+							aria-expanded={ isOpen }
+							focus={ focus }
+							onFocus={ this.onFocus }
+							onBlur={ this.onBlur }
+						/>
+					);
+				} }
+				renderContent={ ( { onClose } ) => (
 				// Should this just use a DropdownMenu instead of a DropDown ?
-				<NavigableMenu className="editor-block-settings-menu__content">
-					{ renderBlockMenu( { onClose, children: [
-						count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } role="menuitem" />,
-						count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } role="menuitem" />,
-						<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />,
-						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } role="menuitem" />,
-						count === 1 && <SharedBlockSettings key="shared-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
-						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsRole="menuitem" />,
-					] } ) }
-				</NavigableMenu>
-			) }
-		/>
-	);
+					<NavigableMenu className="editor-block-settings-menu__content">
+						{ renderBlockMenu( { onClose, children: [
+							count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } role="menuitem" />,
+							count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } role="menuitem" />,
+							<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />,
+							<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } role="menuitem" />,
+							count === 1 && <SharedBlockSettings key="shared-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
+							<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsRole="menuitem" />,
+						] } ) }
+					</NavigableMenu>
+				) }
+			/>
+		);
+	}
 }
 
 export default connect(

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -1,3 +1,11 @@
+.editor-block-settings-menu {
+	opacity: 0;
+
+	&.is-visible {
+		@include fade_in;
+	}
+}
+
 // The Blocks "More" Menu ellipsis icon button
 .editor-block-settings-menu__toggle {
 	justify-content: center;


### PR DESCRIPTION
For unselected blocks, we only show movers the movers when we're close to them and same for the block settings menu.

**Testing instructions**

 - Add several blocks
 - Try hovering next to the left and the right area of the blocks
 - When you're close to the left the movers appear
 - When you're close to the right the settings menu appear

closes #3044