### PR TITLE
Editor Module: Use withSelect/withDispatch instead of connect (round 2)

### DIFF
--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -35,7 +35,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     type="text"
     value="Write your story"
   />
-  <WithEditorSettings(Connect(WithDispatch(InserterWithShortcuts))) />
+  <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
   <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
     position="top right"
   />
@@ -59,7 +59,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     type="text"
     value="Write your story"
   />
-  <WithEditorSettings(Connect(WithDispatch(InserterWithShortcuts))) />
+  <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
   <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
     position="top right"
   />
@@ -83,7 +83,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     type="text"
     value=""
   />
-  <WithEditorSettings(Connect(WithDispatch(InserterWithShortcuts))) />
+  <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
   <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
     position="top right"
   />

--- a/editor/components/document-title/index.js
+++ b/editor/components/document-title/index.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { Component } from 'react';
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import { getDocumentTitle } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 class DocumentTitle extends Component {
 	constructor( props ) {
@@ -38,8 +37,6 @@ class DocumentTitle extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		title: getDocumentTitle( state ),
-	} ),
-)( DocumentTitle );
+export default withSelect( ( select ) => ( {
+	title: select( 'core/editor' ).getDocumentTitle(),
+} ) )( DocumentTitle );

--- a/editor/components/editor-history/redo.js
+++ b/editor/components/editor-history/redo.js
@@ -1,18 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { hasEditorRedo } from '../../store/selectors';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 function EditorHistoryRedo( { hasRedo, redo } ) {
 	return (
@@ -26,11 +18,11 @@ function EditorHistoryRedo( { hasRedo, redo } ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		hasRedo: hasEditorRedo( state ),
-	} ),
-	( dispatch ) => ( {
-		redo: () => dispatch( { type: 'REDO' } ),
-	} )
-)( EditorHistoryRedo );
+export default compose( [
+	withSelect( ( select ) => ( {
+		hasRedo: select( 'core/editor' ).hasEditorRedo(),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
+		redo: () => dispatch( 'core/editor' ).redo(),
+	} ) ),
+] )( EditorHistoryRedo );

--- a/editor/components/editor-history/undo.js
+++ b/editor/components/editor-history/undo.js
@@ -1,18 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { hasEditorUndo } from '../../store/selectors';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 function EditorHistoryUndo( { hasUndo, undo } ) {
 	return (
@@ -26,11 +18,11 @@ function EditorHistoryUndo( { hasUndo, undo } ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		hasUndo: hasEditorUndo( state ),
-	} ),
-	( dispatch ) => ( {
-		undo: () => dispatch( { type: 'UNDO' } ),
-	} )
-)( EditorHistoryUndo );
+export default compose( [
+	withSelect( ( select ) => ( {
+		hasUndo: select( 'core/editor' ).hasEditorUndo(),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
+		undo: () => dispatch( 'core/editor' ).undo(),
+	} ) ),
+] )( EditorHistoryUndo );

