### PR TITLE
[WIP] Child blocks

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -9,6 +9,7 @@ import { get, isFunction, some } from 'lodash';
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
+import { deprecated } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -159,6 +160,14 @@ export function registerBlockType( name, settings ) {
 	}
 	if ( ! settings.icon ) {
 		settings.icon = 'block-default';
+	}
+	if ( 'isPrivate' in settings ) {
+		deprecated( 'isPrivate', {
+			version: '3.0',
+			alternative: 'allowedPostTypes',
+			plugin: 'Gutenberg',
+		} );
+		settings.allowedParents = !! settings.isPrivate;
 	}
 
 	return blocks[ name ] = settings;

--- a/core-blocks/block/index.js
+++ b/core-blocks/block/index.js
@@ -173,7 +173,7 @@ export const name = 'core/block';
 export const settings = {
 	title: __( 'Shared Block' ),
 	category: 'shared',
-	isPrivate: true,
+	allowedParents: false,
 
 	attributes: {
 		ref: {

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -24,6 +24,16 @@ function filterItems( items ) {
 }
 
 function orderItems( items ) {
+	/**
+	 * Sort items in the following order:
+	 *
+	 * 1. Blocks that are contextually useful (utility = 3)
+	 * 2. Blocks that have been previously inserted (utility = 2)
+	 * 3. Blocks that are in the common category (utility = 1)
+	 * 4. All other blocks (utility = 0)
+	 *
+	 * @see selectors.getInserterItems()
+	 */
 	return orderBy( items, [ 'utility', 'frecency' ], [ 'desc', 'desc' ] );
 }
 

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -41,15 +36,15 @@ class Inserter extends Component {
 
 	render() {
 		const {
+			items,
 			position,
 			title,
 			children,
 			onInsertBlock,
-			hasSupportedBlocks,
 			isLocked,
 		} = this.props;
 
-		if ( ! hasSupportedBlocks || isLocked ) {
+		if ( items.length === 0 || isLocked ) {
 			return null;
 		}
 
@@ -79,7 +74,7 @@ class Inserter extends Component {
 						onClose();
 					};
 
-					return <InserterMenu onSelect={ onSelect } />;
+					return <InserterMenu items={ items } onSelect={ onSelect } />;
 				} }
 			/>
 		);
@@ -100,17 +95,16 @@ export default compose( [
 			getEditedPostAttribute,
 			getBlockInsertionPoint,
 			getSelectedBlock,
-			getSupportedBlocks,
+			getInserterItems,
 		} = select( 'core/editor' );
 
 		const insertionPoint = getBlockInsertionPoint();
 		const { rootUID } = insertionPoint;
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			insertionPoint,
 			selectedBlock: getSelectedBlock(),
-			hasSupportedBlocks: true === supportedBlocks || ! isEmpty( supportedBlocks ),
+			items: getInserterItems( allowedBlockTypes, rootUID ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -147,6 +147,16 @@ export class InserterMenu extends Component {
 
 	sortItems( items ) {
 		if ( 'suggested' === this.state.tab && ! this.state.filterValue ) {
+			/**
+			 * Sort items in the following order:
+			 *
+			 * 1. Blocks that are contextually useful (utility = 3)
+			 * 2. Blocks that have been previously inserted (utility = 2)
+			 * 3. Blocks that are in the common category (utility = 1)
+			 * 4. All other blocks (utility = 0)
+			 *
+			 * @see selectors.getInserterItems()
+			 */
 			const sortedItems = orderBy( items, [ 'utility', 'frecency' ], [ 'desc', 'desc' ] );
 
 			const maxSuggestedItems = this.props.maxSuggestedItems || MAX_SUGGESTED_ITEMS;

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -148,7 +148,9 @@ export class InserterMenu extends Component {
 	sortItems( items ) {
 		if ( 'suggested' === this.state.tab && ! this.state.filterValue ) {
 			const sortedItems = orderBy( items, [ 'utility', 'frecency' ], [ 'desc', 'desc' ] );
-			return sortedItems.slice( 0, MAX_SUGGESTED_ITEMS );
+
+			const maxSuggestedItems = this.props.maxSuggestedItems || MAX_SUGGESTED_ITEMS;
+			return sortedItems.slice( 0, maxSuggestedItems );
 		}
 
 		const getCategoryIndex = ( item ) => {

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -16,6 +16,8 @@ const textItem = {
 	title: 'Text',
 	category: 'common',
 	isDisabled: false,
+	utility: 2,
+	frecency: 1,
 };
 
 const advancedTextItem = {
@@ -25,6 +27,8 @@ const advancedTextItem = {
 	title: 'Advanced Text',
 	category: 'common',
 	isDisabled: false,
+	utility: 2,
+	frecency: 3,
 };
 
 const someOtherItem = {
@@ -34,6 +38,8 @@ const someOtherItem = {
 	title: 'Some Other Block',
 	category: 'common',
 	isDisabled: false,
+	utility: 1,
+	frecency: 1,
 };
 
 const moreItem = {
@@ -43,6 +49,8 @@ const moreItem = {
 	title: 'More',
 	category: 'layout',
 	isDisabled: true,
+	utility: 1,
+	frecency: 0,
 };
 
 const youtubeItem = {
@@ -53,6 +61,8 @@ const youtubeItem = {
 	category: 'embed',
 	keywords: [ 'google' ],
 	isDisabled: false,
+	utility: 0,
+	frecency: 0,
 };
 
 const textEmbedItem = {
@@ -62,6 +72,8 @@ const textEmbedItem = {
 	title: 'A Text Embed',
 	category: 'embed',
 	isDisabled: false,
+	utility: 0,
+	frecency: 0,
 };
 
 const sharedItem = {
@@ -71,6 +83,8 @@ const sharedItem = {
 	title: 'My shared block',
 	category: 'shared',
 	isDisabled: false,
+	utility: 0,
+	frecency: 0,
 };
 
 const items = [
@@ -94,7 +108,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ [] }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 				blockTypes
@@ -114,7 +127,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ [] }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -130,17 +142,17 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [ advancedTextItem, textItem, someOtherItem ] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
 		);
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
-		expect( visibleBlocks ).toHaveLength( 3 );
+		expect( visibleBlocks ).toHaveLength( 4 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Advanced Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 2 ).text() ).toBe( 'Some Other Block' );
+		expect( visibleBlocks.at( 3 ).text() ).toBe( 'More' );
 	} );
 
 	it( 'should show items from the embed category in the embed tab', () => {
@@ -149,7 +161,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -173,7 +184,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -196,7 +206,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -222,7 +231,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ items }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -239,7 +247,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -262,7 +269,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -136,7 +136,7 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 0 );
 	} );
 
-	it( 'should show frecently used items in the suggested tab', () => {
+	it( 'should show items in the suggested tab ordered by utility,frecency', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
@@ -153,6 +153,22 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 2 ).text() ).toBe( 'Some Other Block' );
 		expect( visibleBlocks.at( 3 ).text() ).toBe( 'More' );
+	} );
+
+	it( 'should limit the number of items shown in the suggested tab', () => {
+		const wrapper = mount(
+			<InserterMenu
+				position={ 'top center' }
+				instanceId={ 1 }
+				items={ items }
+				debouncedSpeak={ noop }
+				fetchSharedBlocks={ noop }
+				maxSuggestedItems={ 2 }
+			/>
+		);
+
+		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
+		expect( visibleBlocks ).toHaveLength( 2 );
 	} );
 
 	it( 'should show items from the embed category in the embed tab', () => {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -2,20 +2,18 @@
  * External dependencies
  */
 import {
-	map,
+	castArray,
+	find,
 	first,
 	get,
 	has,
+	includes,
 	intersection,
 	last,
+	map,
+	orderBy,
 	reduce,
 	size,
-	compact,
-	find,
-	unionWith,
-	includes,
-	values,
-	castArray,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -26,6 +24,12 @@ import { serialize, getBlockType, getBlockTypes } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { moment } from '@wordpress/date';
+import { deprecated } from '@wordpress/utils';
+
+/**
+ * Internal dependencies
+ */
+import { parseAllowList } from '../utils/allow-list';
 
 /***
  * Module constants
@@ -1193,8 +1197,29 @@ export function getNotices( state ) {
 }
 
 /**
- * An item that appears in the inserter. Inserting this item will create a new
- * block. Inserter items encapsulate both regular blocks and shared blocks.
+ * Returns information about how recently and frequently a block has been inserted.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} id    A string which identifies the insert, e.g. 'core/block/12'
+ *
+ * @return {{ time: ?number, count: number }} An object containing `time` which is when the last
+ *                                            insert occured as a UNIX epoch, and `count` which is
+ *                                            the number of inserts that have occurred.
+ */
+function getInsertUsage( state, id ) {
+	return state.preferences.insertUsage[ id ] || { time: undefined, count: 0 };
+}
+
+/**
+ * Determines the items that appear in the the inserter. Includes both static
+ * items (e.g. a regular block type) and dynamic items (e.g. a shared block).
+ *
+ * @param {Object}           state                   Global application state.
+ * @param {string[]|boolean} editorAllowedBlockTypes Allowed block types, or true/false to
+ *                                                   enable/disable all types.
+ * @param {?string}          parentUID               The block we are inserting into, if any.
+ *
+ * @return {Editor.InserterItem[]} Items that appear in inserter.
  *
  * @typedef {Object} Editor.InserterItem
  * @property {string}   id                Unique identifier for the item.
@@ -1204,156 +1229,37 @@ export function getNotices( state ) {
  * @property {string}   icon              Dashicon for the item, as it appears in the inserter.
  * @property {string}   category          Block category that the item is associated with.
  * @property {string[]} keywords          Keywords that can be searched to find this item.
- * @property {boolean}  isDisabled        Whether or not the user should be prevented from inserting this item.
+ * @property {boolean}  isDisabled        Whether or not the user should be prevented from inserting
+ *                                        this item.
+ * @property {number}   utility           How useful we think this item is, between 0 and 3.
+ * @property {number}   frecency          Hueristic that combines recency and frecency. Useful for
+ *                                        ordering items by relevancy.
  */
+export function getInserterItems( state, editorAllowedBlockTypes, parentUID = null ) {
+	const editorAllowList = parseAllowList( editorAllowedBlockTypes );
 
-/**
- * Given a regular block type, constructs an item that appears in the inserter.
- *
- * @param {Object}           state             Global application state.
- * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
- * @param {Object}           blockType         Block type, likely from getBlockType().
- *
- * @return {Editor.InserterItem} Item that appears in inserter.
- */
-function buildInserterItemFromBlockType( state, allowedBlockTypes, blockType ) {
-	if ( ! allowedBlockTypes || ! blockType ) {
-		return null;
+	let parentAllowList, parentName;
+	if ( parentUID ) {
+		const parentBlockListSettings = getBlockListSettings( state, parentUID );
+		const parentAllowedBlockTypes = get( parentBlockListSettings, [ 'supportedBlocks' ] );
+		parentAllowList = parseAllowList( parentAllowedBlockTypes );
+		parentName = getBlockName( state, parentUID );
+	} else {
+		parentAllowList = parseAllowList( true );
+		parentName = getCurrentPostType( state );
 	}
 
-	const blockTypeIsDisabled = Array.isArray( allowedBlockTypes ) && ! includes( allowedBlockTypes, blockType.name );
-	if ( blockTypeIsDisabled ) {
-		return null;
-	}
-
-	if ( blockType.isPrivate ) {
-		return null;
-	}
-
-	return {
-		id: blockType.name,
-		name: blockType.name,
-		initialAttributes: {},
-		title: blockType.title,
-		icon: blockType.icon,
-		category: blockType.category,
-		keywords: blockType.keywords,
-		isDisabled: !! blockType.useOnce && getBlocks( state ).some( ( block ) => block.name === blockType.name ),
-	};
-}
-
-/**
- * Given a shared block, constructs an item that appears in the inserter.
- *
- * @param {Object}           state             Global application state.
- * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
- * @param {Object}           sharedBlock       Shared block, likely from getSharedBlock().
- *
- * @return {Editor.InserterItem} Item that appears in inserter.
- */
-function buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock ) {
-	if ( ! allowedBlockTypes || ! sharedBlock ) {
-		return null;
-	}
-
-	const blockTypeIsDisabled = Array.isArray( allowedBlockTypes ) && ! includes( allowedBlockTypes, 'core/block' );
-	if ( blockTypeIsDisabled ) {
-		return null;
-	}
-
-	const referencedBlock = getBlock( state, sharedBlock.uid );
-	if ( ! referencedBlock ) {
-		return null;
-	}
-
-	const referencedBlockType = getBlockType( referencedBlock.name );
-	if ( ! referencedBlockType ) {
-		return null;
-	}
-
-	return {
-		id: `core/block/${ sharedBlock.id }`,
-		name: 'core/block',
-		initialAttributes: { ref: sharedBlock.id },
-		title: sharedBlock.title,
-		icon: referencedBlockType.icon,
-		category: 'shared',
-		keywords: [],
-		isDisabled: false,
-	};
-}
-
-/**
- * Determines the items that appear in the the inserter. Includes both static
- * items (e.g. a regular block type) and dynamic items (e.g. a shared block).
- *
- * @param {Object}           state             Global application state.
- * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
- *
- * @return {Editor.InserterItem[]} Items that appear in inserter.
- */
-export function getInserterItems( state, allowedBlockTypes ) {
-	if ( ! allowedBlockTypes ) {
-		return [];
-	}
-
-	const staticItems = getBlockTypes().map( ( blockType ) =>
-		buildInserterItemFromBlockType( state, allowedBlockTypes, blockType )
-	);
-
-	const dynamicItems = getSharedBlocks( state ).map( ( sharedBlock ) =>
-		buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock )
-	);
-
-	const items = [ ...staticItems, ...dynamicItems ];
-	return compact( items );
-}
-
-function fillWithCommonBlocks( inserts ) {
-	// Filter out any inserts that are associated with a block type that isn't registered
-	const items = inserts.filter( ( insert ) => getBlockType( insert.name ) );
-
-	// Common blocks that we'll use to pad out our list
-	const commonInserts = getBlockTypes()
-		.filter( ( blockType ) => blockType.category === 'common' )
-		.map( ( blockType ) => ( { name: blockType.name } ) );
-
-	const areInsertsEqual = ( a, b ) => a.name === b.name && a.ref === b.ref;
-	return unionWith( items, commonInserts, areInsertsEqual );
-}
-
-function getItemsFromInserts( state, inserts, allowedBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
-	if ( ! allowedBlockTypes ) {
-		return [];
-	}
-
-	const items = fillWithCommonBlocks( inserts ).map( ( insert ) => {
-		if ( insert.ref ) {
-			const sharedBlock = getSharedBlock( state, insert.ref );
-			return buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock );
+	const calculateUtility = ( category, count, isContextual ) => {
+		if ( isContextual ) {
+			return 3;
+		} else if ( count > 0 ) {
+			return 2;
+		} else if ( category === 'common' ) {
+			return 1;
 		}
+		return 0;
+	};
 
-		const blockType = getBlockType( insert.name );
-		return buildInserterItemFromBlockType( state, allowedBlockTypes, blockType );
-	} );
-
-	return compact( items ).slice( 0, maximum );
-}
-
-/**
- * Returns a list of items which the user is likely to want to insert. These
- * are ordered by 'frecency', which is a heuristic that combines block usage
- * frequency and recency.
- *
- * https://en.wikipedia.org/wiki/Frecency
- *
- * @param {Object}           state             Global application state.
- * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
- * @param {number}           maximum           Number of items to return.
- *
- * @return {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
- */
-export function getFrecentInserterItems( state, allowedBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
 	const calculateFrecency = ( time, count ) => {
 		if ( ! time ) {
 			return count;
@@ -1372,10 +1278,136 @@ export function getFrecentInserterItems( state, allowedBlockTypes, maximum = MAX
 		}
 	};
 
-	const sortedInserts = values( state.preferences.insertUsage )
-		.sort( ( a, b ) => calculateFrecency( b.time, b.count ) - calculateFrecency( a.time, a.count ) )
-		.map( ( { insert } ) => insert );
-	return getItemsFromInserts( state, sortedInserts, allowedBlockTypes, maximum );
+	const canInsertBlockType = ( blockType ) => {
+		const isAllowedInEditor = editorAllowList[ blockType.name ] || editorAllowList[ '*' ];
+		if ( ! isAllowedInEditor ) {
+			return false;
+		}
+
+		if ( blockType.name in parentAllowList ) {
+			return parentAllowList[ blockType.name ];
+		}
+
+		const blockAllowList = parseAllowList( blockType.allowedParents );
+
+		if ( parentName in blockAllowList ) {
+			return blockAllowList[ parentName ];
+		}
+
+		return parentAllowList[ '*' ] && blockAllowList[ '*' ];
+	};
+
+	const buildBlockTypeInserterItem = ( blockType ) => {
+		const id = blockType.name;
+
+		let isDisabled = false;
+		if ( blockType.useOnce ) {
+			isDisabled = getBlocks( state ).some( ( block ) => block.name === blockType.name );
+		}
+
+		const blockAllowList = parseAllowList( blockType.allowedParents );
+		const isContextual = blockType.name in parentAllowList || parentName in blockAllowList;
+
+		const { time, count } = getInsertUsage( state, id );
+		const utility = calculateUtility( blockType.category, count, isContextual );
+		const frecency = calculateFrecency( time, count );
+
+		return {
+			id,
+			name: blockType.name,
+			initialAttributes: {},
+			title: blockType.title,
+			icon: blockType.icon,
+			category: blockType.category,
+			keywords: blockType.keywords,
+			isDisabled,
+			utility,
+			frecency,
+		};
+	};
+
+	const canInsertSharedBlock = ( sharedBlock ) => {
+		const isAllowedInEditor = editorAllowList[ 'core/block' ] || editorAllowList[ '*' ];
+		if ( ! isAllowedInEditor ) {
+			return false;
+		}
+
+		const isAllowedInParent = parentAllowList[ 'core/block' ] || parentAllowList[ '*' ];
+		if ( ! isAllowedInParent ) {
+			return false;
+		}
+
+		const referencedBlock = getBlock( state, sharedBlock.uid );
+		if ( ! referencedBlock ) {
+			return false;
+		}
+
+		const referencedBlockType = getBlockType( referencedBlock.name );
+		if ( ! referencedBlockType ) {
+			return false;
+		}
+
+		if ( ! canInsertBlockType( referencedBlockType ) ) {
+			return false;
+		}
+
+		return true;
+	};
+
+	const buildSharedBlockInserterItem = ( sharedBlock ) => {
+		const id = `core/block/${ sharedBlock.id }`;
+
+		const referencedBlock = getBlock( state, sharedBlock.uid );
+		const referencedBlockType = getBlockType( referencedBlock.name );
+
+		const { time, count } = getInsertUsage( state, id );
+		const utility = calculateUtility( 'shared', count, false );
+		const frecency = calculateFrecency( time, count );
+
+		return {
+			id,
+			name: 'core/block',
+			initialAttributes: { ref: sharedBlock.id },
+			title: sharedBlock.title,
+			icon: referencedBlockType.icon,
+			category: 'shared',
+			keywords: [],
+			isDisabled: false,
+			utility,
+			frecency,
+		};
+	};
+
+	return [
+		...getBlockTypes().filter( canInsertBlockType ).map( buildBlockTypeInserterItem ),
+		...getSharedBlocks( state ).filter( canInsertSharedBlock ).map( buildSharedBlockInserterItem ),
+	];
+}
+
+/**
+ * Returns a list of items which the user is likely to want to insert. These
+ * are ordered by 'frecency', which is a heuristic that combines block usage
+ * frequency and recency.
+ *
+ * https://en.wikipedia.org/wiki/Frecency
+ *
+ * @param {Object}           state             Global application state.
+ * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
+ * @param {number}           maximum           Number of items to return.
+ *
+ * @return {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
+ */
+export function getFrecentInserterItems( state, allowedBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
+	deprecated( 'getFrecentInserterItems', {
+		version: '3.0',
+		alternative: 'getInserterItems',
+		plugin: 'Gutenberg',
+	} );
+
+	const items = getInserterItems( state, allowedBlockTypes );
+	const usefulItems = items.filter( ( item ) => item.utility > 0 );
+	const sortedItems = orderBy( usefulItems, [ 'utility', 'frecency' ], [ 'desc', 'desc' ] );
+	return sortedItems.slice( 0, maximum );
 }
 
 /**
@@ -1595,6 +1627,11 @@ export function getBlockListSettings( state, uid ) {
  * @return {string[]|boolean} Blocks that can be nested inside the block with the specified uid, or true/false to enable/disable all types.
  */
 export function getSupportedBlocks( state, uid, globallyEnabledBlockTypes ) {
+	deprecated( 'getSupportedBlocks', {
+		version: '3.0',
+		plugin: 'Gutenberg',
+	} );
+
 	if ( ! globallyEnabledBlockTypes ) {
 		return false;
 	}

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1214,6 +1214,21 @@ function getInsertUsage( state, id ) {
  * Determines the items that appear in the the inserter. Includes both static
  * items (e.g. a regular block type) and dynamic items (e.g. a shared block).
  *
+ * Each item object contains what's necessary to display a button in the
+ * inserter and handle its selection.
+ *
+ * The 'utility' property which allows us to suggest items in order of how
+ * useful we think they will be to the user, namely:
+ *
+ * 1. Blocks that are contextually useful (utility = 3)
+ * 2. Blocks that have been previously inserted (utility = 2)
+ * 3. Blocks that are in the common category (utility = 1)
+ * 4. All other blocks (utility = 0)
+ *
+ * The 'frecency' property is a herustic (https://en.wikipedia.org/wiki/Frecency)
+ * that combines block usage frequenty and recency. This is useful for ordering
+ * items within the above categories.
+ *
  * @param {Object}           state                   Global application state.
  * @param {string[]|boolean} editorAllowedBlockTypes Allowed block types, or true/false to
  *                                                   enable/disable all types.

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
-import { filter, property, union } from 'lodash';
+import { filter, property } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType, unregisterBlockType, getBlockTypes } from '@wordpress/blocks';
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { moment } from '@wordpress/date';
-import { registerCoreBlocks } from '@wordpress/core-blocks';
 
 /**
  * Internal dependencies
@@ -79,13 +78,11 @@ const {
 	getStateBeforeOptimisticTransaction,
 	isPublishingPost,
 	getInserterItems,
-	getFrecentInserterItems,
 	getProvisionalBlockUID,
 	isValidTemplate,
 	getTemplate,
 	getTemplateLock,
 	getBlockListSettings,
-	getSupportedBlocks,
 	POST_UPDATE_TRANSACTION_ID,
 	isPermalinkEditable,
 	getPermalink,
@@ -96,13 +93,30 @@ describe( 'selectors', () => {
 	let cachedSelectors;
 
 	beforeAll( () => {
-		registerBlockType( 'core/test-block', {
+		registerBlockType( 'core/test-block-a', {
+			save: ( props ) => props.attributes.text,
+			category: 'formatting',
+			title: 'Test Block A',
+			icon: 'test',
+			keywords: [ 'testing' ],
+		} );
+
+		registerBlockType( 'core/test-block-b', {
 			save: ( props ) => props.attributes.text,
 			category: 'common',
-			title: 'test block',
+			title: 'Test Block B',
 			icon: 'test',
 			keywords: [ 'testing' ],
 			useOnce: true,
+		} );
+
+		registerBlockType( 'core/test-block-c', {
+			save: ( props ) => props.attributes.text,
+			category: 'common',
+			title: 'Test Block C',
+			icon: 'test',
+			keywords: [ 'testing' ],
+			allowedParents: [ 'core/test-block-b' ],
 		} );
 
 		cachedSelectors = filter( selectors, property( 'clear' ) );
@@ -113,7 +127,9 @@ describe( 'selectors', () => {
 	} );
 
 	afterAll( () => {
-		unregisterBlockType( 'core/test-block' );
+		unregisterBlockType( 'core/test-block-a' );
+		unregisterBlockType( 'core/test-block-b' );
+		unregisterBlockType( 'core/test-block-c' );
 	} );
 
 	describe( 'hasEditorUndo', () => {
@@ -1457,6 +1473,8 @@ describe( 'selectors', () => {
 				},
 				innerBlocks: [],
 			} );
+
+			unregisterBlockType( 'core/meta-block' );
 		} );
 	} );
 
@@ -2584,221 +2602,140 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getInserterItems', () => {
-		it( 'should list all non-private regular block types', () => {
-			const state = {
-				editor: {
-					present: {
-						blocksByUid: {},
-						blockOrder: {},
-						edits: {},
+		const state = {
+			editor: {
+				present: {
+					blockOrder: {
+						'': [ 'block1', 'block2' ],
 					},
+					blocksByUid: {
+						block1: { name: 'core/test-block-a' },
+						block2: { name: 'core/test-block-b' },
+						block7: { name: 'core/test-block-a' },
+						block8: { name: 'core/test-block-a' },
+						block9: { name: 'core/invalid-block' },
+					},
+					edits: {},
 				},
-				currentPost: {},
-				sharedBlocks: {
-					data: {},
+			},
+			currentPost: {},
+			sharedBlocks: {
+				data: {
+					1: { uid: 'block8', title: 'Shared Block 1' },
+					2: { uid: 'block8', title: 'Shared Block 2' },
+					3: { uid: 'block9', title: 'Invalid Block' },
+					4: { uid: 'doesnt_exist', title: 'Invalid Block' },
 				},
-			};
+			},
+			preferences: {
+				insertUsage: {
+					'core/block/2': { count: 10, time: 1000 },
+				},
+			},
+			blockListSettings: {
+				block1: {
+					supportedBlocks: [ 'core/test-block-c' ],
+				},
+			},
+		};
 
-			const blockTypes = getBlockTypes().filter( ( blockType ) => ! blockType.isPrivate );
-			expect( getInserterItems( state, true ) ).toHaveLength( blockTypes.length );
+		it( 'should properly list a block type', () => {
+			const items = getInserterItems( state, true );
+			const testBlockAItem = items.find( ( item ) => item.id === 'core/test-block-a' );
+			expect( testBlockAItem ).toEqual( {
+				id: 'core/test-block-a',
+				name: 'core/test-block-a',
+				initialAttributes: {},
+				title: 'Test Block A',
+				icon: 'test',
+				category: 'formatting',
+				keywords: [ 'testing' ],
+				isDisabled: false,
+				utility: 0,
+				frecency: 0,
+			} );
 		} );
 
-		it( 'should properly list a regular block type', () => {
-			const state = {
-				editor: {
-					present: {
-						blocksByUid: {},
-						blockOrder: {},
-						edits: {},
-					},
-				},
-				currentPost: {},
-				sharedBlocks: {
-					data: {},
-				},
-			};
+		it( 'should properly list a shared block', () => {
+			const items = getInserterItems( state, true );
+			const sharedBlock1Item = items.find( ( item ) => item.id === 'core/block/1' );
+			expect( sharedBlock1Item ).toEqual( {
+				id: 'core/block/1',
+				name: 'core/block',
+				initialAttributes: { ref: 1 },
+				title: 'Shared Block 1',
+				icon: 'test',
+				category: 'shared',
+				keywords: [],
+				isDisabled: false,
+				utility: 0,
+				frecency: 0,
+			} );
+		} );
 
-			expect( getInserterItems( state, [ 'core/test-block' ] ) ).toEqual( [
-				{
-					id: 'core/test-block',
-					name: 'core/test-block',
-					initialAttributes: {},
-					title: 'test block',
-					icon: 'test',
-					category: 'common',
-					keywords: [ 'testing' ],
-					isDisabled: false,
-				},
+		it( 'should exclude invalid items', () => {
+			const items = getInserterItems( state, true );
+			const ids = items.map( ( item ) => item.id );
+			expect( ids ).toEqual( [
+				'core/test-block-a',
+				'core/test-block-b',
+				'core/block/1',
+				'core/block/2',
 			] );
 		} );
 
-		it( 'should set isDisabled when a regular block type with useOnce has been used', () => {
-			const state = {
-				editor: {
-					present: {
-						blocksByUid: {
-							1: { uid: 1, name: 'core/test-block', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 1 ],
-						},
-						edits: {},
-					},
-				},
-				currentPost: {},
-				sharedBlocks: {
-					data: {},
-				},
-			};
-
-			const items = getInserterItems( state, [ 'core/test-block' ] );
-			expect( items[ 0 ].isDisabled ).toBe( true );
+		it( 'should exclude items that are disabled by the editor', () => {
+			const items = getInserterItems( state, [ 'core/test-block-a' ] );
+			const ids = items.map( ( item ) => item.id );
+			expect( ids ).toEqual( [ 'core/test-block-a' ] );
 		} );
 
-		it( 'should properly list shared blocks', () => {
-			const state = {
-				editor: {
-					present: {
-						blocksByUid: {
-							carrot: { name: 'core/test-block' },
-						},
-						blockOrder: {},
-						edits: {},
-					},
-				},
-				currentPost: {},
-				sharedBlocks: {
-					data: {
-						123: { uid: 'carrot', title: 'My shared block' },
-					},
-				},
-			};
+		it( 'should respect allowedBlocks when inserting into another block', () => {
+			const items = getInserterItems( state, true, 'block1' );
+			const ids = items.map( ( item ) => item.id );
+			expect( ids ).toEqual( [ 'core/test-block-c' ] );
+		} );
 
-			expect( getInserterItems( state, [ 'core/block' ] ) ).toEqual( [
-				{
-					id: 'core/block/123',
-					name: 'core/block',
-					initialAttributes: { ref: 123 },
-					title: 'My shared block',
-					icon: 'test',
-					category: 'shared',
-					keywords: [],
-					isDisabled: false,
-				},
+		it( 'should respect allowedParents when inserting into another block', () => {
+			const items = getInserterItems( state, true, 'block2' );
+			const ids = items.map( ( item ) => item.id );
+			expect( ids ).toEqual( [
+				'core/test-block-a',
+				'core/test-block-b',
+				'core/test-block-c',
+				'core/block/1',
+				'core/block/2',
 			] );
 		} );
 
-		it( 'should return nothing when all block types are disabled', () => {
-			expect( getInserterItems( {}, false ) ).toEqual( [] );
-		} );
-	} );
-
-	describe( 'getFrecentInserterItems', () => {
-		beforeAll( () => {
-			registerCoreBlocks();
+		it( 'should set isDisabled when a block with useOnce has been used', () => {
+			const items = getInserterItems( state, true );
+			const testBlockBItem = items.find( ( item ) => item.id === 'core/test-block-b' );
+			expect( testBlockBItem.isDisabled ).toBe( true );
 		} );
 
-		it( 'should return the most frecently used blocks', () => {
-			const state = {
-				preferences: {
-					insertUsage: {
-						'core/deleted-block': { time: 1000, count: 10, insert: { name: 'core/deleted-block' } }, // Deleted blocks should be filtered out
-						'core/block/456': { time: 1000, count: 4, insert: { name: 'core/block', ref: 456 } }, // Deleted shared blocks should be filtered out
-						'core/image': { time: 1000, count: 3, insert: { name: 'core/image' } },
-						'core/block/123': { time: 1000, count: 5, insert: { name: 'core/block', ref: 123 } },
-						'core/paragraph': { time: 1000, count: 2, insert: { name: 'core/paragraph' } },
-					},
-				},
-				editor: {
-					present: {
-						blocksByUid: {
-							carrot: { name: 'core/test-block' },
-						},
-						blockOrder: [],
-						edits: {},
-					},
-				},
-				sharedBlocks: {
-					data: {
-						123: { uid: 'carrot' },
-					},
-				},
-				currentPost: {},
-			};
-
-			expect( getFrecentInserterItems( state, true, 3 ) ).toMatchObject( [
-				{ name: 'core/block', initialAttributes: { ref: 123 } },
-				{ name: 'core/image', initialAttributes: {} },
-				{ name: 'core/paragraph', initialAttributes: {} },
-			] );
+		it( 'should give common blocks a medium utility', () => {
+			const items = getInserterItems( state, true );
+			const testBlockBItem = items.find( ( item ) => item.id === 'core/test-block-b' );
+			expect( testBlockBItem.utility ).toBe( 1 );
 		} );
 
-		it( 'should weight by time', () => {
-			const state = {
-				preferences: {
-					insertUsage: {
-						'core/image': { time: Date.now() - 1000, count: 2, insert: { name: 'core/image' } },
-						'core/paragraph': { time: Date.now() - 4000, count: 3, insert: { name: 'core/paragraph' } },
-					},
-				},
-				editor: {
-					present: {
-						blockOrder: [],
-					},
-				},
-				sharedBlocks: {
-					data: {},
-				},
-			};
-
-			expect( getFrecentInserterItems( state, true, 2 ) ).toMatchObject( [
-				{ name: 'core/image', initialAttributes: {} },
-				{ name: 'core/paragraph', initialAttributes: {} },
-			] );
+		it( 'should give used blocks a high utility', () => {
+			const items = getInserterItems( state, true );
+			const sharedBlock2Item = items.find( ( item ) => item.id === 'core/block/2' );
+			expect( sharedBlock2Item.utility ).toBe( 2 );
 		} );
 
-		it( 'should be backwards-compatible with old preferences values', () => {
-			const state = {
-				preferences: {
-					insertUsage: {
-						'core/image': { time: Date.now(), count: 1, insert: { name: 'core/image' } },
-						'core/paragraph': { time: undefined, count: 5, insert: { name: 'core/paragraph' } },
-					},
-				},
-				editor: {
-					present: {
-						blockOrder: [],
-					},
-				},
-				sharedBlocks: {
-					data: {},
-				},
-			};
-
-			expect( getFrecentInserterItems( state, true, 2 ) ).toMatchObject( [
-				{ name: 'core/paragraph', initialAttributes: {} },
-				{ name: 'core/image', initialAttributes: {} },
-			] );
+		it( 'should give used blocks a frecency', () => {
+			const items = getInserterItems( state, true );
+			const sharedBlock2Item = items.find( ( item ) => item.id === 'core/block/2' );
+			expect( sharedBlock2Item.frecency ).toBe( 2.5 );
 		} );
 
-		it( 'should pad list out with blocks from the common category', () => {
-			const state = {
-				preferences: {
-					insertUsage: {
-						'core/image': { time: 1000, count: 2, insert: { name: 'core/paragraph' } },
-					},
-				},
-				editor: {
-					present: {
-						blockOrder: [],
-					},
-				},
-			};
-
-			// We should get back 4 items with no duplicates
-			const items = getFrecentInserterItems( state, true, 4 );
-			const blockNames = items.map( ( item ) => item.name );
-			expect( union( blockNames ) ).toHaveLength( 4 );
+		it( 'should give contextual blocks the highest utility', () => {
+			const items = getInserterItems( state, true, 'block2' );
+			const testBlockCItem = items.find( ( item ) => item.id === 'core/test-block-c' );
+			expect( testBlockCItem.utility ).toBe( 3 );
 		} );
 	} );
 
@@ -3280,94 +3217,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getBlockListSettings( state, 'chicken' ) ).toBe( undefined );
-		} );
-	} );
-
-	describe( 'getSupportedBlocks', () => {
-		it( 'should return false if all blocks are disabled globally', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: [ 'core/block1' ],
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', false ) ).toBe( false );
-		} );
-
-		it( 'should return the supportedBlocks of root block if all blocks are supported globally', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: [ 'core/block1' ],
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', true ) ).toEqual( [ 'core/block1' ] );
-		} );
-
-		it( 'should return the globally supported blocks if all blocks are enable inside the root block', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: true,
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
-		} );
-
-		it( 'should return the globally supported blocks if the root block does not sets the supported blocks', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						chicken: 'ribs',
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
-		} );
-
-		it( 'should return the globally supported blocks if there are no settings for the root block', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: true,
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block2', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
-		} );
-
-		it( 'should return false if all blocks are disabled inside the root block ', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: false,
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toBe( false );
-		} );
-
-		it( 'should return the intersection of globally supported blocks with the supported blocks of the root block if both sets are defined', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: [ 'core/block1', 'core/block2', 'core/block3' ],
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block2', 'core/block4', 'core/block5' ] ) ).toEqual(
-				[ 'core/block2' ]
-			);
 		} );
 	} );
 } );

--- a/editor/utils/allow-list.js
+++ b/editor/utils/allow-list.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import {
+	castArray,
+	isArray,
+	isPlainObject,
+	isString,
+	mapValues,
+	reduce,
+} from 'lodash';
+
+/**
+ * Parses an allow list shorthand into an allow list object.
+ *
+ * An allow list obejct maps block types to whether or not they are explicitly
+ * allowed as a parent or child. A wildcard ('*') case determines whether or
+ * not parents or children are allowed *in general*.
+ *
+ * Some examples:
+ *
+ * { 'core/image': true, '*': false } specifies that only images are allowed.
+ * { 'core/verse': false, '*': true } specifies that everything except verses are allowed.
+ *
+ * Allow lists can be represented using many shorthands. parseAllowList() turns
+ * these shorthand values into a fully strucutred allow list object.
+ *
+ * Some examples:
+ *
+ * undefined -> { '*': true }
+ * true -> { '*': true }
+ * false -> { '*': false }
+ * 'foo' -> { 'foo': true, '*': false }
+ * [ 'foo', 'bar' ] -> { 'foo': true, 'bar': true, '*': false }
+ * [ '!foo', 'bar', '*' ] -> { 'foo': false, 'bar': true, '*': true }
+ *
+ * @param {*} source An allow list shorthand or allow list object.
+ *
+ * @return {Object} A fully strucutred allow list object. All values will be
+ *                  booleans. The '*' key is guaranteed to exist.
+ */
+export function parseAllowList( source ) {
+	if ( source === undefined ) {
+		return { '*': true };
+	}
+
+	if ( isPlainObject( source ) ) {
+		return {
+			...mapValues( source, ( value ) => !! value ),
+			'*': !! source[ '*' ],
+		};
+	}
+
+	if ( isArray( source ) || isString( source ) ) {
+		return reduce( castArray( source ), ( result, value ) => {
+			if ( isString( value ) && value[ 0 ] === '!' ) {
+				const item = value.slice( 1 );
+				result[ item ] = false;
+			} else {
+				result[ value ] = true;
+			}
+			return result;
+		}, { '*': false } );
+	}
+
+	return { '*': !! source };
+}

--- a/editor/utils/test/allow-list.js
+++ b/editor/utils/test/allow-list.js
@@ -1,0 +1,70 @@
+/**
+ * Internal dependencies
+ */
+import { parseAllowList } from '../allow-list';
+
+describe( 'parseAllowList', () => {
+	it( 'should parse undefined', () => {
+		const allowList = parseAllowList( undefined );
+		expect( allowList ).toEqual( {
+			'*': true,
+		} );
+	} );
+
+	it( 'should parse true', () => {
+		const allowList = parseAllowList( true );
+		expect( allowList ).toEqual( {
+			'*': true,
+		} );
+	} );
+
+	it( 'should parse false', () => {
+		const allowList = parseAllowList( false );
+		expect( allowList ).toEqual( {
+			'*': false,
+		} );
+	} );
+
+	it( 'should parse a string', () => {
+		const allowList = parseAllowList( 'core/verse' );
+		expect( allowList ).toEqual( {
+			'core/verse': true,
+			'*': false,
+		} );
+	} );
+
+	it( 'should parse a negated string', () => {
+		const allowList = parseAllowList( '!core/verse' );
+		expect( allowList ).toEqual( {
+			'core/verse': false,
+			'*': false,
+		} );
+	} );
+
+	it( 'should parse a shorthand array', () => {
+		const allowList = parseAllowList( [ 'core/image', '!core/verse', '*' ] );
+		expect( allowList ).toEqual( {
+			'core/image': true,
+			'core/verse': false,
+			'*': true,
+		} );
+	} );
+
+	it( 'should parse a shorthand array with no wildcard', () => {
+		const allowList = parseAllowList( [ 'core/image', '!core/verse' ] );
+		expect( allowList ).toEqual( {
+			'core/image': true,
+			'core/verse': false,
+			'*': false,
+		} );
+	} );
+
+	it( 'should coerce objects into valid allow lists', () => {
+		const allowList = parseAllowList( { 'core/image': 1, 'core/verse': 0 } );
+		expect( allowList ).toEqual( {
+			'core/image': true,
+			'core/verse': false,
+			'*': false,
+		} );
+	} );
+} );


### PR DESCRIPTION
### What this is 🧐

WIP attempt at implementing https://github.com/WordPress/gutenberg/issues/5540. 

The meat of these changes is a new `allowedParents` property which lets you specify which blocks a child is allowed to be nested into:

```js
registerBlockType( 'acme/buy-button', {
	title: 'Buy Button',
	icon: 'cart',
	category: 'common',

	allowedParents: [ 'acme/product' ],
	...
} );
```

See the [test plugin](https://gist.github.com/noisysocks/9b9503bd6489ffa51088d35c7a2a8ba0) for a full code example. I reccomend installing the plugin, checking out this branch, and playing around with the API.

### Implementation details 🤓

#### Block registration API changes

- Introduces `allowedParents` which lets one specify which block types and post types a block can be nested into.
- Deprecates `isPrivate`. Instead, use `allowedParents: false`.

#### Selector changes

- `getInserterItems` now respects the above properties and is the source of truth for whether a block is insertable or not.
- Items returned by `getInserterItems` will include new `utility` and `frecency` attributes. `utility` indicates how useful we think inserting the block will be. This lets us show contextually useful blocks at the top of the Suggested tab.
- Deprecates `getSupportedBlockTypes`. `getInserterItems` will remove any blocks that are not supported.
- Deprecates `getFrecentInserterItems`. Instead, call `getInserterItems` and filter/sort by `frecency`.

#### Inserter changes

- Both `inserter` and `inserter-with-shortcuts` have been changed to use `getInserterItems` and its new functionality.

### How I've tested this ✅

I wrote a [little test plugin](https://gist.github.com/noisysocks/9b9503bd6489ffa51088d35c7a2a8ba0) which defines a custom post type (_Store_) and two blocks (_Product_ & _Buy Button_).

If you install the plugin, you can see that:

1. _Product_ can only be inserted into a _Store_ CPT.
2.  _Buy Button_ can only be inserted into a _Product_.
    1. This occurs even when `allowedBlocks` does not contain _Buy Button_, because `allowedParents` takes precedence.
3. When inserting _Buy Button_, the block **always** appears at the top of the inserter.
    1. This occurs even when `allowedBlocks` is set to `true`.
4. The inserter behaves like it always has.

### Outstanding questions 🤔

1. Is this API flexible enough for plugin developers?
3. Should `getInserterItems` be a selector?  
  **Pro:** It's technically a pure function that takes state as an input.  
  **Pro:** A selector means that this API is available to plugin developers.  
  **Con:** It's *way* more complicated than a regular selector.

### Still to do 👨‍💻

- [x] Write a test plugin
- [x] Fix unit tests for `getInserterItems`
- [x] Improve `getInserterItems` performance (e.g. by using `createSelector`)
- [ ] Write documentation for new API