### PR TITLE
Fixed a bug when using zero min value in RangeControl.

### DIFF
--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -26,7 +26,7 @@ function RangeControl( {
 } ) {
 	const id = `inspector-range-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
-	const initialSliderValue = value || initialPosition || '';
+	const initialSliderValue = value === undefined ? initialPosition || '' : value;
 
 	return (
 		<BaseControl


### PR DESCRIPTION
There was a condition to check initialSliderValue which did not correctly handled that 0 value is false. The condition was updated.

Fixes: https://github.com/WordPress/gutenberg/issues/6230.


## How has this been tested?
We don't' use sliders with min equal to 0.
In some component add a range control for testing purposes:
```
					<RangeControl
						label={ __( 'Test' ) }
						value={ this.state.testValue }
						onChange={ ( testValue ) => this.setState( { testValue } ) }
						min={ 0 }
						max={ 5 }
					/>
```
With test Value store in the component state.
