### PR TITLE
Remove emoji script

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -162,6 +162,12 @@ function gutenberg_init( $return, $post ) {
 	add_filter( 'screen_options_show_screen', '__return_false' );
 	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
 
+	/**
+	 * Remove the emoji script as it is incompatible with both React and any
+	 * contenteditable fields.
+	 */
+	remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+
 	require_once ABSPATH . 'wp-admin/admin-header.php';
 	the_gutenberg_project();
 


### PR DESCRIPTION
## Description
Fixes #2799.

## How Has This Been Tested?
Ensure the emoji scripts are removed from the Gutenberg pages.