### PR TITLE
Block API: Indent serialized block output with tabs

### DIFF
--- a/blocks/api/raw-handling/test/index.js
+++ b/blocks/api/raw-handling/test/index.js
@@ -112,7 +112,7 @@ describe( 'rawHandler', () => {
 			mode: 'AUTO',
 		} ).map( getBlockContent ).join( '' );
 
-		equal( filtered, '<ul>\n    <li>one</li>\n    <li>two</li>\n    <li>three</li>\n</ul>' );
+		equal( filtered, '<ul>\n\t<li>one</li>\n\t<li>two</li>\n\t<li>three</li>\n</ul>' );
 	} );
 
 	it( 'should parse inline Markdown', () => {

--- a/blocks/api/raw-handling/test/integration/apple-out.html
+++ b/blocks/api/raw-handling/test/integration/apple-out.html
@@ -12,60 +12,60 @@
 
 <!-- wp:list -->
 <ul>
-    <li>A</li>
-    <li>Bulleted</li>
-    <ul>
-        <li>Indented</li>
-    </ul>
-    <li>List</li>
+	<li>A</li>
+	<li>Bulleted</li>
+	<ul>
+		<li>Indented</li>
+	</ul>
+	<li>List</li>
 </ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
 <ol>
-    <li>One</li>
-    <li>Two</li>
-    <li>Three</li>
+	<li>One</li>
+	<li>Two</li>
+	<li>Three</li>
 </ol>
 <!-- /wp:list -->
 
 <!-- wp:table -->
 <table class="wp-block-table">
-    <tbody>
-        <tr>
-            <td>
-                One
-            </td>
-            <td>
-                Two
-            </td>
-            <td>
-                Three
-            </td>
-        </tr>
-        <tr>
-            <td>
-                1
-            </td>
-            <td>
-                2
-            </td>
-            <td>
-                3
-            </td>
-        </tr>
-        <tr>
-            <td>
-                I
-            </td>
-            <td>
-                II
-            </td>
-            <td>
-                III
-            </td>
-        </tr>
-    </tbody>
+	<tbody>
+		<tr>
+			<td>
+				One
+			</td>
+			<td>
+				Two
+			</td>
+			<td>
+				Three
+			</td>
+		</tr>
+		<tr>
+			<td>
+				1
+			</td>
+			<td>
+				2
+			</td>
+			<td>
+				3
+			</td>
+		</tr>
+		<tr>
+			<td>
+				I
+			</td>
+			<td>
+				II
+			</td>
+			<td>
+				III
+			</td>
+		</tr>
+	</tbody>
 </table>
 <!-- /wp:table -->
 

--- a/blocks/api/raw-handling/test/integration/evernote-out.html
+++ b/blocks/api/raw-handling/test/integration/evernote-out.html
@@ -1,30 +1,30 @@
 <!-- wp:paragraph -->
 <p>This is a <em>paragraph</em>.
-    <br/>This is a <a href="https://w.org">link</a>.
-    <br/></p>
+	<br/>This is a <a href="https://w.org">link</a>.
+	<br/></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
 <ul>
-    <li>An</li>
-    <li>Unordered
-        <ul>
-            <li>Indented</li>
-        </ul>
-    </li>
-    <li>List</li>
+	<li>An</li>
+	<li>Unordered
+		<ul>
+			<li>Indented</li>
+		</ul>
+	</li>
+	<li>List</li>
 </ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
 <ol>
-    <li>One</li>
-    <li>Two
-        <ol>
-            <li>Indented</li>
-        </ol>
-    </li>
-    <li>Three</li>
+	<li>One</li>
+	<li>Two
+		<ol>
+			<li>Indented</li>
+		</ol>
+	</li>
+	<li>Three</li>
 </ol>
 <!-- /wp:list -->
 
@@ -34,24 +34,24 @@
 
 <!-- wp:table -->
 <table class="wp-block-table">
-    <tbody>
-        <tr>
-            <td>One
-            </td>
-            <td>Two
-            </td>
-            <td>Three
-            </td>
-        </tr>
-        <tr>
-            <td>Four
-            </td>
-            <td>Five
-            </td>
-            <td>Six
-            </td>
-        </tr>
-    </tbody>
+	<tbody>
+		<tr>
+			<td>One
+			</td>
+			<td>Two
+			</td>
+			<td>Three
+			</td>
+		</tr>
+		<tr>
+			<td>Four
+			</td>
+			<td>Five
+			</td>
+			<td>Six
+			</td>
+		</tr>
+	</tbody>
 </table>
 <!-- /wp:table -->
 

--- a/blocks/api/raw-handling/test/integration/google-docs-out.html
+++ b/blocks/api/raw-handling/test/integration/google-docs-out.html
@@ -12,42 +12,42 @@
 
 <!-- wp:list -->
 <ul>
-    <li>A</li>
-    <li>Bulleted</li>
-    <ul>
-        <li>Indented</li>
-    </ul>
-    <li>List</li>
+	<li>A</li>
+	<li>Bulleted</li>
+	<ul>
+		<li>Indented</li>
+	</ul>
+	<li>List</li>
 </ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
 <ol>
-    <li>One</li>
-    <li>Two</li>
-    <li>Three</li>
+	<li>One</li>
+	<li>Two</li>
+	<li>Three</li>
 </ol>
 <!-- /wp:list -->
 
 <!-- wp:table -->
 <table class="wp-block-table">
-    <tbody>
-        <tr>
-            <td>One</td>
-            <td>Two</td>
-            <td>Three</td>
-        </tr>
-        <tr>
-            <td>1</td>
-            <td>2</td>
-            <td>3</td>
-        </tr>
-        <tr>
-            <td>I</td>
-            <td>II</td>
-            <td>III</td>
-        </tr>
-    </tbody>
+	<tbody>
+		<tr>
+			<td>One</td>
+			<td>Two</td>
+			<td>Three</td>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td>2</td>
+			<td>3</td>
+		</tr>
+		<tr>
+			<td>I</td>
+			<td>II</td>
+			<td>III</td>
+		</tr>
+	</tbody>
 </table>
 <!-- /wp:table -->
 

--- a/blocks/api/raw-handling/test/integration/ms-word-online-out.html
+++ b/blocks/api/raw-handling/test/integration/ms-word-online-out.html
@@ -8,40 +8,40 @@
 
 <!-- wp:list -->
 <ul>
-    <li>A </li>
-    <li>Bulleted </li>
-    <li>Indented </li>
-    <li>List </li>
+	<li>A </li>
+	<li>Bulleted </li>
+	<li>Indented </li>
+	<li>List </li>
 </ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
 <ol>
-    <li>One </li>
-    <li>Two </li>
-    <li>Three </li>
+	<li>One </li>
+	<li>Two </li>
+	<li>Three </li>
 </ol>
 <!-- /wp:list -->
 
 <!-- wp:table -->
 <table class="wp-block-table">
-    <tbody>
-        <tr>
-            <td>One </td>
-            <td>Two </td>
-            <td>Three </td>
-        </tr>
-        <tr>
-            <td>1 </td>
-            <td>2 </td>
-            <td>3 </td>
-        </tr>
-        <tr>
-            <td>I </td>
-            <td>II </td>
-            <td>III </td>
-        </tr>
-    </tbody>
+	<tbody>
+		<tr>
+			<td>One </td>
+			<td>Two </td>
+			<td>Three </td>
+		</tr>
+		<tr>
+			<td>1 </td>
+			<td>2 </td>
+			<td>3 </td>
+		</tr>
+		<tr>
+			<td>I </td>
+			<td>II </td>
+			<td>III </td>
+		</tr>
+	</tbody>
 </table>
 <!-- /wp:table -->
 

--- a/blocks/api/raw-handling/test/integration/ms-word-out.html
+++ b/blocks/api/raw-handling/test/integration/ms-word-out.html
@@ -22,61 +22,61 @@
 
 <!-- wp:list -->
 <ul>
-    <li>A</li>
-    <li>Bulleted
-        <ul>
-            <li>Indented</li>
-        </ul>
-    </li>
-    <li>List</li>
+	<li>A</li>
+	<li>Bulleted
+		<ul>
+			<li>Indented</li>
+		</ul>
+	</li>
+	<li>List</li>
 </ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
 <ol>
-    <li>One</li>
-    <li>Two</li>
-    <li>Three</li>
+	<li>One</li>
+	<li>Two</li>
+	<li>Three</li>
 </ol>
 <!-- /wp:list -->
 
 <!-- wp:table -->
 <table class="wp-block-table">
-    <tbody>
-        <tr>
-            <td>
-                One
-            </td>
-            <td>
-                Two
-            </td>
-            <td>
-                Three
-            </td>
-        </tr>
-        <tr>
-            <td>
-                1
-            </td>
-            <td>
-                2
-            </td>
-            <td>
-                3
-            </td>
-        </tr>
-        <tr>
-            <td>
-                I
-            </td>
-            <td>
-                II
-            </td>
-            <td>
-                III
-            </td>
-        </tr>
-    </tbody>
+	<tbody>
+		<tr>
+			<td>
+				One
+			</td>
+			<td>
+				Two
+			</td>
+			<td>
+				Three
+			</td>
+		</tr>
+		<tr>
+			<td>
+				1
+			</td>
+			<td>
+				2
+			</td>
+			<td>
+				3
+			</td>
+		</tr>
+		<tr>
+			<td>
+				I
+			</td>
+			<td>
+				II
+			</td>
+			<td>
+				III
+			</td>
+		</tr>
+	</tbody>
 </table>
 <!-- /wp:table -->
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -168,6 +168,7 @@ export function serializeAttributes( attrs ) {
 export function getBeautifulContent( content ) {
 	return beautifyHtml( content, {
 		indent_inner_html: true,
+		indent_with_tabs: true,
 		wrap_line_length: 0,
 	} );
 }

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -42,7 +42,7 @@ describe( 'block serializer', () => {
 		it( 'returns beautiful content', () => {
 			const content = getBeautifulContent( '<div><div>Beautiful</div></div>' );
 
-			expect( content ).toBe( '<div>\n    <div>Beautiful</div>\n</div>' );
+			expect( content ).toBe( '<div>\n\t<div>Beautiful</div>\n</div>' );
 		} );
 	} );
 
@@ -377,9 +377,9 @@ describe( 'block serializer', () => {
 			expect( serialize( block ) ).toEqual(
 				'<!-- wp:test-block -->\n' +
 				'<p class="wp-block-test-block">Invalid\n' +
-				'    <!-- wp:test-block -->\n' +
-				'    <p class="wp-block-test-block"></p>\n' +
-				'    <!-- /wp:test-block -->\n' +
+				'\t<!-- wp:test-block -->\n' +
+				'\t<p class="wp-block-test-block"></p>\n' +
+				'\t<!-- /wp:test-block -->\n' +
 				'</p>\n' +
 				'<!-- /wp:test-block -->'
 			);

--- a/blocks/test/fixtures/core-embed__animoto.serialized.html
+++ b/blocks/test/fixtures/core-embed__animoto.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/animoto {"url":"https://animoto.com/"} -->
 <figure class="wp-block-embed-animoto wp-block-embed">
-    https://animoto.com/
-    <figcaption>Embedded content from animoto</figcaption>
+	https://animoto.com/
+	<figcaption>Embedded content from animoto</figcaption>
 </figure>
 <!-- /wp:core-embed/animoto -->

--- a/blocks/test/fixtures/core-embed__cloudup.serialized.html
+++ b/blocks/test/fixtures/core-embed__cloudup.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/cloudup {"url":"https://cloudup.com/"} -->
 <figure class="wp-block-embed-cloudup wp-block-embed">
-    https://cloudup.com/
-    <figcaption>Embedded content from cloudup</figcaption>
+	https://cloudup.com/
+	<figcaption>Embedded content from cloudup</figcaption>
 </figure>
 <!-- /wp:core-embed/cloudup -->

--- a/blocks/test/fixtures/core-embed__collegehumor.serialized.html
+++ b/blocks/test/fixtures/core-embed__collegehumor.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/collegehumor {"url":"https://collegehumor.com/"} -->
 <figure class="wp-block-embed-collegehumor wp-block-embed">
-    https://collegehumor.com/
-    <figcaption>Embedded content from collegehumor</figcaption>
+	https://collegehumor.com/
+	<figcaption>Embedded content from collegehumor</figcaption>
 </figure>
 <!-- /wp:core-embed/collegehumor -->

--- a/blocks/test/fixtures/core-embed__dailymotion.serialized.html
+++ b/blocks/test/fixtures/core-embed__dailymotion.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/dailymotion {"url":"https://dailymotion.com/"} -->
 <figure class="wp-block-embed-dailymotion wp-block-embed">
-    https://dailymotion.com/
-    <figcaption>Embedded content from dailymotion</figcaption>
+	https://dailymotion.com/
+	<figcaption>Embedded content from dailymotion</figcaption>
 </figure>
 <!-- /wp:core-embed/dailymotion -->

--- a/blocks/test/fixtures/core-embed__facebook.serialized.html
+++ b/blocks/test/fixtures/core-embed__facebook.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/facebook {"url":"https://facebook.com/"} -->
 <figure class="wp-block-embed-facebook wp-block-embed">
-    https://facebook.com/
-    <figcaption>Embedded content from facebook</figcaption>
+	https://facebook.com/
+	<figcaption>Embedded content from facebook</figcaption>
 </figure>
 <!-- /wp:core-embed/facebook -->

--- a/blocks/test/fixtures/core-embed__flickr.serialized.html
+++ b/blocks/test/fixtures/core-embed__flickr.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/flickr {"url":"https://flickr.com/"} -->
 <figure class="wp-block-embed-flickr wp-block-embed">
-    https://flickr.com/
-    <figcaption>Embedded content from flickr</figcaption>
+	https://flickr.com/
+	<figcaption>Embedded content from flickr</figcaption>
 </figure>
 <!-- /wp:core-embed/flickr -->

--- a/blocks/test/fixtures/core-embed__funnyordie.serialized.html
+++ b/blocks/test/fixtures/core-embed__funnyordie.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/funnyordie {"url":"https://funnyordie.com/"} -->
 <figure class="wp-block-embed-funnyordie wp-block-embed">
-    https://funnyordie.com/
-    <figcaption>Embedded content from funnyordie</figcaption>
+	https://funnyordie.com/
+	<figcaption>Embedded content from funnyordie</figcaption>
 </figure>
 <!-- /wp:core-embed/funnyordie -->

--- a/blocks/test/fixtures/core-embed__hulu.serialized.html
+++ b/blocks/test/fixtures/core-embed__hulu.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/hulu {"url":"https://hulu.com/"} -->
 <figure class="wp-block-embed-hulu wp-block-embed">
-    https://hulu.com/
-    <figcaption>Embedded content from hulu</figcaption>
+	https://hulu.com/
+	<figcaption>Embedded content from hulu</figcaption>
 </figure>
 <!-- /wp:core-embed/hulu -->

--- a/blocks/test/fixtures/core-embed__imgur.serialized.html
+++ b/blocks/test/fixtures/core-embed__imgur.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/imgur {"url":"https://imgur.com/"} -->
 <figure class="wp-block-embed-imgur wp-block-embed">
-    https://imgur.com/
-    <figcaption>Embedded content from imgur</figcaption>
+	https://imgur.com/
+	<figcaption>Embedded content from imgur</figcaption>
 </figure>
 <!-- /wp:core-embed/imgur -->

--- a/blocks/test/fixtures/core-embed__instagram.serialized.html
+++ b/blocks/test/fixtures/core-embed__instagram.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/instagram {"url":"https://instagram.com/"} -->
 <figure class="wp-block-embed-instagram wp-block-embed">
-    https://instagram.com/
-    <figcaption>Embedded content from instagram</figcaption>
+	https://instagram.com/
+	<figcaption>Embedded content from instagram</figcaption>
 </figure>
 <!-- /wp:core-embed/instagram -->

--- a/blocks/test/fixtures/core-embed__issuu.serialized.html
+++ b/blocks/test/fixtures/core-embed__issuu.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/issuu {"url":"https://issuu.com/"} -->
 <figure class="wp-block-embed-issuu wp-block-embed">
-    https://issuu.com/
-    <figcaption>Embedded content from issuu</figcaption>
+	https://issuu.com/
+	<figcaption>Embedded content from issuu</figcaption>
 </figure>
 <!-- /wp:core-embed/issuu -->

--- a/blocks/test/fixtures/core-embed__kickstarter.serialized.html
+++ b/blocks/test/fixtures/core-embed__kickstarter.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/kickstarter {"url":"https://kickstarter.com/"} -->
 <figure class="wp-block-embed-kickstarter wp-block-embed">
-    https://kickstarter.com/
-    <figcaption>Embedded content from kickstarter</figcaption>
+	https://kickstarter.com/
+	<figcaption>Embedded content from kickstarter</figcaption>
 </figure>
 <!-- /wp:core-embed/kickstarter -->

--- a/blocks/test/fixtures/core-embed__meetup-com.serialized.html
+++ b/blocks/test/fixtures/core-embed__meetup-com.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/meetup-com {"url":"https://meetup.com/"} -->
 <figure class="wp-block-embed-meetup-com wp-block-embed">
-    https://meetup.com/
-    <figcaption>Embedded content from meetup-com</figcaption>
+	https://meetup.com/
+	<figcaption>Embedded content from meetup-com</figcaption>
 </figure>
 <!-- /wp:core-embed/meetup-com -->

--- a/blocks/test/fixtures/core-embed__mixcloud.serialized.html
+++ b/blocks/test/fixtures/core-embed__mixcloud.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/mixcloud {"url":"https://mixcloud.com/"} -->
 <figure class="wp-block-embed-mixcloud wp-block-embed">
-    https://mixcloud.com/
-    <figcaption>Embedded content from mixcloud</figcaption>
+	https://mixcloud.com/
+	<figcaption>Embedded content from mixcloud</figcaption>
 </figure>
 <!-- /wp:core-embed/mixcloud -->

--- a/blocks/test/fixtures/core-embed__photobucket.serialized.html
+++ b/blocks/test/fixtures/core-embed__photobucket.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/photobucket {"url":"https://photobucket.com/"} -->
 <figure class="wp-block-embed-photobucket wp-block-embed">
-    https://photobucket.com/
-    <figcaption>Embedded content from photobucket</figcaption>
+	https://photobucket.com/
+	<figcaption>Embedded content from photobucket</figcaption>
 </figure>
 <!-- /wp:core-embed/photobucket -->

--- a/blocks/test/fixtures/core-embed__polldaddy.serialized.html
+++ b/blocks/test/fixtures/core-embed__polldaddy.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/polldaddy {"url":"https://polldaddy.com/"} -->
 <figure class="wp-block-embed-polldaddy wp-block-embed">
-    https://polldaddy.com/
-    <figcaption>Embedded content from polldaddy</figcaption>
+	https://polldaddy.com/
+	<figcaption>Embedded content from polldaddy</figcaption>
 </figure>
 <!-- /wp:core-embed/polldaddy -->

--- a/blocks/test/fixtures/core-embed__reddit.serialized.html
+++ b/blocks/test/fixtures/core-embed__reddit.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/reddit {"url":"https://reddit.com/"} -->
 <figure class="wp-block-embed-reddit wp-block-embed">
-    https://reddit.com/
-    <figcaption>Embedded content from reddit</figcaption>
+	https://reddit.com/
+	<figcaption>Embedded content from reddit</figcaption>
 </figure>
 <!-- /wp:core-embed/reddit -->

--- a/blocks/test/fixtures/core-embed__reverbnation.serialized.html
+++ b/blocks/test/fixtures/core-embed__reverbnation.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/reverbnation {"url":"https://reverbnation.com/"} -->
 <figure class="wp-block-embed-reverbnation wp-block-embed">
-    https://reverbnation.com/
-    <figcaption>Embedded content from reverbnation</figcaption>
+	https://reverbnation.com/
+	<figcaption>Embedded content from reverbnation</figcaption>
 </figure>
 <!-- /wp:core-embed/reverbnation -->

--- a/blocks/test/fixtures/core-embed__screencast.serialized.html
+++ b/blocks/test/fixtures/core-embed__screencast.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/screencast {"url":"https://screencast.com/"} -->
 <figure class="wp-block-embed-screencast wp-block-embed">
-    https://screencast.com/
-    <figcaption>Embedded content from screencast</figcaption>
+	https://screencast.com/
+	<figcaption>Embedded content from screencast</figcaption>
 </figure>
 <!-- /wp:core-embed/screencast -->

--- a/blocks/test/fixtures/core-embed__scribd.serialized.html
+++ b/blocks/test/fixtures/core-embed__scribd.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/scribd {"url":"https://scribd.com/"} -->
 <figure class="wp-block-embed-scribd wp-block-embed">
-    https://scribd.com/
-    <figcaption>Embedded content from scribd</figcaption>
+	https://scribd.com/
+	<figcaption>Embedded content from scribd</figcaption>
 </figure>
 <!-- /wp:core-embed/scribd -->

--- a/blocks/test/fixtures/core-embed__slideshare.serialized.html
+++ b/blocks/test/fixtures/core-embed__slideshare.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/slideshare {"url":"https://slideshare.com/"} -->
 <figure class="wp-block-embed-slideshare wp-block-embed">
-    https://slideshare.com/
-    <figcaption>Embedded content from slideshare</figcaption>
+	https://slideshare.com/
+	<figcaption>Embedded content from slideshare</figcaption>
 </figure>
 <!-- /wp:core-embed/slideshare -->

--- a/blocks/test/fixtures/core-embed__smugmug.serialized.html
+++ b/blocks/test/fixtures/core-embed__smugmug.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/smugmug {"url":"https://smugmug.com/"} -->
 <figure class="wp-block-embed-smugmug wp-block-embed">
-    https://smugmug.com/
-    <figcaption>Embedded content from smugmug</figcaption>
+	https://smugmug.com/
+	<figcaption>Embedded content from smugmug</figcaption>
 </figure>
 <!-- /wp:core-embed/smugmug -->

--- a/blocks/test/fixtures/core-embed__soundcloud.serialized.html
+++ b/blocks/test/fixtures/core-embed__soundcloud.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/soundcloud {"url":"https://soundcloud.com/"} -->
 <figure class="wp-block-embed-soundcloud wp-block-embed">
-    https://soundcloud.com/
-    <figcaption>Embedded content from soundcloud</figcaption>
+	https://soundcloud.com/
+	<figcaption>Embedded content from soundcloud</figcaption>
 </figure>
 <!-- /wp:core-embed/soundcloud -->

--- a/blocks/test/fixtures/core-embed__speaker.serialized.html
+++ b/blocks/test/fixtures/core-embed__speaker.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/speaker {"url":"https://speaker.com/"} -->
 <figure class="wp-block-embed-speaker wp-block-embed">
-    https://speaker.com/
-    <figcaption>Embedded content from speaker</figcaption>
+	https://speaker.com/
+	<figcaption>Embedded content from speaker</figcaption>
 </figure>
 <!-- /wp:core-embed/speaker -->

--- a/blocks/test/fixtures/core-embed__spotify.serialized.html
+++ b/blocks/test/fixtures/core-embed__spotify.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/spotify {"url":"https://spotify.com/"} -->
 <figure class="wp-block-embed-spotify wp-block-embed">
-    https://spotify.com/
-    <figcaption>Embedded content from spotify</figcaption>
+	https://spotify.com/
+	<figcaption>Embedded content from spotify</figcaption>
 </figure>
 <!-- /wp:core-embed/spotify -->

--- a/blocks/test/fixtures/core-embed__ted.serialized.html
+++ b/blocks/test/fixtures/core-embed__ted.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/ted {"url":"https://ted.com/"} -->
 <figure class="wp-block-embed-ted wp-block-embed">
-    https://ted.com/
-    <figcaption>Embedded content from ted</figcaption>
+	https://ted.com/
+	<figcaption>Embedded content from ted</figcaption>
 </figure>
 <!-- /wp:core-embed/ted -->

--- a/blocks/test/fixtures/core-embed__tumblr.serialized.html
+++ b/blocks/test/fixtures/core-embed__tumblr.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/tumblr {"url":"https://tumblr.com/"} -->
 <figure class="wp-block-embed-tumblr wp-block-embed">
-    https://tumblr.com/
-    <figcaption>Embedded content from tumblr</figcaption>
+	https://tumblr.com/
+	<figcaption>Embedded content from tumblr</figcaption>
 </figure>
 <!-- /wp:core-embed/tumblr -->

--- a/blocks/test/fixtures/core-embed__twitter.serialized.html
+++ b/blocks/test/fixtures/core-embed__twitter.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/twitter {"url":"https://twitter.com/automattic"} -->
 <figure class="wp-block-embed-twitter wp-block-embed">
-    https://twitter.com/automattic
-    <figcaption>We are Automattic</figcaption>
+	https://twitter.com/automattic
+	<figcaption>We are Automattic</figcaption>
 </figure>
 <!-- /wp:core-embed/twitter -->

--- a/blocks/test/fixtures/core-embed__videopress.serialized.html
+++ b/blocks/test/fixtures/core-embed__videopress.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/videopress {"url":"https://videopress.com/"} -->
 <figure class="wp-block-embed-videopress wp-block-embed">
-    https://videopress.com/
-    <figcaption>Embedded content from videopress</figcaption>
+	https://videopress.com/
+	<figcaption>Embedded content from videopress</figcaption>
 </figure>
 <!-- /wp:core-embed/videopress -->

--- a/blocks/test/fixtures/core-embed__vimeo.serialized.html
+++ b/blocks/test/fixtures/core-embed__vimeo.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/vimeo {"url":"https://vimeo.com/"} -->
 <figure class="wp-block-embed-vimeo wp-block-embed">
-    https://vimeo.com/
-    <figcaption>Embedded content from vimeo</figcaption>
+	https://vimeo.com/
+	<figcaption>Embedded content from vimeo</figcaption>
 </figure>
 <!-- /wp:core-embed/vimeo -->

--- a/blocks/test/fixtures/core-embed__wordpress-tv.serialized.html
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/wordpress-tv {"url":"https://wordpress.tv/"} -->
 <figure class="wp-block-embed-wordpress-tv wp-block-embed">
-    https://wordpress.tv/
-    <figcaption>Embedded content from wordpress-tv</figcaption>
+	https://wordpress.tv/
+	<figcaption>Embedded content from wordpress-tv</figcaption>
 </figure>
 <!-- /wp:core-embed/wordpress-tv -->

--- a/blocks/test/fixtures/core-embed__wordpress.serialized.html
+++ b/blocks/test/fixtures/core-embed__wordpress.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/wordpress {"url":"https://wordpress.com/"} -->
 <figure class="wp-block-embed-wordpress wp-block-embed">
-    https://wordpress.com/
-    <figcaption>Embedded content from WordPress</figcaption>
+	https://wordpress.com/
+	<figcaption>Embedded content from WordPress</figcaption>
 </figure>
 <!-- /wp:core-embed/wordpress -->

--- a/blocks/test/fixtures/core-embed__youtube.serialized.html
+++ b/blocks/test/fixtures/core-embed__youtube.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core-embed/youtube {"url":"https://youtube.com/"} -->
 <figure class="wp-block-embed-youtube wp-block-embed">
-    https://youtube.com/
-    <figcaption>Embedded content from youtube</figcaption>
+	https://youtube.com/
+	<figcaption>Embedded content from youtube</figcaption>
 </figure>
 <!-- /wp:core-embed/youtube -->

--- a/blocks/test/fixtures/core__columns.serialized.html
+++ b/blocks/test/fixtures/core__columns.serialized.html
@@ -1,19 +1,19 @@
 <!-- wp:columns {"columns":3} -->
 <div class="wp-block-columns has-3-columns">
-    <!-- wp:paragraph {"layout":"column-1"} -->
-    <p class="layout-column-1">Column One, Paragraph One</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"layout":"column-1"} -->
+	<p class="layout-column-1">Column One, Paragraph One</p>
+	<!-- /wp:paragraph -->
 
-    <!-- wp:paragraph {"layout":"column-1"} -->
-    <p class="layout-column-1">Column One, Paragraph Two</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"layout":"column-1"} -->
+	<p class="layout-column-1">Column One, Paragraph Two</p>
+	<!-- /wp:paragraph -->
 
-    <!-- wp:paragraph {"layout":"column-2"} -->
-    <p class="layout-column-2">Column Two, Paragraph One</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"layout":"column-2"} -->
+	<p class="layout-column-2">Column Two, Paragraph One</p>
+	<!-- /wp:paragraph -->
 
-    <!-- wp:paragraph {"layout":"column-3"} -->
-    <p class="layout-column-3">Column Three, Paragraph One</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"layout":"column-3"} -->
+	<p class="layout-column-3">Column Three, Paragraph One</p>
+	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:columns -->

--- a/blocks/test/fixtures/core__cover-image.serialized.html
+++ b/blocks/test/fixtures/core__cover-image.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
 <div class="wp-block-cover-image has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)">
-    <p class="wp-block-cover-image-text">Guten Berg!</p>
+	<p class="wp-block-cover-image-text">Guten Berg!</p>
 </div>
 <!-- /wp:cover-image -->

--- a/blocks/test/fixtures/core__embed.serialized.html
+++ b/blocks/test/fixtures/core__embed.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:embed {"url":"https://example.com/"} -->
 <figure class="wp-block-embed">
-    https://example.com/
-    <figcaption>Embedded content from an example URL</figcaption>
+	https://example.com/
+	<figcaption>Embedded content from an example URL</figcaption>
 </figure>
 <!-- /wp:embed -->

--- a/blocks/test/fixtures/core__gallery.serialized.html
+++ b/blocks/test/fixtures/core__gallery.serialized.html
@@ -1,10 +1,10 @@
 <!-- wp:gallery -->
 <ul class="wp-block-gallery alignnone columns-2 is-cropped">
-    <li class="blocks-gallery-item">
-        <figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
-    </li>
-    <li class="blocks-gallery-item">
-        <figure><img src="http://google.com/hi.png" alt="title" /></figure>
-    </li>
+	<li class="blocks-gallery-item">
+		<figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
+	</li>
+	<li class="blocks-gallery-item">
+		<figure><img src="http://google.com/hi.png" alt="title" /></figure>
+	</li>
 </ul>
 <!-- /wp:gallery -->

--- a/blocks/test/fixtures/core__gallery__columns.serialized.html
+++ b/blocks/test/fixtures/core__gallery__columns.serialized.html
@@ -1,10 +1,10 @@
 <!-- wp:gallery {"columns":1} -->
 <ul class="wp-block-gallery alignnone columns-1 is-cropped">
-    <li class="blocks-gallery-item">
-        <figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
-    </li>
-    <li class="blocks-gallery-item">
-        <figure><img src="http://google.com/hi.png" alt="title" /></figure>
-    </li>
+	<li class="blocks-gallery-item">
+		<figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
+	</li>
+	<li class="blocks-gallery-item">
+		<figure><img src="http://google.com/hi.png" alt="title" /></figure>
+	</li>
 </ul>
 <!-- /wp:gallery -->

--- a/blocks/test/fixtures/core__image__center-caption.serialized.html
+++ b/blocks/test/fixtures/core__image__center-caption.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:image {"align":"center"} -->
 <figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt="" />
-    <figcaption>Give it a try. Press the "really wide" button on the image toolbar.</figcaption>
+	<figcaption>Give it a try. Press the "really wide" button on the image toolbar.</figcaption>
 </figure>
 <!-- /wp:image -->

--- a/blocks/test/fixtures/core__list__ul.serialized.html
+++ b/blocks/test/fixtures/core__list__ul.serialized.html
@@ -1,10 +1,10 @@
 <!-- wp:list -->
 <ul>
-    <li>Text &amp; Headings</li>
-    <li>Images &amp; Videos</li>
-    <li>Galleries</li>
-    <li>Embeds, like YouTube, Tweets, or other WordPress posts.</li>
-    <li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li>
-    <li>And <em>Lists</em> like this one of course :)</li>
+	<li>Text &amp; Headings</li>
+	<li>Images &amp; Videos</li>
+	<li>Galleries</li>
+	<li>Embeds, like YouTube, Tweets, or other WordPress posts.</li>
+	<li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li>
+	<li>And <em>Lists</em> like this one of course :)</li>
 </ul>
 <!-- /wp:list -->

