### PR TITLE
Blocks: Avoid duplicate save request in shared block (Firefox)

### DIFF
--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -55,7 +55,7 @@ class SharedBlockEditPanel extends Component {
 	}
 
 	render() {
-		const { isEditing, title, isSaving, onEdit, onSave, onCancel } = this.props;
+		const { isEditing, title, isSaving, onEdit, onCancel } = this.props;
 
 		return (
 			<Fragment>
@@ -92,7 +92,6 @@ class SharedBlockEditPanel extends Component {
 							isBusy={ isSaving }
 							disabled={ ! title || isSaving }
 							className="shared-block-edit-panel__button"
-							onClick={ onSave }
 						>
 							{ __( 'Save' ) }
 						</Button>


### PR DESCRIPTION
This pull request seeks to resolve an issue where a shared block title can be reset inadvertently by clicking "Save" after making a change to the title.

__Implementation notes:__

The button is assigned as `type="submit"` and placed within a form. The form already has a handler to call the `onSave` when submitted. It is therefore not needed to assign `onClick` at all, as the form's submit handler will take effect anyways.

__Testing instructions:__

Verify that changing a shared block title, and submitting the form works as expected:

- Press enter from title field
- Click (or tab navigate and press) the Save button