### PR TITLE
Blocks: Add automatic handling of focus for RichText component

### DIFF
--- a/blocks/block-edit/context.js
+++ b/blocks/block-edit/context.js
@@ -1,13 +1,19 @@
 /**
  * External dependencies
  */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
 import { createContext, createHigherOrderComponent } from '@wordpress/element';
 
 const { Consumer, Provider } = createContext( {
 	name: '',
 	isSelected: false,
 	focusedElement: null,
-	setFocusedElement: () => {},
+	initFocusedElement: noop,
+	setFocusedElement: noop,
 } );
 
 export { Provider as BlockEditContextProvider };

--- a/blocks/block-edit/context.js
+++ b/blocks/block-edit/context.js
@@ -6,6 +6,8 @@ import { createContext, createHigherOrderComponent } from '@wordpress/element';
 const { Consumer, Provider } = createContext( {
 	name: '',
 	isSelected: false,
+	focusedElement: null,
+	setFocusedElement: () => {},
 } );
 
 export { Provider as BlockEditContextProvider };

--- a/blocks/block-edit/context.js
+++ b/blocks/block-edit/context.js
@@ -12,7 +12,6 @@ const { Consumer, Provider } = createContext( {
 	name: '',
 	isSelected: false,
 	focusedElement: null,
-	initFocusedElement: noop,
 	setFocusedElement: noop,
 } );
 

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -19,11 +19,9 @@ import { BlockEditContextProvider } from './context';
 export class BlockEdit extends Component {
 	constructor( props ) {
 		super( props );
-		this.initFocusedElement = this.initFocusedElement.bind( this );
 		this.setFocusedElement = this.setFocusedElement.bind( this );
 		this.state = {
 			focusedElement: null,
-			initFocusedElement: this.initFocusedElement,
 			setFocusedElement: this.setFocusedElement,
 		};
 	}
@@ -42,15 +40,6 @@ export class BlockEdit extends Component {
 				'unfiltered_html',
 			], false ),
 		};
-	}
-
-	initFocusedElement( focusedElement ) {
-		this.setState( ( prevState ) => {
-			if ( prevState.focusedElement !== null ) {
-				return null;
-			}
-			return { focusedElement };
-		} );
 	}
 
 	setFocusedElement( focusedElement ) {

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -19,9 +19,11 @@ import { BlockEditContextProvider } from './context';
 export class BlockEdit extends Component {
 	constructor( props ) {
 		super( props );
+		this.initFocusedElement = this.initFocusedElement.bind( this );
 		this.setFocusedElement = this.setFocusedElement.bind( this );
 		this.state = {
 			focusedElement: null,
+			initFocusedElement: this.initFocusedElement,
 			setFocusedElement: this.setFocusedElement,
 		};
 	}
@@ -40,6 +42,15 @@ export class BlockEdit extends Component {
 				'unfiltered_html',
 			], false ),
 		};
