### PR TITLE
Components: Add test confirming that withFilters does not rerender

### DIFF
--- a/components/higher-order/with-filters/test/index.js
+++ b/components/higher-order/with-filters/test/index.js
@@ -65,6 +65,31 @@ describe( 'withFilters', () => {
 		expect( wrapper.html() ).toBe( '<div><div>My component</div><div>Composed component</div></div>' );
 	} );
 
+	it( 'should not re-render component when new filter added before component was mounted', () => {
+		const spy = jest.fn();
+		const SpiedComponent = () => {
+			spy();
+			return <div>Spied component</div>;
+		};
+		addFilter(
+			hookName,
+			'test/enhanced-component-spy-1',
+			FilteredComponent => () => (
+				<blockquote>
+					<FilteredComponent />
+				</blockquote>
+			),
+		);
+		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
+
+		wrapper = mount( <EnhancedComponent /> );
+
+		jest.runAllTimers();
+
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( wrapper.html() ).toBe( '<blockquote><div>Spied component</div></blockquote>' );
+	} );
+
 	it( 'should re-render component once when new filter added after component was mounted', () => {
 		const spy = jest.fn();
 		const SpiedComponent = () => {


### PR DESCRIPTION
It covers the case when filters added before the component was mounted.

## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
Unit tests: `npm run test`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
