### PR TITLE
Store: Reset change detection on post update

### DIFF
--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -224,8 +224,8 @@ export const editor = flow( [
 	// Track whether changes exist, resetting at each post save. Relies on
 	// editor initialization firing post reset as an effect.
 	withChangeDetection( {
-		resetTypes: [ 'SETUP_EDITOR_STATE', 'RESET_POST' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS' ],
+		resetTypes: [ 'SETUP_EDITOR_STATE', 'UPDATE_POST' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST' ],
 	} ),
 ] )( {
 	edits( state = {}, action ) {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -89,7 +89,7 @@ export function isEditedPostNew( state ) {
  * @return {boolean} Whether unsaved values exist.
  */
 export function isEditedPostDirty( state ) {
-	return state.editor.isDirty || isSavingPost( state );
+	return state.editor.isDirty || inSomeHistory( state, isEditedPostDirty );
 }
 
 /**
@@ -1567,4 +1567,26 @@ export function getPermalinkParts( state ) {
 		postName,
 		suffix,
 	};
+}
+
+/**
+ * Returns true if an optimistic transaction is pending commit, for which the
+ * before state satisfies the given predicate function.
+ *
+ * @param {Object}   state     Editor state.
+ * @param {Function} predicate Function given state, returning true if match.
+ *
+ * @return {boolean} Whether predicate matches for some history.
+ */
+export function inSomeHistory( state, predicate ) {
+	const { optimist } = state;
+
+	// In recursion, optimist state won't exist. Assume exhausted options.
+	if ( ! optimist ) {
+		return false;
+	}
+
+	return optimist.some( ( { beforeState } ) => (
+		beforeState && predicate( beforeState )
+	) );
 }

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -89,7 +89,7 @@ export function isEditedPostNew( state ) {
  * @return {boolean} Whether unsaved values exist.
  */
 export function isEditedPostDirty( state ) {
-	return state.editor.isDirty;
+	return state.editor.isDirty || isSavingPost( state );
 }
 
 /**

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -212,13 +212,19 @@ describe( 'selectors', () => {
 			expect( isEditedPostDirty( state ) ).toBe( true );
 		} );
 
-		it( 'should return true if mid-save', () => {
+		it( 'should return true if pending transaction with dirty state', () => {
 			const state = {
+				optimist: [
+					{
+						beforeState: {
+							editor: {
+								isDirty: true,
+							},
+						},
+					},
+				],
 				editor: {
 					isDirty: false,
-				},
-				saving: {
-					requesting: true,
 				},
 			};
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -204,6 +204,22 @@ describe( 'selectors', () => {
 				editor: {
 					isDirty: true,
 				},
+				saving: {
+					requesting: false,
+				},
+			};
+
+			expect( isEditedPostDirty( state ) ).toBe( true );
+		} );
+
+		it( 'should return true if mid-save', () => {
+			const state = {
+				editor: {
+					isDirty: false,
+				},
+				saving: {
+					requesting: true,
+				},
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( true );
@@ -213,6 +229,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					isDirty: false,
+				},
+				saving: {
+					requesting: false,
 				},
 			};
 
@@ -230,6 +249,9 @@ describe( 'selectors', () => {
 					id: 1,
 					status: 'auto-draft',
 				},
+				saving: {
+					requesting: false,
+				},
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( true );
@@ -244,6 +266,9 @@ describe( 'selectors', () => {
 					id: 1,
 					status: 'draft',
 				},
+				saving: {
+					requesting: false,
+				},
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( false );
@@ -257,6 +282,9 @@ describe( 'selectors', () => {
 				currentPost: {
 					id: 1,
 					status: 'auto-draft',
+				},
+				saving: {
+					requesting: false,
 				},
 			};
 
@@ -432,6 +460,9 @@ describe( 'selectors', () => {
 					},
 					isDirty: false,
 				},
+				saving: {
+					requesting: false,
+				},
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( 'The Title' );
@@ -449,6 +480,9 @@ describe( 'selectors', () => {
 							title: 'Modified Title',
 						},
 					},
+				},
+				saving: {
+					requesting: false,
 				},
 			};
 
@@ -470,6 +504,9 @@ describe( 'selectors', () => {
 					},
 					isDirty: false,
 				},
+				saving: {
+					requesting: false,
+				},
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( __( 'New post' ) );
@@ -489,6 +526,9 @@ describe( 'selectors', () => {
 						blockOrder: {},
 					},
 					isDirty: true,
+				},
+				saving: {
+					requesting: false,
 				},
 			};
 
@@ -719,6 +759,9 @@ describe( 'selectors', () => {
 				currentPost: {
 					status: 'pending',
 				},
+				saving: {
+					requesting: false,
+				},
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( true );
@@ -731,6 +774,9 @@ describe( 'selectors', () => {
 				},
 				currentPost: {
 					status: 'draft',
+				},
+				saving: {
+					requesting: false,
 				},
 			};
 
@@ -745,6 +791,9 @@ describe( 'selectors', () => {
 				currentPost: {
 					status: 'publish',
 				},
+				saving: {
+					requesting: false,
+				},
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( false );
@@ -757,6 +806,9 @@ describe( 'selectors', () => {
 				},
 				currentPost: {
 					status: 'publish',
+				},
+				saving: {
+					requesting: false,
 				},
 			};
 
@@ -771,6 +823,9 @@ describe( 'selectors', () => {
 				currentPost: {
 					status: 'private',
 				},
+				saving: {
+					requesting: false,
+				},
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( false );
@@ -784,6 +839,9 @@ describe( 'selectors', () => {
 				currentPost: {
 					status: 'future',
 				},
+				saving: {
+					requesting: false,
+				},
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( false );
@@ -796,6 +854,9 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					isDirty: true,
+				},
+				saving: {
+					requesting: false,
 				},
 			};
 

--- a/editor/utils/with-change-detection/test/index.js
+++ b/editor/utils/with-change-detection/test/index.js
@@ -14,10 +14,14 @@ describe( 'withChangeDetection()', () => {
 	function originalReducer( state = initialState, action ) {
 		switch ( action.type ) {
 			case 'INCREMENT':
-				return { ...state, count: state.count + 1 };
+				return {
+					count: state.count + 1,
+				};
 
 			case 'RESET_AND_CHANGE_REFERENCE':
-				return { ...state };
+				return {
+					count: state.count,
+				};
 		}
 
 		return state;
@@ -72,8 +76,9 @@ describe( 'withChangeDetection()', () => {
 		state = reducer( deepFreeze( state ), { type: 'INCREMENT' } );
 		expect( state ).toEqual( { count: 1, isDirty: true } );
 
-		state = reducer( deepFreeze( state ), {} );
-		expect( state ).toEqual( { count: 1, isDirty: true } );
+		const afterState = reducer( deepFreeze( state ), {} );
+		expect( afterState ).toEqual( { count: 1, isDirty: true } );
+		expect( afterState ).toBe( state );
 	} );
 
 	it( 'should maintain separate states', () => {

--- a/test/e2e/specs/a11y.test.js
+++ b/test/e2e/specs/a11y.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage } from '../support/utils';
+import { newPost, newDesktopBrowserPage, pressWithModifier } from '../support/utils';
 
 describe( 'a11y', () => {
 	beforeAll( async () => {
@@ -11,9 +11,7 @@ describe( 'a11y', () => {
 	} );
 
 	it( 'tabs header bar', async () => {
-		await page.keyboard.down( 'Control' );
-		await page.keyboard.press( '~' );
-		await page.keyboard.up( 'Control' );
+		await pressWithModifier( 'Control', '~' );
 
 		await page.keyboard.press( 'Tab' );
 

--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -1,0 +1,179 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage, pressWithModifier } from '../support/utils';
+
+describe( 'Change detection', () => {
+	let handleInterceptedRequest;
+
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+	} );
+
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	async function assertIsDirty( isDirty ) {
+		let hadDialog = false;
+
+		function handleOnDialog( dialog ) {
+			dialog.accept();
+			hadDialog = true;
+		}
+
+		try {
+			page.on( 'dialog', handleOnDialog );
+			await page.reload();
+
+			// Ensure whether it was expected that dialog was encountered.
+			expect( hadDialog ).toBe( isDirty );
+		} catch ( error ) {
+			throw error;
+		} finally {
+			page.removeListener( 'dialog', handleOnDialog );
+		}
+	}
+
+	async function interceptSave() {
+		await page.setRequestInterception( true );
+
+		handleInterceptedRequest = ( interceptedRequest ) => {
+			if ( ! interceptedRequest.url().includes( '/wp/v2/posts' ) ) {
+				interceptedRequest.continue();
+			}
+		};
+		page.on( 'request', handleInterceptedRequest );
+	}
+
+	async function releaseSaveIntercept() {
+		page.removeListener( 'request', handleInterceptedRequest );
+		await page.setRequestInterception( false );
+	}
+
+	it( 'Should not prompt to confirm unsaved changes', async () => {
+		await assertIsDirty( false );
+	} );
+
+	it( 'Should prompt if property changed without save', async () => {
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		await assertIsDirty( true );
+	} );
+
+	it( 'Should prompt if content added without save', async () => {
+		await page.click( '.editor-default-block-appender' );
+
+		await assertIsDirty( true );
+	} );
+
+	it( 'Should not prompt if changes saved', async () => {
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		await Promise.all( [
+			// Wait for "Saved" to confirm save complete.
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+
+			// Keyboard shortcut Ctrl+S save.
+			pressWithModifier( 'Mod', 'S' ),
+		] );
+
+		await assertIsDirty( false );
+	} );
+
+	it( 'Should prompt if save failed', async () => {
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		await page.setOfflineMode( true );
+
+		// Keyboard shortcut Ctrl+S save.
+		await pressWithModifier( 'Mod', 'S' );
+
+		// Ensure save update fails and presents button.
+		await page.waitForXPath( '//p[contains(text(), \'Updating failed\')]' );
+		await page.waitForSelector( '.editor-post-save-draft' );
+
+		// Need to disable offline to allow reload.
+		await page.setOfflineMode( false );
+
+		await assertIsDirty( true );
+	} );
+
+	it( 'Should prompt if changes and save is in-flight', async () => {
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		// Hold the posts request so we don't deal with race conditions of the
+		// save completing early. Other requests should be allowed to continue,
+		// for example the page reload test.
+		await interceptSave();
+
+		// Keyboard shortcut Ctrl+S save.
+		await pressWithModifier( 'Mod', 'S' );
+
+		await releaseSaveIntercept();
+
+		await assertIsDirty( true );
+	} );
+
+	it( 'Should prompt if changes made while save is in-flight', async () => {
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		// Hold the posts request so we don't deal with race conditions of the
+		// save completing early. Other requests should be allowed to continue,
+		// for example the page reload test.
+		await interceptSave();
+
+		// Keyboard shortcut Ctrl+S save.
+		await pressWithModifier( 'Mod', 'S' );
+
+		await page.type( '.editor-post-title__input', '!' );
+
+		await releaseSaveIntercept();
+
+		await assertIsDirty( true );
+	} );
+
+	it( 'Should prompt if property changes made while save is in-flight, and save completes', async () => {
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		// Hold the posts request so we don't deal with race conditions of the
+		// save completing early.
+		await interceptSave();
+
+		// Keyboard shortcut Ctrl+S save.
+		await pressWithModifier( 'Mod', 'S' );
+
+		// Dirty post while save is in-flight.
+		await page.type( '.editor-post-title__input', '!' );
+
+		// Allow save to complete. Disabling interception flushes pending.
+		await Promise.all( [
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+			releaseSaveIntercept(),
+		] );
+
+		await assertIsDirty( true );
+	} );
+
+	it( 'Should prompt if block revision is made while save is in-flight, and save completes', async () => {
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		// Hold the posts request so we don't deal with race conditions of the
+		// save completing early.
+		await interceptSave();
+
+		// Keyboard shortcut Ctrl+S save.
+		await pressWithModifier( 'Mod', 'S' );
+
+		await page.click( '.editor-default-block-appender' );
+
+		// Allow save to complete. Disabling interception flushes pending.
+		await Promise.all( [
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+			releaseSaveIntercept(),
+		] );
+
+		await assertIsDirty( true );
+	} );
+} );

--- a/test/e2e/specs/hello.test.js
+++ b/test/e2e/specs/hello.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, visitAdmin, newDesktopBrowserPage } from '../support/utils';
+import { newPost, newDesktopBrowserPage } from '../support/utils';
 
 describe( 'hello', () => {
 	beforeAll( async () => {
@@ -24,10 +24,5 @@ describe( 'hello', () => {
 
 		expect( undoButton ).toBeNull();
 		expect( redoButton ).toBeNull();
-	} );
-
-	it( 'Should not prompt to confirm unsaved changes', async () => {
-		await visitAdmin( 'edit.php' );
-		expect( page.url() ).not.toEqual( expect.stringContaining( 'post-new.php' ) );
 	} );
 } );

--- a/test/e2e/specs/multi-block-selection.test.js
+++ b/test/e2e/specs/multi-block-selection.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage } from '../support/utils';
+import { newPost, newDesktopBrowserPage, pressWithModifier } from '../support/utils';
 
 describe( 'Multi-block selection', () => {
 	beforeAll( async () => {
@@ -62,9 +62,7 @@ describe( 'Multi-block selection', () => {
 
 		// Multiselect via keyboard
 		await page.click( 'body' );
-		await page.keyboard.down( 'Meta' );
-		await page.keyboard.press( 'a' );
-		await page.keyboard.up( 'Meta' );
+		await pressWithModifier( 'Mod', 'a' );
 
 		// Verify selection
 		expectMultiSelected( blocks, true );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -10,6 +10,15 @@ const {
 	WP_PASSWORD = 'password',
 } = process.env;
 
+/**
+ * Platform-specific modifier key.
+ *
+ * @see pressWithModifier
+ *
+ * @type {string}
+ */
+const MOD_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
+
 function getUrl( WPPath, query = '' ) {
 	const url = new URL( WP_BASE_URL );
 
@@ -57,4 +66,36 @@ export async function newPost( postType ) {
 export async function newDesktopBrowserPage() {
 	global.page = await browser.newPage();
 	await page.setViewport( { width: 1000, height: 700 } );
+}
+
+export async function switchToEditor( mode ) {
+	await page.click( '.edit-post-more-menu [aria-label="More"]' );
+	const [ button ] = await page.$x( `//button[contains(text(), \'${ mode } Editor\')]` );
+	await button.click( 'button' );
+}
+
+export async function getHTMLFromCodeEditor() {
+	await switchToEditor( 'Code' );
+	const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+	await switchToEditor( 'Visual' );
+	return textEditorContent;
+}
+
+/**
+ * Performs a key press with modifier (Shift, Control, Meta, Mod), where "Mod"
+ * is normalized to platform-specific modifier (Meta in MacOS, else Control).
+ *
+ * @param {string} modifier Modifier key.
+ * @param {string} key      Key to press while modifier held.
+ *
+ * @return {Promise} Promise resolving when key combination pressed.
+ */
+export async function pressWithModifier( modifier, key ) {
+	if ( modifier.toLowerCase() === 'mod' ) {
+		modifier = MOD_KEY;
+	}
+
+	await page.keyboard.down( modifier );
+	await page.keyboard.press( key );
+	return page.keyboard.up( modifier );
 }


### PR DESCRIPTION
Fixes #6112 

This pull request seeks to resolve an issue where changes made while a post is saving are not accurately reflected in change detection, resulting in the potential for data loss if the user attempts to navigate away after a save completes.

In doing so, it also introduces...

- E2E tests for various "dirty post" prompt conditions.
- A fix for the `withChangeDetection` higher-order reducer where ignored action types may have resulted in the `isDirty` value being lost.

__Testing instructions:__

Verify that end-to-end tests pass:

```
npm run test-e2e
```

Repeat steps to reproduce from #6112, verifying that the editor prompts about unsaved changes if they were introduced in the time between save start and save success.