### PR TITLE
Implemented color class mechanism in button.

### DIFF
--- a/core-blocks/button/style.scss
+++ b/core-blocks/button/style.scss
@@ -5,11 +5,9 @@ $blocks-button__line-height: $big-font-size + 6px;
 	margin-bottom: 1.5em;
 
 	& .wp-block-button__link {
-		background-color: $dark-gray-700;
 		border: none;
 		border-radius: $blocks-button__height / 2;
 		box-shadow: none;
-		color: $white;
 		cursor: pointer;
 		display: inline-block;
 		font-size: $big-font-size;
@@ -20,13 +18,6 @@ $blocks-button__line-height: $big-font-size + 6px;
 		text-decoration: none;
 		white-space: normal;
 		word-break: break-all;
-
-		&:hover,
-		&:focus,
-		&:active {
-			background-color: $dark-gray-700;
-			color: $white;
-		}
 	}
 
 	&.aligncenter {
@@ -35,5 +26,23 @@ $blocks-button__line-height: $big-font-size + 6px;
 
 	&.alignright {
 		text-align: right;
+	}
+}
+
+.wp-block-button__link:not(.has-background) {
+	background-color: $dark-gray-700;
+	&:hover,
+	&:focus,
+	&:active {
+		background-color: $dark-gray-700;
+	}
+}
+
+.wp-block-button__link:not(.has-text-color) {
+	color: $white;
+	&:hover,
+	&:focus,
+	&:active {
+		color: $white;
 	}
 }


### PR DESCRIPTION
## Description
This PR makes button block use classes for colors that are pre-specified in the palette. No visual changes should be expected.

## How has this been tested?
Test the following actions in a theme that does not set the color palette (Gutenberg default is used):

1. Add a button block, change colors of background and or text to colors from the palette.
2. Add a button block, change colors of background and or text to custom colors.
3. Verify in the code view that for the first case classes were used to set the color and in the second case inline styles were used to set the color.
4. Save the post see and see it display correctly on the frontend.

Test the following actions in a theme that sets the color palette in the old mechanism without names and classes:

1. Add a button block, change colors of background and or text to colors from the palette.
2. Add a button block, change colors of background and or text to custom colors.
3. Verify in the code view that for both cases inline styles were used.
4. Save the post see and see it display correctly on the frontend.


