### PR TITLE
Screen takeover using react-modal

### DIFF
--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -34,6 +34,7 @@ import EditorModeKeyboardShortcuts from '../keyboard-shortcuts';
 import MetaBoxes from '../meta-boxes';
 import { getMetaBoxContainer } from '../../utils/meta-boxes';
 import PluginSidebar from '../plugin-sidebar';
+import PluginScreenTakeover from '../plugin-screen-takeover';
 
 function Layout( {
 	mode,
@@ -91,6 +92,7 @@ function Layout( {
 			{
 				isMobileViewport && sidebarIsOpened && <ScrollLock />
 			}
+			<PluginScreenTakeover.Slot />
 			<Popover.Slot />
 			<PluginArea />
 		</div>

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -41,6 +41,7 @@ function Layout( {
 	editorSidebarOpened,
 	pluginSidebarOpened,
 	sidebarName,
+	screenTakeoverName,
 	publishSidebarOpened,
 	hasFixedToolbar,
 	closePublishSidebar,
@@ -92,7 +93,7 @@ function Layout( {
 			{
 				isMobileViewport && sidebarIsOpened && <ScrollLock />
 			}
-			<PluginScreenTakeover.Slot />
+			<PluginScreenTakeover.Slot name={ screenTakeoverName } />
 			<Popover.Slot />
 			<PluginArea />
 		</div>
@@ -104,6 +105,7 @@ export default compose(
 		mode: select( 'core/edit-post' ).getEditorMode(),
 		editorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
 		pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
+		screenTakeoverName: select( 'core/edit-post' ).getActiveScreenTakeoverName(),
 		sidebarName: select( 'core/edit-post' ).getActiveGeneralSidebarName(),
 		publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -93,7 +93,7 @@ function Layout( {
 			{
 				isMobileViewport && sidebarIsOpened && <ScrollLock />
 			}
-			<PluginScreenTakeover.Slot name={ screenTakeoverName } />
+			<PluginScreenTakeover.Slot />
 			<Popover.Slot />
 			<PluginArea />
 		</div>
@@ -105,7 +105,6 @@ export default compose(
 		mode: select( 'core/edit-post' ).getEditorMode(),
 		editorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
 		pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
-		screenTakeoverName: select( 'core/edit-post' ).getActiveScreenTakeoverName(),
 		sidebarName: select( 'core/edit-post' ).getActiveGeneralSidebarName(),
 		publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),

--- a/edit-post/components/plugin-more-menu-item/index.js
+++ b/edit-post/components/plugin-more-menu-item/index.js
@@ -12,6 +12,7 @@ import { Slot, Fill, withContext } from '@wordpress/components';
  * Internal dependencies
  */
 import PluginSidebarMoreMenuItem from './plugin-sidebar-more-menu-item';
+import PluginScreenTakeoverMoreMenuItem from './plugin-screen-takeover-more-menu-item';
 
 /**
  * Name of slot in which the more menu items should fill.
@@ -30,6 +31,8 @@ let PluginMoreMenuItem = ( props ) => (
 			switch ( type ) {
 				case 'sidebar':
 					return <PluginSidebarMoreMenuItem { ...newProps } />;
+				case 'screen-takeover':
+					return <PluginScreenTakeoverMoreMenuItem { ...newProps } />;
 			}
 			return null;
 		} }

--- a/edit-post/components/plugin-more-menu-item/plugin-screen-takeover-more-menu-item.js
+++ b/edit-post/components/plugin-more-menu-item/plugin-screen-takeover-more-menu-item.js
@@ -5,7 +5,7 @@ import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { MenuItem } from '@wordpress/components';
 
-const PluginSidebarMoreMenuItem = ( { children, isSelected, icon, onClick } ) => (
+const PluginScreenTakeoverMoreMenuItem = ( { children, isSelected, icon, onClick } ) => (
 	<MenuItem
 		icon={ isSelected ? 'yes' : icon }
 		isSelected={ isSelected }
@@ -38,4 +38,4 @@ export default compose( [
 			},
 		};
 	} ),
-] )( PluginSidebarMoreMenuItem );
+] )( PluginScreenTakeoverMoreMenuItem );

--- a/edit-post/components/plugin-more-menu-item/plugin-screen-takeover-more-menu-item.js
+++ b/edit-post/components/plugin-more-menu-item/plugin-screen-takeover-more-menu-item.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { MenuItem } from '@wordpress/components';
+
+const PluginSidebarMoreMenuItem = ( { children, isSelected, icon, onClick } ) => (
+	<MenuItem
+		icon={ isSelected ? 'yes' : icon }
+		isSelected={ isSelected }
+		onClick={ onClick }
+	>
+		{ children }
+	</MenuItem>
+);
+
+export default compose( [
+	withSelect( ( select, ownProps ) => {
+		const { target } = ownProps;
+		return {
+			isSelected: select( 'core/edit-post' ).getActiveScreenTakeoverName() === target,
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		const { target, isSelected } = ownProps;
+		const {
+			openScreenTakeover,
+			closeScreenTakeover,
+		} = dispatch( 'core/edit-post' );
+		const onClick = isSelected ?
+			closeScreenTakeover :
+			() => openScreenTakeover( target );
+		return {
+			onClick: () => {
+				ownProps.onClick();
+				onClick();
+			},
+		};
+	} ),
+] )( PluginSidebarMoreMenuItem );

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
@@ -10,7 +10,9 @@ const ScreenTakeoverHeader = ( { icon, title, onClose, closeLabel } ) => {
 			className={ 'edit-post-plugin-screen-takeover__editor-screen-takeover-header' }
 		>
 			<div>
-				{ icon }
+				<span aria-hidden="true">
+					{ icon }
+				</span>
 				<h1>
 					{ title }
 				</h1>

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
@@ -11,9 +11,9 @@ const ScreenTakeoverHeader = ( { icon, title, onClose, closeLabel } ) => {
 		>
 			<div>
 				{ icon }
-				<span>
+				<h1>
 					{ title }
-				</span>
+				</h1>
 			</div>
 			<IconButton
 				onClick={ onClose }

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
@@ -1,5 +1,6 @@
 import { NavigableToolbar } from '../../../editor/components';
 import { IconButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 const ScreenTakeoverHeader = ( { icon, title, onClose, closeLabel } ) => {
 	const label = closeLabel ? closeLabel : __( 'Close window' );

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
@@ -1,6 +1,9 @@
 import { NavigableToolbar } from '../../../editor/components';
+import { IconButton } from '@wordpress/components';
 
-const ScreenTakeoverHeader = ( { icon, title } ) => {
+const ScreenTakeoverHeader = ( { icon, title, onClose, closeLabel } ) => {
+	const label = closeLabel ? closeLabel : __( 'Close window' );
+
 	return (
 		<NavigableToolbar
 			className={ 'edit-post-plugin-screen-takeover__editor-screen-takeover-header' }
@@ -11,9 +14,11 @@ const ScreenTakeoverHeader = ( { icon, title } ) => {
 					{ title }
 				</span>
 			</div>
-			<button>
-				close
-			</button>
+			<IconButton
+				onClick={ onClose }
+				icon="no-alt"
+				label={ label }
+			/>
 		</NavigableToolbar>
 	);
 };

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover-header.js
@@ -1,0 +1,21 @@
+import { NavigableToolbar } from '../../../editor/components';
+
+const ScreenTakeoverHeader = ( { icon, title } ) => {
+	return (
+		<NavigableToolbar
+			className={ 'edit-post-plugin-screen-takeover__editor-screen-takeover-header' }
+		>
+			<div>
+				{ icon }
+				<span>
+					{ title }
+				</span>
+			</div>
+			<button>
+				close
+			</button>
+		</NavigableToolbar>
+	);
+};
+
+export default ScreenTakeoverHeader;

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -51,7 +51,9 @@ export default class EditorScreenTakeover extends Component {
 			} }
 		>
 			<ScreenTakeoverHeader icon={ icon } title={ title } onClose={ onClose } />
-			{ children }
+			<div className="edit-post-plugin-screen-takeover__editor-screen-takeover-content">
+				{ children }
+			</div>
 		</Modal>;
 	}
 

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component, compose } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import Modal from 'react-modal';
 
 /**
@@ -56,7 +56,6 @@ export default class EditorScreenTakeover extends Component {
 	}
 
 	render() {
-		console.log( 'Modal props=', this.props );
 		return this.getModal();
 	}
 }

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -1,8 +1,12 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import Modal from 'react-modal';
+
+/**
+ * Internal dependencies
+ */
 import ScreenTakeoverHeader from './editor-screen-takeover-header';
 
 Modal.setAppElement( document.getElementById( 'editor' ) );
@@ -14,6 +18,16 @@ export default class EditorScreenTakeover extends Component {
 		this.state = {
 			height: window.innerHeight - 32,
 		};
+
+		this.updateWindowHeight = this.updateWindowHeight.bind( this );
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'resize', this.updateWindowHeight );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.updateWindowHeight );
 	}
 
 	updateWindowHeight() {
@@ -22,19 +36,11 @@ export default class EditorScreenTakeover extends Component {
 		} );
 	}
 
-	componentDidMount() {
-		window.addEventListener( 'resize', this.updateWindowHeight.bind( this ) );
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.updateWindowHeight.bind( this ) );
-	}
-
 	getModal() {
-		const height = this.state.height;
-		const { icon, title, children } = this.props;
+		const { height } = this.state;
+		const { icon, title, children, isOpen, onClose } = this.props;
 		return <Modal
-			isOpen={ true }
+			isOpen={ isOpen }
 			className={ 'edit-post-plugin-screen-takeover__editor-screen-takeover' }
 			overlayClassName={ 'edit-post-plugin-screen-takeover__editor-screen-takeover-overlay' }
 			parentSelector={ () => document.getElementsByClassName( 'gutenberg' )[ 0 ] }
@@ -44,7 +50,7 @@ export default class EditorScreenTakeover extends Component {
 				},
 			} }
 		>
-			<ScreenTakeoverHeader icon={ icon } title={ title } />
+			<ScreenTakeoverHeader icon={ icon } title={ title } onClose={ onClose } />
 			{ children }
 		</Modal>;
 	}

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -2,12 +2,16 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import Modal from 'react-modal';
 
 /**
  * Internal dependencies
  */
 import ScreenTakeoverHeader from './editor-screen-takeover-header';
+
+/**
+ * External dependencies
+ */
+import Modal from 'react-modal';
 
 Modal.setAppElement( document.getElementById( 'editor' ) );
 

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress Dependencies
+ */
+import { Component } from '@wordpress/element';
+import Modal from 'react-modal';
+import ScreenTakeoverHeader from './editor-screen-takeover-header';
+
+Modal.setAppElement( document.getElementById( 'editor' ) );
+
+export default class EditorScreenTakeover extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			height: window.innerHeight - 32,
+		};
+	}
+
+	updateWindowHeight() {
+		this.setState( {
+			height: window.innerHeight - 32,
+		} );
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'resize', this.updateWindowHeight.bind( this ) );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.updateWindowHeight.bind( this ) );
+	}
+
+	getModal() {
+		const height = this.state.height;
+		const { icon, title, children } = this.props;
+		return <Modal
+			isOpen={ true }
+			className={ 'edit-post-plugin-screen-takeover__editor-screen-takeover' }
+			overlayClassName={ 'edit-post-plugin-screen-takeover__editor-screen-takeover-overlay' }
+			parentSelector={ () => document.getElementsByClassName( 'gutenberg' )[ 0 ] }
+			style={ {
+				overlay: {
+					height: height,
+				},
+			} }
+		>
+			<ScreenTakeoverHeader icon={ icon } title={ title } />
+			{ children }
+		</Modal>;
+	}
+
+	render() {
+		return this.getModal();
+	}
+}

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -51,7 +51,9 @@ export default class EditorScreenTakeover extends Component {
 			} }
 		>
 			<ScreenTakeoverHeader icon={ icon } title={ title } onClose={ onClose } />
