### PR TITLE
Blocks: Extend BlockEdit context with name and use it for autocompleters

### DIFF
--- a/blocks/autocomplete/index.js
+++ b/blocks/autocomplete/index.js
@@ -7,8 +7,13 @@ import { clone } from 'lodash';
  * WordPress dependencies
  */
 import { applyFilters, hasFilter } from '@wordpress/hooks';
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { Autocomplete as OriginalAutocomplete } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { withBlockEditContext } from '../block-edit/context';
 
 /*
  * Use one array instance for fallback rather than inline array literals
@@ -69,6 +74,7 @@ export function withFilteredAutocompleters( Autocomplete ) {
 		}
 
 		updateCompletersState() {
+			const { blockEditContext } = this.props;
 			let { completers: nextCompleters } = this.props;
 			const lastFilteredCompletersProp = nextCompleters;
 
@@ -76,7 +82,8 @@ export function withFilteredAutocompleters( Autocomplete ) {
 				nextCompleters = applyFilters(
 					'blocks.Autocomplete.completers',
 					// Provide copies so filters may directly modify them.
-					nextCompleters && nextCompleters.map( clone )
+					nextCompleters && nextCompleters.map( clone ),
+					blockEditContext.name,
 				);
 			}
 
@@ -106,4 +113,7 @@ export function withFilteredAutocompleters( Autocomplete ) {
 	};
 }
 
-export default withFilteredAutocompleters( OriginalAutocomplete );
+export default compose( [
+	withBlockEditContext,
+	withFilteredAutocompleters,
+] )( OriginalAutocomplete );

--- a/blocks/autocomplete/index.js
+++ b/blocks/autocomplete/index.js
@@ -74,8 +74,8 @@ export function withFilteredAutocompleters( Autocomplete ) {
 		}
 
 		updateCompletersState() {
-			const { blockEditContext } = this.props;
-			let { completers: nextCompleters } = this.props;
+			const { blockName, completers } = this.props;
+			let nextCompleters = completers;
 			const lastFilteredCompletersProp = nextCompleters;
 
 			if ( hasFilter( 'blocks.Autocomplete.completers' ) ) {
@@ -83,7 +83,7 @@ export function withFilteredAutocompleters( Autocomplete ) {
 					'blocks.Autocomplete.completers',
 					// Provide copies so filters may directly modify them.
 					nextCompleters && nextCompleters.map( clone ),
-					blockEditContext.name,
+					blockName,
 				);
 			}
 
@@ -114,6 +114,10 @@ export function withFilteredAutocompleters( Autocomplete ) {
 }
 
 export default compose( [
-	withBlockEditContext,
+	withBlockEditContext( ( { name } ) => {
+		return {
+			blockName: name,
+		};
+	} ),
 	withFilteredAutocompleters,
 ] )( OriginalAutocomplete );

--- a/blocks/autocomplete/test/index.js
+++ b/blocks/autocomplete/test/index.js
@@ -40,15 +40,15 @@ describe( 'Autocomplete', () => {
 		);
 
 		const expectedCompleters = [ {}, {}, {} ];
-		wrapper = mount( <FilteredComponent completers={ expectedCompleters } /> );
+		wrapper = mount( <FilteredComponent completers={ expectedCompleters } blockName="core/foo" /> );
 
 		expect( completersFilter ).not.toHaveBeenCalled();
 		wrapper.find( 'input' ).simulate( 'focus' );
-		expect( completersFilter ).toHaveBeenCalledWith( expectedCompleters );
+		expect( completersFilter ).toHaveBeenCalledWith( expectedCompleters, 'core/foo' );
 	} );
 
 	it( 'filters completers supplied when already focused', () => {
-		wrapper = mount( <FilteredComponent completers={ [] } /> );
+		wrapper = mount( <FilteredComponent completers={ [] } blockName="core/foo" /> );
 
 		wrapper.find( 'input' ).getDOMNode().focus();
 		expect( wrapper.getDOMNode().contains( document.activeElement ) ).toBeTruthy();
@@ -64,7 +64,7 @@ describe( 'Autocomplete', () => {
 
 		expect( completersFilter ).not.toHaveBeenCalled();
 		wrapper.setProps( { completers: expectedCompleters } );
-		expect( completersFilter ).toHaveBeenCalledWith( expectedCompleters );
+		expect( completersFilter ).toHaveBeenCalledWith( expectedCompleters, 'core/foo' );
 	} );
 
 	it( 'provides copies of completers to filter', () => {

--- a/blocks/block-edit/context.js
+++ b/blocks/block-edit/context.js
@@ -14,17 +14,19 @@ export { Provider as BlockEditContextProvider };
  * A Higher Order Component used to inject BlockEdit context to the
  * wrapped component.
  *
- * @param {Component} OriginalComponent Component to wrap.
+ * @param {Function} mapContextToProps Function called on every context change,
+ *                                     expected to return object of props to
+ *                                     merge with the component's own props.
  *
- * @return {Component} Component which has BlockEdit context injected.
+ * @return {Component} Enhanced component with injected context as props.
  */
