### PR TITLE
Fix undefine global variable $wp_version in gutenberg_pre_init()

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -109,6 +109,8 @@ function gutenberg_build_files_notice() {
  * @since 1.5.0
  */
 function gutenberg_pre_init() {
+	global $wp_version;
+
 	if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE && ! file_exists( dirname( __FILE__ ) . '/blocks/build' ) ) {
 		add_action( 'admin_notices', 'gutenberg_build_files_notice' );
 		return;


### PR DESCRIPTION
Fix undefine global variable $wp_version in gutenberg_pre_init()