### PR TITLE
Fix classic block regression after extraction of the blocks into a separate script

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -191,7 +191,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	// Loading the old editor and its config to ensure the classic block works as expected.
 	wp_add_inline_script(
-		'wp-core-blocks', 'window.wp.oldEditor = window.wp.editor;', 'before'
+		'editor', 'window.wp.oldEditor = window.wp.editor;', 'after'
 	);
 	$tinymce_settings = apply_filters( 'tiny_mce_before_init', array(
 		'plugins'          => implode( ',', array_unique( apply_filters( 'tiny_mce_plugins', array(


### PR DESCRIPTION
Since we have an `editor` module in Gutenberg, we do this trick to assign the old `wp.editor` to the `oldEditor` variable, but we shouldn't attach this inline script to the script using the editor (here `core-blocks`) but we should do it right after the old editor's script `editor` to avoid any error due to script loading order.

**Testing instructions**

 - Try using the classic block