### PR TITLE
Fixed centered image caption toolbar on IE11.

### DIFF
--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -84,7 +84,7 @@
 		margin-right: auto;
 	}
 
-	&[data-resized="false"] .wp-block-image div {
+	&[data-resized="false"] .wp-block-image > div {
 		margin-left: auto;
 		margin-right: auto;
 	}


### PR DESCRIPTION
## Description
In the image block we had a CSS rule for centered images that should not be applied to the toolbar and when applied caused a problem in IE11.
This PR fixes the rule.
Fixes: https://github.com/WordPress/gutenberg/issues/5792
I tried to replicate the problem and find similar rules in other blocks but it looks like this problem only affects images.

## How Has This Been Tested?
In IE11, add an image block, center it, verify the toolbar continue to display correctly in the center.
