### PR TITLE
RichText: Add the RichText.Content component to be used in conjunction with RichText

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -169,7 +169,11 @@ export const settings = {
 		return (
 			<figure>
 				<audio controls="controls" src={ src } />
-				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
+				{ caption && caption.length > 0 && (
+					<figcaption>
+						<RichText.Content>{ caption }</RichText.Content>
+					</figcaption>
+				) }
 			</figure>
 		);
 	},

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -169,11 +169,7 @@ export const settings = {
 		return (
 			<figure>
 				<audio controls="controls" src={ src } />
-				{ caption && caption.length > 0 && (
-					<figcaption>
-						<RichText.Content>{ caption }</RichText.Content>
-					</figcaption>
-				) }
+				{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 			</figure>
 		);
 	},

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -217,7 +217,7 @@ export const settings = {
 		return (
 			<div className={ `align${ align }` }>
 				<a className={ linkClass } href={ url } title={ title } style={ buttonStyle }>
-					{ text }
+					<RichText.Content>{ text }</RichText.Content>
 				</a>
 			</div>
 		);
@@ -232,7 +232,7 @@ export const settings = {
 			return (
 				<div className={ `align${ align }` } style={ { backgroundColor: color } }>
 					<a href={ url } title={ title } style={ { color: textColor } }>
-						{ text }
+						<RichText.Content>{ text }</RichText.Content>
 					</a>
 				</div>
 			);

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -216,9 +216,14 @@ export const settings = {
 
 		return (
 			<div className={ `align${ align }` }>
-				<a className={ linkClass } href={ url } title={ title } style={ buttonStyle }>
-					<RichText.Content>{ text }</RichText.Content>
-				</a>
+				<RichText.Content
+					tagName="a"
+					className={ linkClass }
+					href={ url }
+					title={ title }
+					style={ buttonStyle }
+					value={ text }
+				/>
 			</div>
 		);
 	},
@@ -231,9 +236,13 @@ export const settings = {
 
 			return (
 				<div className={ `align${ align }` } style={ { backgroundColor: color } }>
-					<a href={ url } title={ title } style={ { color: textColor } }>
-						<RichText.Content>{ text }</RichText.Content>
-					</a>
+					<RichText.Content
+						tagName="a"
+						href={ url }
+						title={ title }
+						style={ { color: textColor } }
+						value={ text }
+					/>
 				</div>
 			);
 		},

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -233,9 +233,7 @@ export const settings = {
 		return (
 			<div className={ classes } style={ style }>
 				{ title && title.length > 0 && (
-					<p className="wp-block-cover-image-text">
-						<RichText.Content>{ title }</RichText.Content>
-					</p>
+					<RichText.Content tagName="p" className="wp-block-cover-image-text" value={ title } />
 				) }
 			</div>
 		);
@@ -266,9 +264,7 @@ export const settings = {
 
 			return (
 				<section className={ classes } style={ style }>
-					<h2>
-						<RichText.Content>{ title }</RichText.Content>
-					</h2>
+					<RichText.Content tagName="h2" value={ title } />
 				</section>
 			);
 		},

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -233,7 +233,9 @@ export const settings = {
 		return (
 			<div className={ classes } style={ style }>
 				{ title && title.length > 0 && (
-					<p className="wp-block-cover-image-text">{ title }</p>
+					<p className="wp-block-cover-image-text">
+						<RichText.Content>{ title }</RichText.Content>
+					</p>
 				) }
 			</div>
 		);
@@ -264,7 +266,9 @@ export const settings = {
 
 			return (
 				<section className={ classes } style={ style }>
-					<h2>{ title }</h2>
+					<h2>
+						<RichText.Content>{ title }</RichText.Content>
+					</h2>
 				</section>
 			);
 		},

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -250,7 +250,11 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 			return (
 				<figure className={ embedClassName }>
 					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
-					{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
+					{ caption && caption.length > 0 && (
+						<figcaption>
+							<RichText.Content>{ caption }</RichText.Content>
+						</figcaption>
+					) }
 				</figure>
 			);
 		},

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -250,11 +250,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 			return (
 				<figure className={ embedClassName }>
 					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
-					{ caption && caption.length > 0 && (
-						<figcaption>
-							<RichText.Content>{ caption }</RichText.Content>
-						</figcaption>
-					) }
+					{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 				</figure>
 			);
 		},

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -188,9 +188,7 @@ export const settings = {
 							<figure>
 								{ href ? <a href={ href }>{ img }</a> : img }
 								{ image.caption && image.caption.length > 0 && (
-									<figcaption>
-										<RichText.Content>{ image.caption }</RichText.Content>
-									</figcaption>
+									<RichText.Content tagName="figcaption" value={ image.caption } />
 								) }
 							</figure>
 						</li>

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -15,6 +15,7 @@ import { mediaUpload } from '@wordpress/utils';
 import './editor.scss';
 import './style.scss';
 import { createBlock } from '../../api';
+import RichText from '../../rich-text';
 import { default as GalleryBlock, defaultColumnsNumber } from './block';
 
 const blockAttributes = {
@@ -186,7 +187,11 @@ export const settings = {
 						<li key={ image.id || image.url } className="blocks-gallery-item">
 							<figure>
 								{ href ? <a href={ href }>{ img }</a> : img }
-								{ image.caption && image.caption.length > 0 && <figcaption>{ image.caption }</figcaption> }
+								{ image.caption && image.caption.length > 0 && (
+									<figcaption>
+										<RichText.Content>{ image.caption }</RichText.Content>
+									</figcaption>
+								) }
 							</figure>
 						</li>
 					);

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -168,12 +168,13 @@ export const settings = {
 
 	save( { attributes } ) {
 		const { align, nodeName, content } = attributes;
-		const Tag = nodeName.toLowerCase();
 
 		return (
-			<Tag style={ { textAlign: align } } >
-				<RichText.Content>{ content }</RichText.Content>
-			</Tag>
+			<RichText.Content
+				tagName={ nodeName.toLowerCase() }
+				style={ { textAlign: align } }
+				value={ content }
+			/>
 		);
 	},
 };

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -172,7 +172,7 @@ export const settings = {
 
 		return (
 			<Tag style={ { textAlign: align } } >
-				{ content }
+				<RichText.Content>{ content }</RichText.Content>
 			</Tag>
 		);
 	},

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -174,11 +174,7 @@ export const settings = {
 		return (
 			<figure className={ align ? `align${ align }` : null }>
 				{ href ? <a href={ href }>{ image }</a> : image }
-				{ caption && caption.length > 0 && (
-					<figcaption>
-						<RichText.Content>{ caption }</RichText.Content>
-					</figcaption>
-				) }
+				{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 			</figure>
 		);
 	},
@@ -202,11 +198,7 @@ export const settings = {
 				return (
 					<figure className={ align ? `align${ align }` : null } style={ figureStyle }>
 						{ href ? <a href={ href }>{ image }</a> : image }
-						{ caption && caption.length > 0 && (
-							<figcaption>
-								<RichText.Content>{ caption }</RichText.Content>
-							</figcaption>
-						) }
+						{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 					</figure>
 				);
 			},

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import './editor.scss';
 import { createBlock, getBlockAttributes, getBlockType } from '../../api';
+import RichText from '../../rich-text';
 import ImageBlock from './block';
 
 export const name = 'core/image';
@@ -173,7 +174,11 @@ export const settings = {
 		return (
 			<figure className={ align ? `align${ align }` : null }>
 				{ href ? <a href={ href }>{ image }</a> : image }
-				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
+				{ caption && caption.length > 0 && (
+					<figcaption>
+						<RichText.Content>{ caption }</RichText.Content>
+					</figcaption>
+				) }
 			</figure>
 		);
 	},
@@ -197,7 +202,11 @@ export const settings = {
 				return (
 					<figure className={ align ? `align${ align }` : null } style={ figureStyle }>
 						{ href ? <a href={ href }>{ image }</a> : image }
-						{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
+						{ caption && caption.length > 0 && (
+							<figcaption>
+								<RichText.Content>{ caption }</RichText.Content>
+							</figcaption>
+						) }
 					</figure>
 				);
 			},

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -6,7 +6,7 @@ import { find, compact, get, initial, last, isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, createElement, Fragment } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -304,11 +304,12 @@ export const settings = {
 
 	save( { attributes } ) {
 		const { nodeName, values } = attributes;
+		const Tag = nodeName.toLowerCase();
 
-		return createElement(
-			nodeName.toLowerCase(),
-			null,
-			values
+		return (
+			<Tag>
+				<RichText.Content>{ values }</RichText.Content>
+			</Tag>
 		);
 	},
 };

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -304,12 +304,9 @@ export const settings = {
 
 	save( { attributes } ) {
 		const { nodeName, values } = attributes;
-		const Tag = nodeName.toLowerCase();
 
 		return (
-			<Tag>
-				<RichText.Content>{ values }</RichText.Content>
-			</Tag>
+			<RichText.Content tagName={ nodeName.toLowerCase() } value={ values } />
 		);
 	},
 };

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -435,6 +435,10 @@ export const settings = {
 			textAlign: align,
 		};
 
-		return <p style={ styles } className={ className ? className : undefined }>{ content }</p>;
+		return (
+			<p style={ styles } className={ className ? className : undefined }>
+				<RichText.Content>{ content }</RichText.Content>
+			</p>
+		);
 	},
 };

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -436,9 +436,12 @@ export const settings = {
 		};
 
 		return (
-			<p style={ styles } className={ className ? className : undefined }>
-				<RichText.Content>{ content }</RichText.Content>
-			</p>
+			<RichText.Content
+				tagName="p"
+				style={ styles }
+				className={ className ? className : undefined }
+				value={ content }
+			/>
 		);
 	},
 };

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -79,6 +79,6 @@ export const settings = {
 	save( { attributes } ) {
 		const { content } = attributes;
 
-		return <pre><RichText.Content>{ content }</RichText.Content></pre>;
+		return <RichText.Content tagName="pre" value={ content } />;
 	},
 };

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -79,6 +79,6 @@ export const settings = {
 	save( { attributes } ) {
 		const { content } = attributes;
 
-		return <pre>{ content }</pre>;
+		return <pre><RichText.Content>{ content }</RichText.Content></pre>;
 	},
 };

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -124,9 +124,7 @@ export const settings = {
 				{ value && value.map( ( paragraph, i ) =>
 					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 				) }
-				{ citation && citation.length > 0 && (
-					<cite><RichText.Content>{ citation }</RichText.Content></cite>
-				) }
+				{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>
 		);
 	},
@@ -149,9 +147,7 @@ export const settings = {
 					{ value && value.map( ( paragraph, i ) =>
 						<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 					) }
-					{ citation && citation.length > 0 && (
-						<footer><RichText.Content>{ citation }</RichText.Content></footer>
-					) }
+					{ citation && citation.length > 0 && <RichText.Content tagName="footer" value={ citation } /> }
 				</blockquote>
 			);
 		},

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -121,9 +121,7 @@ export const settings = {
 
 		return (
 			<blockquote className={ `align${ align }` }>
-				{ value && value.map( ( paragraph, i ) =>
-					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-				) }
+				<RichText.Content value={ toRichTextValue( value ) } />
 				{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>
 		);
@@ -144,9 +142,7 @@ export const settings = {
 
 			return (
 				<blockquote className={ `align${ align }` }>
-					{ value && value.map( ( paragraph, i ) =>
-						<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-					) }
+					<RichText.Content value={ toRichTextValue( value ) } />
 					{ citation && citation.length > 0 && <RichText.Content tagName="footer" value={ citation } /> }
 				</blockquote>
 			);

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -125,7 +125,7 @@ export const settings = {
 					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 				) }
 				{ citation && citation.length > 0 && (
-					<cite>{ citation }</cite>
+					<cite><RichText.Content>{ citation }</RichText.Content></cite>
 				) }
 			</blockquote>
 		);
@@ -150,7 +150,7 @@ export const settings = {
 						<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 					) }
 					{ citation && citation.length > 0 && (
-						<footer>{ citation }</footer>
+						<footer><RichText.Content>{ citation }</RichText.Content></footer>
 					) }
 				</blockquote>
 			);

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -246,7 +246,9 @@ export const settings = {
 					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 				) ) }
 				{ citation && citation.length > 0 && (
-					<cite>{ citation }</cite>
+					<cite>
+						<RichText.Content>{ citation }</RichText.Content>
+					</cite>
 				) }
 			</blockquote>
 		);
@@ -275,7 +277,9 @@ export const settings = {
 							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 						) ) }
 						{ citation && citation.length > 0 && (
-							<footer>{ citation }</footer>
+							<footer>
+								<RichText.Content>{ citation }</RichText.Content>
+							</footer>
 						) }
 					</blockquote>
 				);

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -245,11 +245,7 @@ export const settings = {
 				{ value.map( ( paragraph, i ) => (
 					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 				) ) }
-				{ citation && citation.length > 0 && (
-					<cite>
-						<RichText.Content>{ citation }</RichText.Content>
-					</cite>
-				) }
+				{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>
 		);
 	},
