### PR TITLE
Refine side UI

### DIFF
--- a/edit-post/assets/stylesheets/_variables.scss
+++ b/edit-post/assets/stylesheets/_variables.scss
@@ -47,6 +47,7 @@ $block-mover-margin: 18px;
 $block-spacing: 4px;
 $block-side-ui-padding: 36px;
 $block-side-ui-width: 28px;		// The side UI max height matches a single line of text, 56px. 28px is half, allowing 2 mover arrows
+$block-side-ui-clearance: 2px;
 
 // Buttons & UI Widgets
 $button-style__radius-roundrect: 4px;

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -23,7 +23,7 @@ $z-layers: (
 	'.editor-block-list__insertion-point': 5,
 	'.blocks-format-toolbar__link-modal': 6,
 	'.blocks-gallery-item__inline-menu': 20,
-	'.editor-block-settings-menu__popover': 20, // Below the header
+	'.editor-block-settings-menu__popover': 21, // Below the header, but above the block toolbar
 	'.blocks-url-input__suggestions': 30,
 	'.edit-post-header': 30,
 	'.wp-block-image__resize-handlers': 1, // Resize handlers above sibling inserter

--- a/editor/components/block-list/block-mobile-toolbar.js
+++ b/editor/components/block-list/block-mobile-toolbar.js
@@ -7,7 +7,6 @@ import { ifViewportMatches } from '@wordpress/viewport';
  * Internal dependencies
  */
 import BlockMover from '../block-mover';
-import BlockRemoveButton from '../block-settings-menu/block-remove-button';
 import BlockSettingsMenu from '../block-settings-menu';
 import VisualEditorInserter from '../inserter';
 
@@ -16,7 +15,6 @@ function BlockMobileToolbar( { rootUID, uid, renderBlockMenu } ) {
 		<div className="editor-block-list__block-mobile-toolbar">
 			<VisualEditorInserter />
 			<BlockMover uids={ [ uid ] } />
-			<BlockRemoveButton uids={ [ uid ] } small />
 			<BlockSettingsMenu rootUID={ rootUID } uids={ [ uid ] } renderBlockMenu={ renderBlockMenu } />
 		</div>
 	);

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -333,43 +333,41 @@
 			border-right-width: 0;
 		}
 
-		// Adjust how movers behave on the full-wide block, and don't affect children
-		> .editor-block-mover {
-			display: none;
-		}
-
-		@include break-wide() {
-			> .editor-block-mover {
-				display: block;
-				top: -29px;
-				left: 10px;
-				height: auto;
-				width: auto;
-				z-index: inherit;
-
-				&:before {
-					content: none;
-				}
-			}
-
-			> .editor-block-mover .editor-block-mover__control {
-				float: left;
-			}
-		}
-
-		// Also adjust block settings menu
+		// Mover and settings in wide
+		> .editor-block-mover,
 		> .editor-block-settings-menu {
-			top: -41px;
-			right: 10px;
+			top: -29px;
+			bottom: auto;
 			height: auto;
+			width: auto;
+			z-index: inherit;
 
 			&:before {
 				content: none;
 			}
 		}
 
-		> .editor-block-settings-menu .editor-block-settings-menu__control {
+		> .editor-block-mover {
+			left: 10px;
+		}
+
+		> .editor-block-settings-menu {
+			right: 10px;
+		}
+
+		> .editor-block-mover .editor-block-mover__control,
+		> .editor-block-settings-menu .components-icon-button {
 			float: left;
+		}
+
+		// Hide mover until wide breakpoints, or it might be covered by toolbar
+		> .editor-block-mover {
+			display: none;
+		}
+		@include break-wide() {
+			> .editor-block-mover {
+				display: block;
+			}
 		}
 	}
 
@@ -399,7 +397,7 @@
 		position: absolute;
 		top: -.9px; // .9px because of the collapsing margins hack, see line 27, @todo revisit when we allow margins to collapse
 		bottom: -.9px; // utilize full vertical space to increase hoverable area
-		padding: 0;
+		padding: .1px 0;
 		width: $block-side-ui-width;
 
 		/* Necessary for drag indicator */
@@ -408,12 +406,14 @@
 	}
 
 	// Elevate when selected or hovered
