### PR TITLE
Try adding a pure Higher Order Component

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -9,7 +9,7 @@ import memoize from 'memize';
 /**
  * WordPress dependencies
  */
-import { Component, createHigherOrderComponent } from '@wordpress/element';
+import { Component, createHigherOrderComponent, purify } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -242,17 +242,13 @@ export function dispatch( reducerKey ) {
  * @return {Component} Enhanced component with merged state data props.
  */
 export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( WrappedComponent ) => {
-	return class ComponentWithSelect extends Component {
+	return purify( class ComponentWithSelect extends Component {
 		constructor() {
 			super( ...arguments );
 
 			this.runSelection = this.runSelection.bind( this );
 
 			this.state = {};
-		}
-
-		shouldComponentUpdate( nextProps, nextState ) {
-			return ! isShallowEqual( nextProps, this.props ) || ! isShallowEqual( nextState, this.state );
 		}
 
 		componentWillMount() {
@@ -300,7 +296,7 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 		render() {
 			return <WrappedComponent { ...this.props } { ...this.state.mergeProps } />;
 		}
-	};
+	} );
 }, 'withSelect' );
 
 /**
@@ -316,7 +312,7 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
  * @return {Component} Enhanced component with merged dispatcher props.
  */
 export const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent( ( WrappedComponent ) => {
-	return class ComponentWithDispatch extends Component {
+	return purify( class ComponentWithDispatch extends Component {
 		constructor() {
 			super( ...arguments );
 
@@ -355,7 +351,7 @@ export const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent
 		render() {
 			return <WrappedComponent { ...this.props } { ...this.proxyProps } />;
 		}
-	};
+	} );
 }, 'withDispatch' );
 
 /**

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -705,5 +705,5 @@ export default compose(
 		};
 	} ),
 	withFilters( 'editor.BlockListBlock' ),
-	withHoverAreas
+	withHoverAreas,
 )( BlockListBlock );

--- a/element/index.js
+++ b/element/index.js
@@ -222,7 +222,7 @@ export function RawHTML( { children, ...props } ) {
  *
  * @return {WPComponent} Component class with generated display name assigned.
  */
-export const purify = createHigherOrderComponent( ( Wrapped ) => {
+export const pure = createHigherOrderComponent( ( Wrapped ) => {
 	if ( Wrapped.prototype instanceof Component ) {
 		return class extends Wrapped {
 			shouldComponentUpdate( nextProps, nextState ) {
@@ -240,4 +240,4 @@ export const purify = createHigherOrderComponent( ( Wrapped ) => {
 			return <Wrapped { ...this.props } />;
 		}
 	};
-}, 'purify' );
+}, 'pure' );

--- a/element/index.js
+++ b/element/index.js
@@ -17,6 +17,7 @@ import {
 	isString,
 	upperFirst,
 } from 'lodash';
+import isShallowEqual from 'shallowequal';
 
 /**
  * Internal dependencies
@@ -209,3 +210,34 @@ export function RawHTML( { children, ...props } ) {
 		...props,
 	} );
 }
+
+/**
+ * Given a component returns the enhanced component augmented with a component
+ * only rerendering when its props/state change
+ *
+ * @param {Function} mapComponentToEnhancedComponent Function mapping component
+ *                                                   to enhanced component.
+ * @param {string}   modifierName                    Seed name from which to
+ *                                                   generated display name.
+ *
+ * @return {WPComponent} Component class with generated display name assigned.
+ */
+export const purify = createHigherOrderComponent( ( Wrapped ) => {
+	if ( Wrapped.prototype instanceof Component ) {
+		return class extends Wrapped {
+			shouldComponentUpdate( nextProps, nextState ) {
+				return ! isShallowEqual( nextProps, this.props ) || ! isShallowEqual( nextState, this.state );
+			}
+		};
+	}
+
+	return class extends Component {
+		shouldComponentUpdate( nextProps ) {
+			return ! isShallowEqual( nextProps, this.props );
+		}
+
+		render() {
+			return <Wrapped { ...this.props } />;
+		}
+	};
+}, 'purify' );

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import {
 	renderToString,
 	switchChildrenNodeName,
 	RawHTML,
+	pure,
 } from '../';
 
 describe( 'element', () => {
@@ -210,6 +211,50 @@ describe( 'element', () => {
 			expect( element.prop( 'className' ) ).toBe( 'foo' );
 			expect( element.prop( 'dangerouslySetInnerHTML' ).__html ).toBe( html );
 			expect( element.prop( 'children' ) ).toBe( undefined );
+		} );
+	} );
+
+	describe( 'pure', () => {
+		it( 'functional component should rerender only when props change', () => {
+			let i = 0;
+			const MyComp = pure( () => {
+				return <p>{ ++i }</p>;
+			} );
+			const wrapper = mount( <MyComp /> );
+			wrapper.update(); // Updating with same props doesn't rerender
+			expect( wrapper.html() ).toBe( '<p>1</p>' );
+			wrapper.setProps( { prop: 'a' } ); // New prop should trigger a rerender
+			expect( wrapper.html() ).toBe( '<p>2</p>' );
+			wrapper.setProps( { prop: 'a' } ); // Keeping the same prop value should not rerender
+			expect( wrapper.html() ).toBe( '<p>2</p>' );
+			wrapper.setProps( { prop: 'b' } ); // Changing the prop value should rerender
+			expect( wrapper.html() ).toBe( '<p>3</p>' );
+		} );
+
+		it( 'class component should rerender if the props or state change', () => {
+			let i = 0;
+			const MyComp = pure( class extends Component {
+				constructor() {
+					super( ...arguments );
+					this.state = {};
+				}
+				render() {
+					return <p>{ ++i }</p>;
+				}
+			} );
+			const wrapper = mount( <MyComp /> );
+			wrapper.update(); // Updating with same props doesn't rerender
+			expect( wrapper.html() ).toBe( '<p>1</p>' );
+			wrapper.setProps( { prop: 'a' } ); // New prop should trigger a rerender
+			expect( wrapper.html() ).toBe( '<p>2</p>' );
+			wrapper.setProps( { prop: 'a' } ); // Keeping the same prop value should not rerender
+			expect( wrapper.html() ).toBe( '<p>2</p>' );
+			wrapper.setProps( { prop: 'b' } ); // Changing the prop value should rerender
+			expect( wrapper.html() ).toBe( '<p>3</p>' );
+			wrapper.setState( { state: 'a' } ); // New state value should trigger a rerender
+			expect( wrapper.html() ).toBe( '<p>4</p>' );
+			wrapper.setState( { state: 'a' } ); // Keeping the same state value should not trigger a rerender
+			expect( wrapper.html() ).toBe( '<p>4</p>' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a purify Higher Order Component used to wrap `withSelect` and `withDispatch` components (for now) to make them pure.

Pure components mean they don't rerender unless their props or state changed (shallow equality).

**Testing instructions**

 - Turn the lights on (the "highlight updates" in the React dev tools panel)
 - Compare the lights when typing in a block with master

**Notes**

 - Using "pure" pattern extensively means we're adding "checks" computation in favor of rendering computation. I think globally it's more performant because we do only shallow comparison but this is something to keep in mind.