### PR TITLE
Fix SCSS color variable typos

### DIFF
--- a/components/tooltip/style.scss
+++ b/components/tooltip/style.scss
@@ -18,7 +18,7 @@
 	padding: 4px 12px;
 	background: $dark-gray-400;
 	border-width: 0;
-	color: white;
+	color: $white;
 	white-space: nowrap;
 }
 

--- a/core-blocks/cover-image/style.scss
+++ b/core-blocks/cover-image/style.scss
@@ -30,7 +30,7 @@
 
 	h2,
 	.wp-block-cover-image-text {
-		color: white;
+		color: $white;
 		font-size: 2em;
 		line-height: 1.25;
 		z-index: 1;
@@ -43,7 +43,7 @@
 		a:hover,
 		a:focus,
 		a:active {
-			color: white;
+			color: $white;
 		}
 	}
 
@@ -58,12 +58,12 @@
 		left: 0;
 		bottom: 0;
 		right: 0;
-		background-color: rgba( black, 0.5 );
+		background-color: rgba( $black, 0.5 );
 	}
 
 	@for $i from 1 through 10 {
 		&.has-background-dim.has-background-dim-#{ $i * 10 }:before {
-			background-color: rgba( black, $i * 0.1 );
+			background-color: rgba( $black, $i * 0.1 );
 		}
 	}
 

--- a/core-blocks/image/editor.scss
+++ b/core-blocks/image/editor.scss
@@ -22,7 +22,7 @@
 .wp-block-image__resize-handler-bottom-left {
 	display: none;
 	border-radius: 50%;
-	border: 2px solid white;
+	border: 2px solid $white;
 	width: 15px !important;
 	height: 15px !important;
 	position: absolute;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -1,6 +1,6 @@
 .components-draggable__clone {
 	& > .editor-block-list__block > .editor-block-list__block-draggable {
-		background: white;
+		background: $white;
 		box-shadow: $shadow-popover;
 
 		@include break-small {
@@ -151,7 +151,7 @@
 		bottom: 0;
 		left: 0;
 		background-color: rgba( $white, 0.6 );
-		background-image: linear-gradient( to bottom, transparent, #fff );
+		background-image: linear-gradient( to bottom, transparent, $white );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Fix SCSS color variable typos 

Closes #6412  

## How Has This Been Tested?
This has been tested with "npm test" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
