### PR TITLE
Used color name in ColorPalette aria-label.

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -8,7 +8,7 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Dropdown } from '@wordpress/components';
+import { Dropdown, Tooltip } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -21,23 +21,25 @@ export function ColorPalette( { colors, disableCustomColors = false, value, onCh
 	function applyOrUnset( color ) {
 		return () => onChange( value === color ? undefined : color );
 	}
-
+	const customColorPickerLabel = __( 'Custom color picker' );
 	return (
 		<div className="blocks-color-palette">
-			{ map( colors, ( { color } ) => {
+			{ map( colors, ( { color, name } ) => {
 				const style = { color: color };
 				const className = classnames( 'blocks-color-palette__item', { 'is-active': value === color } );
 
 				return (
 					<div key={ color } className="blocks-color-palette__item-wrapper">
-						<button
-							type="button"
-							className={ className }
-							style={ style }
-							onClick={ applyOrUnset( color ) }
-							aria-label={ sprintf( __( 'Color: %s' ), color ) }
-							aria-pressed={ value === color }
-						/>
+						<Tooltip text={ name || sprintf( __( 'Color code: %s' ), color ) }>
+							<button
+								type="button"
+								className={ className }
+								style={ style }
+								onClick={ applyOrUnset( color ) }
+								aria-label={ name ? sprintf( __( 'Color: %s' ), name ) : sprintf( __( 'Color code: %s' ), color ) }
+								aria-pressed={ value === color }
+							/>
+						</Tooltip>
 					</div>
 				);
 			} ) }
@@ -47,15 +49,17 @@ export function ColorPalette( { colors, disableCustomColors = false, value, onCh
 					className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"
 					contentClassName="blocks-color-palette__picker "
 					renderToggle={ ( { isOpen, onToggle } ) => (
-						<button
-							type="button"
-							aria-expanded={ isOpen }
-							className="blocks-color-palette__item"
-							onClick={ onToggle }
-							aria-label={ __( 'Custom color picker' ) }
-						>
-							<span className="blocks-color-palette__custom-color-gradient" />
-						</button>
+						<Tooltip text={ customColorPickerLabel }>
+							<button
+								type="button"
+								aria-expanded={ isOpen }
+								className="blocks-color-palette__item"
+								onClick={ onToggle }
+								aria-label={ customColorPickerLabel }
+							>
+								<span className="blocks-color-palette__custom-color-gradient" />
+							</button>
+						</Tooltip>
 					) }
 					renderContent={ () => (
 						<ChromePicker

--- a/blocks/color-palette/test/__snapshots__/index.js.snap
+++ b/blocks/color-palette/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`] = `
 <Chrome
-  color="red"
+  color="#f00"
   disableAlpha={true}
   hex="#ff0000"
   hsl={
@@ -69,54 +69,66 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
 >
   <div
     className="blocks-color-palette__item-wrapper"
-    key="red"
+    key="#f00"
   >
-    <button
-      aria-label="Color: red"
-      aria-pressed={true}
-      className="blocks-color-palette__item is-active"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "red",
+    <Tooltip
+      text="red"
+    >
+      <button
+        aria-label="Color: red"
+        aria-pressed={true}
+        className="blocks-color-palette__item is-active"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#f00",
+          }
         }
-      }
-      type="button"
-    />
+        type="button"
+      />
+    </Tooltip>
   </div>
   <div
     className="blocks-color-palette__item-wrapper"
-    key="white"
+    key="#fff"
   >
-    <button
-      aria-label="Color: white"
-      aria-pressed={false}
-      className="blocks-color-palette__item"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "white",
+    <Tooltip
+      text="white"
+    >
+      <button
+        aria-label="Color: white"
+        aria-pressed={false}
+        className="blocks-color-palette__item"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#fff",
+          }
         }
-      }
-      type="button"
-    />
+        type="button"
+      />
+    </Tooltip>
   </div>
   <div
     className="blocks-color-palette__item-wrapper"
-    key="blue"
+    key="#00f"
   >
-    <button
-      aria-label="Color: blue"
-      aria-pressed={false}
-      className="blocks-color-palette__item"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "blue",
+    <Tooltip
+      text="blue"
+    >
+      <button
+        aria-label="Color: blue"
+        aria-pressed={false}
+        className="blocks-color-palette__item"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#00f",
+          }
         }
-      }
-      type="button"
-    />
+        type="button"
+      />
+    </Tooltip>
   </div>
   <button
     className="button-link blocks-color-palette__clear"
@@ -134,54 +146,66 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
 >
   <div
     className="blocks-color-palette__item-wrapper"
-    key="red"
+    key="#f00"
   >
-    <button
-      aria-label="Color: red"
-      aria-pressed={true}
-      className="blocks-color-palette__item is-active"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "red",
+    <Tooltip
+      text="red"
+    >
+      <button
+        aria-label="Color: red"
+        aria-pressed={true}
+        className="blocks-color-palette__item is-active"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#f00",
+          }
         }
