### PR TITLE
Replace react-redux with the data module in the editor module

### DIFF
--- a/editor/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/editor/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PostSavedState returns a switch to draft link if the post is published 1`] = `<Connect(PostSwitchToDraftButton) />`;
+exports[`PostSavedState returns a switch to draft link if the post is published 1`] = `<WithSelect(WithDispatch(PostSwitchToDraftButton)) />`;

--- a/editor/components/post-schedule/check.js
+++ b/editor/components/post-schedule/check.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -9,11 +8,7 @@ import { get } from 'lodash';
  */
 import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { getCurrentPostType } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 export function PostScheduleCheck( { user, children } ) {
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
@@ -25,23 +20,17 @@ export function PostScheduleCheck( { user, children } ) {
 	return children;
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postType: getCurrentPostType( state ),
-		};
-	},
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) => {
+		return {
+			postType: select( 'core/editor' ).getCurrentPostType(),
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} ),
 ] )( PostScheduleCheck );

--- a/editor/components/post-schedule/index.js
+++ b/editor/components/post-schedule/index.js
@@ -1,19 +1,14 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { settings } from '@wordpress/date';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { DateTimePicker } from '@wordpress/components';
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 
 export function PostSchedule( { date, onUpdateDate } ) {
 	// To know if the current timezone is a 12 hour time with look for "a" in the time format
@@ -36,17 +31,17 @@ export function PostSchedule( { date, onUpdateDate } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			date: getEditedPostAttribute( state, 'date' ),
+			date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
 		};
-	},
-	( dispatch ) => {
+	} ),
+	withDispatch( ( dispatch ) => {
 		return {
 			onUpdateDate( date ) {
-				dispatch( editPost( { date } ) );
+				dispatch( 'core/editor' ).editPost( { date } );
 			},
 		};
-	}
-)( PostSchedule );
+	} ),
+] )( PostSchedule );

--- a/editor/components/post-schedule/label.js
+++ b/editor/components/post-schedule/label.js
@@ -1,18 +1,9 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { dateI18n, settings } from '@wordpress/date';
-
-/**
- * Internal dependencies
- */
-import { getEditedPostAttribute } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 function PostScheduleLabel( { date } ) {
 	return date ?
@@ -20,10 +11,8 @@ function PostScheduleLabel( { date } ) {
 		__( 'Immediately' );
 }
 
-export default connect(
-	( state ) => {
-		return {
-			date: getEditedPostAttribute( state, 'date' ),
-		};
-	}
-)( PostScheduleLabel );
+export default withSelect( ( select ) => {
+	return {
+		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
+	};
+} )( PostScheduleLabel );

--- a/editor/components/post-sticky/check.js
+++ b/editor/components/post-sticky/check.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -9,11 +8,7 @@ import { get } from 'lodash';
  */
 import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { getCurrentPostType } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 export function PostStickyCheck( { postType, children, user } ) {
 	const userCan = get( user.data, 'post_type_capabilities', false );
@@ -29,23 +24,17 @@ export function PostStickyCheck( { postType, children, user } ) {
 	return children;
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postType: getCurrentPostType( state ),
-		};
-	},
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) => {
+		return {
+			postType: select( 'core/editor' ).getCurrentPostType(),
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} ),
 ] )( PostStickyCheck );

--- a/editor/components/post-sticky/index.js
+++ b/editor/components/post-sticky/index.js
@@ -1,20 +1,14 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FormToggle, withInstanceId } from '@wordpress/components';
 import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 import PostStickyCheck from './check';
 
 export function PostSticky( { onUpdateSticky, postSticky = false, instanceId } ) {
@@ -33,22 +27,18 @@ export function PostSticky( { onUpdateSticky, postSticky = false, instanceId } )
 	);
 }
 
-const applyConnect = connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
 		return {
-			postSticky: getEditedPostAttribute( state, 'sticky' ),
+			postSticky: select( 'core/editor' ).getEditedPostAttribute( 'sticky' ),
 		};
-	},
-	( dispatch ) => {
+	} ),
+	withDispatch( ( dispatch ) => {
 		return {
 			onUpdateSticky( postSticky ) {
-				dispatch( editPost( { sticky: postSticky } ) );
+				dispatch( 'core/editor' ).editPost( { sticky: postSticky } );
 			},
 		};
-	},
-);
-
-export default compose( [
-	applyConnect,
+	} ),
 	withInstanceId,
 ] )( PostSticky );

--- a/editor/components/post-switch-to-draft-button/index.js
+++ b/editor/components/post-switch-to-draft-button/index.js
@@ -1,22 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import { editPost, savePost } from '../../store/actions';
-import {
-	isSavingPost,
-	isCurrentPostPublished,
-} from '../../store/selectors';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 function PostSwitchToDraftButton( { isSaving, isPublished, onClick } ) {
 	if ( ! isPublished ) {
@@ -42,17 +30,22 @@ function PostSwitchToDraftButton( { isSaving, isPublished, onClick } ) {
 	);
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		isSaving: isSavingPost( state ),
-		isPublished: isCurrentPostPublished( state ),
+export default compose( [
+	withSelect( ( select ) => {
+		const { isSavingPost, isCurrentPostPublished } = select( 'core/editor' );
+		return {
+			isSaving: isSavingPost(),
+			isPublished: isCurrentPostPublished(),
+		};
 	} ),
-	{
-		onClick: () => [
-			editPost( { status: 'draft' } ),
-			savePost(),
-		],
-	}
-);
+	withDispatch( ( dispatch ) => {
+		const { editPost, savePost } = dispatch( 'core/editor' );
+		return {
+			onClick: () => {
+				editPost( { status: 'draft' } );
+				savePost();
+			},
+		};
+	} ),
+] )( PostSwitchToDraftButton );
 
-export default applyConnect( PostSwitchToDraftButton );

--- a/editor/components/post-taxonomies/check.js
+++ b/editor/components/post-taxonomies/check.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import { connect } from 'react-redux';
 import { some, includes } from 'lodash';
 
 /**
@@ -9,11 +8,7 @@ import { some, includes } from 'lodash';
  */
 import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { getCurrentPostType } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 export function PostTaxonomiesCheck( { postType, taxonomies, children } ) {
 	const hasTaxonomies = some( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
@@ -24,20 +19,14 @@ export function PostTaxonomiesCheck( { postType, taxonomies, children } ) {
 	return children;
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postType: getCurrentPostType( state ),
-		};
-	},
-);
-
-const applyWithAPIData = withAPIData( () => ( {
-	taxonomies: '/wp/v2/taxonomies?context=edit',
-} ) );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) => {
+		return {
+			postType: select( 'core/editor' ).getCurrentPostType(),
+		};
+	} ),
+	withAPIData( () => ( {
+		taxonomies: '/wp/v2/taxonomies?context=edit',
+	} ) ),
 ] )( PostTaxonomiesCheck );
 

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { isEmpty, get, unescape as unescapeString, find, throttle, uniqBy, invoke } from 'lodash';
 import { stringify } from 'querystring';
 
@@ -11,12 +10,7 @@ import { stringify } from 'querystring';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { FormTokenField, withAPIData } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Module constants
@@ -200,29 +194,23 @@ class FlatTermSelector extends Component {
 	}
 }
 
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { slug } = props;
-	return {
-		taxonomy: `/wp/v2/taxonomies/${ slug }?context=edit`,
-	};
-} );
-
-const applyConnect = connect(
-	( state, ownProps ) => {
+export default compose(
+	withAPIData( ( props ) => {
+		const { slug } = props;
 		return {
-			terms: getEditedPostAttribute( state, ownProps.restBase ),
+			taxonomy: `/wp/v2/taxonomies/${ slug }?context=edit`,
 		};
-	},
-	( dispatch ) => {
+	} ),
+	withSelect( ( select, ownProps ) => {
+		return {
+			terms: select( 'core/editor' ).getEditedPostAttribute( ownProps.restBase ),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
 		return {
 			onUpdateTerms( terms, restBase ) {
-				dispatch( editPost( { [ restBase ]: terms } ) );
+				dispatch( 'core/editor' ).editPost( { [ restBase ]: terms } );
 			},
 		};
-	}
-);
-
-export default compose(
-	applyWithAPIData,
-	applyConnect,
+	} )
 )( FlatTermSelector );

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get, unescape as unescapeString, without, find, some, invoke } from 'lodash';
 import { stringify } from 'querystring';
 
@@ -12,12 +11,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { TreeSelect, withAPIData, withInstanceId, withSpokenMessages } from '@wordpress/components';
 import { buildTermsTree } from '@wordpress/utils';
-
-/**
- * Internal dependencies
- */
-import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Module Constants
@@ -299,29 +293,23 @@ class HierarchicalTermSelector extends Component {
 	}
 }
 
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { slug } = props;
-	return {
-		taxonomy: `/wp/v2/taxonomies/${ slug }?context=edit`,
-	};
-} );
-
-const applyConnect = connect(
-	( state, ownProps ) => {
+export default compose( [
+	withAPIData( ( props ) => {
+		const { slug } = props;
 		return {
-			terms: getEditedPostAttribute( state, ownProps.restBase ),
+			taxonomy: `/wp/v2/taxonomies/${ slug }?context=edit`,
 		};
-	},
-	{
+	} ),
+	withSelect( ( select, ownProps ) => {
+		return {
+			terms: select( 'core/editor' ).getEditedPostAttribute( ownProps.restBase ),
+		};
+	} ),
+	withDispatch( ( dispatch ) => ( {
 		onUpdateTerms( terms, restBase ) {
-			return editPost( { [ restBase ]: terms } );
+			dispatch( 'core/editor' ).editPost( { [ restBase ]: terms } );
 		},
-	}
-);
-
-export default compose(
-	applyWithAPIData,
-	applyConnect,
+	} ) ),
 	withSpokenMessages,
-	withInstanceId
-)( HierarchicalTermSelector );
+	withInstanceId,
+] )( HierarchicalTermSelector );

--- a/editor/components/post-taxonomies/index.js
+++ b/editor/components/post-taxonomies/index.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import { connect } from 'react-redux';
 import { filter, identity, includes } from 'lodash';
 
 /**
@@ -9,6 +8,7 @@ import { filter, identity, includes } from 'lodash';
  */
 import { withAPIData } from '@wordpress/components';
 import { compose, Fragment } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,7 +16,6 @@ import { compose, Fragment } from '@wordpress/element';
 import './style.scss';
 import HierarchicalTermSelector from './hierarchical-term-selector';
 import FlatTermSelector from './flat-term-selector';
-import { getCurrentPostType } from '../../store/selectors';
 
 export function PostTaxonomies( { postType, taxonomies, taxonomyWrapper = identity } ) {
 	const availableTaxonomies = filter( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
@@ -39,20 +38,14 @@ export function PostTaxonomies( { postType, taxonomies, taxonomyWrapper = identi
 	} );
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postType: getCurrentPostType( state ),
-		};
-	},
-);
-
-const applyWithAPIData = withAPIData( () => ( {
-	taxonomies: '/wp/v2/taxonomies?context=edit',
-} ) );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) => {
+		return {
+			postType: select( 'core/editor' ).getCurrentPostType(),
+		};
+	} ),
+	withAPIData( () => ( {
+		taxonomies: '/wp/v2/taxonomies?context=edit',
+	} ) ),
 ] )( PostTaxonomies );
 

--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -2,20 +2,18 @@
  * External dependencies
  */
 import Textarea from 'react-autosize-textarea';
-import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { getEditedPostContent } from '../../store/selectors';
-import { editPost, resetBlocks, checkTemplateValidity } from '../../store/actions';
 
 class PostTextEditor extends Component {
 	constructor() {
@@ -73,19 +71,20 @@ class PostTextEditor extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		value: getEditedPostContent( state ),
+export default compose( [
+	withSelect( ( select ) => ( {
+		value: select( 'core/editor' ).getEditedPostContent(),
+	} ) ),
+	withDispatch( ( dispatch ) => {
+		const { editPost, resetBlocks, checkTemplateValidity } = dispatch( 'core/editor' );
+		return {
+			onChange( content ) {
+				editPost( { content } );
+			},
+			onPersist( content ) {
+				resetBlocks( parse( content ) );
+				checkTemplateValidity();
+			},
+		};
 	} ),
-	{
-		onChange( content ) {
-			return editPost( { content } );
-		},
-		onPersist( content ) {
-			return [
-				resetBlocks( parse( content ) ),
-				checkTemplateValidity(),
-			];
-		},
-	}
-)( PostTextEditor );
+] )( PostTextEditor );

--- a/editor/components/post-trash/check.js
+++ b/editor/components/post-trash/check.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { isEditedPostNew, getCurrentPostId } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 function PostTrashCheck( { isNew, postId, children } ) {
 	if ( isNew || ! postId ) {
@@ -16,11 +11,10 @@ function PostTrashCheck( { isNew, postId, children } ) {
 	return children;
 }
 
-export default connect(
-	( state ) => {
-		return {
-			isNew: isEditedPostNew( state ),
-			postId: getCurrentPostId( state ),
-		};
-	},
-)( PostTrashCheck );
+export default withSelect( ( select ) => {
+	const { isEditedPostNew, getCurrentPostId } = select( 'core/editor' );
+	return {
+		isNew: isEditedPostNew(),
+		postId: getCurrentPostId(),
+	};
+} )( PostTrashCheck );

--- a/editor/components/post-trash/index.js
+++ b/editor/components/post-trash/index.js
@@ -1,24 +1,15 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Button, Dashicon } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import {
-	isEditedPostNew,
-	getCurrentPostId,
-	getCurrentPostType,
-} from '../../store/selectors';
-import { trashPost } from '../../store/actions';
 
 function PostTrash( { isNew, postId, postType, ...props } ) {
 	if ( isNew || ! postId ) {
@@ -35,13 +26,20 @@ function PostTrash( { isNew, postId, postType, ...props } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			isEditedPostNew,
+			getCurrentPostId,
+			getCurrentPostType,
+		} = select( 'core/editor' );
 		return {
-			isNew: isEditedPostNew( state ),
-			postId: getCurrentPostId( state ),
-			postType: getCurrentPostType( state ),
+			isNew: isEditedPostNew(),
+			postId: getCurrentPostId(),
+			postType: getCurrentPostType(),
 		};
-	},
-	{ trashPost }
-)( PostTrash );
+	} ),
+	withDispatch( ( dispatch ) => ( {
+		trashPost: dispatch( 'core/editor' ).trashPost,
+	} ) ),
+] )( PostTrash );

--- a/editor/components/post-visibility/check.js
+++ b/editor/components/post-visibility/check.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
@@ -9,11 +8,7 @@ import { get } from 'lodash';
  */
 import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
-
-/**
- * Internal Dependencies
- */
-import { getCurrentPostType } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 export function PostVisibilityCheck( { user, render } ) {
 	const canEdit = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
@@ -21,23 +16,17 @@ export function PostVisibilityCheck( { user, render } ) {
 	return render( { canEdit } );
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postType: getCurrentPostType( state ),
-		};
-	},
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postType } = props;
-
-	return {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	withSelect( ( select ) => {
+		return {
+			postType: select( 'core/editor' ).getCurrentPostType(),
+		};
+	} ),
+	withAPIData( ( props ) => {
+		const { postType } = props;
+
+		return {
+			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		};
+	} ),
 ] )( PostVisibilityCheck );

--- a/editor/components/post-visibility/index.js
+++ b/editor/components/post-visibility/index.js
@@ -1,24 +1,15 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal Dependencies
  */
 import { visibilityOptions } from './utils';
-import {
-	getEditedPostAttribute,
-	getEditedPostVisibility,
-} from '../../store/selectors';
-import { editPost, savePost } from '../../store/actions';
 
 export class PostVisibility extends Component {
 	constructor( props ) {
@@ -132,21 +123,26 @@ export class PostVisibility extends Component {
 	}
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		status: getEditedPostAttribute( state, 'status' ),
-		visibility: getEditedPostVisibility( state ),
-		password: getEditedPostAttribute( state, 'password' ),
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			getEditedPostAttribute,
+			getEditedPostVisibility,
+		} = select( 'core/editor' );
+		return {
+			status: getEditedPostAttribute( 'status' ),
+			visibility: getEditedPostVisibility(),
+			password: getEditedPostAttribute( 'password' ),
+		};
 	} ),
-	{
-		onSave: savePost,
-		onUpdateVisibility( status, password = null ) {
-			return editPost( { status, password } );
-		},
-	}
-);
-
-export default compose(
-	applyConnect,
-	withInstanceId
-)( PostVisibility );
+	withDispatch( ( dispatch ) => {
+		const { savePost, editPost } = dispatch( 'core/editor' );
+		return {
+			onSave: savePost,
+			onUpdateVisibility( status, password = null ) {
+				editPost( { status, password } );
+			},
+		};
+	} ),
+	withInstanceId,
+] )( PostVisibility );

--- a/editor/components/post-visibility/label.js
+++ b/editor/components/post-visibility/label.js
@@ -1,13 +1,16 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { find } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal Dependencies
  */
-import { getEditedPostVisibility } from '../../store/selectors';
 import { visibilityOptions } from './utils';
 
 function PostVisibilityLabel( { visibility } ) {
@@ -16,8 +19,6 @@ function PostVisibilityLabel( { visibility } ) {
 	return getVisibilityLabel( visibility );
 }
 
-export default connect(
-	( state ) => ( {
-		visibility: getEditedPostVisibility( state ),
-	} )
-)( PostVisibilityLabel );
+export default withSelect( ( select ) => ( {
+	visibility: select( 'core/editor' ).getEditedPostVisibility(),
+} ) )( PostVisibilityLabel );

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import { bindActionCreators } from 'redux';
-import { Provider as ReduxProvider } from 'react-redux';
 import { flow, pick } from 'lodash';
 
 /**
@@ -15,32 +13,29 @@ import {
 	DropZoneProvider,
 	SlotFillProvider,
 } from '@wordpress/components';
-
-/**
- * Internal Dependencies
- */
-import { setupEditor, undo, redo, createUndoLevel } from '../../store/actions';
-import store from '../../store';
+import { withDispatch } from '@wordpress/data';
 
 class EditorProvider extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
-		this.store = store;
-
 		// Assume that we don't need to initialize in the case of an error recovery.
 		if ( ! props.recovery ) {
-			this.store.dispatch(
-				setupEditor( props.post, {
-					...EditorSettings.defaultSettings,
-					...this.props.settings,
-				} )
-			);
+			this.props.setupEditor( props.post, {
+				...EditorSettings.defaultSettings,
+				...this.props.settings,
+			} );
 		}
 	}
 
 	render() {
-		const { children, settings } = this.props;
+		const {
+			children,
+			settings,
+			undo,
+			redo,
+			createUndoLevel,
+		} = this.props;
 		const providers = [
 			// Editor settings provider
 			[
@@ -53,14 +48,6 @@ class EditorProvider extends Component {
 				},
 			],
 
-			// Redux provider:
-			//
-			//  - context.store
-			[
-				ReduxProvider,
-				{ store: this.store },
-			],
-
 			// RichText provider:
 			//
 			//  - context.onUndo
@@ -68,11 +55,11 @@ class EditorProvider extends Component {
 			//  - context.onCreateUndoLevel
 			[
 				RichTextProvider,
-				bindActionCreators( {
+				{
 					onUndo: undo,
 					onRedo: redo,
 					onCreateUndoLevel: createUndoLevel,
-				}, this.store.dispatch ),
+				},
 			],
 
 			// Slot / Fill provider:
@@ -116,4 +103,17 @@ class EditorProvider extends Component {
 	}
 }
 
-export default EditorProvider;
+export default withDispatch( ( dispatch ) => {
+	const {
+		setupEditor,
+		undo,
+		redo,
+		createUndoLevel,
+	} = dispatch( 'core/editor' );
+	return {
+		setupEditor,
+		undo,
+		redo,
+		createUndoLevel,
+	};
+} )( EditorProvider );

--- a/editor/components/template-validation-notice/index.js
+++ b/editor/components/template-validation-notice/index.js
@@ -1,20 +1,15 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { Notice, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { isValidTemplate } from '../../store/selectors';
-import { setTemplateValidity, synchronizeTemplate } from '../../store/actions';
 
 function TemplateValidationNotice( { isValid, ...props } ) {
 	if ( isValid ) {
@@ -39,12 +34,15 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		isValid: isValidTemplate( state ),
+export default compose( [
+	withSelect( ( select ) => ( {
+		isValid: select( 'core/editor' ).isValidTemplate(),
+	} ) ),
+	withDispatch( ( dispatch ) => {
+		const { setTemplateValidity, synchronizeTemplate } = dispatch( 'core/editor' );
+		return {
+			resetTemplateValidity: () => setTemplateValidity( true ),
+			synchronizeTemplate,
+		};
 	} ),
-	{
-		resetTemplateValidity: () => setTemplateValidity( true ),
-		synchronizeTemplate,
-	}
-)( TemplateValidationNotice );
+] )( TemplateValidationNotice );

--- a/editor/components/unsaved-changes-warning/index.js
+++ b/editor/components/unsaved-changes-warning/index.js
@@ -1,18 +1,9 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { isEditedPostDirty } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 class UnsavedChangesWarning extends Component {
 	/**
@@ -59,8 +50,6 @@ class UnsavedChangesWarning extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		isDirty: isEditedPostDirty( state ),
-	} )
-)( UnsavedChangesWarning );
+export default withSelect( ( select ) => ( {
+	isDirty: select( 'core/editor' ).isEditedPostDirty(),
+} ) )( UnsavedChangesWarning );

--- a/editor/components/word-count/index.js
+++ b/editor/components/word-count/index.js
@@ -1,17 +1,8 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { serialize } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
-import { getBlocks } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 function WordCount( { content } ) {
 	const wordCount = wp.utils.WordCounter.prototype.count( content );
@@ -20,10 +11,8 @@ function WordCount( { content } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
-		return {
-			content: serialize( getBlocks( state ) ),
-		};
-	}
-)( WordCount );
+export default withSelect( ( select ) => {
+	return {
+		content: serialize( select( 'core/editor' ).getBlocks() ),
+	};
+} )( WordCount );

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { overEvery, find, findLast, reverse, get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import {
 	keycodes,
 	focus,
@@ -18,22 +17,12 @@ import {
 	placeCaretAtHorizontalEdge,
 	placeCaretAtVerticalEdge,
 } from '@wordpress/utils';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import {
-	getPreviousBlockUid,
-	getNextBlockUid,
-	getMultiSelectedBlocksStartUid,
-	getMultiSelectedBlocks,
-	getSelectedBlock,
-} from '../../store/selectors';
-import {
-	multiSelect,
-	selectBlock,
-} from '../../store/actions';
 import {
 	isBlockFocusStop,
 	isInSameBlock,
@@ -267,16 +256,28 @@ class WritingFlow extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		previousBlockUid: getPreviousBlockUid( state ),
-		nextBlockUid: getNextBlockUid( state ),
-		selectionStart: getMultiSelectedBlocksStartUid( state ),
-		hasMultiSelection: getMultiSelectedBlocks( state ).length > 1,
-		selectedBlockUID: get( getSelectedBlock( state ), [ 'uid' ] ),
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			getPreviousBlockUid,
+			getNextBlockUid,
+			getMultiSelectedBlocksStartUid,
+			getMultiSelectedBlocks,
+			getSelectedBlock,
+		} = select( 'core/editor' );
+		return {
+			previousBlockUid: getPreviousBlockUid(),
+			nextBlockUid: getNextBlockUid(),
+			selectionStart: getMultiSelectedBlocksStartUid(),
+			hasMultiSelection: getMultiSelectedBlocks().length > 1,
+			selectedBlockUID: get( getSelectedBlock(), [ 'uid' ] ),
+		};
 	} ),
-	{
-		onMultiSelect: multiSelect,
-		onSelectBlock: selectBlock,
-	}
-)( WritingFlow );
+	withDispatch( ( dispatch ) =>{
+		const { multiSelect, selectBlock } = dispatch( 'core/editor' );
+		return {
+			onMultiSelect: multiSelect,
+			onSelectBlock: selectBlock,
+		};
+	} ),
+] )( WritingFlow );

--- a/editor/index.js
+++ b/editor/index.js
@@ -1,1 +1,3 @@
+import './store';
+
 export * from './components';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7324,6 +7324,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -12035,26 +12036,6 @@
 						"loose-envify": "1.3.1",
 						"object-assign": "4.1.1"
 					}
-				}
-			}
-		},
-		"react-redux": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-			"integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
-			"requires": {
-				"hoist-non-react-statics": "2.3.1",
-				"invariant": "2.2.2",
-				"lodash": "4.17.5",
-				"lodash-es": "4.17.5",
-				"loose-envify": "1.3.1",
-				"prop-types": "15.5.10"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-					"integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
 		"react-color": "2.13.4",
 		"react-datepicker": "0.61.0",
 		"react-dom": "16.3.0",
-		"react-redux": "5.0.6",
 		"redux": "3.7.2",
 		"redux-multi": "0.1.12",
 		"redux-optimist": "1.0.0",


### PR DESCRIPTION
This PR updates all occurrences of react-redux in the `editor` module with `withSelect` and `withDispatch` from the data module. I notice a gain of `100Kb` unminified in the editor module. It's not huge but still a good improvement.

**Testing instructions**
 
Check that:

 - Post visibility, post sticky, post schedule date, post tags, post categories are updated and saved properly
 - Reverting to draft work
 - The code editor works
 - Leaving with dirty changes trigger a modal
 - The writing flow works (arrow navigation)

