### PR TITLE
Fix Issue #6105 regarding drop cap-related display error

### DIFF
--- a/blocks/library/paragraph/style.scss
+++ b/blocks/library/paragraph/style.scss
@@ -29,10 +29,6 @@ p {
 	}
 }
 
-p.has-drop-cap:not( :focus )  {
-	overflow: hidden;
-}
-
 p.has-background {
 	padding: 20px 30px;
 }

--- a/blocks/rich-text/style.scss
+++ b/blocks/rich-text/style.scss
@@ -89,10 +89,6 @@
 	}
 }
 
-.has-drop-cap:not( :focus )  {
-	overflow: hidden;
-}
-
 .block-rich-text__inline-toolbar {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
## Description
I removed the "overflow: hidden" property that was being applied to blocks with drop caps when they were not in focus.  This code was causing text to not properly wrap, as described in issue #6105, and did not seem to have any other effects in other situations unrelated to the issue.

Fixes #6105

## How Has This Been Tested?
I tested this by recreating the problem with the steps in the aforementioned issue, changing the code, and ensuring that it had the desired effect without any unintended consequences.

## Screenshots (jpeg or gifs if applicable):
This is how the text looked when out of focus before the issue was fixed:
![dropcap2](https://user-images.githubusercontent.com/12479754/38656339-d67b6606-3de7-11e8-8abe-285041fd1417.PNG)

This is how it looks when out of focus after the fix:
![dropcap1](https://user-images.githubusercontent.com/12479754/38656363-f60ccc80-3de7-11e8-9b98-b578d6dfab16.PNG)


## Types of changes
This is a bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
