### PR TITLE
Fixed Publish Button Text

### DIFF
--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -61,7 +61,7 @@ function PostPublishPanelToggle( {
 			disabled={ ! isButtonEnabled }
 			isBusy={ isSaving && isPublished }
 		>
-			{ isBeingScheduled ? __( 'Schedule...' ) : __( 'Publish...' ) }
+			{ isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' ) }
 		</Button>
 	);
 }


### PR DESCRIPTION
## Description
Fixed Publish Button Text from `Publish&hellip;` to Publish&hellip;
Also changed Schedule Button Text to match.

## How Has This Been Tested?
Tested on local dev environment

## Screenshots:
![2018-04-11_gutenberg-publish-button-text](https://user-images.githubusercontent.com/9543581/38616560-067a1be8-3dc7-11e8-8678-ed7c6996da18.jpg)

## Types of changes
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation (N/A)
