### PR TITLE
Disable Preview button when post type doesn't support it

### DIFF
--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -16,7 +16,7 @@ import { _x } from '@wordpress/i18n';
  */
 import {
 	getEditedPostPreviewLink,
-	getEditedPostAttribute,
+	getEditedPostAttribute as getStateEditedPostAttribute,
 	isEditedPostDirty,
 	isEditedPostNew,
 	isEditedPostSaveable,
@@ -141,7 +141,7 @@ export default compose(
 			isDirty: isEditedPostDirty( state ),
 			isNew: isEditedPostNew( state ),
 			isSaveable: isEditedPostSaveable( state ),
-			modified: getEditedPostAttribute( state, 'modified' ),
+			modified: getStateEditedPostAttribute( state, 'modified' ),
 		} ),
 		{ autosave }
 	)

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -6,8 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Component, compose } from '@wordpress/element';
+import { Button, ifCondition } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -123,14 +124,25 @@ export class PostPreviewButton extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		postId: state.currentPost.id,
-		link: getEditedPostPreviewLink( state ),
-		isDirty: isEditedPostDirty( state ),
-		isNew: isEditedPostNew( state ),
-		isSaveable: isEditedPostSaveable( state ),
-		modified: getEditedPostAttribute( state, 'modified' ),
+export default compose(
+	withSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getPostType } = select( 'core' );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+		return {
+			isPreviewable: postType.previewable,
+		};
 	} ),
-	{ autosave }
+	ifCondition( ( isPreviewable ) => isPreviewable ),
+	connect(
+		( state ) => ( {
+			postId: state.currentPost.id,
+			link: getEditedPostPreviewLink( state ),
+			isDirty: isEditedPostDirty( state ),
+			isNew: isEditedPostNew( state ),
+			isSaveable: isEditedPostSaveable( state ),
+			modified: getEditedPostAttribute( state, 'modified' ),
+		} ),
+		{ autosave }
+	)
 )( PostPreviewButton );

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -130,7 +130,7 @@ export default compose(
 		const { getPostType } = select( 'core' );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		return {
-			isPreviewable: postType.previewable,
+			isPreviewable: postType && postType.previewable,
 		};
 	} ),
 	ifCondition( ( { isPreviewable } ) => isPreviewable ),

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -133,7 +133,7 @@ export default compose(
 			isPreviewable: postType.previewable,
 		};
 	} ),
-	ifCondition( ( isPreviewable ) => isPreviewable ),
+	ifCondition( ( { isPreviewable } ) => isPreviewable ),
 	connect(
 		( state ) => ( {
 			postId: state.currentPost.id,

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -130,7 +131,7 @@ export default compose(
 		const { getPostType } = select( 'core' );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		return {
-			isPreviewable: postType && postType.previewable,
+			isPreviewable: get( postType, 'viewable', false ),
 		};
 	} ),
 	ifCondition( ( { isPreviewable } ) => isPreviewable ),

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -316,29 +316,29 @@ function gutenberg_register_rest_api_post_type_capabilities() {
 add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_type_capabilities' );
 
 /**
- * Includes the value for the 'previewable' attribute of a post type resource.
+ * Includes the value for the 'viewable' attribute of a post type resource.
  *
  * @see https://core.trac.wordpress.org/ticket/43739
  *
  * @param object $post_type Post type response object.
- * @return boolean Whether or not the post type can be previewed.
+ * @return boolean Whether or not the post type can be viewed.
  */
-function gutenberg_get_post_type_previewable( $post_type ) {
+function gutenberg_get_post_type_viewable( $post_type ) {
 	return is_post_type_viewable( $post_type['slug'] );
 }
 
 /**
- * Adds the 'previewable' attribute to the REST API response of a post type.
+ * Adds the 'viewable' attribute to the REST API response of a post type.
  *
  * @see https://core.trac.wordpress.org/ticket/43739
  */
-function gutenberg_register_rest_api_post_type_previewable() {
+function gutenberg_register_rest_api_post_type_viewable() {
 	register_rest_field( 'type',
-		'previewable',
+		'viewable',
 		array(
-			'get_callback' => 'gutenberg_get_post_type_previewable',
+			'get_callback' => 'gutenberg_get_post_type_viewable',
 			'schema'       => array(
-				'description' => __( 'Whether or not the post type can be previewed', 'gutenberg' ),
+				'description' => __( 'Whether or not the post type can be viewed.', 'gutenberg' ),
 				'type'        => 'boolean',
 				'context'     => array( 'edit' ),
 				'readonly'    => true,
@@ -346,7 +346,7 @@ function gutenberg_register_rest_api_post_type_previewable() {
 		)
 	);
 }
-add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_type_previewable' );
+add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_type_viewable' );
 
 
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -320,12 +320,11 @@ add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_type_capabilities
  *
  * @see https://core.trac.wordpress.org/ticket/43739
  *
- * @param object $post_type Post type object.
- * @param string $name      Post type name.
+ * @param object $post_type Post type response object.
  * @return boolean Whether or not the post type can be previewed.
  */
-function gutenberg_get_post_type_previewable( $post_type, $name ) {
-	return is_post_type_viewable( $name );
+function gutenberg_get_post_type_previewable( $post_type ) {
+	return is_post_type_viewable( $post_type['slug'] );
 }
 
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -316,6 +316,41 @@ function gutenberg_register_rest_api_post_type_capabilities() {
 add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_type_capabilities' );
 
 /**
+ * Includes the value for the 'previewable' attribute of a post type resource.
+ *
+ * @see https://core.trac.wordpress.org/ticket/43739
+ *
+ * @param object $post_type Post type object.
+ * @param string $name      Post type name.
+ * @return boolean Whether or not the post type can be previewed.
+ */
+function gutenberg_get_post_type_previewable( $post_type, $name ) {
+	return is_post_type_viewable( $name );
+}
+
+/**
+ * Adds the 'previewable' attribute to the REST API response of a post type.
+ *
+ * @see https://core.trac.wordpress.org/ticket/43739
+ */
+function gutenberg_register_rest_api_post_type_previewable() {
+	register_rest_field( 'type',
+		'previewable',
+		array(
+			'get_callback' => 'gutenberg_get_post_type_previewable',
+			'schema'       => array(
+				'description' => __( 'Whether or not the post type can be previewed', 'gutenberg' ),
+				'type'        => 'boolean',
+				'context'     => array( 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_type_previewable' );
+
+
+/**
  * Make sure oEmbed REST Requests apply the WP Embed security mechanism for WordPress embeds.
  *
  * @see  https://core.trac.wordpress.org/ticket/32522


### PR DESCRIPTION
## Description

In the classic editor, the preview button is only available if is_post_type_viewable returns true. We are updating the logic to follow the same behavior.

Fixes #5749 

Previously #5770

## How Has This Been Tested?

Register a post type with publicly_queryable set to false.
E.g:
```
function create_product_type() {
    register_post_type( 'acme_product',
        array(
			'label'  => 'Product',
            'labels' => array(
                'name' => __( 'Products' ),
                'singular_name' => __( 'Product' )
            ),
            'public' => true,
			'show_in_rest' => true,
			'publicly_queryable' => false,
        )
    );
}
add_action( 'init', 'create_product_type' );
```
Verify preview button is not available for posts of this Post Type.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/36432/38642537-32f4ea64-3d8f-11e8-8ad4-74e48ee756db.png">

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/36432/38642517-27dbc4a4-3d8f-11e8-813c-7b412ceb0d50.png">
