### PR TITLE
Bugfix for permalink linking to preview URL (#6267)

### DIFF
--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -51,7 +51,7 @@ class PostPermalink extends Component {
 	}
 
 	render() {
-		const { isNew, previewLink, isEditable, samplePermalink } = this.props;
+		const { isNew, previewLink, isEditable, samplePermalink, isPublished } = this.props;
 		const { iconClass, isEditingPermalink } = this.state;
 
 		if ( isNew || ! previewLink ) {
@@ -75,7 +75,7 @@ class PostPermalink extends Component {
 				{ ! isEditingPermalink &&
 					<Button
 						className="editor-post-permalink__link"
-						href={ previewLink }
+						href={ ! isPublished ? previewLink : samplePermalink }
 						target="_blank"
 						ref={ ( permalinkButton ) => this.permalinkButton = permalinkButton }
 					>
@@ -118,12 +118,13 @@ class PostPermalink extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isEditedPostNew, isPermalinkEditable, getEditedPostPreviewLink, getPermalink } = select( 'core/editor' );
+		const { isEditedPostNew, isPermalinkEditable, getEditedPostPreviewLink, getPermalink, isCurrentPostPublished } = select( 'core/editor' );
 		return {
 			isNew: isEditedPostNew(),
 			previewLink: getEditedPostPreviewLink(),
 			isEditable: isPermalinkEditable(),
 			samplePermalink: getPermalink(),
+			isPublished: isCurrentPostPublished(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {


### PR DESCRIPTION
## Description
The issue (#6267) stated that regardless of the post being published or not, that the preview URL was being used to link people to the post inside the editor. This doesn't reflect the behaviour of the old editor.

(Made a mistake and got the wrong issue number when naming the branch - if this is an issue, I can re-submit the pull request... and maybe not use issue numbers in the branch name again!)

## How has this been tested?
Tried setting the post to different states (Password Protected, Private, Public), and then also setting the published date and time to different points in time, and in the instances where the published time was after the current time, the permalink used the preview URL. I also ran the test unit (npm run test) and they all passed.

## Screenshots

## Types of changes
This is a bug fix of which the code is isolated to a particular block/component, so the impact of the change is minor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->