### PR TITLE
Show Update button on mobile

### DIFF
--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -27,8 +27,7 @@
 		top: $admin-bar-height;
 	}
 
-	.editor-post-switch-to-draft + .editor-post-preview,
-	.editor-post-switch-to-draft + .editor-post-preview + .editor-post-publish-button {
+	.editor-post-switch-to-draft + .editor-post-preview	{
 		display: none;
 
 		@include break-small {


### PR DESCRIPTION
This fixes a regression where the Update button was invisible for already published posts on mobile.

<img width="459" alt="screen shot 2018-04-23 at 12 56 43" src="https://user-images.githubusercontent.com/1204802/39122674-f26a761a-46f5-11e8-87b8-4cce946c874a.png">
