### PR TITLE
Add arrow-spacing rule to eslint config

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -219,7 +219,7 @@ class ImageBlock extends Component {
 
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && ( ! viewPort.isExtraSmall() );
 
-		const getInspectorControls = ( imageWidth, imageHeight )=> (
+		const getInspectorControls = ( imageWidth, imageHeight ) => (
 			<InspectorControls>
 				<PanelBody title={ __( 'Image Settings' ) }>
 					<TextareaControl

--- a/components/higher-order/with-api-data/test/request.js
+++ b/components/higher-order/with-api-data/test/request.js
@@ -50,7 +50,7 @@ describe( 'request', () => {
 		wp.apiRequest = wpApiRequest;
 	} );
 
-	describe( 'getResponseHeaders()', () =>{
+	describe( 'getResponseHeaders()', () => {
 		it( 'returns tuples of array headers', () => {
 			expect( getResponseHeaders( xhr ) ).toEqual( [
 				[ 'connection', 'Keep-Alive' ],

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -60,7 +60,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 						onSelect={ onUpdateImage }
 						type="image"
 						modalClass="editor-post-featured-image__media-modal"
-						render={ ( { open } )=>(
+						render={ ( { open } ) => (
 							<Button className="editor-post-featured-image__toggle button-link" onClick={ open }>
 								{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
 							</Button>

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -136,7 +136,7 @@ export default compose( [
 			modified: getEditedPostAttribute( 'modified' ),
 		};
 	} ),
-	withDispatch( ( dispatch )=>( {
+	withDispatch( ( dispatch ) => ( {
 		autosave: dispatch( 'core/editor' ).autosave,
 	} ) ),
 	ifCondition( ( { isViewable } ) => isViewable ),

--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -57,7 +57,7 @@ function PostPublishPanelToggle( {
 }
 
 export default compose( [
-	withSelect( ( select ) =>{
+	withSelect( ( select ) => {
 		const {
 			isSavingPost,
 			isEditedPostSaveable,

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -273,7 +273,7 @@ export default compose( [
 			selectedBlockUID: get( getSelectedBlock(), [ 'uid' ] ),
 		};
 	} ),
-	withDispatch( ( dispatch ) =>{
+	withDispatch( ( dispatch ) => {
 		const { multiSelect, selectBlock } = dispatch( 'core/editor' );
 		return {
 			onMultiSelect: multiSelect,

--- a/eslint/config.js
+++ b/eslint/config.js
@@ -35,6 +35,7 @@ module.exports = {
 	rules: {
 		'array-bracket-spacing': [ 'error', 'always' ],
 		'arrow-parens': [ 'error', 'always' ],
+		'arrow-spacing': 'error',
 		'brace-style': [ 'error', '1tbs' ],
 		camelcase: [ 'error', { properties: 'never' } ],
 		'comma-dangle': [ 'error', 'always-multiline' ],


### PR DESCRIPTION
Require that there is a space before and after the arrow (`=>`) in an arrow function.