--- a/editor/components/editor-notices/index.js
+++ b/editor/components/editor-notices/index.js
@@ -1,18 +1,13 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { NoticeList } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { removeNotice } from '../../store/actions';
-import { getNotices } from '../../store/selectors';
 import TemplateValidationNotice from '../template-validation-notice';
 
 function EditorNotices( props ) {
@@ -23,9 +18,11 @@ function EditorNotices( props ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		notices: getNotices( state ),
-	} ),
-	{ onRemove: removeNotice }
-)( EditorNotices );
+export default compose( [
+	withSelect( ( select ) => ( {
+		notices: select( 'core/editor' ).getNotices(),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
+		onRemove: dispatch( 'core/editor' ).removeNotice,
+	} ) ),
+] )( EditorNotices );

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { filter, isEmpty } from 'lodash';
 
 /**
@@ -11,13 +10,12 @@ import { BlockIcon, createBlock, getDefaultBlockName, withEditorSettings } from 
 import { compose } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { withDispatch } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { getFrecentInserterItems } from '../../store/selectors';
 
 function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 	if ( isLocked ) {
@@ -54,11 +52,9 @@ export default compose(
 			allowedBlockTypes,
 		};
 	} ),
-	connect(
-		( state, { allowedBlockTypes } ) => ( {
-			items: getFrecentInserterItems( state, allowedBlockTypes, 4 ),
-		} )
-	),
+	withSelect( ( select, { allowedBlockTypes } ) => ( {
+		items: select( 'core/editor' ).getFrecentInserterItems( allowedBlockTypes, 4 ),
+	} ) ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const { uid, rootUID, layout } = ownProps;
 

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -12,7 +12,6 @@ import {
 	sortBy,
 	isEmpty,
 } from 'lodash';
-import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
@@ -27,16 +26,14 @@ import {
 } from '@wordpress/components';
 import { getCategories, isSharedBlock, withEditorSettings } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import NoBlocks from './no-blocks';
-
-import { getInserterItems, getFrecentInserterItems } from '../../store/selectors';
-import { fetchSharedBlocks } from '../../store/actions';
-import { default as InserterGroup } from './group';
+import InserterGroup from './group';
 import BlockPreview from '../block-preview';
 
 export const searchItems = ( items, searchTerm ) => {
@@ -346,15 +343,16 @@ export default compose(
 			allowedBlockTypes,
 		};
 	} ),
-	connect(
-		( state, { allowedBlockTypes } ) => {
-			return {
-				items: getInserterItems( state, allowedBlockTypes ),
-				frecentItems: getFrecentInserterItems( state, allowedBlockTypes ),
-			};
-		},
-		{ fetchSharedBlocks }
-	),
+	withSelect( ( select, { allowedBlockTypes } ) => {
+		const { getInserterItems, getFrecentInserterItems } = select( 'core/editor' );
+		return {
+			items: getInserterItems( allowedBlockTypes ),
+			frecentItems: getFrecentInserterItems( allowedBlockTypes ),
+		};
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		fetchSharedBlocks: dispatch( 'core/editor' ).fetchSharedBlocks,
+	} ) ),
 	withSpokenMessages,
 	withInstanceId
 )( InserterMenu );

--- a/editor/components/page-attributes/order.js
+++ b/editor/components/page-attributes/order.js
@@ -1,21 +1,15 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { withInstanceId } from '@wordpress/components';
 import { compose, Fragment } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
-import { editPost } from '../../store/actions';
-import { getEditedPostAttribute } from '../../store/selectors';
 
 export function PageAttributesOrder( { onUpdateOrder, instanceId, order } ) {
 	const setUpdatedOrder = ( event ) => {
@@ -51,22 +45,18 @@ function PageAttributesOrderWithChecks( props ) {
 	);
 }
 
-const applyConnect = connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			order: getEditedPostAttribute( state, 'menu_order' ),
+			order: select( 'core/editor' ).getEditedPostAttribute( 'menu_order' ),
 		};
-	},
-	{
+	} ),
+	withDispatch( ( dispatch ) => ( {
 		onUpdateOrder( order ) {
-			return editPost( {
+			dispatch( 'core/editor' ).editPost( {
 				menu_order: order,
 			} );
 		},
-	}
-);
-
-export default compose( [
-	applyConnect,
+	} ) ),
 	withInstanceId,
 ] )( PageAttributesOrderWithChecks );

--- a/editor/components/page-attributes/template.js
+++ b/editor/components/page-attributes/template.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { isEmpty, map } from 'lodash';
 
 /**
@@ -11,13 +10,12 @@ import { __ } from '@wordpress/i18n';
 import { withInstanceId } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withEditorSettings } from '@wordpress/blocks';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 
 export function PageTemplate( { availableTemplates, selectedTemplate, instanceId, onUpdate } ) {
 	if ( isEmpty( availableTemplates ) ) {
@@ -42,27 +40,19 @@ export function PageTemplate( { availableTemplates, selectedTemplate, instanceId
 	);
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			selectedTemplate: getEditedPostAttribute( state, 'template' ),
-		};
-	},
-	{
-		onUpdate( templateSlug ) {
-			return editPost( { template: templateSlug || '' } );
-		},
-	}
-);
-
-const applyWithEditorSettings = withEditorSettings(
-	( settings ) => ( {
-		availableTemplates: settings.availableTemplates,
-	} )
-);
-
 export default compose(
-	applyConnect,
-	applyWithEditorSettings,
+	withSelect( ( select ) => {
+		return {
+			selectedTemplate: select( 'core/editor' ).getEditedPostAttribute( 'template' ),
+		};
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		onUpdate( templateSlug ) {
+			dispatch( 'core/editor' ).editPost( { template: templateSlug || '' } );
+		},
+	} ) ),
+	withEditorSettings( ( settings ) => ( {
+		availableTemplates: settings.availableTemplates,
+	} ) ),
 	withInstanceId,
 )( PageTemplate );

--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { filter, get } from 'lodash';
 
 /**
@@ -9,12 +8,12 @@ import { filter, get } from 'lodash';
  */
 import { withAPIData, withInstanceId } from '@wordpress/components';
 import { compose } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