+	}
+
+	initFocusedElement( focusedElement ) {
+		this.setState( ( prevState ) => {
+			if ( prevState.focusedElement !== null ) {
+				return null;
+			}
+			return { focusedElement };
+		} );
 	}
 
 	setFocusedElement( focusedElement ) {

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -19,7 +19,11 @@ import { BlockEditContextProvider } from './context';
 export class BlockEdit extends Component {
 	constructor( props ) {
 		super( props );
-		this.state = {};
+		this.setFocusedElement = this.setFocusedElement.bind( this );
+		this.state = {
+			focusedElement: null,
+			setFocusedElement: this.setFocusedElement,
+		};
 	}
 
 	getChildContext() {
@@ -38,6 +42,15 @@ export class BlockEdit extends Component {
 		};
 	}
 
+	setFocusedElement( focusedElement ) {
+		this.setState( ( prevState ) => {
+			if ( prevState.focusedElement === focusedElement ) {
+				return null;
+			}
+			return { focusedElement };
+		} );
+	}
+
 	static getDerivedStateFromProps( { name, isSelected }, prevState ) {
 		if (
 			name === prevState.name &&
@@ -47,6 +60,7 @@ export class BlockEdit extends Component {
 		}
 
 		return {
+			...prevState,
 			name,
 			isSelected,
 		};

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -928,7 +928,12 @@ const RichTextContainer = compose( [
 		// Ensures that only one RichText component can be focused.
 		return {
 			isSelected: context.isSelected && context.focusedElement === ownProps.instanceId,
-			onFocus: () => context.setFocusedElement( ownProps.instanceId ),
+			onSetup: () => {
+				context.initFocusedElement( ownProps.instanceId );
+			},
+			onFocus: () => {
+				context.setFocusedElement( ownProps.instanceId );
+			},
 		};
 	} ),
 	withSelect( ( select ) => {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -928,9 +928,8 @@ const RichTextContainer = compose( [
 		if ( ownProps.isSelected === false ) {
 			return {};
 		}
-		// When explicitly set as selected or has onFocus prop provided,
-		// use value stored in the context instead.
-		if ( ownProps.isSelected === true || ownProps.onFocus ) {
+		// When explicitly set as selected, use the value stored in the context instead.
+		if ( ownProps.isSelected === true ) {
 			return {
 				isSelected: context.isSelected,
 			};

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -121,6 +121,7 @@ export class RichText extends Component {
 		this.onPastePreProcess = this.onPastePreProcess.bind( this );
 		this.onPaste = this.onPaste.bind( this );
 		this.onCreateUndoLevel = this.onCreateUndoLevel.bind( this );
+		this.setFocusedElement = this.setFocusedElement.bind( this );
 
 		this.state = {
 			formats: {},
@@ -192,6 +193,12 @@ export class RichText extends Component {
 
 		if ( this.props.onSetup ) {
 			this.props.onSetup( editor );
+		}
+	}
+
+	setFocusedElement() {
+		if ( this.props.setFocusedElement ) {
+			this.props.setFocusedElement( this.props.instanceId );
 		}
 	}
 
@@ -850,7 +857,10 @@ export class RichText extends Component {
 		);
 
 		return (
-			<div className={ classes } ref={ this.containerRef }>
+			<div className={ classes }
+				ref={ this.containerRef }
+				onFocus={ this.setFocusedElement }
+			>
 				{ isSelected && ! inlineToolbar && (
 					<BlockFormatControls>
 						{ formatToolbar }
@@ -928,12 +938,7 @@ const RichTextContainer = compose( [
 		// Ensures that only one RichText component can be focused.
 		return {
 			isSelected: context.isSelected && context.focusedElement === ownProps.instanceId,
-			onSetup() {
-				context.initFocusedElement( ownProps.instanceId );
-			},
-			onFocus() {
-				context.setFocusedElement( ownProps.instanceId );
-			},
+			setFocusedElement: context.setFocusedElement,
 		};
 	} ),
 	withSelect( ( select ) => {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -928,10 +928,10 @@ const RichTextContainer = compose( [
 		// Ensures that only one RichText component can be focused.
 		return {
 			isSelected: context.isSelected && context.focusedElement === ownProps.instanceId,
-			onSetup: () => {
+			onSetup() {
 				context.initFocusedElement( ownProps.instanceId );
 			},
-			onFocus: () => {
+			onFocus() {
 				context.setFocusedElement( ownProps.instanceId );
 			},
 		};

--- a/core-blocks/pullquote/index.js
+++ b/core-blocks/pullquote/index.js
@@ -68,12 +68,9 @@ export const settings = {
 		}
 	},
 
-	edit: withState( {
-		editable: 'content',
-	} )( ( { attributes, setAttributes, isSelected, className, editable, setState } ) => {
+	edit: ( { attributes, setAttributes, isSelected, className } ) => {
 		const { value, citation, align } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
-		const onSetActiveEditable = ( newEditable ) => () => setState( { editable: newEditable } );
 
 		return (
 			<Fragment>
@@ -95,8 +92,6 @@ export const settings = {
 						/* translators: the text of the quotation */
 						placeholder={ __( 'Write quote…' ) }
 						wrapperClassName="blocks-pullquote__content"
-						isSelected={ isSelected && editable === 'content' }
-						onFocus={ onSetActiveEditable( 'content' ) }
 					/>
 					{ ( citation || isSelected ) && (
 						<RichText
@@ -109,14 +104,12 @@ export const settings = {
 									citation: nextCitation,
 								} )
 							}
-							isSelected={ isSelected && editable === 'cite' }
-							onFocus={ onSetActiveEditable( 'cite' ) }
 						/>
 					) }
 				</blockquote>
 			</Fragment>
 		);
-	} ),
+	},
 
 	save( { attributes } ) {
 		const { value, citation, align } = attributes;

--- a/core-blocks/pullquote/index.js
+++ b/core-blocks/pullquote/index.js
@@ -67,7 +67,7 @@ export const settings = {
 		}
 	},
 
-	edit: ( { attributes, setAttributes, isSelected, className } ) => {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { value, citation, align } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 

--- a/core-blocks/pullquote/index.js
+++ b/core-blocks/pullquote/index.js
@@ -7,7 +7,6 @@ import { map } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withState } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import {
 	BlockControls,

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -175,7 +175,7 @@ export const settings = {
 		],
 	},
 
-	edit: ( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) => {
+	edit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
 		const { align, value, citation, style } = attributes;
 		const containerClassname = classnames( className, style === 2 ? 'is-large' : '' );
 

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Toolbar, withState } from '@wordpress/components';
+import { Toolbar } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import {
 	createBlock,
@@ -175,14 +175,9 @@ export const settings = {
 		],
 	},
 
-	edit: withState( {
-		editable: 'content',
-	} )( ( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className, editable, setState } ) => {
+	edit: ( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) => {
 		const { align, value, citation, style } = attributes;
 		const containerClassname = classnames( className, style === 2 ? 'is-large' : '' );
-		const onSetActiveEditable = ( newEditable ) => () => {
-			setState( { editable: newEditable } );
-		};
 
 		return (
 			<Fragment>
@@ -223,8 +218,6 @@ export const settings = {
 						} }
 						/* translators: the text of the quotation */
 						placeholder={ __( 'Write quote…' ) }
-						isSelected={ isSelected && editable === 'content' }
-						onFocus={ onSetActiveEditable( 'content' ) }
 					/>
 					{ ( ( citation && citation.length > 0 ) || isSelected ) && (
 						<RichText
@@ -237,14 +230,12 @@ export const settings = {
 							}
 							/* translators: the individual or entity quoted */
 							placeholder={ __( 'Write citation…' ) }
-							isSelected={ isSelected && editable === 'cite' }
-							onFocus={ onSetActiveEditable( 'cite' ) }
 						/>
 					) }
 				</blockquote>
 			</Fragment>
 		);
-	} ),
+	},
 
 	save( { attributes } ) {
 		const { align, value, citation, style } = attributes;

--- a/core-blocks/spacer/index.js
+++ b/core-blocks/spacer/index.js
@@ -34,7 +34,7 @@ export const settings = {
 		},
 	},
 
-	edit( { attributes, setAttributes, isSelected, toggleSelection } ) {
+	edit( { attributes, setAttributes, toggleSelection } ) {
 		const { height } = attributes;
 
 		return (
@@ -68,26 +68,24 @@ export const settings = {
 						toggleSelection( false );
 					} }
 				/>
-				{ isSelected &&
-					<InspectorControls>
-						<PanelBody title={ __( 'Spacer Settings' ) }>
-							<BaseControl label={ __( 'Height in pixels' ) }>
-								<input
-									type="number"
-									onChange={ ( event ) => {
-										setAttributes( {
-											height: parseInt( event.target.value, 10 ),
-										} );
-									} }
-									aria-label={ __( 'Height for the spacer element in pixels.' ) }
-									value={ height }
-									min="20"
-									step="10"
-								/>
-							</BaseControl>
-						</PanelBody>
-					</InspectorControls>
-				}
+				<InspectorControls>
+					<PanelBody title={ __( 'Spacer Settings' ) }>
+						<BaseControl label={ __( 'Height in pixels' ) }>
+							<input
+								type="number"
+								onChange={ ( event ) => {
+									setAttributes( {
+										height: parseInt( event.target.value, 10 ),
+									} );
+								} }
+								aria-label={ __( 'Height for the spacer element in pixels.' ) }
+								value={ height }
+								min="20"
+								step="10"
+							/>
+						</BaseControl>
+					</PanelBody>
+				</InspectorControls>
 			</Fragment>
 		);
 	},

--- a/core-blocks/text-columns/index.js
+++ b/core-blocks/text-columns/index.js
@@ -7,7 +7,7 @@ import { times } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, RangeControl, withState } from '@wordpress/components';
+import { PanelBody, RangeControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import {
 	BlockControls,
@@ -61,13 +61,8 @@ export const settings = {
 		}
 	},
 
-	edit: withState( {
-		editable: 'column-1',
-	} )( ( { attributes, setAttributes, className, isSelected, editable, setState } ) => {
+	edit: ( ( { attributes, setAttributes, className } ) => {
 		const { width, content, columns } = attributes;
-		const onSetActiveEditable = ( newEditable ) => () => {
-			setState( { editable: newEditable } );
-		};
 
 		return (
 			<Fragment>
@@ -91,9 +86,8 @@ export const settings = {
 				</InspectorControls>
 				<div className={ `${ className } align${ width } columns-${ columns }` }>
 					{ times( columns, ( index ) => {
-						const key = `column-${ index }`;
 						return (
-							<div className="wp-block-column" key={ key }>
+							<div className="wp-block-column" key={ `column-${ index }` }>
 								<RichText
 									tagName="p"
 									value={ content && content[ index ] && content[ index ].children }
@@ -107,8 +101,6 @@ export const settings = {
 										} );
 									} }
 									placeholder={ __( 'New Column' ) }
-									isSelected={ isSelected && editable === key }
-									onFocus={ onSetActiveEditable( key ) }
 								/>
 							</div>
 						);

--- a/core-blocks/text-columns/index.js
+++ b/core-blocks/text-columns/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { times } from 'lodash';
+import { get, times } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -90,7 +90,7 @@ export const settings = {
 							<div className="wp-block-column" key={ `column-${ index }` }>
 								<RichText
 									tagName="p"
-									value={ content && content[ index ] && content[ index ].children }
+									value={ get( content, [ index, 'children' ] ) }
 									onChange={ ( nextContent ) => {
 										setAttributes( {
 											content: [
@@ -116,7 +116,7 @@ export const settings = {
 			<div className={ `align${ width } columns-${ columns }` }>
 				{ times( columns, ( index ) =>
 					<div className="wp-block-column" key={ `column-${ index }` }>
-						<RichText.Content tagName="p" value={ content && content[ index ].children } />
+						<RichText.Content tagName="p" value={ get( content, [ index, 'children' ] ) } />
 					</div>
 				) }
 			</div>


### PR DESCRIPTION
## Description
Closes #6213.

Follow up for #5029 where we introduced new context API from React 16.3 to apply `isSelected` prop to a few components used with `BlockEdit`. 

This PR explores this idea further to make it possible to enforce that there can only be one `RichText` component focused at the same time. Historically it was manually enforced by using local state which stored which component is focused and prevented others to be selected at the same time.

I proposed the following
> Yes, multiple RichText is quite difficult to handle and maintain. I will look into it next week. Maybe it wouldn't be that hard to automatically handle active state in a way where only one RichText can be active per block at a time.

@jorgefilipecosta also proposed together with @jayshenk the following:
> I think we can have only one active RichText for the whole post. Maybe we can just use a component id and store id of RichText that is active, it would simplify the logic of some blocks.

I started small by using `BlockEdit` scoped solution to aovid dealing with the global store. I didn't see an immediate need to use `wp.data` to solve the issue we had here. We might want to revisit this later, but at the moment it seems like using the context API limits the number of operation React would have to perform where the focused element changes. I might be wrong here though. 


## How has this been tested?

Made sure it works without any changes for all blocks and for those updated in particular:
- `Pullquote`
- `Quote`
- `Text columns`

## Screenshots <!-- if applicable -->

![auto-focus rich text](https://user-images.githubusercontent.com/699132/39259153-fd5785e2-48b5-11e8-8a93-e8e788bbf5f3.gif)

## Types of changes
Refactoring,  no changes in the UX or UI.

## Next steps

We use a similar technique that uses `withState` to change focus for Gallery and Image blocks, but they are more complex so I excluded them from this PR. However we might look into exposing a general purpose helper that would allow to wrap components and inject this behavior to them.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
