### PR TITLE
Add drop cap help text in paragraph block

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -97,7 +97,7 @@ class ParagraphBlock extends Component {
 	}
 
 	getDropCapHelp( checked ) {
-		return checked ? __( 'Drop Cap is set.' ) : __( 'Drop Cap is not set.' );
+		return checked ? __( 'The paragraph will display with a drop cap.' ) : __( 'The paragraph will not display with a drop cap.' );
 	}
 
 	getFontSize() {

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -97,7 +97,7 @@ class ParagraphBlock extends Component {
 	}
 
 	getDropCapHelp( checked ) {
-		return checked ? __( 'The paragraph will display with a drop cap.' ) : __( 'The paragraph will not display with a drop cap.' );
+		return checked ? __( 'Showing large initial letter.' ) : __( 'Toggle to show a large initial letter.' );
 	}
 
 	getFontSize() {

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -96,6 +96,10 @@ class ParagraphBlock extends Component {
 		setAttributes( { dropCap: ! attributes.dropCap } );
 	}
 
+	getDropCapHelp( checked ) {
+		return checked ? __( 'Thumbnails are cropped to align.' ) : __( 'Thumbnails are not cropped.' );
+	}
+
 	getFontSize() {
 		const { customFontSize, fontSize } = this.props.attributes;
 		if ( fontSize ) {
@@ -210,6 +214,7 @@ class ParagraphBlock extends Component {
 							label={ __( 'Drop Cap' ) }
 							checked={ !! dropCap }
 							onChange={ this.toggleDropCap }
+							help={ this.getDropCapHelp }
 						/>
 					</PanelBody>
 					<PanelColor title={ __( 'Background Color' ) } colorValue={ backgroundColor.value } initialOpen={ false }>

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -97,7 +97,7 @@ class ParagraphBlock extends Component {
 	}
 
 	getDropCapHelp( checked ) {
-		return checked ? __( 'Thumbnails are cropped to align.' ) : __( 'Thumbnails are not cropped.' );
+		return checked ? __( 'Drop Cap is set.' ) : __( 'Drop Cap is not set.' );
 	}
 
 	getFontSize() {


### PR DESCRIPTION
## Description
Adds drop cap help text as mentioned in #2146.

## How has this been tested?
- Run `npm test` without errors.
- Tested toggling the Drop Cap in several paragraps.

## Screenshots <!-- if applicable -->

<img width="266" alt="drop-cap-help-text" src="https://user-images.githubusercontent.com/1820415/39248704-7b477702-48a5-11e8-89b4-72e669a905f4.png">

## Types of changes
Adds help text under Drop Cap in paragraph 

## Checklist:
- [x ] My code is tested.
- [ x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