@@ -276,11 +272,7 @@ export const settings = {
 						{ value.map( ( paragraph, i ) => (
 							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 						) ) }
-						{ citation && citation.length > 0 && (
-							<footer>
-								<RichText.Content>{ citation }</RichText.Content>
-							</footer>
-						) }
+						{ citation && citation.length > 0 && <RichText.Content tagName="footer" value={ citation } /> }
 					</blockquote>
 				);
 			},

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -242,9 +242,7 @@ export const settings = {
 				className={ style === 2 ? 'is-large' : '' }
 				style={ { textAlign: align ? align : null } }
 			>
-				{ value.map( ( paragraph, i ) => (
-					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-				) ) }
+				<RichText.Content value={ toRichTextValue( value ) } />
 				{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>
 		);
@@ -269,9 +267,7 @@ export const settings = {
 						className={ `blocks-quote-style-${ style }` }
 						style={ { textAlign: align ? align : null } }
 					>
-						{ value.map( ( paragraph, i ) => (
-							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-						) ) }
+						<RichText.Content value={ toRichTextValue( value ) } />
 						{ citation && citation.length > 0 && <RichText.Content tagName="footer" value={ citation } /> }
 					</blockquote>
 				);

--- a/blocks/library/subhead/index.js
+++ b/blocks/library/subhead/index.js
@@ -79,9 +79,11 @@ export const settings = {
 		const { content } = attributes;
 
 		return (
-			<p className={ className }>
-				<RichText.Content>{ content }</RichText.Content>
-			</p>
+			<RichText.Content
+				tagName="p"
+				className={ className }
+				value={ content }
+			/>
 		);
 	},
 };

