### PR TITLE
Disable the Preview button when post type isn't viewable 

### DIFF
--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -1,8 +1,13 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component, compose } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Button, ifCondition } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -117,16 +122,22 @@ export default compose( [
 			isEditedPostNew,
 			isEditedPostSaveable,
 		} = select( 'core/editor' );
+		const {
+			getPostType
+		} = select( 'core' );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		return {
 			postId: getCurrentPostId(),
 			link: getEditedPostPreviewLink(),
 			isDirty: isEditedPostDirty(),
 			isNew: isEditedPostNew(),
 			isSaveable: isEditedPostSaveable(),
+			isViewable: get( postType, 'viewable', false ),
 			modified: getEditedPostAttribute( 'modified' ),
 		};
 	} ),
 	withDispatch( ( dispatch )=>( {
 		autosave: dispatch( 'core/editor' ).autosave,
 	} ) ),
+	ifCondition( ( { isViewable } ) => isViewable ),
 ] )( PostPreviewButton );

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -123,7 +123,7 @@ export default compose( [
 			isEditedPostSaveable,
 		} = select( 'core/editor' );
 		const {
-			getPostType
+			getPostType,
 		} = select( 'core' );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		return {

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -110,7 +110,10 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result['viewable'] );
 	}
 
-	function test_viewability_field_without_context() {
+	/**
+	 * Should not return viewable field without context set.
+	 */
+	function test_viewable_field_without_context() {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/types/post' );
 		$response = rest_do_request( $request );
 		$result   = $response->get_data();

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -96,4 +96,24 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( isset( $result['visibility'] ) );
 	}
+
+	/**
+	 * Should return an extra viewable field on response when in edit context.
+	 */
+	function test_viewable_field() {
+		wp_set_current_user( $this->administrator );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/types/post' );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result['viewable'] ) );
+		$this->assertTrue( $result['viewable'] );
+	}
+
+	function test_viewability_field_without_context() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/types/post' );
+		$response = rest_do_request( $request );
+		$result   = $response->get_data();
+		$this->assertFalse( isset( $result['viewable'] ) );
+	}
 }

--- a/test/e2e/specs/hello.test.js
+++ b/test/e2e/specs/hello.test.js
@@ -14,6 +14,8 @@ describe( 'hello', () => {
 		expect( page.url() ).toEqual( expect.stringContaining( 'post-new.php' ) );
 		const title = await page.$( '[placeholder="Add title"]' );
 		expect( title ).not.toBeNull();
+		const postPreviewButton = await page.$( '.editor-post-preview.button' );
+		expect( postPreviewButton ).not.toBeNull();
 	} );
 
 	it( 'Should have no history', async () => {


### PR DESCRIPTION
## Description

In the classic editor, the preview button is only available if is_post_type_viewable returns true. We are updating the logic to follow the same behavior.

Fixes #5749 

Previously #5770 #6120

## How Has This Been Tested?

Register a post type with publicly_queryable set to false.
E.g:
```php
function create_product_type() {
	register_post_type( 'acme_product',
		array(
			'label'  => 'Product',
			'labels' => array(
				'name' => __( 'Products' ),
				'singular_name' => __( 'Product' )
			),
			'public' => true,
			'show_in_rest' => true,
			'publicly_queryable' => false,
		)
	);
}
add_action( 'init', 'create_product_type' );
```
Verify preview button is not available for posts of this Post Type.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/36432/38642537-32f4ea64-3d8f-11e8-8ad4-74e48ee756db.png">

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/36432/38642517-27dbc4a4-3d8f-11e8-813c-7b412ceb0d50.png">
