### PR TITLE
Fix spelling error in components/notice/list.js

### DIFF
--- a/components/notice/list.js
+++ b/components/notice/list.js
@@ -1,5 +1,5 @@
 /**
- * External depednencies
+ * External dependencies
  */
 import { noop, omit } from 'lodash';
 


### PR DESCRIPTION
## Description

Fixed the spelling of "dependencies" in `components/notice/list.js`.