### PR TITLE
Testing: Avoid Puppeteer navigation timeout

### DIFF
--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -10,8 +10,6 @@ const {
 	WP_PASSWORD = 'password',
 } = process.env;
 
-const NAVIGATION_TIMEOUT = 20000;
-
 function getUrl( WPPath, query = '' ) {
 	const url = new URL( WP_BASE_URL );
 
@@ -29,29 +27,18 @@ function isWPPath( WPPath, query = '' ) {
 	return getUrl( WPPath ) === currentUrl.href;
 }
 
-async function navigationTimeout( promise ) {
-	await new Promise( ( resolve ) => {
-		let resolved = false;
-		const markResolvedAndResolve = () => {
-			if ( ! resolved ) {
-				resolve();
-				resolved = true;
-			}
-		};
-		setTimeout( markResolvedAndResolve, NAVIGATION_TIMEOUT );
-		promise.then( markResolvedAndResolve );
-	} );
-}
-
 async function goToWPPath( WPPath, query ) {
-	await navigationTimeout( page.goto( getUrl( WPPath, query ), { timeout: 0 } ) );
+	await page.goto( getUrl( WPPath, query ) );
 }
 
 async function login() {
 	await page.type( '#user_login', WP_USERNAME );
 	await page.type( '#user_pass', WP_PASSWORD );
-	await page.click( '#wp-submit' );
-	await navigationTimeout( page.waitForNavigation( { timeout: 0 } ) );
+
+	await Promise.all( [
+		page.waitForNavigation(),
+		page.click( '#wp-submit' ),
+	] );
 }
 
 export async function visitAdmin( adminPath, query ) {


### PR DESCRIPTION
Supersedes: #5854

This pull request seeks to (try to) avoid the need for a navigation timeout. Mentioned previously, the race conditions observed with Puppeteer are a documented caveat of `click`, with workaround to be a `Promise.all` setting to wait for the navigation before invoking the click:

>Bear in mind that if `click()` triggers a navigation event and there's a separate `page.waitForNavigation()` promise to be resolved, you may end up with a race condition that yields unexpected results. The correct pattern for click and wait for navigation is the following:
>
>```js
>const [response] = await Promise.all([
>  page.waitForNavigation(waitOptions),
>  page.click(selector, clickOptions),
>]);
>```

https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageclickselector-options

__Testing instructions:__

Verify that E2E tests pass:

```
npm run test-e2e
```