### PR TITLE
Remove default pullquote font weight

### DIFF
--- a/blocks/library/pullquote/editor.scss
+++ b/blocks/library/pullquote/editor.scss
@@ -27,7 +27,6 @@
 	& > .blocks-pullquote__content .blocks-rich-text__tinymce[data-is-empty="true"]:before,
 	& > .blocks-rich-text p {
 		font-size: 24px;
-		font-weight: 900;
 		line-height: 1.6;
 	}
 }

--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -16,7 +16,6 @@
 
 	> p {
 		font-size: 24px;
-		font-weight: 900;
 		line-height: 1.6;
 	}
 
@@ -24,7 +23,6 @@
 	footer {
 		color: $dark-gray-600;
 		position: relative;
-		font-weight: 900;
 		text-transform: uppercase;
 		font-size: $default-font-size;
 	}


### PR DESCRIPTION
Fixes #4540.

Before:

<img width="748" alt="screen shot 2018-04-17 at 11 00 40" src="https://user-images.githubusercontent.com/1204802/38859687-dab5fa24-422e-11e8-90dc-43ee5b2cd666.png">

After:

<img width="616" alt="screen shot 2018-04-17 at 11 01 35" src="https://user-images.githubusercontent.com/1204802/38859690-dd0b8bf4-422e-11e8-891d-9dbad1240035.png">
