### PR TITLE
Blocks: Remove obsolete `isSelected` usage (part 3)

### DIFF
--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -58,12 +58,11 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, className, isSelected } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { content } = attributes;
 
-		return [
+		return (
 			<RichText
-				key="block"
 				tagName="pre"
 				value={ content }
 				onChange={ ( nextContent ) => {
@@ -73,9 +72,8 @@ export const settings = {
 				} }
 				placeholder={ __( 'Write preformatted text…' ) }
 				wrapperClassName={ className }
-				isSelected={ isSelected }
-			/>,
-		];
+			/>
+		);
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -8,6 +8,7 @@ import { map } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { withState } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -72,47 +73,47 @@ export const settings = {
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const onSetActiveEditable = ( newEditable ) => () => setState( { editable: newEditable } );
 
-		return [
-			isSelected && (
-				<BlockControls key="controls">
+		return (
+			<Fragment>
+				<BlockControls>
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
 					/>
 				</BlockControls>
-			),
-			<blockquote key="quote" className={ className }>
-				<RichText
-					multiline="p"
-					value={ toRichTextValue( value ) }
-					onChange={
-						( nextValue ) => setAttributes( {
-							value: fromRichTextValue( nextValue ),
-						} )
-					}
-					/* translators: the text of the quotation */
-					placeholder={ __( 'Write quote…' ) }
-					wrapperClassName="blocks-pullquote__content"
-					isSelected={ isSelected && editable === 'content' }
-					onFocus={ onSetActiveEditable( 'content' ) }
-				/>
-				{ ( citation || isSelected ) && (
+				<blockquote className={ className }>
 					<RichText
-						tagName="cite"
-						value={ citation }
-						/* translators: the individual or entity quoted */
-						placeholder={ __( 'Write citation…' ) }
+						multiline="p"
+						value={ toRichTextValue( value ) }
 						onChange={
-							( nextCitation ) => setAttributes( {
-								citation: nextCitation,
+							( nextValue ) => setAttributes( {
+								value: fromRichTextValue( nextValue ),
 							} )
 						}
-						isSelected={ isSelected && editable === 'cite' }
-						onFocus={ onSetActiveEditable( 'cite' ) }
+						/* translators: the text of the quotation */
+						placeholder={ __( 'Write quote…' ) }
+						wrapperClassName="blocks-pullquote__content"
+						isSelected={ isSelected && editable === 'content' }
+						onFocus={ onSetActiveEditable( 'content' ) }
 					/>
-				) }
-			</blockquote>,
-		];
+					{ ( citation || isSelected ) && (
+						<RichText
+							tagName="cite"
+							value={ citation }
+							/* translators: the individual or entity quoted */
+							placeholder={ __( 'Write citation…' ) }
+							onChange={
+								( nextCitation ) => setAttributes( {
+									citation: nextCitation,
+								} )
+							}
+							isSelected={ isSelected && editable === 'cite' }
+							onFocus={ onSetActiveEditable( 'cite' ) }
+						/>
+					) }
+				</blockquote>
+			</Fragment>
+		);
 	} ),
 
 	save( { attributes } ) {

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Toolbar, withState } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -171,9 +172,9 @@ export const settings = {
 			setState( { editable: newEditable } );
 		};
 
-		return [
-			isSelected && (
-				<BlockControls key="controls">
+		return (
+			<Fragment>
+				<BlockControls>
 					<Toolbar controls={ [ 1, 2 ].map( ( variation ) => ( {
 						icon: 1 === variation ? 'format-quote' : 'testimonial',
 						title: sprintf( __( 'Quote style %d' ), variation ),
@@ -189,49 +190,48 @@ export const settings = {
 						} }
 					/>
 				</BlockControls>
-			),
-			<blockquote
-				key="quote"
-				className={ containerClassname }
-				style={ { textAlign: align } }
-			>
-				<RichText
-					multiline="p"
-					value={ toRichTextValue( value ) }
-					onChange={
-						( nextValue ) => setAttributes( {
-							value: fromRichTextValue( nextValue ),
-						} )
-					}
-					onMerge={ mergeBlocks }
-					onRemove={ ( forward ) => {
-						const hasEmptyCitation = ! citation || citation.length === 0;
-						if ( ! forward && hasEmptyCitation ) {
-							onReplace( [] );
-						}
-					} }
-					/* translators: the text of the quotation */
-					placeholder={ __( 'Write quote…' ) }
-					isSelected={ isSelected && editable === 'content' }
-					onFocus={ onSetActiveEditable( 'content' ) }
-				/>
-				{ ( ( citation && citation.length > 0 ) || isSelected ) && (
+				<blockquote
+					className={ containerClassname }
+					style={ { textAlign: align } }
+				>
 					<RichText
-						tagName="cite"
-						value={ citation }
+						multiline="p"
+						value={ toRichTextValue( value ) }
 						onChange={
-							( nextCitation ) => setAttributes( {
-								citation: nextCitation,
+							( nextValue ) => setAttributes( {
+								value: fromRichTextValue( nextValue ),
 							} )
 						}
-						/* translators: the individual or entity quoted */
-						placeholder={ __( 'Write citation…' ) }
-						isSelected={ isSelected && editable === 'cite' }
-						onFocus={ onSetActiveEditable( 'cite' ) }
+						onMerge={ mergeBlocks }
+						onRemove={ ( forward ) => {
+							const hasEmptyCitation = ! citation || citation.length === 0;
+							if ( ! forward && hasEmptyCitation ) {
+								onReplace( [] );
+							}
+						} }
+						/* translators: the text of the quotation */
+						placeholder={ __( 'Write quote…' ) }
+						isSelected={ isSelected && editable === 'content' }
+						onFocus={ onSetActiveEditable( 'content' ) }
 					/>
-				) }
-			</blockquote>,
-		];
+					{ ( ( citation && citation.length > 0 ) || isSelected ) && (
+						<RichText
+							tagName="cite"
+							value={ citation }
+							onChange={
+								( nextCitation ) => setAttributes( {
+									citation: nextCitation,
+								} )
+							}
+							/* translators: the individual or entity quoted */
+							placeholder={ __( 'Write citation…' ) }
+							isSelected={ isSelected && editable === 'cite' }
+							onFocus={ onSetActiveEditable( 'cite' ) }
+						/>
+					) }
+				</blockquote>
+			</Fragment>
+		);
 	} ),
 
 	save( { attributes } ) {

--- a/blocks/library/subhead/index.js
+++ b/blocks/library/subhead/index.js
@@ -57,13 +57,12 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, isSelected, className } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { content, placeholder } = attributes;
 
 		return (
 			<RichText
 				tagName="p"
-				key="editable"
 				value={ content }
 				onChange={ ( nextContent ) => {
 					setAttributes( {
@@ -72,7 +71,6 @@ export const settings = {
 				} }
 				className={ className }
 				placeholder={ placeholder || __( 'Write subhead…' ) }
-				isSelected={ isSelected }
 			/>
 		);
 	},

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -4,6 +4,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import './editor.scss';
@@ -56,25 +61,24 @@ export const settings = {
 	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { content } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
-		return [
-			isSelected && (
-				<BlockControls key="toolbar">
+		return (
+			<Fragment>
+				<BlockControls>
 					<BlockAlignmentToolbar
 						value={ attributes.align }
 						onChange={ updateAlignment }
 					/>
 				</BlockControls>
-			),
-			<TableBlock
-				key="editor"
-				onChange={ ( nextContent ) => {
-					setAttributes( { content: nextContent } );
-				} }
-				content={ content }
-				className={ className }
-				isSelected={ isSelected }
-			/>,
-		];
+				<TableBlock
+					onChange={ ( nextContent ) => {
+						setAttributes( { content: nextContent } );
+					} }
+					content={ content }
+					className={ className }
+					isSelected={ isSelected }
+				/>
+			</Fragment>
+		);
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { Toolbar, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -94,23 +94,21 @@ export default class TableBlock extends Component {
 	render() {
 		const { content, onChange, className, isSelected } = this.props;
 
-		return [
-			<RichText
-				key="editor"
-				tagName="table"
-				wrapperClassName={ className }
-				getSettings={ ( settings ) => ( {
-					...settings,
-					plugins: ( settings.plugins || [] ).concat( 'table' ),
-					table_tab_navigation: false,
-				} ) }
-				onSetup={ ( editor ) => this.handleSetup( editor, isSelected ) }
-				onChange={ onChange }
-				value={ content }
-				isSelected={ isSelected }
-			/>,
-			isSelected && (
-				<BlockControls key="menu">
+		return (
+			<Fragment>
+				<RichText
+					tagName="table"
+					wrapperClassName={ className }
+					getSettings={ ( settings ) => ( {
+						...settings,
+						plugins: ( settings.plugins || [] ).concat( 'table' ),
+						table_tab_navigation: false,
+					} ) }
+					onSetup={ ( editor ) => this.handleSetup( editor, isSelected ) }
+					onChange={ onChange }
+					value={ content }
+				/>
+				<BlockControls>
 					<Toolbar>
 						<DropdownMenu
 							icon="editor-table"
@@ -123,7 +121,7 @@ export default class TableBlock extends Component {
 						/>
 					</Toolbar>
 				</BlockControls>
-			),
-		];
+			</Fragment>
+		);
 	}
 }

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -50,7 +50,7 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, className, isSelected } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { content } = attributes;
 
 		return (
@@ -65,7 +65,6 @@ export const settings = {
 				placeholder={ __( 'Write…' ) }
 				wrapperClassName={ className }
 				formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
-				isSelected={ isSelected }
 			/>
 		);
 	},

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -13,7 +13,7 @@ import {
 	Placeholder,
 	Toolbar,
 } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { mediaUpload } from '@wordpress/utils';
 
 /**
@@ -102,8 +102,8 @@ export const settings = {
 			};
 			const setVideo = ( [ audio ] ) => onSelectVideo( audio );
 			const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setVideo, 'video' );
-			const controls = isSelected && (
-				<BlockControls key="controls">
+			const controls = (
+				<BlockControls>
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
@@ -122,66 +122,68 @@ export const settings = {
 			);
 
 			if ( editing ) {
-				return [
-					controls,
-					<Placeholder
-						key="placeholder"
-						icon="media-video"
-						label={ __( 'Video' ) }
-						instructions={ __( 'Select a video file from your library, or upload a new one' ) }
-						className={ className }>
-						<form onSubmit={ onSelectUrl }>
-							<input
-								type="url"
-								className="components-placeholder__input"
-								placeholder={ __( 'Enter URL of video file here…' ) }
-								onChange={ ( event ) => this.setState( { src: event.target.value } ) }
-								value={ src || '' } />
-							<Button
-								isLarge
-								type="submit">
-								{ __( 'Use URL' ) }
-							</Button>
-						</form>
-						<FormFileUpload
-							isLarge
-							className="wp-block-video__upload-button"
-							onChange={ uploadFromFiles }
-							accept="video/*"
-						>
-							{ __( 'Upload' ) }
-						</FormFileUpload>
-						<MediaUpload
-							onSelect={ onSelectVideo }
-							type="video"
-							id={ id }
-							render={ ( { open } ) => (
-								<Button isLarge onClick={ open } >
-									{ __( 'Media Library' ) }
+				return (
+					<Fragment>
+						{ controls }
+						<Placeholder
+							icon="media-video"
+							label={ __( 'Video' ) }
+							instructions={ __( 'Select a video file from your library, or upload a new one' ) }
+							className={ className }>
+							<form onSubmit={ onSelectUrl }>
+								<input
+									type="url"
+									className="components-placeholder__input"
+									placeholder={ __( 'Enter URL of video file here…' ) }
+									onChange={ ( event ) => this.setState( { src: event.target.value } ) }
+									value={ src || '' } />
+								<Button
+									isLarge
+									type="submit">
+									{ __( 'Use URL' ) }
 								</Button>
-							) }
-						/>
-					</Placeholder>,
-				];
+							</form>
+							<FormFileUpload
+								isLarge
+								className="wp-block-video__upload-button"
+								onChange={ uploadFromFiles }
+								accept="video/*"
+							>
+								{ __( 'Upload' ) }
+							</FormFileUpload>
+							<MediaUpload
+								onSelect={ onSelectVideo }
+								type="video"
+								id={ id }
+								render={ ( { open } ) => (
+									<Button isLarge onClick={ open } >
+										{ __( 'Media Library' ) }
+									</Button>
+								) }
+							/>
+						</Placeholder>
+					</Fragment>
+				);
 			}
 
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-			return [
-				controls,
-				<figure key="video" className={ className }>
-					<video controls src={ src } />
-					{ ( ( caption && caption.length ) || isSelected ) && (
-						<RichText
-							tagName="figcaption"
-							placeholder={ __( 'Write caption…' ) }
-							value={ caption }
-							onChange={ ( value ) => setAttributes( { caption: value } ) }
-							isSelected={ isSelected }
-							inlineToolbar
-						/>
-					) }
-				</figure>,
-			];
+			return (
+				<Fragment>
+					{ controls }
+					<figure className={ className }>
+						<video controls src={ src } />
+						{ ( ( caption && caption.length ) || isSelected ) && (
+							<RichText
+								tagName="figcaption"
+								placeholder={ __( 'Write caption…' ) }
+								value={ caption }
+								onChange={ ( value ) => setAttributes( { caption: value } ) }
+								inlineToolbar
+							/>
+						) }
+					</figure>
+				</Fragment>
+			);
 			/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		}
 	},


### PR DESCRIPTION
## Description
Closes #5633.

Follow up for #5029, #6201 and #6248.

> `isSelected` usage is no longer mandatory with `BlockControls`, `InspectorControls` and `RichText`. It's now handled by the editor internally to ensure that controls are visible only when the block is selected.

Refactored blocks:
- `Preformatted`
- `Pullquote`
- `Quote`
- `Tabel`
- `Text columns`
- `Subhead`
- `Verse`
- `Video`

This covers all core blocks  🎉 

When updating `Text columns` block I also fixed the following issue reported in #5633:

> The Text Columns block allows to create text over N columns. When creating a Text Columns block with 3 columns, and you attempt to change the formatting of the text in one column (i.e. add a link, make bold, etc), the text formatting toolbar appears 3 times. Furthermore, when adding a link, the "add link" popup will appear three times. This issue also scales, so when creating 5 columns, the formatting toolbar will show 5 times
> ![4 - 4col toolbar](https://user-images.githubusercontent.com/16672507/37458822-1b233104-283e-11e8-83bc-c0f39d90a250.PNG)

It should be much easier to review this diff without whitespace changes:

https://github.com/WordPress/gutenberg/pull/6280/files?w=1

## How has this been tested?
Manually, unit tests and e2e tests.


## Types of changes
Refactoring, no visual changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
