### PR TITLE
Add missing label and focus style to the code editor textarea 

### DIFF
--- a/edit-post/components/text-editor/style.scss
+++ b/edit-post/components/text-editor/style.scss
@@ -27,8 +27,7 @@
 	}
 
 	// Always show outlines in code editor
-	.editor-post-title div,
-	.editor-post-text-editor {
+	.editor-post-title div {
 		border: 1px solid $light-gray-500;
 	}
 

--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -67,7 +67,7 @@ class PostTextEditor extends Component {
 		return (
 			<Fragment>
 				<label htmlFor={ `post-content-${ instanceId }` } className="screen-reader-text">
-					{ decodedPlaceholder || __( 'Add content' ) }
+					{ decodedPlaceholder || __( 'Write your story' ) }
 				</label>
 				<Textarea
 					autoComplete="off"
@@ -77,7 +77,7 @@ class PostTextEditor extends Component {
 					onBlur={ this.stopEditing }
 					className="editor-post-text-editor"
 					id={ `post-content-${ instanceId }` }
-					placeholder={ decodedPlaceholder || __( 'Add content' ) }
+					placeholder={ decodedPlaceholder || __( 'Write your story' ) }
 				/>
 			</Fragment>
 		);
@@ -101,7 +101,7 @@ export default compose( [
 		};
 	} ),
 	withEditorSettings( ( settings ) => ( {
-		placeholder: settings.contentPlaceholder,
+		placeholder: settings.bodyPlaceholder,
 	} ) ),
 	withInstanceId,
 ] )( PostTextEditor );

--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -6,9 +6,12 @@ import Textarea from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { Component, compose } from '@wordpress/element';
-import { parse } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/utils';
+import { Component, compose, Fragment } from '@wordpress/element';
+import { parse, withEditorSettings } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -58,15 +61,25 @@ class PostTextEditor extends Component {
 	}
 
 	render() {
+		const { value, placeholder, instanceId } = this.props;
+		const decodedPlaceholder = decodeEntities( placeholder );
+
 		return (
-			<Textarea
-				autoComplete="off"
-				value={ this.state.value || this.props.value }
-				onFocus={ this.startEditing }
-				onChange={ this.edit }
-				onBlur={ this.stopEditing }
-				className="editor-post-text-editor"
-			/>
+			<Fragment>
+				<label htmlFor={ `post-content-${ instanceId }` } className="screen-reader-text">
+					{ decodedPlaceholder || __( 'Add content' ) }
+				</label>
+				<Textarea
+					autoComplete="off"
+					value={ this.state.value || value }
+					onFocus={ this.startEditing }
+					onChange={ this.edit }
+					onBlur={ this.stopEditing }
+					className="editor-post-text-editor"
+					id={ `post-content-${ instanceId }` }
+					placeholder={ decodedPlaceholder || __( 'Add content' ) }
+				/>
+			</Fragment>
 		);
 	}
 }
@@ -87,4 +100,8 @@ export default compose( [
 			},
 		};
 	} ),
+	withEditorSettings( ( settings ) => ( {
+		placeholder: settings.contentPlaceholder,
+	} ) ),
+	withInstanceId,
 ] )( PostTextEditor );

--- a/editor/components/post-text-editor/style.scss
+++ b/editor/components/post-text-editor/style.scss
@@ -1,9 +1,8 @@
 .editor-post-text-editor {
+	border: 1px solid $light-gray-500;
 	display: block;
-	margin: 0;
+	margin: 0 0 2em;
 	width: 100%;
-	border: none;
-	outline: none;
 	box-shadow: none;
 	resize: none;
 	overflow: hidden;
@@ -11,8 +10,13 @@
 	font-size: $text-editor-font-size;
 	line-height: 150%;
 
+	&:hover,
 	&:focus {
+		border: 1px solid $light-gray-500;
 		box-shadow: none;
+		// Emulate the effect used on the post title.
+		outline: 1px solid $light-gray-500;
+		outline-offset: -2px;
 	}
 }
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -948,7 +948,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
-		'contentPlaceholder'  => apply_filters( 'add_content', __( 'Add content', 'gutenberg' ), $post ),
 		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
 	);
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -948,6 +948,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
+		'contentPlaceholder'  => apply_filters( 'add_content', __( 'Add content', 'gutenberg' ), $post ),
 		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
 	);
 


### PR DESCRIPTION
This PR adds a `<label>` element to the "Code editor" mode textarea using the same pattern used for the post title. Worth noting this pattern matches the visible placeholder text with the visually hidden label to ensure it works for all users and all assistive technology but it's basically a hack and should be avoided as much as possible. Visible labels are always preferable (and a WCAG requirement) for the reasons explained in https://github.com/WordPress/gutenberg/issues/6199 and https://github.com/WordPress/gutenberg/pull/6206#issuecomment-382304688

Also adds a filter, in the same way a filter is used for the post title.

Adds a focus (and hover) style to the content textarea to match the same effects used on the post title (see the code editor polish and focus style #1837 / #4803). The `outline-offset` property won't work in IE11 that just means on hover and focus the outline will appear externally to the box. I guess we can live with that.

It also adds a small bottom margin to the content textarea, because currently, with long content, the textarea touches the viewport bottom edge. I guess avoiding that is a better option.

To test:
- create a new post
- using a screen reader, focus the content and verify the label is announced correctly
- verify the CSS effects on hover and focus
- try to use the filter to change the label and placeholder

Fixes #6260

Screenshots (normal and hover/focus):

<img width="998" alt="screen shot 2018-04-18 at 23 13 54" src="https://user-images.githubusercontent.com/1682452/38959333-7f315cc4-4360-11e8-8f0a-eb64708a88d2.png">

<img width="991" alt="screen shot 2018-04-18 at 23 14 00" src="https://user-images.githubusercontent.com/1682452/38959334-7f4d5eec-4360-11e8-926d-f6868850ae2d.png">
