### PR TITLE
Framework: Bump @wordpress/i18n to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -335,9 +335,9 @@
 			"integrity": "sha512-+7s5j296RTXRabaubvNK35ED/+WUYJgM8oeiHWP6RvPGd/2rkei3cI0SNwjBdaRrlNQ22vtzvCfhdDCyb9W1xQ=="
 		},
 		"@wordpress/i18n": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-1.0.0.tgz",
-			"integrity": "sha512-ckdvb9xy2UNmioLItFdT6dZV+h7GgdAIilW0TBz59UAaeM7quJePy4ZNN71CJuJ2PuUctNnnjVw8BBsfsLA3Hw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-1.1.0.tgz",
+			"integrity": "sha512-zzpyhSaVOv5iLIwkJ4nrPt7FO+50xHlGDSJljfGdS+ypvFAnEHpCkkJ84F3NhHaYIIZqMEn5lC4k1edIaIqAbA==",
 			"requires": {
 				"gettext-parser": "1.3.1",
 				"jed": "1.1.1",
@@ -345,15 +345,6 @@
 				"memize": "1.0.5"
 			},
 			"dependencies": {
-				"gettext-parser": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
-					"integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
-					"requires": {
-						"encoding": "0.1.12",
-						"safe-buffer": "5.1.1"
-					}
-				},
 				"lodash": {
 					"version": "4.17.5",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
@@ -6570,6 +6561,15 @@
 			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
+			}
+		},
+		"gettext-parser": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
+			"integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"gh-got": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@wordpress/a11y": "1.0.6",
 		"@wordpress/autop": "1.0.4",
 		"@wordpress/hooks": "1.1.6",
-		"@wordpress/i18n": "1.0.0",
+		"@wordpress/i18n": "1.1.0",
 		"@wordpress/url": "1.0.3",
 		"classnames": "2.2.5",
 		"clipboard": "1.7.1",


### PR DESCRIPTION
This pull request seeks to bump the `@wordpress/i18n` dependency to 1.1.0

[View Changelog](https://github.com/WordPress/packages/releases/tag/%40wordpress%2Fi18n%401.1.0)

__Testing instructions:__

Verify there are no regressions in the behavior of localization.

cc @nerrad