### PR TITLE
Missing trailing dot to viewable callback description for consistency in translatable strings

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -501,7 +501,7 @@ function gutenberg_register_rest_api_post_type_viewable() {
 		array(
 			'get_callback' => 'gutenberg_get_post_type_viewable',
 			'schema'       => array(
-				'description' => __( 'Whether or not the post type can be viewed', 'gutenberg' ),
+				'description' => __( 'Whether or not the post type can be viewed.', 'gutenberg' ),
 				'type'        => 'boolean',
 				'context'     => array( 'edit' ),
 				'readonly'    => true,


### PR DESCRIPTION
## Description
There is a missing trailing dot in `gutenberg_get_post_type_viewable` string content.
Since every other strings contain a trailing dot, I guess we need to add this one too, for consistency purpose.

## How has this been tested?
I found this small consistency issue by translating Gutenberg plugin into fr_FR locale.
This can be tested in viewable Rest field.

## Types of changes
Small i18n string change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Cheers,
Jb