### PR TITLE
Try label on the side

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -601,8 +601,7 @@
  * Block Toolbar
  */
 
-.editor-block-contextual-toolbar,
-.editor-block-list__breadcrumb {
+.editor-block-contextual-toolbar {
 	position: sticky;
 	z-index: z-index( '.editor-block-contextual-toolbar' );
 	white-space: nowrap;
@@ -650,8 +649,7 @@
 
 }
 
-.editor-block-contextual-toolbar .editor-block-toolbar,
-.editor-block-list__breadcrumb .components-toolbar {
+.editor-block-contextual-toolbar .editor-block-toolbar {
 	border: 1px solid $light-gray-500;
 	width: 100%;
 	background: $white;
@@ -675,27 +673,42 @@
 	}
 }
 
-.editor-block-list__breadcrumb .components-toolbar {
-	padding: 0px 12px;
-	line-height: $block-toolbar-height - 1px;
-	font-family: $default-font;
-	font-size: $default-font-size;
-	color: $dark-gray-500;
-	cursor: default;
 
-	.components-button {
-		margin-left: -12px;
-		margin-right: 12px;
-		border-right: 1px solid $light-gray-500;
-		color: $dark-gray-500;
-		padding-top: 6px;
-	}
-}
+/**
+ * Hover Breadcrumb
+ */
 
 .editor-block-list__breadcrumb {
+	// Hide on mobile
+	display: none;
+
+	@include break-large() {
+		display: block;
+	}
+
+	position: absolute;
+	z-index: z-index( '.editor-block-contextual-toolbar' );
+	white-space: nowrap;
+	text-align: right;
+	height: $block-toolbar-height;
+	font-family: $default-font;
+	font-size: $default-font-size;
+
+	// Position to the left of the movers
+	right: calc( 100% + #{ $block-side-ui-width + $block-side-ui-clearance + $block-side-ui-clearance } );
+	top: $block-padding;
+
+	// Hide until hovered
 	opacity: 0;
 
 	&.is-visible {
 		@include fade_in;
+	}
+
+	.components-toolbar {
+		background: transparent;
+		border: none;
+		color: $dark-gray-300;
+		cursor: default;
 	}
 }


### PR DESCRIPTION
This is an experiment to lighten the burden of the hover label, by putting it on the side and only showing it on large breakpoints.

It's very much a work in progress experiment, and it would need more polish before we can ship, especially in nested contexts.

<img width="277" alt="screen shot 2018-04-24 at 11 23 41" src="https://user-images.githubusercontent.com/1204802/39178576-618c37a6-47b2-11e8-9f66-41e44fb35304.png">
