### PR TITLE
Improve accessibility of PanelColor.

### DIFF
--- a/blocks/colors/with-colors.js
+++ b/blocks/colors/with-colors.js
@@ -33,6 +33,7 @@ export default createHigherOrderComponent(
 						props.attributes[ colorAttribute ],
 						props.attributes[ customColorAttribute ]
 					),
+					name: props.attributes[ colorAttribute ],
 					class: getColorClass( colorContext, props.attributes[ colorAttribute ] ),
 					set: setColorValue( colors, colorAttribute, customColorAttribute, props.setAttributes ),
 				} ),

--- a/components/panel/color.js
+++ b/components/panel/color.js
@@ -1,16 +1,25 @@
 /**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 import PanelBody from './body';
 
-function PanelColor( { colorValue, title, ...props } ) {
+function PanelColor( { colorValue, colorName, title, ...props } ) {
+	// translators: %s: The name of the color e.g: "vivid red" or color hex code if name is not available e.g: "#f00".
+	const currentColorLabel = sprintf( __( '(current color: %s)' ), colorName || colorValue );
 	return (
 		<PanelBody
 			{ ...props }
 			title={ [
 				<span className="components-panel__color-title" key="title">{ title }</span>,
-				colorValue && <span className="components-panel__color-area" key="color" style={ { background: colorValue } } />,
+				colorValue && (
+					<span className="components-panel__color-area" aria-label={ currentColorLabel } key="color" style={ { background: colorValue } } />
+				),
 			] }
 		/>
 	);

--- a/components/panel/test/color.js
+++ b/components/panel/test/color.js
@@ -19,7 +19,15 @@ describe( 'PanelColor', () => {
 		const wrapper = shallow( <PanelColor colorValue="red" title="sample title" /> );
 
 		expect( wrapper.prop( 'title' ) ).toContainEqual(
-			<span className="components-panel__color-area" key="color" style={ { background: 'red' } } />
+			<span className="components-panel__color-area" aria-label="(current color: red)" key="color" style={ { background: 'red' } } />
+		);
+	} );
+
+	it( 'should use color name in area label if provided', () => {
+		const wrapper = shallow( <PanelColor colorValue="#f00" colorName="red" title="sample title" /> );
+
+		expect( wrapper.prop( 'title' ) ).toContainEqual(
+			<span className="components-panel__color-area" aria-label="(current color: red)" key="color" style={ { background: '#f00' } } />
 		);
 	} );
 } );

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -213,13 +213,13 @@ class ParagraphBlock extends Component {
 							help={ this.getDropCapHelp }
 						/>
 					</PanelBody>
-					<PanelColor title={ __( 'Background Color' ) } colorValue={ backgroundColor.value } initialOpen={ false }>
+					<PanelColor title={ __( 'Background Color' ) } colorValue={ backgroundColor.value } colorName={ backgroundColor.name } initialOpen={ false }>
 						<ColorPalette
 							value={ backgroundColor.value }
 							onChange={ backgroundColor.set }
 						/>
 					</PanelColor>
-					<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor.value } initialOpen={ false }>
+					<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor.value } colorName={ textColor.name } initialOpen={ false }>
 						<ColorPalette
 							value={ textColor.value }
 							onChange={ textColor.set }


### PR DESCRIPTION
PanelColor displayed the color in a visual way as a square with the color, but for users with accessibility needs, we should also provide that information in a textual/descriptive way.

## Description
In a theme that does not change the color palette or in the theme that sets the color palette with color names (mandatory now, but not using it was not yet deprecated), add a paragraph and verify that the aria-labels for the color square in the color panel appear.

![image](https://user-images.githubusercontent.com/11271197/39259528-85201dc0-48ae-11e8-86f5-74be561e3831.png)

