### PR TITLE
Add arrow-parens rule to eslint config

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -141,7 +141,7 @@ export function getPossibleBlockTransformations( blocks ) {
 	const blocksToBeTransformedFrom = filter(
 		getBlockTypes(),
 		createIsTypeTransformableFrom( sourceBlockName, isMultiBlock ),
-	).map( type => type.name );
+	).map( ( type ) => type.name );
 
 	const blockType = getBlockType( sourceBlockName );
 	const transformsTo = getBlockTransforms( 'to', blockType.name );
@@ -149,7 +149,7 @@ export function getPossibleBlockTransformations( blocks ) {
 	// Generate list of block transformations using the supplied "transforms to".
 	const blocksToBeTransformedTo = flatMap(
 		isMultiBlock ? filter( transformsTo, 'isMultiBlock' ) : transformsTo,
-		transformation => transformation.blocks
+		( transformation ) => transformation.blocks
 	);
 
 	// Returns a unique list of available block transformations.
@@ -256,11 +256,11 @@ export function switchToBlockType( blocks, name ) {
 	const transformation =
 		findTransform(
 			transformationsTo,
-			t => t.type === 'block' && t.blocks.indexOf( name ) !== -1 && ( ! isMultiBlock || t.isMultiBlock )
+			( t ) => t.type === 'block' && t.blocks.indexOf( name ) !== -1 && ( ! isMultiBlock || t.isMultiBlock )
 		) ||
 		findTransform(
 			transformationsFrom,
-			t => t.type === 'block' && t.blocks.indexOf( sourceName ) !== -1 && ( ! isMultiBlock || t.isMultiBlock )
+			( t ) => t.type === 'block' && t.blocks.indexOf( sourceName ) !== -1 && ( ! isMultiBlock || t.isMultiBlock )
 		);
 
 	// Stop if there is no valid transformation.

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -97,7 +97,7 @@ function isInlineForTag( nodeName, tagName ) {
 	if ( ! tagName || ! nodeName ) {
 		return false;
 	}
-	return inlineWhitelistTagGroups.some( tagGroup =>
+	return inlineWhitelistTagGroups.some( ( tagGroup ) =>
 		includes( tagGroup, nodeName ) && includes( tagGroup, tagName )
 	);
 }

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -34,7 +34,7 @@ describe( 'blocks', () => {
 	} );
 
 	afterEach( () => {
-		getBlockTypes().forEach( block => {
+		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
 		} );
 		setUnknownTypeHandlerName( undefined );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -33,7 +33,7 @@ describe( 'block serializer', () => {
 
 	afterEach( () => {
 		setUnknownTypeHandlerName( undefined );
-		getBlockTypes().forEach( block => {
+		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
 		} );
 	} );

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -36,7 +36,7 @@ export function isUnmodifiedDefaultBlock( block ) {
 		...keys( block.attributes ),
 	] );
 
-	return every( attributeKeys, key =>
+	return every( attributeKeys, ( key ) =>
 		isEqual( newDefaultBlock.attributes[ key ], block.attributes[ key ] )
 	);
 }

--- a/blocks/autocompleters/test/block.js
+++ b/blocks/autocompleters/test/block.js
@@ -59,9 +59,9 @@ describe( 'block', () => {
 
 		// Only verify that a populated label is returned.
 		// It is likely to be fragile to assert that the contents are renderable by @wordpress/element.
-		const isAllowedLabelType = label => Array.isArray( label ) || ( typeof label === 'string' );
+		const isAllowedLabelType = ( label ) => Array.isArray( label ) || ( typeof label === 'string' );
 
-		getBlockTypes().forEach( blockType => {
+		getBlockTypes().forEach( ( blockType ) => {
 			const label = blockAutocompleter.getOptionLabel( blockType );
 			expect( isAllowedLabelType( label ) ).toBeTruthy();
 		} );

--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -47,7 +47,7 @@ export function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CON
 	return (
 		<Toolbar
 			controls={
-				enabledControls.map( control => {
+				enabledControls.map( ( control ) => {
 					return {
 						...BLOCK_ALIGNMENTS_CONTROLS[ control ],
 						isActive: value === control,

--- a/blocks/editor-settings/index.js
+++ b/blocks/editor-settings/index.js
@@ -46,7 +46,7 @@ export const withEditorSettings = ( mapSettingsToProps ) => createHigherOrderCom
 		return function WithSettingsComponent( props ) {
 			return (
 				<EditorSettings.Consumer>
-					{ settings => (
+					{ ( settings ) => (
 						<Component
 							{ ...props }
 							{ ...( mapSettingsToProps ? mapSettingsToProps( settings, props ) : { settings } ) }

--- a/blocks/hooks/test/align.js
+++ b/blocks/hooks/test/align.js
@@ -32,7 +32,7 @@ describe( 'align', () => {
 	};
 
 	afterEach( () => {
-		getBlockTypes().forEach( block => {
+		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
 		} );
 	} );

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -103,7 +103,7 @@ export const settings = {
 								type="url"
 								className="components-placeholder__input"
 								placeholder={ __( 'Enter URL of audio file here…' ) }
-								onChange={ event => this.setState( { src: event.target.value } ) }
+								onChange={ ( event ) => this.setState( { src: event.target.value } ) }
 								value={ src || '' } />
 							<Button
 								isLarge

--- a/blocks/library/categories/block.js
+++ b/blocks/library/categories/block.js
@@ -56,7 +56,7 @@ class CategoriesBlock extends Component {
 			return categories;
 		}
 
-		return categories.filter( category => category.parent === parentId );
+		return categories.filter( ( category ) => category.parent === parentId );
 	}
 
 	getCategoryListClassName( level ) {
@@ -79,7 +79,7 @@ class CategoriesBlock extends Component {
 
 		return (
 			<ul className={ this.getCategoryListClassName( 0 ) }>
-				{ categories.map( category => this.renderCategoryListItem( category, 0 ) ) }
+				{ categories.map( ( category ) => this.renderCategoryListItem( category, 0 ) ) }
 			</ul>
 		);
 	}
@@ -101,7 +101,7 @@ class CategoriesBlock extends Component {
 					showHierarchy &&
 					!! childCategories.length && (
 						<ul className={ this.getCategoryListClassName( level + 1 ) }>
-							{ childCategories.map( childCategory => this.renderCategoryListItem( childCategory, level + 1 ) ) }
+							{ childCategories.map( ( childCategory ) => this.renderCategoryListItem( childCategory, level + 1 ) ) }
 						</ul>
 					)
 				}
@@ -116,7 +116,7 @@ class CategoriesBlock extends Component {
 
 		return (
 			<select className={ `${ this.props.className }__dropdown` }>
-				{ categories.map( category => this.renderCategoryDropdownItem( category, 0 ) ) }
+				{ categories.map( ( category ) => this.renderCategoryDropdownItem( category, 0 ) ) }
 			</select>
 		);
 	}
@@ -137,7 +137,7 @@ class CategoriesBlock extends Component {
 			</option>,
 			showHierarchy &&
 			!! childCategories.length && (
-				childCategories.map( childCategory => this.renderCategoryDropdownItem( childCategory, level + 1 ) )
+				childCategories.map( ( childCategory ) => this.renderCategoryDropdownItem( childCategory, level + 1 ) )
 			),
 		];
 	}

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -159,7 +159,7 @@ export default class OldEditor extends Component {
 			<div
 				key="toolbar"
 				id={ `toolbar-${ id }` }
-				ref={ ref => this.ref = ref }
+				ref={ ( ref ) => this.ref = ref }
 				className="freeform-toolbar"
 				onClick={ this.focus }
 				data-placeholder={ __( 'Classic' ) }

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -137,7 +137,7 @@ class GalleryImage extends Component {
 						placeholder={ __( 'Write caption…' ) }
 						value={ caption }
 						isSelected={ this.state.captionSelected }
-						onChange={ newCaption => setAttributes( { caption: newCaption } ) }
+						onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
 						onFocus={ this.onSelectCaption }
 						inlineToolbar
 					/>

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -73,7 +73,7 @@ export const settings = {
 					value={ attributes.content }
 					focus={ isSelected }
 					onFocus={ toggleSelection }
-					onChange={ content => setAttributes( { content } ) }
+					onChange={ ( content ) => setAttributes( { content } ) }
 				/>
 			) }
 		</div>

--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -164,7 +164,7 @@ export default withAPIData( ( props ) => {
 		orderBy,
 		per_page: postsToShow,
 		_fields: [ 'date_gmt', 'link', 'title' ],
-	}, value => ! isUndefined( value ) ) );
+	}, ( value ) => ! isUndefined( value ) ) );
 	const categoriesListQuery = stringify( {
 		per_page: 100,
 		_fields: [ 'id', 'name', 'parent' ],

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -65,7 +65,7 @@ export const settings = {
 				type: 'block',
 				blocks: [ 'core/quote' ],
 				transform: ( { value, citation } ) => {
-					const items = value.map( p => get( p, 'children.props.children' ) );
+					const items = value.map( ( p ) => get( p, 'children.props.children' ) );
 					if ( ! isEmpty( citation ) ) {
 						items.push( citation );
 					}

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -18,8 +18,8 @@ import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-const toRichTextValue = value => map( value, ( subValue => subValue.children ) );
-const fromRichTextValue = value => map( value, ( subValue ) => ( {
+const toRichTextValue = ( value ) => map( value, ( ( subValue ) => subValue.children ) );
+const fromRichTextValue = ( value ) => map( value, ( subValue ) => ( {
 	children: subValue,
 } ) );
 const blockAttributes = {

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -20,8 +20,8 @@ import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import RichText from '../../rich-text';
 
-const toRichTextValue = value => value.map( ( subValue => subValue.children ) );
-const fromRichTextValue = value => value.map( ( subValue ) => ( {
+const toRichTextValue = ( value ) => value.map( ( ( subValue ) => subValue.children ) );
+const fromRichTextValue = ( value ) => value.map( ( subValue ) => ( {
 	children: subValue,
 } ) );
 
@@ -111,7 +111,7 @@ export const settings = {
 						return createBlock( 'core/paragraph' );
 					}
 					// transforming a quote with content
-					return ( value || [] ).map( item => createBlock( 'core/paragraph', {
+					return ( value || [] ).map( ( item ) => createBlock( 'core/paragraph', {
 						content: [ get( item, 'children.props.children', '' ) ],
 					} ) ).concat( citation ? createBlock( 'core/paragraph', {
 						content: citation,

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -135,7 +135,7 @@ export const settings = {
 								type="url"
 								className="components-placeholder__input"
 								placeholder={ __( 'Enter URL of video file here…' ) }
-								onChange={ event => this.setState( { src: event.target.value } ) }
+								onChange={ ( event ) => this.setState( { src: event.target.value } ) }
 								value={ src || '' } />
 							<Button
 								isLarge

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -148,7 +148,7 @@ class FormatToolbar extends Component {
 		const { isAddingLink, isEditingLink, newLinkValue, settingsVisible, opensInNewWindow } = this.state;
 
 		const toolbarControls = FORMATTING_CONTROLS.concat( customControls )
-			.filter( control => enabledControls.indexOf( control.format ) !== -1 )
+			.filter( ( control ) => enabledControls.indexOf( control.format ) !== -1 )
 			.map( ( control ) => {
 				if ( control.format === 'link' ) {
 					const isFormatActive = this.isFormatActive( 'link' );

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -104,7 +104,7 @@ export function filterEmptyNodes( childNodes ) {
 export function getFormatProperties( formatName, parents ) {
 	switch ( formatName ) {
 		case 'link' : {
-			const anchor = find( parents, node => node.nodeName.toLowerCase() === 'a' );
+			const anchor = find( parents, ( node ) => node.nodeName.toLowerCase() === 'a' );
 			return !! anchor ? { value: anchor.getAttribute( 'href' ) || '', target: anchor.getAttribute( 'target' ) || '', node: anchor } : {};
 		}
 		default:

--- a/blocks/test/full-content.js
+++ b/blocks/test/full-content.js
@@ -25,8 +25,8 @@ const fixturesDir = path.join( __dirname, 'fixtures' );
 // Get the "base" name for each fixture first.
 const fileBasenames = uniq(
 	fs.readdirSync( fixturesDir )
-		.filter( f => /(\.html|\.json)$/.test( f ) )
-		.map( f => f.replace( /\..+$/, '' ) )
+		.filter( ( f ) => /(\.html|\.json)$/.test( f ) )
+		.map( ( f ) => f.replace( /\..+$/, '' ) )
 );
 
 function readFixtureFile( filename ) {
@@ -49,7 +49,7 @@ function writeFixtureFile( filename, content ) {
 
 function normalizeReactTree( element ) {
 	if ( Array.isArray( element ) ) {
-		return element.map( child => normalizeReactTree( child ) );
+		return element.map( ( child ) => normalizeReactTree( child ) );
 	}
 
 	// Check if we got an object first, then if it actually has a `type` like a
@@ -103,7 +103,7 @@ describe( 'full post content fixture', () => {
 		registerCoreBlocks();
 	} );
 
-	fileBasenames.forEach( f => {
+	fileBasenames.forEach( ( f ) => {
 		it( f, () => {
 			const content = readFixtureFile( f + '.html' );
 			if ( content === null ) {
@@ -216,14 +216,14 @@ describe( 'full post content fixture', () => {
 	it( 'should be present for each block', () => {
 		const errors = [];
 
-		getBlockTypes().map( block => block.name ).forEach( name => {
+		getBlockTypes().map( ( block ) => block.name ).forEach( ( name ) => {
 			const nameToFilename = name.replace( /\//g, '__' );
 			const foundFixtures = fileBasenames
-				.filter( basename => (
+				.filter( ( basename ) => (
 					basename === nameToFilename ||
 					startsWith( basename, nameToFilename + '__' )
 				) )
-				.map( basename => {
+				.map( ( basename ) => {
 					// The file that contains the input HTML for this test.
 					const inputFilename = basename + '.html';
 					// The parser output for this test.  For missing files,
@@ -240,7 +240,7 @@ describe( 'full post content fixture', () => {
 						firstBlock,
 					};
 				} )
-				.filter( fixture => fixture.parserOutput !== null );
+				.filter( ( fixture ) => fixture.parserOutput !== null );
 
 			if ( ! foundFixtures.length ) {
 				errors.push( format(
@@ -250,7 +250,7 @@ describe( 'full post content fixture', () => {
 				) );
 			}
 
-			foundFixtures.forEach( fixture => {
+			foundFixtures.forEach( ( fixture ) => {
 				if ( name !== fixture.firstBlock ) {
 					errors.push( format(
 						'Expected fixture file \'%s\' to test the \'%s\' block.',

--- a/components/autocomplete/completer-compat.js
+++ b/components/autocomplete/completer-compat.js
@@ -25,7 +25,7 @@ export function toCompatibleCompleter( deprecatedCompleter ) {
 	} );
 
 	const optionalProperties = [ 'className', 'allowNode', 'allowContext' ]
-		.filter( key => key in deprecatedCompleter )
+		.filter( ( key ) => key in deprecatedCompleter )
 		.reduce( ( properties, key ) => {
 			return {
 				...properties,

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -221,7 +221,7 @@ export class Autocomplete extends Component {
 			let completers = nextCompleters;
 
 			if ( completers.some( isDeprecatedCompleter ) ) {
-				completers = completers.map( completer => {
+				completers = completers.map( ( completer ) => {
 					return isDeprecatedCompleter( completer ) ?
 						toCompatibleCompleter( completer ) :
 						completer;
@@ -370,7 +370,7 @@ export class Autocomplete extends Component {
 		 */
 		Promise.resolve(
 			typeof options === 'function' ? options( query ) : options
-		).then( optionsData => {
+		).then( ( optionsData ) => {
 			const keyedOptions = optionsData.map( ( optionData, optionIndex ) => ( {
 				key: `${ completer.idx }-${ optionIndex }`,
 				value: optionData,

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -159,8 +159,8 @@ describe( 'Autocomplete', () => {
 
 	const basicCompleter = {
 		options,
-		getOptionLabel: option => option.label,
-		getOptionKeywords: option => option.keywords,
+		getOptionLabel: ( option ) => option.label,
+		getOptionKeywords: ( option ) => option.keywords,
 	};
 
 	const slashCompleter = {
@@ -377,8 +377,8 @@ describe( 'Autocomplete', () => {
 				const itemWrappers = wrapper.find( 'button.components-autocomplete__result' );
 				expect( itemWrappers ).toHaveLength( 3 );
 
-				const expectedLabelContent = options.map( o => o.label );
-				const actualLabelContent = itemWrappers.map( itemWrapper => itemWrapper.text() );
+				const expectedLabelContent = options.map( ( o ) => o.label );
+				const actualLabelContent = itemWrappers.map( ( itemWrapper ) => itemWrapper.text() );
 				expect( actualLabelContent ).toEqual( expectedLabelContent );
 
 				done();
@@ -402,8 +402,8 @@ describe( 'Autocomplete', () => {
 				const itemWrappers = wrapper.find( 'button.components-autocomplete__result' );
 				expect( itemWrappers ).toHaveLength( 3 );
 
-				const expectedLabelContent = options.map( o => o.label );
-				const actualLabelContent = itemWrappers.map( itemWrapper => itemWrapper.text() );
+				const expectedLabelContent = options.map( ( o ) => o.label );
+				const actualLabelContent = itemWrappers.map( ( itemWrapper ) => itemWrapper.text() );
 				expect( actualLabelContent ).toEqual( expectedLabelContent );
 
 				done();
@@ -427,8 +427,8 @@ describe( 'Autocomplete', () => {
 				const itemWrappers = wrapper.find( 'button.components-autocomplete__result' );
 				expect( itemWrappers ).toHaveLength( 3 );
 
-				const expectedLabelContent = options.map( o => o.label );
-				const actualLabelContent = itemWrappers.map( itemWrapper => itemWrapper.text() );
+				const expectedLabelContent = options.map( ( o ) => o.label );
+				const actualLabelContent = itemWrappers.map( ( itemWrapper ) => itemWrapper.text() );
 				expect( actualLabelContent ).toEqual( expectedLabelContent );
 
 				done();

--- a/components/code-editor/editor.js
+++ b/components/code-editor/editor.js
@@ -98,7 +98,7 @@ class CodeEditor extends Component {
 	}
 
 	render() {
-		return <textarea ref={ ref => ( this.textarea = ref ) } value={ this.props.value } />;
+		return <textarea ref={ ( ref ) => ( this.textarea = ref ) } value={ this.props.value } />;
 	}
 }
 

--- a/components/draggable/index.js
+++ b/components/draggable/index.js
@@ -120,7 +120,7 @@ class Draggable extends Component {
 		}
 
 		// Hack: Remove iFrames as it's causing the embeds drag clone to freeze
-		[ ...clone.querySelectorAll( 'iframe' ) ].forEach( child => child.parentNode.removeChild( child ) );
+		[ ...clone.querySelectorAll( 'iframe' ) ].forEach( ( child ) => child.parentNode.removeChild( child ) );
 
 		this.cloneWrapper.appendChild( clone );
 		elementWrapper.appendChild( this.cloneWrapper );

--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -125,8 +125,8 @@ class DropZoneProvider extends Component {
 		);
 
 		// Find the leaf dropzone not containing another dropzone
-		const hoveredDropZone = find( hoveredDropZones, zone => (
-			! some( hoveredDropZones, subZone => subZone !== zone && zone.element.parentElement.contains( subZone.element ) )
+		const hoveredDropZone = find( hoveredDropZones, ( zone ) => (
+			! some( hoveredDropZones, ( subZone ) => subZone !== zone && zone.element.parentElement.contains( subZone.element ) )
 		) );
 
 		const hoveredDropZoneIndex = this.dropzones.indexOf( hoveredDropZone );

--- a/components/form-toggle/test/index.js
+++ b/components/form-toggle/test/index.js
@@ -36,14 +36,14 @@ describe( 'FormToggle', () => {
 
 		it( 'should render a checkbox with a noop onChange', () => {
 			const formToggle = shallow( <FormToggle /> );
-			const checkBox = formToggle.prop( 'children' ).find( child => 'input' === child.type && 'checkbox' === child.props.type );
+			const checkBox = formToggle.prop( 'children' ).find( ( child ) => 'input' === child.type && 'checkbox' === child.props.type );
 			expect( checkBox.props.onChange ).toBe( noop );
 		} );
 
 		it( 'should render a checkbox with a user-provided onChange', () => {
 			const testFunction = ( event ) => event;
 			const formToggle = shallow( <FormToggle onChange={ testFunction } /> );
-			const checkBox = formToggle.prop( 'children' ).find( child => 'input' === child.type && 'checkbox' === child.props.type );
+			const checkBox = formToggle.prop( 'children' ).find( ( child ) => 'input' === child.type && 'checkbox' === child.props.type );
 			expect( checkBox.props.onChange ).toBe( testFunction );
 		} );
 	} );

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -343,7 +343,7 @@ class FormTokenField extends Component {
 			tokens
 				.map( this.props.saveTransform )
 				.filter( Boolean )
-				.filter( token => ! this.valueContainsToken( token ) )
+				.filter( ( token ) => ! this.valueContainsToken( token ) )
 		);
 
 		if ( tokensToAdd.length > 0 ) {

--- a/components/form-token-field/test/index.js
+++ b/components/form-token-field/test/index.js
@@ -83,9 +83,9 @@ maybeDescribe( 'FormTokenField', function() {
 		return map(
 			filter(
 				div.firstChild.childNodes,
-				childNode => childNode.nodeType !== window.Node.COMMENT_NODE
+				( childNode ) => childNode.nodeType !== window.Node.COMMENT_NODE
 			),
-			childNode => childNode.textContent
+			( childNode ) => childNode.textContent
 		);
 	}
 

--- a/components/higher-order/with-filters/test/index.js
+++ b/components/higher-order/with-filters/test/index.js
@@ -74,7 +74,7 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
-			FilteredComponent => () => (
+			( FilteredComponent ) => () => (
 				<blockquote>
 					<FilteredComponent />
 				</blockquote>
@@ -104,7 +104,7 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
-			FilteredComponent => () => (
+			( FilteredComponent ) => () => (
 				<blockquote>
 					<FilteredComponent />
 				</blockquote>
@@ -130,7 +130,7 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
-			FilteredComponent => () => (
+			( FilteredComponent ) => () => (
 				<blockquote>
 					<FilteredComponent />
 				</blockquote>
@@ -139,7 +139,7 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-2',
-			FilteredComponent => () => (
+			( FilteredComponent ) => () => (
 				<section>
 					<FilteredComponent />
 				</section>
@@ -164,7 +164,7 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy',
-			FilteredComponent => () => (
+			( FilteredComponent ) => () => (
 				<div>
 					<FilteredComponent />
 				</div>
@@ -201,7 +201,7 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
-			FilteredComponent => () => (
+			( FilteredComponent ) => () => (
 				<blockquote>
 					<FilteredComponent />
 				</blockquote>

--- a/edit-post/components/header/mode-switcher/index.js
+++ b/edit-post/components/header/mode-switcher/index.js
@@ -27,7 +27,7 @@ const MODES = [
 ];
 
 function ModeSwitcher( { onSwitch, mode } ) {
-	const choices = MODES.map( choice => {
+	const choices = MODES.map( ( choice ) => {
 		if ( choice.value !== mode ) {
 			return { ...choice, shortcut: shortcuts.toggleEditorMode.label };
 		}

--- a/edit-post/editor.js
+++ b/edit-post/editor.js
@@ -19,6 +19,6 @@ function Editor( { settings, hasFixedToolbar, onError, ...props } ) {
 	);
 }
 
-export default withSelect( select => ( {
+export default withSelect( ( select ) => ( {
 	hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
 } ) )( Editor );

--- a/edit-post/store/middlewares.js
+++ b/edit-post/store/middlewares.js
@@ -33,7 +33,7 @@ function applyMiddlewares( store ) {
 		getState: store.getState,
 		dispatch: ( ...args ) => enhancedDispatch( ...args ),
 	};
-	chain = middlewares.map( middleware => middleware( middlewareAPI ) );
+	chain = middlewares.map( ( middleware ) => middleware( middlewareAPI ) );
 	enhancedDispatch = flowRight( ...chain )( store.dispatch );
 
 	store.dispatch = enhancedDispatch;

--- a/editor/components/block-list/block-html.js
+++ b/editor/components/block-list/block-html.js
@@ -58,7 +58,7 @@ export default compose( [
 	withSelect( ( select, ownProps ) => ( {
 		block: select( 'core/editor' ).getBlock( ownProps.uid ),
 	} ) ),
-	withDispatch( dispatch => ( {
+	withDispatch( ( dispatch ) => ( {
 		onChange( uid, attributes, originalContent, isValid ) {
 			dispatch( 'core/editor' ).updateBlock( uid, { attributes, originalContent, isValid } );
 		},

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -13,7 +13,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { cloneBlock, getBlockType, withEditorSettings } from '@wordpress/blocks';
 
 export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, role } ) {
-	const canDuplicate = every( blocks, block => {
+	const canDuplicate = every( blocks, ( block ) => {
 		const type = getBlockType( block.name );
 		return ! type.useOnce;
 	} );
@@ -43,7 +43,7 @@ export default compose(
 	} ) ),
 	withDispatch( ( dispatch, { blocks, index, rootUID } ) => ( {
 		onDuplicate() {
-			const clonedBlocks = blocks.map( block => cloneBlock( block ) );
+			const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
 			dispatch( 'core/editor' ).insertBlocks(
 				clonedBlocks,
 				index + 1,

--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -33,7 +33,7 @@ const multipleH1Headings = [
 	<em key="incorrect-message-multiple-h1">{ __( '(Multiple H1 headings are not recommended)' ) }</em>,
 ];
 
-const getHeadingLevel = heading => {
+const getHeadingLevel = ( heading ) => {
 	switch ( heading.attributes.nodeName ) {
 		case 'h1':
 		case 'H1':
@@ -81,7 +81,7 @@ const computeOutlineHeadings = ( blocks = [], path = [] ) => {
 	} );
 };
 
-const isEmptyHeading = heading => ! heading.attributes.content || heading.attributes.content.length === 0;
+const isEmptyHeading = ( heading ) => ! heading.attributes.content || heading.attributes.content.length === 0;
 
 export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupported } ) => {
 	const headings = computeOutlineHeadings( blocks );

--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -31,7 +31,7 @@ export default class InserterGroup extends Component {
 			this.activeItems = deriveActiveItems( nextProps.items );
 
 			// Try and preserve any still valid selected state.
-			const currentIsStillActive = this.state.current && this.activeItems.some( item =>
+			const currentIsStillActive = this.state.current && this.activeItems.some( ( item ) =>
 				item.id === this.state.current.id
 			);
 

--- a/editor/components/post-format/index.js
+++ b/editor/components/post-format/index.js
@@ -47,7 +47,7 @@ function PostFormat( { onUpdatePostFormat, postFormat = 'standard', suggestedFor
 						onChange={ ( event ) => onUpdatePostFormat( event.target.value ) }
 						id={ postFormatSelectorId }
 					>
-						{ POST_FORMATS.map( format => (
+						{ POST_FORMATS.map( ( format ) => (
 							<option key={ format.id } value={ format.id }>{ format.caption }</option>
 						) ) }
 					</select>

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -117,8 +117,8 @@ class FlatTermSelector extends Component {
 					this.addRequest = wp.apiRequest( {
 						path: `/wp/v2/${ basePath }?${ stringify( { ...DEFAULT_QUERY, search: termName } ) }`,
 					} );
-					return this.addRequest.then( searchResult => {
-						resolve( find( searchResult, result => isSameTermName( result.name, termName ) ) );
+					return this.addRequest.then( ( searchResult ) => {
+						resolve( find( searchResult, ( result ) => isSameTermName( result.name, termName ) ) );
 					}, reject );
 				}
 				reject( xhr );

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -69,7 +69,7 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	findTerm( terms, parent, name ) {
-		return find( terms, term => {
+		return find( terms, ( term ) => {
 			return ( ( ! term.parent && ! parent ) || parseInt( term.parent ) === parseInt( parent ) ) &&
 				term.name.toLowerCase() === name.toLowerCase();
 		} );
@@ -87,7 +87,7 @@ class HierarchicalTermSelector extends Component {
 		const existingTerm = this.findTerm( availableTerms, formParent, formName );
 		if ( existingTerm ) {
 			// if the term we are adding exists but is not selected select it
-			if ( ! some( terms, term => term === existingTerm.id ) ) {
+			if ( ! some( terms, ( term ) => term === existingTerm.id ) ) {
 				onUpdateTerms( [ ...terms, existingTerm.id ], restBase );
 			}
 			this.setState( {
@@ -119,7 +119,7 @@ class HierarchicalTermSelector extends Component {
 						this.addRequest = wp.apiRequest( {
 							path: `/wp/v2/${ basePath }?${ stringify( { ...DEFAULT_QUERY, parent: formParent || 0, search: formName } ) }`,
 						} );
-						return this.addRequest.then( searchResult => {
+						return this.addRequest.then( ( searchResult ) => {
 							resolve( this.findTerm( searchResult, formParent, formName ) );
 						}, reject );
 					}

--- a/editor/components/post-type-support-check/index.js
+++ b/editor/components/post-type-support-check/index.js
@@ -10,7 +10,7 @@ import { withSelect } from '@wordpress/data';
 
 function PostTypeSupportCheck( { postType, children, supportKeys } ) {
 	const isSupported = some(
-		castArray( supportKeys ), key => get( postType, [ 'supports', key ], false )
+		castArray( supportKeys ), ( key ) => get( postType, [ 'supports', key ], false )
 	);
 
 	if ( ! isSupported ) {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -490,8 +490,8 @@ export default {
 
 		// Remove any other blocks that reference this shared block
 		const allBlocks = getBlocks( getState() );
-		const associatedBlocks = allBlocks.filter( block => isSharedBlock( block ) && block.attributes.ref === id );
-		const associatedBlockUids = associatedBlocks.map( block => block.uid );
+		const associatedBlocks = allBlocks.filter( ( block ) => isSharedBlock( block ) && block.attributes.ref === id );
+		const associatedBlockUids = associatedBlocks.map( ( block ) => block.uid );
 
 		const transactionId = uniqueId();
 

--- a/editor/store/middlewares.js
+++ b/editor/store/middlewares.js
@@ -35,7 +35,7 @@ function applyMiddlewares( store ) {
 		getState: store.getState,
 		dispatch: ( ...args ) => enhancedDispatch( ...args ),
 	};
-	chain = middlewares.map( middleware => middleware( middlewareAPI ) );
+	chain = middlewares.map( ( middleware ) => middleware( middlewareAPI ) );
 	enhancedDispatch = flowRight( ...chain )( store.dispatch );
 
 	store.dispatch = enhancedDispatch;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1237,7 +1237,7 @@ function buildInserterItemFromBlockType( state, allowedBlockTypes, blockType ) {
 		icon: blockType.icon,
 		category: blockType.category,
 		keywords: blockType.keywords,
-		isDisabled: !! blockType.useOnce && getBlocks( state ).some( block => block.name === blockType.name ),
+		isDisabled: !! blockType.useOnce && getBlocks( state ).some( ( block ) => block.name === blockType.name ),
 	};
 }
 
@@ -1305,11 +1305,11 @@ export function getInserterItems( state, allowedBlockTypes ) {
 		return [];
 	}
 
-	const staticItems = getBlockTypes().map( blockType =>
+	const staticItems = getBlockTypes().map( ( blockType ) =>
 		buildInserterItemFromBlockType( state, allowedBlockTypes, blockType )
 	);
 
-	const dynamicItems = getSharedBlocks( state ).map( sharedBlock =>
+	const dynamicItems = getSharedBlocks( state ).map( ( sharedBlock ) =>
 		buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock )
 	);
 
@@ -1319,12 +1319,12 @@ export function getInserterItems( state, allowedBlockTypes ) {
 
 function fillWithCommonBlocks( inserts ) {
 	// Filter out any inserts that are associated with a block type that isn't registered
-	const items = inserts.filter( insert => getBlockType( insert.name ) );
+	const items = inserts.filter( ( insert ) => getBlockType( insert.name ) );
 
 	// Common blocks that we'll use to pad out our list
 	const commonInserts = getBlockTypes()
-		.filter( blockType => blockType.category === 'common' )
-		.map( blockType => ( { name: blockType.name } ) );
+		.filter( ( blockType ) => blockType.category === 'common' )
+		.map( ( blockType ) => ( { name: blockType.name } ) );
 
 	const areInsertsEqual = ( a, b ) => a.name === b.name && a.ref === b.ref;
 	return unionWith( items, commonInserts, areInsertsEqual );
@@ -1335,7 +1335,7 @@ function getItemsFromInserts( state, inserts, allowedBlockTypes, maximum = MAX_R
 		return [];
 	}
 
-	const items = fillWithCommonBlocks( inserts ).map( insert => {
+	const items = fillWithCommonBlocks( inserts ).map( ( insert ) => {
 		if ( insert.ref ) {
 			const sharedBlock = getSharedBlock( state, insert.ref );
 			return buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2529,7 +2529,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const blockTypes = getBlockTypes().filter( blockType => ! blockType.isPrivate );
+			const blockTypes = getBlockTypes().filter( ( blockType ) => ! blockType.isPrivate );
 			expect( getInserterItems( state, true ) ).toHaveLength( blockTypes.length );
 		} );
 
@@ -2727,7 +2727,7 @@ describe( 'selectors', () => {
 
 			// We should get back 4 items with no duplicates
 			const items = getFrecentInserterItems( state, true, 4 );
-			const blockNames = items.map( item => item.name );
+			const blockNames = items.map( ( item ) => item.name );
 			expect( union( blockNames ) ).toHaveLength( 4 );
 		} );
 	} );

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -126,7 +126,7 @@ describe( 'element', () => {
 	describe( 'createHigherOrderComponent', () => {
 		it( 'should use default name for anonymous function', () => {
 			const TestComponent = createHigherOrderComponent(
-				OriginalComponent => OriginalComponent,
+				( OriginalComponent ) => OriginalComponent,
 				'withTest'
 			)( () => <div /> );
 
@@ -135,7 +135,7 @@ describe( 'element', () => {
 
 		it( 'should use camel case starting with upper for wrapper prefix ', () => {
 			const TestComponent = createHigherOrderComponent(
-				OriginalComponent => OriginalComponent,
+				( OriginalComponent ) => OriginalComponent,
 				'with-one-two_threeFOUR'
 			)( () => <div /> );
 
@@ -147,7 +147,7 @@ describe( 'element', () => {
 				return <div />;
 			}
 			const TestComponent = createHigherOrderComponent(
-				OriginalComponent => OriginalComponent,
+				( OriginalComponent ) => OriginalComponent,
 				'withTest'
 			)( SomeComponent );
 
@@ -161,7 +161,7 @@ describe( 'element', () => {
 				}
 			}
 			const TestComponent = createHigherOrderComponent(
-				OriginalComponent => OriginalComponent,
+				( OriginalComponent ) => OriginalComponent,
 				'withTest'
 			)( SomeAnotherComponent );
 
@@ -176,7 +176,7 @@ describe( 'element', () => {
 			}
 			SomeYetAnotherComponent.displayName = 'CustomDisplayName';
 			const TestComponent = createHigherOrderComponent(
-				OriginalComponent => OriginalComponent,
+				( OriginalComponent ) => OriginalComponent,
 				'withTest'
 			)( SomeYetAnotherComponent );
 

--- a/eslint/config.js
+++ b/eslint/config.js
@@ -34,6 +34,7 @@ module.exports = {
 	},
 	rules: {
 		'array-bracket-spacing': [ 'error', 'always' ],
+		'arrow-parens': [ 'error', 'always' ],
 		'brace-style': [ 'error', '1tbs' ],
 		camelcase: [ 'error', { properties: 'never' } ],
 		'comma-dangle': [ 'error', 'always-multiline' ],

--- a/test/e2e/support/plugins.js
+++ b/test/e2e/support/plugins.js
@@ -44,7 +44,7 @@ export async function deactivatePlugin( slug ) {
  */
 export async function uninstallPlugin( slug ) {
 	await visitAdmin( 'plugins.php' );
-	const confirmPromise = new Promise( resolve => {
+	const confirmPromise = new Promise( ( resolve ) => {
 		const confirmDialog = ( dialog ) => {
 			dialog.accept();
 			page.removeListener( 'dialog', confirmDialog );

--- a/test/unit/setup-wp-aliases.js
+++ b/test/unit/setup-wp-aliases.js
@@ -18,7 +18,7 @@ global.wp = {
 	'edit-post',
 	'viewport',
 	'plugins',
-].forEach( entryPointName => {
+].forEach( ( entryPointName ) => {
 	Object.defineProperty( global.wp, entryPointName, {
 		get: () => require( entryPointName ),
 	} );

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -80,7 +80,7 @@ function createMediaFromFile( file ) {
  * @return {Promise}     Pormise resolved once the image is preloaded.
  */
 export function preloadImage( url ) {
-	return new Promise( resolve => {
+	return new Promise( ( resolve ) => {
 		const newImg = new window.Image();
 		newImg.onload = function() {
 			resolve( url );


### PR DESCRIPTION
Closes #611.

Require that there are parens around the arguments of an arrow function. This option got the most :+1: reactions in https://github.com/WordPress/gutenberg/issues/611#issuecomment-298784132.

(I'm not that phased by this to be honest—it's just that I was in the neighbourhood while fixing https://github.com/WordPress/gutenberg/pull/6263.)