### PR TITLE
Blocks: Remove obsolete `isSelected` usage (part 1)

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -13,7 +9,7 @@ import {
 	Placeholder,
 	Toolbar,
 } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { mediaUpload } from '@wordpress/utils';
 
 /**
@@ -138,9 +134,9 @@ export const settings = {
 			}
 
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-			return [
-				isSelected && (
-					<BlockControls key="controls">
+			return (
+				<Fragment>
+					<BlockControls>
 						<Toolbar>
 							<IconButton
 								className="components-icon-button components-toolbar__control"
@@ -150,21 +146,20 @@ export const settings = {
 							/>
 						</Toolbar>
 					</BlockControls>
-				),
-				<figure key="audio" className={ className }>
-					<audio controls="controls" src={ src } />
-					{ ( ( caption && caption.length ) || !! isSelected ) && (
-						<RichText
-							tagName="figcaption"
-							placeholder={ __( 'Write caption…' ) }
-							value={ caption }
-							onChange={ ( value ) => setAttributes( { caption: value } ) }
-							isSelected={ isSelected }
-							inlineToolbar
-						/>
-					) }
-				</figure>,
-			];
+					<figure className={ className }>
+						<audio controls="controls" src={ src } />
+						{ ( ( caption && caption.length ) || !! isSelected ) && (
+							<RichText
+								tagName="figcaption"
+								placeholder={ __( 'Write caption…' ) }
+								value={ caption }
+								onChange={ ( value ) => setAttributes( { caption: value } ) }
+								inlineToolbar
+							/>
+						) }
+					</figure>
+				</Fragment>
+			);
 			/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		}
 	},

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import {
 	Dashicon,
 	IconButton,
@@ -80,29 +80,26 @@ class ButtonBlock extends Component {
 			clear,
 		} = attributes;
 
-		return [
-			isSelected && (
-				<BlockControls key="controls">
+		return (
+			<Fragment>
+				<BlockControls>
 					<BlockAlignmentToolbar value={ align } onChange={ this.updateAlignment } />
 				</BlockControls>
-			),
-			<span key="button" className={ className } title={ title } ref={ this.bindRef }>
-				<RichText
-					tagName="span"
-					placeholder={ __( 'Add text…' ) }
-					value={ text }
-					onChange={ ( value ) => setAttributes( { text: value } ) }
-					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
-					className="wp-block-button__link"
-					style={ {
-						backgroundColor: color,
-						color: textColor,
-					} }
-					isSelected={ isSelected }
-					keepPlaceholderOnFocus
-				/>
-				{ isSelected &&
-					<InspectorControls key="inspector">
+				<span className={ className } title={ title } ref={ this.bindRef }>
+					<RichText
+						tagName="span"
+						placeholder={ __( 'Add text…' ) }
+						value={ text }
+						onChange={ ( value ) => setAttributes( { text: value } ) }
+						formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+						className="wp-block-button__link"
+						style={ {
+							backgroundColor: color,
+							color: textColor,
+						} }
+						keepPlaceholderOnFocus
+					/>
+					<InspectorControls>
 						<PanelBody>
 							<ToggleControl
 								label={ __( 'Wrap text' ) }
@@ -129,22 +126,21 @@ class ButtonBlock extends Component {
 							/> }
 						</PanelBody>
 					</InspectorControls>
-				}
-			</span>,
-			isSelected && (
-				<form
-					key="form-link"
-					className="blocks-button__inline-link"
-					onSubmit={ ( event ) => event.preventDefault() }>
-					<Dashicon icon="admin-links" />
-					<UrlInput
-						value={ url }
-						onChange={ ( value ) => setAttributes( { url: value } ) }
-					/>
-					<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-				</form>
-			),
-		];
+				</span>
+				{ isSelected && (
+					<form
+						className="blocks-button__inline-link"
+						onSubmit={ ( event ) => event.preventDefault() }>
+						<Dashicon icon="admin-links" />
+						<UrlInput
+							value={ url }
+							onChange={ ( value ) => setAttributes( { url: value } ) }
+						/>
+						<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
+					</form>
+				) }
+			</Fragment>
+		);
 	}
 }
 

--- a/blocks/library/categories/block.js
+++ b/blocks/library/categories/block.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { PanelBody, Placeholder, Spinner, ToggleControl } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -143,11 +143,11 @@ class CategoriesBlock extends Component {
 	}
 
 	render() {
-		const { attributes, focus, setAttributes, isRequesting } = this.props;
+		const { attributes, setAttributes, isRequesting } = this.props;
 		const { align, displayAsDropdown, showHierarchy, showPostCounts } = attributes;
 
-		const inspectorControls = focus && (
-			<InspectorControls key="inspector">
+		const inspectorControls = (
+			<InspectorControls>
 				<PanelBody title={ __( 'Categories Settings' ) }>
 					<ToggleControl
 						label={ __( 'Display as dropdown' ) }
@@ -169,22 +169,23 @@ class CategoriesBlock extends Component {
 		);
 
 		if ( isRequesting ) {
-			return [
-				inspectorControls,
-				<Placeholder
-					key="placeholder"
-					icon="admin-post"
-					label={ __( 'Categories' ) }
-				>
-					<Spinner />
-				</Placeholder>,
-			];
+			return (
+				<Fragment>
+					{ inspectorControls }
+					<Placeholder
+						icon="admin-post"
+						label={ __( 'Categories' ) }
+					>
+						<Spinner />
+					</Placeholder>
+				</Fragment>
+			);
 		}
 
-		return [
-			inspectorControls,
-			focus && (
-				<BlockControls key="controls">
+		return (
+			<Fragment>
+				{ inspectorControls }
+				<BlockControls>
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ ( nextAlign ) => {
@@ -193,15 +194,15 @@ class CategoriesBlock extends Component {
 						controls={ [ 'left', 'center', 'right', 'full' ] }
 					/>
 				</BlockControls>
-			),
-			<div key="categories" className={ this.props.className }>
-				{
-					displayAsDropdown ?
-						this.renderCategoryDropdown() :
-						this.renderCategoryList()
-				}
-			</div>,
-		];
+				<div className={ this.props.className }>
+					{
+						displayAsDropdown ?
+							this.renderCategoryDropdown() :
+							this.renderCategoryList()
+					}
+				</div>
+			</Fragment>
+		);
 	}
 }
 

--- a/blocks/library/columns/index.js
+++ b/blocks/library/columns/index.js
@@ -10,6 +10,7 @@ import memoize from 'memize';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { PanelBody, RangeControl } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -68,13 +69,13 @@ export const settings = {
 		return { 'data-align': align };
 	},
 
-	edit( { attributes, setAttributes, className, focus } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { align, columns } = attributes;
 		const classes = classnames( className, `has-${ columns }-columns` );
 
-		return [
-			...focus ? [
-				<BlockControls key="controls">
+		return (
+			<Fragment>
+				<BlockControls>
 					<BlockAlignmentToolbar
 						controls={ [ 'wide', 'full' ] }
 						value={ align }
@@ -82,8 +83,8 @@ export const settings = {
 							setAttributes( { align: nextAlign } );
 						} }
 					/>
-				</BlockControls>,
-				<InspectorControls key="inspector">
+				</BlockControls>
+				<InspectorControls>
 					<PanelBody>
 						<RangeControl
 							label={ __( 'Columns' ) }
@@ -97,12 +98,12 @@ export const settings = {
 							max={ 6 }
 						/>
 					</PanelBody>
-				</InspectorControls>,
-			] : [],
-			<div className={ classes } key="container">
-				<InnerBlocks layouts={ getColumnLayouts( columns ) } />
-			</div>,
-		];
+				</InspectorControls>
+				<div className={ classes }>
+					<InnerBlocks layouts={ getColumnLayouts( columns ) } />
+				</div>
+			</Fragment>
+		);
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -7,6 +7,7 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { IconButton, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 
@@ -122,51 +123,53 @@ export const settings = {
 				} }
 			/>
 		);
-		const controls = isSelected && [
-			<BlockControls key="controls">
-				<BlockAlignmentToolbar
-					value={ align }
-					onChange={ updateAlignment }
-				/>
+		const controls = (
+			<Fragment>
+				<BlockControls>
+					<BlockAlignmentToolbar
+						value={ align }
+						onChange={ updateAlignment }
+					/>
 
-				{ alignmentToolbar }
-				<Toolbar>
-					<MediaUpload
-						onSelect={ onSelectImage }
-						type="image"
-						value={ id }
-						render={ ( { open } ) => (
-							<IconButton
-								className="components-toolbar__control"
-								label={ __( 'Edit image' ) }
-								icon="edit"
-								onClick={ open }
-							/>
-						) }
-					/>
-				</Toolbar>
-			</BlockControls>,
-			<InspectorControls key="inspector">
-				<PanelBody title={ __( 'Cover Image Settings' ) }>
-					<ToggleControl
-						label={ __( 'Fixed Background' ) }
-						checked={ !! hasParallax }
-						onChange={ toggleParallax }
-					/>
-					<RangeControl
-						label={ __( 'Background Dimness' ) }
-						value={ dimRatio }
-						onChange={ setDimRatio }
-						min={ 0 }
-						max={ 100 }
-						step={ 10 }
-					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Text Alignment' ) }>
 					{ alignmentToolbar }
-				</PanelBody>
-			</InspectorControls>,
-		];
+					<Toolbar>
+						<MediaUpload
+							onSelect={ onSelectImage }
+							type="image"
+							value={ id }
+							render={ ( { open } ) => (
+								<IconButton
+									className="components-toolbar__control"
+									label={ __( 'Edit image' ) }
+									icon="edit"
+									onClick={ open }
+								/>
+							) }
+						/>
+					</Toolbar>
+				</BlockControls>
+				<InspectorControls>
+					<PanelBody title={ __( 'Cover Image Settings' ) }>
+						<ToggleControl
+							label={ __( 'Fixed Background' ) }
+							checked={ !! hasParallax }
+							onChange={ toggleParallax }
+						/>
+						<RangeControl
+							label={ __( 'Background Dimness' ) }
+							value={ dimRatio }
+							onChange={ setDimRatio }
+							min={ 0 }
+							max={ 100 }
+							step={ 10 }
+						/>
+					</PanelBody>
+					<PanelBody title={ __( 'Text Alignment' ) }>
+						{ alignmentToolbar }
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
 
 		if ( ! url ) {
 			const hasTitle = ! isEmpty( title );
@@ -176,40 +179,41 @@ export const settings = {
 					tagName="h2"
 					value={ title }
 					onChange={ ( value ) => setAttributes( { title: value } ) }
-					isSelected={ isSelected }
 					inlineToolbar
 				/>
 			) : __( 'Cover Image' );
 
-			return [
-				controls,
-				<ImagePlaceholder key="cover-image-placeholder"
-					{ ...{ className, icon, label, onSelectImage } }
-				/>,
-			];
+			return (
+				<Fragment>
+					{ controls }
+					<ImagePlaceholder
+						{ ...{ className, icon, label, onSelectImage } }
+					/>
+				</Fragment>
+			);
 		}
 
-		return [
-			controls,
-			<div
-				key="preview"
-				data-url={ url }
-				style={ style }
-				className={ classes }
-			>
-				{ title || isSelected ? (
-					<RichText
-						tagName="p"
-						className="wp-block-cover-image-text"
-						placeholder={ __( 'Write title…' ) }
-						value={ title }
-						onChange={ ( value ) => setAttributes( { title: value } ) }
-						isSelected={ isSelected }
-						inlineToolbar
-					/>
-				) : null }
-			</div>,
-		];
+		return (
+			<Fragment>
+				{ controls }
+				<div
+					data-url={ url }
+					style={ style }
+					className={ classes }
+				>
+					{ title || isSelected ? (
+						<RichText
+							tagName="p"
+							className="wp-block-cover-image-text"
+							placeholder={ __( 'Write title…' ) }
+							value={ title }
+							onChange={ ( value ) => setAttributes( { title: value } ) }
+							inlineToolbar
+						/>
+					) : null }
+				</div>
+			</Fragment>
+		);
 	},
 
 	save( { attributes, className } ) {

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -9,7 +9,7 @@ import { stringify } from 'querystring';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Component, renderToString } from '@wordpress/element';
+import { Component, Fragment, renderToString } from '@wordpress/element';
 import { Button, Placeholder, Spinner, SandBox } from '@wordpress/components';
 import classnames from 'classnames';
 
@@ -148,8 +148,8 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				const { setAttributes, isSelected, className } = this.props;
 				const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
-				const controls = isSelected && (
-					<BlockControls key="controls">
+				const controls = (
+					<BlockControls>
 						<BlockAlignmentToolbar
 							value={ align }
 							onChange={ updateAlignment }
@@ -158,38 +158,42 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				);
 
 				if ( fetching ) {
-					return [
-						controls,
-						<div key="loading" className="wp-block-embed is-loading">
-							<Spinner />
-							<p>{ __( 'Embedding…' ) }</p>
-						</div>,
-					];
+					return (
+						<Fragment>
+							{ controls }
+							<div className="wp-block-embed is-loading">
+								<Spinner />
+								<p>{ __( 'Embedding…' ) }</p>
+							</div>
+						</Fragment>
+					);
 				}
 
 				if ( ! html ) {
 					const label = sprintf( __( '%s URL' ), title );
 
-					return [
-						controls,
-						<Placeholder key="placeholder" icon={ icon } label={ label } className="wp-block-embed">
-							<form onSubmit={ this.doServerSideRender }>
-								<input
-									type="url"
-									value={ url || '' }
-									className="components-placeholder__input"
-									aria-label={ label }
-									placeholder={ __( 'Enter URL to embed here…' ) }
-									onChange={ ( event ) => setAttributes( { url: event.target.value } ) } />
-								<Button
-									isLarge
-									type="submit">
-									{ __( 'Embed' ) }
-								</Button>
-								{ error && <p className="components-placeholder__error">{ __( 'Sorry, we could not embed that content.' ) }</p> }
-							</form>
-						</Placeholder>,
-					];
+					return (
+						<Fragment>
+							{ controls }
+							<Placeholder icon={ icon } label={ label } className="wp-block-embed">
+								<form onSubmit={ this.doServerSideRender }>
+									<input
+										type="url"
+										value={ url || '' }
+										className="components-placeholder__input"
+										aria-label={ label }
+										placeholder={ __( 'Enter URL to embed here…' ) }
+										onChange={ ( event ) => setAttributes( { url: event.target.value } ) } />
+									<Button
+										isLarge
+										type="submit">
+										{ __( 'Embed' ) }
+									</Button>
+									{ error && <p className="components-placeholder__error">{ __( 'Sorry, we could not embed that content.' ) }</p> }
+								</form>
+							</Placeholder>
+						</Fragment>
+					);
 				}
 
 				const parsedUrl = parse( url );
@@ -210,27 +214,28 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 					</div>
 				);
 
-				return [
-					controls,
-					<figure key="embed" className={ classnames( className, { 'is-video': 'video' === type } ) }>
-						{ ( cannotPreview ) ? (
-							<Placeholder icon={ icon } label={ __( 'Embed URL' ) }>
-								<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>
-								<p className="components-placeholder__error">{ __( 'Previews for this are unavailable in the editor, sorry!' ) }</p>
-							</Placeholder>
-						) : embedWrapper }
-						{ ( caption && caption.length > 0 ) || isSelected ? (
-							<RichText
-								tagName="figcaption"
-								placeholder={ __( 'Write caption…' ) }
-								value={ caption }
-								onChange={ ( value ) => setAttributes( { caption: value } ) }
-								isSelected={ isSelected }
-								inlineToolbar
-							/>
-						) : null }
-					</figure>,
-				];
+				return (
+					<Fragment>
+						{ controls }
+						<figure className={ classnames( className, { 'is-video': 'video' === type } ) }>
+							{ ( cannotPreview ) ? (
+								<Placeholder icon={ icon } label={ __( 'Embed URL' ) }>
+									<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>
+									<p className="components-placeholder__error">{ __( 'Previews for this are unavailable in the editor, sorry!' ) }</p>
+								</Placeholder>
+							) : embedWrapper }
+							{ ( caption && caption.length > 0 ) || isSelected ? (
+								<RichText
+									tagName="figcaption"
+									placeholder={ __( 'Write caption…' ) }
+									value={ caption }
+									onChange={ ( value ) => setAttributes( { caption: value } ) }
+									inlineToolbar
+								/>
+							) : null }
+						</figure>
+					</Fragment>
+				);
 			}
 		},
 

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -6,7 +6,7 @@ import { filter, pick } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { mediaUpload } from '@wordpress/utils';
 import {
@@ -165,52 +165,52 @@ class GalleryBlock extends Component {
 		);
 
 		const controls = (
-			isSelected && (
-				<BlockControls key="controls">
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ this.updateAlignment }
-					/>
-					{ !! images.length && (
-						<Toolbar>
-							<MediaUpload
-								onSelect={ this.onSelectImages }
-								type="image"
-								multiple
-								gallery
-								value={ images.map( ( img ) => img.id ) }
-								render={ ( { open } ) => (
-									<IconButton
-										className="components-toolbar__control"
-										label={ __( 'Edit Gallery' ) }
-										icon="edit"
-										onClick={ open }
-									/>
-								) }
-							/>
-						</Toolbar>
-					) }
-				</BlockControls>
-			)
+			<BlockControls>
+				<BlockAlignmentToolbar
+					value={ align }
+					onChange={ this.updateAlignment }
+				/>
+				{ !! images.length && (
+					<Toolbar>
+						<MediaUpload
+							onSelect={ this.onSelectImages }
+							type="image"
+							multiple
+							gallery
+							value={ images.map( ( img ) => img.id ) }
+							render={ ( { open } ) => (
+								<IconButton
+									className="components-toolbar__control"
+									label={ __( 'Edit Gallery' ) }
+									icon="edit"
+									onClick={ open }
+								/>
+							) }
+						/>
+					</Toolbar>
+				) }
+			</BlockControls>
 		);
 
 		if ( images.length === 0 ) {
-			return [
-				controls,
-				<ImagePlaceholder key="gallery-placeholder"
-					className={ className }
-					icon="format-gallery"
-					label={ __( 'Gallery' ) }
-					onSelectImage={ this.onSelectImages }
-					multiple
-				/>,
-			];
+			return (
+				<Fragment>
+					{ controls }
+					<ImagePlaceholder
+						className={ className }
+						icon="format-gallery"
+						label={ __( 'Gallery' ) }
+						onSelectImage={ this.onSelectImages }
+						multiple
+					/>
+				</Fragment>
+			);
 		}
 
-		return [
-			controls,
-			isSelected && (
-				<InspectorControls key="inspector">
+		return (
+			<Fragment>
+				{ controls }
+				<InspectorControls>
 					<PanelBody title={ __( 'Gallery Settings' ) }>
 						{ images.length > 1 && <RangeControl
 							label={ __( 'Columns' ) }
@@ -233,39 +233,39 @@ class GalleryBlock extends Component {
 						/>
 					</PanelBody>
 				</InspectorControls>
-			),
-			<ul key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
-				{ dropZone }
-				{ images.map( ( img, index ) => (
-					<li className="blocks-gallery-item" key={ img.id || img.url }>
-						<GalleryImage
-							url={ img.url }
-							alt={ img.alt }
-							id={ img.id }
-							isSelected={ isSelected && this.state.selectedImage === index }
-							onRemove={ this.onRemoveImage( index ) }
-							onSelect={ this.onSelectImage( index ) }
-							setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
-							caption={ img.caption }
-						/>
-					</li>
-				) ) }
-				{ isSelected &&
-					<li className="blocks-gallery-item">
-						<FormFileUpload
-							multiple
-							isLarge
-							className="blocks-gallery-add-item-button"
-							onChange={ this.uploadFromFiles }
-							accept="image/*"
-							icon="insert"
-						>
-							{ __( 'Upload an image' ) }
-						</FormFileUpload>
-					</li>
-				}
-			</ul>,
-		];
+				<ul className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
+					{ dropZone }
+					{ images.map( ( img, index ) => (
+						<li className="blocks-gallery-item" key={ img.id || img.url }>
+							<GalleryImage
+								url={ img.url }
+								alt={ img.alt }
+								id={ img.id }
+								isSelected={ isSelected && this.state.selectedImage === index }
+								onRemove={ this.onRemoveImage( index ) }
+								onSelect={ this.onSelectImage( index ) }
+								setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
+								caption={ img.caption }
+							/>
+						</li>
+					) ) }
+					{ isSelected &&
+						<li className="blocks-gallery-item">
+							<FormFileUpload
+								multiple
+								isLarge
+								className="blocks-gallery-add-item-button"
+								onChange={ this.uploadFromFiles }
+								accept="image/*"
+								icon="insert"
+							>
+								{ __( 'Upload an image' ) }
+							</FormFileUpload>
+						</li>
+					}
+				</ul>
+			</Fragment>
+		);
 	}
 }
 

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -50,24 +50,22 @@ export const settings = {
 		preview: false,
 	} )( ( { attributes, setAttributes, setState, isSelected, toggleSelection, preview } ) => (
 		<div className="wp-block-html">
-			{ isSelected && (
-				<BlockControls>
-					<div className="components-toolbar">
-						<button
-							className={ `components-tab-button ${ ! preview ? 'is-active' : '' }` }
-							onClick={ () => setState( { preview: false } ) }
-						>
-							<span>HTML</span>
-						</button>
-						<button
-							className={ `components-tab-button ${ preview ? 'is-active' : '' }` }
-							onClick={ () => setState( { preview: true } ) }
-						>
-							<span>{ __( 'Preview' ) }</span>
-						</button>
-					</div>
-				</BlockControls>
-			) }
+			<BlockControls>
+				<div className="components-toolbar">
+					<button
+						className={ `components-tab-button ${ ! preview ? 'is-active' : '' }` }
+						onClick={ () => setState( { preview: false } ) }
+					>
+						<span>HTML</span>
+					</button>
+					<button
+						className={ `components-tab-button ${ preview ? 'is-active' : '' }` }
+						onClick={ () => setState( { preview: true } ) }
+					>
+						<span>{ __( 'Preview' ) }</span>
+					</button>
+				</div>
+			</BlockControls>
 			{ preview ? (
 				<SandBox html={ attributes.content } />
 			) : (

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -6,7 +6,7 @@ import { find, compact, get, initial, last, isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, createElement } from '@wordpress/element';
+import { Component, createElement, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -229,7 +229,6 @@ export const settings = {
 		render() {
 			const {
 				attributes,
-				isSelected,
 				insertBlocksAfter,
 				setAttributes,
 				mergeBlocks,
@@ -238,10 +237,9 @@ export const settings = {
 			} = this.props;
 			const { nodeName, values } = attributes;
 
-			return [
-				isSelected && (
+			return (
+				<Fragment>
 					<BlockControls
-						key="controls"
 						controls={ [
 							{
 								icon: 'editor-ul',
@@ -267,42 +265,40 @@ export const settings = {
 							},
 						] }
 					/>
-				),
-				<RichText
-					multiline="li"
-					key="editable"
-					tagName={ nodeName.toLowerCase() }
-					getSettings={ this.getEditorSettings }
-					onSetup={ this.setupEditor }
-					onChange={ this.setNextValues }
-					value={ values }
-					wrapperClassName="blocks-list"
-					className={ className }
-					placeholder={ __( 'Write list…' ) }
-					onMerge={ mergeBlocks }
-					onSplit={
-						insertBlocksAfter ?
-							( before, after, ...blocks ) => {
-								if ( ! blocks.length ) {
-									blocks.push( createBlock( 'core/paragraph' ) );
-								}
+					<RichText
+						multiline="li"
+						tagName={ nodeName.toLowerCase() }
+						getSettings={ this.getEditorSettings }
+						onSetup={ this.setupEditor }
+						onChange={ this.setNextValues }
+						value={ values }
+						wrapperClassName="blocks-list"
+						className={ className }
+						placeholder={ __( 'Write list…' ) }
+						onMerge={ mergeBlocks }
+						onSplit={
+							insertBlocksAfter ?
+								( before, after, ...blocks ) => {
+									if ( ! blocks.length ) {
+										blocks.push( createBlock( 'core/paragraph' ) );
+									}
 
-								if ( after.length ) {
-									blocks.push( createBlock( 'core/list', {
-										nodeName,
-										values: after,
-									} ) );
-								}
+									if ( after.length ) {
+										blocks.push( createBlock( 'core/list', {
+											nodeName,
+											values: after,
+										} ) );
+									}
 
-								setAttributes( { values: before } );
-								insertBlocksAfter( blocks );
-							} :
-							undefined
-					}
-					onRemove={ () => onReplace( [] ) }
-					isSelected={ isSelected }
-				/>,
-			];
+									setAttributes( { values: before } );
+									insertBlocksAfter( blocks );
+								} :
+								undefined
+						}
+						onRemove={ () => onReplace( [] ) }
+					/>
+				</Fragment>
+			);
 		}
 	},
 

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -8,7 +8,7 @@ import { compact } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Component, RawHTML } from '@wordpress/element';
+import { Component, Fragment, RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -90,16 +90,16 @@ export const settings = {
 
 		render() {
 			const { customText, noTeaser } = this.props.attributes;
-			const { setAttributes, isSelected } = this.props;
+			const { setAttributes } = this.props;
 
 			const toggleNoTeaser = () => setAttributes( { noTeaser: ! noTeaser } );
 			const { defaultText } = this.state;
 			const value = customText !== undefined ? customText : defaultText;
 			const inputLength = value.length + 1;
 
-			return [
-				isSelected && (
-					<InspectorControls key="inspector">
+			return (
+				<Fragment>
+					<InspectorControls>
 						<PanelBody>
 							<ToggleControl
 								label={ __( 'Hide the teaser before the "More" tag' ) }
@@ -108,16 +108,16 @@ export const settings = {
 							/>
 						</PanelBody>
 					</InspectorControls>
-				),
-				<div key="more-tag" className="wp-block-more">
-					<input
-						type="text"
-						value={ value }
-						size={ inputLength }
-						onChange={ this.onChangeInput }
-					/>
-				</div>,
-			];
+					<div className="wp-block-more">
+						<input
+							type="text"
+							value={ value }
+							size={ inputLength }
+							onChange={ this.onChangeInput }
+						/>
+					</div>
+				</Fragment>
+			);
 		}
 	},
 


### PR DESCRIPTION
## Description
Follow up for #5029.

> `isSelected` usage is no longer mandatory with `BlockControls`, `InspectorControls` and `RichText`. It's now handled by the editor internally to ensure that controls are visible only when the block is selected.

Refactored blocks:
- `Audio`
- `Button`
- `Categories`
- `Columns`
- `Cover Image`
- `Embed`
- `Gallery`
- `HTML`
- `List`
- `More`

It should be much easier to review this diff without whitespace changes:

https://github.com/WordPress/gutenberg/pull/6201/files?w=1

## How has this been tested?
Manually, unit tests and e2e tests.


## Types of changes
Refactoring, no visual changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