-import { getCurrentPostType } from '../../store/selectors';
 
 export function PostAuthorCheck( { user, users, children } ) {
 	const authors = filter( users.data, ( { capabilities } ) => get( capabilities, [ 'level_1' ], false ) );
@@ -27,25 +26,19 @@ export function PostAuthorCheck( { user, users, children } ) {
 	return <PostTypeSupportCheck supportKeys="author">{ children }</PostTypeSupportCheck>;
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postType: getCurrentPostType( state ),
-		};
-	},
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		users: '/wp/v2/users?context=edit&per_page=100',
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) => {
+		return {
+			postType: select( 'core/editor' ).getCurrentPostType(),
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			users: '/wp/v2/users?context=edit&per_page=100',
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} ),
 	withInstanceId,
 ] )( PostAuthorCheck );

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get, filter } from 'lodash';
 
 /**
@@ -10,13 +9,12 @@ import { get, filter } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { withAPIData, withInstanceId } from '@wordpress/components';
 import { Component, compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import PostAuthorCheck from './check';
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 
 export class PostAuthor extends Component {
 	constructor() {
@@ -70,27 +68,21 @@ export class PostAuthor extends Component {
 	}
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postAuthor: getEditedPostAttribute( state, 'author' ),
-		};
-	},
-	{
-		onUpdateAuthor( author ) {
-			return editPost( { author } );
-		},
-	},
-);
-
-const applyWithAPIData = withAPIData( () => {
-	return {
-		users: '/wp/v2/users?context=edit&per_page=100',
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) => {
+		return {
+			postAuthor: select( 'core/editor' ).getEditedPostAttribute( 'author' ),
+		};
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		onUpdateAuthor( author ) {
+			dispatch( 'core/editor' ).editPost( { author } );
+		},
+	} ) ),
+	withAPIData( () => {
+		return {
+			users: '/wp/v2/users?context=edit&per_page=100',
+		};
+	} ),
 	withInstanceId,
 ] )( PostAuthor );

--- a/editor/components/post-comments/index.js
+++ b/editor/components/post-comments/index.js
@@ -1,19 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FormToggle, withInstanceId } from '@wordpress/components';
-
-/**
- * Internal Dependencies
- */
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 function PostComments( { commentStatus = 'open', instanceId, ...props } ) {
 	const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
@@ -31,13 +22,14 @@ function PostComments( { commentStatus = 'open', instanceId, ...props } ) {
 	];
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			commentStatus: getEditedPostAttribute( state, 'comment_status' ),
+			commentStatus: select( 'core/editor' ).getEditedPostAttribute( 'comment_status' ),
 		};
-	},
-	{
-		editPost,
-	}
-)( withInstanceId( PostComments ) );
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		editPost: dispatch( 'core/editor' ).editPost,
+	} ) ),
+	withInstanceId,
+] )( PostComments );

