### PR TITLE
Make URL replacement on save a removable action

### DIFF
--- a/editor/hooks/index.js
+++ b/editor/hooks/index.js
@@ -1,0 +1,1 @@
+import './saved-post-url';

--- a/editor/hooks/saved-post-url/index.js
+++ b/editor/hooks/saved-post-url/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies.
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies.
+ */
+import { addAction } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies.
+ */
+import { getPostEditUrl } from '../../utils/url';
+
+addAction(
+	'editor.postSaveSucceeded',
+	'core/editor/set-saved-post-url',
+	function( post ) {
+		if ( get( window.history.state, 'id' ) !== post.id ) {
+			window.history.replaceState(
+				{ id: post.id },
+				'Post ' + post.id,
+				getPostEditUrl( post.id )
+			);
+		}
+	}
+);

--- a/editor/index.js
+++ b/editor/index.js
@@ -1,3 +1,4 @@
+import './hooks';
 import './store';
 
 export * from './components';

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -18,13 +18,14 @@ import {
 	doBlocksMatchTemplate,
 	synchronizeBlocksWithTemplate,
 } from '@wordpress/blocks';
+import { doAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
-import { getPostEditUrl, getWPAdminURL } from '../utils/url';
+import { getWPAdminURL } from '../utils/url';
 import {
 	setupEditorState,
 	resetPost,
@@ -176,13 +177,12 @@ export default {
 			) );
 		}
 
-		if ( get( window.history.state, 'id' ) !== post.id ) {
-			window.history.replaceState(
-				{ id: post.id },
-				'Post ' + post.id,
-				getPostEditUrl( post.id )
-			);
-		}
+		/**
+		 * Fires after the post is saved.
+		 *
+		 * @param {Object} post Post object.
+		 */
+		doAction( 'editor.postSaveSucceeded', post );
 	},
 	REQUEST_POST_UPDATE_FAILURE( action, store ) {
 		const { post, edits } = action;


### PR DESCRIPTION
## Description
Closed #4674.

When the editor saves a new post, it replaces the current URL with the post's edit URL, but this is not always desired behavior. For example, in a P2 blog, the editor is embedded in the home page, and publishing a post should leave the URL as-is.

This PR moves the URL replacement to an action so the action may removed in scenarios like the one mentioned above. The actual removal is by name:
```js
wp.hooks.removeAction( 'editor.postSaveSucceeded', 'core/editor/set-saved-post-url' );
```
A couple of questions:
1. Is there a better mechanism for making this behavior optional?
2. If we keep this action, is it worth adding 'editor.postSaveFailed' and 'editor.postSaveRequested' actions for completeness?

## How has this been tested?
1. I created a new post, saved it, and observed the URL being updated.
2. I created a new post, removed the action hook via the dev tools console, saved the post, and observed the URL remained the same.

## Types of changes
Adds an `editor.postSaveSucceeded` action and moves post URL replacement to occur as part of that action.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
