### PR TITLE
Fix regression with columns appender

### DIFF
--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -1,7 +1,7 @@
 $empty-paragraph-height: $text-editor-font-size * 4;
 
 .editor-default-block-appender {
-	.editor-default-block-appender__content {
+	input[type=text].editor-default-block-appender__content { // needs specificity
 		border: none;
 		background: none;
 		box-shadow: none;


### PR DESCRIPTION
This fixes an issue where the default appender in columns would have a border, and the wrong font. This was introduced as part of the input style consistency PR. Increasing selector specificity fixes this.

Before:

<img width="763" alt="screen shot 2018-04-18 at 10 56 26" src="https://user-images.githubusercontent.com/1204802/38922048-8ea05bce-42f7-11e8-97b1-4071010920ab.png">

After:

<img width="795" alt="screen shot 2018-04-18 at 10 57 09" src="https://user-images.githubusercontent.com/1204802/38922056-914bac16-42f7-11e8-892b-52c9b620dbe9.png">

👋 don't mind the yellow background color, I'm experimenting with editor styles :D 