--- a/editor/components/post-excerpt/index.js
+++ b/editor/components/post-excerpt/index.js
@@ -1,20 +1,15 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { ExternalLink, withInstanceId } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
-import { getEditedPostExcerpt } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 
 function PostExcerpt( { excerpt, onUpdateExcerpt, instanceId } ) {
 	const id = `editor-post-excerpt-${ instanceId }`;
@@ -36,15 +31,16 @@ function PostExcerpt( { excerpt, onUpdateExcerpt, instanceId } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			excerpt: getEditedPostExcerpt( state ),
+			excerpt: select( 'core/editor' ).getEditedPostExcerpt(),
 		};
-	},
-	{
+	} ),
+	withDispatch( ( dispatch ) => ( {
 		onUpdateExcerpt( excerpt ) {
-			return editPost( { excerpt } );
+			dispatch( 'core/editor' ).editPost( { excerpt } );
 		},
-	}
-)( withInstanceId( PostExcerpt ) );
+	} ) ),
+	withInstanceId,
+] )( PostExcerpt );

--- a/editor/components/post-format/index.js
+++ b/editor/components/post-format/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { find } from 'lodash';
 
 /**
@@ -10,14 +9,13 @@ import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { withInstanceId } from '@wordpress/components';
 import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import PostFormatCheck from './check';
-import { getEditedPostAttribute, getSuggestedPostFormat } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 
 const POST_FORMATS = [
 	{ id: 'aside', caption: __( 'Aside' ) },
@@ -70,18 +68,17 @@ function PostFormat( { onUpdatePostFormat, postFormat = 'standard', suggestedFor
 }
 
 export default compose( [
-	connect(
-		( state ) => {
-			return {
-				postFormat: getEditedPostAttribute( state, 'format' ),
-				suggestedFormat: getSuggestedPostFormat( state ),
-			};
+	withSelect( ( select ) => {
+		const { getEditedPostAttribute, getSuggestedPostFormat } = select( 'core/editor' );
+		return {
+			postFormat: getEditedPostAttribute( 'format' ),
+			suggestedFormat: getSuggestedPostFormat(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		onUpdatePostFormat( postFormat ) {
+			dispatch( 'core/editor' ).editPost( { format: postFormat } );
 		},
-		{
-			onUpdatePostFormat( postFormat ) {
-				return editPost( { format: postFormat } );
-			},
-		},
-	),
+	} ) ),
 	withInstanceId,
 ] )( PostFormat );

--- a/editor/components/post-last-revision/check.js
+++ b/editor/components/post-last-revision/check.js
@@ -1,12 +1,11 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { connect } from 'react-redux';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { getCurrentPostLastRevisionId, getCurrentPostRevisionsCount } from '../../store/selectors';
 import PostTypeSupportCheck from '../post-type-support-check';
 
 export function PostLastRevisionCheck( { lastRevisionId, revisionsCount, children } ) {
@@ -17,11 +16,12 @@ export function PostLastRevisionCheck( { lastRevisionId, revisionsCount, childre
 	return <PostTypeSupportCheck supportKeys="revisions" >{ children }</PostTypeSupportCheck>;
 }
 
-export default connect(
-	( state ) => {
+export default withSelect(
+	( select ) => {
+		const { getCurrentPostLastRevisionId, getCurrentPostRevisionsCount } = select( 'core/editor' );
 		return {
-			lastRevisionId: getCurrentPostLastRevisionId( state ),
-			revisionsCount: getCurrentPostRevisionsCount( state ),
+			lastRevisionId: getCurrentPostLastRevisionId(),
+			revisionsCount: getCurrentPostRevisionsCount(),
 		};
 	}
 )( PostLastRevisionCheck );

--- a/editor/components/post-last-revision/index.js
+++ b/editor/components/post-last-revision/index.js
@@ -1,23 +1,15 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { sprintf, _n } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import PostLastRevisionCheck from './check';
-import {
-	getCurrentPostLastRevisionId,
-	getCurrentPostRevisionsCount,
-} from '../../store/selectors';
 import { getWPAdminURL } from '../../utils/url';
 
 function LastRevision( { lastRevisionId, revisionsCount } ) {
@@ -39,11 +31,15 @@ function LastRevision( { lastRevisionId, revisionsCount } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
+export default withSelect(
+	( select ) => {
+		const {
+			getCurrentPostLastRevisionId,
+			getCurrentPostRevisionsCount,
+		} = select( 'core/editor' );
 		return {
-			lastRevisionId: getCurrentPostLastRevisionId( state ),
-			revisionsCount: getCurrentPostRevisionsCount( state ),
+			lastRevisionId: getCurrentPostLastRevisionId(),
+			revisionsCount: getCurrentPostRevisionsCount(),
 		};
 	}
 )( LastRevision );

--- a/editor/components/post-pending-status/check.js
+++ b/editor/components/post-pending-status/check.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -9,11 +8,7 @@ import { get } from 'lodash';
  */
 import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { isCurrentPostPublished, getCurrentPostType } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 export function PostPendingStatusCheck( { isPublished, children, user } ) {
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
@@ -25,22 +20,19 @@ export function PostPendingStatusCheck( { isPublished, children, user } ) {
 	return children;
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		isPublished: isCurrentPostPublished( state ),
-		postType: getCurrentPostType( state ),
-	} ),
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose(
-	applyConnect,
-	applyWithAPIData
+	withSelect( ( select ) => {
+		const { isCurrentPostPublished, getCurrentPostType } = select( 'core/editor' );
+		return {
+			isPublished: isCurrentPostPublished(),
+			postType: getCurrentPostType(),
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} )
 )( PostPendingStatusCheck );

--- a/editor/components/post-pending-status/index.js
+++ b/editor/components/post-pending-status/index.js
@@ -1,21 +1,15 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FormToggle, withInstanceId } from '@wordpress/components';
 import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import PostPendingStatusCheck from './check';
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 
 export function PostPendingStatus( { instanceId, status, onUpdateStatus } ) {
 	const pendingId = 'pending-toggle-' + instanceId;
@@ -36,18 +30,14 @@ export function PostPendingStatus( { instanceId, status, onUpdateStatus } ) {
 	);
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		status: getEditedPostAttribute( state, 'status' ),
-	} ),
-	{
-		onUpdateStatus( status ) {
-			return editPost( { status } );
-		},
-	}
-);
-
 export default compose(
-	applyConnect,
+	withSelect( ( select ) => ( {
+		status: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
+		onUpdateStatus( status ) {
+			dispatch( 'core/editor' ).editPost( { status } );
+		},
+	} ) ),
 	withInstanceId
 )( PostPendingStatus );

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -4,7 +4,7 @@
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component, compose } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon, Button, ClipboardButton, Tooltip } from '@wordpress/components';
+import { Dashicon, ClipboardButton, Button, Tooltip } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/components/post-pingbacks/index.js
+++ b/editor/components/post-pingbacks/index.js
@@ -1,19 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FormToggle, withInstanceId } from '@wordpress/components';
-
-/**
- * Internal Dependencies
- */
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 function PostPingbacks( { pingStatus = 'open', instanceId, ...props } ) {
 	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
@@ -31,13 +22,14 @@ function PostPingbacks( { pingStatus = 'open', instanceId, ...props } ) {
 	];
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			pingStatus: getEditedPostAttribute( state, 'ping_status' ),
+			pingStatus: select( 'core/editor' ).getEditedPostAttribute( 'ping_status' ),
 		};
