### PR TITLE
Editor: Make sure createInnerBlockList never updates when passed using context

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -76,6 +76,7 @@ export class BlockListBlock extends Component {
 		this.onDragStart = this.onDragStart.bind( this );
 		this.onDragEnd = this.onDragEnd.bind( this );
 		this.selectOnOpen = this.selectOnOpen.bind( this );
+		this.createInnerBlockList = this.createInnerBlockList.bind( this );
 		this.hadTouchStart = false;
 
 		this.state = {
@@ -83,6 +84,11 @@ export class BlockListBlock extends Component {
 			dragging: false,
 			isHovered: false,
 		};
+	}
+
+	createInnerBlockList( uid ) {
+		const { renderBlockMenu } = this.props;
+		return createInnerBlockList( uid, renderBlockMenu );
 	}
 
 	/**
@@ -96,10 +102,7 @@ export class BlockListBlock extends Component {
 		// is defined in `@wordpress/blocks`, so to avoid a circular dependency
 		// we inject this function via context.
 		return {
-			createInnerBlockList: ( uid ) => {
-				const { renderBlockMenu } = this.props;
-				return createInnerBlockList( uid, renderBlockMenu );
-			},
+			createInnerBlockList: this.createInnerBlockList,
 		};
 	}
 

--- a/editor/components/block-preview/index.js
+++ b/editor/components/block-preview/index.js
@@ -29,9 +29,7 @@ class BlockPreview extends Component {
 		// is defined in `@wordpress/blocks`, so to avoid a circular dependency
 		// we inject this function via context.
 		return {
-			createInnerBlockList: ( uid ) => {
-				return createInnerBlockList( uid );
-			},
+			createInnerBlockList,
 		};
 	}
 


### PR DESCRIPTION
## Description
When working on another PR I discovered that `createInnerBlockList` passed through context to `BlockEdit` trigger tons of rerenders. This PR tries to fix it. 

I included also `shouldComponentUpdate( nextProps, nextState )` method inside `BlockEdit` component in 909844f commit. It is bundled with debugging tools by design, because it should be fixed with another PR which @youknowriad is working on: #6313. In effect, this PR depends on #6313 and shouldn't be merged before we confirm that `pure` HOC resolves all re-renders when `props` and `state` don't change.

## How has this been tested?
In the browser using some debugging hacks on the JS console. I included them in the PR with 
909844f. It must be removed before this branch gets merged :)

In general, we need to make sure that there is no regression introduced in all blocks, in particular, nested blocks should be examined very carefully.

## Screenshots <!-- if applicable -->

### Before

![createinnerblock](https://user-images.githubusercontent.com/699132/39253817-0d65e274-48a9-11e8-9947-712148b5f253.gif)

### After

![blockedit render after](https://user-images.githubusercontent.com/699132/39253917-487ea26a-48a9-11e8-89cd-c37d5d7a804a.gif)

## Types of changes
Performance improvements.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
