### PR TITLE
Editor: Ensure there is no blinking Toolbar when inserting blocks between lines

### DIFF
--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -19,6 +19,11 @@ class BlockInsertionPoint extends Component {
 		props.startTyping();
 	}
 
+	onFocus( event ) {
+		// Ensures that focus doesn't get propagated to BlockContextualToolbar
+		event.stopPropagation();
+	}
+
 	render() {
 		const { showInsertionPoint, showInserter } = this.props;
 
@@ -29,6 +34,7 @@ class BlockInsertionPoint extends Component {
 					<button
 						className="editor-block-list__insertion-point-inserter"
 						onClick={ this.onClick }
+						onFocus={ this.onFocus }
 						aria-label={ __( 'Insert block' ) }
 					/>
 				) }


### PR DESCRIPTION
## Description
When testing other PRs I noticed a very subtle bug where Block Toolbar blinks after you click on the in-between line inserter. This happens when you reach a very specific area close to the top and bottom edges. See screenshots.

This PR fixes this issue by preventing propagation of `focus` event to the `BlockContextualToolbar`. I'm not convinced this is the best solution in the long run, so happy to update if you have a better idea how to fix it.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

![unexpected-toolbar-up](https://user-images.githubusercontent.com/699132/38986937-5c7c10a2-43ce-11e8-9bf3-5dbe3fe48dc2.gif)
![unexpected-toolbar](https://user-images.githubusercontent.com/699132/38986938-5c9bb2cc-43ce-11e8-9095-f541de052f11.gif)


## Types of changes
 Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
