### PR TITLE
Make media library refresh on open

### DIFF
--- a/edit-post/hooks/blocks/media-upload/index.js
+++ b/edit-post/hooks/blocks/media-upload/index.js
@@ -170,6 +170,17 @@ class MediaUpload extends Component {
 	}
 
 	openModal() {
+		const frameContent = this.frame.content.get();
+		// hacky way to refresh the gallery if frame was open before and already has content, should be improved.
+		if ( frameContent ) {
+			const collection = frameContent.collection;
+			// clean all attachments we have in memory.
+			collection.toArray().forEach( ( model ) => model.trigger( 'destroy', model ) );
+			// reset has more flag, if library had small amount of items all items may have been loaded before.
+			collection.mirroring._hasMore = true;
+			// request items
+			collection.more();
+		}
 		this.frame.open();
 	}
 


### PR DESCRIPTION
These changes make sure that when we open the media library if a new item was inserted since the last time the library was opened, it will appear in the media library.

Fixes: https://github.com/WordPress/gutenberg/issues/4612

## How has this been tested?
Add three empty image blocks.
One the first select an image from the media library.
On the second drag&drop an image that is not on the media library from your computer to the image block.
On the third open the media library and verify the image that was added in step 2 is shown in the media library (in master it was not).
