### PR TITLE
embed: fix translation string

### DIFF
--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -31,7 +31,7 @@ const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 function getEmbedBlockSettings( { title, description, icon, category = 'embed', transforms, keywords = [] } ) {
 	return {
 		title,
-		description: description || __( `Paste URLs from ${ title } to embed the content in this block.` ),
+		description: description || sprintf( __( 'Paste URLs from %s to embed the content in this block' ), title ),
 		icon,
 		category,
 		keywords,

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -29,9 +29,11 @@ import './editor.scss';
 const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 
 function getEmbedBlockSettings( { title, description, icon, category = 'embed', transforms, keywords = [] } ) {
+	// translators: %s: Name of service (e.g. VideoPress, YouTube)
+	const blockDescription = description || sprintf( __( 'Paste URLs from %s to embed the content in this block' ), title );
 	return {
 		title,
-		description: description || sprintf( __( 'Paste URLs from %s to embed the content in this block' ), title ),
+		description: blockDescription,
 		icon,
 		category,
 		keywords,


### PR DESCRIPTION
## Description
Fix translation string to use  sprintf

## How has this been tested?
- Manually 
- `npm run test:unit`

## Screenshots <!-- if applicable -->
N/A

## Types of changes
Translation fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