-	&.is-multi-selected,
-	&.is-selected,
-	&.is-hovered {
-		.editor-block-settings-menu,
-		.editor-block-mover {
-			z-index: z-index( '.editor-block-list__block.is-{selected,hovered} .editor-block-{settings-menu,mover}' );
+	@include break-small() {
+		&.is-multi-selected,
+		&.is-selected,
+		&.is-hovered {
+			.editor-block-settings-menu,
+			.editor-block-mover {
+				z-index: z-index( '.editor-block-list__block.is-{selected,hovered} .editor-block-{settings-menu,mover}' );
+			}
 		}
 	}
 

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -303,7 +303,7 @@
 
 	// Full-wide
 	&[data-align="full"] {
-		
+
 		// compensate for main container padding
 		@include break-small() {
 			margin-left: -$block-side-ui-padding;
@@ -355,7 +355,7 @@
 		}
 
 		> .editor-block-mover .editor-block-mover__control,
-		> .editor-block-settings-menu .components-icon-button {
+		> .editor-block-settings-menu > * {
 			float: left;
 		}
 
@@ -484,9 +484,9 @@
 				float: left;
 			}
 		}
-	
+
 		// Block Settings
-		.editor-block-settings-menu .components-button {
+		.editor-block-settings-menu > * {
 			float: left;
 		}
 	}

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -110,9 +110,8 @@
 	}
 
 	// Prevent collapsing margins @todo try and revisit this, it's conducive to theming to allow these to collapse
-	padding-top: .1px;
-	padding-bottom: .1px;
-
+	padding-top: 1px;
+	padding-bottom: 1px;
 
 	// Space every block using margins instead of padding
 	// This allows margins to collapse, which gives a better representation of how it looks on the frontend
@@ -121,8 +120,8 @@
 		margin-bottom: $block-padding;
 
 		// Prevent collapsing margins @todo try and revisit this, it's conducive to theming to allow these to collapse
-		padding-top: .1px;
-		padding-bottom: .1px;
+		padding-top: 1px;
+		padding-bottom: 1px;
 	}
 
 	margin-bottom: $block-spacing;
@@ -395,9 +394,8 @@
 	> .editor-block-settings-menu,
 	> .editor-block-mover {
 		position: absolute;
-		top: -.9px; // .9px because of the collapsing margins hack, see line 27, @todo revisit when we allow margins to collapse
-		bottom: -.9px; // utilize full vertical space to increase hoverable area
-		padding: .1px 0;
+		top: 0; // stretch to bottom to utilize full vertical space to increase hoverable area
+		bottom: 0;
 		width: $block-side-ui-width;
 
 		/* Necessary for drag indicator */

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -459,9 +459,8 @@
 		}
 
 		.editor-inserter__toggle,
