### PR TITLE
Fix regressions in link UI

### DIFF
--- a/blocks/library/button/editor.scss
+++ b/blocks/library/button/editor.scss
@@ -13,17 +13,6 @@
 	margin-bottom: 0;
 	position: relative;
 
-	.blocks-format-toolbar__link-modal {
-		z-index: 2;
-		top: calc( 100% + 2px );
-		left: 50%;
-		transform: translateX( -50% );
-	}
-
-	.blocks-link-url__suggestions {
-		right: -35px;
-	}
-
 	.blocks-rich-text__tinymce {
 		cursor: text;
 	}
@@ -31,7 +20,6 @@
 
 .blocks-button__inline-link {
 	background: #fff;
-	width: 280px;
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
@@ -39,8 +27,20 @@
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 
+	$blocks-button__link-input-width: 280px;
+	width: $blocks-button__link-input-width;
+
 	.blocks-url-input {
 		width: auto;
+	}
+
+	.blocks-url-input__suggestions {
+		width: $blocks-button__link-input-width - $icon-button-size - $icon-button-size;
+		z-index: z-index( '.blocks-button__inline-link .blocks-url-input__suggestions' );
+	}
+
+	> .dashicon {
+		width: $icon-button-size;
 	}
 
 	.dashicon {

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -55,16 +55,6 @@
 }
 /*!rtl:end:ignore*/
 
-.editor-block-list__block[data-type="core/image"] {
-	.blocks-format-toolbar__link-modal {
-		top: 0;
-		left: 0;
-		position: absolute;
-		border: none;
-		width: 100%;
-	}
-}
-
 .wp-core-ui .wp-block-audio__upload-button.button,
 .wp-core-ui .wp-block-image__upload-button.button,
 .wp-core-ui .wp-block-video__upload-button.button {

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -17,10 +17,6 @@
 }
 
 .blocks-format-toolbar__link-modal-line {
-	$button-size: 36px;
-	$input-padding: 10px;
-	$input-size: 230px;
-
 	display: flex;
 	flex-direction: row;
 	flex-grow: 1;
@@ -30,30 +26,8 @@
 
 	.components-button {
 		flex-shrink: 0;
-		width: $button-size;
-		height: $button-size;
-	}
-
-	.blocks-url-input {
-		width: $input-size;
-
-		input {
-			padding: $input-padding;
-			margin: 0;
-		}
-	}
-
-	.blocks-url-input__suggestions {
-		border-top: 1px solid $light-gray-500;
-		box-shadow: none;
-		padding: 4px 0;
-		position: relative;
-		width: $input-size + $button-size * 2;
-	}
-
-	.blocks-url-input__suggestion {
-		color: $dark-gray-100;
-		padding: 4px ( $button-size + $input-padding );
+		width: $icon-button-size;
+		height: $icon-button-size;
 	}
 }
 
@@ -62,7 +36,7 @@
 }
 
 .blocks-format-toolbar__link-value {
-	margin: 10px;
+	margin: $item-spacing - 1px; // subtract border
 	flex-grow: 1;
 	flex-shrink: 1;
 	overflow: hidden;

--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -30,7 +30,6 @@ $input-size: 230px;
 // Suggestions
 .blocks-url-input__suggestions {
 	position: absolute;
-	z-index: 0;	// place underneath the input field so focus isn't cropped
 	background: $white;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;

--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -29,21 +29,22 @@ $input-size: 230px;
 
 // Suggestions
 .blocks-url-input__suggestions {
-	position: relative;
+	position: absolute;
 	z-index: 0;	// place underneath the input field so focus isn't cropped
 	background: $white;
+	box-shadow: $shadow-popover;
+	border: 1px solid $light-gray-500;
 	max-height: 200px;
 	overflow-y: scroll;
 	transition: all .15s ease-in-out;
 	list-style: none;
-	margin: 0;
+	margin: 0 -1px;
 	padding: 4px 0;
-	border-top: 1px solid $light-gray-500;
-	width: $input-size + $icon-button-size * 2;
+	width: $input-size + $icon-button-size * 2 + 2px; // add borders
 }
 
 .blocks-url-input__suggestion {
-	padding: 4px ( $icon-button-size + $input-padding );
+	padding: 4px #{ $icon-button-size + $input-padding } 4px $input-padding;
 	color: $dark-gray-300; // lightest we can use for contrast
 	display: block;
 	font-size: $default-font-size;
@@ -52,10 +53,17 @@ $input-size: 230px;
 	width: 100%;
 	border: none;
 	text-align: left;
+	@include menu-style__neutral();
 
+	&:hover {
+		background: $light-gray-500;
+	}
+
+	&:focus,
 	&.is-selected {
 		background: darken( $blue-medium-500, 15 ); // is overridden in _admin-schemes.scss to be theme dependant
 		color: $white;
+		outline: none;
 	}
 }
 

--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -1,25 +1,22 @@
 // Link input
-.blocks-url-input {
+$input-padding: 10px;
+$input-size: 230px;
+
+.editor-block-list__block .blocks-url-input {
 	width: 100%;
 	flex-grow: 1;
 	position: relative;
+	width: $input-size;
 
 	input[type=text] {
-		padding: 10px;
-		font-size: $default-font-size;
 		width: 100%;
+		padding: $input-padding;
 		border: none;
-		outline: none;
-		box-shadow: none;
+		margin: 0;
+
 		&::-ms-clear {
 			display: none;
 		}
-	}
-
-	&:focus {
-		border: none;
-		box-shadow: none;
-		outline: none;
 	}
 
 	.spinner {
@@ -30,26 +27,26 @@
 	}
 }
 
+// Suggestions
 .blocks-url-input__suggestions {
-	position: absolute;
-	top: 100%;
-	left: 0;
-	right: -64px; // to match the link modal borders
+	position: relative;
+	z-index: 0;	// place underneath the input field so focus isn't cropped
 	background: $white;
 	max-height: 200px;
 	overflow-y: scroll;
 	transition: all .15s ease-in-out;
 	list-style: none;
 	margin: 0;
-	box-shadow: 0 3px 20px rgba( 18, 24, 30, .1 ), 0 1px 3px rgba( 18, 24, 30, .1 );
-	z-index: z-index( '.blocks-url-input__suggestions' )
+	padding: 4px 0;
+	border-top: 1px solid $light-gray-500;
+	width: $input-size + $icon-button-size * 2;
 }
 
 .blocks-url-input__suggestion {
-	color: $dark-gray-500;
+	padding: 4px ( $icon-button-size + $input-padding );
+	color: $dark-gray-300; // lightest we can use for contrast
 	display: block;
 	font-size: $default-font-size;
-	padding: 4px 8px;
 	cursor: pointer;
 	background: $white;
 	width: 100%;
@@ -57,7 +54,7 @@
 	text-align: left;
 
 	&.is-selected {
-		background: $blue-dark-900;
+		background: darken( $blue-medium-500, 15 ); // is overridden in _admin-schemes.scss to be theme dependant
 		color: $white;
 	}
 }

--- a/edit-post/assets/stylesheets/_admin-schemes.scss
+++ b/edit-post/assets/stylesheets/_admin-schemes.scss
@@ -66,6 +66,7 @@ $scheme-sunrise__spot-color: #de823f;
 		}
 
 		// URL suggestions
+		.blocks-url-input__suggestion:focus,
 		.blocks-url-input__suggestion.is-selected {
 			background: darken( $spot-color, 15 );
 		}

--- a/edit-post/assets/stylesheets/_admin-schemes.scss
+++ b/edit-post/assets/stylesheets/_admin-schemes.scss
@@ -64,5 +64,10 @@ $scheme-sunrise__spot-color: #de823f;
 		.react-datepicker__day--selected {
 			background-color: $spot-color;
 		}
+
+		// URL suggestions
+		.blocks-url-input__suggestion.is-selected {
+			background: darken( $spot-color, 15 );
+		}
 	}
 }

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -26,6 +26,7 @@ $z-layers: (
 	'.editor-block-settings-menu__popover': 20, // Below the header
 	'.blocks-url-input__suggestions': 30,
 	'.edit-post-header': 30,
+	'.blocks-button__inline-link .blocks-url-input__suggestions': 6, // URL suggestions for button block above sibling inserter
 	'.wp-block-image__resize-handlers': 1, // Resize handlers above sibling inserter
 
 	// Should have lower index than anything else positioned inside the block containers


### PR DESCRIPTION
Recently we merged in some improvements to the design of input fields. As part of that, some regressions to the link UI on buttons and link modals were introduced. This PR fixes those.

Screenshots:

<img width="520" alt="screen shot 2018-04-17 at 09 51 45" src="https://user-images.githubusercontent.com/1204802/38857774-5575d3f6-422a-11e8-978e-44d862febb0e.png">

<img width="684" alt="screen shot 2018-04-17 at 10 27 49" src="https://user-images.githubusercontent.com/1204802/38857776-56abf232-422a-11e8-92c9-152cb514cd56.png">

<img width="697" alt="screen shot 2018-04-17 at 10 27 56" src="https://user-images.githubusercontent.com/1204802/38857778-5803f666-422a-11e8-83cc-217de70305af.png">

<img width="321" alt="screen shot 2018-04-17 at 10 28 03" src="https://user-images.githubusercontent.com/1204802/38857779-5978b0ea-422a-11e8-824e-ac6a7ab82147.png">

As part of this, I did some major cleanup too, to use more SCSS variables stored in the variables stylesheet. I also added some admin scheme color to the selected item in the suggest dropdown. In fact, quite a bit of CSS was messy, duplicate and redundant, so this is quite a nice cleanup to get in. But it also means that it's a fair bit of deep surgery, and would be good to test. 

@karmatosed I know you've filed a few tickets around link interface improvements. Does this PR address some of those?