### PR TITLE
Make the navigateRegions shortcuts work from anywhere.

### DIFF
--- a/components/higher-order/navigate-regions/index.js
+++ b/components/higher-order/navigate-regions/index.js
@@ -62,10 +62,13 @@ function navigateRegions( WrappedComponent ) {
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 			return (
 				<div ref={ this.bindContainer } className={ className } onClick={ this.onClick }>
-					<KeyboardShortcuts shortcuts={ {
-						'ctrl+`': this.focusNextRegion,
-						'ctrl+shift+`': this.focusPreviousRegion,
-					} } />
+					<KeyboardShortcuts
+						bindGlobal
+						shortcuts={ {
+							'ctrl+`': this.focusNextRegion,
+							'ctrl+shift+`': this.focusPreviousRegion,
+						} }
+					/>
 					<WrappedComponent { ...this.props } />
 				</div>
 			);


### PR DESCRIPTION
This PR simply adds the prop `bindGlobal` to the navigable regions keyboard shortcuts (`Ctrl+backtick`) to make them work also from the contenteditable areas, input fields, and textareas.

Keyboard users would greatly benefit from being able to jump through the main editor region at any moment. For example, when editing a paragraph they can now jump to the sidebar and enable the drop cap. This wasn't possible before because tabbing away from the paragraph selected another block.

Reference:
https://craig.is/killing/mice#api.bind.text-fields
https://github.com/ccampbell/mousetrap/tree/master/plugins/global-bind

Fixes #5847 