### PR TITLE
Fix JS error when ap.apiRequest has no preload data

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -126,7 +126,7 @@ function gutenberg_shim_api_request( $scripts ) {
 	wp.apiRequest = function( request ) {
 		var method, path;
 
-		if ( typeof request.path === 'string' ) {
+		if ( typeof request.path === 'string' && window._wpAPIDataPreload ) {
 			method = request.method || 'GET';
 			path = getStablePath( request.path );
 


### PR DESCRIPTION
in #6076 we added preloading suppport to wp.apiRequest but when using `wp.apiRequest` in other pages (other than the Gutenberg page), we have a JS error due to the undefined `window._wpAPIDataPreload` variable.

This PRs adds a check for the existence of this variable.

**Testing instructions**

Comment the Gutenberg preloaded data (in client-assets) and check that you don't see any JS error when loading Gutenberg.