### PR TITLE
Block: Avoid creating a new prop uids prop on each block rerender

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -520,7 +520,7 @@ export class BlockListBlock extends Component {
 				/>
 				{ shouldRenderMovers && (
 					<BlockMover
-						uids={ [ uid ] }
+						uids={ uid }
 						rootUID={ rootUID }
 						layout={ layout }
 						isFirst={ isFirst }
@@ -530,7 +530,7 @@ export class BlockListBlock extends Component {
 				) }
 				{ shouldRenderBlockSettings && (
 					<BlockSettingsMenu
-						uids={ [ uid ] }
+						uids={ uid }
 						rootUID={ rootUID }
 						renderBlockMenu={ renderBlockMenu }
 						isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'right' }

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -45,7 +45,7 @@ export class BlockMover extends Component {
 	render() {
 		const { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked, instanceId, isHidden } = this.props;
 		const { isFocused } = this.state;
-		const countBlocks = castArray( uids ).length;
+		const blocksCount = castArray( uids ).length;
 		if ( isLocked ) {
 			return null;
 		}
@@ -79,7 +79,7 @@ export class BlockMover extends Component {
 				<span id={ `editor-block-mover__up-description-${ instanceId }` } className="editor-block-mover__description">
 					{
 						getBlockMoverDescription(
-							countBlocks,
+							blocksCount,
 							blockType && blockType.title,
 							firstIndex,
 							isFirst,
@@ -91,7 +91,7 @@ export class BlockMover extends Component {
 				<span id={ `editor-block-mover__down-description-${ instanceId }` } className="editor-block-mover__description">
 					{
 						getBlockMoverDescription(
-							countBlocks,
+							blocksCount,
 							blockType && blockType.title,
 							firstIndex,
 							isFirst,

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { first, partial } from 'lodash';
+import { first, partial, castArray } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -45,6 +45,7 @@ export class BlockMover extends Component {
 	render() {
 		const { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked, instanceId, isHidden } = this.props;
 		const { isFocused } = this.state;
+		const countBlocks = castArray( uids ).length;
 		if ( isLocked ) {
 			return null;
 		}
@@ -78,7 +79,7 @@ export class BlockMover extends Component {
 				<span id={ `editor-block-mover__up-description-${ instanceId }` } className="editor-block-mover__description">
 					{
 						getBlockMoverDescription(
-							uids.length,
+							countBlocks,
 							blockType && blockType.title,
 							firstIndex,
 							isFirst,
@@ -90,7 +91,7 @@ export class BlockMover extends Component {
 				<span id={ `editor-block-mover__down-description-${ instanceId }` } className="editor-block-mover__description">
 					{
 						getBlockMoverDescription(
-							uids.length,
+							countBlocks,
 							blockType && blockType.title,
 							firstIndex,
 							isFirst,
@@ -107,10 +108,11 @@ export class BlockMover extends Component {
 export default compose(
 	withSelect( ( select, { uids, rootUID } ) => {
 		const { getBlock, getBlockIndex } = select( 'core/editor' );
-		const block = getBlock( first( uids ) );
+		const firstUID = first( castArray( uids ) );
+		const block = getBlock( firstUID );
 
 		return {
-			firstIndex: getBlockIndex( first( uids ), rootUID ),
+			firstIndex: getBlockIndex( firstUID, rootUID ),
 			blockType: block ? getBlockType( block.name ) : null,
 		};
 	} ),

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, noop, last, every, first } from 'lodash';
+import { flow, noop, last, every, first, castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -39,7 +39,7 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 export default compose(
 	withSelect( ( select, { uids, rootUID } ) => ( {
 		blocks: select( 'core/editor' ).getBlocksByUID( uids ),
-		index: select( 'core/editor' ).getBlockIndex( last( uids ), rootUID ),
+		index: select( 'core/editor' ).getBlockIndex( last( castArray( uids ) ), rootUID ),
 	} ) ),
 	withDispatch( ( dispatch, { blocks, index, rootUID } ) => ( {
 		onDuplicate() {

--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -51,9 +51,9 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 	);
 }
 export default compose( [
-	withSelect( ( select, ownProps ) => {
+	withSelect( ( select, { uids } ) => {
 		return {
-			blocks: ownProps.uids.map( ( uid ) => select( 'core/editor' ).getBlock( uid ) ),
+			blocks: select( 'core/editor' ).getBlocksByUID( uids ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -54,7 +55,9 @@ export class BlockSettingsMenu extends Component {
 			isHidden,
 		} = this.props;
 		const { isFocused } = this.state;
-		const count = uids.length;
+		const blockUIDs = castArray( uids );
+		const count = blockUIDs.length;
+		const firstBlockUID = blockUIDs[ 0 ];
 
 		return (
 			<div
@@ -74,8 +77,8 @@ export class BlockSettingsMenu extends Component {
 							<IconButton
 								className={ toggleClassname }
 								onClick={ () => {
-									if ( uids.length === 1 ) {
-										onSelect( uids[ 0 ] );
+									if ( count === 1 ) {
+										onSelect( firstBlockUID );
 									}
 									onToggle();
 								} }
@@ -92,10 +95,10 @@ export class BlockSettingsMenu extends Component {
 						// Should this just use a DropdownMenu instead of a DropDown ?
 						<NavigableMenu className="editor-block-settings-menu__content">
 							{ renderBlockMenu( { onClose, children: [
-								count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } role="menuitem" />,
-								count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } role="menuitem" />,
+								count === 1 && <BlockModeToggle key="mode-toggle" uid={ firstBlockUID } onToggle={ onClose } role="menuitem" />,
+								count === 1 && <UnknownConverter key="unknown-converter" uid={ firstBlockUID } role="menuitem" />,
 								<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } role="menuitem" />,
-								count === 1 && <SharedBlockSettings key="shared-block" uid={ uids[ 0 ] } onToggle={ onClose } itemsRole="menuitem" />,
+								count === 1 && <SharedBlockSettings key="shared-block" uid={ firstBlockUID } onToggle={ onClose } itemsRole="menuitem" />,
 								<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } itemsRole="menuitem" />,
 							] } ) }
 						</NavigableMenu>

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -432,8 +432,8 @@ export function createUndoLevel() {
  * Returns an action object used in signalling that the blocks
  * corresponding to the specified UID set are to be removed.
  *
- * @param {string[]} uids           Block UIDs.
- * @param {boolean}  selectPrevious True if the previous block should be selected when a block is removed.
+ * @param {string|string[]} uids           Block UIDs.
+ * @param {boolean}         selectPrevious True if the previous block should be selected when a block is removed.
  *
  * @return {Object} Action object.
  */

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -220,8 +220,8 @@ export function replaceBlock( uid, block ) {
 function createOnMove( type ) {
 	return ( uids, rootUID ) => {
 		return {
+			uids: castArray( uids ),
 			type,
-			uids,
 			rootUID,
 		};
 	};
@@ -440,7 +440,7 @@ export function createUndoLevel() {
 export function removeBlocks( uids, selectPrevious = true ) {
 	return {
 		type: 'REMOVE_BLOCKS',
-		uids,
+		uids: castArray( uids ),
 		selectPrevious,
 	};
 }

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -14,6 +14,7 @@ import {
 	unionWith,
 	includes,
 	values,
+	castArray,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -505,7 +506,7 @@ export const getGlobalBlockCount = createSelector(
 
 export const getBlocksByUID = createSelector(
 	( state, uids ) => {
-		return map( uids, ( uid ) => getBlock( state, uid ) );
+		return map( castArray( uids ), ( uid ) => getBlock( state, uid ) );
 	},
 	( state ) => [
 		state.editor.present.blocksByUid,


### PR DESCRIPTION
Some block related components are meant to work for single and multiple blocks. So make this work we pass a `[ uid ]` when for single blocks. But this has the downside of generating a new prop on each render and causing a rerender.

This PR updates those components to accept a scalar uids prop as well and leverage `castArray` when needed to avoid useless rerenders.

**Testing instructions**

 - Check that the block movers work for single and multi-selection
 - Check that the block settings menu items work for single and multi-selection.