### PR TITLE
Try compensating nested blocks for block padding

### DIFF
--- a/core-blocks/columns/editor.scss
+++ b/core-blocks/columns/editor.scss
@@ -2,6 +2,9 @@
 // This is sort of an experiment at making sure the editor looks as much like the end result as possible
 // Potentially the rules here can apply to all nested blocks and enable stacking, in which case it should be moved elsewhere
 .wp-block-columns .editor-block-list__layout {
+	margin-left: 0;
+	margin-right: 0;
+
 	&:first-child {
 		margin-left: -$block-padding;
 	}
@@ -12,16 +15,6 @@
 	// This max-width is used to constrain the main editor column, it should not cascade into columns
 	.editor-block-list__block {
 		max-width: none;
-	}
-}
-
-// Wide: show no left/right margin on wide, so they stack with the column side UI
-.editor-block-list__block[data-align="wide"] .wp-block-columns .editor-block-list__layout {
-	&:first-child {
-		margin-left: 0;
-	}
-	&:last-child {
-		margin-right: 0;
 	}
 }
 

--- a/core-blocks/quote/editor.scss
+++ b/core-blocks/quote/editor.scss
@@ -1,6 +1,10 @@
 .wp-block-quote {
 	margin: 0;
 
+	// compensate nested blocks for collapsing margins
+	padding-top: 1px;
+	padding-bottom: 1px;
+
 	cite {
 		display: block;
 		font-size: $default-font-size;

--- a/core-blocks/quote/editor.scss
+++ b/core-blocks/quote/editor.scss
@@ -1,10 +1,6 @@
 .wp-block-quote {
 	margin: 0;
 
-	// compensate nested blocks for collapsing margins
-	padding-top: 1px;
-	padding-bottom: 1px;
-
 	cite {
 		display: block;
 		font-size: $default-font-size;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -111,10 +111,19 @@
 		padding-right: $block-side-ui-padding;
 	}
 
-	// Don't add side padding for nested blocks, @todo see if this can be scoped better
+	// Don't add side padding for nested blocks, and compensate for block padding
 	.editor-block-list__block & {
+		// compensate for side UI
 		padding-left: 0;
 		padding-right: 0;
+
+		// compensate for block padding horizontally
+		margin-left: -$block-padding;
+		margin-right: -$block-padding;
+
+		// compensate for block padding and collapsing margins vertically
+		margin-top: -$block-padding + 1px;
+		margin-top: -$block-padding + 1px;
 	}
 }
 


### PR DESCRIPTION
As we make more and more blocks support nested blocks, we need to think about a way for nested blocks to compensate for their block padding. That's the 14px that surrounds the block itself, and on which the 1px selected-block border is painted.

If we don't, any block that goes from non-nested blocks to nested blocks will suddenly have an extra 14px amount of padding inside.

This PR is an experiment to fix that, and adds compensation before and after any nested context. What's missing here is a fix for collapsing margins — otherwise the negative top and bottom margins will apply to the _parent_, not the nesting context. The way to fix this is to apply a padding to any context in which childrens margins should not collapse into the parent. This PR adds that to the blockquote block itself, but if we think the general approach in this PR has merit, then we should find a way to make this more generic. For example a block that has nested children, if it had a `has-children` classname, then we could simply add the padding to that.

Before:

![screen shot 2018-04-25 at 13 07 36](https://user-images.githubusercontent.com/1204802/39242221-a40a6526-4889-11e8-9484-bfd07fb8cb43.png)


After:

![screen shot 2018-04-25 at 13 01 25](https://user-images.githubusercontent.com/1204802/39242191-80f23cf8-4889-11e8-89a6-d2381fd98c9c.png)
