### PR TITLE
Restore hiding drop cap on focus to prevent bugs with contenteditable

### DIFF
--- a/blocks/library/paragraph/style.scss
+++ b/blocks/library/paragraph/style.scss
@@ -15,22 +15,20 @@ p {
 		font-size: 48px;
 	}
 
-	&.has-drop-cap {
-		&:first-letter {
-			float: left;
-			font-size: 4.1em;
-			line-height: 0.7;
-			font-family: serif;
-			font-weight: 600;
-			margin: .07em .23em 0 0;
-			text-transform: uppercase;
-			font-style: normal;
-		}
+	// Don't show the drop cap when editing the paragraph's content. It causes a
+	// number of bugs in combination with `contenteditable` fields. The caret
+	// cannot be set around it, caret position calculation fails in Chrome, and
+	// typing at the end of the paragraph doesn't work.
+	&.has-drop-cap:not( :focus ):first-letter {
+		float: left;
+		font-size: 4.1em;
+		line-height: 0.7;
+		font-family: serif;
+		font-weight: 600;
+		margin: .07em .23em 0 0;
+		text-transform: uppercase;
+		font-style: normal;
 	}
-}
-
-p.has-drop-cap:not( :focus )  {
-	overflow: hidden;
 }
 
 p.has-background {

--- a/blocks/rich-text/style.scss
+++ b/blocks/rich-text/style.scss
@@ -80,23 +80,6 @@
 	}
 }
 
-.has-drop-cap .blocks-rich-text__tinymce:not( :focus )  {
-	&:first-letter {
-		float: left;
-		font-size: 4.1em;
-		line-height: 0.7;
-		font-family: serif;
-		font-weight: 600;
-		margin: .07em .23em 0 0;
-		text-transform: uppercase;
-		font-style: normal;
-	}
-}
-
-.has-drop-cap:not( :focus )  {
-	overflow: hidden;
-}
-
 .block-rich-text__inline-toolbar {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
## Description

Fixes #6273.

This behaviour seems to have been dropped by accident in #1418. Not sure why, but maybe @BE-Webdesign recalls this PR?

We can't show the drop cap when the user is editing the paragraph for some reasons:

* You cannot move the caret around it.
* Chrome (maybe others) fails to calculate the caret position with `range.getClientRects()`, which causes errors and things that rely on that such as the link inserter and writing flow to break.
* Typing seems broken in different ways in different browsers. Chrome and Safari seem to insert characters in the wrong position, and additionally Safari just overwrites the last character when the caret is at then end.

I know this isn't a nice solution, but it's all I can come up with at the moment. These CSS rules and `contenteditable` just don't seem compatible and I've not found a way to make it work. I'm unsure if there's any way we can let the user know that the block has a drop cap while the editable field has focus. Cc @jasmussen.

## How has this been tested?
Ensure the above points work fine.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->