### PR TITLE
Typo in “Changing the innerBlocks” section

### DIFF
--- a/docs/block-api/deprecated-blocks.md
+++ b/docs/block-api/deprecated-blocks.md
@@ -257,7 +257,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 			},
 
 			save( props ) {
-				return <p>{ props.attributes.title }</div>;
+				return <p>{ props.attributes.title }</p>;
 			},
 		}
 	]


### PR DESCRIPTION
In the ES.next version we were opening a `p` tag, but closing a `div`.