### PR TITLE
Better description for embed blocks

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -29,15 +29,10 @@ const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, keywords = [] } ) {
 	return {
 		title,
-
-		description: __( 'The Embed block allows you to easily add videos, images, tweets, audio, and other content to your post or page.' ),
-
+		description: __( `This embed block embeds content from ${ title }` ),
 		icon,
-
 		category,
-
 		keywords,
-
 		attributes: {
 			url: {
 				type: 'string',

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -29,7 +29,9 @@ const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, keywords = [] } ) {
 	return {
 		title,
-		description: __( `This embed block embeds content from ${ title }` ),
+		description: 'Embed' !== title ?
+			__( `Paste URLs from ${ title } to embed the content in this block` ) :
+			__( 'The Embed block allows you to easily add videos, images, tweets, audio, and other content to your post or page.' ),
 		icon,
 		category,
 		keywords,

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -29,7 +29,7 @@ const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 function getEmbedBlockSettings( { title, description, icon, category = 'embed', transforms, keywords = [] } ) {
 	return {
 		title,
-		description: description || __( `Paste URLs from ${ title } to embed the content in this block` ),
+		description: description || __( `Paste URLs from ${ title } to embed the content in this block.` ),
 		icon,
 		category,
 		keywords,

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -26,12 +26,10 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 // These embeds do not work in sandboxes
 const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 
-function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, keywords = [] } ) {
+function getEmbedBlockSettings( { title, description, icon, category = 'embed', transforms, keywords = [] } ) {
 	return {
 		title,
-		description: 'Embed' !== title ?
-			__( `Paste URLs from ${ title } to embed the content in this block` ) :
-			__( 'The Embed block allows you to easily add videos, images, tweets, audio, and other content to your post or page.' ),
+		description: description || __( `Paste URLs from ${ title } to embed the content in this block` ),
 		icon,
 		category,
 		keywords,
@@ -256,6 +254,7 @@ export const name = 'core/embed';
 
 export const settings = getEmbedBlockSettings( {
 	title: __( 'Embed' ),
+	description: __( 'The Embed block allows you to easily add videos, images, tweets, audio, and other content to your post or page.' ),
 	icon: 'embed-generic',
 	transforms: {
 		from: [


### PR DESCRIPTION
## Description
Fixes #6110 
Generic description for embed blocks replaced with a personalized message by using embed title/aliases as suggested by @jasmussen 

`This embed block embeds content from ${ title }` 

## How Has This Been Tested?
- Manually adding embed blocks and inspecting description in inspector/sidebar
- `npm run test-unit`

## Screenshots (jpeg or gifs if applicable):
N/A

## Types of changes
Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