--- a/blocks/test/fixtures/core__pullquote.serialized.html
+++ b/blocks/test/fixtures/core__pullquote.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-    <p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote>
+	<p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote>
 <!-- /wp:pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-    <p>Paragraph <strong>one</strong></p>
-    <p>Paragraph two</p><cite>by whomever</cite></blockquote>
+	<p>Paragraph <strong>one</strong></p>
+	<p>Paragraph two</p><cite>by whomever</cite></blockquote>
 <!-- /wp:pullquote -->

--- a/blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:quote -->
 <blockquote class="wp-block-quote">
-    <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:quote -->

--- a/blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:quote {"style":2} -->
 <blockquote class="wp-block-quote is-large">
-    <p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+	<p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:quote -->

--- a/blocks/test/fixtures/core__table.serialized.html
+++ b/blocks/test/fixtures/core__table.serialized.html
@@ -1,48 +1,48 @@
 <!-- wp:table -->
 <table class="wp-block-table">
-    <thead>
-        <tr>
-            <th>Version</th>
-            <th>Musician</th>
-            <th>Date</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="https://wordpress.org/news/2003/05/wordpress-now-available/">.70</a></td>
-            <td>No musician chosen.</td>
-            <td>May 27, 2003</td>
-        </tr>
-        <tr>
-            <td><a href="https://wordpress.org/news/2004/01/wordpress-10/">1.0</a></td>
-            <td>Miles Davis</td>
-            <td>January 3, 2004</td>
-        </tr>
-        <tr>
-            <td>Lots of versions skipped, see <a href="https://codex.wordpress.org/WordPress_Versions">the full list</a></td>
-            <td>…</td>
-            <td>…</td>
-        </tr>
-        <tr>
-            <td><a href="https://wordpress.org/news/2015/12/clifford/">4.4</a></td>
-            <td>Clifford Brown</td>
-            <td>December 8, 2015</td>
-        </tr>
-        <tr>
-            <td><a href="https://wordpress.org/news/2016/04/coleman/">4.5</a></td>
-            <td>Coleman Hawkins</td>
-            <td>April 12, 2016</td>
-        </tr>
-        <tr>
-            <td><a href="https://wordpress.org/news/2016/08/pepper/">4.6</a></td>
-            <td>Pepper Adams</td>
-            <td>August 16, 2016</td>
-        </tr>
-        <tr>
-            <td><a href="https://wordpress.org/news/2016/12/vaughan/">4.7</a></td>
-            <td>Sarah Vaughan</td>
-            <td>December 6, 2016</td>
-        </tr>
-    </tbody>
+	<thead>
+		<tr>
+			<th>Version</th>
+			<th>Musician</th>
+			<th>Date</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><a href="https://wordpress.org/news/2003/05/wordpress-now-available/">.70</a></td>
+			<td>No musician chosen.</td>
+			<td>May 27, 2003</td>
+		</tr>
+		<tr>
+			<td><a href="https://wordpress.org/news/2004/01/wordpress-10/">1.0</a></td>
+			<td>Miles Davis</td>
+			<td>January 3, 2004</td>
+		</tr>
+		<tr>
+			<td>Lots of versions skipped, see <a href="https://codex.wordpress.org/WordPress_Versions">the full list</a></td>
+			<td>…</td>
+			<td>…</td>
+		</tr>
+		<tr>
+			<td><a href="https://wordpress.org/news/2015/12/clifford/">4.4</a></td>
+			<td>Clifford Brown</td>
+			<td>December 8, 2015</td>
+		</tr>
+		<tr>
+			<td><a href="https://wordpress.org/news/2016/04/coleman/">4.5</a></td>
+			<td>Coleman Hawkins</td>
+			<td>April 12, 2016</td>
+		</tr>
+		<tr>
+			<td><a href="https://wordpress.org/news/2016/08/pepper/">4.6</a></td>
+			<td>Pepper Adams</td>
+			<td>August 16, 2016</td>
+		</tr>
+		<tr>
+			<td><a href="https://wordpress.org/news/2016/12/vaughan/">4.7</a></td>
+			<td>Sarah Vaughan</td>
+			<td>December 6, 2016</td>
+		</tr>
+	</tbody>
 </table>
 <!-- /wp:table -->

