### PR TITLE
Added missing custom class in the latest posts & categories block 

### DIFF
--- a/blocks/library/categories/index.php
+++ b/blocks/library/categories/index.php
@@ -48,6 +48,10 @@ function render_block_core_categories( $attributes ) {
 
 	$class = "wp-block-categories wp-block-categories-{$type} align{$align}";
 
+	if ( isset( $attributes['className'] ) ) {
+		$class .= ' ' . $attributes['className'];
+	}
+
 	$block_content = sprintf(
 		$wrapper_markup,
 		esc_attr( $class ),

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -56,6 +56,10 @@ function render_block_core_latest_posts( $attributes ) {
 		$class .= ' columns-' . $attributes['columns'];
 	}
 
+	if ( isset( $attributes['className'] ) ) {
+		$class .= ' ' . $attributes['className'];
+	}
+
 	$block_content = sprintf(
 		'<ul class="%1$s">%2$s</ul>',
 		esc_attr( $class ),
@@ -72,6 +76,9 @@ function register_block_core_latest_posts() {
 	register_block_type( 'core/latest-posts', array(
 		'attributes'      => array(
 			'categories'      => array(
+				'type' => 'string',
+			),
+			'className'       => array(
 				'type' => 'string',
 			),
 			'postsToShow'     => array(


### PR DESCRIPTION
## Description
This PR adds a custom class in the front end in the latest post and categories block.
Fixes: https://github.com/WordPress/gutenberg/issues/5644


## How has this been tested?
Add a latest posts block, set a custom class, save the post verify the custom class appears in the front end (in master it does not appear).
Repeat the same steps for the categories block.
