### PR TITLE
Make the block Remove button appear on focus.

### DIFF
--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -12,7 +12,7 @@ import { compose } from '@wordpress/element';
 import { withDispatch } from '@wordpress/data';
 import { withEditorSettings } from '@wordpress/blocks';
 
-export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, role } ) {
+export function BlockRemoveButton( { onRemove, onClick = noop, onFocus, onBlur, isLocked, role } ) {
 	if ( isLocked ) {
 		return null;
 	}
@@ -26,6 +26,8 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, role } 
 			icon="trash"
 			label={ label }
 			role={ role }
+			onFocus={ onFocus }
+			onBlur={ onBlur }
 		/>
 	);
 }

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -12,7 +12,7 @@ import { compose } from '@wordpress/element';
 import { withDispatch } from '@wordpress/data';
 import { withEditorSettings } from '@wordpress/blocks';
 
-export function BlockRemoveButton( { onRemove, onClick = noop, onFocus, onBlur, isLocked, role } ) {
+export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, role, ...props } ) {
 	if ( isLocked ) {
 		return null;
 	}
@@ -26,8 +26,7 @@ export function BlockRemoveButton( { onRemove, onClick = noop, onFocus, onBlur, 
 			icon="trash"
 			label={ label }
 			role={ role }
-			onFocus={ onFocus }
-			onBlur={ onBlur }
+			{ ...props }
 		/>
 	);
 }

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -101,7 +101,11 @@ export class BlockSettingsMenu extends Component {
 						</NavigableMenu>
 					) }
 				/>
-				<BlockRemoveButton uids={ uids } />
+				<BlockRemoveButton
+					uids={ uids }
+					onFocus={ this.onFocus }
+					onBlur={ this.onBlur }
+				/>
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR makes the block Remove button appear when focused using a keyboard.

Aside: I don't fully understand why JavaScript is used to control presentation, there's CSS for this. I've followed the existing pattern though.

Please also see the considerations about the placement of this button on the related issue.

See #6270 