--- a/blocks/test/fixtures/core__text-columns.serialized.html
+++ b/blocks/test/fixtures/core__text-columns.serialized.html
@@ -1,10 +1,10 @@
 <!-- wp:text-columns {"width":"center"} -->
 <div class="wp-block-text-columns aligncenter columns-2">
-    <div class="wp-block-column">
-        <p>One</p>
-    </div>
-    <div class="wp-block-column">
-        <p>Two</p>
-    </div>
+	<div class="wp-block-column">
+		<p>One</p>
+	</div>
+	<div class="wp-block-column">
+		<p>Two</p>
+	</div>
 </div>
 <!-- /wp:text-columns -->

--- a/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
@@ -11,7 +11,7 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 
 <!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\">
-    <p>Quote block</p>
+	<p>Quote block</p>
 </blockquote>
 <!-- /wp:quote -->
 

--- a/test/e2e/specs/__snapshots__/templates.test.js.snap
+++ b/test/e2e/specs/__snapshots__/templates.test.js.snap
@@ -15,13 +15,13 @@ exports[`Using a CPT with a predefined template Should add a custom post types w
 
 <!-- wp:columns -->
 <div class=\\"wp-block-columns has-2-columns\\">
-    <!-- wp:image {\\"layout\\":\\"column-1\\"} -->
-    <figure class=\\"wp-block-image layout-column-1\\"><img alt=\\"\\" /></figure>
-    <!-- /wp:image -->
+	<!-- wp:image {\\"layout\\":\\"column-1\\"} -->
+	<figure class=\\"wp-block-image layout-column-1\\"><img alt=\\"\\" /></figure>
+	<!-- /wp:image -->
 
-    <!-- wp:paragraph {\\"placeholder\\":\\"Add a inner paragraph\\",\\"layout\\":\\"column-2\\"} -->
-    <p class=\\"layout-column-2\\"></p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {\\"placeholder\\":\\"Add a inner paragraph\\",\\"layout\\":\\"column-2\\"} -->
+	<p class=\\"layout-column-2\\"></p>
+	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:columns -->"
 `;


### PR DESCRIPTION
Related: #4456

This pull request seeks to propose indenting the serialized block output with tabs, rather than four spaces. Aside from being the objectively superior mode of indentation, tabs are advantageous for reducing the storage requirements of post content. As an example, for the demo post, using tabs saves 93 bytes. This number would be higher for content with significant indentation, notably heavily nested content.

I encountered this as part of implementing a custom serialize beautifier for https://github.com/WordPress/gutenberg/issues/4456#issuecomment-381592662 , extracted here since there's a large number of affected fixture files and test assertions. The change itself is merely a single option to `js-beautify`: `indent_with_tabs: true`.

The block validator is intended to be whitespace-agnostic (aside from "meaningful" HTML whitespace), so there is intended to be no invalidations incurred by this change.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```

Verify that saving a post and reloading the editor results in no invalid blocks.