### PR TITLE
Fixed bug where when creating a new post the default sidebar may be edit-post/block

### DIFF
--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -27,6 +27,11 @@ export const preferences = combineReducers( {
 
 			case 'CLOSE_GENERAL_SIDEBAR':
 				return null;
+			case 'SERIALIZE': {
+				if ( state === 'edit-post/block' ) {
+					return PREFERENCES_DEFAULTS.activeGeneralSidebar;
+				}
+			}
 		}
 
 		return state;

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -35,6 +35,24 @@ describe( 'state', () => {
 			expect( state.activeGeneralSidebar ).toBe( 'edit-post/document' );
 		} );
 
+		it( 'should save activeGeneralSidebar default value when serializing if the value was edit-post/block', () => {
+			const state = preferences( {
+				activeGeneralSidebar: 'edit-post/block',
+				editorMode: 'visual',
+				panels: { 'post-status': true },
+				features: { fixedToolbar: false },
+			}, {
+				type: 'SERIALIZE',
+			} );
+
+			expect( state ).toEqual( {
+				activeGeneralSidebar: 'edit-post/document',
+				editorMode: 'visual',
+				panels: { 'post-status': true },
+				features: { fixedToolbar: false },
+			} );
+		} );
+
 		it( 'should does not update if sidebar is already set to value', () => {
 			const original = deepFreeze( preferences( undefined, {
 				type: 'OPEN_GENERAL_SIDEBAR',


### PR DESCRIPTION
When creating a new post, if the last sidebar that was opened was edit-post/block we opened this sidebar by default. This is a bug as in this case the edit-post/block should not be opened we should open the default sidebar instead edit-post/document.

The reducer logic was updated to include a custom SERIALIZE handler that sets the default sidebar when serializing the state if the sidebar that was opened was edit-post/block.

Fixes: https://github.com/WordPress/gutenberg/issues/6377

## How has this been tested?
Add a new post, select a paragraph, write something verify the block sidebar is open. Press Posts -> Add new in WordPress sidebar and verify the sidebar that is open is edit-post/document and not edit-post/block.

