### PR TITLE
Raw handling: skip inline shortcodes

### DIFF
--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { some, castArray, first, mapValues, pickBy } from 'lodash';
+import { some, castArray, first, mapValues, pickBy, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,9 +38,14 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 
 		lastIndex = match.index + match.content.length;
 
-		// If not on new line (or in paragraph from Markdown converter),
-		// consider shortcode as inline text.
-		if ( ! /(\n|<p>)\s*$/.test( beforeHTML ) ) {
+		// If the shortcode content does not contain HTML and the shortcode is
+		// not on a new line (or in paragraph from Markdown converter),
+		// consider the shortcode as inline text, and thus skip conversion for
+		// this segment.
+		if (
+			! includes( match.shortcode.content || '', '<' ) &&
+			! /(\n|<p>)\s*$/.test( beforeHTML )
+		) {
 			return segmentHTMLToShortcodeBlock( HTML, lastIndex );
 		}
 


### PR DESCRIPTION
## Description

This PR implements https://github.com/WordPress/gutenberg/issues/3806#issuecomment-381950888.

Fixes #3806.

Only if the shortcode is preceded by a newline (or a plain paragraph tag from the Markdown converter), we should create a shortcode block. Otherwise we should like the shortcode alone as text.

I think this may be a bit too simplistic, but generally goes in the right direction. Maybe we should also check if the shortcode contains any HTML. If it does, maybe it should be "preserved" in a block.

## How has this been tested?
See https://github.com/WordPress/gutenberg/issues/3806#issuecomment-381950888.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->