--- a/blocks/library/subhead/index.js
+++ b/blocks/library/subhead/index.js
@@ -78,6 +78,10 @@ export const settings = {
 	save( { attributes, className } ) {
 		const { content } = attributes;
 
-		return <p className={ className }>{ content }</p>;
+		return (
+			<p className={ className }>
+				<RichText.Content>{ content }</RichText.Content>
+			</p>
+		);
 	},
 };

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -85,9 +85,7 @@ export const settings = {
 	save( { attributes } ) {
 		const { content, align } = attributes;
 		return (
-			<table className={ align ? `align${ align }` : null }>
-				<RichText.Content>{ content }</RichText.Content>
-			</table>
+			<RichText.Content className={ align ? `align${ align }` : null } value={ content } />
 		);
 	},
 };

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -85,7 +85,7 @@ export const settings = {
 	save( { attributes } ) {
 		const { content, align } = attributes;
 		return (
-			<RichText.Content className={ align ? `align${ align }` : null } value={ content } />
+			<RichText.Content tagName="table" className={ align ? `align${ align }` : null } value={ content } />
 		);
 	},
 };

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -16,6 +16,7 @@ import './style.scss';
 import TableBlock from './table-block';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import RichText from '../../rich-text';
 
 export const name = 'core/table';
 
