### PR TITLE
Pass content to block render callback

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -104,7 +104,7 @@ function gutenberg_render_block( $block ) {
 	if ( $block_name ) {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 		if ( null !== $block_type && $block_type->is_dynamic() ) {
-			return $block_type->render( $attributes, $raw_content );
+			return $block_type->render( $attributes, $raw_content, $block_name );
 		}
 	}
 
@@ -194,7 +194,7 @@ function do_blocks( $content ) {
 		}
 
 		// Replace dynamic block with server-rendered output.
-		$rendered_content .= $block_type->render( $attributes, $block_content );
+		$rendered_content .= $block_type->render( $attributes, $block_content, $block_name );
 
 		if ( ! $is_self_closing ) {
 			$content = substr( $content, $end_offset + strlen( $end_tag ) );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -104,7 +104,7 @@ function gutenberg_render_block( $block ) {
 	if ( $block_name ) {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 		if ( null !== $block_type && $block_type->is_dynamic() ) {
-			return $block_type->render( $attributes, $raw_content, $block_name );
+			return $block_type->render( $attributes, $raw_content );
 		}
 	}
 
@@ -194,7 +194,7 @@ function do_blocks( $content ) {
 		}
 
 		// Replace dynamic block with server-rendered output.
-		$rendered_content .= $block_type->render( $attributes, $block_content, $block_name );
+		$rendered_content .= $block_type->render( $attributes, $block_content );
 
 		if ( ! $is_self_closing ) {
 			$content = substr( $content, $end_offset + strlen( $end_tag ) );

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -95,7 +95,7 @@ class WP_Block_Type {
 	 * @since 0.6.0
 	 *
 	 * @param array  $attributes Optional. Block attributes. Default empty array.
-	 * @param string $content Optional. Block content. Default empty string.
+	 * @param string $content    Optional. Block content. Default empty string.
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
@@ -105,7 +105,7 @@ class WP_Block_Type {
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return (string) call_user_func( $this->render_callback, $attributes, $content );
+		return (string) call_user_func( $this->render_callback, $attributes, $content, $this->name );
 	}
 
 	/**

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -95,18 +95,17 @@ class WP_Block_Type {
 	 * @since 0.6.0
 	 *
 	 * @param array  $attributes Optional. Block attributes. Default empty array.
-	 * @param string $content    Optional. Block content. Default empty string.
-	 * @param string $block_name Optional. Block Name. The name of the block.
+	 * @param string $content Optional. Block content. Default empty string.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '', $block_name = null ) {
+	public function render( $attributes = array(), $content = '' ) {
 		if ( ! $this->is_dynamic() ) {
 			return '';
 		}
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return (string) call_user_func( $this->render_callback, $attributes, $content, $block_name );
+		return (string) call_user_func( $this->render_callback, $attributes, $content );
 	}
 
 	/**

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -94,17 +94,18 @@ class WP_Block_Type {
 	 *
 	 * @since 0.6.0
 	 *
-	 * @param array $attributes Optional. Block attributes. Default empty array.
+	 * @param array  $attributes Optional. Block attributes. Default empty array.
+	 * @param string $content Optional. Block content. Default empty string.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array() ) {
+	public function render( $attributes = array(), $content = '' ) {
 		if ( ! $this->is_dynamic() ) {
 			return '';
 		}
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return (string) call_user_func( $this->render_callback, $attributes );
+		return (string) call_user_func( $this->render_callback, $attributes, $content );
 	}
 
 	/**

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -105,7 +105,7 @@ class WP_Block_Type {
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return (string) call_user_func( $this->render_callback, $attributes, $content, $this->name );
+		return (string) call_user_func( $this->render_callback, $attributes, $content, $this );
 	}
 
 	/**

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -100,7 +100,7 @@ class WP_Block_Type {
 	 */
 	public function render( $attributes = array(), $content = '' ) {
 		if ( ! $this->is_dynamic() ) {
-			return '';
+			return $content;
 		}
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -95,17 +95,18 @@ class WP_Block_Type {
 	 * @since 0.6.0
 	 *
 	 * @param array  $attributes Optional. Block attributes. Default empty array.
-	 * @param string $content Optional. Block content. Default empty string.
+	 * @param string $content    Optional. Block content. Default empty string.
+	 * @param string $block_name Optional. Block Name. The name of the block.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
+	public function render( $attributes = array(), $content = '', $block_name = null ) {
 		if ( ! $this->is_dynamic() ) {
 			return '';
 		}
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return (string) call_user_func( $this->render_callback, $attributes, $content );
+		return (string) call_user_func( $this->render_callback, $attributes, $content, $block_name );
 	}
 
 	/**

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -115,9 +115,9 @@ class Block_Type_Test extends WP_UnitTestCase {
 		return json_encode( $attributes );
 	}
 
-	function render_dummy_block_with_content( $attributes, $content, $block_name ) {
+	function render_dummy_block_with_content( $attributes, $content, $instance ) {
 		$attributes['_content']    = $content;
-		$attributes['_block_name'] = $block_name;
+		$attributes['_block_name'] = $instance->name;
 
 		return json_encode( $attributes );
 	}

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -36,11 +36,18 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$this->assertEquals( $attributes, json_decode( $output, true ) );
 	}
 
-	function test_render_for_static_block() {
+	function test_render_for_static_block_default() {
 		$block_type = new WP_Block_Type( 'core/dummy', array() );
 		$output     = $block_type->render();
 
 		$this->assertEquals( '', $output );
+	}
+
+	function test_render_for_static_block_with_content() {
+		$block_type = new WP_Block_Type( 'core/dummy', array() );
+		$output     = $block_type->render( array(), 'some dummy content' );
+
+		$this->assertEquals( 'some dummy content', $output );
 	}
 
 	function test_is_dynamic_for_static_block() {

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -63,6 +63,7 @@ class Block_Type_Test extends WP_UnitTestCase {
 		) );
 		$output     = json_decode( $block_type->render( array(), 'hello world' ), true );
 		$this->assertEquals( 'hello world', $output['_content'] );
+		$this->assertEquals( 'core/dummy', $output['_block_name'] );
 	}
 
 	function test_prepare_attributes() {
@@ -107,8 +108,9 @@ class Block_Type_Test extends WP_UnitTestCase {
 		return json_encode( $attributes );
 	}
 
-	function render_dummy_block_with_content( $attributes, $content ) {
-		$attributes['_content'] = $content;
+	function render_dummy_block_with_content( $attributes, $content, $block_name ) {
+		$attributes['_content']    = $content;
+		$attributes['_block_name'] = $block_name;
 
 		return json_encode( $attributes );
 	}

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -61,8 +61,9 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$block_type = new WP_Block_Type( 'core/dummy', array(
 			'render_callback' => array( $this, 'render_dummy_block_with_content' ),
 		) );
-		$output     = json_decode( $block_type->render( array(), 'hello world' ), true );
+		$output     = json_decode( $block_type->render( array(), 'hello world', 'core/dummy' ), true );
 		$this->assertEquals( 'hello world', $output['_content'] );
+		$this->assertEquals( 'core/dummy', $output['_block_name'] );
 	}
 
 	function test_prepare_attributes() {
@@ -107,8 +108,9 @@ class Block_Type_Test extends WP_UnitTestCase {
 		return json_encode( $attributes );
 	}
 
-	function render_dummy_block_with_content( $attributes, $content ) {
-		$attributes['_content'] = $content;
+	function render_dummy_block_with_content( $attributes, $content, $block_name ) {
+		$attributes['_content']    = $content;
+		$attributes['_block_name'] = $block_name;
 
 		return json_encode( $attributes );
 	}

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -57,6 +57,14 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$this->assertTrue( $block_type->is_dynamic() );
 	}
 
+	function test_dynamic_block_with_content() {
+		$block_type = new WP_Block_Type( 'core/dummy', array(
+			'render_callback' => array( $this, 'render_dummy_block_with_content' ),
+		) );
+		$output     = json_decode( $block_type->render( array(), 'hello world' ), true );
+		$this->assertEquals( 'hello world', $output['_content'] );
+	}
+
 	function test_prepare_attributes() {
 		$attributes = array(
 			'correct'            => 'include',

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -61,9 +61,8 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$block_type = new WP_Block_Type( 'core/dummy', array(
 			'render_callback' => array( $this, 'render_dummy_block_with_content' ),
 		) );
-		$output     = json_decode( $block_type->render( array(), 'hello world', 'core/dummy' ), true );
+		$output     = json_decode( $block_type->render( array(), 'hello world' ), true );
 		$this->assertEquals( 'hello world', $output['_content'] );
-		$this->assertEquals( 'core/dummy', $output['_block_name'] );
 	}
 
 	function test_prepare_attributes() {
@@ -108,9 +107,8 @@ class Block_Type_Test extends WP_UnitTestCase {
 		return json_encode( $attributes );
 	}
 
-	function render_dummy_block_with_content( $attributes, $content, $block_name ) {
-		$attributes['_content']    = $content;
-		$attributes['_block_name'] = $block_name;
+	function render_dummy_block_with_content( $attributes, $content ) {
+		$attributes['_content'] = $content;
 
 		return json_encode( $attributes );
 	}

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -24,9 +24,9 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 *
 	 * @return string             Block output.
 	 */
-	function render_dummy_block( $attributes ) {
+	function render_dummy_block( $attributes, $content = '' ) {
 		$this->dummy_block_instance_number += 1;
-		return $this->dummy_block_instance_number . ':' . $attributes['value'];
+		return $this->dummy_block_instance_number . ':' . $attributes['value'] . ':' . $content;
 	}
 
 	/**
@@ -51,7 +51,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test dynamic blocks that lack content, including void blocks.
+	 * Test dynamic blocks, including void blocks.
 	 *
 	 * @covers ::do_blocks
 	 */
@@ -68,21 +68,22 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$post_content =
 			'before' .
 			'<!-- wp:core/dummy {"value":"b1"} --><!-- /wp:core/dummy -->' .
-			'<!-- wp:core/dummy {"value":"b1"} --><!-- /wp:core/dummy -->' .
+			'<!-- wp:core/dummy {"value":"b1"} -->hello world<!-- /wp:core/dummy -->' .
 			'between' .
 			'<!-- wp:core/dummy {"value":"b2"} /-->' .
 			'<!-- wp:core/dummy {"value":"b2"} /-->' .
 			'after';
 
 		$updated_post_content = do_blocks( $post_content );
-		$this->assertEquals( $updated_post_content,
+		$this->assertEquals(
 			'before' .
-			'1:b1' .
-			'2:b1' .
+			'1:b1:' .
+			'2:b1:hello world' .
 			'between' .
-			'3:b2' .
-			'4:b2' .
-			'after'
+			'3:b2:' .
+			'4:b2:' .
+			'after',
+			$updated_post_content
 		);
 	}
 


### PR DESCRIPTION
## Description

See #5760 

Support for passing of a blocks content to the render block was removed in https://github.com/WordPress/gutenberg/pull/4591

## How has this been tested?
* Locally I used the docker dev environment provided by the Gutenberg project. 
* [I created a custom block to test this](https://gist.github.com/mattheu/7cf235b4f932de891bc21cb5f3ff3de6).
* I tested single and multiple instances of the same block, as well as with other blocks on the page.
* I updated the custom block to support inner content.
* I wrote PHP unit tests for the changes.

## Types of changes
This is not a breaking change. 
It simply passes the block content to the render callback as the second param, in addition to the attributes which are passed currently.
For self closing blocks, this will always be an empty string.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
