### PR TITLE
Use the @wordpress/word-count package

### DIFF
--- a/editor/components/word-count/index.js
+++ b/editor/components/word-count/index.js
@@ -1,18 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { serialize } from '@wordpress/blocks';
 import { withSelect } from '@wordpress/data';
+import { count as wordCount } from '@wordpress/wordcount';
 
 function WordCount( { content } ) {
-	const wordCount = wp.utils.WordCounter.prototype.count( content );
 	return (
-		<span className="word-count">{ wordCount }</span>
+		<span className="word-count">{ wordCount( content, 'words' ) }</span>
 	);
 }
 
 export default withSelect( ( select ) => {
 	return {
-		content: serialize( select( 'core/editor' ).getBlocks() ),
+		content: select( 'core/editor' ).getEditedPostAttribute( 'content' ),
 	};
 } )( WordCount );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -275,7 +275,6 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-viewport',
 			'wp-plugins',
 			'wp-core-data',
-			'word-count',
 			'editor',
 			'lodash',
 		),

--- a/package-lock.json
+++ b/package-lock.json
@@ -462,6 +462,14 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-1.0.3.tgz",
 			"integrity": "sha512-0nqf62SWS0DiFnSD5miszPuAey01OrBsdqBFzOCYChjtB7AZm+8Q06qpeV02rpLY5FHaUxVgL+2JRljYIAFlpA=="
 		},
+		"@wordpress/wordcount": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-1.0.0.tgz",
+			"integrity": "sha512-N7JyhF+wdFDgDJbxZdscQ0vivdimvk/CjmNdonoSx4QHqgYfZOSSsFgpYg/rzeRBRFfT+e3RSu7LTdOZ/t54LA==",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@wordpress/hooks": "1.1.6",
 		"@wordpress/i18n": "1.1.0",
 		"@wordpress/url": "1.0.3",
+		"@wordpress/wordcount": "1.0.0",
 		"classnames": "2.2.5",
 		"clipboard": "1.7.1",
 		"dom-react": "2.2.0",


### PR DESCRIPTION
This PR updates the word count in Gutenberg to use the newly published WordPress package `@wordpress/word-count`

**Testing instructions**

 - Check that the word count is still showing as expected in the document outline