### PR TITLE
Links: Add ref="noreferrer noopener" for target="_blank" links

### DIFF
--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -112,7 +112,8 @@ class FormatToolbar extends Component {
 	setLinkTarget( opensInNewWindow ) {
 		this.setState( { opensInNewWindow } );
 		if ( this.props.formats.link ) {
-			this.props.onChange( { link: { value: this.props.formats.link.value, target: opensInNewWindow ? '_blank' : '' } } );
+			const extraParams = opensInNewWindow ? { target: '_blank', rel: 'noreferrer noopener' } : {};
+			this.props.onChange( { link: { value: this.props.formats.link.value, ...extraParams } } );
 		}
 	}
 
@@ -133,7 +134,8 @@ class FormatToolbar extends Component {
 	submitLink( event ) {
 		event.preventDefault();
 		this.setState( { isEditingLink: false, isAddingLink: false, newLinkValue: '' } );
-		this.props.onChange( { link: { value: this.state.newLinkValue, target: this.state.opensInNewWindow ? '_blank' : '' } } );
+		const extraParams = this.state.opensInNewWindow ? { target: '_blank', rel: 'noreferrer noopener' } : {};
+		this.props.onChange( { link: { value: this.state.newLinkValue, ...extraParams } } );
 		if ( this.state.isAddingLink ) {
 			this.props.speak( __( 'Link added.' ), 'assertive' );
 		}

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -112,8 +112,11 @@ class FormatToolbar extends Component {
 	setLinkTarget( opensInNewWindow ) {
 		this.setState( { opensInNewWindow } );
 		if ( this.props.formats.link ) {
-			const extraParams = opensInNewWindow ? { target: '_blank', rel: 'noreferrer noopener' } : {};
-			this.props.onChange( { link: { value: this.props.formats.link.value, ...extraParams } } );
+			this.props.onChange( { link: {
+				value: this.props.formats.link.value,
+				target: opensInNewWindow ? '_blank' : null,
+				rel: opensInNewWindow ? 'noreferrer noopener' : null,
+			} } );
 		}
 	}
 
@@ -134,8 +137,11 @@ class FormatToolbar extends Component {
 	submitLink( event ) {
 		event.preventDefault();
 		this.setState( { isEditingLink: false, isAddingLink: false, newLinkValue: '' } );
-		const extraParams = this.state.opensInNewWindow ? { target: '_blank', rel: 'noreferrer noopener' } : {};
-		this.props.onChange( { link: { value: this.state.newLinkValue, ...extraParams } } );
+		this.props.onChange( { link: {
+			value: this.state.newLinkValue,
+			target: this.state.opensInNewWindow ? '_blank' : null,
+			rel: this.state.opensInNewWindow ? 'noreferrer noopener' : null,
+		} } );
 		if ( this.state.isAddingLink ) {
 			this.props.speak( __( 'Link added.' ), 'assertive' );
 		}

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -744,7 +744,8 @@ export class RichText extends Component {
 					if ( ! anchor ) {
 						this.removeFormat( 'link' );
 					}
-					this.applyFormat( 'link', { href: formatValue.value, target: formatValue.target }, anchor );
+					const { value: href, ...params } = formatValue;
+					this.applyFormat( 'link', { href, ...params }, anchor );
 				} else {
 					this.editor.execCommand( 'Unlink' );
 				}


### PR DESCRIPTION
closes #6186

This PR adds ref="noreferrer noopener" to target="_blank" links for security reasons.

**Testing instructions**

 - Add a new link that open in a separate tab using the link formatting control.
 - Ensure the attribute `ref="noreferrer noopener"` is added to the link in the code editor.

