### PR TITLE
Shared block form: add missing label.

### DIFF
--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -76,11 +76,12 @@ class SharedBlockEditPanel extends Component {
 				) }
 				{ ( isEditing || isSaving ) && (
 					<form className="shared-block-edit-panel" onSubmit={ this.handleFormSubmit }>
-						<span className="shared-block-edit-panel__label-wrapper">
-							<label htmlFor={ `shared-block-edit-panel__title-${ instanceId }` }>
-								{ __( 'Shared block name:' ) }
-							</label>
-						</span>
+						<label
+							htmlFor={ `shared-block-edit-panel__title-${ instanceId }` }
+							className="shared-block-edit-panel__label"
+						>
+							{ __( 'Shared block name:' ) }
+						</label>
 						<input
 							ref={ this.titleField }
 							type="text"

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, withInstanceId } from '@wordpress/components';
 import { Component, Fragment, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { keycodes } from '@wordpress/utils';
@@ -55,7 +55,7 @@ class SharedBlockEditPanel extends Component {
 	}
 
 	render() {
-		const { isEditing, title, isSaving, onEdit, onCancel } = this.props;
+		const { isEditing, title, isSaving, onEdit, onCancel, instanceId } = this.props;
 
 		return (
 			<Fragment>
@@ -76,6 +76,11 @@ class SharedBlockEditPanel extends Component {
 				) }
 				{ ( isEditing || isSaving ) && (
 					<form className="shared-block-edit-panel" onSubmit={ this.handleFormSubmit }>
+						<span className="shared-block-edit-panel__label-wrapper">
+							<label htmlFor={ `shared-block-edit-panel__title-${ instanceId }` }>
+								{ __( 'Shared block name:' ) }
+							</label>
+						</span>
 						<input
 							ref={ this.titleField }
 							type="text"
@@ -84,6 +89,7 @@ class SharedBlockEditPanel extends Component {
 							value={ title }
 							onChange={ this.handleTitleChange }
 							onKeyDown={ this.handleTitleKeyDown }
+							id={ `shared-block-edit-panel__title-${ instanceId }` }
 						/>
 						<Button
 							type="submit"
@@ -110,4 +116,4 @@ class SharedBlockEditPanel extends Component {
 	}
 }
 
-export default SharedBlockEditPanel;
+export default withInstanceId( SharedBlockEditPanel );

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -80,7 +80,7 @@ class SharedBlockEditPanel extends Component {
 							htmlFor={ `shared-block-edit-panel__title-${ instanceId }` }
 							className="shared-block-edit-panel__label"
 						>
-							{ __( 'Shared block name:' ) }
+							{ __( 'Name:' ) }
 						</label>
 						<input
 							ref={ this.titleField }

--- a/blocks/library/block/edit-panel/style.scss
+++ b/blocks/library/block/edit-panel/style.scss
@@ -26,10 +26,10 @@
 	}
 
 	.shared-block-edit-panel__title {
+		flex: 1 1 100%;
 		font-size: 14px;
 		height: 30px;
 		margin: #{ $item-spacing / 2 } 0 $item-spacing;
-		min-width: 100%;
 	}
 
 	// Needs specificity to override the margin-bottom set by .button
@@ -41,9 +41,7 @@
 		flex-wrap: nowrap;
 
 		.shared-block-edit-panel__title {
-			flex-grow: 1;
 			margin: 0;
-			width: auto;
 		}
 
 		.wp-core-ui & .shared-block-edit-panel__button {

--- a/blocks/library/block/edit-panel/style.scss
+++ b/blocks/library/block/edit-panel/style.scss
@@ -3,6 +3,7 @@
 	background: $light-gray-100;
 	color: $dark-gray-500;
 	display: flex;
+	flex-wrap: wrap;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	justify-content: flex-end;
@@ -17,6 +18,11 @@
 
 	.shared-block-edit-panel__info {
 		margin-right: auto;
+	}
+
+	.shared-block-edit-panel__label-wrapper {
+		min-width: 100%;
+		padding-bottom: ($block-padding / 2);
 	}
 
 	.shared-block-edit-panel__title {

--- a/blocks/library/block/edit-panel/style.scss
+++ b/blocks/library/block/edit-panel/style.scss
@@ -37,7 +37,7 @@
 		margin: 0 5px 0 0;
 	}
 
-	@include break-medium() {
+	@include break-large() {
 		flex-wrap: nowrap;
 
 		.shared-block-edit-panel__title {

--- a/blocks/library/block/edit-panel/style.scss
+++ b/blocks/library/block/edit-panel/style.scss
@@ -29,7 +29,7 @@
 		font-size: 14px;
 		height: 30px;
 		margin: #{ $item-spacing / 2 } 0 $item-spacing;
-		width: 100%;
+		min-width: 100%;
 	}
 
 	// Needs specificity to override the margin-bottom set by .button

--- a/blocks/library/block/edit-panel/style.scss
+++ b/blocks/library/block/edit-panel/style.scss
@@ -6,7 +6,6 @@
 	flex-wrap: wrap;
 	font-family: $default-font;
 	font-size: $default-font-size;
-	justify-content: flex-end;
 	margin: 0 (-$block-padding);
 	padding: 10px $block-padding;
 	position: relative;
@@ -20,21 +19,35 @@
 		margin-right: auto;
 	}
 
-	.shared-block-edit-panel__label-wrapper {
-		min-width: 100%;
-		padding-bottom: ($block-padding / 2);
+	.shared-block-edit-panel__label {
+		margin-right: $item-spacing;
+		white-space: nowrap;
+		font-weight: 600;
 	}
 
 	.shared-block-edit-panel__title {
-		flex-grow: 1;
 		font-size: 14px;
 		height: 30px;
-		margin: 0 auto 0 0;
-		max-width: 230px;
+		margin: #{ $item-spacing / 2 } 0 $item-spacing;
+		width: 100%;
 	}
 
 	// Needs specificity to override the margin-bottom set by .button
 	.wp-core-ui & .shared-block-edit-panel__button {
-		margin: 0 0 0 5px;
+		margin: 0 5px 0 0;
+	}
+
+	@include break-medium() {
+		flex-wrap: nowrap;
+
+		.shared-block-edit-panel__title {
+			flex-grow: 1;
+			margin: 0;
+			width: auto;
+		}
+
+		.wp-core-ui & .shared-block-edit-panel__button {
+			margin: 0 0 0 5px;
+		}
 	}
 }

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -546,7 +546,7 @@ export default {
 		const sharedBlock = {
 			id: uniqueId( 'shared' ),
 			uid: parsedBlock.uid,
-			title: __( 'Untitled block' ),
+			title: __( 'Untitled shared block' ),
 		};
 
 		dispatch( receiveSharedBlocks( [ {

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -923,7 +923,7 @@ describe( 'effects', () => {
 						sharedBlock: {
 							id: expect.stringMatching( /^shared/ ),
 							uid: staticBlock.uid,
-							title: 'Untitled block',
+							title: 'Untitled shared block',
 						},
 						parsedBlock: staticBlock,
 					} ] )


### PR DESCRIPTION
This PR adds a missing `<label>` element to the Shared block form. It does it in the simpler way, just adding a visible `<label>` so there's also a minor visual change:

<img width="713" alt="screen shot 2018-04-16 at 13 17 19" src="https://user-images.githubusercontent.com/1682452/38808658-42558f22-4181-11e8-8204-87b6fe34f17d.png">


Rationale:
- all users need to clearly understand what a form field is about
- screen reader users need to know what the form field is about when they land on it
- speech recognition software need the label to be visible so they're able to voice a proper command "Click {field name}" to move to the field

Fixes #6199 

