### PR TITLE
Fix issue with high contrast indicator in Edge

### DIFF
--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -20,9 +20,6 @@ $toggle-border-width: 2px;
 
 	.components-form-toggle__on {
 		left: $toggle-border-width * 3 + 2px; // indent 2px extra because icon is thinner
-		filter: invert( 100% ) contrast( 500% ); // this makes the icon white, and it makes it dark blue in Windows High Contrast Mode
-		outline: 1px solid transparent; // this makes the dark blue all black in Windows High Contrast Mode
-		outline-offset: -1px;
 	}
 
 	// unchecked state
@@ -102,4 +99,24 @@ $toggle-border-width: 2px;
 	margin: 0;
 	padding: 0;
 	z-index: z-index( '.components-form-toggle__input' );
+}
+
+// Ensure on indicator works in normal and Windows high contrast mode both
+.components-form-toggle .components-form-toggle__on {
+	// outlines show up in windows high contrast mode
+	outline: 1px solid transparent;
+	outline-offset: -1px;
+
+	// this colors the indicator black, then inverts it for normal mode
+	border: 1px solid $black;
+	filter: invert( 100% ) contrast( 500% ); // this makes the icon white for normal mode, and it makes it dark blue in Windows High Contrast Mode
+}
+
+@supports ( -ms-high-contrast-adjust: auto ) {
+	// Edge stacks outlines on top of the SVG itself, and when showing them in high contrast mode it means they get inverted again
+	// Therefore, show a different style for the on indicator only in Edge and IE11
+	.components-form-toggle .components-form-toggle__on {
+		filter: none;
+		border: 1px solid $white;
+	}
 }


### PR DESCRIPTION
This rejiggers the Switch high contrast mode a bit, to enhance how it works in Edge. Edge has an obscure bug where it overlays the outline on the SVG, regardless of outline-offset. This fixes that, and makes the switch work in high contrast mode in IE, Edge and Firefox on Windows. Chrome on Windows does not support high contrast mode.

The switch still works unchanged on Chrome and Firefox MacOS.

Screenshots of Edge:

<img width="265" alt="screen shot 2018-04-24 at 10 23 43" src="https://user-images.githubusercontent.com/1204802/39175209-06988186-47aa-11e8-866b-9d550d8013b1.png">

<img width="285" alt="screen shot 2018-04-24 at 10 19 03" src="https://user-images.githubusercontent.com/1204802/39175215-0957b0ea-47aa-11e8-9d56-fbac9facbe6f.png">
