### PR TITLE
Testing: Enforce array as Lodash path argument

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,8 +91,8 @@ module.exports = {
 				message: 'Deprecated functions must be removed before releasing this version.',
 			},
 			{
-				selector: 'CallExpression[callee.name="get"] > Literal:nth-child(2)',
-				message: 'Always pass an array as the second argument of Lodash.get',
+				selector: 'CallExpression[callee.name=/^(invokeMap|get|has|hasIn|invoke|result|set|setWith|unset|update|updateWith)$/] > Literal:nth-child(2)',
+				message: 'Always pass an array as the path argument',
 			},
 		],
 	},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,10 @@ module.exports = {
 				selector: 'CallExpression[callee.name="deprecated"] Property[key.name="version"][value.value=/' + majorMinorRegExp + '/]',
 				message: 'Deprecated functions must be removed before releasing this version.',
 			},
+			{
+				selector: 'CallExpression[callee.name="get"] > Literal:nth-child(2)',
+				message: 'Always pass an array as the second argument of Lodash.get',
+			},
 		],
 	},
 	overrides: [

--- a/components/code-editor/test/editor.js
+++ b/components/code-editor/test/editor.js
@@ -11,7 +11,7 @@ import CodeEditor from '../editor';
 
 describe( 'CodeEditor', () => {
 	it( 'should render without an error', () => {
-		set( global, 'wp.codeEditor.initialize', () => ( {
+		set( global, [ 'wp', 'codeEditor', 'initialize' ], () => ( {
 			codemirror: {
 				on: noop,
 				hasFocus: () => false,

--- a/core-blocks/latest-posts/block.js
+++ b/core-blocks/latest-posts/block.js
@@ -61,7 +61,7 @@ class LatestPostsBlock extends Component {
 					<QueryControls
 						{ ...{ order, orderBy } }
 						numberOfItems={ postsToShow }
-						categoriesList={ get( categoriesList, 'data', {} ) }
+						categoriesList={ get( categoriesList, [ 'data' ], {} ) }
 						selectedCategoryId={ categories }
 						onOrderChange={ ( value ) => setAttributes( { order: value } ) }
 						onOrderByChange={ ( value ) => setAttributes( { orderBy: value } ) }

--- a/core-blocks/list/index.js
+++ b/core-blocks/list/index.js
@@ -67,7 +67,7 @@ export const settings = {
 				type: 'block',
 				blocks: [ 'core/quote' ],
 				transform: ( { value, citation } ) => {
-					const items = value.map( ( p ) => get( p, 'children.props.children' ) );
+					const items = value.map( ( p ) => get( p, [ 'children', 'props', 'children' ] ) );
 					if ( ! isEmpty( citation ) ) {
 						items.push( citation );
 					}
@@ -108,7 +108,7 @@ export const settings = {
 				type: 'block',
 				blocks: [ 'core/paragraph' ],
 				transform: ( { values } ) =>
-					compact( values.map( ( value ) => get( value, 'props.children', null ) ) )
+					compact( values.map( ( value ) => get( value, [ 'props', 'children' ], null ) ) )
 						.map( ( content ) => createBlock( 'core/paragraph', {
 							content: [ content ],
 						} ) ),
@@ -119,9 +119,9 @@ export const settings = {
 				transform: ( { values } ) => {
 					return createBlock( 'core/quote', {
 						value: compact( ( values.length === 1 ? values : initial( values ) )
-							.map( ( value ) => get( value, 'props.children', null ) ) )
+							.map( ( value ) => get( value, [ 'props', 'children' ], null ) ) )
 							.map( ( children ) => ( { children: <p>{ children }</p> } ) ),
-						citation: ( values.length === 1 ? undefined : [ get( last( values ), 'props.children' ) ] ),
+						citation: ( values.length === 1 ? undefined : [ get( last( values ), [ 'props', 'children' ] ) ] ),
 					} );
 				},
 			},

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -115,7 +115,7 @@ export const settings = {
 					}
 					// transforming a quote with content
 					return ( value || [] ).map( ( item ) => createBlock( 'core/paragraph', {
-						content: [ get( item, 'children.props.children', '' ) ],
+						content: [ get( item, [ 'children', 'props', 'children' ], '' ) ],
 					} ) ).concat( citation ? createBlock( 'core/paragraph', {
 						content: citation,
 					} ) : [] );

--- a/edit-post/components/sidebar/page-attributes/index.js
+++ b/edit-post/components/sidebar/page-attributes/index.js
@@ -24,7 +24,7 @@ export function PageAttributes( { isOpened, onTogglePanel, postType } ) {
 	return (
 		<PageAttributesCheck>
 			<PanelBody
-				title={ get( postType, 'labels.attributes', __( 'Page Attributes' ) ) }
+				title={ get( postType, [ 'labels', 'attributes' ], __( 'Page Attributes' ) ) }
 				opened={ isOpened }
 				onToggle={ onTogglePanel }
 			>

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -64,7 +64,7 @@ export default compose(
 		} = select( 'core/editor' );
 		const isEmpty = ! getBlockCount( ownProps.rootUID );
 		const lastBlock = getBlock( ownProps.lastBlockUID );
-		const isLastBlockDefault = get( lastBlock, 'name' ) === getDefaultBlockName();
+		const isLastBlockDefault = get( lastBlock, [ 'name' ] ) === getDefaultBlockName();
 
 		return {
 			isVisible: isEmpty || ! isLastBlockDefault,

--- a/editor/components/page-attributes/check.js
+++ b/editor/components/page-attributes/check.js
@@ -11,7 +11,7 @@ import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
 export function PageAttributesCheck( { availableTemplates, postType, children } ) {
-	const supportsPageAttributes = get( postType, 'supports.page-attributes', false );
+	const supportsPageAttributes = get( postType, [ 'supports', 'page-attributes' ], false );
 
 	// Only render fields if post type supports page attributes or available templates exist.
 	if ( ! supportsPageAttributes && isEmpty( availableTemplates ) ) {

--- a/editor/components/page-attributes/parent.js
+++ b/editor/components/page-attributes/parent.js
@@ -14,9 +14,9 @@ import { buildTermsTree } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 export function PageAttributesParent( { parent, postType, items, onUpdateParent } ) {
-	const isHierarchical = get( postType, 'hierarchical', false );
-	const parentPageLabel = get( postType, 'labels.parent_item_colon' );
-	const pageItems = get( items, 'data', [] );
+	const isHierarchical = get( postType, [ 'hierarchical' ], false );
+	const parentPageLabel = get( postType, [ 'labels', 'parent_item_colon' ] );
+	const pageItems = get( items, [ 'data' ], [] );
 	if ( ! isHierarchical || ! parentPageLabel || ! pageItems.length ) {
 		return null;
 	}
@@ -60,7 +60,7 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 
 const applyWithAPIDataItems = withAPIData( ( props, { type } ) => {
 	const { postTypeSlug, postId } = props;
-	const isHierarchical = get( props, 'postType.hierarchical', false );
+	const isHierarchical = get( props, [ 'postType', 'hierarchical' ], false );
 	const queryString = stringify( {
 		context: 'edit',
 		per_page: 100,

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -23,7 +23,7 @@ const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
 const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove featured image' );
 
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
-	const postLabel = get( postType, 'labels', {} );
+	const postLabel = get( postType, [ 'labels' ], {} );
 
 	return (
 		<PostFeaturedImageCheck>

--- a/editor/components/post-format/index.js
+++ b/editor/components/post-format/index.js
@@ -75,7 +75,7 @@ export default compose( [
 		const themeSupports = select( 'core' ).getThemeSupports();
 		// Ensure current format is always in the set.
 		// The current format may not be a format supported by the theme.
-		const supportedFormats = union( [ postFormat ], get( themeSupports, 'formats', [] ) );
+		const supportedFormats = union( [ postFormat ], get( themeSupports, [ 'formats' ], [] ) );
 		return {
 			postFormat,
 			supportedFormats,

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -132,7 +132,7 @@ export default compose( [
 			isDirty: isEditedPostDirty(),
 			isNew: isEditedPostNew(),
 			isSaveable: isEditedPostSaveable(),
-			isViewable: get( postType, 'viewable', false ),
+			isViewable: get( postType, [ 'viewable' ], false ),
 			modified: getEditedPostAttribute( 'modified' ),
 		};
 	} ),

--- a/editor/components/post-sticky/check.js
+++ b/editor/components/post-sticky/check.js
@@ -11,7 +11,7 @@ import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
 export function PostStickyCheck( { postType, children, user } ) {
-	const userCan = get( user.data, 'post_type_capabilities', false );
+	const userCan = get( user.data, [ 'post_type_capabilities' ], false );
 
 	if (
 		postType !== 'post' ||

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -124,7 +124,7 @@ export default {
 			( err ) => {
 				dispatch( {
 					type: 'REQUEST_POST_UPDATE_FAILURE',
-					error: get( err, 'responseJSON', {
+					error: get( err, [ 'responseJSON' ], {
 						code: 'unknown_error',
 						message: __( 'An unknown error occurred.' ),
 					} ),
@@ -176,7 +176,7 @@ export default {
 			) );
 		}
 
-		if ( get( window.history.state, 'id' ) !== post.id ) {
+		if ( get( window.history.state, [ 'id' ] ) !== post.id ) {
 			window.history.replaceState(
 				{ id: post.id },
 				'Post ' + post.id,
@@ -218,7 +218,7 @@ export default {
 				dispatch( {
 					...action,
 					type: 'TRASH_POST_FAILURE',
-					error: get( err, 'responseJSON', {
+					error: get( err, [ 'responseJSON' ], {
 						code: 'unknown_error',
 						message: __( 'An unknown error occurred.' ),
 					} ),
@@ -464,7 +464,7 @@ export default {
 			( error ) => {
 				dispatch( { type: 'SAVE_SHARED_BLOCK_FAILURE', id } );
 				const message = __( 'An unknown error occurred.' );
-				dispatch( createErrorNotice( get( error.responseJSON, 'message', message ), {
+				dispatch( createErrorNotice( get( error.responseJSON, [ 'message' ], message ), {
 					id: SHARED_BLOCK_NOTICE_ID,
 					spokenMessage: message,
 				} ) );
@@ -524,7 +524,7 @@ export default {
 					optimist: { type: REVERT, id: transactionId },
 				} );
 				const message = __( 'An unknown error occurred.' );
-				dispatch( createErrorNotice( get( error.responseJSON, 'message', message ), {
+				dispatch( createErrorNotice( get( error.responseJSON, [ 'message' ], message ), {
 					id: SHARED_BLOCK_NOTICE_ID,
 					spokenMessage: message,
 				} ) );
@@ -573,7 +573,7 @@ export default {
 	},
 
 	EDIT_POST( action, { getState } ) {
-		const format = get( action, 'edits.format' );
+		const format = get( action, [ 'edits', 'format' ] );
 		if ( ! format ) {
 			return;
 		}

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -148,7 +148,7 @@ export function getCurrentPostId( state ) {
  * @return {number} Number of revisions.
  */
 export function getCurrentPostRevisionsCount( state ) {
-	return get( getCurrentPost( state ), 'revisions.count', 0 );
+	return get( getCurrentPost( state ), [ 'revisions', 'count' ], 0 );
 }
 
 /**
@@ -160,7 +160,7 @@ export function getCurrentPostRevisionsCount( state ) {
  * @return {?number} ID of the last revision.
  */
 export function getCurrentPostLastRevisionId( state ) {
-	return get( getCurrentPost( state ), 'revisions.last_id', null );
+	return get( getCurrentPost( state ), [ 'revisions', 'last_id' ], null );
 }
 
 /**
@@ -635,7 +635,7 @@ export function getBlockRootUID( state, uid ) {
 export function getAdjacentBlockUid( state, startUID, modifier = 1 ) {
 	// Default to selected block.
 	if ( startUID === undefined ) {
-		startUID = get( getSelectedBlock( state ), 'uid' );
+		startUID = get( getSelectedBlock( state ), [ 'uid' ] );
 	}
 
 	// Try multi-selection starting at extent based on modifier.

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -607,8 +607,8 @@ describe( 'effects', () => {
 					},
 				] );
 
-				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
-				set( global, 'wp.apiRequest', () => promise );
+				set( global, [ 'wp', 'api', 'getPostTypeRoute' ], () => 'blocks' );
+				set( global, [ 'wp', 'apiRequest' ], () => promise );
 
 				const dispatch = jest.fn();
 				const store = { getState: noop, dispatch };
@@ -645,8 +645,8 @@ describe( 'effects', () => {
 					content: '<!-- wp:test-block {"name":"Big Bird"} /-->',
 				} );
 
-				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
-				set( global, 'wp.apiRequest', () => promise );
+				set( global, [ 'wp', 'api', 'getPostTypeRoute' ], () => 'blocks' );
+				set( global, [ 'wp', 'apiRequest' ], () => promise );
 
 				const dispatch = jest.fn();
 				const store = { getState: noop, dispatch };
@@ -679,8 +679,8 @@ describe( 'effects', () => {
 			it( 'should handle an API error', () => {
 				const promise = Promise.reject( {} );
 
-				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
-				set( global, 'wp.apiRequest', () => promise );
+				set( global, [ 'wp', 'api', 'getPostTypeRoute' ], () => 'blocks' );
+				set( global, [ 'wp', 'apiRequest' ], () => promise );
 
 				const dispatch = jest.fn();
 				const store = { getState: noop, dispatch };
@@ -722,8 +722,8 @@ describe( 'effects', () => {
 				let modelAttributes;
 				const promise = Promise.resolve( { id: 456 } );
 
-				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
-				set( global, 'wp.apiRequest', ( request ) => {
+				set( global, [ 'wp', 'api', 'getPostTypeRoute' ], () => 'blocks' );
+				set( global, [ 'wp', 'apiRequest' ], ( request ) => {
 					modelAttributes = request.data;
 					return promise;
 				} );
@@ -759,8 +759,8 @@ describe( 'effects', () => {
 			it( 'should handle an API error', () => {
 				const promise = Promise.reject( {} );
 
-				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
-				set( global, 'wp.apiRequest', () => promise );
+				set( global, [ 'wp', 'api', 'getPostTypeRoute' ], () => 'blocks' );
+				set( global, [ 'wp', 'apiRequest' ], () => promise );
 
 				const sharedBlock = { id: 123, title: 'My cool block' };
 				const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
@@ -790,8 +790,8 @@ describe( 'effects', () => {
 			it( 'should delete a shared block', () => {
 				const promise = Promise.resolve( {} );
 
-				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
-				set( global, 'wp.apiRequest', () => promise );
+				set( global, [ 'wp', 'api', 'getPostTypeRoute' ], () => 'blocks' );
+				set( global, [ 'wp', 'apiRequest' ], () => promise );
 
 				const associatedBlock = createBlock( 'core/block', { ref: 123 } );
 				const sharedBlock = { id: 123, title: 'My cool block' };
@@ -830,8 +830,8 @@ describe( 'effects', () => {
 			it( 'should handle an API error', () => {
 				const promise = Promise.reject( {} );
 
-				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
-				set( global, 'wp.apiRequest', () => promise );
+				set( global, [ 'wp', 'api', 'getPostTypeRoute' ], () => 'blocks' );
+				set( global, [ 'wp', 'apiRequest' ], () => promise );
 
 				const sharedBlock = { id: 123, title: 'My cool block' };
 				const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );


### PR DESCRIPTION
This pull request seeks to enforce a new custom ESLint rule encouraging the use of an array as the second parameter of Lodash functions accepting a "path" (e.g. [`_.get`](https://lodash.com/docs/4.17.5#get)). The intent here is to skip a parsing step to convert a string path to its array equivalent, which occurs internally in Lodash ([source](https://github.com/lodash/lodash/blob/4.17.5/lodash.js#L4459-L4472)).

The performance impact is not as bad as I had suspected for simple strings, as the internal logic tests for properties, skipping the parse for use like `_.get( foo, 'bar' )`. Further, its `stringToPath` is memoized so only calculated once. All the same, this rule encourages consistency, avoids any such regular expression testing, avoids memory overhead of memoization, and avoids the string _ever_ needing to be parsed.

__Testing instructions:__

There should be no behavior impact of these changes.

Ensure tests pass:

```
npm test
```