-		.editor-block-settings-menu__toggle,
-		& > .editor-block-settings-menu__control,
-		.editor-block-mover__control {
+		.editor-block-mover__control,
+		.editor-block-settings-menu .components-button {
 			width: $icon-button-size;
 			height: $icon-button-size;
 			border-radius: $button-style__radius-roundrect;
@@ -484,6 +483,11 @@
 			.editor-block-mover__control {
 				float: left;
 			}
+		}
+	
+		// Block Settings
+		.editor-block-settings-menu .components-button {
+			float: left;
 		}
 	}
 }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -464,6 +464,7 @@
 		.editor-block-mover__control {
 			width: $icon-button-size;
 			height: $icon-button-size;
+			border-radius: $button-style__radius-roundrect;
 			padding: 3px;
 			margin: 0;
 			justify-content: center;
@@ -649,6 +650,7 @@
 .editor-block-list__breadcrumb .components-toolbar {
 	border: 1px solid $light-gray-500;
 	width: 100%;
+	background: $white;
 
 	// this prevents floats from messing up the position
 	position: absolute;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -396,7 +396,7 @@
 		position: absolute;
 		top: 0; // stretch to bottom to utilize full vertical space to increase hoverable area
 		bottom: 0;
-		width: $block-side-ui-width;
+		width: $block-side-ui-width + $block-side-ui-clearance;
 
 		/* Necessary for drag indicator */
 		cursor: move;/* Fallback for IE/Edge < 14 */
@@ -417,7 +417,8 @@
 
 	// Right side UI
 	> .editor-block-settings-menu {
-		right: -$block-side-ui-width;
+		right: -$block-side-ui-width - $block-side-ui-clearance;
+		padding-left: $block-side-ui-clearance;
 
 		// Mobile
 		display: none;
@@ -429,7 +430,8 @@
 
 	// Left side UI
 	> .editor-block-mover {
-		left: -$block-side-ui-width;
+		left: -$block-side-ui-width - $block-side-ui-clearance;
+		padding-right: $block-side-ui-clearance;
 
 		// Mobile
 		display: none;

--- a/editor/components/block-mover/arrows.js
+++ b/editor/components/block-mover/arrows.js
@@ -1,11 +1,11 @@
 export const upArrow = (
-	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
-		<path d="M12.293 12.207L9 8.914l-3.293 3.293-1.414-1.414L9 6.086l4.707 4.707z" />
+	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" aria-hidden role="img" focusable="false">
+		<polygon points="9,4.5 3.3,10.1 4.8,11.5 9,7.3 13.2,11.5 14.7,10.1 " />
 	</svg>
 );
 
 export const downArrow = (
-	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
-		<path d="M12.293 6.086L9 9.379 5.707 6.086 4.293 7.5 9 12.207 13.707 7.5z" />
+	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" aria-hidden role="img" focusable="false">
+		<polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 " />
 	</svg>
 );

--- a/editor/components/block-mover/arrows.js
+++ b/editor/components/block-mover/arrows.js
@@ -1,11 +1,11 @@
 export const upArrow = (
-	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" aria-hidden role="img" focusable="false">
+	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" aria-hidden role="img" focusable="false">
 		<polygon points="9,4.5 3.3,10.1 4.8,11.5 9,7.3 13.2,11.5 14.7,10.1 " />
 	</svg>
 );
 
 export const downArrow = (
-	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" aria-hidden role="img" focusable="false">
+	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" aria-hidden role="img" focusable="false">
 		<polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 " />
 	</svg>
 );

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -8,7 +8,9 @@
 
 // Mover icon buttons
 .editor-block-mover__control {
-	display: block;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	border: none;
 	outline: none;
 	background: none;
@@ -17,6 +19,7 @@
 	padding: 0;
 	width: $block-side-ui-width;
 	height: $block-side-ui-width;	// the side UI can be no taller than 2 * $block-side-ui-width, which matches the height of a line of text
+	border-radius: $button-style__radius-roundrect;
 
 	&[aria-disabled="true"] {
 		cursor: default;
@@ -24,7 +27,13 @@
 		pointer-events: none;
 	}
 
-	// Try a background, only for nested situations @todo
+	svg {
+		width: $block-side-ui-width;
+		height: $block-side-ui-width;
+		padding: ( $block-side-ui-width - 18px ) / 2;	// this makes the SVG fill the whole available area, without scaling the artwork
+	}
+
+	// Apply a background in nested contexts, only on desktop
 	@include break-small() {
 		.editor-block-list__layout .editor-block-list__layout & {
 			background: $white;
@@ -41,35 +50,17 @@
 		}
 	}
 
-	// apply styles to SVG for movers on the desktop breakpoint
-	@include break-small {
-		// unstyle inherited icon button styles
-		&:not(:disabled):hover,
-		&:not(:disabled):active,
-		&:not(:disabled):focus {
-			box-shadow: none;
-			color: inherit;
-		}
+	// Hover, active and focus styles
+	&:not(:disabled):hover {
+		@include button-style__hover;
+	}
 
-		svg {
-			display: block;
-			position: relative; // Fixing the Safari bug for `<button>`s overflow
-			border-radius: 50%;
-			margin: auto;
+	&:not(:disabled):active {
+		@include button-style__active;
+	}
 
-		}
-
-		&:not(:disabled):hover svg {
-			box-shadow: inset 0 0 0 1px $light-gray-500;
-		}
-
-		&:not(:disabled):active svg {
-			@include button-style__active;
-		}
-
-		&:not(:disabled):focus svg {
-			@include button-style__focus-active;
-		}
+	&:not(:disabled):focus {
+		@include button-style__focus-active;
 	}
 }
 

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -12,7 +12,7 @@ import { compose } from '@wordpress/element';
 import { withDispatch } from '@wordpress/data';
 import { withEditorSettings } from '@wordpress/blocks';
 
-export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false, role } ) {
+export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, role } ) {
 	if ( isLocked ) {
 		return null;
 	}
@@ -21,14 +21,12 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small =
 
 	return (
 		<IconButton
-			className="editor-block-settings-menu__control"
+			className="editor-block-settings-remove"
 			onClick={ flow( onRemove, onClick ) }
 			icon="trash"
-			label={ small ? label : undefined }
+			label={ label }
 			role={ role }
-		>
-			{ ! small && label }
-		</IconButton>
+		/>
 	);
 }
 

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { IconButton, Dropdown, NavigableMenu } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 
@@ -68,24 +68,26 @@ export class BlockSettingsMenu extends Component {
 						'is-opened': isOpen,
 					} );
 
-					return [
-						<IconButton
-							className={ toggleClassname }
-							onClick={ () => {
-								if ( uids.length === 1 ) {
-									onSelect( uids[ 0 ] );
-								}
-								onToggle();
-							} }
-							icon="ellipsis"
-							label={ __( 'More Options' ) }
-							aria-expanded={ isOpen }
-							focus={ focus }
-							onFocus={ this.onFocus }
-							onBlur={ this.onBlur }
-						/>,
-						<BlockRemoveButton key="remove" uids={ uids } />
-					];
+					return (
+						<Fragment>
+							<IconButton
+								className={ toggleClassname }
+								onClick={ () => {
+									if ( uids.length === 1 ) {
+										onSelect( uids[ 0 ] );
+									}
+									onToggle();
+								} }
+								icon="ellipsis"
+								label={ __( 'More Options' ) }
+								aria-expanded={ isOpen }
+								focus={ focus }
+								onFocus={ this.onFocus }
+								onBlur={ this.onBlur }
+							/>
+							<BlockRemoveButton uids={ uids } />
+						</Fragment>
+					);
 				} }
 				renderContent={ ( { onClose } ) => (
 				// Should this just use a DropdownMenu instead of a DropDown ?

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -69,7 +69,6 @@ export class BlockSettingsMenu extends Component {
 					} );
 
 					return [
-						<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />,
 						<IconButton
 							className={ toggleClassname }
 							onClick={ () => {
@@ -84,7 +83,8 @@ export class BlockSettingsMenu extends Component {
 							focus={ focus }
 							onFocus={ this.onFocus }
 							onBlur={ this.onBlur }
-						/>
+						/>,
+						<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />
 					];
 				} }
 				renderContent={ ( { onClose } ) => (

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -84,7 +84,7 @@ export class BlockSettingsMenu extends Component {
 							onFocus={ this.onFocus }
 							onBlur={ this.onBlur }
 						/>,
-						<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />
+						<BlockRemoveButton key="remove" uids={ uids } />
 					];
 				} }
 				renderContent={ ( { onClose } ) => (
@@ -93,7 +93,6 @@ export class BlockSettingsMenu extends Component {
 						{ renderBlockMenu( { onClose, children: [
 							count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } role="menuitem" />,
 							count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } role="menuitem" />,
-							<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />,
 							<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } role="menuitem" />,
 							count === 1 && <SharedBlockSettings key="shared-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
 							<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsRole="menuitem" />,

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { IconButton, Dropdown, NavigableMenu } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 
@@ -57,19 +57,20 @@ export class BlockSettingsMenu extends Component {
 		const count = uids.length;
 
 		return (
-			<Dropdown
+			<div
 				className={ classnames( 'editor-block-settings-menu', {
 					'is-visible': isFocused || ! isHidden,
 				} ) }
-				contentClassName="editor-block-settings-menu__popover"
-				position="bottom left"
-				renderToggle={ ( { onToggle, isOpen } ) => {
-					const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
-						'is-opened': isOpen,
-					} );
+			>
+				<Dropdown
+					contentClassName="editor-block-settings-menu__popover"
+					position="bottom left"
+					renderToggle={ ( { onToggle, isOpen } ) => {
+						const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
+							'is-opened': isOpen,
+						} );
 
-					return (
-						<Fragment>
+						return (
 							<IconButton
 								className={ toggleClassname }
 								onClick={ () => {
@@ -85,23 +86,23 @@ export class BlockSettingsMenu extends Component {
 								onFocus={ this.onFocus }
 								onBlur={ this.onBlur }
 							/>
-							<BlockRemoveButton uids={ uids } />
-						</Fragment>
-					);
-				} }
-				renderContent={ ( { onClose } ) => (
-				// Should this just use a DropdownMenu instead of a DropDown ?
-					<NavigableMenu className="editor-block-settings-menu__content">
-						{ renderBlockMenu( { onClose, children: [
-							count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } role="menuitem" />,
-							count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } role="menuitem" />,
-							<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } role="menuitem" />,
-							count === 1 && <SharedBlockSettings key="shared-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
-							<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsRole="menuitem" />,
-						] } ) }
-					</NavigableMenu>
-				) }
-			/>
+						);
+					} }
+					renderContent={ ( { onClose } ) => (
+						// Should this just use a DropdownMenu instead of a DropDown ?
+						<NavigableMenu className="editor-block-settings-menu__content">
+							{ renderBlockMenu( { onClose, children: [
+								count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } role="menuitem" />,
+								count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } role="menuitem" />,
+								<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } role="menuitem" />,
+								count === 1 && <SharedBlockSettings key="shared-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
+								<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsRole="menuitem" />,
+							] } ) }
+						</NavigableMenu>
+					) }
+				/>
+				<BlockRemoveButton uids={ uids } />
+			</div>
 		);
 	}
 }

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -68,7 +68,8 @@ export class BlockSettingsMenu extends Component {
 						'is-opened': isOpen,
 					} );
 
