### PR TITLE
Improved RangeControl condition.

### DIFF
--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isFinite } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import classnames from 'classnames';
@@ -26,7 +31,7 @@ function RangeControl( {
 } ) {
 	const id = `inspector-range-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
-	const initialSliderValue = value === undefined ? initialPosition || '' : value;
+	const initialSliderValue = isFinite( value ) ? value : initialPosition || '';
 
 	return (
 		<BaseControl


### PR DESCRIPTION
RangeControl check for undefined in initialSliderValue did not catch the case where the value is equal to empty string for example. The condition was improved to handle this case.


## How has this been tested?
Create a new paragraph verify the fontSize slider does not appear in the middle but at the start.