-      }
-      type="button"
-    />
+        type="button"
+      />
+    </Tooltip>
   </div>
   <div
     className="blocks-color-palette__item-wrapper"
-    key="white"
+    key="#fff"
   >
-    <button
-      aria-label="Color: white"
-      aria-pressed={false}
-      className="blocks-color-palette__item"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "white",
+    <Tooltip
+      text="white"
+    >
+      <button
+        aria-label="Color: white"
+        aria-pressed={false}
+        className="blocks-color-palette__item"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#fff",
+          }
         }
-      }
-      type="button"
-    />
+        type="button"
+      />
+    </Tooltip>
   </div>
   <div
     className="blocks-color-palette__item-wrapper"
-    key="blue"
+    key="#00f"
   >
-    <button
-      aria-label="Color: blue"
-      aria-pressed={false}
-      className="blocks-color-palette__item"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "blue",
+    <Tooltip
+      text="blue"
+    >
+      <button
+        aria-label="Color: blue"
+        aria-pressed={false}
+        className="blocks-color-palette__item"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#00f",
+          }
         }
-      }
-      type="button"
-    />
+        type="button"
+      />
+    </Tooltip>
   </div>
   <Dropdown
     className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"

--- a/blocks/color-palette/test/index.js
+++ b/blocks/color-palette/test/index.js
@@ -9,12 +9,12 @@ import { shallow } from 'enzyme';
 import { ColorPalette } from '../';
 
 describe( 'ColorPalette', () => {
-	const colors = [ { name: 'red', color: 'red' }, { name: 'white', color: 'white' }, { name: 'blue', color: 'blue' } ];
-	const currentColor = 'red';
+	const colors = [ { name: 'red', color: '#f00' }, { name: 'white', color: '#fff' }, { name: 'blue', color: '#00f' } ];
+	const currentColor = '#f00';
 	const onChange = jest.fn();
 
 	const wrapper = shallow( <ColorPalette colors={ colors } value={ currentColor } onChange={ onChange } /> );
-	const buttons = wrapper.find( '.blocks-color-palette__item-wrapper > button' );
+	const buttons = wrapper.find( '.blocks-color-palette__item-wrapper button' );
 
 	beforeEach( () => {
 		onChange.mockClear();
@@ -69,14 +69,14 @@ describe( 'ColorPalette', () => {
 			const isOpen = true;
 			const onToggle = jest.fn();
 
-			const renderedToggle = shallow( dropdown.props().renderToggle( { isOpen, onToggle } ) );
+			const renderedToggleButton = shallow( dropdown.props().renderToggle( { isOpen, onToggle } ).props.children );
 
 			test( 'should render dropdown content', () => {
-				expect( renderedToggle ).toMatchSnapshot();
+				expect( renderedToggleButton ).toMatchSnapshot();
 			} );
 
 			test( 'should call onToggle on click.', () => {
-				renderedToggle.simulate( 'click' );
+				renderedToggleButton.simulate( 'click' );
 
 				expect( onToggle ).toHaveBeenCalledTimes( 1 );
 			} );


### PR DESCRIPTION
This improves accessibility as displaying color code is not very useful for users to understand the color.

Fixes part of: https://github.com/WordPress/gutenberg/issues/2699

## Description
In a theme that does not change the color palette or in the theme that sets the color palette with color names (mandatory now, but not using it was not yet deprecated), verify that the aria-labels for the items of the color palette specify the color names (before they always used color code).