-export const withBlockEditContext = createHigherOrderComponent( ( OriginalComponent ) => {
+export const withBlockEditContext = ( mapContextToProps ) => createHigherOrderComponent( ( OriginalComponent ) => {
 	return ( props ) => (
 		<Consumer>
 			{ ( context ) => (
 				<OriginalComponent
 					{ ...props }
-					blockEditContext={ context }
+					{ ...mapContextToProps( context ) }
 				/>
 			) }
 		</Consumer>

--- a/blocks/block-edit/context.js
+++ b/blocks/block-edit/context.js
@@ -26,7 +26,7 @@ export const withBlockEditContext = ( mapContextToProps ) => createHigherOrderCo
 			{ ( context ) => (
 				<OriginalComponent
 					{ ...props }
-					{ ...mapContextToProps( context ) }
+					{ ...mapContextToProps( context, props ) }
 				/>
 			) }
 		</Consumer>

--- a/blocks/block-edit/context.js
+++ b/blocks/block-edit/context.js
@@ -4,6 +4,7 @@
 import { createContext, createHigherOrderComponent } from '@wordpress/element';
 
 const { Consumer, Provider } = createContext( {
+	name: '',
 	isSelected: false,
 } );
 

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -38,21 +38,23 @@ export class BlockEdit extends Component {
 		};
 	}
 
-	static getDerivedStateFromProps( nextProps, prevState ) {
-		if ( nextProps.isSelected === get( prevState, [ 'context', 'isSelected' ] ) ) {
+	static getDerivedStateFromProps( { name, isSelected }, prevState ) {
+		if (
+			name === prevState.name &&
+			isSelected === prevState.isSelected
+		) {
 			return null;
 		}
 
 		return {
-			context: {
-				isSelected: nextProps.isSelected,
-			},
+			name,
+			isSelected,
 		};
 	}
 
 	render() {
 		return (
-			<BlockEditContextProvider value={ this.state.context }>
+			<BlockEditContextProvider value={ this.state }>
 				<Edit { ...this.props } />
 			</BlockEditContextProvider>
 		);

--- a/blocks/hooks/default-autocompleters.js
+++ b/blocks/hooks/default-autocompleters.js
@@ -12,6 +12,7 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { blockAutocompleter, userAutocompleter } from '../autocompleters';
+import { getDefaultBlockName } from '../api/registration';
 
 const defaultAutocompleters = [ userAutocompleter ];
 
@@ -20,7 +21,7 @@ function setDefaultCompleters( completers, blockName ) {
 		// Provide copies so filters may directly modify them.
 		completers = defaultAutocompleters.map( clone );
 		// Add blocks autocompleter for Paragraph block
-		if ( blockName === 'core/paragraph' ) {
+		if ( blockName === getDefaultBlockName() ) {
 			completers.push( clone( blockAutocompleter ) );
 		}
 	}

--- a/blocks/hooks/default-autocompleters.js
+++ b/blocks/hooks/default-autocompleters.js
@@ -11,14 +11,18 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { userAutocompleter } from '../autocompleters';
+import { blockAutocompleter, userAutocompleter } from '../autocompleters';
 
 const defaultAutocompleters = [ userAutocompleter ];
 
-function setDefaultCompleters( completers ) {
+function setDefaultCompleters( completers, blockName ) {
 	if ( ! completers ) {
 		// Provide copies so filters may directly modify them.
 		completers = defaultAutocompleters.map( clone );
+		// Add blocks autocompleter for Paragraph block
+		if ( blockName === 'core/paragraph' ) {
+			completers.push( clone( blockAutocompleter ) );
+		}
 	}
 	return completers;
 }

--- a/blocks/hooks/test/default-autocompleters.js
+++ b/blocks/hooks/test/default-autocompleters.js
@@ -10,10 +10,11 @@ import '../default-autocompleters';
 import { userAutocompleter } from '../../autocompleters';
 
 describe( 'default-autocompleters', () => {
+	const BLOCK_NAME = 'core/foo';
 	const defaultAutocompleters = [ userAutocompleter ];
 
 	it( 'provides default completers if none are provided', () => {
-		const result = applyFilters( 'blocks.Autocomplete.completers', null );
+		const result = applyFilters( 'blocks.Autocomplete.completers', null, BLOCK_NAME );
 		/*
 		 * Assert structural equality because defaults are provided as a
 		 * list of cloned completers (and not referentially equal).
@@ -23,20 +24,20 @@ describe( 'default-autocompleters', () => {
 
 	it( 'does not provide default completers for empty completer list', () => {
 		const emptyList = [];
-		const result = applyFilters( 'blocks.Autocomplete.completers', emptyList );
+		const result = applyFilters( 'blocks.Autocomplete.completers', emptyList, BLOCK_NAME );
 		// Assert referential equality because the list should be unchanged.
 		expect( result ).toBe( emptyList );
 	} );
 
 	it( 'does not provide default completers for a populated completer list', () => {
 		const populatedList = [ {}, {} ];
-		const result = applyFilters( 'blocks.Autocomplete.completers', populatedList );
+		const result = applyFilters( 'blocks.Autocomplete.completers', populatedList, BLOCK_NAME );
 		// Assert referential equality because the list should be unchanged.
 		expect( result ).toBe( populatedList );
 	} );
 
 	it( 'provides copies of defaults so they may be directly modified', () => {
-		const result = applyFilters( 'blocks.Autocomplete.completers', null );
+		const result = applyFilters( 'blocks.Autocomplete.completers', null, BLOCK_NAME );
 		result.forEach( ( completer, i ) => {
 			const defaultCompleter = defaultAutocompleters[ i ];
 			expect( completer ).not.toBe( defaultCompleter );

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -888,13 +888,17 @@ RichText.defaultProps = {
 };
 
 const RichTextContainer = compose( [
-	withBlockEditContext,
-	withSelect( ( select, { isSelected, blockEditContext } ) => {
+	withBlockEditContext( ( { isSelected } ) => {
+		return {
+			isBlockSelected: isSelected,
+		};
+	} ),
+	withSelect( ( select, { isSelected, isBlockSelected } ) => {
 		const { isViewportMatch = identity } = select( 'core/viewport' ) || {};
 
 		return {
 			isViewportSmall: isViewportMatch( '< small' ),
-			isSelected: isSelected !== false && blockEditContext.isSelected,
+			isSelected: isSelected !== false && isBlockSelected,
 		};
 	} ),
 	withSafeTimeout,

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -26,10 +26,8 @@ import {
 } from '@wordpress/components';
 import {
 	createBlock,
-	blockAutocompleter,
 	getColorClass,
 	withColors,
-	userAutocompleter,
 	AlignmentToolbar,
 	BlockAlignmentToolbar,
 	BlockControls,
@@ -65,8 +63,6 @@ const FONT_SIZES = {
 	large: 36,
 	larger: 48,
 };
-
-const autocompleters = [ blockAutocompleter, userAutocompleter ];
 
 class ParagraphBlock extends Component {
 	constructor() {
@@ -274,7 +270,6 @@ class ParagraphBlock extends Component {
 						onReplace={ this.onReplace }
 						onRemove={ () => onReplace( [] ) }
 						placeholder={ placeholder || __( 'Add text or type / to add content' ) }
-						autocompleters={ autocompleters }
 					/>
 				</div>
 			</Fragment>

--- a/docs/extensibility/autocomplete.md
+++ b/docs/extensibility/autocomplete.md
@@ -38,8 +38,10 @@ var acronymCompleter = {
 };
 
 // Our filter function
-function appendAcronymCompleter( completers ) {
-	return completers.concat( acronymCompleter );
+function appendAcronymCompleter( completers, blockName ) {
+	return blockName === 'my-plugin/foo' ?
+		completers.concat( acronymCompleter ) :
+		completers;
 }
 
 // Adding the filter
@@ -71,8 +73,10 @@ const acronymCompleter = {
 };
 
 // Our filter function
-function appendAcronymCompleter( completers ) {
-	return [ ...completers, acronymCompleter ];
+function appendAcronymCompleter( completers, blockName ) {
+	return blockName === 'my-plugin/foo' ?
+		[ ...completers, acronymCompleter ] :
+		completers;
 }
 
 // Adding the filter


### PR DESCRIPTION
## Description
This PR extends `BlockEdit` context to include block's name property. This allows us to make Paragraph block's completers extensible by injecting `block` autocompleter using the existing filter. As part of this refactoring, I also added new method `withBlockEditContext` HOC to explicitly set how context should be mapped to props. The reason behind this change is readability and having less magic to guess where props come from inside the code that implements HOC.

This issue was raised while working on #6351 and @youknowriad had to expose the default completers to make it work with Core block moved to their own module.

In general, this change makes setting completers much more flexible, as developers would be able to set different completers based on the type of block.

## How has this been tested?
Manually - make sure all autocompleters works as before and it is still possible to use block completer only with Paragraph block. 

It is still not possible to add proper tests for the Context API because of Enzyme library still haven't published version that works fully with React 16.3 :(

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
