### PR TITLE
URL input polish

### DIFF
--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -184,7 +184,7 @@ class FormatToolbar extends Component {
 
 				{ ( isAddingLink || isEditingLink || formats.link ) && (
 					<Fill name="RichText.Siblings">
-						<div style={ { position: 'absolute', transform: 'translateX( -50% )', ...focusPosition } }>
+						<div className="blocks-format-toolbar__link-container" style={ { ...focusPosition } }>
 							{ ( isAddingLink || isEditingLink ) && (
 								// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
 								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -184,7 +184,7 @@ class FormatToolbar extends Component {
 
 				{ ( isAddingLink || isEditingLink || formats.link ) && (
 					<Fill name="RichText.Siblings">
-						<div style={ { position: 'absolute', ...focusPosition } }>
+						<div style={ { position: 'absolute', transform: 'translateX( -50% )', ...focusPosition } }>
 							{ ( isAddingLink || isEditingLink ) && (
 								// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
 								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -14,6 +14,12 @@
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 	z-index: z-index( '.blocks-format-toolbar__link-modal' );
+
+	.edit-post-header-toolbar__block-toolbar & {
+		position: absolute;
+    	left: 0;
+		right: 0;
+	}
 }
 
 .blocks-format-toolbar__link-modal-line {

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -4,7 +4,6 @@
 
 .blocks-format-toolbar__link-modal {
 	position: relative;
-	//left: -50%;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;
@@ -17,9 +16,15 @@
 
 	.edit-post-header-toolbar__block-toolbar & {
 		position: absolute;
-    	left: 0;
+		left: 0;
 		right: 0;
 	}
+}
+
+.blocks-format-toolbar__link-container {
+    position: absolute;
+	transform: translateX( -50% );
+	z-index: z-index( '.blocks-format-toolbar__link-container' );
 }
 
 .blocks-format-toolbar__link-modal-line {

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -4,7 +4,7 @@
 
 .blocks-format-toolbar__link-modal {
 	position: relative;
-	left: -50%;
+	//left: -50%;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -22,7 +22,7 @@
 }
 
 .blocks-format-toolbar__link-container {
-    position: absolute;
+	position: absolute;
 	transform: translateX( -50% );
 	z-index: z-index( '.blocks-format-toolbar__link-container' );
 }

--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -2,6 +2,7 @@
 $input-padding: 10px;
 $input-size: 230px;
 
+.editor-block-list__block .blocks-url-input,
 .editor-block-toolbar .blocks-url-input {
 	width: 100%;
 	flex-grow: 1;

--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -2,7 +2,7 @@
 $input-padding: 10px;
 $input-size: 230px;
 
-.editor-block-list__block .blocks-url-input {
+.editor-block-toolbar .blocks-url-input {
 	width: 100%;
 	flex-grow: 1;
 	position: relative;

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -22,6 +22,7 @@ $z-layers: (
 	'.components-popover__close': 5,
 	'.editor-block-list__insertion-point': 5,
 	'.blocks-format-toolbar__link-modal': 81, // should appear above block controls
+	'.blocks-format-toolbar__link-container': 81, // link suggestions should also
 	'.blocks-gallery-item__inline-menu': 20,
 	'.editor-block-settings-menu__popover': 21, // Below the header, but above the block toolbar
 	'.blocks-url-input__suggestions': 30,

--- a/editor/components/block-toolbar/style.scss
+++ b/editor/components/block-toolbar/style.scss
@@ -4,6 +4,7 @@
 	width: 100%;
 	background: $white;
 	overflow: auto; // allow horizontal scrolling on mobile
+	position: relative;
 
 	// allow overflow on desktop
 	@include break-small() {


### PR DESCRIPTION
This PR fixes two issues with the URL input dialog.

The first issue is that the URL bar, in very tight circumstances, would create a horizontal scrollbar — because it was abs positioned at the center of where it needed to be and then pulled leftwards 50% — but the invisible div was still poking out at the right. First commit fixes this.

The second was a scoping issue with the URL input when used for the Image block, when toolbar is fixed to top. This fixes that:

<img width="458" alt="screen shot 2018-04-20 at 10 17 36" src="https://user-images.githubusercontent.com/1204802/39038804-9fda72ec-4484-11e8-8b0a-41f67dc7f6b5.png">
