### PR TITLE
Add a type attribute to <input> elements

### DIFF
--- a/docs/block-api/attributes.md
+++ b/docs/block-api/attributes.md
@@ -137,7 +137,7 @@ edit( { attributes, setAttributes } ) {
 		setAttributes( { author: event.target.value } );
 	}
 
-	return <input value={ attributes.author } onChange={ onChange } />;
+	return <input value={ attributes.author } onChange={ onChange } type="text" />;
 },
 ```
 {% end %}

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -62,6 +62,7 @@ class PostPermalinkEditor extends Component {
 						aria-label={ __( 'Edit post permalink' ) }
 						value={ editedPostName }
 						onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
+						type="text"
 						required
 						autoFocus
 					/>

--- a/editor/components/post-publish-panel/postpublish.js
+++ b/editor/components/post-publish-panel/postpublish.js
@@ -70,6 +70,7 @@ class PostPublishPanelPostpublish extends Component {
 						readOnly
 						value={ post.link }
 						onFocus={ this.onSelectInput }
+						type="text"
 					/>
 					<div className="post-publish-panel__postpublish-buttons">
 						{ ! isScheduled && (


### PR DESCRIPTION
## Description

While `<input>` elements technically don't need `type` attribute to be specified (as all browsers will default to the `text` type), this does cause styling issues in some browsers, as described in #6334.

The `<input>` elements that don't have a `type` attribute were found with the magic of negative lookarounds:

`ag '<input(?:(?!type)(.|\n))*?/>'`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.