### PR TITLE
Fix select box regression.

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -152,6 +152,17 @@ body.gutenberg-editor-page {
 			@include input-style__focus();
 		}
 	}
+
+	select {
+		padding: 2px;
+
+		&:focus {
+			border-color: $blue-medium-600;
+			// Windows High Contrast mode will show this outline
+			outline: 2px solid transparent;
+			outline-offset: 0;
+		}
+	}
 }
 
 // Placeholder colors


### PR DESCRIPTION
Fixes #6326.

This "undoes" a change to the select box styling, and polishes the focus style as well.

The regression was to introduce a padding change that conflicted with upstream select box styles. This essentially reverts that. This also polishes the focus styles a bit.

Screenshots. Chrome mac:

<img width="103" alt="screen shot 2018-04-23 at 11 15 57" src="https://user-images.githubusercontent.com/1204802/39119222-a1184f80-46eb-11e8-8627-ba3e96195ea0.png">

Chrome Windows:

<img width="128" alt="screen shot 2018-04-23 at 11 16 10" src="https://user-images.githubusercontent.com/1204802/39119230-a48c76e6-46eb-11e8-9473-58169eea37f2.png">

Windows high contrast:

<img width="214" alt="screen shot 2018-04-23 at 11 38 50" src="https://user-images.githubusercontent.com/1204802/39119243-aa873f68-46eb-11e8-884f-c407996f0b58.png">

All those are focused. 

Steps to test:

- Verify that select boxes look and behave right in all the browsers and platforms. Verify that text is never cropped inside.