### PR TITLE
Add e2e embedded block creation test

### DIFF
--- a/test/e2e/specs/__snapshots__/add-embed-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/add-embed-blocks.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`embedding media Should insert a Youtube video 1`] = `
+"<!-- wp:embed {\\"url\\":\\"https://www.youtube.com/watch?v=CiwJx557ttk\\",\\"type\\":\\"video\\",\\"providerNameSlug\\":\\"youtube\\"} -->
+<figure class=\\"wp-block-embed is-type-video is-provider-youtube\\">
+    https://www.youtube.com/watch?v=CiwJx557ttk
+</figure>
+<!-- /wp:embed -->"
+`;
+
+exports[`embedding media Should insert an embedded tweet 1`] = `
+"<!-- wp:embed {\\"url\\":\\"https://twitter.com/WordPress/status/980716623060455424\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\"} -->
+<figure class=\\"wp-block-embed is-type-rich is-provider-twitter\\">
+    https://twitter.com/WordPress/status/980716623060455424
+</figure>
+<!-- /wp:embed -->"
+`;

--- a/test/e2e/specs/add-embed-blocks.test.js
+++ b/test/e2e/specs/add-embed-blocks.test.js
@@ -13,7 +13,6 @@ describe( 'embedding media', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
-
 	} );
 
 	afterEach( async () => {
@@ -30,15 +29,15 @@ describe( 'embedding media', () => {
 		await page.keyboard.press( 'Enter' );
 
 		//wait for link to resolve and block to rerender
-		await page.waitFor(2000);
+		await page.waitFor( 2000 );
 
 		//Check HTML output
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
 		await codeEditorButton.click( 'button' );
 
 		//Assert that the editor now has an embedded tweet block
-		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
 		expect( textEditorContent ).toMatchSnapshot();
 	} );
 
@@ -49,15 +48,15 @@ describe( 'embedding media', () => {
 		await page.keyboard.press( 'Enter' );
 
 		//wait for link to resolve and block to rerender
-		await page.waitFor(2000);
+		await page.waitFor( 2000 );
 
 		//Check HTML output
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
 		await codeEditorButton.click( 'button' );
 
 		//Assert that the editor now has an embedded youtube block
-		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
 		expect( textEditorContent ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/add-embed-blocks.test.js
+++ b/test/e2e/specs/add-embed-blocks.test.js
@@ -1,0 +1,63 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage } from '../support/utils';
+
+describe( 'embedding media', () => {
+	beforeEach( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+		await page.click( '.edit-post-header [aria-label="Add block"]' );
+		await page.keyboard.type( 'embed' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+
+	} );
+
+	afterEach( async () => {
+		//reset view to visual editor for next test
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		const visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
+		await visualEditorButton.click( 'button' );
+	} );
+
+	it( 'Should insert an embedded tweet', async () => {
+		//insert a twitter link
+		await page.keyboard.type( 'https://twitter.com/WordPress/status/980716623060455424' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+
+		//wait for link to resolve and block to rerender
+		await page.waitFor(2000);
+
+		//Check HTML output
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		await codeEditorButton.click( 'button' );
+
+		//Assert that the editor now has an embedded tweet block
+		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toMatchSnapshot();
+	} );
+
+	it( 'Should insert a Youtube video', async () => {
+		//insert a youtube link
+		await page.keyboard.type( 'https://www.youtube.com/watch?v=CiwJx557ttk' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+
+		//wait for link to resolve and block to rerender
+		await page.waitFor(2000);
+
+		//Check HTML output
+		await page.click( '.edit-post-more-menu [aria-label="More"]' );
+		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		await codeEditorButton.click( 'button' );
+
+		//Assert that the editor now has an embedded youtube block
+		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		expect( textEditorContent ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description
This is a test for the proper creation of embedded blocks, and verifying that the blocks correctly parse the link type.

## How Has This Been Tested?
This test was manually observed by running puppeteer in non-headless mode, and verifying the contents of the jest snapshot afterwards.

## Screenshots (jpeg or gifs if applicable):
n/a

## Types of changes
This adds a new test for embedded blocks, so anything which modifies how those work may cause this test to fail.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
