### PR TITLE
Add accessibility standards reference and context

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 ## Description
-<!-- Please describe your changes -->
+<!-- Please describe what you have changed or added -->
 
-## How Has This Been Tested?
+## How has this been tested?
 <!-- Please describe in detail how you tested your changes. -->
 <!-- Include details of your testing environment, tests ran to see how -->
 <!-- your change affects other areas of the code, etc. -->
 
-## Screenshots (jpeg or gifs if applicable):
+## Screenshots <!-- if applicable -->
 
 ## Types of changes
 <!-- What types of changes does your code introduce?  -->
@@ -16,5 +16,6 @@
 
 ## Checklist:
 - [ ] My code is tested.
-- [ ] My code follows the WordPress code style.
-- [ ] My code has proper inline documentation.
+- [ ] My code follows the WordPress code style. <!-- Check code: `yarn lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
+- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
+- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,6 @@
 
 ## Checklist:
 - [ ] My code is tested.
-- [ ] My code follows the WordPress code style. <!-- Check code: `yarn lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
+- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
 - [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
 - [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->


### PR DESCRIPTION
## Description
During WordCamp London me and @rianrietveld came up with this approach to help provide a reminder to the accessibility standards, and also to add a direct connection to them to make sure the creator of a PR knows how to retrieve the needed information and context.

It is very easy to forget about this concern if it is not explicitly mentioned.
And the specific needs related to it are also quite complex, so a reference should be a big help in checking what the standards actually are.

While adding this, it seemed the logical step to also add standards references to the other items already present in the template.

## How has this been tested?
Not applicable.

## Checklist:
- [ ] ~My code is tested.~
- [ ] ~My code follows the WordPress code style.~ <!-- Check code: `yarn lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] ~My code follows the accessibility standards.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] ~My code has proper inline documentation.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
