### PR TITLE
Updates the image's container size when we resize the window

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -251,10 +251,12 @@ class ImageBlock extends Component {
 
 						return (
 							<ResizableBox
-								size={ {
-									width: currentWidth,
-									height: currentHeight,
-								} }
+								size={
+									width && height ? {
+										width,
+										height,
+									} : undefined
+								}
 								minWidth={ minWidth }
 								maxWidth={ settings.maxWidth }
 								minHeight={ minHeight }

--- a/blocks/library/image/image-size.js
+++ b/blocks/library/image/image-size.js
@@ -6,6 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { withGlobalEvents } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 
 class ImageSize extends Component {
@@ -79,4 +80,6 @@ class ImageSize extends Component {
 	}
 }
 
-export default ImageSize;
+export default withGlobalEvents( {
+	resize: 'calculateSize',
+} )( ImageSize );


### PR DESCRIPTION
closes #6191

This PR fixes the resizing behavior of image blocks when we resize the browser size.

**Testing instructions**

 - Repeat the instructions in #6191 
 - The image should scale according to its container size.