### PR TITLE
Meta Boxes: Only attempt apiRequest preload if path (fix meta box save breakage)

### DIFF
--- a/editor/components/post-saved-state/index.js
+++ b/editor/components/post-saved-state/index.js
@@ -39,7 +39,7 @@ export class PostSavedState extends Component {
 		const { forceSavedMessage } = this.state;
 		if ( isSaving ) {
 			return (
-				<span className="editor-post-saved-state editor-post-saved-state__saving">
+				<span className="editor-post-saved-state is-saving">
 					<Dashicon icon="cloud" />
 					{ __( 'Saving' ) }
 				</span>
@@ -56,7 +56,7 @@ export class PostSavedState extends Component {
 
 		if ( forceSavedMessage || ( ! isNew && ! isDirty ) ) {
 			return (
-				<span className="editor-post-saved-state">
+				<span className="editor-post-saved-state is-saved">
 					<Dashicon icon="saved" />
 					{ __( 'Saved' ) }
 				</span>

--- a/editor/components/post-saved-state/style.scss
+++ b/editor/components/post-saved-state/style.scss
@@ -4,6 +4,10 @@
 	color: $dark-gray-500;
 	overflow: hidden;
 
+	&.is-saving {
+		animation: loading_fade .5s infinite;
+	}
+
 	.dashicon {
 		display: inline-block;
 	    flex: 0 0 auto;
@@ -29,8 +33,4 @@
 			margin-right: 4px;
 		}
 	}
-}
-
-.editor-post-saved-state__saving {
-	animation: loading_fade .5s infinite;
 }

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -124,12 +124,17 @@ function gutenberg_shim_api_request( $scripts ) {
 	// Add preloading support
 	var previousApiRequest = wp.apiRequest;
 	wp.apiRequest = function( request ) {
-		var method = request.method || 'GET';
-		var path = getStablePath( request.path );
-		if ( 'GET' === method && window._wpAPIDataPreload[ path ] ) {
-			var deferred = jQuery.Deferred();
-			deferred.resolve( window._wpAPIDataPreload[ path ].body );
-			return deferred.promise();
+		var method, path;
+
+		if ( typeof request.path === 'string' ) {
+			method = request.method || 'GET';
+			path = getStablePath( request.path );
+
+			if ( 'GET' === method && window._wpAPIDataPreload[ path ] ) {
+				var deferred = jQuery.Deferred();
+				deferred.resolve( window._wpAPIDataPreload[ path ].body );
+				return deferred.promise();
+			}
 		}
 
 		return previousApiRequest.call( previousApiRequest, request );

--- a/test/e2e/specs/meta-boxes.test.js
+++ b/test/e2e/specs/meta-boxes.test.js
@@ -26,9 +26,10 @@ describe( 'Meta boxes', () => {
 		expect( await page.$( '.editor-post-save-draft' ) ).not.toBe( null );
 
 		await Promise.all( [
-			// Transitions between two states "Saving..." -> "Save Draft" (the
-			// button is always visible while meta are present).
-			page.waitForSelector( '.editor-post-saved-state__saving' ),
+			// Transitions between three states "Saving..." -> "Saved" -> "Save
+			// Draft" (the button is always visible while meta are present).
+			page.waitForSelector( '.editor-post-saved-state.is-saving' ),
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
 			page.waitForSelector( '.editor-post-save-draft' ),
 
 			// Keyboard shortcut Ctrl+S save.

--- a/test/e2e/specs/meta-boxes.test.js
+++ b/test/e2e/specs/meta-boxes.test.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage } from '../support/utils';
+import { activatePlugin, deactivatePlugin } from '../support/plugins';
+
+describe( 'Meta boxes', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await activatePlugin( 'gutenberg-test-plugin-meta-box' );
+		await newPost();
+	} );
+
+	afterAll( async () => {
+		await newDesktopBrowserPage();
+		await deactivatePlugin( 'gutenberg-test-plugin-meta-box' );
+	} );
+
+	it( 'Should save the post', async () => {
+		// Save should not be an option for new empty post.
+		expect( await page.$( '.editor-post-save-draft' ) ).toBe( null );
+
+		// Add title to enable valid non-empty post save.
+		await page.type( '.editor-post-title__input', 'Hello Meta' );
+		expect( await page.$( '.editor-post-save-draft' ) ).not.toBe( null );
+
+		await Promise.all( [
+			// Transitions between two states "Saving..." -> "Save Draft" (the
+			// button is always visible while meta are present).
+			page.waitForSelector( '.editor-post-saved-state__saving' ),
+			page.waitForSelector( '.editor-post-save-draft' ),
+
+			// Keyboard shortcut Ctrl+S save.
+			page.keyboard.down( 'Meta' ),
+			page.keyboard.press( 'S' ),
+			page.keyboard.up( 'Meta' ),
+		] );
+	} );
+} );

--- a/test/e2e/test-plugins/meta-box.php
+++ b/test/e2e/test-plugins/meta-box.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Plugin Name: Gutenberg Test Plugin, Meta Box
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-meta-box
+ */
+
+function gutenberg_test_meta_box_render_meta_box() {
+	echo 'Hello World';
+}
+
+function gutenberg_test_meta_box_add_meta_box() {
+	add_meta_box(
+		'gutenberg-test-meta-box',
+		'Gutenberg Test Meta Box',
+		'gutenberg_test_meta_box_render_meta_box',
+		'post',
+		'normal',
+		'high'
+	);
+}
+add_action( 'add_meta_boxes', 'gutenberg_test_meta_box_add_meta_box' );

--- a/test/e2e/test-plugins/templates.php
+++ b/test/e2e/test-plugins/templates.php
@@ -10,7 +10,7 @@
 /**
  * Registers a book CPT with a template
  */
-function register_book_type() {
+function gutenberg_test_templates_register_book_type() {
 	$args = array(
 		'public' => true,
 		'label'  => 'Books',
@@ -43,4 +43,4 @@ function register_book_type() {
 	register_post_type( 'book', $args );
 }
 
-add_action( 'init', 'register_book_type' );
+add_action( 'init', 'gutenberg_test_templates_register_book_type' );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/6076#issuecomment-380573081

This pull request seeks to resolve an error which prevents saving a post while a meta box is present. See https://github.com/WordPress/gutenberg/pull/6076#issuecomment-380573081 for more context on the reason for the error.

Included is a new end-to-end test suite for meta boxes. Currently this only includes a verification that the post is saveable after dirtying, previously failing and now passing with the fix to the `wp.apiRequest` shim.

__Testing instructions:__

Verify in your own browser that a post with meta boxes present can be saved.

Ensure end-to-end tests pass:

```
npm run test-e2e
```