### PR TITLE
RTL: Fix showing/hiding the right block side UI on RTL languages

### DIFF
--- a/editor/components/block-list/with-hover-areas.js
+++ b/editor/components/block-list/with-hover-areas.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Component, findDOMNode, createHigherOrderComponent } from '@wordpress/element';
+import { withEditorSettings } from '@wordpress/blocks';
 
 const withHoverAreas = createHigherOrderComponent( ( WrappedComponent ) => {
 	class WithHoverAreasComponent extends Component {
@@ -34,13 +35,14 @@ const withHoverAreas = createHigherOrderComponent( ( WrappedComponent ) => {
 		}
 
 		onMouseMove( event ) {
+			const { isRTL } = this.props;
 			const { width, left, right } = this.container.getBoundingClientRect();
 
 			let hoverArea = null;
 			if ( ( event.clientX - left ) < width / 3 ) {
-				hoverArea = 'left';
+				hoverArea = isRTL ? 'right' : 'left';
 			} else if ( ( right - event.clientX ) < width / 3 ) {
-				hoverArea = 'right';
+				hoverArea = isRTL ? 'left' : 'right';
 			}
 
 			if ( hoverArea !== this.state.hoverArea ) {
@@ -56,7 +58,11 @@ const withHoverAreas = createHigherOrderComponent( ( WrappedComponent ) => {
 		}
 	}
 
-	return WithHoverAreasComponent;
+	return withEditorSettings( ( { isRTL } ) => {
+		return {
+			isRTL,
+		};
+	} )( WithHoverAreasComponent );
 } );
 
 export default withHoverAreas;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -964,6 +964,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
 		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
+		'isRTL'               => is_rtl(),
 	);
 
 	if ( ! empty( $color_palette ) ) {


### PR DESCRIPTION
closes #6366

In RTL languages, if we hover the right area, the left side UI was shown and vice verca. This PR fixes it.

**Testing instructions**

1. Change wordpress admin language to an RTL language such as arabic
2. On new post, create a new block.
3. Try to delete the post by clicking on the trash can icon.
4. you'll notice the trash can disappear when the cursor is in the right place and reappear only when the cursor is on the other side of the block.

(Do the same on LTR languages as well)