### PR TITLE
E2E testing: Add test for multi-block selection tools

### DIFF
--- a/test/e2e/specs/__snapshots__/multi-block-utilities.test.js.snap
+++ b/test/e2e/specs/__snapshots__/multi-block-utilities.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Multi-block selection Should duplicate a multi-block selection 1`] = `
+"<!-- wp:paragraph -->
+<p>First Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Third Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>First Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Third Paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection Should transform 3 paragraphs into a list 1`] = `
+"<!-- wp:list -->
+<ul>
+    <li>First Paragraph</li>
+    <li>Second Paragraph</li>
+    <li>Third Paragraph</li>
+</ul>
+<!-- /wp:list -->"
+`;

--- a/test/e2e/specs/multi-block-utilities.test.js
+++ b/test/e2e/specs/multi-block-utilities.test.js
@@ -27,21 +27,21 @@ describe( 'Multi-block selection', () => {
 
 		// Transform blocks into list
 		await page.click( '.editor-block-settings-menu' );
-		let listButton = ( await page.$x( '//button[contains(text(), \'List\')]' ) )[ 0 ];
+		const listButton = ( await page.$x( '//button[contains(text(), \'List\')]' ) )[ 0 ];
 		await listButton.click( 'button' );
 
 		//Switch to Code Editor to check HTML output
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
 		await codeEditorButton.click( 'button' );
 
 		//Assert that there is only 1 list block
-		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
 		expect( textEditorContent ).toMatchSnapshot();
 
 		//Switch to Visual Editor to continue testing
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
+		const visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
 		await visualEditorButton.click( 'button' );
 		await page.close();
 	} );
@@ -58,8 +58,8 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.type( 'Paragraph' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Second Paragraph' );
-		
+        await page.keyboard.type( 'Second Paragraph' );
+
 		// Multiselect blocks via Shift + click
 		await page.keyboard.down( 'Shift' );
 		await page.keyboard.press( 'ArrowUp' );
@@ -71,8 +71,8 @@ describe( 'Multi-block selection', () => {
 		await page.click( '.editor-block-settings-menu' );
 		let listButtonVisible = true;
 		try {
-			let listButton = ( await page.$( '//button[contains(text(), \'List\')]' ) )[ 0 ];
-		} catch( object ) {
+			await page.$( '//button[contains(text(), \'List\')]' )[ 0 ];
+		} catch ( object ) {
 			listButtonVisible = false;
 		}
 		expect( listButtonVisible ).toBe( false );
@@ -95,21 +95,21 @@ describe( 'Multi-block selection', () => {
 
 		// Duplicate blocks
 		await page.click( '.editor-block-settings-menu' );
-		let duplicateButton = ( await page.$x( '//button[contains(text(), \'Duplicate\')]' ) )[ 0 ];
+		const duplicateButton = ( await page.$x( '//button[contains(text(), \'Duplicate\')]' ) )[ 0 ];
 		await duplicateButton.click( 'button' );
 
 		//Switch to Code Editor to check HTML output
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
 		await codeEditorButton.click( 'button' );
 
 		//Assert that there are 6 paragraph blocks
-		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
 		expect( textEditorContent ).toMatchSnapshot();
 
 		//Switch to Visual Editor to continue testing
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
+		const visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
 		await visualEditorButton.click( 'button' );
 		await page.close();
 	} );
@@ -131,16 +131,16 @@ describe( 'Multi-block selection', () => {
 
 		// Remove blocks
 		await page.click( '.editor-block-settings-menu' );
-		let removeButton = ( await page.$x( '//button[contains(text(), \'Remove\')]' ) )[ 0 ];
+		const removeButton = ( await page.$x( '//button[contains(text(), \'Remove\')]' ) )[ 0 ];
 		await removeButton.click( 'button' );
 
 		//Switch to Code Editor to check HTML output
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
 		await codeEditorButton.click( 'button' );
 
 		//Assert that there are no paragraph blocks
-		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-		expect( textEditorContent ).toEqual( "" );
-	} );   
+		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toEqual( '' );
+	} );
 } );

--- a/test/e2e/specs/multi-block-utilities.test.js
+++ b/test/e2e/specs/multi-block-utilities.test.js
@@ -1,0 +1,146 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage } from '../support/utils';
+
+describe( 'Multi-block selection', () => {
+	beforeEach( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+	} );
+
+	it( 'Should transform 3 paragraphs into a list', async () => {
+		// Create test blocks
+		await page.click( '.editor-default-block-appender' );
+		await page.keyboard.type( 'First Paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Second Paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Third Paragraph' );
+
+		// Multiselect blocks via Shift + click
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.up( 'Shift' );
+
+		// Transform blocks into list
+		await page.click( '.editor-block-settings-menu' );
+		let listButton = ( await page.$x( '//button[contains(text(), \'List\')]' ) )[ 0 ];
+		await listButton.click( 'button' );
+
+		//Switch to Code Editor to check HTML output
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		await codeEditorButton.click( 'button' );
+
+		//Assert that there is only 1 list block
+		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toMatchSnapshot();
+
+		//Switch to Visual Editor to continue testing
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
+		await visualEditorButton.click( 'button' );
+		await page.close();
+	} );
+
+	it( 'Should not transform an image block into a list', async () => {
+		//Create test blocks
+		await page.click( '.editor-default-block-appender' );
+		await page.keyboard.type( 'First Paragraph' );
+		await page.click( '.edit-post-header [aria-label="Add block"]' );
+		await page.keyboard.type( 'Image' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+		await page.click( '.edit-post-header [aria-label="Add block"]' );
+		await page.keyboard.type( 'Paragraph' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Second Paragraph' );
+		
+		// Multiselect blocks via Shift + click
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.up( 'Shift' );
+
+		//Assert that the list button does not appear
+		//in the multi-block selection menu
+		await page.click( '.editor-block-settings-menu' );
+		let listButtonVisible = true;
+		try {
+			let listButton = ( await page.$( '//button[contains(text(), \'List\')]' ) )[ 0 ];
+		} catch( object ) {
+			listButtonVisible = false;
+		}
+		expect( listButtonVisible ).toBe( false );
+	} );
+
+	it( 'Should duplicate a multi-block selection', async () => {
+		// Create test blocks
+		await page.click( '.editor-default-block-appender' );
+		await page.keyboard.type( 'First Paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Second Paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Third Paragraph' );
+
+		// Multiselect blocks via Shift + click
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.up( 'Shift' );
+
+		// Duplicate blocks
+		await page.click( '.editor-block-settings-menu' );
+		let duplicateButton = ( await page.$x( '//button[contains(text(), \'Duplicate\')]' ) )[ 0 ];
+		await duplicateButton.click( 'button' );
+
+		//Switch to Code Editor to check HTML output
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		await codeEditorButton.click( 'button' );
+
+		//Assert that there are 6 paragraph blocks
+		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toMatchSnapshot();
+
+		//Switch to Visual Editor to continue testing
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
+		await visualEditorButton.click( 'button' );
+		await page.close();
+	} );
+
+	it( 'Should remove a multi-block selection', async () => {
+		// Create test blocks
+		await page.click( '.editor-default-block-appender' );
+		await page.keyboard.type( 'First Paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Second Paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Third Paragraph' );
+
+		// Multiselect blocks via Shift + click
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.up( 'Shift' );
+
+		// Remove blocks
+		await page.click( '.editor-block-settings-menu' );
+		let removeButton = ( await page.$x( '//button[contains(text(), \'Remove\')]' ) )[ 0 ];
+		await removeButton.click( 'button' );
+
+		//Switch to Code Editor to check HTML output
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		await codeEditorButton.click( 'button' );
+
+		//Assert that there are no paragraph blocks
+		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toEqual( "" );
+	} );   
+} );


### PR DESCRIPTION
## Description
This PR seeks to add to the E2E multi-block selection testing by asserting with Jest and Puppeteer that various functions work when multiple blocks are selected. 'multi-block-utilities.test.js' tests that the convert to list button works as intended and does not appear when non-paragraph block types (e.g. images) are selected, along with testing the remove and duplicate buttons.

## How Has This Been Tested?
This script was added to the e2e tests and ran using the 'npm run test-e2e' command. It was tested on a local version of Gutenberg. The tests were also ran in visual mode and performed manually to verify accuracy.

## Types of changes
This is a non-breaking addition that adds test functionality.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
