### PR TITLE
Used IconButton on breadcrumbs to increase accessibility.

### DIFF
--- a/editor/components/block-list/breadcrumb.js
+++ b/editor/components/block-list/breadcrumb.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { compose, Component } from '@wordpress/element';
-import { Dashicon, Tooltip, Toolbar, Button } from '@wordpress/components';
+import { IconButton, Tooltip, Toolbar } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -56,6 +56,7 @@ export class BlockBreadcrumb extends Component {
 	render( ) {
 		const { uid, rootUID, selectRootBlock, isHidden } = this.props;
 		const { isFocused } = this.state;
+		const selectParentLabel = __( 'Select parent block' );
 
 		return (
 			<NavigableToolbar className={ classnames( 'editor-block-list__breadcrumb', {
@@ -63,14 +64,14 @@ export class BlockBreadcrumb extends Component {
 			} ) }>
 				<Toolbar>
 					{ rootUID && (
-						<Tooltip text={ __( 'Select parent block' ) }>
-							<Button
+						<Tooltip text={ selectParentLabel }>
+							<IconButton
 								onClick={ selectRootBlock }
 								onFocus={ this.onFocus }
 								onBlur={ this.onBlur }
-							>
-								<Dashicon icon="arrow-left-alt" uid={ uid } />
-							</Button>
+								label={ selectParentLabel }
+								icon="arrow-left-alt"
+							/>
 						</Tooltip>
 					) }
 					<BlockTitle uid={ uid } />


### PR DESCRIPTION
## Description
This PR replaces the usage of Button + Dashicon with IconButton in order to increase accessibility. IconButton label is used as aria-label.
It looks like uid prop was passed to dashicon by mistake as the component does not do anything with this prop.

## How has this been tested?
Add a paragraph inside a column, hover the paragraph and verify it is still possible to use the select parent button to select the parent block.
