### PR TITLE
Better order for the inserter shortcuts buttons.

### DIFF
--- a/editor/components/inserter-with-shortcuts/style.scss
+++ b/editor/components/inserter-with-shortcuts/style.scss
@@ -1,7 +1,6 @@
 .editor-inserter-with-shortcuts {
 	display: flex;
 	align-items: center;
-	flex-direction: row-reverse;
 
 	.components-icon-button {
 		border-radius: $button-style__radius-roundrect;


### PR DESCRIPTION
This PR improves the order of the buttons in the "inserter with shortcuts", that is the empty block displayed at the bottom which shows 3 buttons with the most frequently used block types.

At the moment, the order of these buttons is reversed using CSS `flex-direction: row-reverse`. I'm not sure if there's a specific reason for this or maybe it's a leftover but seems to me the order doesn't match the real frequency. 

Worth also reminding there's a specific WCAG Success Criterion about ordering and the visual order should always match the DOM order.

Success Criterion 2.4.3 Focus Order
https://www.w3.org/TR/WCAG21/#focus-order

C27: Making the DOM order match the visual order
https://www.w3.org/TR/WCAG20-TECHS/C27.html

See in the screenshot below: for me, the most frequently used blocks (except Paragraph) are Heading, Image, and List. However, they're shown in a reversed order in the suggestions (on the right):

<img width="996" alt="screen shot 2018-04-17 at 18 52 54" src="https://user-images.githubusercontent.com/1682452/38888088-ecc8db72-427a-11e8-8f83-9937ed2b7b81.png">

This PR addresses just the order of these 3 buttons. There are other controls that visually don't match the DOM order. I'd like to discuss them with the accessibility team and maybe propose changes in a separate issue / PR.

Fixes #6024 