### PR TITLE
WIP: Add dynamic block

### DIFF
--- a/bin/create-php-parser.js
+++ b/bin/create-php-parser.js
@@ -12,6 +12,7 @@ const parser = pegjs.generate(
 	{
 		plugins: [ phpegjs ],
 		phpegjs: {
+			allowedStartRules: [ 'Block_List', 'Rendered_Output' ],
 			parserNamespace: null,
 			parserGlobalNamePrefix: 'Gutenberg_PEG_',
 			mbstringAllowed: false,

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -259,8 +259,14 @@ class Gutenberg_PEG_Parser {
 
     private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
     private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
-    private function peg_f2($blockName, $a) { return $a; }
-    private function peg_f3($blockName, $attrs) {
+    private function peg_f2($ts) { return implode( '', $ts ); }
+    private function peg_f3() { return ''; }
+    private function peg_f4($s) { return peg_is_dynamic_block( $s['blockName'] ); }
+    private function peg_f5($s) { return 'dynamic'; }
+    private function peg_f6($s, $c, $e) { return 'dynamic'; }
+    private function peg_f7($s) { return $s; }
+    private function peg_f8($blockName, $a) { return $a; }
+    private function peg_f9($blockName, $attrs) {
         return array(
           'blockName'  => $blockName,
           'attrs'      => $attrs,
@@ -268,7 +274,7 @@ class Gutenberg_PEG_Parser {
           'innerHTML' => '',
         );
         }
-    private function peg_f4($s, $children, $e) {
+    private function peg_f10($s, $children, $e) {
         list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
 
         return array(
@@ -278,19 +284,19 @@ class Gutenberg_PEG_Parser {
           'innerHTML'  => implode( '', $innerHTML ),
         );
         }
-    private function peg_f5($blockName, $attrs) {
+    private function peg_f11($blockName, $attrs) {
         return array(
           'blockName' => $blockName,
           'attrs'     => $attrs,
         );
         }
-    private function peg_f6($blockName) {
+    private function peg_f12($blockName) {
         return array(
           'blockName' => $blockName,
         );
         }
-    private function peg_f7($type) { return "core/$type"; }
-    private function peg_f8($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f13($type) { return "core/$type"; }
+    private function peg_f14($attrs) { return json_decode( $attrs, true ); }
 
     private function peg_parseBlock_List() {
 
@@ -601,6 +607,220 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
+    private function peg_parseRendered_Output() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = array();
+      $s2 = $this->peg_parseRendered_Token();
+      while ($s2 !== $this->peg_FAILED) {
+        $s1[] = $s2;
+        $s2 = $this->peg_parseRendered_Token();
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f2($s1);
+      }
+      $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseRendered_Token() {
+
+      $s0 = $this->peg_parseDynamic_Block();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_currPos;
+        $s1 = $this->peg_parseBlock_Start();
+        if ($s1 !== $this->peg_FAILED) {
+          $this->peg_reportedPos = $s0;
+          $s1 = $this->peg_f3();
+        }
+        $s0 = $s1;
+        if ($s0 === $this->peg_FAILED) {
+          $s0 = $this->peg_currPos;
+          $s1 = $this->peg_parseBlock_End();
+          if ($s1 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f3();
+          }
+          $s0 = $s1;
+          if ($s0 === $this->peg_FAILED) {
+            $s0 = $this->peg_currPos;
+            $s1 = $this->peg_parseBlock_Void();
+            if ($s1 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s0;
+              $s1 = $this->peg_f3();
+            }
+            $s0 = $s1;
+            if ($s0 === $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s0 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s0 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseDynamic_Block() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_parseBlock_Void();
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $this->peg_currPos;
+        $s2 = $this->peg_f4($s1);
+        if ($s2) {
+          $s2 = null;
+        } else {
+          $s2 = $this->peg_FAILED;
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $this->peg_reportedPos = $s0;
+          $s1 = $this->peg_f5($s1);
+          $s0 = $s1;
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_currPos;
+        $s1 = $this->peg_parseDynamic_Block_Start();
+        if ($s1 !== $this->peg_FAILED) {
+          $s2 = array();
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s5 = $this->peg_parseBlock_End();
+          $this->peg_silentFails--;
+          if ($s5 === $this->peg_FAILED) {
+            $s4 = null;
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $s4 = array($s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            while ($s3 !== $this->peg_FAILED) {
+              $s2[] = $s3;
+              $s3 = $this->peg_currPos;
+              $s4 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s5 = $this->peg_parseBlock_End();
+              $this->peg_silentFails--;
+              if ($s5 === $this->peg_FAILED) {
+                $s4 = null;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+              if ($s4 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s5 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s5 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s5 !== $this->peg_FAILED) {
+                  $s4 = array($s4, $s5);
+                  $s3 = $s4;
+                } else {
+                  $this->peg_currPos = $s3;
+                  $s3 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s3;
+                $s3 = $this->peg_FAILED;
+              }
+            }
+          } else {
+            $s2 = $this->peg_FAILED;
+          }
+          if ($s2 !== $this->peg_FAILED) {
+            $s3 = $this->peg_parseBlock_End();
+            if ($s3 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s0;
+              $s1 = $this->peg_f6($s1, $s2, $s3);
+              $s0 = $s1;
+            } else {
+              $this->peg_currPos = $s0;
+              $s0 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseDynamic_Block_Start() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_parseBlock_Start();
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $this->peg_currPos;
+        $s2 = $this->peg_f4($s1);
+        if ($s2) {
+          $s2 = null;
+        } else {
+          $s2 = $this->peg_FAILED;
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $this->peg_reportedPos = $s0;
+          $s1 = $this->peg_f7($s1);
+          $s0 = $s1;
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      return $s0;
+    }
+
     private function peg_parseToken() {
 
       $s0 = $this->peg_parseBlock_Void();
@@ -673,7 +893,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f2($s4, $s7);
+                    $s7 = $this->peg_f8($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -698,7 +918,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f3($s4, $s6);
+                    $s1 = $this->peg_f9($s4, $s6);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -827,7 +1047,7 @@ class Gutenberg_PEG_Parser {
           $s3 = $this->peg_parseBlock_End();
           if ($s3 !== $this->peg_FAILED) {
             $this->peg_reportedPos = $s0;
-            $s1 = $this->peg_f4($s1, $s2, $s3);
+            $s1 = $this->peg_f10($s1, $s2, $s3);
             $s0 = $s1;
           } else {
             $this->peg_currPos = $s0;
@@ -907,7 +1127,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f2($s4, $s7);
+                    $s7 = $this->peg_f8($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -932,7 +1152,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f5($s4, $s6);
+                    $s1 = $this->peg_f11($s4, $s6);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -1024,7 +1244,7 @@ class Gutenberg_PEG_Parser {
                 }
                 if ($s6 !== $this->peg_FAILED) {
                   $this->peg_reportedPos = $s0;
-                  $s1 = $this->peg_f6($s4);
+                  $s1 = $this->peg_f12($s4);
                   $s0 = $s1;
                 } else {
                   $this->peg_currPos = $s0;
@@ -1117,7 +1337,7 @@ class Gutenberg_PEG_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f7($s1);
+        $s1 = $this->peg_f13($s1);
       }
       $s0 = $s1;
 
@@ -1431,7 +1651,7 @@ class Gutenberg_PEG_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f8($s1);
+        $s1 = $this->peg_f14($s1);
       }
       $s0 = $s1;
 
@@ -1585,6 +1805,18 @@ class Gutenberg_PEG_Parser {
             }
 
             return array( $truthy, $falsey );
+        }
+    }
+
+    if ( ! function_exists( 'peg_is_dynamic_block' ) ) {
+        function peg_is_dynamic_block( $block_name ) {
+            static $dynamic_blocks = null;
+
+            if ( null === $dynamic_blocks ) {
+                $dynamic_blocks = get_dynamic_block_names();
+            }
+
+            return in_array( $block_nam, $dynamic_blocks );
         }
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -144,7 +144,7 @@ const config = {
 		rules: [
 			{
 				test: /\.pegjs/,
-				use: 'pegjs-loader',
+				use: 'pegjs-loader?allowedStartRules[]=Block_List,allowedStartRules[]=Rendered_Output',
 			},
 			{
 				test: /\.js$/,


### PR DESCRIPTION
In #4591 we build a custom parser for Gutenberg blocks whose intent was to skip building the entire parse tree and to replace dynamic blocks with their server-rendered output. This custom parser is designed to be faster than the full parse.

This custom parser has served well thanks to the work @aduth put into it but it diverges from one of the project goals, which is to have a clear semantic for how `post_content` translates in the editor and in page views.

This PR is an attempt to "internalize" or "build natively" that same parser into the existing post grammar. Since the grammar defines concepts shared among the different parser productions we can overlap their code and keep the two in sync more easily when we remove that duplication. The PEG is also a bit more declarative and in my opinion easier to follow intent.

The main distinctions in these new rules and the main method of parsing follow:
 - Everything is either a dynamic block, a normal block boundary, or content to feed to the rendered output
 - Replace dynamic blocks with the rendered output from the server
 - Strip away all other block boundaries
 - Leave everything else

Although my instinct tells me that this should be considerably faster than the default parser I don't have any measurements. That's being worked on thankfully in #6030 and other efforts right now to polish the flexibility of the parse system.

Currently this doesn't replace dynamic blocks with server-generated content but rather with the string `dynamic`. It would be helpful to me if someone could point me to an efficient way to find the right render callback and feed in the block attributes to it.