### PR TITLE
Shared block form: manage focus to avoid focus losses.

### DIFF
--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -20,7 +20,7 @@ class SharedBlockEditPanel extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.sharedBlockNameField = createRef();
+		this.titleField = createRef();
 		this.editButton = createRef();
 		this.handleFormSubmit = this.handleFormSubmit.bind( this );
 		this.handleTitleChange = this.handleTitleChange.bind( this );
@@ -30,7 +30,7 @@ class SharedBlockEditPanel extends Component {
 	componentDidUpdate( prevProps ) {
 		// Select the input text only once when the form opens.
 		if ( ! prevProps.isEditing && this.props.isEditing ) {
-			this.sharedBlockNameField.current.select();
+			this.titleField.current.select();
 		}
 		// Move focus back to the Edit button after pressing the Escape key, Cancel, or Save.
 		if ( ( prevProps.isEditing || prevProps.isSaving ) && ! this.props.isEditing && ! this.props.isSaving ) {
@@ -77,7 +77,7 @@ class SharedBlockEditPanel extends Component {
 				{ ( isEditing || isSaving ) && (
 					<form className="shared-block-edit-panel" onSubmit={ this.handleFormSubmit }>
 						<input
-							ref={ this.sharedBlockNameField }
+							ref={ this.titleField }
 							type="text"
 							disabled={ isSaving }
 							className="shared-block-edit-panel__title"

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -21,19 +21,29 @@ class SharedBlockEditPanel extends Component {
 		super( ...arguments );
 
 		this.bindTitleRef = this.bindTitleRef.bind( this );
+		this.bindEditButtonRef = this.bindEditButtonRef.bind( this );
 		this.handleFormSubmit = this.handleFormSubmit.bind( this );
 		this.handleTitleChange = this.handleTitleChange.bind( this );
 		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
 	}
 
-	componentDidMount() {
-		if ( this.props.isEditing ) {
+	componentDidUpdate( prevProps ) {
+		// Select the input text only once when the form opens.
+		if ( ! prevProps.isEditing && this.props.isEditing ) {
 			this.titleRef.select();
+		}
+		// Move focus back to the Edit button after pressing Save or Cancel.
+		if ( ! this.props.isEditing && ! this.props.isSaving ) {
+			this.editButton.focus();
 		}
 	}
 
 	bindTitleRef( ref ) {
 		this.titleRef = ref;
+	}
+
+	bindEditButtonRef( ref ) {
+		this.editButton = ref;
 	}
 
 	handleFormSubmit( event ) {
@@ -62,7 +72,12 @@ class SharedBlockEditPanel extends Component {
 						<b className="shared-block-edit-panel__info">
 							{ title }
 						</b>
-						<Button isLarge className="shared-block-edit-panel__button" onClick={ onEdit }>
+						<Button
+							ref={ this.bindEditButtonRef }
+							isLarge
+							className="shared-block-edit-panel__button"
+							onClick={ onEdit }
+						>
 							{ __( 'Edit' ) }
 						</Button>
 					</div>

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, Fragment, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { keycodes } from '@wordpress/utils';
 
@@ -20,8 +20,8 @@ class SharedBlockEditPanel extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.bindTitleRef = this.bindTitleRef.bind( this );
-		this.bindEditButtonRef = this.bindEditButtonRef.bind( this );
+		this.sharedBlockNameField = createRef();
+		this.editButton = createRef();
 		this.handleFormSubmit = this.handleFormSubmit.bind( this );
 		this.handleTitleChange = this.handleTitleChange.bind( this );
 		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
@@ -30,20 +30,12 @@ class SharedBlockEditPanel extends Component {
 	componentDidUpdate( prevProps ) {
 		// Select the input text only once when the form opens.
 		if ( ! prevProps.isEditing && this.props.isEditing ) {
-			this.titleRef.select();
+			this.sharedBlockNameField.current.select();
 		}
 		// Move focus back to the Edit button after pressing Save or Cancel.
 		if ( ! this.props.isEditing && ! this.props.isSaving ) {
-			this.editButton.focus();
+			this.editButton.current.focus();
 		}
-	}
-
-	bindTitleRef( ref ) {
-		this.titleRef = ref;
-	}
-
-	bindEditButtonRef( ref ) {
-		this.editButton = ref;
 	}
 
 	handleFormSubmit( event ) {
@@ -73,7 +65,7 @@ class SharedBlockEditPanel extends Component {
 							{ title }
 						</b>
 						<Button
-							ref={ this.bindEditButtonRef }
+							ref={ this.editButton }
 							isLarge
 							className="shared-block-edit-panel__button"
 							onClick={ onEdit }
@@ -85,7 +77,7 @@ class SharedBlockEditPanel extends Component {
 				{ ( isEditing || isSaving ) && (
 					<form className="shared-block-edit-panel" onSubmit={ this.handleFormSubmit }>
 						<input
-							ref={ this.bindTitleRef }
+							ref={ this.sharedBlockNameField }
 							type="text"
 							disabled={ isSaving }
 							className="shared-block-edit-panel__title"

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -32,8 +32,8 @@ class SharedBlockEditPanel extends Component {
 		if ( ! prevProps.isEditing && this.props.isEditing ) {
 			this.sharedBlockNameField.current.select();
 		}
-		// Move focus back to the Edit button after pressing Save or Cancel.
-		if ( ! this.props.isEditing && ! this.props.isSaving ) {
+		// Move focus back to the Edit button after pressing the Escape key, Cancel, or Save.
+		if ( ( prevProps.isEditing || prevProps.isSaving ) && ! this.props.isEditing && ! this.props.isSaving ) {
 			this.editButton.current.focus();
 		}
 	}


### PR DESCRIPTION
This PR tries to avoid focus losses on the Shared block form when the component gets fully re-rendered. For details, please see the related issue #6204.

Previously, the component attempted to `select()` the input field contents on `componentDidMount()` however, at that point the component is already mounted so the selection (and focus moved to the input field) just didn't happen.

Using `componentDidUpdate()` seems appropriate, and allows to check when the form gets open so we can select the text just once. Also allows to move focus back to the Edit button when the component is not being edited or saved (i.e. when the form closes).

To test:
- using the keyboard, press the Edit button
- verify focus is moved to the input field and its content gets selected
- modify the shared block name
- using the keyboard, tab to focus the Save or Cancel buttons, press them and verify that:
  - focus is moved back to the Edit button
  - anything else works as expected
  - [Edit]: verify the previous 2 points also pressing the Escape key on your keyboard

Fixes #6204 