### PR TITLE
Extensibility: Pass the post object to `allowed_block_types` filter

### DIFF
--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -120,10 +120,13 @@ wp.blocks.getBlockTypes().forEach( function( blockType ) {
 
 ## Hiding blocks from the inserter
 
-On the server, you can filter the list of blocks shown in the inserter using the `allowed_block_types` filter. you can return either true (all block types supported), false (no block types supported), or an array of block type names to allow.
+On the server, you can filter the list of blocks shown in the inserter using the `allowed_block_types` filter. You can return either true (all block types supported), false (no block types supported), or an array of block type names to allow. You can also use the second provided param `$post` to filter block types based on its content.
 
 ```php
-add_filter( 'allowed_block_types', function() {
+add_filter( 'allowed_block_types', function( $allowed_block_types, $post ) {
+	if ( $post->post_type === 'post' ) {
+	    return $allowed_block_types;
+	}
 	return [ 'core/paragraph' ];
-} );
+}, 10, 2 );
 ```

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -937,8 +937,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	 *
 	 * @param bool|array $allowed_block_types Array of block type slugs, or
 	 *                                        boolean to enable/disable all.
+	 * @param object $post                    The post resource data.
 	 */
-	$allowed_block_types = apply_filters( 'allowed_block_types', true );
+	$allowed_block_types = apply_filters( 'allowed_block_types', true, $post );
 
 	$editor_settings = array(
 		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.


### PR DESCRIPTION
## Description
Closes #2685.

This PR open an access to the current post to the `allowed_block_types` filter to make it possible to provide a different set of allowed block types per post type or based on other properties.

## How has this been tested?
Manually added the following filter:

```php
function my_test_allowed_block_types( $allowed_block_types, $post ) {
	if ( $post->post_type === 'post' ) {
		return $allowed_block_types;
	}
	return [ 'core/paragraph' ];
}
	
add_filter( 'allowed_block_types', 'my_test_allowed_block_types', 10, 2 );
```

## Types of changes
Improvement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
