### PR TITLE
Improve performance of the gallery block, by removing unnecessary requests.

### DIFF
--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -58,17 +58,21 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 			( schema ) => schema.shortcode( match.shortcode.attrs, match ),
 		);
 
-		const block = createBlock(
-			transformation.blockName,
-			getBlockAttributes(
-				{
-					...getBlockType( transformation.blockName ),
-					attributes: transformation.attributes,
-				},
-				match.shortcode.content,
-				attributes,
-			)
+		const blockAttributes = getBlockAttributes(
+			{
+				...getBlockType( transformation.blockName ),
+				attributes: transformation.attributes,
+			},
+			match.shortcode.content,
+			attributes,
 		);
+
+		const block = transformation.transform ?
+			transformation.transform( blockAttributes ) :
+			createBlock(
+				transformation.blockName,
+				blockAttributes
+			);
 
 		return [
 			beforeHTML,

--- a/core-blocks/gallery/gallery-image.js
+++ b/core-blocks/gallery/gallery-image.js
@@ -10,7 +10,6 @@ import { Component } from '@wordpress/element';
 import { IconButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { keycodes } from '@wordpress/utils';
-import { withSelect } from '@wordpress/data';
 import { RichText } from '@wordpress/editor';
 
 /**
@@ -72,14 +71,7 @@ class GalleryImage extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isSelected, image, url } = this.props;
-		if ( image && ! url ) {
-			this.props.setAttributes( {
-				url: image.source_url,
-				alt: image.alt_text,
-			} );
-		}
-
+		const { isSelected } = this.props;
 		// unselect the caption so when the user selects other image and comeback
 		// the caption is not immediately selected
 		if ( this.state.captionSelected && ! isSelected && prevProps.isSelected ) {
@@ -145,11 +137,4 @@ class GalleryImage extends Component {
 	}
 }
 
-export default withSelect( ( select, ownProps ) => {
-	const { getMedia } = select( 'core' );
-	const { id } = ownProps;
-
-	return {
-		image: id ? getMedia( id ) : null,
-	};
-} )( GalleryImage );
+export default GalleryImage;

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -660,9 +660,10 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		},
 		onReplace( blocks ) {
 			const { layout } = ownProps;
-			blocks = castArray( blocks ).map( ( block ) => (
-				cloneBlock( block, { layout } )
-			) );
+			blocks = castArray( blocks ).map( ( block ) => ( {
+				...block,
+				layout,
+			} ) );
 			replaceBlocks( [ ownProps.uid ], blocks );
 		},
 		onMetaChange( meta ) {


### PR DESCRIPTION
## Description
This PR adds a check in GalleryImage block to verify if we already have the URL if yes the media is not requested. Until now the media was requested anyway even if the value was not used. So we were requesting each image of the gallery without a need.

This PR had improvements to the gallery frame because I did not notice PR https://github.com/WordPress/gutenberg/pull/2488. I prefer the changes in that PR so I remove frame changes from this PR and I will try to rebase the existing PR.

Fixes: https://github.com/WordPress/gutenberg/issues/4032

## How has this been tested?
Add a gallery to post, save the post, reload the post verify the images are not requested.
See the conversion from shortcodes still works, for example by pasting `[gallery ids="10868,10875,10872"]`.
