### PR TITLE
Update plugin version to 2.7.0

### DIFF
--- a/element/index.js
+++ b/element/index.js
@@ -19,11 +19,6 @@ import {
 } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import { deprecated } from '@wordpress/utils';
-
-/**
  * Internal dependencies
  */
 import serialize from './serialize';
@@ -174,27 +169,6 @@ export function switchChildrenNodeName( children, nodeName ) {
  * @return {Function} Returns the new composite function.
  */
 export { flowRight as compose };
-
-/**
- * Returns a wrapped version of a React component's display name.
- * Higher-order components use getWrapperDisplayName().
- *
- * @param {Function|Component} BaseComponent Used to detect the existing display name.
- * @param {string} wrapperName Wrapper name to prepend to the display name.
- *
- * @return {string} Wrapped display name.
- */
-export function getWrapperDisplayName( BaseComponent, wrapperName ) {
-	deprecated( 'getWrapperDisplayName', {
-		version: '2.7',
-		alternative: 'wp.element.createHigherOrderComponent',
-		plugin: 'Gutenberg',
-	} );
-
-	const { displayName = BaseComponent.name || 'Component' } = BaseComponent;
-
-	return `${ upperFirst( camelCase( wrapperName ) ) }(${ displayName })`;
-}
 
 /**
  * Given a function mapping a component to an enhanced component and modifier

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 2.6.0
+ * Version: 2.7.0
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "2.6.0",
+	"version": "2.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "2.6.0",
+	"version": "2.7.0",
 	"description": "A new WordPress editor experience",
 	"main": "build/app.js",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
## Changelog

* Add pagination block (handles page breaks core functionality).
* Add left/right block hover areas for displaying contextual block tools. This aims to reduce the visual UI and make it more aware of intention when hovering around blocks.
* Improve emulated caret positioning in writing flow, which places caret at the right position when clicking below the editor.
* Several updates to link insertion interface:
  * Restore the "Open in new window" setting.
  * Remove the Unlink button. Instead, links can be removed by toggling off the Link button in the formatting toolbar.
  * Move link settings to the left.
  * Update suggested links dropdown design.
  * Allow UI to expand to fit long URLs when not in editing mode.
  * Improve visibility of insertion UI when selecting a link
* Rework Classic block visual display to show old style toolbar. This aims to help clarify when you have content being displayed through a Classic block.
* Add ability to edit post permalinks from the post title area.
* Improve display of image placeholder buttons to accommodate i18n and smaller screens.
* Add nesting support to document outline feature.
* Refactor and expose PluginSidebar as final API.
* Refactor and expose SidebarMoreMenuItem as part of Plugins API.
* Simplify block development by leveraging context API to let block controls render on their own when a block is selected.
* Add ability to manage innerBlocks while migrating deprecated blocks.
* Add a "Skip link" to jump back from the inspector to the selected block.
* Add preloading support to wp.apiRequest.
* Add isFulfilled API for advanced resolver use cases in data module.
* Add support for custom icon in Placeholder component.
* Disable Drag & Drop into empty placeholders.
* Refine the UI of the sides of a block.
* Ensure the "saved" message is shown for at least a second when meta-boxes are present.
* Make sure block controls don't show over the sidebar on small viewport.
* Add ability to manually set image dimensions.
* Make Popover initial focus work with screen readers.
* Improve Disabled component (disabled attribute, tabindex removal, pointer-events).
* Improve visual display of captions within galleries.
* Remove default font weight from Pullquote block.
* Keep "advanced" block settings panel closed by default.
* Use fallback styles to compute font size slider initial value.
* Allow filtering of allowed_block_types based on post object.
* Allow really long captions to scroll in galleries.
* Redesign toggle switch UI component to add clarity.
* Improve handling of empty containers in DOM utilities.
* Filter out private taxonomies from sidebar UI.
* Make input styles consistent.
* Update inline "code" background color when part of multi-selection.
* Replace TextControl with TextareaControl for image alt attribute.
* Allow mod+shift+alt+m (toggle between Visual and Code modes) keyboard shortcut to work regardless of focus area and context.
* Allow ctrl+backtick and ctrl+shift+backtick (navigate across regions) keyboard shortcuts to work regardless of focus area and context.
* Improve Classic block accessibility by supporting keyboard (alt+f10 and arrows) navigation.
* Apply wrapper div for RawHTML with non-children props.
* Improve and clarify allowedBlockTypes in inserter.
* Improve handling of block hover areas.
* Improve figure widths and floats in imagery blocks, improving theming experience.
* Eliminate obsolete call to onChange when RichText componentWillUnmount.
* Unify styling of Read More and Pagination blocks.
* Replace instances of smaller font with default font size.
* Fix styling issue with nested blocks ghost.
* Fix CSS bug that made it impossible to close the sidebar on mobile with meta-boxes present.
* Fix disappearing input when adding link to image.
* Fix issue with publish button text occasionally showing HTML entity.
* Fix issue with side UI not showing as expected on selected blocks.
* Fix sticky post saving when using meta-boxes.
* Fix nested blocks' contextual toolbar not being fixed to top when requested.
* Fix centered image caption toolbar on IE11.
* Fix issue with meta-box saving case by only attempt apiRequest preload if path is set. Also improve tests for meta-boxes.
* Fix JS error when wp.apiRequest has no preload data.
* Fix regression with image link UI, and another.
* Fix regression with columns appender.
* Avoid focus losses in Shared block form.
* Fix ability to select Embed blocks via clicking.
* Fix handling of long strings in permalink container.
* Fix resizing behavior of Image block upon browser resize.
* Show Image block with external image URL and support resizing.
* Fix hiding of update/publish confirmation notices under WP-Admin sidebar.
* Fix ID and key generation in SelectControl and RadioControl components.
* Fix z-index of link UI.
* Fix default width of embeds in the editor.
* Revert unintended changes in default font size handling on Paragraph.
* Disable the Preview button when post type isn't viewable.
* Remove unused variable.
* Rename "advanced settings" in block menu to "block settings". Update labels and docs accordingly.
* Improve description of embed blocks.
* Default to empty object for previous defined wp-utils.
* Finalize renaming of reusable blocks to shared blocks.
* Update 20 components from the editor module to use wp.data's withSelect and withDispatch instead of react-redux's connect.
* Update another batch of components from the editor module to use wp.data's tools.
* Replace remaining uses of react-redux in the editor module.
* Update a batch of core blocks to drop explicit management of isSelected thanks to new context API.
* Attempt to avoid triggering modsec rules.
* Use wp-components script handle to pass locale data to wp.i18n.
* Reference lodash as an external module. This also reduces bundle size.
* Use border-box on input and textarea within meta-boxes to restore radio buttons to normal appearance.
* Clarify demo instructions on wide image support.
* Update docs to address broken sketch file links.
* Reduce and rename rules in Gutenberg block grammar for clarity.
* Add test confirming that withFilters does not rerender.
* Allow E2E tests to work in a larger variety of environments.
* Add mention of JSON workaround to including structured data in attributes.
* Document use of GitHub projects in Repository Management.
* Fix some documentation links.
* Add accessibility standards checkbox and reference to the project's pull request template.
* Remove emoji script as it causes different issues. Pending resolution on how to introduce it back.
* Avoid needing navigation timeout in Puppeteer.
* Disable login screen autofocus in Puppeteer tests.
* Allow developers to opt out from some devtool settings to speed up incremental builds.
* Use the WordPress i18n package and remove the built-in implementation. Update to 1.1.0.
* Remove deprecated function `getWrapperDisplayName`.