### PR TITLE
Try: Fix caption widths using CSS variable

### DIFF
--- a/core-blocks/image/block.js
+++ b/core-blocks/image/block.js
@@ -295,12 +295,17 @@ class ImageBlock extends Component {
 			</InspectorControls>
 		);
 
+		// Pass optional width as variable
+		const figureWidth = {
+			'--caption-width': width + 'px',
+		};
+
 		// Disable reason: Each block can be selected by clicking on it
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<Fragment>
 				{ controls }
-				<figure className={ classes }>
+				<figure className={ classes } style={ figureWidth }>
 					<ImageSize src={ url } dirtynessTrigger={ align }>
 						{ ( sizes ) => {
 							const {

--- a/core-blocks/image/editor.scss
+++ b/core-blocks/image/editor.scss
@@ -114,13 +114,19 @@
 	}
 }
 
-.editor-block-list__block[data-type="core/image"] .editor-block-toolbar .blocks-format-toolbar__link-modal {
-	position: absolute;
-	left: 0;
-	right: 0;
-	margin: -1px 0;
+.editor-block-list__block[data-type="core/image"] {
+	.editor-block-toolbar .blocks-format-toolbar__link-modal {
+		position: absolute;
+		left: 0;
+		right: 0;
+		margin: -1px 0;
 
-	@include break-small() {
-		margin: -1px;
+		@include break-small() {
+			margin: -1px;
+		}
+	}
+
+	&[data-resized=true] figcaption {
+		max-width: var( --caption-width ); // use optional width variable for captions
 	}
 }

--- a/core-blocks/image/editor.scss
+++ b/core-blocks/image/editor.scss
@@ -126,6 +126,7 @@
 		}
 	}
 
+	.is-resized figcaption,
 	&[data-resized=true] figcaption {
 		max-width: var( --caption-width ); // use optional width variable for captions
 	}

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -104,6 +104,7 @@
 	margin-left: auto;
 	margin-right: auto;
 	position: relative;
+	clear: both; // Clear floats
 
 	&[data-root-uid=""] .editor-default-block-appender__content:hover {
 		// Outline on root-level default block appender is redundant with the


### PR DESCRIPTION
This is a try branch.

Since merging in changes to the Image Block that leverage `fit-content` to allow the `figure` to collapse in width around the image inside, captions on resized images
have regressed. Specifically because the figcaption needs a max-width or it'll be wider than the image itself.

This PR fixes that. It works in Safari, Chrome, Firefox.

Not only does it fix that, but it does so in an "optional way". I.e. should we choose to expand this to the frontend as well, there aren't any obscure inline styles to override — there are only inline styles that you can _leverage_ in your own way.

That's the good news.

If you look closely at the code you'll notice that it is perhaps bordering on _hack territory_. Look at this codepen for the details: https://codepen.io/joen/pen/RyPaLY — specifically, in order to avoid creating an inline style that you can only override using !important, it uses CSS variables that you can then choose to use or not.

Would love your thoughts on this. It solves a very specific problem, without handcuffing themers.

Screenshot, before:

<img width="725" alt="screen shot 2018-04-20 at 09 27 58" src="https://user-images.githubusercontent.com/1204802/39037510-01a618b8-4481-11e8-8687-2d0cc644099c.png">

After:

<img width="388" alt="screen shot 2018-04-20 at 09 48 22" src="https://user-images.githubusercontent.com/1204802/39037516-05b8f588-4481-11e8-928a-d135848dd23c.png">

Edit: oh, and I threw in a little appender fix for good measure (ノ^v^)ノ彡┻━┻