-	},
-	{
-		editPost,
-	}
-)( withInstanceId( PostPingbacks ) );
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		editPost: dispatch( 'core/editor' ).editPost,
+	} ) ),
+	withInstanceId,
+] )( PostPingbacks );

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -1,26 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import {
-	getEditedPostPreviewLink,
-	getEditedPostAttribute,
-	isEditedPostDirty,
-	isEditedPostNew,
-	isEditedPostSaveable,
-} from '../../store/selectors';
-import { autosave } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 export class PostPreviewButton extends Component {
 	constructor() {
@@ -123,14 +107,26 @@ export class PostPreviewButton extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		postId: state.currentPost.id,
-		link: getEditedPostPreviewLink( state ),
-		isDirty: isEditedPostDirty( state ),
-		isNew: isEditedPostNew( state ),
-		isSaveable: isEditedPostSaveable( state ),
-		modified: getEditedPostAttribute( state, 'modified' ),
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			getCurrentPostId,
+			getEditedPostPreviewLink,
+			getEditedPostAttribute,
+			isEditedPostDirty,
+			isEditedPostNew,
+			isEditedPostSaveable,
+		} = select( 'core/editor' );
+		return {
+			postId: getCurrentPostId(),
+			link: getEditedPostPreviewLink(),
+			isDirty: isEditedPostDirty(),
+			isNew: isEditedPostNew(),
+			isSaveable: isEditedPostSaveable(),
+			modified: getEditedPostAttribute( 'modified' ),
+		};
 	} ),
