### PR TITLE
Try to make the inline toolbars navigable toolbars and make Alt+F10 work

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -22,6 +22,7 @@ import { Component, Fragment, compose } from '@wordpress/element';
 import { keycodes, createBlobURL, isHorizontalEdge, getRectangleFromRange, getScrollContainer } from '@wordpress/utils';
 import { withSafeTimeout, Slot } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -37,6 +38,7 @@ import patterns from './patterns';
 import { EVENTS } from './constants';
 import { withBlockEditContext } from '../block-edit/context';
 import { domToFormat, valueToString, isEmpty } from './format';
+import NavigableToolbar from '../../editor/components/navigable-toolbar';
 
 const { BACKSPACE, DELETE, ENTER } = keycodes;
 
@@ -822,9 +824,12 @@ export class RichText extends Component {
 					</BlockFormatControls>
 				) }
 				{ isSelected && inlineToolbar && (
-					<div className="block-rich-text__inline-toolbar">
+					<NavigableToolbar
+						className="block-rich-text__inline-toolbar"
+						aria-label={ __( 'Block secondary controls' ) }
+					>
 						{ formatToolbar }
-					</div>
+					</NavigableToolbar>
 				) }
 				<Autocomplete onReplace={ this.props.onReplace } completers={ autocompleters }>
 					{ ( { isExpanded, listBoxId, activeId } ) => (

--- a/editor/components/block-list/block-contextual-toolbar.js
+++ b/editor/components/block-list/block-contextual-toolbar.js
@@ -13,7 +13,7 @@ function BlockContextualToolbar() {
 	return (
 		<NavigableToolbar
 			className="editor-block-contextual-toolbar"
-			aria-label={ __( 'Block Toolbar' ) }
+			aria-label={ __( 'Block controls' ) }
 		>
 			<BlockToolbar />
 		</NavigableToolbar>

--- a/editor/components/navigable-toolbar/index.js
+++ b/editor/components/navigable-toolbar/index.js
@@ -7,7 +7,7 @@ import { cond, matchesProperty } from 'lodash';
  * WordPress dependencies
  */
 import { NavigableMenu, KeyboardShortcuts } from '@wordpress/components';
-import { Component, findDOMNode } from '@wordpress/element';
+import { Component, findDOMNode, createRef } from '@wordpress/element';
 import { focus, keycodes } from '@wordpress/utils';
 
 /**
@@ -25,7 +25,7 @@ class NavigableToolbar extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.bindNode = this.bindNode.bind( this );
+		this.toolbar = createRef();
 		this.focusToolbar = this.focusToolbar.bind( this );
 		this.focusSelection = this.focusSelection.bind( this );
 
@@ -34,15 +34,13 @@ class NavigableToolbar extends Component {
 		] );
 	}
 
-	bindNode( ref ) {
+	focusToolbar() {
 		// Disable reason: Need DOM node for finding first focusable element
 		// on keyboard interaction to shift to toolbar.
 		// eslint-disable-next-line react/no-find-dom-node
-		this.toolbar = findDOMNode( ref );
-	}
+		const toolbar = findDOMNode( this.toolbar.current );
 
-	focusToolbar() {
-		const tabbables = focus.tabbable.find( this.toolbar );
+		const tabbables = focus.tabbable.find( toolbar );
 		if ( tabbables.length ) {
 			tabbables[ 0 ].focus();
 		}
@@ -79,7 +77,7 @@ class NavigableToolbar extends Component {
 				orientation="horizontal"
 				role="toolbar"
 				deep
-				ref={ this.bindNode }
+				ref={ this.toolbar }
 				onKeyDown={ this.switchOnKeyDown }
 				{ ...props }
 			>


### PR DESCRIPTION
Work in progress, don't merge.

Inline toolbars should work like the block toolbars: 
- Alt+F10 should move focus from the editable field to the inline toolbar
- arrows navigation should work in the inline toolbars
- Escape should move focus back to the editable field

This was quickly discussed in #5840 together with a couple other issues. Was thinking a bit at this and seems to me the most logical thing would be wrapping the inline toolbar within a `NavigableToolbar` component. And it works, in a way. It's amazing to see how reusing a component in a bit unexpected way works because the component is abstracted enough that it just works 🙂 

However, playing with this highlighted an issue with `focusToolbar()` because it assumes there's just one toolbar. Actually, there may be up to three toolbars:

![screen shot 2018-04-20 at 08 43 43](https://user-images.githubusercontent.com/1682452/39035003-c4063c7a-4478-11e8-927c-640f150ed8f6.jpg)

Also on current master, when pressing Alt+F10 `focusToolbar()` returns two toolbars (depending also on the "fix to top" option) and it works just by coincidence because the last toolbar happens to be the right one. I guess some DOM methods could help getting the right toolbar but that would be fragile and non-Reactish. The main issue I see here is that when pressing Alt+F10, the focus/selection methods used here don't know 1) the selected block 2) the field being edited 3) which toolbar is the one to move focus to.

Considering also some blocks, for example the cover image, are going to be nested blocks, how can we preserve the Alt+F10 functionality and give the application knowledge of which toolbar to focus?

/Cc @aduth @youknowriad 