### PR TITLE
Fixed empty quote block issue on copy paste

### DIFF
--- a/blocks/api/raw-handling/blockquote-normaliser.js
+++ b/blocks/api/raw-handling/blockquote-normaliser.js
@@ -2,11 +2,22 @@
  * Internal dependencies
  */
 import normaliseBlocks from './normalise-blocks';
+import { isInlineWrapper } from './utils';
 
 /**
  * Browser dependencies
  */
 const { ELEMENT_NODE } = window.Node;
+
+function replace( node, tagName ) {
+	const newNode = document.createElement( tagName );
+
+	while ( node.firstChild ) {
+		newNode.appendChild( node.firstChild );
+	}
+
+	node.parentNode.replaceChild( newNode, node );
+}
 
 export default function( node ) {
 	if ( node.nodeType !== ELEMENT_NODE ) {
@@ -16,6 +27,15 @@ export default function( node ) {
 	if ( node.nodeName !== 'BLOCKQUOTE' ) {
 		return;
 	}
+
+	Array.from( node.childNodes ).forEach( ( childNode ) => {
+		// Quote component only handle p tag inside blockquote tag
+		// normaliseBlocks will not wrap any inline wrapper tag with p so we have to do it manually.
+		// If child node is inline wrapper node and not paragraph then convert it to paragraph.
+		if ( isInlineWrapper( childNode ) && node.nodeName.toLowerCase() !== 'p' ) {
+			replace( childNode, 'p' );
+		}
+	} );
 
 	node.innerHTML = normaliseBlocks( node.innerHTML );
 }

--- a/blocks/api/raw-handling/test/blockquote-normaliser.js
+++ b/blocks/api/raw-handling/test/blockquote-normaliser.js
@@ -15,4 +15,22 @@ describe( 'blockquoteNormaliser', () => {
 		const output = '<blockquote><p>test</p></blockquote>';
 		equal( deepFilterHTML( input, [ blockquoteNormaliser ] ), output );
 	} );
+
+	it( 'should normalise blockquote containing inline wrapper tag', () => {
+		const input = '<blockquote><h2>test</h2></blockquote>';
+		const output = '<blockquote><p>test</p></blockquote>';
+		equal( deepFilterHTML( input, [ blockquoteNormaliser ] ), output );
+	} );
+
+	it( 'should normalise blockquote containing multiple inline tags', () => {
+		const input = '<blockquote><p>test</p><h1>test2</h1></blockquote>';
+		const output = '<blockquote><p>test</p><p>test2</p></blockquote>';
+		equal( deepFilterHTML( input, [ blockquoteNormaliser ] ), output );
+	} );
+
+	it( 'should normalise blockquote containing multiple inline tags and caption', () => {
+		const input = '<blockquote><h1>test</h1><cite>cite</cite></blockquote>';
+		const output = '<blockquote><p>test</p><cite>cite</cite></blockquote>';
+		equal( deepFilterHTML( input, [ blockquoteNormaliser ] ), output );
+	} );
 } );


### PR DESCRIPTION
## Description
Fixed empty quote block issue on copy paste

## How Has This Been Tested?
- Copy text from [this post](https://ownyourcontent.wordpress.com/2018/03/26/maria-popova/) — include the paragraph before and after the pullquote 
- Paste in Gutenberg

## Types of changes
In raw-handling, Added additional normalizer code for blockquote.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
