### PR TITLE
Improve terms tokens feedback and accessibility.

### DIFF
--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -451,9 +451,11 @@ class FormTokenField extends Component {
 		return components;
 	}
 
-	renderToken( token ) {
+	renderToken( token, index, tokens ) {
 		const value = this.getTokenValue( token );
 		const status = token.status ? token.status : undefined;
+		const termPosition = index + 1;
+		const termsCount = tokens.length;
 
 		return (
 			<Token
@@ -468,6 +470,8 @@ class FormTokenField extends Component {
 				onMouseLeave={ token.onMouseLeave }
 				disabled={ 'error' !== status && this.props.disabled }
 				messages={ this.props.messages }
+				termsCount={ termsCount }
+				termPosition={ termPosition }
 			/>
 		);
 	}
@@ -583,7 +587,7 @@ FormTokenField.defaultProps = {
 	messages: {
 		added: __( 'Item added.' ),
 		removed: __( 'Item removed.' ),
-		remove: __( 'Remove item: %s.' ),
+		remove: __( 'Remove item' ),
 	},
 };
 

--- a/components/form-token-field/token.js
+++ b/components/form-token-field/token.js
@@ -7,7 +7,8 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { sprintf } from '@wordpress/i18n';
+import withInstanceId from '../higher-order/with-instance-id';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -25,6 +26,9 @@ function Token( {
 	onMouseEnter,
 	onMouseLeave,
 	messages,
+	termPosition,
+	termsCount,
+	instanceId,
 } ) {
 	const tokenClasses = classnames( 'components-form-token-field__token', {
 		'is-error': 'error' === status,
@@ -36,6 +40,15 @@ function Token( {
 
 	const onClick = () => onClickRemove( { value } );
 
+	const transformedValue = displayTransform( value );
+	const termPositionAndCount = sprintf(
+		/* translators: 1: term name, 2: term position in a set of terms, 3: total term set count. */
+		__( '%1$s (%2$s of %3$s)' ),
+		transformedValue,
+		termPosition,
+		termsCount
+	);
+
 	return (
 		<span
 			className={ tokenClasses }
@@ -43,18 +56,23 @@ function Token( {
 			onMouseLeave={ onMouseLeave }
 			title={ title }
 		>
-			<span className="components-form-token-field__token-text">
-				{ displayTransform( value ) }
+			<span
+				className="components-form-token-field__token-text"
+				id={ `components-form-token-field__token-text-${ instanceId }` }
+			>
+				<span className="screen-reader-text">{ termPositionAndCount }</span>
+				<span aria-hidden="true">{ transformedValue }</span>
 			</span>
 
 			<IconButton
 				className="components-form-token-field__remove-token"
 				icon="dismiss"
 				onClick={ ! disabled && onClick }
-				label={ sprintf( messages.remove, displayTransform( value ) ) }
+				label={ messages.remove }
+				aria-describedby={ `components-form-token-field__token-text-${ instanceId }` }
 			/>
 		</span>
 	);
 }
 
-export default Token;
+export default withInstanceId( Token );

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -172,7 +172,7 @@ class FlatTermSelector extends Component {
 		);
 		const termAddedLabel = sprintf( _x( '%s added', 'term' ), singularName );
 		const termRemovedLabel = sprintf( _x( '%s removed', 'term' ), singularName );
-		const removeTermLabel = sprintf( _x( 'Remove %s: %%s', 'term' ), singularName );
+		const removeTermLabel = sprintf( _x( 'Remove %s', 'term' ), singularName );
 
 		return (
 			<FormTokenField


### PR DESCRIPTION
This PR tries to improve the information provided by the terms (tags) tokens for assistive technology users following the feedback from https://github.com/WordPress/gutenberg/issues/1339#issuecomment-381137013

- simplifies the aria-label and text displayed in the tooltips
- uses `aria-describedby` to reference the term's name
- adds information about the position and total count of the terms (`nn of nn`)

Since it's not possible to change the tokens to an unordered list (which would natively provide the info about `nn of nn`) I've thought to grab this info from the array of tokens and put them in a visually hidden text. The value of the information added is the same, except it won't be announced as a list.

In a following PR I'd like to try to:
- not create/add a new term when tabbing away from the input field: just using the keyboard on this component for a while, I've not intentionally created tons of new terms in my tags list... this should be avoided
- maybe (to evaluate) add the total count of terms added in a visible text before the field, something along the lines of `{plural term name} added: 3`
- ideally, the tokens should be placed after the input field but it's not possible to change this because of the way this component works 😞 

For now, this first part addresses feedback from @aardrian and improves the experience for screen reader users.

See #1339