### PR TITLE
Fix RangeControl when margin set to 0 for inputs

### DIFF
--- a/components/range-control/style.scss
+++ b/components/range-control/style.scss
@@ -19,6 +19,7 @@
 	.components-range-control__slider {
 		margin-left: 0;
 		flex: 1;
+		min-width: 100px;
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Sets `min-width` for `RangeControl` slider (`.components-range-control__slider`)

Sometimes `margin:0` is added by some plugins (happened for me on two live sites with several plugins). Which breaks `RangeControl` input. This intends to fix that.

## How has this been tested?
Add Columns (Experimental) block... Verify range control looks good even with `input {margin:0}` style applied.

## Screenshots <!-- if applicable -->

Before:
![image](https://user-images.githubusercontent.com/11048263/38970078-17dca5fa-43b1-11e8-8792-0e7e18c41d6c.png)

After:
![image](https://user-images.githubusercontent.com/11048263/38970564-d22d28d8-43b3-11e8-88e4-b92b13634818.png)

## Types of changes
Simple CSS tweak. Sets min-width for RangeControl slider.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
