### PR TITLE
Fixed some Embed's width in the editor.

### DIFF
--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -142,6 +142,9 @@ class Sandbox extends Component {
 				width: 100%;
 				height: 100%;
 			}
+			body > div > iframe {
+				width: 100%;
+			}
 			body > div > * {
 				margin-top: 0 !important;	/* has to have !important to override inline styles */
 				margin-bottom: 0 !important;


### PR DESCRIPTION
## Description
This Pr corrects a style rule so the non-video embed's also become responsive (videos like youtube already were).

Fixes: https://github.com/WordPress/gutenberg/issues/5757
 
## How has this been tested?
Verify the problem described in https://github.com/WordPress/gutenberg/issues/5757 does not happen and the embed correctly resizes to the available space.

