### PR TITLE
Pre-load REST API index data to avoid FOMD

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -864,6 +864,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	// Preload common data.
 	$preload_paths = array(
+		'/',
 		sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
 		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
 		'/wp/v2/taxonomies?context=edit',


### PR DESCRIPTION
Because `theme_supports` data present in the index is used in rendering
UI, it'd be better to include it in the initial payload, instead of
incurring a second API request.

FOMD = Flash of Missing Data

Previously https://github.com/WordPress/gutenberg/pull/6318#issuecomment-383242644