### PR TITLE
Fixes Latests Post Block Front End Output

### DIFF
--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -51,7 +51,7 @@ class LatestPostsBlock extends Component {
 	render() {
 		const latestPosts = this.props.latestPosts.data;
 		const { attributes, categoriesList, isSelected, setAttributes } = this.props;
-		const { displayPostDate, align, layout, columns, order, orderBy, categories, postsToShow } = attributes;
+		const { displayPostDate, align, postLayout, columns, order, orderBy, categories, postsToShow } = attributes;
 
 		const inspectorControls = isSelected && (
 			<InspectorControls key="inspector">
@@ -71,7 +71,7 @@ class LatestPostsBlock extends Component {
 						checked={ displayPostDate }
 						onChange={ this.toggleDisplayPostDate }
 					/>
-					{ layout === 'grid' &&
+					{ postLayout === 'grid' &&
 						<RangeControl
 							label={ __( 'Columns' ) }
 							value={ columns }
@@ -109,14 +109,14 @@ class LatestPostsBlock extends Component {
 			{
 				icon: 'list-view',
 				title: __( 'List View' ),
-				onClick: () => setAttributes( { layout: 'list' } ),
-				isActive: layout === 'list',
+				onClick: () => setAttributes( { postLayout: 'list' } ),
+				isActive: postLayout === 'list',
 			},
 			{
 				icon: 'grid-view',
 				title: __( 'Grid View' ),
-				onClick: () => setAttributes( { layout: 'grid' } ),
-				isActive: layout === 'grid',
+				onClick: () => setAttributes( { postLayout: 'grid' } ),
+				isActive: postLayout === 'grid',
 			},
 		];
 
@@ -136,8 +136,8 @@ class LatestPostsBlock extends Component {
 			),
 			<ul
 				className={ classnames( this.props.className, {
-					'is-grid': layout === 'grid',
-					[ `columns-${ columns }` ]: layout === 'grid',
+					'is-grid': postLayout === 'grid',
+					[ `columns-${ columns }` ]: postLayout === 'grid',
 				} ) }
 				key="latest-posts"
 			>


### PR DESCRIPTION
## Description
Closes #5870 

That issue points out, as I today noticed, that the layout doesn't actually translate to the front end. Attributes for layout type was being overwritten by the default value `list`.

Our latest-posts `index.php` attributes were being set as:

``` php
'postLayout'      => array(
   'type'    => 'string',
   'default' => 'list',
),
```

but the `props.attribute` was defined as `layout`.

Updated the prop name to `postLayout` to match the PHP output. Given the existing `postsToShow` updating "layout" to `postLayout` seemed more consistent than changing the PHP attribute to "layout".

Fixes visual output on the front end, doesn't affect the back end/editor styles.

## How has this been tested?
Tested block manually layout types both grid and list as well as alignment to confirm the behavior.

Run unit tests and e2e tests via npm.

_Gutenberg 2.7.0
Affects All Browsers — Tested in Version 65.0.3325.181 (Official Build) (64-bit)
WP 4.9.5_

## Screenshots
Before
![screenshot 2018-04-18 12 49 50](https://user-images.githubusercontent.com/5230729/38951821-ff59ad66-4306-11e8-84ed-21258bfb9ef4.jpg)
![screenshot 2018-04-18 12 59 14](https://user-images.githubusercontent.com/5230729/38952289-5076bf08-4308-11e8-816c-17b519517710.jpg)

After
![screenshot 2018-04-18 12 49 38](https://user-images.githubusercontent.com/5230729/38951823-01b037c4-4307-11e8-8cf1-cb9e57adbfae.jpg)
![screenshot 2018-04-18 12 59 02](https://user-images.githubusercontent.com/5230729/38952292-5346c8e0-4308-11e8-8fa5-037cff2532c9.jpg)

## Types of changes
Bug fix—updates variable throughout the block. No visual changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
