### PR TITLE
Show side UI on selected blocks

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -522,7 +522,7 @@ export class BlockListBlock extends Component {
 						layout={ layout }
 						isFirst={ isFirst }
 						isLast={ isLast }
-						isHidden={ ! isHovered || hoverArea !== 'left' }
+						isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' }
 					/>
 				) }
 				{ shouldRenderBlockSettings && (
@@ -530,10 +530,10 @@ export class BlockListBlock extends Component {
 						uids={ [ uid ] }
 						rootUID={ rootUID }
 						renderBlockMenu={ renderBlockMenu }
-						isHidden={ ! isHovered || hoverArea !== 'right' }
+						isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'right' }
 					/>
 				) }
-				{ shouldShowBreadcrumb && <BlockBreadcrumb uid={ uid } isHidden={ hoverArea !== 'left' } /> }
+				{ shouldShowBreadcrumb && <BlockBreadcrumb uid={ uid } isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' } /> }
 				{ shouldShowContextualToolbar && <BlockContextualToolbar /> }
 				{ isFirstMultiSelected && <BlockMultiControls rootUID={ rootUID } /> }
 				<IgnoreNestedEvents


### PR DESCRIPTION
Fix a small bug where the side UI doesn't show up if you hover close to it and the block is selected.

related #6101 