### PR TITLE
Move save post from editor to edit-post; Solve bug where update message appears before save is concluded.

### DIFF
--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -25,7 +25,6 @@ function Header( {
 	isPublishSidebarOpened,
 	togglePublishSidebar,
 	hasActiveMetaboxes,
-	isSaving,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
@@ -41,14 +40,12 @@ function Header( {
 				<div className="edit-post-header__settings">
 					<PostSavedState
 						forceIsDirty={ hasActiveMetaboxes }
-						forceIsSaving={ isSaving }
 					/>
 					<PostPreviewButton />
 					<PostPublishPanelToggle
 						isOpen={ isPublishSidebarOpened }
 						onToggle={ togglePublishSidebar }
 						forceIsDirty={ hasActiveMetaboxes }
-						forceIsSaving={ isSaving }
 					/>
 					<IconButton
 						icon="admin-generic"
@@ -69,7 +66,6 @@ export default compose(
 		isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
 		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
-		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 	} ) ),
 	withDispatch( ( dispatch ) => ( {
 		openGeneralSidebar: () => dispatch( 'core/edit-post' ).openGeneralSidebar( 'edit-post/document' ),

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -45,7 +45,6 @@ function Layout( {
 	closePublishSidebar,
 	metaBoxes,
 	hasActiveMetaboxes,
-	isSaving,
 	isMobileViewport,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
@@ -83,7 +82,6 @@ function Layout( {
 				<PostPublishPanel
 					onClose={ closePublishSidebar }
 					forceIsDirty={ hasActiveMetaboxes }
-					forceIsSaving={ isSaving }
 				/>
 			) }
 			<DocumentSidebar />
@@ -107,7 +105,6 @@ export default compose(
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
 		metaBoxes: select( 'core/edit-post' ).getMetaBoxes(),
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
-		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 	} ) ),
 	withDispatch( ( dispatch ) => ( {
 		closePublishSidebar: dispatch( 'core/edit-post' ).closePublishSidebar,

--- a/edit-post/store/utils.js
+++ b/edit-post/store/utils.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { subscribe } from '@wordpress/data';
+
+/**
  * Given a selector returns a functions that returns the listener only
  * if the returned value from the selector changes.
  *
@@ -15,4 +20,26 @@ export const onChangeListener = ( selector, listener ) => {
 			listener( selectedValue );
 		}
 	};
+};
+
+/**
+ * Given a selector, the desired value and a listener,
+ * the function calls the listener when the selector matches the passed value.
+ * If the selector does not matches the value right away the function subscribes to data module changes.
+ *
+ * @param  {function} selector Selector.
+ * @param  {*} value           The value to compare against the selector result.
+ * @param  {function} listener Listener to be called when selector matches value.
+ */
+export const onValueMatch = ( selector, value, listener ) => {
+	if ( selector() === value ) {
+		listener();
+		return;
+	}
+	const unsubscribe = subscribe( () => {
+		if ( selector() === value ) {
+			unsubscribe();
+			listener();
+		}
+	} );
 };

--- a/editor/components/post-publish-button/index.js
+++ b/editor/components/post-publish-button/index.js
@@ -27,7 +27,6 @@ export function PostPublishButton( {
 	isSaveable,
 	user,
 	onSubmit = noop,
-	forceIsSaving,
 } ) {
 	const isButtonEnabled = user.data && ! isSaving && isPublishable && isSaveable;
 	const isContributor = ! get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
@@ -61,13 +60,13 @@ export function PostPublishButton( {
 			disabled={ ! isButtonEnabled }
 			className={ className }
 		>
-			<PublishButtonLabel forceIsSaving={ forceIsSaving } />
+			<PublishButtonLabel />
 		</Button>
 	);
 }
 
 export default compose( [
-	withSelect( ( select, { forceIsSaving, forceIsDirty } ) => {
+	withSelect( ( select, { forceIsDirty } ) => {
 		const {
 			isSavingPost,
 			isEditedPostBeingScheduled,
@@ -77,7 +76,7 @@ export default compose( [
 			getCurrentPostType,
 		} = select( 'core/editor' );
 		return {
-			isSaving: forceIsSaving || isSavingPost(),
+			isSaving: isSavingPost(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			visibility: getEditedPostVisibility(),
 			isSaveable: isEditedPostSaveable(),

--- a/editor/components/post-publish-button/label.js
+++ b/editor/components/post-publish-button/label.js
@@ -46,7 +46,7 @@ export function PublishButtonLabel( {
 }
 
 export default compose( [
-	withSelect( ( select, { forceIsSaving } ) => {
+	withSelect( ( select ) => {
 		const {
 			isCurrentPostPublished,
 			isEditedPostBeingScheduled,
@@ -57,7 +57,7 @@ export default compose( [
 		return {
 			isPublished: isCurrentPostPublished(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
-			isSaving: forceIsSaving || isSavingPost(),
+			isSaving: isSavingPost(),
 			isPublishing: isPublishingPost(),
 			postType: getCurrentPostType(),
 		};

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -62,14 +62,14 @@ class PostPublishPanel extends Component {
 	}
 
 	render() {
-		const { isScheduled, onClose, forceIsDirty, forceIsSaving } = this.props;
+		const { isScheduled, onClose, forceIsDirty } = this.props;
 		const { loading, submitted } = this.state;
 		return (
 			<div className="editor-post-publish-panel">
 				<div className="editor-post-publish-panel__header">
 					{ ! submitted && (
 						<div className="editor-post-publish-panel__header-publish-button">
-							<PostPublishButton onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
+							<PostPublishButton onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } />
 						</div>
 					) }
 					{ submitted && (

--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -28,10 +28,9 @@ function PostPublishPanelToggle( {
 	onToggle,
 	isOpen,
 	forceIsDirty,
-	forceIsSaving,
 } ) {
 	const isButtonEnabled = (
-		! isSaving && ! forceIsSaving && isPublishable && isSaveable
+		! isSaving && isPublishable && isSaveable
 	) || isPublished;
 
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
@@ -39,7 +38,7 @@ function PostPublishPanelToggle( {
 	const showToggle = ! isPublished && ! ( isScheduled && isBeingScheduled ) && ! ( isPending && isContributor );
 
 	if ( ! showToggle ) {
-		return <PostPublishButton forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />;
+		return <PostPublishButton forceIsDirty={ forceIsDirty } />;
 	}
 
 	return (

--- a/editor/components/post-saved-state/index.js
+++ b/editor/components/post-saved-state/index.js
@@ -76,7 +76,7 @@ export class PostSavedState extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { forceIsDirty, forceIsSaving } ) => {
+	withSelect( ( select, { forceIsDirty } ) => {
 		const {
 			isEditedPostNew,
 			isCurrentPostPublished,
@@ -90,7 +90,7 @@ export default compose( [
 			isNew: isEditedPostNew(),
 			isPublished: isCurrentPostPublished(),
 			isDirty: forceIsDirty || isEditedPostDirty(),
-			isSaving: forceIsSaving || isSavingPost(),
+			isSaving: isSavingPost(),
 			isSaveable: isEditedPostSaveable(),
 		};
 	} ),

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import uuid from 'uuid/v4';
+import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
 import { partial, castArray } from 'lodash';
 
 /**
@@ -11,6 +12,13 @@ import {
 	getDefaultBlockName,
 	createBlock,
 } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import {
+	POST_UPDATE_TRANSACTION_ID,
+} from './selectors';
 
 /**
  * Returns an action object used in signalling that editor has initialized with
@@ -664,5 +672,55 @@ export function insertDefaultBlock( attributes, rootUID, index ) {
 	return {
 		...insertBlock( block, index, rootUID ),
 		isProvisional: true,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the post update process started.
+ *
+ * @param {Object} edits Object representing the editions the post contains.
+ *
+ * @return {Object} Action object
+ */
+export function updatePost( edits ) {
+	return {
+		type: 'UPDATE_POST',
+		edits: edits,
+		optimist: { type: BEGIN, id: POST_UPDATE_TRANSACTION_ID },
+	};
+}
+
+/**
+ * Returns an action object used to signal that the post update process ended with success.
+ *
+ * @param {Object} edits        Object representing the editions the post contains.
+ * @param {Object} previousPost Object containing a representation of the post when the update process started.
+ * @param {Object} post         Object containing a new representation of the post after the update.
+ *
+ * @return {Object} Action object
+ */
+export function requestPostUpdateSuccess( edits, previousPost, post ) {
+	return {
+		type: 'REQUEST_POST_UPDATE_SUCCESS',
+		...{ previousPost, post, edits },
+		optimist: { type: COMMIT, id: POST_UPDATE_TRANSACTION_ID },
+
+	};
+}
+
+/**
+ * Returns an action object used to signal that the post update process failed.
+ *
+ * @param {Object} edits Object representing the editions the post contains.
+ * @param {Object} post  Object containing a representation of the post when the update process started.
+ * @param {string} error Message with the specifying why the post update failed.
+ *
+ * @return {Object} Action object
+ */
+export function requestPostUpdateFailure( edits, post, error ) {
+	return {
+		type: 'REQUEST_POST_UPDATE_FAILURE',
+		...{ post, edits, error },
+		optimist: { type: REVERT, id: POST_UPDATE_TRANSACTION_ID },
 	};
 }

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -47,8 +47,6 @@ import {
 import {
 	getCurrentPost,
 	getCurrentPostType,
-	getEditedPostContent,
-	getPostEdits,
 	isCurrentPostPublished,
 	isEditedPostDirty,
 	isEditedPostNew,
@@ -63,7 +61,6 @@ import {
 	getSelectedBlock,
 	isBlockSelected,
 	getTemplate,
-	POST_UPDATE_TRANSACTION_ID,
 	getTemplateLock,
 } from './selectors';
 
@@ -93,47 +90,8 @@ export function removeProvisionalBlock( action, store ) {
 
 export default {
 	REQUEST_POST_UPDATE( action, store ) {
-		const { dispatch, getState } = store;
-		const state = getState();
-		const post = getCurrentPost( state );
-		const edits = getPostEdits( state );
-		const toSend = {
-			...edits,
-			content: getEditedPostContent( state ),
-			id: post.id,
-		};
-
-		dispatch( {
-			type: 'UPDATE_POST',
-			edits: toSend,
-			optimist: { type: BEGIN, id: POST_UPDATE_TRANSACTION_ID },
-		} );
+		const { dispatch } = store;
 		dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
-		const basePath = wp.api.getPostTypeRoute( getCurrentPostType( state ) );
-		wp.apiRequest( { path: `/wp/v2/${ basePath }/${ post.id }`, method: 'PUT', data: toSend } ).then(
-			( newPost ) => {
-				dispatch( resetPost( newPost ) );
-				dispatch( {
-					type: 'REQUEST_POST_UPDATE_SUCCESS',
-					previousPost: post,
-					post: newPost,
-					edits: toSend,
-					optimist: { type: COMMIT, id: POST_UPDATE_TRANSACTION_ID },
-				} );
-			},
-			( err ) => {
-				dispatch( {
-					type: 'REQUEST_POST_UPDATE_FAILURE',
-					error: get( err, 'responseJSON', {
-						code: 'unknown_error',
-						message: __( 'An unknown error occurred.' ),
-					} ),
-					post,
-					edits,
-					optimist: { type: REVERT, id: POST_UPDATE_TRANSACTION_ID },
-				} );
-			}
-		);
 	},
 	REQUEST_POST_UPDATE_SUCCESS( action, store ) {
 		const { previousPost, post } = action;


### PR DESCRIPTION
The PR moves the request to save the post from editor module to the edit-post module.
Conceptually I think this change makes sense as the edit post should be the one saving the pos. In an alternative implementation, the logic can even be different and use localStorage for example. The editor should not handle saving.

The edit post already had an event to check when post update was in progress in order to save meta boxes. Meta boxes were only saved after post itself is saved. The update button stayed with update state until both post and meta boxes are saved, a special prop was passed down just to handle the meta boxes save state. The post-update message was shown right after the post was updated, this caused a temporary difference between what the message said (post was updated) and what the button showed (update is in progress). This PR simplifies this logic and fixes this problem, the flag for meta boxes save state was removed as it is no longer required. The post-update action is only dispatched when both post and meta boxes are saved, so isSaving state of the post now includes the metaboxes.

Fixes:
https://github.com/WordPress/gutenberg/issues/5868

## How has this been tested?
Try to save posts, publish, schedule, with and without meta boxes, verify the post is always correctly saved. And the update message appears at the same time the update state is removed from the button.

## Screenshots <!-- if applicable -->
Before:
![apr-19-2018 17-23-26](https://user-images.githubusercontent.com/11271197/39004856-6e21bc1c-43f6-11e8-89ba-e1321332e1cf.gif)
After:
![apr-19-2018 17-22-39](https://user-images.githubusercontent.com/11271197/39004871-7599e348-43f6-11e8-9f3a-0e81a4971788.gif)



