### PR TITLE
Update CodeEditor extensibility

### DIFF
--- a/components/code-editor/README.md
+++ b/components/code-editor/README.md
@@ -57,7 +57,7 @@ editor. It is passed the new value as an argument.
 
 ### settings
 
-Used to setup the Code Editor and includes options for linting and CodeMirror. By default this will use window._wpGutenbergCodeEditorSettings.
+Used to setup the Code Editor and includes options for linting and CodeMirror. By default this will use `window._wpGutenbergCodeEditorSettings`.
 
 - Type: `Object`
 - Required: No

--- a/components/code-editor/README.md
+++ b/components/code-editor/README.md
@@ -54,3 +54,21 @@ editor. It is passed the new value as an argument.
 
 - Type: `Function`
 - Required: No
+
+### settings
+
+Used to setup the Code Editor and includes options for linting and CodeMirror. By default this will use window._wpGutenbergCodeEditorSettings.
+
+- Type: `Object`
+- Required: No
+
+### editorRef
+
+A reference to the initialized editor so that it can be dynamically updated from a parent component:
+
+`editorRef={ ( ref ) => this.editorInstance = ref }`
+
+This allows an external component to make changes to the code editor by modifying or updating `this.editorInstance`.
+
+- Type `Function`
+- Required: No

--- a/components/code-editor/README.md
+++ b/components/code-editor/README.md
@@ -57,18 +57,32 @@ editor. It is passed the new value as an argument.
 
 ### settings
 
-Used to setup the Code Editor and includes options for linting and CodeMirror. By default this will use `window._wpGutenbergCodeEditorSettings`.
+The settings object used to intialize the WordPress code editor. The object contains all of the settings for the editor, including specific settings for CodeMirror. This object is passed into `wp.codeEditor.intialize()`. If you do not specify a settings object, `window._wpGutenbergCodeEditorSettings` will be used instead.
+
+If you are extending `window._wpGutenbergCodeEditorSettings` make sure to clone the object using `Object.assign` or something similar instead of modifying it directly so the default settings remain the same.
+
+```
+const settings = Object.assign(  {
+	codemirror: {
+		mode: css,
+		lint: false,
+	} },
+	window._wpGutenbergCodeEditorSetting
+);
+```
 
 - Type: `Object`
 - Required: No
 
 ### editorRef
 
-A reference to the initialized editor so that it can be dynamically updated from a parent component:
+A reference to the instance of CodeMirror intiailized when the editor is loaded so that it can be dynamically updated from a parent component.
 
 `editorRef={ ( ref ) => this.editorInstance = ref }`
 
-This allows an external component to make changes to the code editor by modifying or updating `this.editorInstance`.
+`this.editorInstance` will contain a full instance of `CodeMirror` which can then be modified or updated from the component it is being reference from using the [CodeMirror API](https://codemirror.net/doc/manual.html#api). For example, to dynamically change the language mode of CodeMirror to CSS you can call:
+
+`this.editorInstance.setOption( 'mode', 'css' );`
 
 - Type `Function`
 - Required: No

--- a/components/code-editor/editor.js
+++ b/components/code-editor/editor.js
@@ -20,7 +20,8 @@ class CodeEditor extends Component {
 	}
 
 	componentDidMount() {
-		const instance = wp.codeEditor.initialize( this.textarea, window._wpGutenbergCodeEditorSettings );
+		const settings = this.props.settings || window._wpGutenbergCodeEditorSettings;
+		const instance = wp.codeEditor.initialize( this.textarea, settings );
 		this.editor = instance.codemirror;
 
 		this.editor.on( 'focus', this.onFocus );
@@ -38,6 +39,10 @@ class CodeEditor extends Component {
 
 		if ( this.props.focus !== prevProps.focus ) {
 			this.updateFocus();
+		}
+
+		if ( this.props.editorUpdate ) {
+			this.props.editorUpdate( this.editor, prevProps );
 		}
 	}
 

--- a/components/code-editor/editor.js
+++ b/components/code-editor/editor.js
@@ -41,6 +41,7 @@ class CodeEditor extends Component {
 			this.updateFocus();
 		}
 
+		// If an editorUpdate prop has been passed down, call it now.
 		if ( this.props.editorUpdate ) {
 			this.props.editorUpdate( this.editor, prevProps );
 		}

--- a/components/code-editor/editor.js
+++ b/components/code-editor/editor.js
@@ -29,6 +29,11 @@ class CodeEditor extends Component {
 		this.editor.on( 'cursorActivity', this.onCursorActivity );
 		this.editor.on( 'keyHandled', this.onKeyHandled );
 
+		// Pass a reference to the editor back up.
+		if ( this.props.editorRef ) {
+			this.props.editorRef( this.editor );
+		}
+
 		this.updateFocus();
 	}
 
@@ -39,11 +44,6 @@ class CodeEditor extends Component {
 
 		if ( this.props.focus !== prevProps.focus ) {
 			this.updateFocus();
-		}
-
-		// If an editorUpdate prop has been passed down, call it now.
-		if ( this.props.editorUpdate ) {
-			this.props.editorUpdate( this.editor, prevProps );
 		}
 	}
 


### PR DESCRIPTION
## Description
This is in reference to the issue I brought up in #6043. It adds two props to the CodeEditor, which are passed from the `LazyCodeEditor` component down to the `CodeEditor` component. The first is `settings` which will let others using this component change the basic settings of CodeMirror. The second is and `editorUpdate` method that will be fired off every time the editor updates, and contains a reference to the editor to itself, as well as its previous props. This allows other authors who want to extend the editor's functionality a bit to be able to do so.

I also think it would be useful to add a similar `editorWillUpdate` prop that is called in the `componentWillUpdate` lifecycle method, but I wanted to ensure that this approach looks good.

## How Has This Been Tested?
- This has been tested in the browser to ensure that an extended version of the component as well as the currently used version of the component in the HTML editor both work
- All tests run and pass
- This will check for the existence of props before it uses anything, so it does not effect existing code.

## Types of changes
Extends CodeMirror

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code has proper inline documentation.
