### PR TITLE
Editor Module: Replace connect usage with withSelect/withDispatch (1st round)

### DIFF
--- a/editor/components/autosave-monitor/index.js
+++ b/editor/components/autosave-monitor/index.js
@@ -1,21 +1,8 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { autosave } from '../../store/actions';
-import {
-	isEditedPostDirty,
-	isEditedPostSaveable,
-} from '../../store/selectors';
+import { Component, compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 export class AutosaveMonitor extends Component {
 	componentDidUpdate( prevProps ) {
@@ -46,12 +33,16 @@ export class AutosaveMonitor extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
-		return {
-			isDirty: isEditedPostDirty( state ),
-			isSaveable: isEditedPostSaveable( state ),
-		};
-	},
-	{ autosave }
-)( AutosaveMonitor );
+export default compose( [
+	withSelect(
+		( select ) => {
+			const { isEditedPostDirty, isEditedPostSaveable } = select( 'core/editor' );
+			return {
+				isDirty: isEditedPostDirty(),
+				isSaveable: isEditedPostSaveable(),
+			};
+		} ),
+	withDispatch( ( dispatch ) => ( {
+		autosave: dispatch( 'core/editor' ).autosave,
+	} ) ),
+] )( AutosaveMonitor );

--- a/editor/components/autosave-monitor/index.js
+++ b/editor/components/autosave-monitor/index.js
@@ -34,14 +34,13 @@ export class AutosaveMonitor extends Component {
 }
 
 export default compose( [
-	withSelect(
-		( select ) => {
-			const { isEditedPostDirty, isEditedPostSaveable } = select( 'core/editor' );
-			return {
-				isDirty: isEditedPostDirty(),
-				isSaveable: isEditedPostSaveable(),
-			};
-		} ),
+	withSelect( ( select ) => {
+		const { isEditedPostDirty, isEditedPostSaveable } = select( 'core/editor' );
+		return {
+			isDirty: isEditedPostDirty(),
+			isSaveable: isEditedPostSaveable(),
+		};
+	} ),
 	withDispatch( ( dispatch ) => ( {
 		autosave: dispatch( 'core/editor' ).autosave,
 	} ) ),

--- a/editor/components/block-inspector/index.js
+++ b/editor/components/block-inspector/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { isEmpty } from 'lodash';
-import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
@@ -15,13 +14,13 @@ import {
 	InspectorAdvancedControls,
 } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
 import SkipToSelectedBlock from '../skip-to-selected-block';
-import { getSelectedBlock, getSelectedBlockCount } from '../../store/selectors';
 
 const BlockInspector = ( { selectedBlock, count } ) => {
 	if ( count > 1 ) {
@@ -60,11 +59,12 @@ const BlockInspector = ( { selectedBlock, count } ) => {
 	];
 };
 
-export default connect(
-	( state ) => {
+export default withSelect(
+	( select ) => {
+		const { getSelectedBlock, getSelectedBlockCount } = select( 'core/editor' );
 		return {
-			selectedBlock: getSelectedBlock( state ),
-			count: getSelectedBlockCount( state ),
+			selectedBlock: getSelectedBlock(),
+			count: getSelectedBlockCount(),
 		};
 	}
 )( BlockInspector );

--- a/editor/components/block-list/block-html.js
+++ b/editor/components/block-list/block-html.js
@@ -1,21 +1,16 @@
-/**
- * WordPress Dependencies
- */
-import { isEqual } from 'lodash';
-import { Component } from '@wordpress/element';
-import { getBlockAttributes, getBlockContent, getBlockType, isValidBlock } from '@wordpress/blocks';
 
 /**
  * External Dependencies
  */
-import { connect } from 'react-redux';
 import TextareaAutosize from 'react-autosize-textarea';
+import { isEqual } from 'lodash';
 
 /**
- * Internal Dependencies
+ * WordPress Dependencies
  */
-import { updateBlock } from '../../store/actions';
-import { getBlock } from '../../store/selectors';
+import { Component, compose } from '@wordpress/element';
+import { getBlockAttributes, getBlockContent, getBlockType, isValidBlock } from '@wordpress/blocks';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 class BlockHTML extends Component {
 	constructor( props ) {
@@ -59,13 +54,13 @@ class BlockHTML extends Component {
 	}
 }
 
-export default connect(
-	( state, ownProps ) => ( {
-		block: getBlock( state, ownProps.uid ),
-	} ),
-	{
+export default compose( [
+	withSelect( ( select, ownProps ) => ( {
+		block: select( 'core/editor' ).getBlock( ownProps.uid ),
+	} ) ),
+	withDispatch( dispatch => ( {
 		onChange( uid, attributes, originalContent, isValid ) {
-			return updateBlock( uid, { attributes, originalContent, isValid } );
+			dispatch( 'core/editor' ).updateBlock( uid, { attributes, originalContent, isValid } );
 		},
-	}
-)( BlockHTML );
+	} ) ),
+] )( BlockHTML );

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -51,16 +51,17 @@ export default compose(
 		const insertIndex = blockIndex;
 		const insertionPoint = getBlockInsertionPoint();
 		const block = uid ? getBlock( uid ) : null;
-
-		return {
-			showInsertionPoint: (
-				isBlockInsertionPointVisible() &&
+		const showInsertionPoint = (
+			isBlockInsertionPointVisible() &&
 			insertionPoint.index === insertIndex &&
 			insertionPoint.rootUID === rootUID &&
 			( ! block || ! isUnmodifiedDefaultBlock( block ) )
-			),
+		);
+
+		return {
 			showInserter: ! isTyping(),
 			index: insertIndex,
+			showInsertionPoint,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -1,36 +1,18 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
 import { ifCondition, withContext } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import {
-	getBlockIndex,
-	getBlockInsertionPoint,
-	isBlockInsertionPointVisible,
-	getBlock,
-	isTyping,
-} from '../../store/selectors';
-import {
-	insertDefaultBlock,
-	startTyping,
-} from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 class BlockInsertionPoint extends Component {
 	constructor() {
 		super( ...arguments );
 		this.onClick = this.onClick.bind( this );
 	}
+
 	onClick() {
 		const { layout, rootUID, index, ...props } = this.props;
 		props.insertDefaultBlock( { layout }, rootUID, index );
@@ -57,24 +39,35 @@ class BlockInsertionPoint extends Component {
 export default compose(
 	withContext( 'editor' )( ( { templateLock } ) => ( { templateLock } ) ),
 	ifCondition( ( { templateLock } ) => ! templateLock ),
-	connect(
-		( state, { uid, rootUID } ) => {
-			const blockIndex = uid ? getBlockIndex( state, uid, rootUID ) : -1;
-			const insertIndex = blockIndex;
-			const insertionPoint = getBlockInsertionPoint( state );
-			const block = uid ? getBlock( state, uid ) : null;
+	withSelect( ( select, { uid, rootUID } ) => {
+		const {
+			getBlockIndex,
+			getBlockInsertionPoint,
+			getBlock,
+			isBlockInsertionPointVisible,
+			isTyping,
+		} = select( 'core/editor' );
+		const blockIndex = uid ? getBlockIndex( uid, rootUID ) : -1;
+		const insertIndex = blockIndex;
+		const insertionPoint = getBlockInsertionPoint();
+		const block = uid ? getBlock( uid ) : null;
 
-			return {
-				showInsertionPoint: (
-					isBlockInsertionPointVisible( state ) &&
-				insertionPoint.index === insertIndex &&
-				insertionPoint.rootUID === rootUID &&
-				( ! block || ! isUnmodifiedDefaultBlock( block ) )
-				),
-				showInserter: ! isTyping( state ),
-				index: insertIndex,
-			};
-		},
-		{ insertDefaultBlock, startTyping }
-	)
+		return {
+			showInsertionPoint: (
+				isBlockInsertionPointVisible() &&
+			insertionPoint.index === insertIndex &&
+			insertionPoint.rootUID === rootUID &&
+			( ! block || ! isUnmodifiedDefaultBlock( block ) )
+			),
+			showInserter: ! isTyping(),
+			index: insertIndex,
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { insertDefaultBlock, startTyping } = dispatch( 'core/editor' );
+		return {
+			insertDefaultBlock,
+			startTyping,
+		};
+	} )
 )( BlockInsertionPoint );

--- a/editor/components/block-list/invalid-block-warning.js
+++ b/editor/components/block-list/invalid-block-warning.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -13,11 +8,11 @@ import {
 	createBlock,
 	rawHandler,
 } from '@wordpress/blocks';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { replaceBlock } from '../../store/actions';
 import Warning from '../warning';
 
 function InvalidBlockWarning( { convertToHTML, convertToBlocks } ) {
@@ -41,19 +36,19 @@ function InvalidBlockWarning( { convertToHTML, convertToBlocks } ) {
 	);
 }
 
-export default connect(
-	null,
-	( dispatch, { block } ) => ( {
+export default withDispatch( ( dispatch, { block } ) => {
+	const { replaceBlock } = dispatch( 'core/editor' );
+	return {
 		convertToHTML() {
-			dispatch( replaceBlock( block.uid, createBlock( 'core/html', {
+			replaceBlock( block.uid, createBlock( 'core/html', {
 				content: block.originalContent,
-			} ) ) );
+			} ) );
 		},
 		convertToBlocks() {
-			dispatch( replaceBlock( block.uid, rawHandler( {
+			replaceBlock( block.uid, rawHandler( {
 				HTML: block.originalContent,
 				mode: 'BLOCKS',
-			} ) ) );
+			} ) );
 		},
-	} )
-)( InvalidBlockWarning );
+	};
+} )( InvalidBlockWarning );

--- a/editor/components/block-list/multi-controls.js
+++ b/editor/components/block-list/multi-controls.js
@@ -1,20 +1,18 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { first, last } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import BlockMover from '../block-mover';
 import BlockSettingsMenu from '../block-settings-menu';
-import {
-	getMultiSelectedBlockUids,
-	isMultiSelecting,
-	getBlockIndex,
-	getBlockCount,
-} from '../../store/selectors';
 
 function BlockListMultiControls( { multiSelectedBlockUids, rootUID, isSelecting, isFirst, isLast } ) {
 	if ( isSelecting ) {
@@ -38,17 +36,21 @@ function BlockListMultiControls( { multiSelectedBlockUids, rootUID, isSelecting,
 	];
 }
 
-export default connect( ( state, ownProps ) => {
-	const { rootUID } = ownProps;
-	const uids = getMultiSelectedBlockUids( state );
-
-	const firstIndex = getBlockIndex( state, first( uids ), rootUID );
-	const lastIndex = getBlockIndex( state, last( uids ), rootUID );
+export default withSelect( ( select, { rootUID } ) => {
+	const {
+		getMultiSelectedBlockUids,
+		isMultiSelecting,
+		getBlockIndex,
+		getBlockCount,
+	} = select( 'core/editor' );
+	const uids = getMultiSelectedBlockUids();
+	const firstIndex = getBlockIndex( first( uids ), rootUID );
+	const lastIndex = getBlockIndex( last( uids ), rootUID );
 
 	return {
 		multiSelectedBlockUids: uids,
-		isSelecting: isMultiSelecting( state ),
+		isSelecting: isMultiSelecting(),
 		isFirst: firstIndex === 0,
-		isLast: lastIndex + 1 === getBlockCount( state ),
+		isLast: lastIndex + 1 === getBlockCount(),
 	};
 } )( BlockListMultiControls );

--- a/editor/components/block-settings-menu/block-mode-toggle.js
+++ b/editor/components/block-settings-menu/block-mode-toggle.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { noop } from 'lodash';
 
 /**
@@ -10,12 +9,8 @@ import { noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
-import { getBlockMode, getBlock } from '../../store/selectors';
-import { toggleBlockMode } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, role } ) {
 	if ( ! hasBlockSupport( blockType, 'html', true ) ) {
@@ -39,19 +34,20 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false,
 	);
 }
 
-export default connect(
-	( state, { uid } ) => {
-		const block = getBlock( state, uid );
+export default compose( [
+	withSelect( ( select, { uid } ) => {
+		const { getBlock, getBlockMode } = select( 'core/editor' );
+		const block = getBlock( uid );
 
 		return {
-			mode: getBlockMode( state, uid ),
+			mode: getBlockMode( uid ),
 			blockType: block ? getBlockType( block.name ) : null,
 		};
-	},
-	( dispatch, { onToggle = noop, uid } ) => ( {
+	} ),
+	withDispatch( ( dispatch, { onToggle = noop, uid } ) => ( {
 		onToggleMode() {
-			dispatch( toggleBlockMode( uid ) );
+			dispatch( 'core/editor' ).toggleBlockMode( uid );
 			onToggle();
 		},
-	} )
-)( BlockModeToggle );
+	} ) ),
+] )( BlockModeToggle );

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { flow, noop } from 'lodash';
 
 /**
@@ -10,11 +9,7 @@ import { flow, noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { IconButton, withContext } from '@wordpress/components';
 import { compose } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { removeBlocks } from '../../store/actions';
+import { withDispatch } from '@wordpress/data';
 
 export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small = false, role } ) {
 	if ( isLocked ) {
@@ -37,14 +32,11 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, small =
 }
 
 export default compose(
-	connect(
-		undefined,
-		( dispatch, ownProps ) => ( {
-			onRemove() {
-				dispatch( removeBlocks( ownProps.uids ) );
-			},
-		} )
-	),
+	withDispatch( ( dispatch, { uids } ) => ( {
+		onRemove() {
+			dispatch( 'core/editor' ).removeBlocks( uids );
+		},
+	} ) ),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;
 

--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { noop } from 'lodash';
 
 /**
@@ -11,13 +10,12 @@ import { __ } from '@wordpress/i18n';
 import { IconButton, withContext } from '@wordpress/components';
 import { getPossibleBlockTransformations, switchToBlockType } from '@wordpress/blocks';
 import { compose, Fragment } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { getBlock } from '../../store/selectors';
-import { replaceBlocks } from '../../store/actions';
 
 function BlockTransformations( { blocks, small = false, onTransform, onClick = noop, isLocked, itemsRole } ) {
 	const possibleBlockTransformations = getPossibleBlockTransformations( blocks );
@@ -53,21 +51,19 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 	);
 }
 export default compose(
-	connect(
-		( state, ownProps ) => {
-			return {
-				blocks: ownProps.uids.map( ( uid ) => getBlock( state, uid ) ),
-			};
+	withSelect( ( select, ownProps ) => {
+		return {
+			blocks: ownProps.uids.map( ( uid ) => select( 'core/editor' ).getBlock( uid ) ),
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => ( {
+		onTransform( blocks, name ) {
+			dispatch( 'core/editor' ).replaceBlocks(
+				ownProps.uids,
+				switchToBlockType( blocks, name )
+			);
 		},
-		( dispatch, ownProps ) => ( {
-			onTransform( blocks, name ) {
-				dispatch( replaceBlocks(
-					ownProps.uids,
-					switchToBlockType( blocks, name )
-				) );
-			},
-		} )
-	),
+	} ) ),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;
 

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
@@ -10,6 +9,7 @@ import { connect } from 'react-redux';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { IconButton, Dropdown, NavigableMenu } from '@wordpress/components';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,7 +21,6 @@ import BlockDuplicateButton from './block-duplicate-button';
 import BlockTransformations from './block-transformations';
 import SharedBlockSettings from './shared-block-settings';
 import UnknownConverter from './unknown-converter';
-import { selectBlock } from '../../store/actions';
 
 export class BlockSettingsMenu extends Component {
 	constructor() {
@@ -105,11 +104,8 @@ export class BlockSettingsMenu extends Component {
 	}
 }
 
-export default connect(
-	undefined,
-	( dispatch ) => ( {
-		onSelect( uid ) {
-			dispatch( selectBlock( uid ) );
-		},
-	} )
-)( BlockSettingsMenu );
+export default withDispatch( ( dispatch ) => ( {
+	onSelect( uid ) {
+		dispatch( 'core/editor' ).selectBlock( uid );
+	},
+} ) )( BlockSettingsMenu );

--- a/editor/components/block-settings-menu/shared-block-settings.js
+++ b/editor/components/block-settings-menu/shared-block-settings.js
@@ -75,11 +75,11 @@ export default compose( [
 				onToggle();
 			},
 			onDelete( id ) {
-			// TODO: Make this a <Confirm /> component or similar
-			// eslint-disable-next-line no-alert
+				// TODO: Make this a <Confirm /> component or similar
+				// eslint-disable-next-line no-alert
 				const hasConfirmed = window.confirm( __(
 					'Are you sure you want to delete this Shared Block?\n\n' +
-				'It will be permanently removed from all posts and pages that use it.'
+					'It will be permanently removed from all posts and pages that use it.'
 				) );
 
 				if ( hasConfirmed ) {

--- a/editor/components/block-settings-menu/shared-block-settings.js
+++ b/editor/components/block-settings-menu/shared-block-settings.js
@@ -1,22 +1,16 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
+import { Fragment, compose } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isSharedBlock } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
-import { getBlock, getSharedBlock } from '../../store/selectors';
-import { convertBlockToStatic, convertBlockToShared, deleteSharedBlock } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 export function SharedBlockSettings( { sharedBlock, onConvertToStatic, onConvertToShared, onDelete, itemsRole } ) {
 	return (
@@ -56,34 +50,43 @@ export function SharedBlockSettings( { sharedBlock, onConvertToStatic, onConvert
 	);
 }
 
-export default connect(
-	( state, { uid } ) => {
-		const block = getBlock( state, uid );
+export default compose( [
+	withSelect( ( select, { uid } ) => {
+		const { getBlock, getSharedBlock } = select( 'core/editor' );
+		const block = getBlock( uid );
 		return {
-			sharedBlock: isSharedBlock( block ) ? getSharedBlock( state, block.attributes.ref ) : null,
+			sharedBlock: block && isSharedBlock( block ) ? getSharedBlock( block.attributes.ref ) : null,
 		};
-	},
-	( dispatch, { uid, onToggle = noop } ) => ( {
-		onConvertToStatic() {
-			dispatch( convertBlockToStatic( uid ) );
-			onToggle();
-		},
-		onConvertToShared() {
-			dispatch( convertBlockToShared( uid ) );
-			onToggle();
-		},
-		onDelete( id ) {
+	} ),
+	withDispatch( ( dispatch, { uid, onToggle = noop } ) => {
+		const {
+			convertBlockToShared,
+			convertBlockToStatic,
+			deleteSharedBlock,
+		} = dispatch( 'core/editor' );
+
+		return {
+			onConvertToStatic() {
+				convertBlockToStatic( uid );
+				onToggle();
+			},
+			onConvertToShared() {
+				convertBlockToShared( uid );
+				onToggle();
+			},
+			onDelete( id ) {
 			// TODO: Make this a <Confirm /> component or similar
 			// eslint-disable-next-line no-alert
-			const hasConfirmed = window.confirm( __(
-				'Are you sure you want to delete this Shared Block?\n\n' +
+				const hasConfirmed = window.confirm( __(
+					'Are you sure you want to delete this Shared Block?\n\n' +
 				'It will be permanently removed from all posts and pages that use it.'
-			) );
+				) );
 
-			if ( hasConfirmed ) {
-				dispatch( deleteSharedBlock( id ) );
-				onToggle();
-			}
-		},
-	} )
-)( SharedBlockSettings );
+				if ( hasConfirmed ) {
+					deleteSharedBlock( id );
+					onToggle();
+				}
+			},
+		};
+	} ),
+] )( SharedBlockSettings );

--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -11,12 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { IconButton, withAPIData } from '@wordpress/components';
 import { getUnknownTypeHandlerName, rawHandler, serialize } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { getBlock, getCurrentPostType } from '../../store/selectors';
-import { replaceBlocks } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 export function UnknownConverter( { block, onReplace, small, user, role } ) {
 	if ( ! block || getUnknownTypeHandlerName() !== block.name ) {
@@ -47,15 +41,16 @@ export function UnknownConverter( { block, onReplace, small, user, role } ) {
 }
 
 export default compose(
-	connect(
-		( state, { uid } ) => ( {
-			block: getBlock( state, uid ),
-			postType: getCurrentPostType( state ),
-		} ),
-		{
-			onReplace: replaceBlocks,
-		}
-	),
+	withSelect( ( select, { uid } ) => {
+		const { getBlock, getCurrentPostType } = select( 'core/editor' );
+		return {
+			block: getBlock( uid ),
+			postType: getCurrentPostType(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		onReplace: dispatch( 'core/editor' ).replaceBlocks,
+	} ) ),
 	withAPIData( ( { postType } ) => ( {
 		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 	} ) ),

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -11,13 +6,12 @@ import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu, withContext } f
 import { getBlockType, getPossibleBlockTransformations, switchToBlockType, BlockIcon } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { replaceBlocks } from '../../store/actions';
-import { getBlock } from '../../store/selectors';
 
 /**
  * Module Constants
@@ -102,21 +96,19 @@ export function BlockSwitcher( { blocks, onTransform, isLocked } ) {
 }
 
 export default compose(
-	connect(
-		( state, ownProps ) => {
-			return {
-				blocks: ownProps.uids.map( ( uid ) => getBlock( state, uid ) ),
-			};
+	withSelect( ( select, ownProps ) => {
+		return {
+			blocks: ownProps.uids.map( ( uid ) => select( 'core/editor' ).getBlock( uid ) ),
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => ( {
+		onTransform( blocks, name ) {
+			dispatch( 'core/editor' ).replaceBlocks(
+				ownProps.uids,
+				switchToBlockType( blocks, name )
+			);
 		},
-		( dispatch, ownProps ) => ( {
-			onTransform( blocks, name ) {
-				dispatch( replaceBlocks(
-					ownProps.uids,
-					switchToBlockType( blocks, name )
-				) );
-			},
-		} )
-	),
+	} ) ),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;
 

--- a/editor/components/block-switcher/multi-blocks-switcher.js
+++ b/editor/components/block-switcher/multi-blocks-switcher.js
@@ -1,14 +1,13 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { connect } from 'react-redux';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import BlockSwitcher from './';
-import { getMultiSelectedBlockUids } from '../../store/selectors';
 
 export function MultiBlocksSwitcher( { isMultiBlockSelection, selectedBlockUids } ) {
 	if ( ! isMultiBlockSelection ) {
@@ -19,9 +18,9 @@ export function MultiBlocksSwitcher( { isMultiBlockSelection, selectedBlockUids 
 	);
 }
 
-export default connect(
-	( state ) => {
-		const selectedBlockUids = getMultiSelectedBlockUids( state );
+export default withSelect(
+	( select ) => {
+		const selectedBlockUids = select( 'core/editor' ).getMultiSelectedBlockUids();
 		return {
 			isMultiBlockSelection: selectedBlockUids.length > 1,
 			selectedBlockUids,

--- a/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
+++ b/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MultiBlocksSwitcher should return a BlockSwitcher element matching the snapshot. 1`] = `
-<Connect(WrappedComponent)
+<WithSelect(WithDispatch(WrappedComponent))
   key="switcher"
   uids={
     Array [

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -1,19 +1,14 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress Dependencies
  */
 import { Slot } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
 import BlockSwitcher from '../block-switcher';
-import { getBlockMode, getSelectedBlock } from '../../store/selectors';
 
 function BlockToolbar( { block, mode } ) {
 	if ( ! block || ! block.isValid || mode !== 'visual' ) {
@@ -29,11 +24,12 @@ function BlockToolbar( { block, mode } ) {
 	);
 }
 
-export default connect( ( state ) => {
-	const block = getSelectedBlock( state );
+export default withSelect( ( select ) => {
+	const { getSelectedBlock, getBlockMode } = select( 'core/editor' );
+	const block = getSelectedBlock();
 
-	return ( {
+	return {
 		block,
-		mode: block ? getBlockMode( state, block.uid ) : null,
-	} );
+		mode: block ? getBlockMode( block.uid ) : null,
+	};
 } )( BlockToolbar );

--- a/editor/components/copy-handler/index.js
+++ b/editor/components/copy-handler/index.js
@@ -1,24 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { serialize } from '@wordpress/blocks';
 import { documentHasSelection } from '@wordpress/utils';
-
-/**
- * Internal dependencies
- */
-import { removeBlocks } from '../../store/actions';
-import {
-	getMultiSelectedBlocks,
-	getMultiSelectedBlockUids,
-	getSelectedBlock,
-} from '../../store/selectors';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 class CopyHandler extends Component {
 	constructor() {
@@ -73,13 +59,20 @@ class CopyHandler extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			getMultiSelectedBlocks,
+			getMultiSelectedBlockUids,
+			getSelectedBlock,
+		} = select( 'core/editor' );
 		return {
-			multiSelectedBlocks: getMultiSelectedBlocks( state ),
-			multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
-			selectedBlock: getSelectedBlock( state ),
+			multiSelectedBlocks: getMultiSelectedBlocks(),
+			multiSelectedBlockUids: getMultiSelectedBlockUids(),
+			selectedBlock: getSelectedBlock(),
 		};
-	},
-	{ onRemove: removeBlocks },
-)( CopyHandler );
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		onRemove: dispatch( 'core/editor' ).removeBlocks,
+	} ) ),
+] )( CopyHandler );

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -12,14 +11,13 @@ import { compose } from '@wordpress/element';
 import { getDefaultBlockName } from '@wordpress/blocks';
 import { withContext } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/utils';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import BlockDropZone from '../block-drop-zone';
-import { insertDefaultBlock, startTyping } from '../../store/actions';
-import { getBlock, getBlockCount } from '../../store/selectors';
 import InserterWithShortcuts from '../inserter-with-shortcuts';
 import Inserter from '../inserter';
 
@@ -60,18 +58,26 @@ export function DefaultBlockAppender( {
 	);
 }
 export default compose(
-	connect(
-		( state, ownProps ) => {
-			const isEmpty = ! getBlockCount( state, ownProps.rootUID );
-			const lastBlock = getBlock( state, ownProps.lastBlockUID );
-			const isLastBlockDefault = get( lastBlock, 'name' ) === getDefaultBlockName();
+	withSelect( ( select, ownProps ) => {
+		const {
+			getBlockCount,
+			getBlock,
+		} = select( 'core/editor' );
+		const isEmpty = ! getBlockCount( ownProps.rootUID );
+		const lastBlock = getBlock( ownProps.lastBlockUID );
+		const isLastBlockDefault = get( lastBlock, 'name' ) === getDefaultBlockName();
 
-			return {
-				isVisible: isEmpty || ! isLastBlockDefault,
-				showPrompt: isEmpty,
-			};
-		},
-		( dispatch, ownProps ) => ( {
+		return {
+			isVisible: isEmpty || ! isLastBlockDefault,
+			showPrompt: isEmpty,
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		const {
+			insertDefaultBlock,
+			startTyping,
+		} = dispatch( 'core/editor' );
+		return {
 			onAppend() {
 				const { layout, rootUID } = ownProps;
 
@@ -80,11 +86,11 @@ export default compose(
 					attributes = { layout };
 				}
 
-				dispatch( insertDefaultBlock( attributes, rootUID ) );
-				dispatch( startTyping() );
+				insertDefaultBlock( attributes, rootUID );
+				startTyping();
 			},
-		} )
-	),
+		};
+	} ),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock, bodyPlaceholder } = settings;
 

--- a/editor/components/document-outline/check.js
+++ b/editor/components/document-outline/check.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { filter } from 'lodash';
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import { getBlocks } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 function DocumentOutlineCheck( { blocks, children } ) {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
@@ -19,8 +18,6 @@ function DocumentOutlineCheck( { blocks, children } ) {
 	return children;
 }
 
-export default connect(
-	( state ) => ( {
-		blocks: getBlocks( state ),
-	} )
-)( DocumentOutlineCheck );
+export default withSelect( ( select ) => ( {
+	blocks: select( 'core/editor' ).getBlocks(),
+} ) )( DocumentOutlineCheck );

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -209,6 +209,28 @@ export function replaceBlock( uid, block ) {
 }
 
 /**
+ * Action creator creator which, given the action type to dispatch
+ * creates a prop dispatcher callback for
+ * managing block movement.
+ *
+ * @param {string}   type     Action type to dispatch.
+ *
+ * @return {Function} Prop dispatcher callback.
+ */
+function createOnMove( type ) {
+	return ( uids, rootUID ) => {
+		return {
+			type,
+			uids,
+			rootUID,
+		};
+	};
+}
+
+export const moveBlocksDown = createOnMove( 'MOVE_BLOCKS_DOWN' );
+export const moveBlocksUp = createOnMove( 'MOVE_BLOCKS_UP' );
+
+/**
  * Returns an action object signalling that an indexed block should be moved
  * to a new index.
  *


### PR DESCRIPTION
Just getting rid of some legacy. and to avoid huge PRs, I'm updating 20 components in this first round. There's 45 remaining usage of `connect` in the editor module.

**Testing instructions**

Check that:
 
 - autosaves triggers
 - the block movers work
 - the block toolbar work
 - the block settings menu work
 - the in between inserter works
 - the default appender works.
 - the block inspector works
 - multiselection works
 - transformations work.

I already tested everything, so it should be ok. I'm willing to merge this pretty quickly to avoid a lot of conflicts.