### PR TITLE
Fix issue with tab when it should've been a space

### DIFF
--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -27,7 +27,7 @@
 		top: $admin-bar-height;
 	}
 
-	.editor-post-switch-to-draft + .editor-post-preview	{
+	.editor-post-switch-to-draft + .editor-post-preview {
 		display: none;
 
 		@include break-small {


### PR DESCRIPTION
Caught by @aduth in https://github.com/WordPress/gutenberg/pull/6353#pullrequestreview-114789676 — my typo. This PR fixes it. I'll be sure to fix my linter.