### PR TITLE
Rich Text: Deprecate event proxying

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -19,7 +19,14 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { Component, Fragment, compose, RawHTML, createRef } from '@wordpress/element';
-import { keycodes, createBlobURL, isHorizontalEdge, getRectangleFromRange, getScrollContainer } from '@wordpress/utils';
+import {
+	keycodes,
+	createBlobURL,
+	isHorizontalEdge,
+	getRectangleFromRange,
+	getScrollContainer,
+	deprecated,
+} from '@wordpress/utils';
 import { withSafeTimeout, Slot } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
@@ -154,6 +161,19 @@ export class RichText extends Component {
 		this.editor = editor;
 
 		EVENTS.forEach( ( name ) => {
+			if ( ! this.props.hasOwnProperty( 'on' + name ) ) {
+				return;
+			}
+
+			deprecated( 'Raw TinyMCE event handlers for RichText', {
+				version: '3.0',
+				alternative: (
+					'Documented props, ancestor event handler, or onSetup ' +
+					'access to the internal editor instance event hub'
+				),
+				plugin: 'gutenberg',
+			} );
+
 			editor.on( name, this.proxyPropHandler( name ) );
 		} );
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -3,6 +3,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 ## 3.0.0
 
 - `wp.blocks.registerCoreBlocks` function removed. Please use `wp.coreBlocks.registerCoreBlocks` instead.
+- Raw TinyMCE event handlers for `RichText` have been deprecated. Please use [documented props](https://wordpress.org/gutenberg/handbook/block-api/rich-text-api/), ancestor event handler, or onSetup access to the internal editor instance event hub instead.
 
 ## 2.8.0
 


### PR DESCRIPTION
This pull request seeks to deprecate the `RichText` component's `proxyPropEvents` function, which handles and propagates a [full set of events](https://github.com/WordPress/gutenberg/blob/a1055928b76718dc363be410ad6b2f00ff367c2c/blocks/rich-text/constants.js#L1-L48) bound to TinyMCE.

There are a few motivations for this change:

- Performance. We are handling costly events such as `mousemove` for `RichText`.
- Explicitness. Be very clear about what props are supported for RichText.
- Consistency. Some callbacks like `onChange` have transforms applied in addition to the default event handling, and don't pass `event` as a callback argument.

This was originally introduced in the very first implementation of the autocompleter (#2630), where the autocompleter had applied props directly to the instance of `RichText`. This was refactored away in #2896.

Many alternatives exist, and are included in the deprecation message:

- [Documented props](https://github.com/WordPress/gutenberg/blob/master/blocks/rich-text/README.md)
- Ancestor element event handler
- `onSetup` and binding events directly to the internal editor instance

**Note:** This is not expected to have an impact on the majority usage of `RichText`. The `onChange` callback still behaves as it did previously.

__Testing instructions:__

Verify there are no regressions in the behavior of `RichText`.

Try adding an event like `onContextMenu` to a `RichText` element and verify that a deprecation warning occurs.