@@ -85,7 +86,7 @@ export const settings = {
 		const { content, align } = attributes;
 		return (
 			<table className={ align ? `align${ align }` : null }>
-				{ content }
+				<RichText.Content>{ content }</RichText.Content>
 			</table>
 		);
 	},

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -122,7 +122,11 @@ export const settings = {
 			<div className={ `align${ width } columns-${ columns }` }>
 				{ times( columns, ( index ) =>
 					<div className="wp-block-column" key={ `column-${ index }` }>
-						<p>{ content && content[ index ].children }</p>
+						<p>
+							<RichText.Content>
+								{ content && content[ index ].children }
+							</RichText.Content>
+						</p>
 					</div>
 				) }
 			</div>

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -122,11 +122,7 @@ export const settings = {
 			<div className={ `align${ width } columns-${ columns }` }>
 				{ times( columns, ( index ) =>
 					<div className="wp-block-column" key={ `column-${ index }` }>
-						<p>
-							<RichText.Content>
-								{ content && content[ index ].children }
-							</RichText.Content>
-						</p>
+						<RichText.Content tagName="p" value={ content && content[ index ].children } />
 					</div>
 				) }
 			</div>

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -71,9 +71,11 @@ export const settings = {
 
 	save( { attributes, className } ) {
 		return (
-			<pre className={ className }>
-				<RichText.Content>{ attributes.content }</RichText.Content>
-			</pre>
+			<RichText.Content
+				tagName="pre"
+				className={ className }
+				value={ attributes.content }
+			/>
 		);
 	},
 };

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -70,6 +70,10 @@ export const settings = {
 	},
 
 	save( { attributes, className } ) {
-		return <pre className={ className }>{ attributes.content }</pre>;
+		return (
+			<pre className={ className }>
+				<RichText.Content>{ attributes.content }</RichText.Content>
+			</pre>
+		);
 	},
 };

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -194,7 +194,11 @@ export const settings = {
 
 			<figure className={ align ? `align${ align }` : null }>
 				{ src && <video controls src={ src } /> }
-				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
+				{ caption && caption.length > 0 && (
+					<figcaption>
+						<RichText.Content>{ caption }</RichText.Content>
+					</figcaption>
+				) }
 			</figure>
 		);
 	},

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -194,11 +194,7 @@ export const settings = {
 
 			<figure className={ align ? `align${ align }` : null }>
 				{ src && <video controls src={ src } /> }
-				{ caption && caption.length > 0 && (
-					<figcaption>
-						<RichText.Content>{ caption }</RichText.Content>
-					</figcaption>
-				) }
+				{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 			</figure>
 		);
 	},

