### PR TITLE
Blocks: Remove backward compatibility solution for focus

### DIFF
--- a/blocks/block-edit/edit.js
+++ b/blocks/block-edit/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,7 +18,7 @@ import {
 } from '../api';
 
 export const Edit = ( props ) => {
-	const { attributes = {}, isSelected, name } = props;
+	const { attributes = {}, name } = props;
 	const blockType = getBlockType( name );
 
 	if ( ! blockType ) {
@@ -37,14 +36,10 @@ export const Edit = ( props ) => {
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
 
-	// For backwards compatibility concerns adds a focus and setFocus prop
-	// These should be removed after some time (maybe when merging to Core)
 	return (
 		<Component
 			{ ...props }
 			className={ className }
-			focus={ isSelected ? {} : false }
-			setFocus={ noop }
 		/>
 	);
 };

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -51,8 +51,6 @@ export class BlockEdit extends Component {
 	}
 
 	render() {
-		// For backwards compatibility concerns adds a focus and setFocus prop
-		// These should be removed after some time (maybe when merging to Core)
 		return (
 			<BlockEditContextProvider value={ this.state.context }>
 				<Edit { ...this.props } />


### PR DESCRIPTION
## Description
Raised by @noisysocks in https://github.com/WordPress/gutenberg/pull/6312#discussion_r183257240:

> Unrelated, but maybe we should deprecate focus and setFocus more formally, e.g. calling deprecated and removing the functionality in two minor versions.

but clarified by @youknowriad:

> I guess we didn't include those originally because there was no direct alternative. We did several releases since this change, I think we can just remove it on the next release or so.

This was already deprecated when `isSelected` property was introduced a few releases back.

This PR removed no longer used code and all related comments.

## How has this been tested?
Manually. I tested with the demo post and other tests posts and everything worked as expected. It shouldn't be an issue with core blocks anymore. I refactored all existing blocks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