-					return (
+					return [
+						<BlockRemoveButton key="remove" uids={ uids } role="menuitem" />,
 						<IconButton
 							className={ toggleClassname }
 							onClick={ () => {
@@ -84,7 +85,7 @@ export class BlockSettingsMenu extends Component {
 							onFocus={ this.onFocus }
 							onBlur={ this.onBlur }
 						/>
-					);
+					];
 				} }
 				renderContent={ ( { onClose } ) => (
 				// Should this just use a DropdownMenu instead of a DropDown ?

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -15,7 +15,7 @@
 	height: $block-side-ui-width;
 	border-radius: $button-style__radius-roundrect;
 
-	// Try a background, only for nested situations @todo
+	// Apply a background in nested contexts, only on desktop
 	@include break-small() {
 		.editor-block-list__layout .editor-block-list__layout & {
 			background: $white;
@@ -24,15 +24,12 @@
 			border-width: 1px;
 		}
 	}
-
 }
 
-.editor-block-settings-menu__toggle {
-	.dashicon {
-		transform: rotate( 90deg );
-	}
+.editor-block-settings-menu__toggle .dashicon {
+	transform: rotate( 90deg );
 }
-
+	
 // Popout menu
 .editor-block-settings-menu__popover {
 	z-index: z-index( '.editor-block-settings-menu__popover' );

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -7,11 +7,12 @@
 }
 
 // The Blocks "More" Menu ellipsis icon button
+.editor-block-settings-remove,
 .editor-block-settings-menu__toggle {
 	justify-content: center;
 	padding: 0;
 	width: $block-side-ui-width;
-	height: $block-side-ui-width * 2;	// same height as a single line of text, our smallest block
+	height: $block-side-ui-width;
 	border-radius: $button-style__radius-roundrect;
 
 	// Try a background, only for nested situations @todo
@@ -24,6 +25,9 @@
 		}
 	}
 
+}
+
+.editor-block-settings-menu__toggle {
 	.dashicon {
 		transform: rotate( 90deg );
 	}

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -12,6 +12,7 @@
 	padding: 0;
 	width: $block-side-ui-width;
 	height: $block-side-ui-width * 2;	// same height as a single line of text, our smallest block
+	border-radius: $button-style__radius-roundrect;
 
 	// Try a background, only for nested situations @todo
 	@include break-small() {


### PR DESCRIPTION
This PR optimizes and refines the side UI. In doing so, it fixes #5400 and #4223 by making the arrows visually bigger. It also simplifies the hover styles and improves mobile in the process.

These are now essentially "icon buttons", in that they have the same hover, click and border radius style. Although the buttons are only slightly bigger, the visually bigger hit area makes it _feel_ more clickable as well.

![refine side ui](https://user-images.githubusercontent.com/1204802/38673180-d385e57a-3e50-11e8-958e-f25bca69c21c.gif)

As you can see, I also snuck in a trash button. Let me know your thoughts on that — it's easy to remove and restore later on, if we need to do that to ship the other enhancements, but it's very nice to have it surfaced there, and brings with it a nice consistency with mobile. 