### PR TITLE
Blocks: Fix BlockEdit hooks not working properly with context

### DIFF
--- a/blocks/block-edit/context.js
+++ b/blocks/block-edit/context.js
@@ -4,7 +4,7 @@
 import { createContext, createHigherOrderComponent } from '@wordpress/element';
 
 const { Consumer, Provider } = createContext( {
-	isSelected: true,
+	isSelected: false,
 } );
 
 export { Provider as BlockEditContextProvider };

--- a/blocks/block-edit/edit.js
+++ b/blocks/block-edit/edit.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withFilters } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getBlockType,
+	getBlockDefaultClassName,
+	hasBlockSupport,
+} from '../api';
+
+export const Edit = ( props ) => {
+	const { attributes = {}, isSelected, name } = props;
+	const blockType = getBlockType( name );
+
+	if ( ! blockType ) {
+		return null;
+	}
+
+	// Generate a class name for the block's editable form
+	const generatedClassName = hasBlockSupport( blockType, 'className', true ) ?
+		getBlockDefaultClassName( name ) :
+		null;
+	const className = classnames( generatedClassName, attributes.className );
+
+	// `edit` and `save` are functions or components describing the markup
+	// with which a block is displayed. If `blockType` is valid, assign
+	// them preferentially as the render value for the block.
+	const Component = blockType.edit || blockType.save;
+
+	// For backwards compatibility concerns adds a focus and setFocus prop
+	// These should be removed after some time (maybe when merging to Core)
+	return (
+		<Component
+			{ ...props }
+			className={ className }
+			focus={ isSelected ? {} : false }
+			setFocus={ noop }
+		/>
+	);
+};
+
+export default withFilters( 'blocks.BlockEdit' )( Edit );

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { noop, get } from 'lodash';
 
 /**
@@ -9,16 +8,12 @@ import { noop, get } from 'lodash';
  */
 import { withSelect } from '@wordpress/data';
 import { Component, compose } from '@wordpress/element';
-import { withContext, withFilters, withAPIData } from '@wordpress/components';
+import { withContext, withAPIData } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import {
-	getBlockType,
-	getBlockDefaultClassName,
-	hasBlockSupport,
-} from '../api';
+import Edit from './edit';
 import { BlockEditContextProvider } from './context';
 
 export class BlockEdit extends Component {
@@ -56,34 +51,11 @@ export class BlockEdit extends Component {
 	}
 
 	render() {
-		const { name, attributes = {}, isSelected } = this.props;
-		const blockType = getBlockType( name );
-
-		if ( ! blockType ) {
-			return null;
-		}
-
-		// Generate a class name for the block's editable form
-		const generatedClassName = hasBlockSupport( blockType, 'className', true ) ?
-			getBlockDefaultClassName( name ) :
-			null;
-		const className = classnames( generatedClassName, attributes.className );
-
-		// `edit` and `save` are functions or components describing the markup
-		// with which a block is displayed. If `blockType` is valid, assign
-		// them preferentially as the render value for the block.
-		const Edit = blockType.edit || blockType.save;
-
 		// For backwards compatibility concerns adds a focus and setFocus prop
 		// These should be removed after some time (maybe when merging to Core)
 		return (
 			<BlockEditContextProvider value={ this.state.context }>
-				<Edit
-					{ ...this.props }
-					className={ className }
-					focus={ isSelected ? {} : false }
-					setFocus={ noop }
-				/>
+				<Edit { ...this.props } />
 			</BlockEditContextProvider>
 		);
 	}
@@ -95,7 +67,6 @@ BlockEdit.childContextTypes = {
 };
 
 export default compose( [
-	withFilters( 'blocks.BlockEdit' ),
 	withSelect( ( select ) => ( {
 		postType: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
 	} ) ),

--- a/blocks/block-edit/test/edit.js
+++ b/blocks/block-edit/test/edit.js
@@ -7,14 +7,14 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { BlockEdit } from '../';
+import { Edit } from '../edit';
 import {
 	registerBlockType,
 	unregisterBlockType,
 	getBlockTypes,
 } from '../../api';
 
-describe( 'BlockEdit', () => {
+describe( 'Edit', () => {
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
@@ -22,7 +22,7 @@ describe( 'BlockEdit', () => {
 	} );
 
 	it( 'should return null if block type not defined', () => {
-		const wrapper = shallow( <BlockEdit name="core/test-block" /> );
+		const wrapper = shallow( <Edit name="core/test-block" /> );
 
 		expect( wrapper.type() ).toBe( null );
 	} );
@@ -36,7 +36,7 @@ describe( 'BlockEdit', () => {
 			edit,
 		} );
 
-		const wrapper = shallow( <BlockEdit name="core/test-block" /> );
+		const wrapper = shallow( <Edit name="core/test-block" /> );
 
 		expect( wrapper.find( edit ) ).toBePresent();
 	} );
@@ -49,7 +49,7 @@ describe( 'BlockEdit', () => {
 			title: 'block title',
 		} );
 
-		const wrapper = shallow( <BlockEdit name="core/test-block" /> );
+		const wrapper = shallow( <Edit name="core/test-block" /> );
 
 		expect( wrapper.find( save ) ).toBePresent();
 	} );
@@ -67,7 +67,7 @@ describe( 'BlockEdit', () => {
 		} );
 
 		const wrapper = shallow(
-			<BlockEdit name="core/test-block" attributes={ attributes } />
+			<Edit name="core/test-block" attributes={ attributes } />
 		);
 
 		expect( wrapper.find( edit ) ).toHaveClassName( 'wp-block-test-block my-class' );


### PR DESCRIPTION
## Description

Addresses the [comment](https://github.com/WordPress/gutenberg/pull/6237#issuecomment-383021051) shared by @phpbits:

> I can't find the changes where the `blocks.BlockEdit` were disabled on blocks inside the columns. I thought it's this one, would you mind pointing me to the right direction? 
> 
> I've created this plugin : http://wordpress.org/plugins/block-options/ and the options I've added are not showing on the inner columns anymore. Thanks!

When introducing `BlockEditContext` the handling of `blocks.BlockEdit` hook regressed for the nested blocks. It was caused by the fact that most of the filters wrap `BlockEdit` block with additional logic. This made nested blocks to use the parent context which had `isSelected` obviously set to `false` when editing the child block. I'm not sure why it worked for all other blocks, maybe because `isSelected` was set to `true` for backward compatibility (I changed to `false` since we migrated all core blocks`). This PR extracts `Edit` block to apply filters directly to it and leaves `BlockEdit` block responsible to handle or contexts.

## How has this been tested?
`npm run test` 
Manual tests. Make sure you can see `Advanced` section for the nested blocks.

## Types of changes
 Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
