### PR TITLE
Grammar: Reduce and rename for clarity

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -161,19 +161,19 @@ function partition( predicate, list ) {
 //////////////////////////////////////////////////////
 
 Block_List
-  = pre:$(!Token .)*
-    ts:(t:Token html:$((!Token .)*) { /** <?php return array( $t, $html ); ?> **/ return [ t, html ] })*
+  = pre:$(!Block .)*
+    bs:(b:Block html:$((!Block .)*) { /** <?php return array( $b, $html ); ?> **/ return [ b, html ] })*
     post:$(.*)
-  { /** <?php return peg_join_blocks( $pre, $ts, $post ); ?> **/
-    return joinBlocks( pre, ts, post );
+  { /** <?php return peg_join_blocks( $pre, $bs, $post ); ?> **/
+    return joinBlocks( pre, bs, post );
   }
 
-Token
+Block
   = Block_Void
   / Block_Balanced
 
 Block_Void
-  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
+  = "<!--" __ "wp:" blockName:Block_Name __ attrs:(a:Block_Attributes __ {
     /** <?php return $a; ?> **/
     return a;
   })? "/-->"
@@ -196,7 +196,7 @@ Block_Void
   }
 
 Block_Balanced
-  = s:Block_Start children:(Token / $(!Block_End .))* e:Block_End
+  = s:Block_Start children:(Block / $(!Block_End .))* e:Block_End
   {
     /** <?php
     list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
@@ -222,7 +222,7 @@ Block_Balanced
   }
 
 Block_Start
-  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
+  = "<!--" __ "wp:" blockName:Block_Name __ attrs:(a:Block_Attributes __ {
     /** <?php return $a; ?> **/
     return a;
   })? "-->"
@@ -241,7 +241,7 @@ Block_Start
   }
 
 Block_End
-  = "<!--" WS+ "/wp:" blockName:Block_Name WS+ "-->"
+  = "<!--" __ "/wp:" blockName:Block_Name __ "-->"
   {
     /** <?php
     return array(
@@ -272,23 +272,11 @@ Block_Name_Part
   = $( [a-z][a-z0-9_-]* )
 
 Block_Attributes
-  = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")
+  = attrs:$("{" (!("}" __ """/"? "-->") .)* "}")
   {
     /** <?php return json_decode( $attrs, true ); ?> **/
     return maybeJSON( attrs );
   }
 
-WS
-  = [ \t\r\n]
-
-Newline
-  = [\r\n]
-
-_
-  = [ \t]
-
 __
