### PR TITLE
Add documentation for undefined attribute source (fixes #5545)

### DIFF
--- a/docs/block-api/attributes.md
+++ b/docs/block-api/attributes.md
@@ -4,6 +4,8 @@
 
 Attribute sources are used to define the strategy by which block attribute values are extracted from saved post content. They provide a mechanism to map from the saved markup to a JavaScript representation of a block.
 
+If no attribute source is specified, the attribute will be saved to (and read from) the block's [comment delimiter](../language.md).
+
 Each source accepts an optional selector as the first argument. If a selector is specified, the source behavior will be run against the corresponding element(s) contained within the block. Otherwise it will be run against the block's root node.
 
 Under the hood, attribute sources are a superset of functionality provided by [hpq](https://github.com/aduth/hpq), a small library used to parse and query HTML markup into an object shape. In an object of attributes sources, you can name the keys as you see fit. The resulting object will assign as a value to each key the result of its attribute source.


### PR DESCRIPTION
## Description
As reported #5545, this PR adds a note to the attributes documentation indicating that the attribute source can be undefined (and what happens when an attribute's source is undefined).

## How has this been tested?

Not applicable.

## Types of changes
- Docs

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
