### PR TITLE
Force Link UI to appear below a link if one is selected

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -656,6 +656,7 @@ export class RichText extends Component {
 		if ( document.activeElement !== this.editor.getBody() ) {
 			return;
 		}
+
 		const formatNames = this.props.formattingControls;
 		const formats = this.editor.formatter.matchAll( formatNames ).reduce( ( accFormats, activeFormat ) => {
 			accFormats[ activeFormat ] = {
@@ -666,7 +667,15 @@ export class RichText extends Component {
 			return accFormats;
 		}, {} );
 
-		const rect = getRectangleFromRange( this.editor.selection.getRng() );
+		let rect;
+		const selectedAnchor = find( parents, ( node ) => node.tagName === 'A' );
+		if ( selectedAnchor ) {
+			// If we selected a link, position the Link UI below the link
+			rect = selectedAnchor.getBoundingClientRect();
+		} else {
+			// Otherwise, position the Link UI below the cursor or text selection
+			rect = getRectangleFromRange( this.editor.selection.getRng() );
+		}
 		const focusPosition = this.getFocusPosition( rect );
 
 		this.setState( { formats, focusPosition, selectedNodeId: this.state.selectedNodeId + 1 } );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/6028#issuecomment-380175237.

Before:

![before](https://user-images.githubusercontent.com/253067/38571795-67e66758-3ce9-11e8-8e63-106ec64fa6e2.gif)

Now:

![link](https://user-images.githubusercontent.com/612155/38592324-c0b6c4b4-3d7e-11e8-8ee5-d928be2b3d73.gif)