--- a/blocks/rich-text/README.md
+++ b/blocks/rich-text/README.md
@@ -69,6 +69,11 @@ a traditional `input` field, usually when the user exits the field.
 
 *Optional.* A list of autocompleters to use instead of the default.
 
+## RichText.Content
+
+When using RichText in the edit function of blocks, the usage of `RichText.Content` is recommended in the save function of your blocks to save the correct HTML.
+
+
 ## Example
 
 {% codetabs %}
@@ -95,6 +100,12 @@ wp.blocks.registerBlockType( /* ... */, {
 			}
 		} );
 	},
+
+	save: function() {
+		return wp.element.createElement( 'h2, {},
+			wp.element.createElement( wp.blocks.RichText.Content, {}, props.attributes.content )
+		);
+	}
 } );
 ```
 {% ESNext %}
@@ -122,6 +133,14 @@ registerBlockType( /* ... */, {
 			/>
 		);
 	},
+
+	save( { attributes } ) {
+		return (
+			<h2>
+				<RichText.Content>{attributes.content}</RichText.Content>
+			</h2>
+		);
+	}
 } );
 ```
 {% end %}

--- a/blocks/rich-text/README.md
+++ b/blocks/rich-text/README.md
@@ -102,9 +102,9 @@ wp.blocks.registerBlockType( /* ... */, {
 	},
 
 	save: function() {
-		return wp.element.createElement( 'h2, {},
-			wp.element.createElement( wp.blocks.RichText.Content, {}, props.attributes.content )
-		);
+		return wp.element.createElement( wp.blocks.RichText.Content, {
+			tagName: 'h2', value: props.attributes.content
+		} );
 	}
 } );
 ```
@@ -135,11 +135,7 @@ registerBlockType( /* ... */, {
 	},
 
 	save( { attributes } ) {
-		return (
-			<h2>
-				<RichText.Content>{attributes.content}</RichText.Content>
-			</h2>
-		);
+		return <RichText.Content tagName="h2" value={ attributes.content } />;
 	}
 } );
 ```

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -876,7 +876,7 @@ RichText.defaultProps = {
 	format: 'element',
 };
 
