### PR TITLE
Fix Markdown paste containing HTML

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -42,7 +42,7 @@ import slackMarkdownVariantCorrector from './slack-markdown-variant-corrector';
  *
  * @return {Array|string} A list of blocks or a string, depending on `handlerMode`.
  */
-export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagName, canUserUseUnfilteredHTML = false } ) {
+export default function rawHandler( { HTML = '', plainText = '', mode = 'AUTO', tagName, canUserUseUnfilteredHTML = false } ) {
 	// First of all, strip any meta tags.
 	HTML = HTML.replace( /<meta[^>]+>/, '' );
 
@@ -54,7 +54,7 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 	// Parse Markdown (and HTML) if:
 	// * There is a plain text version.
 	// * The HTML version has no formatting.
-	if ( plainText && isPlain( HTML ) ) {
+	if ( plainText && ( ! HTML || isPlain( HTML ) ) ) {
 		const converter = new showdown.Converter();
 
 		converter.setOption( 'noHeaderId', true );

--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -51,9 +51,9 @@ export default function rawHandler( { HTML = '', plainText = '', mode = 'AUTO', 
 		return parseWithGrammar( HTML );
 	}
 
-	// Parse Markdown (and HTML) if:
+	// Parse Markdown (and encoded HTML) if:
 	// * There is a plain text version.
-	// * The HTML version has no formatting.
+	// * There is no HTML version, or it has no formatting.
 	if ( plainText && ( ! HTML || isPlain( HTML ) ) ) {
 		const converter = new showdown.Converter();
 

--- a/blocks/api/raw-handling/test/index.js
+++ b/blocks/api/raw-handling/test/index.js
@@ -134,6 +134,16 @@ describe( 'rawHandler', () => {
 
 		equal( filtered, '<p>Some <strong>bold</strong> text.</p>' );
 	} );
+
+	it( 'should parse Markdown with HTML', () => {
+		const filtered = rawHandler( {
+			HTML: '',
+			plainText: '# Some <em>heading</em>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		equal( filtered, '<h1>Some <em>heading</em></h1>' );
+	} );
 } );
 
 import './integration';

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -301,7 +301,7 @@ export class RichText extends Component {
 	 *                                     by tinyMCE.
 	 */
 	onPastePreProcess( event ) {
-		const HTML = this.isPlainTextPaste ? this.pastedPlainText : event.content;
+		const HTML = this.isPlainTextPaste ? '' : event.content;
 		// Allows us to ask for this information when we get a report.
 		window.console.log( 'Received HTML:\n\n', HTML );
 		window.console.log( 'Received plain text:\n\n', this.pastedPlainText );


### PR DESCRIPTION
## Description
This branch fixes the following issue: when pasting Markdown that contains any (unencoded) HTML, `isPlain( HTML )` will stumble upon the tag and return false, skipping Markdown parsing and pasting the content inline. The solution here is to not pass any HTML at all to the `rawHandler` when no HTML has been pasted.

## How has this been tested?
Paste any Markdown that contains HTML tags (which is valid Markdown). On the master branch this will not paste nicely (inline). On this branch the Markdown should be parsed and blocks should be inserted.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
