### PR TITLE
Try mobile toolbar below the block

### DIFF
--- a/edit-post/assets/stylesheets/_variables.scss
+++ b/edit-post/assets/stylesheets/_variables.scss
@@ -28,6 +28,7 @@ $admin-sidebar-width-collapsed: 36px;
 // Visuals
 $shadow-popover: 0 3px 20px rgba( $dark-gray-900, .1 ), 0 1px 3px rgba( $dark-gray-900, .1 );
 $shadow-toolbar: 0 2px 10px rgba( $dark-gray-900, .1 ), 0 0 2px rgba( $dark-gray-900, .1 );
+$shadow-below-only: 0 5px 10px rgba( $dark-gray-900, .1 ), 0 2px 2px rgba( $dark-gray-900, .1 );
 
 // Editor Widths
 $sidebar-width: 280px;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -603,16 +603,33 @@
 
 .editor-block-contextual-toolbar,
 .editor-block-list__breadcrumb {
-	position: sticky;
 	z-index: z-index( '.editor-block-contextual-toolbar' );
 	white-space: nowrap;
 	text-align: left;
 	pointer-events: none;
 	height: $block-toolbar-height;
 
+	// Position toolbar below the block on mobile
+	position: absolute;
+	bottom: -$block-toolbar-height + 1px;
+	left: $block-padding;
+	right: $block-padding;
+	box-shadow: $shadow-below-only;
+
 	// Position the contextual toolbar above the block, add 1px to each to stack borders
-	margin-top: -$block-toolbar-height - 1px;
-	margin-bottom: $block-padding + 1px;
+	@include break-mobile() {
+		position: sticky;
+		bottom: auto;
+		left: auto;
+		right: auto;
+		box-shadow: none;
+		margin-top: -$block-toolbar-height - 1px;
+		margin-bottom: $block-padding + 1px;
+	}
+
+	@include break-small() {
+		top: -1px;	// stack borders
+	}
 
 	// Floated items have special needs for the contextual toolbar position
 	.editor-block-list__block[data-align="left"] &,
@@ -635,12 +652,6 @@
 			margin-left: -$block-padding - $block-side-ui-padding;
 			margin-right: -$block-padding - $block-side-ui-padding;
 		}
-	}
-
-	// on mobile, toolbars fix differently
-	top: $header-height - 1px; // stack borders
-	@include break-small() {
-		top: -1px;	// stack borders
 	}
 
 	// Reset pointer-events on children.


### PR DESCRIPTION
This is very much an experiment, intended to help solve problems discovered in https://github.com/WordPress/gutenberg/pull/6307#issuecomment-383480187.

Basically, on iOS you won't have access to the block toolbar until you scroll way up to the top. And if we dock the toolbar to the top of the block, it will be covered by cut/copy/paste. This PR moves the toolbar below the block instead, mitigating that.

GIF:

![below-the-block](https://user-images.githubusercontent.com/1204802/39116058-b6158a86-46e3-11e8-9b0f-b603a1b25726.gif)

Note that we probably want to also _disable entirely_ the `isTyping` feature which hides the block UI when you're typing. It is too hard to get back on mobile, and isn't helping much there anyway. Riad is it hard to disable `isTyping` only on mobile? Would appreciate help here. 
