### PR TITLE
Fixed SelectControl keys; Removed unnecessary key from RadioControl;

### DIFF
--- a/components/radio-control/index.js
+++ b/components/radio-control/index.js
@@ -18,20 +18,20 @@ function RadioControl( { label, selected, help, instanceId, onChange, options = 
 		<BaseControl label={ label } id={ id } help={ help } className="components-radio-control">
 			{ options.map( ( option, index ) =>
 				<div
-					key={ ( id + '-' + index ) }
+					key={ `${ id }-${ index }` }
 					className="components-radio-control__option"
 				>
 					<input
-						id={ ( id + '-' + index ) }
+						id={ `${ id }-${ index }` }
 						className="components-radio-control__input"
 						type="radio"
 						name={ id }
 						value={ option.value }
 						onChange={ onChangeValue }
 						checked={ option.value === selected }
-						aria-describedby={ !! help ? id + '__help' : undefined }
+						aria-describedby={ !! help ? `${ id }__help` : undefined }
 					/>
-					<label key={ option.value } htmlFor={ ( id + '-' + index ) }>
+					<label htmlFor={ `${ id }-${ index }` }>
 						{ option.label }
 					</label>
 				</div>

--- a/components/select-control/index.js
+++ b/components/select-control/index.js
@@ -39,13 +39,13 @@ function SelectControl( {
 				id={ id }
 				className="components-select-control__input"
 				onChange={ onChangeValue }
-				aria-describedby={ !! help ? id + '__help' : undefined }
+				aria-describedby={ !! help ? `${ id }__help` : undefined }
 				multiple={ multiple }
 				{ ...props }
 			>
-				{ options.map( ( option ) =>
+				{ options.map( ( option, index ) =>
 					<option
-						key={ option.value }
+						key={ `${ option.label }-${ option.value }-${ index }` }
 						value={ option.value }
 					>
 						{ option.label }


### PR DESCRIPTION
SelectControl used value as the key, but a user may pass two options with the same value in a select control. Now we use value and label as the pair to create the key.
label key in RadionControl is unnecessary as it is not inside an array.

Passing repeated values to a SelectControl may not make sense, but we should not throw errors even if that happens. In pure HTML an user can have a select with repeated values and no errors happen so using our control the same behavior is expected.

Fixes: https://github.com/WordPress/gutenberg/issues/4873


## How Has This Been Tested?
Follow the steps described on https://github.com/WordPress/gutenberg/issues/4873 and verify no duplicate key errors happen.
