### PR TITLE
Fix some documentation links - links to md files require the `.md` extension

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -25,13 +25,13 @@ wp.blocks.registerBlockType( 'mytheme/red-block', {
 } );
 ```
 
-If you want to learn more about block creation, the [Blocks Tutorial](./blocks) is the best place to start.
+If you want to learn more about block creation, the [Blocks Tutorial](./blocks.md) is the best place to start.
 
 ## Extending Blocks
 
 It is also possible to modify the behavior of existing blocks or even remove them completely using filters.
 
-Learn more in the [Extending Blocks](./extensibility/extending-blocks) section.
+Learn more in the [Extending Blocks](./extensibility/extending-blocks.md) section.
 
 ## Extending the Editor UI
 
@@ -43,14 +43,14 @@ Refer to the [Plugins](https://github.com/WordPress/gutenberg/blob/master/plugin
 
 **Porting PHP meta boxes to blocks is highly encouraged!**
 
-Discover how [Meta Box](./extensibility/meta-box) support works in Gutenberg.
+Discover how [Meta Box](./extensibility/meta-box.md) support works in Gutenberg.
 
 ## Theme Support
 
 By default, blocks provide their styles to enable basic support for blocks in themes without any change. Themes can add/override these styles, or rely on defaults.
 
-There are some advanced block features which require opt-in support in the theme. See [theme support](./extensibility/theme-support).
+There are some advanced block features which require opt-in support in the theme. See [theme support](./extensibility/theme-support.md).
 
 ## Autocomplete
 
-Autocompleters within blocks may be extended and overridden. See [autocomplete](./extensibility/autocomplete).
+Autocompleters within blocks may be extended and overridden. See [autocomplete](./extensibility/autocomplete.md).


### PR DESCRIPTION
* Fix navigating from https://github.com/WordPress/gutenberg/blob/master/docs/extensibility.md
