### PR TITLE
Ensure underscore is loaded before lodash

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -433,7 +433,8 @@ function gutenberg_register_vendor_scripts() {
 	);
 	gutenberg_register_vendor_script(
 		'lodash',
-		'https://unpkg.com/lodash@4.17.5/lodash' . $suffix . '.js'
+		'https://unpkg.com/lodash@4.17.5/lodash' . $suffix . '.js',
+		array( 'underscore' )
 	);
 	wp_add_inline_script( 'lodash', 'window.lodash = _.noConflict();' );
 	gutenberg_register_vendor_script(


### PR DESCRIPTION
## Description

While underscore obviously isn't a dependency of lodash, it _is_ a dependency of ensuring 
that `_.noConflict()` works as expected.

If a JS concat tool is being used, it's possible that lodash and underscore will be grouped into the same concat bundle. Without specifying this dependency, then it's possible for the bundle to put lodash first, then underscore, _then_ do the `_.noConflict()` call, which will cause underscore to be assigned to `window.lodash`, which is not the ideal outcome. 🙂

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
