### PR TITLE
Add Embed Preview support for classic embed providers

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -107,7 +107,6 @@ function gutenberg_filter_oembed_result( $response, $handler, $request ) {
 
 	// External embeds.
 	if ( '/oembed/1.0/proxy' === $request->get_route() ) {
-		$local_oembed = false;
 		if ( is_wp_error( $response ) ) {
 			// It's possibly a local post, so lets try and retrieve it that way.
 			$post_id = url_to_postid( $_GET['url'] );
@@ -115,19 +114,17 @@ function gutenberg_filter_oembed_result( $response, $handler, $request ) {
 
 			if ( $data ) {
 				// It's a local post!
-				$local_oembed = true;
-				$response     = (object) $data;
-			}
-		}
-
-		if ( is_wp_error( $response ) || ! $local_oembed ) {
-			global $wp_embed;
-			$html = $wp_embed->shortcode( array(), $_GET['url'] );
-			if ( $html ) {
-				return array(
-					'provider_name' => __( 'Embed Handler', 'gutenberg' ),
-					'html'          => $html,
-				);
+				$response = (object) $data;
+			} else {
+				// Try using a classic embed, instead.
+				global $wp_embed;
+				$html = $wp_embed->shortcode( array(), $_GET['url'] );
+				if ( $html ) {
+					return array(
+						'provider_name' => __( 'Embed Handler', 'gutenberg' ),
+						'html'          => $html,
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description

Before the magic of oEmbed, there was `wp_embed_register_handler()`. It was kind of hacky, but it was a forerunner for easy embedding we have today.

There are lots of plugins that still use it, however, so we should bring them into the Gutenberg-y future. This PR extends Embed Block previews to include classic embed providers.

Fixes #3499.

## How has this been tested?

Tested with some plugins that use embeds.

- Install/activate Jetpack
- Enable the Shortcode Embeds module
- Paste an Instagram URL (eg: https://www.instagram.com/p/BhR3XVRFSJL/)

Or:

- Install/activate [Content Cards](https://wordpress.org/plugins/content-cards/)
- Whitelist a domain that provides OpenGraph data (eg, chrome.google.com)
- Paste a Chrome Extension URL (eg: https://chrome.google.com/webstore/detail/click-sync/occoadgobmeenmclllmpbnkfcgkjkoel)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.