### PR TITLE
Update inline "code" background when part of multiselection.

### DIFF
--- a/blocks/rich-text/style.scss
+++ b/blocks/rich-text/style.scss
@@ -37,6 +37,10 @@
 		background: $light-gray-200;
 		font-family: $editor-html-font;
 		font-size: 14px;
+
+		.is-multi-selected & {
+			background: darken( $blue-medium-highlight, 15% );
+		}
 	}
 
 	&:focus code[data-mce-selected] {


### PR DESCRIPTION
Small improvement to how we display inline code within a multi-selected group.

Before:
![image](https://user-images.githubusercontent.com/548849/38678209-b105a336-3e60-11e8-85e1-c7e7ca5ebe19.png)

After:
![image](https://user-images.githubusercontent.com/548849/38678174-940f5f1a-3e60-11e8-8569-adde4b2fa2f8.png)
