### PR TITLE
Framework: Add queried-data state helper utility

### DIFF
--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -4,19 +4,27 @@
 import { castArray } from 'lodash';
 
 /**
- * Returns an action object used in signalling that the request for a given
- * data type has been made.
+ * Internal dependencies
+ */
+import {
+	toggleIsRequesting,
+	receiveQueriedItems,
+} from './queried-data';
+
+/**
+ * Returns an action object used in signalling whether a request for a given
+ * terms of a taxonomy is in progress.
  *
- * @param {string}  dataType Data type requested.
- * @param {?string} subType  Optional data sub-type.
+ * @param {string}  taxonomy     Data type requested.
+ * @param {?Object} query        Optional terms query.
+ * @param {boolean} isRequesting Whether a request is in progress.
  *
  * @return {Object} Action object.
  */
-export function setRequested( dataType, subType ) {
+export function toggleIsRequestingTerms( taxonomy, query, isRequesting ) {
 	return {
-		type: 'SET_REQUESTED',
-		dataType,
-		subType,
+		...toggleIsRequesting( query, isRequesting ),
+		taxonomy,
 	};
 }
 
@@ -25,15 +33,15 @@ export function setRequested( dataType, subType ) {
  * for a given taxonomy.
  *
  * @param {string}   taxonomy Taxonomy name.
+ * @param {?Object}  query    Optional terms query.
  * @param {Object[]} terms    Terms received.
  *
  * @return {Object} Action object.
  */
-export function receiveTerms( taxonomy, terms ) {
+export function receiveTerms( taxonomy, query, terms ) {
 	return {
-		type: 'RECEIVE_TERMS',
+		...receiveQueriedItems( query, terms ),
 		taxonomy,
-		terms,
 	};
 }
 

--- a/core-data/queried-data/actions.js
+++ b/core-data/queried-data/actions.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import {
+	TOGGLE_IS_REQUESTING,
+	RECEIVE_ITEMS,
+} from './constant';
+
+/**
+ * Returns an action object used in signalling whether a request for queried
+ * data is in progress.
+ *
+ * @param {?Object} query        Optional query object.
+ * @param {boolean} isRequesting Whether request is in progress.
+ *
+ * @return {Object} Action object.
+ */
+export function toggleIsRequesting( query = {}, isRequesting ) {
+	return {
+		type: TOGGLE_IS_REQUESTING,
+		query,
+		isRequesting,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that items have been received.
+ *
+ * @param {Array} items Items received.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveItems( items ) {
+	return {
+		type: RECEIVE_ITEMS,
+		items,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that queried data has been
+ * received.
+ *
+ * @param {?Object} query Optional query object.
+ * @param {Array}   items Queried items received.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveQueriedItems( query = {}, items ) {
+	return {
+		...receiveItems( items ),
+		query,
+	};
+}

--- a/core-data/queried-data/constant.js
+++ b/core-data/queried-data/constant.js
@@ -1,0 +1,14 @@
+/**
+ * Action type used in signalling that a queried items page has been received.
+ *
+ * @type {string}
+ */
+export const RECEIVE_ITEMS = '@@queried-data/RECEIVE_ITEMS';
+
+/**
+ * Action type used in signalling that a request has started or stopped for an
+ * items query.
+ *
+ * @type {string}
+ */
+export const TOGGLE_IS_REQUESTING = '@@queried-data/TOGGLE_IS_REQUESTING';

--- a/core-data/queried-data/get-query-parts.js
+++ b/core-data/queried-data/get-query-parts.js
@@ -23,7 +23,7 @@ import { withWeakMapCache } from './utils';
  *
  * @return {WPQueriedDataQueryParts} Query parts.
  */
-export function getQueryParts( query = {} ) {
+export function getQueryParts( query ) {
 	/**
 	 * @type {WPQueriedDataQueryParts}
 	 */

--- a/core-data/queried-data/get-query-parts.js
+++ b/core-data/queried-data/get-query-parts.js
@@ -1,0 +1,64 @@
+/**
+ * Internal dependencies
+ */
+import { withWeakMapCache } from './utils';
+
+/**
+ * An object of properties describing a specific query.
+ *
+ * @typedef {WPQueriedDataQueryParts}
+ *
+ * @property {number} page      The query page (1-based index, default 1).
+ * @property {number} perPage   Items per page for query (default 10).
+ * @property {string} stableKey An encoded stable string of all non-pagination
+ *                              query parameters.
+ */
+
+/**
+ * Given a query object, returns an object of parts, including pagination
+ * details (`page` and `perPage`, or default values). All other properties are
+ * encoded into a stable (idempotent) `stableKey` value.
+ *
+ * @param {Object} query Optional query object.
+ *
+ * @return {WPQueriedDataQueryParts} Query parts.
+ */
+export function getQueryParts( query = {} ) {
+	/**
+	 * @type {WPQueriedDataQueryParts}
+	 */
+	const parts = {
+		stableKey: '',
+		page: 1,
+		perPage: 10,
+	};
+
+	// Ensure stable key by sorting keys. Also more efficient for iterating.
+	const keys = Object.keys( query ).sort();
+
+	for ( let i = 0; i < keys.length; i++ ) {
+		const key = keys[ i ];
+		const value = query[ key ];
+
+		switch ( key ) {
+			case 'page':
+			case 'perPage':
+				parts[ key ] = value;
+				break;
+
+			default:
+				// While it's not required to be one, for simplicity's sake
+				// mimic querystring encoding for stable key.
+				parts.stableKey += (
+					( parts.stableKey ? '&' : '' ) +
+					encodeURIComponent( key ) +
+					'=' +
+					encodeURIComponent( value )
+				);
+		}
+	}
+
+	return parts;
+}
+
+export default withWeakMapCache( getQueryParts );

--- a/core-data/queried-data/index.js
+++ b/core-data/queried-data/index.js
@@ -1,0 +1,5 @@
+export * from './constant';
+export * from './actions';
+export * from './selectors';
+export { default as reducer } from './reducer';
+export { default as getQueryParts } from './get-query-parts';

--- a/core-data/queried-data/reducer.js
+++ b/core-data/queried-data/reducer.js
@@ -29,7 +29,7 @@ import getQueryParts from './get-query-parts';
  *
  * @return {number[]} Merged array of item IDs.
  */
-export function getMergedItemIds( itemIds = [], nextItemIds, page, perPage ) {
+export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 	const nextItemIdsStartIndex = ( page - 1 ) * perPage;
 
 	// If later page has already been received, default to the larger known
@@ -125,7 +125,7 @@ const queries = flowRight( [
 	// for default query on initialization.
 	withReturnUndefinedOnUnhandledDefault,
 ] )( combineReducers( {
-	itemIds( state = [], action ) {
+	itemIds( state = null, action ) {
 		const { type, page, perPage } = action;
 
 		if ( type !== RECEIVE_ITEMS ) {
@@ -133,7 +133,7 @@ const queries = flowRight( [
 		}
 
 		return getMergedItemIds(
-			state,
+			state || [],
 			map( action.items, 'id' ),
 			page,
 			perPage

--- a/core-data/queried-data/reducer.js
+++ b/core-data/queried-data/reducer.js
@@ -1,0 +1,160 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+import { keyBy, map, flowRight, merge } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ifMatchingAction,
+	replaceAction,
+	onSubKey,
+} from './utils';
+import {
+	RECEIVE_ITEMS,
+	TOGGLE_IS_REQUESTING,
+} from './constant';
+import getQueryParts from './get-query-parts';
+
+/**
+ * Returns a merged array of item IDs, given details of the received paginated
+ * items. The array is sparse-like with `undefined` entries where holes exist.
+ *
+ * @param {?Array<number>} itemIds     Original item IDs (default empty array).
+ * @param {number[]}       nextItemIds Item IDs to merge.
+ * @param {number}         page        Page of items merged.
+ * @param {number}         perPage     Number of items per page.
+ *
+ * @return {number[]} Merged array of item IDs.
+ */
+export function getMergedItemIds( itemIds = [], nextItemIds, page, perPage ) {
+	const nextItemIdsStartIndex = ( page - 1 ) * perPage;
+
+	// If later page has already been received, default to the larger known
+	// size of the existing array, else calculate as extending the existing.
+	const size = Math.max(
+		itemIds.length,
+		nextItemIdsStartIndex + nextItemIds.length
+	);
+
+	// Preallocate array since size is known.
+	const mergedItemIds = new Array( size );
+
+	for ( let i = 0; i < size; i++ ) {
+		// Preserve existing item ID except for subset of range of next items.
+		const isInNextItemsRange = (
+			i >= nextItemIdsStartIndex &&
+			i < nextItemIdsStartIndex + nextItemIds.length
+		);
+
+		mergedItemIds[ i ] = isInNextItemsRange ?
+			nextItemIds[ i - nextItemIdsStartIndex ] :
+			itemIds[ i ];
+	}
+
+	return mergedItemIds;
+}
+
+/**
+ * Higher-order reducer which returns undefined if the original reducer returns
+ * the default state value. Used in combination with `onSubKey` in avoiding
+ * assingment for undefined value to key.
+ *
+ * @param {Function} reducer Original reducer.
+ *
+ * @return {Function} Enhanced reducer.
+ */
+function withReturnUndefinedOnUnhandledDefault( reducer ) {
+	const defaultState = reducer( undefined, {} );
+	return ( state = defaultState, action ) => {
+		const nextState = reducer( state, action );
+		if ( nextState !== defaultState ) {
+			return nextState;
+		}
+	};
+}
+
+/**
+ * Reducer tracking items state, keyed by ID. Items are assumed to be normal,
+ * where identifiers are common across all queries.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Next state.
+ */
+function items( state = {}, action ) {
+	switch ( action.type ) {
+		case RECEIVE_ITEMS:
+			return {
+				...state,
+				...keyBy( action.items, 'id' ),
+			};
+	}
+
+	return state;
+}
+
+/**
+ * Reducer tracking queries state, keyed by stable query key. Each reducer
+ * query object includes `itemIds` and `requestingPageByPerPage`.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Next state.
+ */
+const queries = flowRight( [
+	// Limit to matching action type so we don't attempt to replace action on
+	// an unhandled action.
+	ifMatchingAction( ( action ) => 'query' in action ),
+
+	// Inject query parts into action for use both in `onSubKey` and reducer.
+	replaceAction( ( action ) => ( {
+		...action,
+		...getQueryParts( action.query ),
+	} ) ),
+
+	// Queries shape is shared, but keyed by query `stableKey` part. Original
+	// reducer tracks only a single query object.
+	onSubKey( 'stableKey' ),
+
+	// Since query is optional for handled actions, avoid tracking empty object
+	// for default query on initialization.
+	withReturnUndefinedOnUnhandledDefault,
+] )( combineReducers( {
+	itemIds( state = [], action ) {
+		const { type, page, perPage } = action;
+
+		if ( type !== RECEIVE_ITEMS ) {
+			return state;
+		}
+
+		return getMergedItemIds(
+			state,
+			map( action.items, 'id' ),
+			page,
+			perPage
+		);
+	},
+	requestingPageByPerPage( state = {}, action ) {
+		const { type, page, perPage, isRequesting } = action;
+
+		if ( type !== TOGGLE_IS_REQUESTING ) {
+			return state;
+		}
+
+		return merge( {}, state, {
+			[ perPage ]: {
+				[ page ]: isRequesting,
+			},
+		} );
+	},
+} ) );
+
+export default combineReducers( {
+	items,
+	queries,
+} );

--- a/core-data/queried-data/selectors.js
+++ b/core-data/queried-data/selectors.js
@@ -19,7 +19,7 @@ import getQueryParts from './get-query-parts';
  *
  * @return {?boolean} `requestingPageByPerPage` value for query.
  */
-function getRequestingPageByPerPage( state, query ) {
+function getRequestingPageByPerPage( state, query = {} ) {
 	const { stableKey, page, perPage } = getQueryParts( query );
 
 	return get( state, [
@@ -39,7 +39,7 @@ function getRequestingPageByPerPage( state, query ) {
  *
  * @return {?Array} Query items.
  */
-export function getQueriedItems( state, query ) {
+export function getQueriedItems( state, query = {} ) {
 	const { stableKey, page, perPage } = getQueryParts( query );
 	if ( ! state.queries[ stableKey ] ) {
 		return null;

--- a/core-data/queried-data/selectors.js
+++ b/core-data/queried-data/selectors.js
@@ -46,6 +46,10 @@ export function getQueriedItems( state, query ) {
 	}
 
 	const itemIds = state.queries[ stableKey ].itemIds;
+	if ( ! itemIds ) {
+		return null;
+	}
+
 	const startOffset = ( page - 1 ) * perPage;
 	const endOffset = startOffset + perPage;
 

--- a/core-data/queried-data/selectors.js
+++ b/core-data/queried-data/selectors.js
@@ -2,11 +2,22 @@
  * External dependencies
  */
 import { get } from 'lodash';
+import createSelector from 'rememo';
+import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
  * Internal dependencies
  */
 import getQueryParts from './get-query-parts';
+
+/**
+ * Cache of state keys to EquivalentKeyMap where the inner map tracks queries
+ * to their resulting items set. WeakMap allows garbage collection on expired
+ * state references.
+ *
+ * @type {WeakMap<Object,EquivalentKeyMap>}
+ */
+const queriedItemsCacheByState = new WeakMap();
 
 /**
  * Utility function returning the current value of `requestingPageByPerPage`
@@ -39,7 +50,7 @@ function getRequestingPageByPerPage( state, query = {} ) {
  *
  * @return {?Array} Query items.
  */
-export function getQueriedItems( state, query = {} ) {
+function getQueriedItemsUncached( state, query ) {
 	const { stableKey, page, perPage } = getQueryParts( query );
 	if ( ! state.queries[ stableKey ] ) {
 		return null;
@@ -51,7 +62,10 @@ export function getQueriedItems( state, query = {} ) {
 	}
 
 	const startOffset = ( page - 1 ) * perPage;
-	const endOffset = startOffset + perPage;
+	const endOffset = Math.min(
+		startOffset + perPage,
+		itemIds.length
+	);
 
 	const items = [];
 	for ( let i = startOffset; i < endOffset; i++ ) {
@@ -61,6 +75,36 @@ export function getQueriedItems( state, query = {} ) {
 
 	return items;
 }
+
+/**
+ * Returns items for a given query, or null if the items are not known. Caches
+ * result by both per state (by reference) and per query (by deep equality).
+ * The caching approach is intended to be durable to query objects which are
+ * deeply but not referentially equal, since otherwise:
+ *
+ * `getQueriedItems( state, {} ) !== getQueriedItems( state, {} )`
+ *
+ * @param {Object}  state State object.
+ * @param {?Object} query Optional query.
+ *
+ * @return {?Array} Query items.
+ */
+export const getQueriedItems = createSelector( ( state, query = {} ) => {
+	let queriedItemsCache = queriedItemsCacheByState.get( state );
+	if ( queriedItemsCache ) {
+		const queriedItems = queriedItemsCache.get( query );
+		if ( queriedItems !== undefined ) {
+			return queriedItems;
+		}
+	} else {
+		queriedItemsCache = new EquivalentKeyMap();
+		queriedItemsCacheByState.set( state, queriedItemsCache );
+	}
+
+	const items = getQueriedItemsUncached( state, query );
+	queriedItemsCache.set( query, items );
+	return items;
+} );
 
 /**
  * Returns true if a request has been initiated for query items, or false

--- a/core-data/queried-data/selectors.js
+++ b/core-data/queried-data/selectors.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getQueryParts from './get-query-parts';
+
+/**
+ * Utility function returning the current value of `requestingPageByPerPage`
+ * for the given state and optional query. Returns undefined if no requests
+ * have been initiated for the given query page, otherwise a boolean value
+ * representing whether a request is in progress.
+ *
+ * @param {Object}  state State object.
+ * @param {?Object} query Optional query.
+ *
+ * @return {?boolean} `requestingPageByPerPage` value for query.
+ */
+function getRequestingPageByPerPage( state, query ) {
+	const { stableKey, page, perPage } = getQueryParts( query );
+
+	return get( state, [
+		'queries',
+		stableKey,
+		'requestingPageByPerPage',
+		perPage,
+		page,
+	] );
+}
+
+/**
+ * Returns items for a given query, or null if the items are not known.
+ *
+ * @param {Object}  state State object.
+ * @param {?Object} query Optional query.
+ *
+ * @return {?Array} Query items.
+ */
+export function getQueriedItems( state, query ) {
+	const { stableKey, page, perPage } = getQueryParts( query );
+	if ( ! state.queries[ stableKey ] ) {
+		return null;
+	}
+
+	const itemIds = state.queries[ stableKey ].itemIds;
+	const startOffset = ( page - 1 ) * perPage;
+	const endOffset = startOffset + perPage;
+
+	const items = [];
+	for ( let i = startOffset; i < endOffset; i++ ) {
+		const itemId = itemIds[ i ];
+		items.push( state.items[ itemId ] );
+	}
+
+	return items;
+}
+
+/**
+ * Returns true if a request has been initiated for query items, or false
+ * otherwise.
+ *
+ * @param {Object}  state State object.
+ * @param {?Object} query Optional query.
+ *
+ * @return {boolean} Whether a request has been initiated.
+ */
+export function hasRequestedQueryItems( state, query ) {
+	return undefined !== getRequestingPageByPerPage( state, query );
+}
+
+/**
+ * Returns true if a request is in progress for query items, or false
+ * otherwise.
+ *
+ * @param {Object}  state State object.
+ * @param {?Object} query Optional query.
+ *
+ * @return {boolean} Whether a request is in progress.
+ */
+export function isRequestingQueryItems( state, query ) {
+	return Boolean( getRequestingPageByPerPage( state, query ) );
+}

--- a/core-data/queried-data/test/get-query-parts.js
+++ b/core-data/queried-data/test/get-query-parts.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import { getQueryParts } from '../get-query-parts';
+
+describe( 'getQueryParts', () => {
+	it( 'returns default value if passed undefined', () => {
+		const parts = getQueryParts();
+
+		expect( parts ).toEqual( {
+			page: 1,
+			perPage: 10,
+			stableKey: '',
+		} );
+	} );
+
+	it( 'parses out pagination data', () => {
+		const parts = getQueryParts( { page: 2, perPage: 2 } );
+
+		expect( parts ).toEqual( {
+			page: 2,
+			perPage: 2,
+			stableKey: '',
+		} );
+	} );
+
+	it( 'encodes stable string key', () => {
+		const first = getQueryParts( { '?': '&', b: 2 } );
+		const second = getQueryParts( { b: 2, '?': '&' } );
+
+		expect( first ).toEqual( second );
+		expect( first ).toEqual( {
+			page: 1,
+			perPage: 10,
+			stableKey: '%3F=%26&b=2',
+		} );
+	} );
+} );

--- a/core-data/queried-data/test/get-query-parts.js
+++ b/core-data/queried-data/test/get-query-parts.js
@@ -4,16 +4,6 @@
 import { getQueryParts } from '../get-query-parts';
 
 describe( 'getQueryParts', () => {
-	it( 'returns default value if passed undefined', () => {
-		const parts = getQueryParts();
-
-		expect( parts ).toEqual( {
-			page: 1,
-			perPage: 10,
-			stableKey: '',
-		} );
-	} );
-
 	it( 'parses out pagination data', () => {
 		const parts = getQueryParts( { page: 2, perPage: 2 } );
 

--- a/core-data/queried-data/test/reducer.js
+++ b/core-data/queried-data/test/reducer.js
@@ -1,0 +1,177 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import {
+	RECEIVE_ITEMS,
+	TOGGLE_IS_REQUESTING,
+} from '../';
+import reducer, {
+	getMergedItemIds,
+} from '../reducer';
+
+describe( 'getMergedItemIds', () => {
+	it( 'should receive a page', () => {
+		const result = getMergedItemIds( undefined, [ 4, 5, 6 ], 2, 3 );
+
+		expect( result ).toEqual( [
+			undefined,
+			undefined,
+			undefined,
+			4,
+			5,
+			6,
+		] );
+	} );
+
+	it( 'should merge into existing items', () => {
+		const original = deepFreeze( [
+			undefined,
+			undefined,
+			undefined,
+			4,
+			5,
+			6,
+		] );
+		const result = getMergedItemIds( original, [ 1, 2, 3 ], 1, 3 );
+
+		expect( result ).toEqual( [
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+		] );
+	} );
+
+	it( 'should replace with new page', () => {
+		const original = deepFreeze( [
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+		] );
+		const result = getMergedItemIds( original, [ 'replaced', 5, 6 ], 2, 3 );
+
+		expect( result ).toEqual( [
+			1,
+			2,
+			3,
+			'replaced',
+			5,
+			6,
+		] );
+	} );
+
+	it( 'should append a new partial page', () => {
+		const original = deepFreeze( [
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+		] );
+		const result = getMergedItemIds( original, [ 7 ], 3, 3 );
+
+		expect( result ).toEqual( [
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+			7,
+		] );
+	} );
+} );
+
+describe( 'reducer', () => {
+	it( 'returns a default value of its combined keys defaults', () => {
+		const state = reducer( undefined, {} );
+
+		expect( state ).toEqual( {
+			items: {},
+			queries: {},
+		} );
+	} );
+
+	it( 'receives a page of queried data', () => {
+		const original = deepFreeze( {
+			items: {},
+			queries: {},
+		} );
+		const state = reducer( original, {
+			type: RECEIVE_ITEMS,
+			query: { s: 'a', page: 1, perPage: 3 },
+			items: [
+				{ id: 1, name: 'abc' },
+			],
+		} );
+
+		expect( state ).toEqual( {
+			items: {
+				1: { id: 1, name: 'abc' },
+			},
+			queries: {
+				's=a': {
+					itemIds: [ 1 ],
+					requestingPageByPerPage: {},
+				},
+			},
+		} );
+	} );
+
+	it( 'receives an unqueried page of items', () => {
+		const original = deepFreeze( {
+			items: {},
+			queries: {},
+		} );
+		const state = reducer( original, {
+			type: RECEIVE_ITEMS,
+			items: [
+				{ id: 1, name: 'abc' },
+			],
+		} );
+
+		expect( state ).toEqual( {
+			items: {
+				1: { id: 1, name: 'abc' },
+			},
+			queries: {},
+		} );
+	} );
+
+	it( 'toggles requesting by page', () => {
+		const original = deepFreeze( {
+			items: {},
+			queries: {},
+		} );
+		const state = reducer( original, {
+			type: TOGGLE_IS_REQUESTING,
+			query: {},
+			isRequesting: true,
+		} );
+
+		expect( state ).toEqual( {
+			items: {},
+			queries: {
+				'': {
+					itemIds: [],
+					requestingPageByPerPage: {
+						10: {
+							1: true,
+						},
+					},
+				},
+			},
+		} );
+	} );
+} );

--- a/core-data/queried-data/test/reducer.js
+++ b/core-data/queried-data/test/reducer.js
@@ -16,7 +16,7 @@ import reducer, {
 
 describe( 'getMergedItemIds', () => {
 	it( 'should receive a page', () => {
-		const result = getMergedItemIds( undefined, [ 4, 5, 6 ], 2, 3 );
+		const result = getMergedItemIds( [], [ 4, 5, 6 ], 2, 3 );
 
 		expect( result ).toEqual( [
 			undefined,
@@ -164,7 +164,7 @@ describe( 'reducer', () => {
 			items: {},
 			queries: {
 				'': {
-					itemIds: [],
+					itemIds: null,
 					requestingPageByPerPage: {
 						10: {
 							1: true,

--- a/core-data/queried-data/test/selectors.js
+++ b/core-data/queried-data/test/selectors.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { getQueriedItems } from '../selectors';
+
+describe( 'getQueriedItems', () => {
+	it( 'should return null if requesting but no item IDs', () => {
+		const state = {
+			items: {},
+			queries: {
+				'': {
+					itemIds: null,
+					requestingPageByPerPage: {
+						10: {
+							1: true,
+						},
+					},
+				},
+			},
+		};
+
+		const result = getQueriedItems( state );
+
+		expect( result ).toBe( null );
+	} );
+} );

--- a/core-data/queried-data/test/selectors.js
+++ b/core-data/queried-data/test/selectors.js
@@ -23,4 +23,54 @@ describe( 'getQueriedItems', () => {
 
 		expect( result ).toBe( null );
 	} );
+
+	it( 'should return an array of items', () => {
+		const state = {
+			items: {
+				1: { id: 1 },
+				2: { id: 2 },
+			},
+			queries: {
+				'': {
+					itemIds: [ 1, 2 ],
+					requestingPageByPerPage: {
+						10: {
+							1: true,
+						},
+					},
+				},
+			},
+		};
+
+		const result = getQueriedItems( state );
+
+		expect( result ).toEqual( [
+			{ id: 1 },
+			{ id: 2 },
+		] );
+	} );
+
+	it( 'should cache on query by state', () => {
+		const state = {
+			items: {
+				1: { id: 1 },
+				2: { id: 2 },
+			},
+			queries: {
+				'': {
+					itemIds: [ 1, 2 ],
+					requestingPageByPerPage: {
+						10: {
+							1: true,
+						},
+					},
+				},
+			},
+		};
+
+		const resultA = getQueriedItems( state, {} );
+		const resultB = getQueriedItems( state, {} );
+
+		expect( resultA ).toBe( resultB );
+	} );
 } );

--- a/core-data/queried-data/utils/if-matching-action.js
+++ b/core-data/queried-data/utils/if-matching-action.js
@@ -1,0 +1,18 @@
+/**
+ * A higher-order reducer creator which invokes the original reducer only if
+ * the dispatching action matches the given predicate, **OR** if state is
+ * initializing (undefined).
+ *
+ * @param {Function} isMatch Function predicate for allowing reducer call.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+const ifMatchingAction = ( isMatch ) => ( reducer ) => ( state, action ) => {
+	if ( state === undefined || isMatch( action ) ) {
+		return reducer( state, action );
+	}
+
+	return state;
+};
+
+export default ifMatchingAction;

--- a/core-data/queried-data/utils/index.js
+++ b/core-data/queried-data/utils/index.js
@@ -1,0 +1,4 @@
+export { default as ifMatchingAction } from './if-matching-action';
+export { default as onSubKey } from './on-sub-key';
+export { default as replaceAction } from './replace-action';
+export { default as withWeakMapCache } from './with-weak-map-cache';

--- a/core-data/queried-data/utils/on-sub-key.js
+++ b/core-data/queried-data/utils/on-sub-key.js
@@ -1,0 +1,30 @@
+/**
+ * Higher-order reducer creator which creates a combined reducer object, keyed
+ * by a property on the action object.
+ *
+ * @param {string} actionProperty Action property by which to key object.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+export const onSubKey = ( actionProperty ) => ( reducer ) => ( state = {}, action ) => {
+	// Retrieve subkey from action. Do not track if undefined; useful for cases
+	// where reducer is scoped by action shape.
+	const key = action[ actionProperty ];
+	if ( key === undefined ) {
+		return state;
+	}
+
+	// Avoid updating state if unchanged. Note that this also accounts for a
+	// reducer which returns undefined on a key which is not yet tracked.
+	const nextKeyState = reducer( state[ key ], action );
+	if ( nextKeyState === state[ key ] ) {
+		return state;
+	}
+
+	return {
+		...state,
+		[ key ]: nextKeyState,
+	};
+};
+
+export default onSubKey;

--- a/core-data/queried-data/utils/replace-action.js
+++ b/core-data/queried-data/utils/replace-action.js
@@ -1,0 +1,13 @@
+/**
+ * Higher-order reducer creator which substitutes the action object before
+ * passing to the original reducer.
+ *
+ * @param {Function} replacer Function mapping original action to replacement.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+const replaceAction = ( replacer ) => ( reducer ) => ( state, action ) => {
+	return reducer( state, replacer( action ) );
+};
+
+export default replaceAction;

--- a/core-data/queried-data/utils/test/if-matching-action.js
+++ b/core-data/queried-data/utils/test/if-matching-action.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import ifMatchingAction from '../if-matching-action';
+
+describe( 'ifMatchingAction', () => {
+	function createEnhancedReducer( predicate ) {
+		const enhanceReducer = ifMatchingAction( predicate );
+		return enhanceReducer( () => 'Called' );
+	}
+
+	it( 'should call reducer if predicate returns true', () => {
+		const reducer = createEnhancedReducer( () => true );
+		const nextState = reducer( undefined, { type: '@@INIT' } );
+
+		expect( nextState ).toBe( 'Called' );
+	} );
+
+	it( 'should not call reducer if predicate returns false', () => {
+		const state = {};
+		const reducer = createEnhancedReducer( () => false );
+		const nextState = reducer( state, { type: 'DO_FOO' } );
+
+		expect( nextState ).toBe( state );
+	} );
+} );

--- a/core-data/queried-data/utils/test/on-sub-key.js
+++ b/core-data/queried-data/utils/test/on-sub-key.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import onSubKey from '../on-sub-key';
+
+describe( 'onSubKey', () => {
+	function createEnhancedReducer( actionProperty ) {
+		const enhanceReducer = onSubKey( actionProperty );
+		return enhanceReducer( ( state, action ) => 'Called by ' + action.caller );
+	}
+
+	it( 'should default to an empty object', () => {
+		const reducer = createEnhancedReducer( 'caller' );
+		const nextState = reducer( undefined, { type: '@@INIT' } );
+
+		expect( nextState ).toEqual( {} );
+	} );
+
+	it( 'should ignore actions where property not present', () => {
+		const state = {};
+		const reducer = createEnhancedReducer( 'caller' );
+		const nextState = reducer( state, { type: 'DO_FOO' } );
+
+		expect( nextState ).toBe( state );
+	} );
+
+	it( 'should key by action property', () => {
+		const reducer = createEnhancedReducer( 'caller' );
+
+		let state = Object.freeze( {} );
+		state = reducer( state, { type: 'DO_FOO', caller: 1 } );
+		state = reducer( state, { type: 'DO_FOO', caller: 2 } );
+
+		expect( state ).toEqual( {
+			1: 'Called by 1',
+			2: 'Called by 2',
+		} );
+	} );
+} );

--- a/core-data/queried-data/utils/test/replace-action.js
+++ b/core-data/queried-data/utils/test/replace-action.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import replaceAction from '../replace-action';
+
+describe( 'replaceAction', () => {
+	function createEnhancedReducer( replacer ) {
+		const enhanceReducer = replaceAction( replacer );
+		return enhanceReducer( ( state, action ) => 'Called by ' + action.after );
+	}
+
+	it( 'should replace the action passed to the reducer', () => {
+		const reducer = createEnhancedReducer( ( action ) => ( { after: action.before } ) );
+		const state = reducer( undefined, { before: 'foo' } );
+
+		expect( state ).toBe( 'Called by foo' );
+	} );
+} );

--- a/core-data/queried-data/utils/test/with-weak-map-cache.js
+++ b/core-data/queried-data/utils/test/with-weak-map-cache.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import withWeakMapCache from '../with-weak-map-cache';
+
+describe( 'withWeakMapCache', () => {
+	it( 'calls and returns from the original function', () => {
+		const cachedFn = withWeakMapCache( () => 'Called' );
+		const result = cachedFn();
+
+		expect( result ).toBe( 'Called' );
+	} );
+
+	it( 'caches by weak reference', () => {
+		const a = {};
+		const b = {};
+		const fn = jest.fn().mockReturnValue( 'Called' );
+		const cachedFn = withWeakMapCache( fn );
+
+		cachedFn( a );
+		cachedFn( a );
+		expect( fn ).toHaveBeenCalledTimes( 1 );
+
+		cachedFn( b );
+		expect( fn ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/core-data/queried-data/utils/with-weak-map-cache.js
+++ b/core-data/queried-data/utils/with-weak-map-cache.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { isObjectLike } from 'lodash';
+
+/**
+ * Given a function, returns an enhanced function which caches the result and
+ * tracks in WeakMap. The result is only cached if the original function is
+ * passed a valid object-like argument (requirement for WeakMap key).
+ *
+ * @param {Function} fn Original function.
+ *
+ * @return {Function} Enhanced caching function.
+ */
+function withWeakMapCache( fn ) {
+	const cache = new WeakMap();
+
+	return function( key ) {
+		let value;
+		if ( cache.has( key ) ) {
+			value = cache.get( key );
+		} else {
+			value = fn( key );
+
+			// Can reach here if key is not valid for WeakMap, since `has`
+			// will return false for invalid key. Since `set` will throw,
+			// ensure that key is valid before setting into cache.
+			if ( isObjectLike( key ) ) {
+				cache.set( key, value );
+			}
+		}
+
+		return value;
+	};
+}
+
+export default withWeakMapCache;

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -12,6 +12,8 @@ import { combineReducers } from '@wordpress/data';
  * Internal dependencies
  */
 import entitiesConfig from './entities';
+import { reducer as queriedDataReducer } from './queried-data';
+import { onSubKey } from './utils';
 
 /**
  * Reducer managing terms state. Keyed by taxonomy slug, the value is either
@@ -24,28 +26,7 @@ import entitiesConfig from './entities';
  *
  * @return {Object} Updated state.
  */
-export function terms( state = {}, action ) {
-	switch ( action.type ) {
-		case 'RECEIVE_TERMS':
-			return {
-				...state,
-				[ action.taxonomy ]: action.terms,
-			};
-
-		case 'SET_REQUESTED':
-			const { dataType, subType: taxonomy } = action;
-			if ( dataType !== 'terms' || state.hasOwnProperty( taxonomy ) ) {
-				return state;
-			}
-
-			return {
-				...state,
-				[ taxonomy ]: null,
-			};
-	}
-
-	return state;
-}
+export const terms = onSubKey( 'taxonomy' )( queriedDataReducer );
 
 /**
  * Reducer managing authors state. Keyed by id.

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -2,28 +2,35 @@
  * WordPress dependencies
  */
 import apiRequest from '@wordpress/api-request';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import {
-	setRequested,
+	toggleIsRequestingTerms,
 	receiveTerms,
 	receiveUserQuery,
 	receiveEntityRecords,
 	receiveThemeSupportsFromIndex,
 } from './actions';
 import { getEntity } from './entities';
+import { hasRequestedCategories } from './selectors';
 
 /**
  * Requests categories from the REST API, yielding action objects on request
  * progress.
  */
-export async function* getCategories() {
-	yield setRequested( 'terms', 'categories' );
-	const categories = await apiRequest( { path: '/wp/v2/categories' } );
-	yield receiveTerms( 'categories', categories );
-}
+export const getCategories = {
+	fulfill: async function* ( state, query ) {
+		yield toggleIsRequestingTerms( 'categories', query, true );
+		const path = addQueryArgs( '/wp/v2/categories', query );
+		const categories = await apiRequest( { path } );
+		yield receiveTerms( 'categories', query, categories );
+		yield toggleIsRequestingTerms( 'categories', query, false );
+	},
+	isFulfilled: hasRequestedCategories,
+};
 
 /**
  * Requests authors from the REST API.

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -4,51 +4,103 @@
 import { map } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import {
+	getQueriedItems,
+	isRequestingQueryItems,
+	hasRequestedQueryItems,
+} from './queried-data';
+
+/**
  * Returns all the available terms for the given taxonomy.
  *
- * @param {Object} state    Data state.
- * @param {string} taxonomy Taxonomy name.
+ * @param {Object}  state    Data state.
+ * @param {string}  taxonomy Taxonomy name.
+ * @param {?Object} query    Optional terms query.
  *
  * @return {Array} Categories list.
  */
-export function getTerms( state, taxonomy ) {
-	return state.terms[ taxonomy ];
+export function getTerms( state, taxonomy, query ) {
+	if ( ! state.terms.hasOwnProperty( taxonomy ) ) {
+		return [];
+	}
+
+	return getQueriedItems( state.terms[ taxonomy ], query );
 }
 
 /**
  * Returns all the available categories.
  *
- * @param {Object} state Data state.
+ * @param {Object}  state Data state.
+ * @param {?Object} query Optional categories query.
  *
  * @return {Array} Categories list.
  */
-export function getCategories( state ) {
-	return getTerms( state, 'categories' );
+export function getCategories( state, query ) {
+	return getTerms( state, 'categories', query );
 }
 
 /**
  * Returns true if a request is in progress for terms data of a given taxonomy,
  * or false otherwise.
  *
- * @param {Object} state    Data state.
- * @param {string} taxonomy Taxonomy name.
+ * @param {Object}  state    Data state.
+ * @param {string}  taxonomy Taxonomy name.
+ * @param {?Object} query    Optional terms query.
  *
  * @return {boolean} Whether a request is in progress for taxonomy's terms.
  */
-export function isRequestingTerms( state, taxonomy ) {
-	return state.terms[ taxonomy ] === null;
+export function isRequestingTerms( state, taxonomy, query ) {
+	if ( ! state.terms.hasOwnProperty( taxonomy ) ) {
+		return false;
+	}
+
+	return isRequestingQueryItems( state.terms[ taxonomy ], query );
+}
+
+/**
+ * Returns true if a request has been issued for terms data of a given
+ * taxonomy, or false otherwise.
+ *
+ * @param {Object}  state    Data state.
+ * @param {string}  taxonomy Taxonomy name.
+ * @param {?Object} query    Optional terms query.
+ *
+ * @return {boolean} Whether a request has been issued for taxonomy's terms.
+ */
+export function hasRequestedTerms( state, taxonomy, query ) {
+	if ( ! state.terms.hasOwnProperty( taxonomy ) ) {
+		return false;
+	}
+
+	return hasRequestedQueryItems( state.terms[ taxonomy ], query );
 }
 
 /**
  * Returns true if a request is in progress for categories data, or false
  * otherwise.
  *
- * @param {Object} state Data state.
+ * @param {Object}  state Data state.
+ * @param {?Object} query Optional categories query.
  *
  * @return {boolean} Whether a request is in progress for categories.
  */
-export function isRequestingCategories( state ) {
-	return isRequestingTerms( state, 'categories' );
+export function isRequestingCategories( state, query ) {
+	return isRequestingTerms( state, 'categories', query );
+}
+
+/**
+ * Returns true if a request has been issued for categories data, or false
+ * otherwise.
+ *
+ * @param {Object}  state Data state.
+ * @param {?Object} query Optional categories query.
+ *
+ * @return {boolean} Whether a request has been issued for categories.
+ */
+export function hasRequestedCategories( state, query ) {
+	return hasRequestedTerms( state, 'categories', query );
 }
 
 /**

--- a/core-data/test/reducer.js
+++ b/core-data/test/reducer.js
@@ -7,6 +7,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { terms, entities } from '../reducer';
+import { receiveTerms } from '../actions';
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -15,56 +16,14 @@ describe( 'terms()', () => {
 		expect( state ).toEqual( {} );
 	} );
 
-	it( 'returns with received terms', () => {
+	it( 'keys by taxonomy', () => {
 		const originalState = deepFreeze( {} );
-		const state = terms( originalState, {
-			type: 'RECEIVE_TERMS',
-			taxonomy: 'categories',
-			terms: [ { id: 1 } ],
-		} );
+		const state = terms(
+			originalState,
+			receiveTerms( 'categories', undefined, [ { id: 1 } ] )
+		);
 
-		expect( state ).toEqual( {
-			categories: [ { id: 1 } ],
-		} );
-	} );
-
-	it( 'assigns requested taxonomy to null', () => {
-		const originalState = deepFreeze( {} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'terms',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {
-			categories: null,
-		} );
-	} );
-
-	it( 'does not assign requested taxonomy to null if received', () => {
-		const originalState = deepFreeze( {
-			categories: [ { id: 1 } ],
-		} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'terms',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {
-			categories: [ { id: 1 } ],
-		} );
-	} );
-
-	it( 'does not assign requested taxonomy if not terms data type', () => {
-		const originalState = deepFreeze( {} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'foo',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {} );
+		expect( state ).toHaveProperty( 'categories' );
 	} );
 } );
 

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -7,7 +7,7 @@ import apiRequest from '@wordpress/api-request';
  * Internal dependencies
  */
 import { getCategories, getEntityRecord } from '../resolvers';
-import { setRequested, receiveTerms, receiveEntityRecords } from '../actions';
+import { toggleIsRequestingTerms, receiveTerms, receiveEntityRecords } from '../actions';
 
 jest.mock( '@wordpress/api-request' );
 
@@ -23,11 +23,12 @@ describe( 'getCategories', () => {
 	} );
 
 	it( 'yields with requested terms', async () => {
-		const fulfillment = getCategories();
+		const fulfillment = getCategories.fulfill();
 		const requested = ( await fulfillment.next() ).value;
-		expect( requested.type ).toBe( setRequested().type );
+		expect( requested.type ).toBe( toggleIsRequestingTerms().type );
+		expect( requested.isRequesting ).toBe( true );
 		const received = ( await fulfillment.next() ).value;
-		expect( received ).toEqual( receiveTerms( 'categories', CATEGORIES ) );
+		expect( received ).toEqual( receiveTerms( 'categories', undefined, CATEGORIES ) );
 	} );
 } );
 

--- a/core-data/test/selectors.js
+++ b/core-data/test/selectors.js
@@ -6,56 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getTerms, isRequestingTerms, getEntityRecord } from '../selectors';
-
-describe( 'getTerms()', () => {
-	it( 'returns value of terms by taxonomy', () => {
-		let state = deepFreeze( {
-			terms: {},
-		} );
-		expect( getTerms( state, 'categories' ) ).toBe( undefined );
-
-		state = deepFreeze( {
-			terms: {
-				categories: [ { id: 1 } ],
-			},
-		} );
-		expect( getTerms( state, 'categories' ) ).toEqual( [ { id: 1 } ] );
-	} );
-} );
-
-describe( 'isRequestingTerms()', () => {
-	it( 'returns false if never requested', () => {
-		const state = deepFreeze( {
-			terms: {},
-		} );
-
-		const result = isRequestingTerms( state, 'categories' );
-		expect( result ).toBe( false );
-	} );
-
-	it( 'returns false if terms received', () => {
-		const state = deepFreeze( {
-			terms: {
-				categories: [ { id: 1 } ],
-			},
-		} );
-
-		const result = isRequestingTerms( state, 'categories' );
-		expect( result ).toBe( false );
-	} );
-
-	it( 'returns true if requesting', () => {
-		const state = deepFreeze( {
-			terms: {
-				categories: null,
-			},
-		} );
-
-		const result = isRequestingTerms( state, 'categories' );
-		expect( result ).toBe( true );
-	} );
-} );
+import { getEntityRecord } from '../selectors';
 
 describe( 'getEntityRecord', () => {
 	it( 'should return undefined for unknown record\'s key', () => {

--- a/core-data/utils/index.js
+++ b/core-data/utils/index.js
@@ -1,0 +1,3 @@
+// Temporary: `queried-data` is modeled as an indepent module, so while its
+// implementation is reused here, the source location may change.
+export { default as onSubKey } from '../queried-data/utils/on-sub-key';


### PR DESCRIPTION
Related: #6180 
Related: #6360

This pull request seeks to work toward a generalized solution for queried / paginated data resources. It is implemented as an independent (but currently bundled) set of state helpers, including reducer, selectors, and action creators for operating on queried data. Currently, only the categories data has been refactored, and it does not currently take advantage of pagination (as this is not used by the Categories block). Further, as discovered in #6360, some additional work is required for memoization of "same" (but not strictly equal) query fulfillment.

The hope is that each resource (`core-data` state key) can simply reuse the existing helpers from `queried-data`. For terms, this looks like:

```js
export const terms = onSubKey( 'taxonomy' )( queriedDataReducer );
```

Some additional helpers may be required to expand this out to other state like media, particularly for ensuring that the reducer only operates on relevant queried data. For terms this is handled automatically through the `onSubKey` higher-order reducer creator, where state is only tracked for actions which include a `taxonomy` property. Likewise, we may create other higher-order reducers which test for the presence of some resource-specific marker, to be applied as an extension of the baseline `receiveQueriedItems` action creator (e.g. `ifActionMatches( ( action ) => action.queried === 'media' )`).

The state shape is normalized, with queries tracked as stable keys, both to avoid storing redundant data, and to avoid duplicate tracking for equivalent queries:

Example:

```json
{
	"terms": {
		"categories": {
			"items": {
				"1": {
					"id": 1,
					"name": "Uncategorized"
				},
				"2": {
					"id": 2,
					"name": "Cats"
				}
			},
			"queries": {
				"s=cat": {
					"itemIds": [ 1, 2 ],
					"requestingPageByPerPage": {}
				},
				"s=cats": {
					"itemIds": [ 2 ],
					"requestingPageByPerPage": {}
				}
			}
		}
	}
}
```

__Testing instructions:__

This should only impact the Categories block, which is the sole consumer of categories data. Verify that there are no regressions in the display of categories block, including the "Loading" placeholder and ultimately the display of categories.

Ensure unit tests pass:

```
npm test
```