-RichText = compose( [
+const RichTextContainer = compose( [
 	withBlockEditContext,
 	withSelect( ( select, { isSelected, blockEditContext } ) => {
 		const { isViewportMatch = identity } = select( 'core/viewport' ) || {};
@@ -889,7 +889,7 @@ RichText = compose( [
 	withSafeTimeout,
 ] )( RichText );
 
-RichText.Content = ( { value, format = 'element', tagName: Tag, ...props } ) => {
+RichTextContainer.Content = ( { value, format = 'element', tagName: Tag, ...props } ) => {
 	let children;
 	switch ( format ) {
 		case 'string':
@@ -907,4 +907,4 @@ RichText.Content = ( { value, format = 'element', tagName: Tag, ...props } ) => 
 	return children;
 };
 
-export default RichText;
+export default RichTextContainer;

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -18,7 +18,7 @@ import 'element-closest';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment, compose } from '@wordpress/element';
+import { Component, Fragment, compose, RawHTML } from '@wordpress/element';
 import { keycodes, createBlobURL, isHorizontalEdge, getRectangleFromRange, getScrollContainer } from '@wordpress/utils';
 import { withSafeTimeout, Slot } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
@@ -876,7 +876,7 @@ RichText.defaultProps = {
 	format: 'element',
 };
 
-export default compose( [
+const RichTextContainer = compose( [
 	withBlockEditContext,
 	withSelect( ( select, { isSelected, blockEditContext } ) => {
 		const { isViewportMatch = identity } = select( 'core/viewport' ) || {};
@@ -888,3 +888,14 @@ export default compose( [
 	} ),
 	withSafeTimeout,
 ] )( RichText );
+
+RichTextContainer.Content = ( { children, format = 'element' } ) => {
+	switch ( format ) {
+		case 'string':
+			return <RawHTML>{ children }</RawHTML>;
+		default:
+			return children;
+	}
+};
+
+export default RichTextContainer;

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -876,7 +876,7 @@ RichText.defaultProps = {
 	format: 'element',
 };
 
-const RichTextContainer = compose( [
+RichText = compose( [
 	withBlockEditContext,
 	withSelect( ( select, { isSelected, blockEditContext } ) => {
 		const { isViewportMatch = identity } = select( 'core/viewport' ) || {};
@@ -889,13 +889,22 @@ const RichTextContainer = compose( [
 	withSafeTimeout,
 ] )( RichText );
 
-RichTextContainer.Content = ( { children, format = 'element' } ) => {
+RichText.Content = ( { value, format = 'element', tagName: Tag, ...props } ) => {
+	let children;
 	switch ( format ) {
 		case 'string':
-			return <RawHTML>{ children }</RawHTML>;
+			children = <RawHTML>{ value }</RawHTML>;
+			break;
 		default:
-			return children;
+			children = value;
+			break;
 	}
+
+	if ( Tag ) {
+		return <Tag { ...props }>{ children }</Tag>;
+	}
+
+	return children;
 };
 
-export default RichTextContainer;
+export default RichText;

--- a/docs/blocks/block-controls-toolbars-and-inspector.md
+++ b/docs/blocks/block-controls-toolbars-and-inspector.md
@@ -79,9 +79,11 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 		var content = props.attributes.content,
 			alignment = props.attributes.alignment;
 
-		return el( 'p', { className: props.className, style: { textAlign: alignment } },
-			el( RichText.Content, {}, content )
-		);
+		return el( RichText.Content, {
+			className: props.className,
+			style: { textAlign: alignment },
+			value: content
+		} );
 	},
 } );
 ```
@@ -146,9 +148,11 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 		const { content, alignment } = attributes;
 
 		return (
-			<p className={ className } style={ { textAlign: alignment } }>
-				<RichText.Content>{ content }</RichText.Content>
-			</p>
+			<RichText.Content
+				className={ className }
+				style={ { textAlign: alignment } }
+				value={ content }
+			/>
 		);
 	},
 } );

--- a/docs/blocks/block-controls-toolbars-and-inspector.md
+++ b/docs/blocks/block-controls-toolbars-and-inspector.md
@@ -79,7 +79,9 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 		var content = props.attributes.content,
 			alignment = props.attributes.alignment;
 
-		return el( 'p', { className: props.className, style: { textAlign: alignment } }, content );
+		return el( 'p', { className: props.className, style: { textAlign: alignment } },
+			el( RichText.Content, {}, content )
+		);
 	},
 } );
 ```
@@ -143,13 +145,17 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 	save( { attributes, className } ) {
 		const { content, alignment } = attributes;
 
-		return <p className={ className } style={ { textAlign: alignment } }>{ content }</p>;
+		return (
+			<p className={ className } style={ { textAlign: alignment } }>
+				<RichText.Content>{ content }</RichText.Content>
+			</p>
+		);
 	},
 } );
 ```
 {% end %}
 
-Note that `BlockControls` is only visible when the block is currently selected. 
+Note that `BlockControls` is only visible when the block is currently selected.
 
 ## Inspector
 

--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -51,9 +51,10 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 	save: function( props ) {
 		var content = props.attributes.content;
 
-		return el( 'p', { className: props.className },
-			el( RichText.Content, {}, content
-		);
+		return el( RichText.Content, {
+			className: props.className,
+			value: content
+		} );
 	},
 } );
 ```
@@ -97,9 +98,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 		const { content } = attributes;
 
 		return (
-			<p className={ className }>
-				<RichText.Content>{ content }</RichText.Content>
-			</p>
+			<RichText.Content className={ className } value={ content } />
 		);
 	},
 } );
@@ -118,4 +117,4 @@ The `RichText` component can be considered as a super-powered `textarea` element
 
 Implementing this behavior as a component enables you as the block implementer to be much more granular about editable fields. Your block may not need `RichText` at all, or it may need many independent `RichText` elements, each operating on a subset of the overall block state.
 
-Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `children` attribute source when extracting the value from saved content. You'll also most likely use `RichText.Content` in the `save` function to output RichText values.
+Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `children` attribute source when extracting the value from saved content. You'll also use `RichText.Content` in the `save` function to output RichText values.

--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -51,7 +51,9 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 	save: function( props ) {
 		var content = props.attributes.content;
 
-		return el( 'p', { className: props.className }, content );
+		return el( 'p', { className: props.className },
+			el( RichText.Content, {}, content
+		);
 	},
 } );
 ```
@@ -94,7 +96,11 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 	save( { attributes, className } ) {
 		const { content } = attributes;
 
-		return <p className={ className }>{ content }</p>;
+		return (
+			<p className={ className }>
+				<RichText.Content>{ content }</RichText.Content>
+			</p>
+		);
 	},
 } );
 ```
@@ -112,4 +118,4 @@ The `RichText` component can be considered as a super-powered `textarea` element
 
 Implementing this behavior as a component enables you as the block implementer to be much more granular about editable fields. Your block may not need `RichText` at all, or it may need many independent `RichText` elements, each operating on a subset of the overall block state.
 
-Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `children` attribute source when extracting the value from saved content.
+Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `children` attribute source when extracting the value from saved content. You'll also most likely use `RichText.Content` in the `save` function to output RichText values.


### PR DESCRIPTION
related #6034 

This PR adds a `RichText.Content` to clarify the usage of RichText values in the `save` function. Block authors don't need to know that the value is a react element and can be embedded. They just declare that it's a richtext value with a given format:

```js
<RichText.Content>{ value }</RichText.Content>
```

**Questions**

Right now the API of RichText.Content doesn't match directly the API of RichText so we end up with something like this:

```js
<RichText tagName="h2" value={ attributes.content ) /> // This is the edit function 

<h2><RichText.Content>{attributes.content}</RichText.Content></h2> // This is the save function
```

I was thinking that we could align both which means:

 - Adding `tagName` prop to `RichText.Content` 
 - Use `value` prop instead of `children`
 - Support `multiple` (if multiple is not false, don't render any parent tag name)

Thoughts?

**Notes**

One of the ideas behind this component is that it will allow us to switch the default format at some point (tree or string) with a clear deprecation strategy.