-	{ autosave }
-)( PostPreviewButton );
+	withDispatch( ( dispatch )=>( {
+		autosave: dispatch( 'core/editor' ).autosave,
+	} ) ),
+] )( PostPreviewButton );

--- a/editor/components/post-publish-button/index.js
+++ b/editor/components/post-publish-button/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { noop, get } from 'lodash';
 
@@ -10,21 +9,13 @@ import { noop, get } from 'lodash';
  */
 import { Button, withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import PublishButtonLabel from './label';
-import { editPost, savePost } from '../../store/actions';
-import {
-	isSavingPost,
-	isEditedPostBeingScheduled,
-	getEditedPostVisibility,
-	isEditedPostSaveable,
-	isEditedPostPublishable,
-	getCurrentPostType,
-} from '../../store/selectors';
 
 export function PostPublishButton( {
 	isSaving,
@@ -75,30 +66,37 @@ export function PostPublishButton( {
 	);
 }
 
-const applyConnect = connect(
-	( state, { forceIsSaving, forceIsDirty } ) => ( {
-		isSaving: forceIsSaving || isSavingPost( state ),
-		isBeingScheduled: isEditedPostBeingScheduled( state ),
-		visibility: getEditedPostVisibility( state ),
-		isSaveable: isEditedPostSaveable( state ),
-		isPublishable: forceIsDirty || isEditedPostPublishable( state ),
-		postType: getCurrentPostType( state ),
-	} ),
-	{
-		onStatusChange: ( status ) => editPost( { status } ),
-		onSave: savePost,
-	}
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select, { forceIsSaving, forceIsDirty } ) => {
+		const {
+			isSavingPost,
+			isEditedPostBeingScheduled,
+			getEditedPostVisibility,
+			isEditedPostSaveable,
+			isEditedPostPublishable,
+			getCurrentPostType,
+		} = select( 'core/editor' );
+		return {
+			isSaving: forceIsSaving || isSavingPost(),
+			isBeingScheduled: isEditedPostBeingScheduled(),
+			visibility: getEditedPostVisibility(),
+			isSaveable: isEditedPostSaveable(),
+			isPublishable: forceIsDirty || isEditedPostPublishable(),
+			postType: getCurrentPostType(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { editPost, savePost } = dispatch( 'core/editor' );
+		return {
+			onStatusChange: ( status ) => editPost( { status } ),
+			onSave: savePost,
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} ),
 ] )( PostPublishButton );

--- a/editor/components/post-publish-button/label.js
+++ b/editor/components/post-publish-button/label.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -10,18 +9,12 @@ import { get } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import {
-	isCurrentPostPublished,
-	isEditedPostBeingScheduled,
-	isSavingPost,
-	isPublishingPost,
-	getCurrentPostType,
-} from '../../store/selectors';
 
 export function PublishButtonLabel( {
 	isPublished,
@@ -52,25 +45,28 @@ export function PublishButtonLabel( {
 	return __( 'Publish' );
 }
 
-const applyConnect = connect(
-	( state, { forceIsSaving } ) => ( {
-		isPublished: isCurrentPostPublished( state ),
-		isBeingScheduled: isEditedPostBeingScheduled( state ),
-		isSaving: forceIsSaving || isSavingPost( state ),
-		isPublishing: isPublishingPost( state ),
-		postType: getCurrentPostType( state ),
-	} )
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select, { forceIsSaving } ) => {
+		const {
+			isCurrentPostPublished,
+			isEditedPostBeingScheduled,
+			isSavingPost,
+			isPublishingPost,
+			getCurrentPostType,
+		} = select( 'core/editor' );
+		return {
+			isPublished: isCurrentPostPublished(),
+			isBeingScheduled: isEditedPostBeingScheduled(),
+			isSaving: forceIsSaving || isSavingPost(),
+			isPublishing: isPublishingPost(),
+			postType: getCurrentPostType(),
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} ),
 ] )( PublishButtonLabel );

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -10,6 +9,7 @@ import { get } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { compose, Component } from '@wordpress/element';
 import { withAPIData, IconButton, Spinner } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal Dependencies
@@ -18,13 +18,6 @@ import './style.scss';
 import PostPublishButton from '../post-publish-button';
 import PostPublishPanelPrepublish from './prepublish';
 import PostPublishPanelPostpublish from './postpublish';
-import {
-	getCurrentPostType,
-	isCurrentPostPublished,
-	isCurrentPostScheduled,
-	isSavingPost,
-	isEditedPostDirty,
-} from '../../store/selectors';
 
 class PostPublishPanel extends Component {
 	constructor() {
@@ -100,27 +93,28 @@ class PostPublishPanel extends Component {
 	}
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postType: getCurrentPostType( state ),
-			isPublished: isCurrentPostPublished( state ),
-			isScheduled: isCurrentPostScheduled( state ),
-			isSaving: isSavingPost( state ),
-			isDirty: isEditedPostDirty( state ),
-		};
-	},
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) => {
+		const {
+			getCurrentPostType,
+			isCurrentPostPublished,
+			isCurrentPostScheduled,
+			isSavingPost,
+			isEditedPostDirty,
+		} = select( 'core/editor' );
+		return {
+			postType: getCurrentPostType(),
+			isPublished: isCurrentPostPublished(),
+			isScheduled: isCurrentPostScheduled(),
+			isSaving: isSavingPost(),
+			isDirty: isEditedPostDirty(),
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} ),
 ] )( PostPublishPanel );

--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -10,21 +9,12 @@ import { get } from 'lodash';
 import { Button, withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal Dependencies
  */
 import PostPublishButton from '../post-publish-button';
-import {
-	isSavingPost,
-	isEditedPostSaveable,
-	isEditedPostPublishable,
-	isCurrentPostPending,
-	isCurrentPostPublished,
-	isEditedPostBeingScheduled,
-	isCurrentPostScheduled,
-	getCurrentPostType,
-} from '../../store/selectors';
 
 function PostPublishPanelToggle( {
 	user,
@@ -66,28 +56,34 @@ function PostPublishPanelToggle( {
 	);
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		isSaving: isSavingPost( state ),
-		isSaveable: isEditedPostSaveable( state ),
-		isPublishable: isEditedPostPublishable( state ),
-		isPending: isCurrentPostPending( state ),
-		isPublished: isCurrentPostPublished( state ),
-		isScheduled: isCurrentPostScheduled( state ),
-		isBeingScheduled: isEditedPostBeingScheduled( state ),
-		postType: getCurrentPostType( state ),
-	} ),
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) =>{
+		const {
+			isSavingPost,
+			isEditedPostSaveable,
+			isEditedPostPublishable,
+			isCurrentPostPending,
+			isCurrentPostPublished,
+			isEditedPostBeingScheduled,
+			isCurrentPostScheduled,
+			getCurrentPostType,
+		} = select( 'core/editor' );
+		return {
+			isSaving: isSavingPost(),
+			isSaveable: isEditedPostSaveable(),
+			isPublishable: isEditedPostPublishable(),
+			isPending: isCurrentPostPending(),
+			isPublished: isCurrentPostPublished(),
+			isScheduled: isCurrentPostScheduled(),
+			isBeingScheduled: isEditedPostBeingScheduled(),
+			postType: getCurrentPostType(),
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} ),
 ] )( PostPublishPanelToggle );


### PR DESCRIPTION
Just getting rid of some legacy. and to avoid huge PRs, I'm updating 20 components in this first round. There's 42 remaining usage of `connect` in the editor module.

**Testing instructions**

Check that:
 
 - the document title updates
 - the undo/redo buttons work
 - the editor notices show up
 - the inserter works
 - publishing/updating a post work
 - Changing the author/pending stats/post format/page attributes work/comment status work

I already tested everything, so it should be ok. I'm willing to merge this pretty quickly to avoid a lot of conflicts.