### PR TITLE
Remove `permalink_structure` from REST API index

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -217,28 +217,6 @@ function gutenberg_add_rest_nonce_to_heartbeat_response_headers( $response ) {
 add_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
 
 /**
- * Ensure that the wp-json index contains the `permalink_structure` setting as
- * part of its site info elements.
- *
- * @see https://core.trac.wordpress.org/ticket/42465
- *
- * @param WP_REST_Response $response WP REST API response of the wp-json index.
- * @return WP_REST_Response Response that contains the permalink structure.
- */
-function gutenberg_ensure_wp_json_has_permalink_structure( $response ) {
-	$site_info = $response->get_data();
-
-	if ( ! array_key_exists( 'permalink_structure', $site_info ) ) {
-		$site_info['permalink_structure'] = get_option( 'permalink_structure' );
-	}
-
-	$response->set_data( $site_info );
-
-	return $response;
-}
-add_filter( 'rest_index', 'gutenberg_ensure_wp_json_has_permalink_structure' );
-
-/**
  * As a substitute for the default content `wpautop` filter, applies autop
  * behavior only for posts where content does not contain blocks.
  *


### PR DESCRIPTION
Given Gutenberg ended up using a different implementation, and that
`permalink_structure` is a writable-option (i.e. better off in
settings), I don't think this change is necessary at this time.

Related https://core.trac.wordpress.org/ticket/42465#comment:7