### PR TITLE
Amend spelling issue for pull quotes and line breaks

### DIFF
--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -15,7 +15,7 @@ export const name = 'core/preformatted';
 export const settings = {
 	title: __( 'Preformatted' ),
 
-	description: __( 'Preformatted text keeps your spaces, tabs and linebreaks as they are.' ),
+	description: __( 'Preformatted text keeps your spaces, tabs and line breaks as they are.' ),
 
 	icon: 'text',
 

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -48,9 +48,9 @@ export const name = 'core/pullquote';
 
 export const settings = {
 
-	title: __( 'Pullquote' ),
+	title: __( 'Pull quote' ),
 
-	description: __( 'A pullquote is a brief, attention-catching quotation taken from the main text of an article and used as a subheading or graphic feature.' ),
+	description: __( 'A pull quote is a brief, attention-catching quotation taken from the main text of an article and used as a subheading or graphic feature.' ),
 
 	icon: 'format-quote',
 

--- a/blocks/test/fixtures/core__pullquote.html
+++ b/blocks/test/fixtures/core__pullquote.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-<p>Testing pullquote block...</p><cite>...with a caption</cite>
+<p>Testing pull quote block...</p><cite>...with a caption</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote.json
+++ b/blocks/test/fixtures/core__pullquote.json
@@ -11,7 +11,7 @@
                         "key": null,
                         "ref": null,
                         "props": {
-                            "children": "Testing pullquote block..."
+                            "children": "Testing pull quote block..."
                         },
                         "_owner": null,
                         "_store": {}
@@ -24,6 +24,6 @@
             "align": "none"
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n<p>Testing pull quote block...</p><cite>...with a caption</cite>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote.parsed.json
+++ b/blocks/test/fixtures/core__pullquote.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/pullquote",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n<p>Testing pull quote block...</p><cite>...with a caption</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__pullquote.serialized.html
+++ b/blocks/test/fixtures/core__pullquote.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-	<p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote>
+	<p>Testing pull quote block...</p><cite>...with a caption</cite></blockquote>
 <!-- /wp:pullquote -->

--- a/phpunit/fixtures/long-content.html
+++ b/phpunit/fixtures/long-content.html
@@ -105,7 +105,7 @@ https://vimeo.com/22439234
 </figure>
 <!-- /wp:embed -->
 <!-- wp:paragraph -->
-<p>You can build any block you like, static or dynamic, decorative or plain. Here&#x27;s a pullquote block:</p>
+<p>You can build any block you like, static or dynamic, decorative or plain. Here&#x27;s a pull quote block:</p>
 <!-- /wp:paragraph -->
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">


### PR DESCRIPTION
## Description
I noticed when doing the en_GB translations that `pullquote` and `linebreaks` are incorrect. They are two words which need a space between them. I've amended both of these issues in this PR.

## How has this been tested?
No actual testing done as it's just string changes.

## Screenshots
N/A

## Types of changes
Bug fix with only string changes made.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows the accessibility standards.
- [X] My code has proper inline documentation.