-  = _+
-
-Any
-  = .
+  = [ \t\r\n]+

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -252,13 +252,9 @@ class Gutenberg_PEG_Parser {
     private $peg_c21;
     private $peg_c22;
     private $peg_c23;
-    private $peg_c24;
-    private $peg_c25;
-    private $peg_c26;
-    private $peg_c27;
 
-    private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
-    private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
+    private function peg_f0($pre, $b, $html) { return array( $b, $html ); }
+    private function peg_f1($pre, $bs, $post) { return peg_join_blocks( $pre, $bs, $post ); }
     private function peg_f2($blockName, $a) { return $a; }
     private function peg_f3($blockName, $attrs) {
         return array(
@@ -300,7 +296,7 @@ class Gutenberg_PEG_Parser {
       $s3 = $this->peg_currPos;
       $s4 = $this->peg_currPos;
       $this->peg_silentFails++;
-      $s5 = $this->peg_parseToken();
+      $s5 = $this->peg_parseBlock();
       $this->peg_silentFails--;
       if ($s5 === $this->peg_FAILED) {
         $s4 = null;
@@ -334,7 +330,7 @@ class Gutenberg_PEG_Parser {
         $s3 = $this->peg_currPos;
         $s4 = $this->peg_currPos;
         $this->peg_silentFails++;
-        $s5 = $this->peg_parseToken();
+        $s5 = $this->peg_parseBlock();
         $this->peg_silentFails--;
         if ($s5 === $this->peg_FAILED) {
           $s4 = null;
@@ -372,14 +368,14 @@ class Gutenberg_PEG_Parser {
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
         $s3 = $this->peg_currPos;
-        $s4 = $this->peg_parseToken();
+        $s4 = $this->peg_parseBlock();
         if ($s4 !== $this->peg_FAILED) {
           $s5 = $this->peg_currPos;
           $s6 = array();
           $s7 = $this->peg_currPos;
           $s8 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s9 = $this->peg_parseToken();
+          $s9 = $this->peg_parseBlock();
           $this->peg_silentFails--;
           if ($s9 === $this->peg_FAILED) {
             $s8 = null;
@@ -413,7 +409,7 @@ class Gutenberg_PEG_Parser {
             $s7 = $this->peg_currPos;
             $s8 = $this->peg_currPos;
             $this->peg_silentFails++;
-            $s9 = $this->peg_parseToken();
+            $s9 = $this->peg_parseBlock();
             $this->peg_silentFails--;
             if ($s9 === $this->peg_FAILED) {
               $s8 = null;
@@ -463,14 +459,14 @@ class Gutenberg_PEG_Parser {
         while ($s3 !== $this->peg_FAILED) {
           $s2[] = $s3;
           $s3 = $this->peg_currPos;
-          $s4 = $this->peg_parseToken();
+          $s4 = $this->peg_parseBlock();
           if ($s4 !== $this->peg_FAILED) {
             $s5 = $this->peg_currPos;
             $s6 = array();
             $s7 = $this->peg_currPos;
             $s8 = $this->peg_currPos;
             $this->peg_silentFails++;
-            $s9 = $this->peg_parseToken();
+            $s9 = $this->peg_parseBlock();
             $this->peg_silentFails--;
             if ($s9 === $this->peg_FAILED) {
               $s8 = null;
@@ -504,7 +500,7 @@ class Gutenberg_PEG_Parser {
               $s7 = $this->peg_currPos;
               $s8 = $this->peg_currPos;
               $this->peg_silentFails++;
-              $s9 = $this->peg_parseToken();
+              $s9 = $this->peg_parseBlock();
               $this->peg_silentFails--;
               if ($s9 === $this->peg_FAILED) {
                 $s8 = null;
@@ -601,7 +597,7 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseToken() {
+    private function peg_parseBlock() {
 
       $s0 = $this->peg_parseBlock_Void();
       if ($s0 === $this->peg_FAILED) {
@@ -624,16 +620,7 @@ class Gutenberg_PEG_Parser {
         }
       }
       if ($s1 !== $this->peg_FAILED) {
-        $s2 = array();
-        $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
-        }
+        $s2 = $this->peg_parse__();
         if ($s2 !== $this->peg_FAILED) {
           if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c3) {
             $s3 = $this->peg_c3;
@@ -647,30 +634,12 @@ class Gutenberg_PEG_Parser {
           if ($s3 !== $this->peg_FAILED) {
             $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = array();
-              $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
-              }
+              $s5 = $this->peg_parse__();
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
                 $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
-                  $s8 = array();
-                  $s9 = $this->peg_parseWS();
-                  if ($s9 !== $this->peg_FAILED) {
-                    while ($s9 !== $this->peg_FAILED) {
-                      $s8[] = $s9;
-                      $s9 = $this->peg_parseWS();
-                    }
-                  } else {
-                    $s8 = $this->peg_FAILED;
-                  }
+                  $s8 = $this->peg_parse__();
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
                     $s7 = $this->peg_f2($s4, $s7);
@@ -738,7 +707,7 @@ class Gutenberg_PEG_Parser {
       $s1 = $this->peg_parseBlock_Start();
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_parseToken();
+        $s3 = $this->peg_parseBlock();
         if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
           $s4 = $this->peg_currPos;
@@ -781,7 +750,7 @@ class Gutenberg_PEG_Parser {
         }
         while ($s3 !== $this->peg_FAILED) {
           $s2[] = $s3;
-          $s3 = $this->peg_parseToken();
+          $s3 = $this->peg_parseBlock();
           if ($s3 === $this->peg_FAILED) {
             $s3 = $this->peg_currPos;
             $s4 = $this->peg_currPos;
@@ -858,16 +827,7 @@ class Gutenberg_PEG_Parser {
         }
       }
       if ($s1 !== $this->peg_FAILED) {
-        $s2 = array();
-        $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
-        }
+        $s2 = $this->peg_parse__();
         if ($s2 !== $this->peg_FAILED) {
           if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c3) {
             $s3 = $this->peg_c3;
@@ -881,30 +841,12 @@ class Gutenberg_PEG_Parser {
           if ($s3 !== $this->peg_FAILED) {
             $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = array();
-              $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
-              }
+              $s5 = $this->peg_parse__();
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
                 $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
-                  $s8 = array();
-                  $s9 = $this->peg_parseWS();
-                  if ($s9 !== $this->peg_FAILED) {
-                    while ($s9 !== $this->peg_FAILED) {
-                      $s8[] = $s9;
-                      $s9 = $this->peg_parseWS();
-                    }
-                  } else {
-                    $s8 = $this->peg_FAILED;
-                  }
+                  $s8 = $this->peg_parse__();
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
                     $s7 = $this->peg_f2($s4, $s7);
@@ -979,16 +921,7 @@ class Gutenberg_PEG_Parser {
         }
       }
       if ($s1 !== $this->peg_FAILED) {
-        $s2 = array();
-        $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
-        }
+        $s2 = $this->peg_parse__();
         if ($s2 !== $this->peg_FAILED) {
           if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c9) {
             $s3 = $this->peg_c9;
@@ -1002,16 +935,7 @@ class Gutenberg_PEG_Parser {
           if ($s3 !== $this->peg_FAILED) {
             $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = array();
-              $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
-              }
+              $s5 = $this->peg_parse__();
               if ($s5 !== $this->peg_FAILED) {
                 if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
                   $s6 = $this->peg_c7;
@@ -1210,16 +1134,7 @@ class Gutenberg_PEG_Parser {
           }
         }
         if ($s8 !== $this->peg_FAILED) {
-          $s9 = array();
-          $s10 = $this->peg_parseWS();
-          if ($s10 !== $this->peg_FAILED) {
-            while ($s10 !== $this->peg_FAILED) {
-              $s9[] = $s10;
-              $s10 = $this->peg_parseWS();
-            }
-          } else {
-            $s9 = $this->peg_FAILED;
-          }
+          $s9 = $this->peg_parse__();
           if ($s9 !== $this->peg_FAILED) {
             $s10 = $this->peg_c21;
             if ($s10 !== $this->peg_FAILED) {
@@ -1312,16 +1227,7 @@ class Gutenberg_PEG_Parser {
             }
           }
           if ($s8 !== $this->peg_FAILED) {
-            $s9 = array();
-            $s10 = $this->peg_parseWS();
-            if ($s10 !== $this->peg_FAILED) {
-              while ($s10 !== $this->peg_FAILED) {
-                $s9[] = $s10;
-                $s10 = $this->peg_parseWS();
-              }
-            } else {
-              $s9 = $this->peg_FAILED;
-            }
+            $s9 = $this->peg_parse__();
             if ($s9 !== $this->peg_FAILED) {
               $s10 = $this->peg_c21;
               if ($s10 !== $this->peg_FAILED) {
@@ -1438,77 +1344,33 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseWS() {
+    private function peg_parse__() {
 
+      $s0 = array();
       if (Gutenberg_PEG_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
+        $s1 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
-        $s0 = $this->peg_FAILED;
+        $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
             $this->peg_fail($this->peg_c23);
         }
       }
-
-      return $s0;
-    }
-
-    private function peg_parseNewline() {
-
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parse_() {
-
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c27);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parse__() {
-
-      $s0 = array();
-      $s1 = $this->peg_parse_();
       if ($s1 !== $this->peg_FAILED) {
         while ($s1 !== $this->peg_FAILED) {
           $s0[] = $s1;
-          $s1 = $this->peg_parse_();
+          if (Gutenberg_PEG_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
+            $s1 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s1 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c23);
+            }
+          }
         }
       } else {
         $s0 = $this->peg_FAILED;
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseAny() {
-
-      if ($this->input_length > $this->peg_currPos) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c0);
-        }
       }
 
       return $s0;
@@ -1552,10 +1414,6 @@ class Gutenberg_PEG_Parser {
     $this->peg_c21 = "";
     $this->peg_c22 = array(array(32,32), array(9,9), array(13,13), array(10,10));
     $this->peg_c23 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c24 = array(array(13,13), array(10,10));
-    $this->peg_c25 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c26 = array(array(32,32), array(9,9));
-    $this->peg_c27 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
     $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
     $peg_startRuleFunction  = array($this, "peg_parseBlock_List");


### PR DESCRIPTION
## Description

Spin-off from #6116.

Grammar changes:
* Rename `Token` to `Block`
* Rename `Block_Void` to `Block_Empty`
* Port `WS+` to `__`, merging together white-space rules


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
