### PR TITLE
Testing: Disable login screen autofocus in Puppeteer tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - wordpress:/var/www/html
       - .:/var/www/html/wp-content/plugins/gutenberg
       - ./test/e2e/test-plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
+      - ./test/e2e/test-mu-plugins:/var/www/html/wp-content/mu-plugins
 
   cli:
     image: wordpress:cli

--- a/test/e2e/test-mu-plugins/disable-login-autofocus.php
+++ b/test/e2e/test-mu-plugins/disable-login-autofocus.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Plugin Name: Gutenberg Test Plugin, Disable Login Autofocus
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-disable-login-autofocus
+ */
+
+add_filter( 'enable_login_autofocus', '__return_false' );


### PR DESCRIPTION
This pull request seeks to resolve an issue where the E2E test runner can have its login input clobbered by a [script in the WordPress login screen](https://github.com/WordPress/WordPress/blob/9bbb2618e4f5058682ac81db81488eca8210c460/wp-login.php#L1121-L1152) which calls `Element#select` on the user login field _after a 200 millisecond delay_. While arguably this should be improved within core to check whether the field is already focused before trying to focus (or, more importantly, select), there is a filter exposed to disable the autofocus, which is taken advantage of here.

__Testing instructions:__

This is most noticeable with a short delay in the Puppeteer test runner. Verify there are no errors:

```
PUPPETEER_HEADLESS=false PUPPETEER_SLOWMO=20 npm run test-e2e
```

(You may need to re-setup your local Docker install to associate the new volume)