### PR TITLE
Data: Call resolver isFulfilled once per argument set

### DIFF
--- a/data/test/index.js
+++ b/data/test/index.js
@@ -139,27 +139,61 @@ describe( 'registerResolvers', () => {
 	} );
 
 	it( 'should use isFulfilled definition before calling the side effect', () => {
-		const resolver = jest.fn();
-		let count = 0;
+		const fulfill = jest.fn().mockImplementation( ( state, page ) => {
+			return { type: 'SET_PAGE', page, result: [] };
+		} );
+		const isFulfilled = jest.fn().mockImplementation( ( state, page ) => {
+			return state.hasOwnProperty( page );
+		} );
 
-		registerReducer( 'demo', ( state = 'OK' ) => state );
+		const store = registerReducer( 'demo', ( state = {}, action ) => {
+			switch ( action.type ) {
+				case 'SET_PAGE':
+					return {
+						...state,
+						[ action.page ]: action.result,
+					};
+			}
+
+			return state;
+		} );
+
+		store.dispatch( { type: 'SET_PAGE', page: 4, result: [] } );
+
 		registerSelectors( 'demo', {
-			getValue: ( state ) => state,
+			getPage: ( state, page ) => state[ page ],
 		} );
 		registerResolvers( 'demo', {
-			getValue: {
-				fulfill: ( ...args ) => {
-					count++;
-					resolver( ...args );
-				},
-				isFulfilled: () => count > 1,
+			getPage: {
+				fulfill,
+				isFulfilled,
 			},
 		} );
 
-		for ( let i = 0; i < 4; i++ ) {
-			select( 'demo' ).getValue( 'arg1', 'arg2' );
-		}
-		expect( resolver ).toHaveBeenCalledTimes( 2 );
+		select( 'demo' ).getPage( 1 );
+		select( 'demo' ).getPage( 2 );
+
+		expect( fulfill ).toHaveBeenCalledTimes( 2 );
+		expect( isFulfilled ).toHaveBeenCalledTimes( 2 );
+
+		select( 'demo' ).getPage( 1 );
+		select( 'demo' ).getPage( 2 );
+		select( 'demo' ).getPage( 3 );
+
+		// Expected: First and second page fulfillments already triggered, so
+		// should only be one more than previous assertion set.
+		expect( fulfill ).toHaveBeenCalledTimes( 3 );
+		expect( isFulfilled ).toHaveBeenCalledTimes( 3 );
+
+		select( 'demo' ).getPage( 1 );
+		select( 'demo' ).getPage( 2 );
+		select( 'demo' ).getPage( 3 );
+		select( 'demo' ).getPage( 4 );
+
+		// Expected: Fourth page was pre-filled. Necessary to determine via
+		// isFulfilled, but fulfillment resolver should not be triggered.
+		expect( fulfill ).toHaveBeenCalledTimes( 3 );
+		expect( isFulfilled ).toHaveBeenCalledTimes( 4 );
 	} );
 
 	it( 'should resolve action to dispatch', ( done ) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4479,6 +4479,11 @@
 				"lodash": "4.17.5"
 			}
 		},
+		"equivalent-key-map": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.1.1.tgz",
+			"integrity": "sha512-VfHxntFFcApMyX3TTEQg+nuDPoiGgs1WfYm1JN+d9HUM6Shxp2d7LrMrDmdiybYZVs7U8HM9mqAHpwE9/X8pSQ=="
+		},
 		"errno": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"dom-react": "2.2.0",
 		"dom-scroll-into-view": "1.2.1",
 		"element-closest": "2.0.2",
+		"equivalent-key-map": "0.1.1",
 		"escape-string-regexp": "1.0.5",
 		"eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
 		"hpq": "1.2.0",


### PR DESCRIPTION
Related: #6084

This pull request seeks to revise the behavior of a resolver's explicit `isFulfilled` callback to occur a maximum of one time per argument set. `isFulfilled` is only necessary to call once, as it is intended to support cases where a fulfillment resolver may not be needed. It is assumed that after the initial case, fulfillment condition would never revert back to needing to be satisfied.

__Testing instructions:__

Ensure unit tests pass:

```js
npm run test-unit
```