### PR TITLE
Eliminate obsolete call to onChange when RichText componentWillUnmount

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -699,10 +699,6 @@ export class RichText extends Component {
 		return nodeListToReact( this.editor.getBody().childNodes || [], createTinyMCEElement );
 	}
 
-	componentWillUnmount() {
-		this.onChange();
-	}
-
 	componentDidUpdate( prevProps ) {
 		// The `savedContent` var allows us to avoid updating the content right after an `onChange` call
 		if (


### PR DESCRIPTION
Fixes #6134.

When `wp.hooks.addFilter( 'blocks.BlockEdit'… )` is used to extend blocks which contain the `RichEdit` component, this will cause the component to be unmounted and with that `onChange` will be called:

https://github.com/WordPress/gutenberg/blob/004cb8b95a4d7173300bd9142209f2246b7d89e8/blocks/rich-text/index.js#L702-L704

This results in the editor being put into a dirty state upon initialization, even if no changes have been made by the user. This bit of code actually appears to be a remnant of the past, @iseulde in https://github.com/WordPress/gutenberg/issues/6134#issuecomment-380789164:

> Everything should be synced whenever there is a change in the editor. At first sight I think it is fine to remove. It seems to be a remnant from when we only synced the value on blur.

But @youknowriad [adds](https://github.com/WordPress/gutenberg/issues/6134#issuecomment-380791108):

> I agree with this statement, but I'd test carefully the different usecases, of splitting/merging/switching etc... :) fast typing + splitting

I'm not sure how best to go about testing this change, but I wanted to open a PR at least to get the fix off the ground.