### PR TITLE
Modify left positioning of .components-notice-list and .edit-post-header

### DIFF
--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -219,7 +219,9 @@ $float-margin: calc( 50% - #{ $content-width-padding / 2 } );
  * Applies editor left position to the selector passed as argument
  */
 @mixin editor-left( $selector ) {
-	.sticky-menu #{$selector} {	/* Sticky is when on smaller breakpoints, nav menu is manually opened */
+	#{$selector} {	/* Set left position when auto-fold is not on the body element. */
+		left: 0;
+		
 		@include break-medium() {
 			left: $admin-sidebar-width;
 		}

--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -9,7 +9,6 @@
 	.components-notice-list {
 		position: sticky;
 		top: $header-height;
-		left: 0;
 		right: 0;
 
 		@include break-small {


### PR DESCRIPTION
## Description
This PR resolves #6171 by positioning the elements with the `.components-notice-list` and `.edit-post-header` classes to the right of the admin sidebar when it's displaying and not collapsed.

Currently, the `editor-left` mixin assumes the `sticky-menu` class is always present on the body element, but that's [not the case when the sidebar + the admin menu are taller than the window](https://github.com/WordPress/WordPress/blob/f6a37e7d39e2534d05b9e542045174498edfe536/wp-admin/js/common.js#L1238). This change simply removes `.sticky-menu` from the selector, and the low specificity allows the `.auto-fold` class to take precence when it exists (i.e., when the sidebar is collapsed).

## How has this been tested?
Visually verified at various screen widths with the admin sidebar both expanded and collapsed. 

## Screenshots <!-- if applicable -->

### Before
<img width="449" alt="before" src="https://user-images.githubusercontent.com/9020968/38829249-7cca8dc4-4186-11e8-9461-a5a0e6343346.png">

### After
<img width="395" alt="after" src="https://user-images.githubusercontent.com/9020968/38829258-845e0b6a-4186-11e8-8c26-1a0982858b29.png">

## Types of changes

Small changes to two Sass files.