### PR TITLE
Blocks: Remove obsolete `isSelected` usage (part 2)

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { concatChildren } from '@wordpress/element';
+import { concatChildren, Fragment } from '@wordpress/element';
 import { PanelBody, Toolbar } from '@wordpress/components';
 
 /**
@@ -101,13 +101,12 @@ export const settings = {
 		};
 	},
 
-	edit( { attributes, setAttributes, isSelected, mergeBlocks, insertBlocksAfter, onReplace, className } ) {
+	edit( { attributes, setAttributes, mergeBlocks, insertBlocksAfter, onReplace, className } ) {
 		const { align, content, nodeName, placeholder } = attributes;
 
-		return [
-			isSelected && (
+		return (
+			<Fragment>
 				<BlockControls
-					key="controls"
 					controls={
 						'234'.split( '' ).map( ( level ) => ( {
 							icon: 'heading',
@@ -118,9 +117,7 @@ export const settings = {
 						} ) )
 					}
 				/>
-			),
-			isSelected && (
-				<InspectorControls key="inspector">
+				<InspectorControls>
 					<PanelBody title={ __( 'Heading Settings' ) }>
 						<p>{ __( 'Level' ) }</p>
 						<Toolbar
@@ -143,32 +140,30 @@ export const settings = {
 						/>
 					</PanelBody>
 				</InspectorControls>
-			),
-			<RichText
-				key="editable"
-				wrapperClassName="wp-block-heading"
-				tagName={ nodeName.toLowerCase() }
-				value={ content }
-				onChange={ ( value ) => setAttributes( { content: value } ) }
-				onMerge={ mergeBlocks }
-				onSplit={
-					insertBlocksAfter ?
-						( before, after, ...blocks ) => {
-							setAttributes( { content: before } );
-							insertBlocksAfter( [
-								...blocks,
-								createBlock( 'core/paragraph', { content: after } ),
-							] );
-						} :
-						undefined
-				}
-				onRemove={ () => onReplace( [] ) }
-				style={ { textAlign: align } }
-				className={ className }
-				placeholder={ placeholder || __( 'Write heading…' ) }
-				isSelected={ isSelected }
-			/>,
-		];
+				<RichText
+					wrapperClassName="wp-block-heading"
+					tagName={ nodeName.toLowerCase() }
+					value={ content }
+					onChange={ ( value ) => setAttributes( { content: value } ) }
+					onMerge={ mergeBlocks }
+					onSplit={
+						insertBlocksAfter ?
+							( before, after, ...blocks ) => {
+								setAttributes( { content: before } );
+								insertBlocksAfter( [
+									...blocks,
+									createBlock( 'core/paragraph', { content: after } ),
+								] );
+							} :
+							undefined
+					}
+					onRemove={ () => onReplace( [] ) }
+					style={ { textAlign: align } }
+					className={ className }
+					placeholder={ placeholder || __( 'Write heading…' ) }
+				/>
+			</Fragment>
+		);
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -9,7 +9,7 @@ import { stringify } from 'querystringify';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	Placeholder,
@@ -50,11 +50,11 @@ class LatestPostsBlock extends Component {
 
 	render() {
 		const latestPosts = this.props.latestPosts.data;
-		const { attributes, categoriesList, isSelected, setAttributes } = this.props;
+		const { attributes, categoriesList, setAttributes } = this.props;
 		const { displayPostDate, align, layout, columns, order, orderBy, categories, postsToShow } = attributes;
 
-		const inspectorControls = isSelected && (
-			<InspectorControls key="inspector">
+		const inspectorControls = (
+			<InspectorControls>
 				<PanelBody title={ __( 'Latest Posts Settings' ) }>
 					<QueryControls
 						{ ...{ order, orderBy } }
@@ -86,18 +86,20 @@ class LatestPostsBlock extends Component {
 
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
 		if ( ! hasPosts ) {
-			return [
-				inspectorControls,
-				<Placeholder key="placeholder"
-					icon="admin-post"
-					label={ __( 'Latest Posts' ) }
-				>
-					{ ! Array.isArray( latestPosts ) ?
-						<Spinner /> :
-						__( 'No posts found.' )
-					}
-				</Placeholder>,
-			];
+			return (
+				<Fragment>
+					{ inspectorControls }
+					<Placeholder
+						icon="admin-post"
+						label={ __( 'Latest Posts' ) }
+					>
+						{ ! Array.isArray( latestPosts ) ?
+							<Spinner /> :
+							__( 'No posts found.' )
+						}
+					</Placeholder>
+				</Fragment>
+			);
 		}
 
 		// Removing posts from display should be instant.
@@ -120,10 +122,10 @@ class LatestPostsBlock extends Component {
 			},
 		];
 
-		return [
-			inspectorControls,
-			isSelected && (
-				<BlockControls key="controls">
+		return (
+			<Fragment>
+				{ inspectorControls }
+				<BlockControls>
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ ( nextAlign ) => {
@@ -133,26 +135,25 @@ class LatestPostsBlock extends Component {
 					/>
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
-			),
-			<ul
-				className={ classnames( this.props.className, {
-					'is-grid': layout === 'grid',
-					[ `columns-${ columns }` ]: layout === 'grid',
-				} ) }
-				key="latest-posts"
-			>
-				{ displayPosts.map( ( post, i ) =>
-					<li key={ i }>
-						<a href={ post.link } target="_blank">{ decodeEntities( post.title.rendered.trim() ) || __( '(Untitled)' ) }</a>
-						{ displayPostDate && post.date_gmt &&
-							<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
-								{ moment( post.date_gmt ).local().format( 'MMMM DD, Y' ) }
-							</time>
-						}
-					</li>
-				) }
-			</ul>,
-		];
+				<ul
+					className={ classnames( this.props.className, {
+						'is-grid': layout === 'grid',
+						[ `columns-${ columns }` ]: layout === 'grid',
+					} ) }
+				>
+					{ displayPosts.map( ( post, i ) =>
+						<li key={ i }>
+							<a href={ post.link } target="_blank">{ decodeEntities( post.title.rendered.trim() ) || __( '(Untitled)' ) }</a>
+							{ displayPostDate && post.date_gmt &&
+								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
+									{ moment( post.date_gmt ).local().format( 'MMMM DD, Y' ) }
+								</time>
+							}
+						</li>
+					) }
+				</ul>
+			</Fragment>
+		);
 	}
 }
 


### PR DESCRIPTION
## Description
Follow up for #5029 and #6201.

> `isSelected` usage is no longer mandatory with `BlockControls`, `InspectorControls` and `RichText`. It's now handled by the editor internally to ensure that controls are visible only when the block is selected.

Refactored blocks:
- `Heading`
- `Image`
- `Latest posts`
- ~`Preformatted`~
- ~`Pullquote`~
- ~`Quote`~

It should be much easier to review this diff without whitespace changes:

https://github.com/WordPress/gutenberg/pull/6248/files?w=1

## How has this been tested?
Manually, unit tests and e2e tests.


## Types of changes
Refactoring, no visual changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
