### PR TITLE
Make the Classic block toolbar operable with a keyboard.

### DIFF
--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -142,7 +142,7 @@ export default class OldEditor extends Component {
 	onToolbarKeyDown( event ) {
 		// Prevent WritingFlow from kicking in and allow arrows navigation on the toolbar.
 		event.stopPropagation();
-		// Prevent Mousetrap to move focus to the top toolbar when pressing `alt+f10` on this block toolbar.
+		// Prevent Mousetrap from moving focus to the top toolbar when pressing `alt+f10` on this block toolbar.
 		event.nativeEvent.stopImmediatePropagation();
 	}
 

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -5,7 +5,7 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { keycodes } from '@wordpress/utils';
 
-const { BACKSPACE, DELETE } = keycodes;
+const { BACKSPACE, DELETE, F10 } = keycodes;
 
 function isTmceEmpty( editor ) {
 	// When tinyMce is empty the content seems to be:
@@ -99,6 +99,15 @@ export default class OldEditor extends Component {
 				event.preventDefault();
 				event.stopImmediatePropagation();
 			}
+
+			const { altKey } = event;
+			/*
+			 * Prevent Mousetrap from kicking in: TinyMCE already uses its own
+			 * `alt+f10` shortcut to focus its toolbar.
+			 */
+			if ( altKey && event.keyCode === F10 ) {
+				event.stopPropagation();
+			}
 		} );
 
 		editor.addButton( 'kitchensink', {
@@ -130,9 +139,19 @@ export default class OldEditor extends Component {
 		}
 	}
 
+	onToolbarKeyDown( event ) {
+		// Prevent WritingFlow from kicking in and allow arrows navigation on the toolbar.
+		event.stopPropagation();
+		// Prevent Mousetrap to move focus to the top toolbar when pressing `alt+f10` on this block toolbar.
+		event.nativeEvent.stopImmediatePropagation();
+	}
+
 	render() {
 		const { id } = this.props;
 
+		// Disable reason: the toolbar itself is non-interactive, but must capture
+		// events from the KeyboardShortcuts component to stop their propagation.
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return [
 			// Disable reason: Clicking on this visual placeholder should create
 			// the toolbar, it can also be created by focussing the field below.
@@ -144,6 +163,7 @@ export default class OldEditor extends Component {
 				className="freeform-toolbar"
 				onClick={ this.focus }
 				data-placeholder={ __( 'Classic' ) }
+				onKeyDown={ this.onToolbarKeyDown }
 			/>,
 			<div
 				key="editor"
@@ -151,5 +171,6 @@ export default class OldEditor extends Component {
 				className="wp-block-freeform blocks-rich-text__tinymce"
 			/>,
 		];
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }

--- a/editor/components/navigable-toolbar/index.js
+++ b/editor/components/navigable-toolbar/index.js
@@ -85,7 +85,8 @@ class NavigableToolbar extends Component {
 			>
 				<KeyboardShortcuts
 					bindGlobal
-					eventName="keyup"
+					// Use the same event that TinyMCE uses in the Classic block for its own `alt+f10` shortcut.
+					eventName="keydown"
 					shortcuts={ {
 						'alt+f10': this.focusToolbar,
 					} }


### PR DESCRIPTION
This PR tries to solve conflicts that prevent the Classic block toolbar to be operated with a keyboard. Two issues:
- `Alt+F10` to move from the block to the toolbar doesn't work: it conflicts with the Mousetrap global `Alt+F10`
- once the toolbar is focused, arrows navigation with right and left arrows doesn't work: conflicts with WritingFlow I guess and focus goes back to the editable area

I've tested on all browsers, also on Windows, and looks good to me.

To test:
- create a new post, add 1 paragraph, 1 Classic block, and 1 paragraph
- on all the 3 blocks, verify that everything works as expected
- once the editable area has focus, `Alt+F10` moves focus to the block toolbar
- pressing again `Alt+F10` when focus is on the toolbar shouldn't do anything
- arrows and tab navigation works on the toolbar
- Escape moves focus back to the block content (this is buggy on Safari and IE11 for unrelated reasons, will open a new issue)

Verify the above steps with both option for the toolbar placement: normal and "fixed to top:

Note:
the underlying issue is that TinyMCE uses its own `Alt+F10` shortcut with a `keydown` event, while the Mousetrap `Alt+F10` is currently used with a `keyup` event and it's "global", attached to the document. So when pressing `Alt+F10` on the Classic editor, first the TinyMCE `keydown` fires, then when releasing the keys the Mousetrap `keyup` fires.
I've paired both to `keydown` and stopped propagation of the Classic editor event.

Fixes #6118 