### PR TITLE
Replace TextControl with TextareaControl for image alt

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -21,7 +21,7 @@ import {
 	IconButton,
 	PanelBody,
 	SelectControl,
-	TextControl,
+	TextareaControl,
 	Toolbar,
 	withContext,
 } from '@wordpress/components';
@@ -203,7 +203,7 @@ class ImageBlock extends Component {
 			isSelected && (
 				<InspectorControls key="inspector">
 					<PanelBody title={ __( 'Image Settings' ) }>
-						<TextControl
+						<TextareaControl
 							label={ __( 'Textual Alternative' ) }
 							value={ alt }
 							onChange={ this.updateAlt }


### PR DESCRIPTION
## Description
Fixes #6095 
Replace `TextControl` with `TextAreaControl` for the Textual alternative for the image block

## How Has This Been Tested?
- Manually adding image block & updating textual alternative
- `npm run test-unit`

## Screenshots (jpeg or gifs if applicable):
N/A

## Types of changes
Non-Breaking

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