-			{ children }
+			<div className={ 'edit-post-plugin-screen-takeover__editor-screen-takeover-content' } >
+				{ children }
+			</div>
 		</Modal>;
 	}
 

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -56,6 +56,7 @@ export default class EditorScreenTakeover extends Component {
 	}
 
 	render() {
+		console.log( 'Modal props=', this.props );
 		return this.getModal();
 	}
 }

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -51,9 +51,7 @@ export default class EditorScreenTakeover extends Component {
 			} }
 		>
 			<ScreenTakeoverHeader icon={ icon } title={ title } onClose={ onClose } />
-			<div className={ 'edit-post-plugin-screen-takeover__editor-screen-takeover-content' } >
-				{ children }
-			</div>
+			{ children }
 		</Modal>;
 	}
 

--- a/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
+++ b/edit-post/components/plugin-screen-takeover/editor-screen-takeover.js
@@ -40,7 +40,7 @@ export default class EditorScreenTakeover extends Component {
 		} );
 	}
 
-	getModal() {
+	render() {
 		const { height } = this.state;
 		const { icon, title, children, isOpen, onClose } = this.props;
 		return <Modal
@@ -48,6 +48,7 @@ export default class EditorScreenTakeover extends Component {
 			className={ 'edit-post-plugin-screen-takeover__editor-screen-takeover' }
 			overlayClassName={ 'edit-post-plugin-screen-takeover__editor-screen-takeover-overlay' }
 			parentSelector={ () => document.getElementsByClassName( 'gutenberg' )[ 0 ] }
+			onRequestClose={ onClose }
 			style={ {
 				overlay: {
 					height: height,
@@ -59,9 +60,5 @@ export default class EditorScreenTakeover extends Component {
 				{ children }
 			</div>
 		</Modal>;
-	}
-
-	render() {
-		return this.getModal();
 	}
 }

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -33,18 +33,11 @@ let PluginScreenTakeover = ( { pluginName, name, icon, children, isOpen, onClose
 
 PluginScreenTakeover = compose( [
 	withContext( 'pluginName' )(),
-	withDispatch( ( dispatch, ownProps ) => {
-		console.log( ownProps );
-		return {
-			onClose: dispatch( 'core/edit-post' ).closeScreenTakover,
-		};
-	} ),
+	withDispatch( ( dispatch ) => ( {
+		onClose: dispatch( 'core/edit-post' ).closeScreenTakeover,
+	} ) ),
 	withSelect( ( select, ownProps ) => {
 		const { name, pluginName } = ownProps;
-		console.log( 'withSelect ownProps=', ownProps );
-		console.log( 'getActiveScreenTakeoverName=', select( 'core/edit-post' ).getActiveScreenTakeoverName() );
-		console.log( 'concatenated name=', `${ pluginName }/${ name }` );
-		console.log( 'isOpen=', select( 'core/edit-post' ).getActiveScreenTakeoverName() === `${ pluginName }/${ name }`);
 		return {
 			isOpen: select( 'core/edit-post' ).getActiveScreenTakeoverName() === `${ pluginName }/${ name }`,
 		};
@@ -55,15 +48,8 @@ PluginScreenTakeover.Slot = ( { activeScreenTakeoverName } ) => {
 	return <Slot name={ [ SLOT_NAME, activeScreenTakeoverName ].join( '/' ) } />;
 };
 
-PluginScreenTakeover.Slot = withSelect( select => {
-	const o = {
-		activeScreenTakeoverName: select('core/edit-post').getActiveScreenTakeoverName(),
-	};
-	console.log( 'slot withSelect=', o );
-	return o;
-} )( PluginScreenTakeover.Slot );
-// PluginScreenTakeover.Slot = withSelect( select => ( {
-// 	activeScreenTakeoverName: select( 'core/edit-post' ).getActiveScreenTakeoverName(),
-// } ) )( PluginScreenTakeover.Slot );
+PluginScreenTakeover.Slot = withSelect( select => ( {
+	activeScreenTakeoverName: select( 'core/edit-post' ).getActiveScreenTakeoverName(),
+} ) )( PluginScreenTakeover.Slot );
 
 export default PluginScreenTakeover;

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/element';
+import { Slot, Fill, withContext } from '@wordpress/components';
+
+/**
+ * Name of slot in which the screen takeover should fill.
+ *
+ * @type {String}
+ */
+const SLOT_NAME = 'PluginScreenTakeover';
+
+let PluginScreenTakeover = ( { pluginName, name } ) => (
+	<Fill name={ [ SLOT_NAME, pluginName, name ].join( '/' ) }>
+		Render some stuff
+	</Fill>
+);
+
+PluginScreenTakeover = compose( [
+	withContext( 'pluginName' )(),
+] )( PluginScreenTakeover );
+
+PluginScreenTakeover.Slot = ( { name } ) => (
+	<Slot name={ [ SLOT_NAME, name ].join( '/' ) } />
+);
+
+export default PluginScreenTakeover;

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -3,7 +3,11 @@
  */
 import { compose } from '@wordpress/element';
 import { Slot, Fill, withContext } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 import EditorScreenTakeover from './editor-screen-takeover';
 
@@ -27,6 +31,18 @@ let PluginScreenTakeover = ( { pluginName, name, icon, children } ) => (
 
 PluginScreenTakeover = compose( [
 	withContext( 'pluginName' )(),
+	// withDispatch( ( dispatch, ownProps ) => {
+	// 	console.log( ownProps );
+	// 	return {
+	// 		onClose: dispatch( 'core/edit-post' ).closeScreenTakover,
+	// 	};
+	// } ),
+	// withSelect( ( select, ownProps ) => {
+	// 	const { name } = ownProps;
+	// 	return {
+	// 		isOpen: select( 'core/edit-post' ).getActiveScreenTakeoverName() === name,
+	// 	};
+	// } ),
 ] )( PluginScreenTakeover );
 
 PluginScreenTakeover.Slot = withSelect( select => ( {

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -3,6 +3,7 @@
  */
 import { compose } from '@wordpress/element';
 import { Slot, Fill, withContext } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Name of slot in which the screen takeover should fill.
@@ -21,8 +22,12 @@ PluginScreenTakeover = compose( [
 	withContext( 'pluginName' )(),
 ] )( PluginScreenTakeover );
 
-PluginScreenTakeover.Slot = ( { name } ) => (
-	<Slot name={ [ SLOT_NAME, name ].join( '/' ) } />
-);
+PluginScreenTakeover.Slot = ( { activeScreenTakeoverName } ) => {
+	return <Slot name={ [ SLOT_NAME, activeScreenTakeoverName ].join( '/' ) } />
+};
+
+PluginScreenTakeover.Slot = withSelect( select => ( {
+	activeScreenTakeoverName: select( 'core/edit-post' ).getActiveScreenTakeoverName(),
+} ) )( PluginScreenTakeover.Slot );
 
 export default PluginScreenTakeover;

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -11,9 +11,9 @@ import { Slot, Fill, withContext } from '@wordpress/components';
  */
 const SLOT_NAME = 'PluginScreenTakeover';
 
-let PluginScreenTakeover = ( { pluginName, name } ) => (
+let PluginScreenTakeover = ( { pluginName, name, children } ) => (
 	<Fill name={ [ SLOT_NAME, pluginName, name ].join( '/' ) }>
-		Render some stuff
+		{ children }
 	</Fill>
 );
 

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -23,7 +23,7 @@ PluginScreenTakeover = compose( [
 ] )( PluginScreenTakeover );
 
 PluginScreenTakeover.Slot = ( { activeScreenTakeoverName } ) => {
-	return <Slot name={ [ SLOT_NAME, activeScreenTakeoverName ].join( '/' ) } />
+	return <Slot name={ [ SLOT_NAME, activeScreenTakeoverName ].join( '/' ) } />;
 };
 
 PluginScreenTakeover.Slot = withSelect( select => ( {

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -29,10 +29,6 @@ PluginScreenTakeover = compose( [
 	withContext( 'pluginName' )(),
 ] )( PluginScreenTakeover );
 
-PluginScreenTakeover.Slot = ( { activeScreenTakeoverName } ) => {
-	return <Slot name={ [ SLOT_NAME, activeScreenTakeoverName ].join( '/' ) } />;
-};
-
 PluginScreenTakeover.Slot = withSelect( select => ( {
 	activeScreenTakeoverName: select( 'core/edit-post' ).getActiveScreenTakeoverName(),
 } ) )( PluginScreenTakeover.Slot );

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -4,6 +4,8 @@
 import { compose } from '@wordpress/element';
 import { Slot, Fill, withContext } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import './style.scss';
+import EditorScreenTakeover from './editor-screen-takeover';
 
 /**
  * Name of slot in which the screen takeover should fill.
@@ -12,9 +14,14 @@ import { withSelect } from '@wordpress/data';
  */
 const SLOT_NAME = 'PluginScreenTakeover';
 
-let PluginScreenTakeover = ( { pluginName, name, children } ) => (
+let PluginScreenTakeover = ( { pluginName, name, icon, children } ) => (
 	<Fill name={ [ SLOT_NAME, pluginName, name ].join( '/' ) }>
-		{ children }
+		<EditorScreenTakeover
+			icon={ icon }
+			title={ 'Screen Takeover Title' }
+		>
+			{ children }
+		</EditorScreenTakeover>
 	</Fill>
 );
 

--- a/edit-post/components/plugin-screen-takeover/index.js
+++ b/edit-post/components/plugin-screen-takeover/index.js
@@ -18,11 +18,13 @@ import EditorScreenTakeover from './editor-screen-takeover';
  */
 const SLOT_NAME = 'PluginScreenTakeover';
 
-let PluginScreenTakeover = ( { pluginName, name, icon, children } ) => (
+let PluginScreenTakeover = ( { pluginName, name, icon, children, isOpen, onClose } ) => (
 	<Fill name={ [ SLOT_NAME, pluginName, name ].join( '/' ) }>
 		<EditorScreenTakeover
 			icon={ icon }
 			title={ 'Screen Takeover Title' }
+			isOpen={ isOpen }
+			onClose={ onClose }
 		>
 			{ children }
 		</EditorScreenTakeover>
@@ -31,22 +33,37 @@ let PluginScreenTakeover = ( { pluginName, name, icon, children } ) => (
 
 PluginScreenTakeover = compose( [
 	withContext( 'pluginName' )(),
-	// withDispatch( ( dispatch, ownProps ) => {
-	// 	console.log( ownProps );
-	// 	return {
-	// 		onClose: dispatch( 'core/edit-post' ).closeScreenTakover,
-	// 	};
-	// } ),
-	// withSelect( ( select, ownProps ) => {
-	// 	const { name } = ownProps;
-	// 	return {
-	// 		isOpen: select( 'core/edit-post' ).getActiveScreenTakeoverName() === name,
-	// 	};
-	// } ),
+	withDispatch( ( dispatch, ownProps ) => {
+		console.log( ownProps );
+		return {
+			onClose: dispatch( 'core/edit-post' ).closeScreenTakover,
+		};
+	} ),
+	withSelect( ( select, ownProps ) => {
+		const { name, pluginName } = ownProps;
+		console.log( 'withSelect ownProps=', ownProps );
+		console.log( 'getActiveScreenTakeoverName=', select( 'core/edit-post' ).getActiveScreenTakeoverName() );
+		console.log( 'concatenated name=', `${ pluginName }/${ name }` );
+		console.log( 'isOpen=', select( 'core/edit-post' ).getActiveScreenTakeoverName() === `${ pluginName }/${ name }`);
+		return {
+			isOpen: select( 'core/edit-post' ).getActiveScreenTakeoverName() === `${ pluginName }/${ name }`,
+		};
+	} ),
 ] )( PluginScreenTakeover );
 
-PluginScreenTakeover.Slot = withSelect( select => ( {
-	activeScreenTakeoverName: select( 'core/edit-post' ).getActiveScreenTakeoverName(),
-} ) )( PluginScreenTakeover.Slot );
+PluginScreenTakeover.Slot = ( { activeScreenTakeoverName } ) => {
+	return <Slot name={ [ SLOT_NAME, activeScreenTakeoverName ].join( '/' ) } />;
+};
+
+PluginScreenTakeover.Slot = withSelect( select => {
+	const o = {
+		activeScreenTakeoverName: select('core/edit-post').getActiveScreenTakeoverName(),
+	};
+	console.log( 'slot withSelect=', o );
+	return o;
+} )( PluginScreenTakeover.Slot );
+// PluginScreenTakeover.Slot = withSelect( select => ( {
+// 	activeScreenTakeoverName: select( 'core/edit-post' ).getActiveScreenTakeoverName(),
+// } ) )( PluginScreenTakeover.Slot );
 
 export default PluginScreenTakeover;

--- a/edit-post/components/plugin-screen-takeover/style.scss
+++ b/edit-post/components/plugin-screen-takeover/style.scss
@@ -1,0 +1,91 @@
+.edit-post-plugin-screen-takeover__editor-screen-takeover {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	right: auto;
+	bottom: auto;
+	width: auto;
+	max-width: 90%;
+	max-height: 90%;
+	min-width: 75%;
+	min-height: 75%;
+	border: 0;
+	border-radius: 0;
+	margin-right: -50%;
+	transform: translate(-50%, -50%);
+	background-color: #fff;
+	outline: none;
+
+	// In small screens the content needs to be full width.
+	@media ( max-width: #{ ( $break-small ) } ) {
+		position: fixed;
+		top: 0;
+		bottom: 0;
+		right: 0;
+		left: 0;
+		margin: 0;
+		transform: initial;
+		max-width: none;
+		max-height: none;
+	}
+}
+
+.edit-post-plugin-screen-takeover__editor-screen-takeover-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba(0, 0, 0, 0.6);
+	z-index: 999999;
+	// on mobile the main content area has to scroll
+	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
+	@include break-small {
+		position: fixed;
+		top: $admin-bar-height-big;
+	}
+
+	@include break-medium() {
+		top: $admin-bar-height;
+	}
+}
+
+@include editor-left('.edit-post-plugin-screen-takeover__editor-screen-takeover-overlay');
+
+// We prevent scrolling of the body when the React Modal screen takeover is opened.
+body.ReactModal__Body--open {
+	overflow-y: hidden;
+}
+
+// The modal needs a separate header that needs its own styling.
+.edit-post-plugin-screen-takeover__editor-screen-takeover-header {
+	height: $header-height;
+	border-bottom: 1px solid $light-gray-500;
+	background: red;
+	padding: 10px;
+	display: flex;
+	flex-direction: row;
+	align-items: stretch;
+	justify-content: space-between;
+	z-index: z-index( '.edit-post-header' );
+	left: 0;
+	right: 0;
+
+	div {
+		align-items: center;
+		flex-grow: 1;
+		display: flex;
+		flex-direction: row;
+		justify-content: left;
+
+		span {
+			display: inline-block;
+		}
+
+		svg {
+			max-width: $icon-button-size;
+			max-height: $icon-button-size;
+			padding: 8px;
+		}
+	}
+}

--- a/edit-post/components/plugin-screen-takeover/style.scss
+++ b/edit-post/components/plugin-screen-takeover/style.scss
@@ -61,7 +61,6 @@ body.ReactModal__Body--open {
 .edit-post-plugin-screen-takeover__editor-screen-takeover-header {
 	height: $header-height;
 	border-bottom: 1px solid $light-gray-500;
-	background: red;
 	padding: 10px;
 	display: flex;
 	flex-direction: row;
@@ -86,6 +85,7 @@ body.ReactModal__Body--open {
 			max-width: $icon-button-size;
 			max-height: $icon-button-size;
 			padding: 8px;
+			padding-right: 10px;
 		}
 	}
 }

--- a/edit-post/components/plugin-screen-takeover/style.scss
+++ b/edit-post/components/plugin-screen-takeover/style.scss
@@ -15,6 +15,7 @@
 	transform: translate(-50%, -50%);
 	background-color: #fff;
 	outline: none;
+	box-shadow: 0px 3px 25px #000;
 
 	// In small screens the content needs to be full width.
 	@media ( max-width: #{ ( $break-small ) } ) {
@@ -77,6 +78,12 @@ body.ReactModal__Body--open {
 		flex-direction: row;
 		justify-content: left;
 
+		h1 {
+			font-size: 1em;
+			font-weight: normal;
+			padding-left: 5px;
+		}
+
 		span {
 			display: inline-block;
 		}
@@ -85,7 +92,17 @@ body.ReactModal__Body--open {
 			max-width: $icon-button-size;
 			max-height: $icon-button-size;
 			padding: 8px;
-			padding-right: 10px;
 		}
+	}
+}
+
+.edit-post-plugin-screen-takeover__editor-screen-takeover-content {
+	padding: 10px 20px 5px 20px;
+	height: 500px;
+	overflow: auto;
+
+	// For small screens, the content needs to be full height.
+	@media ( max-width: #{ ( $break-small ) } ) {
+		height: 100%
 	}
 }

--- a/edit-post/components/plugin-screen-takeover/style.scss
+++ b/edit-post/components/plugin-screen-takeover/style.scss
@@ -16,6 +16,8 @@
 	background-color: #fff;
 	outline: none;
 	box-shadow: 0px 3px 25px #000;
+	overflow: auto;
+	padding: 10px 20px 5px 20px;
 
 	// In small screens the content needs to be full width.
 	@media ( max-width: #{ ( $break-small ) } ) {
@@ -93,16 +95,5 @@ body.ReactModal__Body--open {
 			max-height: $icon-button-size;
 			padding: 8px;
 		}
-	}
-}
-
-.edit-post-plugin-screen-takeover__editor-screen-takeover-content {
-	padding: 10px 20px 5px 20px;
-	height: 500px;
-	overflow: auto;
-
-	// For small screens, the content needs to be full height.
-	@media ( max-width: #{ ( $break-small ) } ) {
-		height: 100%
 	}
 }

--- a/edit-post/components/plugin-screen-takeover/style.scss
+++ b/edit-post/components/plugin-screen-takeover/style.scss
@@ -15,9 +15,7 @@
 	transform: translate(-50%, -50%);
 	background-color: #fff;
 	outline: none;
-	box-shadow: 0px 3px 25px #000;
-	overflow: auto;
-	padding: 10px 20px 5px 20px;
+	box-shadow: 0 3px 25px #000;
 
 	// In small screens the content needs to be full width.
 	@media ( max-width: #{ ( $break-small ) } ) {
@@ -96,4 +94,12 @@ body.ReactModal__Body--open {
 			padding: 8px;
 		}
 	}
+}
+
+// The modal needs a separate header that needs its own styling.
+.edit-post-plugin-screen-takeover__editor-screen-takeover-content {
+	height: calc( 100% - #{ $header-height } );
+	overflow: auto;
+	padding: 10px 20px 5px 20px;
+	position: absolute;
 }

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -20,6 +20,7 @@ import { initializeMetaBoxState } from './store/actions';
 
 import PluginSidebar from './components/plugin-sidebar';
 import PluginMoreMenuItem from './components/plugin-more-menu-item';
+import PluginScreenTakeover from './components/plugin-screen-takeover';
 
 /**
  * Configure heartbeat to refresh the wp-api nonce, keeping the editor
@@ -95,4 +96,5 @@ export function initializeEditor( id, post, settings ) {
 export const __experimental = {
 	PluginSidebar,
 	PluginMoreMenuItem,
+	PluginScreenTakeover,
 };

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -148,3 +148,27 @@ export function setMetaBoxSavedData( dataPerLocation ) {
 		dataPerLocation,
 	};
 }
+
+/**
+ * Returns an action object used in signalling that the user opened a screen takeover.
+ *
+ * @param {string} name        Screen takeover name to be opened.
+ * @return {Object}            Action object.
+ */
+export function openScreenTakeover( name ) {
+	return {
+		type: 'OPEN_SCREEN_TAKEOVER',
+		name,
+	};
+}
+
+/**
+ * Returns an action object signalling that the user closed the screen takeover.
+ *
+ * @return {Object} Action object.
+ */
+export function closeScreenTakeover() {
+	return {
+		type: 'CLOSE_SCREEN_TAKEOVER',
+	};
+}

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -36,6 +36,16 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 				...state,
 				activeGeneralSidebar: null,
 			};
+		case 'OPEN_SCREEN_TAKEOVER':
+			return {
+				...state,
+				activeScreenTakeover: action.name,
+			};
+		case 'CLOSE_SCREEN_TAKEOVER':
+			return {
+				...state,
+				activeScreenTakeover: null,
+			};
 		case 'TOGGLE_GENERAL_SIDEBAR_EDITOR_PANEL':
 			return {
 				...state,

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -50,6 +50,17 @@ export function getActiveGeneralSidebarName( state ) {
 }
 
 /**
+ * Returns the current active screen takeover name.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {?string} Active general screen takeover name.
+ */
+export function getActiveScreenTakeoverName( state ) {
+	return getPreference( state, 'activeScreenTakeover', null );
+}
+
+/**
  * Returns the preferences (these preferences are persisted locally).
  *
  * @param {Object} state Global application state.

--- a/edit-post/store/test/actions.js
+++ b/edit-post/store/test/actions.js
@@ -102,16 +102,20 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'openScreenTakeover', () => {
-		const screenTakeoverName = 'my-screen-takeover';
-		expect( openScreenTakeover( screenTakeoverName ) ).toEqual( {
-			type: 'OPEN_SCREEN_TAKEOVER',
-			name: 'my-screen-takeover',
+		it( 'should return the OPEN_SCREEN_TAKEOVER action', () => {
+			const screenTakeoverName = 'my-screen-takeover';
+			expect( openScreenTakeover( screenTakeoverName ) ).toEqual( {
+				type: 'OPEN_SCREEN_TAKEOVER',
+				name: 'my-screen-takeover',
+			} );
 		} );
 	} );
 
 	describe( 'closeScreenTakeover', () => {
-		expect( closeScreenTakeover() ).toEqual( {
-			type: 'CLOSE_SCREEN_TAKEOVER',
+		it( 'should return the CLOSE_SCREEN_TAKEOVER action', () => {
+			expect( closeScreenTakeover() ).toEqual( {
+				type: 'CLOSE_SCREEN_TAKEOVER',
+			} );
 		} );
 	} );
 } );

--- a/edit-post/store/test/actions.js
+++ b/edit-post/store/test/actions.js
@@ -11,6 +11,8 @@ import {
 	toggleFeature,
 	requestMetaBoxUpdates,
 	initializeMetaBoxState,
+	openScreenTakeover,
+	closeScreenTakeover,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -96,6 +98,20 @@ describe( 'actions', () => {
 				type: 'INITIALIZE_META_BOX_STATE',
 				metaBoxes,
 			} );
+		} );
+	} );
+
+	describe( 'openScreenTakeover', () => {
+		const screenTakeoverName = 'my-screen-takeover';
+		expect( openScreenTakeover( screenTakeoverName ) ).toEqual( {
+			type: 'OPEN_SCREEN_TAKEOVER',
+			name: 'my-screen-takeover',
+		} );
+	} );
+
+	describe( 'closeScreenTakeover', () => {
+		expect( closeScreenTakeover() ).toEqual( {
+			type: 'CLOSE_SCREEN_TAKEOVER',
 		} );
 	} );
 } );

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -25,6 +25,19 @@ describe( 'state', () => {
 			} );
 		} );
 
+		it( 'should set the active screen takeover', () => {
+			const state = preferences( deepFreeze( {
+				activeScreenTakeover: null,
+			} ), {
+				type: 'OPEN_SCREEN_TAKEOVER',
+				name: 'my-namespace/my-screen-takeover',
+			} );
+
+			expect( state ).toEqual( {
+				activeScreenTakeover: 'my-namespace/my-screen-takeover',
+			} );
+		} );
+
 		it( 'should set the general sidebar active panel', () => {
 			const state = preferences( deepFreeze( {
 				activeGeneralSidebar: 'editor',

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	hasMetaBoxes,
 	isSavingMetaBoxes,
 	getMetaBox,
+	getActiveScreenTakeoverName,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -276,6 +277,18 @@ describe( 'selectors', () => {
 			expect( getMetaBox( state, 'side' ) ).toEqual( {
 				isActive: true,
 			} );
+		} );
+	} );
+
+	describe( 'getActiveScreenTakeoverName', () => {
+		it( 'should return the name of the active screen takeover', () => {
+			const state = {
+				preferences: {
+					activeScreenTakeover: 'my-namespace/my-screen-takeover',
+				},
+			};
+
+			expect( getActiveScreenTakeoverName( state ) ).toEqual( 'my-namespace/my-screen-takeover')
 		} );
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"react-color": "2.13.4",
 		"react-datepicker": "0.61.0",
 		"react-dom": "16.2.0",
+		"react-modal": "3.3.2",
 		"react-redux": "5.0.6",
 		"redux": "3.7.2",
 		"redux-multi": "0.1.12",


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

In this pull, I've used react-modal to make a screen takeover. Based on the following mockups:
https://cloudup.com/cRhqngZCduC

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Unit tests have been written for the actions and reducers. It has also been manually tested by adding a screen takeover from a plugin. And seeing if it works as intended.



## Screenshots <!-- if applicable -->
<img width="1142" alt="screen_takeover-2" src="https://user-images.githubusercontent.com/11849359/38933527-7d6540e6-4319-11e8-86f1-624326523396.png">



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->



## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

deleted in favor of #6241, the branch was wrong.