### PR TITLE
Fix spelling error in blocks/api/serializer.js

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -33,7 +33,7 @@ export function getBlockDefaultClassName( blockName ) {
 }
 
 /**
- * Given a block type containg a save render implementation and attributes, returns the
+ * Given a block type containing a save render implementation and attributes, returns the
  * enhanced element to be saved or string when raw HTML expected.
  *
  * @param {Object} blockType   Block type.
@@ -92,7 +92,7 @@ export function getSaveElement( blockType, attributes, innerBlocks = [] ) {
 }
 
 /**
- * Given a block type containg a save render implementation and attributes, returns the
+ * Given a block type containing a save render implementation and attributes, returns the
  * static markup to be saved.
  *
  * @param {Object} blockType   Block type.


### PR DESCRIPTION
## Description
Fixes the spelling of `containing` in `blocks/api/serializer.js`