### PR TITLE
Add polish

### DIFF
--- a/blocks/image-placeholder/index.js
+++ b/blocks/image-placeholder/index.js
@@ -60,7 +60,7 @@ export default function ImagePlaceholder( { className, icon, label, onSelectImag
 				type="image"
 				render={ ( { open } ) => (
 					<Button isLarge onClick={ open }>
-						{ __( 'Add from Media Library' ) }
+						{ __( 'Media Library' ) }
 					</Button>
 				) }
 			/>

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -129,7 +129,7 @@ export const settings = {
 							value={ id }
 							render={ ( { open } ) => (
 								<Button isLarge onClick={ open }>
-									{ __( 'Add from Media Library' ) }
+									{ __( 'Media Library' ) }
 								</Button>
 							) }
 						/>

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -59,6 +59,9 @@
 	.blocks-format-toolbar__link-modal {
 		top: 0;
 		left: 0;
+		position: absolute;
+		border: none;
+		width: 100%;
 	}
 }
 

--- a/blocks/library/more/editor.scss
+++ b/blocks/library/more/editor.scss
@@ -3,32 +3,40 @@
 	text-align: center;
 }
 
-.gutenberg .wp-block-more {
+.gutenberg .wp-block-more { // needs specificity
+	display: block;
+	text-align: center;
+	white-space: nowrap;
+
+	// Label
 	input {
 		font-size: 12px;
 		text-transform: uppercase;
 		font-weight: 600;
 		font-family: $default-font;
 		color: $dark-gray-300;
-		padding-left: 8px;
-		padding-right: 8px;
-		background: $white;
 		border: none;
 		box-shadow: none;
 		white-space: nowrap;
 		text-align: center;
+		margin: 0;
+		border-radius: 4px;
+		background: $white;
+		padding: 6px 8px;
+		height: $icon-button-size-small;
 
 		&:focus {
 			box-shadow: none;
 		}
 	}
 
+	// Dashed line
 	&:before {
 		content: '';
 		position: absolute;
 		top: calc( 50% );
-		left: $block-side-ui-padding + $block-padding;
-		right: $block-side-ui-padding + $block-padding;
+		left: 0;
+		right: 0;
 		border-top: 3px dashed $light-gray-700;
 		z-index: z-index( '.editor-block-list__block .wp-block-more:before' );
 	}

--- a/blocks/library/nextpage/editor.scss
+++ b/blocks/library/nextpage/editor.scss
@@ -5,36 +5,31 @@
 .wp-block-nextpage {
 	display: block;
 	text-align: center;
-	overflow: hidden;
 	white-space: nowrap;
-}
 
-.wp-block-nextpage > span {
-	position: relative;
-	display: inline-block;
-	font-size: 12px;
-	text-transform: uppercase;
-	font-weight: 600;
-	font-family: $default-font;
-	color: $dark-gray-300;
-}
+	// Label
+	> span {
+		position: relative;
+		display: inline-block;
+		font-size: 12px;
+		text-transform: uppercase;
+		font-weight: 600;
+		font-family: $default-font;
+		color: $dark-gray-300;
+		border-radius: 4px;
+		background: $white;
+		padding: 6px 8px;
+		height: $icon-button-size-small;
+	}
 
-.wp-block-nextpage > span:before,
-.wp-block-nextpage > span:after {
-	content: '';
-	position: absolute;
-	top: 50%;
-	width: 100vw;
-	border-top: 3px dashed $light-gray-700;
-	margin-top: -2px;
-}
-
-.wp-block-nextpage > span:before {
-	right: 100%;
-	margin-right: 20px;
-}
-
-.wp-block-nextpage > span:after {
-	left: 100%;
-	margin-left: 20px;
+	// Dashed line
+	&:before {
+		content: '';
+		position: absolute;
+		top: calc( 50% );
+		left: 0;
+		right: 0;
+		border-top: 3px dashed $light-gray-700;
+		z-index: z-index( '.editor-block-list__block .wp-block-more:before' );
+	}
 }

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -157,7 +157,7 @@ export const settings = {
 							id={ id }
 							render={ ( { open } ) => (
 								<Button isLarge onClick={ open } >
-									{ __( 'Add from Media Library' ) }
+									{ __( 'Media Library' ) }
 								</Button>
 							) }
 						/>

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -5,9 +5,9 @@
 .blocks-format-toolbar__link-modal {
 	position: relative;
 	left: -50%;
-	box-shadow: 0 3px 20px rgba( 18, 24, 30, .1 ), 0 1px 3px rgba( 18, 24, 30, .1 );
-	border: 1px solid #e0e5e9;
-	background: #fff;
+	box-shadow: $shadow-popover;
+	border: 1px solid $light-gray-500;
+	background: $white;
 	display: flex;
 	flex-direction: column;
 	font-family: $default-font;
@@ -39,6 +39,7 @@
 
 		input {
 			padding: $input-padding;
+			margin: 0;
 		}
 	}
 

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -37,6 +37,10 @@
 		background-image: linear-gradient( -45deg, $blue-medium-500 28%, $blue-dark-900 28%, $blue-dark-900 72%, $blue-medium-500 72%) !important;
 		border-color: $blue-dark-900 !important;
 	}
+
+	.wp-core-ui.gutenberg-editor-page & {
+		font-size: $default-font-size;
+	}
 }
 
 @keyframes components-button__busy-animation {

--- a/editor/components/block-list/breadcrumb.js
+++ b/editor/components/block-list/breadcrumb.js
@@ -69,7 +69,7 @@ export class BlockBreadcrumb extends Component {
 								onFocus={ this.onFocus }
 								onBlur={ this.onBlur }
 							>
-								<Dashicon icon="arrow-left" uid={ uid } />
+								<Dashicon icon="arrow-left-alt" uid={ uid } />
 							</Button>
 						</Tooltip>
 					) }


### PR DESCRIPTION
This PR contains 3 sets of fixes. 

The first polishes the link dialog a bit, by using color variables. Notably it fixes a regression with the Image link:

<img width="439" alt="screen shot 2018-04-12 at 11 01 05" src="https://user-images.githubusercontent.com/1204802/38670681-c2b82034-3e49-11e8-9214-136180edd158.png">

There's still an issue here, though, as soon as you start typing in the link dialog for images, it disappears. I suspect isEditing is kicking in and hiding the block toolbars. CC: @noisysocks 

The second part unifies the styles between readmore and pagination:

<img width="721" alt="screen shot 2018-04-12 at 11 38 52" src="https://user-images.githubusercontent.com/1204802/38670753-f81a7d30-3e49-11e8-8eef-bf243be0425b.png">

The third is a fix to make sure that placeholders fit in tight spots, by including a shorter Media Library label. It also makes the font sizes on those buttons consistent with all other Gutenberg buttons:

<img width="579" alt="screen shot 2018-04-12 at 12 03 17" src="https://user-images.githubusercontent.com/1204802/38670785-0e2569c8-3e4a-11e8-8a22-64073980bc8b.png">
