### PR TITLE
Fix a race condition in withAPIData()

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -164,12 +164,16 @@ export default ( mapPropsToData ) => createHigherOrderComponent( ( WrappedCompon
 
 			const mapping = mapPropsToData( props, this.routeHelpers );
 			const nextDataProps = reduce( mapping, ( result, path, propName ) => {
-				// Skip if mapping already assigned into state data props
-				// Exmaple: Component updates with one new prop and other
+				// Skip if mapping already assigned into state data props,
+				// and the request isn't pending.
+				// Example: Component updates with one new prop and other
 				// previously existing; previously existing should not be
 				// clobbered or re-trigger fetch
 				const dataProp = dataProps[ propName ];
-				if ( dataProp && dataProp.path === path ) {
+				if ( dataProp && dataProp.path === path &&
+						! dataProp.isLoading && ! dataProp.isCreating &&
+						! dataProp.isSaving && ! dataProp.isPatching &&
+						! dataProp.isDeleting ) {
 					result[ propName ] = dataProp;
 					return result;
 				}

--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -164,16 +164,12 @@ export default ( mapPropsToData ) => createHigherOrderComponent( ( WrappedCompon
 
 			const mapping = mapPropsToData( props, this.routeHelpers );
 			const nextDataProps = reduce( mapping, ( result, path, propName ) => {
-				// Skip if mapping already assigned into state data props,
-				// and the request isn't pending.
-				// Example: Component updates with one new prop and other
+				// Skip if mapping already assigned into state data props
+				// Exmaple: Component updates with one new prop and other
 				// previously existing; previously existing should not be
 				// clobbered or re-trigger fetch
 				const dataProp = dataProps[ propName ];
-				if ( dataProp && dataProp.path === path &&
-						! dataProp.isLoading && ! dataProp.isCreating &&
-						! dataProp.isSaving && ! dataProp.isPatching &&
-						! dataProp.isDeleting ) {
+				if ( dataProp && dataProp.path === path ) {
 					result[ propName ] = dataProp;
 					return result;
 				}


### PR DESCRIPTION
## Description

When mapping data returned from the API to a component's props, we currently re-use data that's already stored in `APIDataComponent`'s state. However, this causes a race condition when simultaneously receiving multiple copies of the same API request, triggered by multiple copies of the same component. The effect of this, is that some instances of the component don't receive the data sent back their API request, as demonstrated in #6277.

A simple workaround for this is to only re-use the state data when the request is complete, as this PR does.

A more comprehensive solution would probably involve merging all of the identical `GET` requests into one, and populating the response for all of them from a single API call. Multi-threaded caching is fraught with danger, however, and I don't think it's a blocker for this smaller fix.

