### PR TITLE
Make the editor switch mode shortcut work from anywhere.

### DIFF
--- a/edit-post/components/keyboard-shortcuts/index.js
+++ b/edit-post/components/keyboard-shortcuts/index.js
@@ -24,9 +24,12 @@ class EditorModeKeyboardShortcuts extends Component {
 
 	render() {
 		return (
-			<KeyboardShortcuts shortcuts={ {
-				[ shortcuts.toggleEditorMode.value ]: this.toggleMode,
-			} } />
+			<KeyboardShortcuts
+				bindGlobal
+				shortcuts={ {
+					[ shortcuts.toggleEditorMode.value ]: this.toggleMode,
+				} }
+			/>
 		);
 	}
 }


### PR DESCRIPTION
This PR makes the keyboard shortcut `mod+shift+alt+m` work from anywhere, even when inside a contenteditable area, input field, and textarea. See also #5847 / #6144.

Keyboard users will benefit from being able to switch editor mode at any time, even when editing content. For example, when they edit content in "Code" mode, focus is in a textarea and now they can quickly switch to "Visual" mode and again to "Code" mode and so on just pressing Command (or Ctrl on WIndows) +shift+alt+m.

A further improvement would be trying to keep the caret position in the Code mode in the block being edited, and vice-versa, as recently implemented in the old WordPress editor.

Fixes #5716