### PR TITLE
Fix line break in permalink

### DIFF
--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -7,6 +7,7 @@
 	font-family: $default-font;
 	font-size: $default-font-size;
 	height: 40px;
+	white-space: nowrap;
 
 	// put toolbar snugly to edge on mobile
 	margin-left: -$block-padding - 1px;	// stack borders


### PR DESCRIPTION
## Description
Permalink element break line with long text strings.

Closes #5437 

## How Has This Been Tested?
This has been tested with "npm test" and manually on Chrome and Firefox.

## Screenshots
![screenshot from 2018-04-13 08-16-19](https://user-images.githubusercontent.com/6010232/38732470-9f69f034-3ef4-11e8-8c62-0999c95fc86b.png)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.