### PR TITLE
Hide body scrollbar on gutenberg editor page (#6094)

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -44,6 +44,10 @@
 	}
 }
 
+body.gutenberg-editor-page::-webkit-scrollbar {
+	display: none;
+}
+
 body.gutenberg-editor-page {
 	background: $white;
 


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/issues/6094