### PR TITLE
Expose Gutenberg Data Format version in the REST API

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -345,6 +345,21 @@ function gutenberg_content_has_blocks( $content ) {
 }
 
 /**
+ * Returns the current version of the block format that the content string is using.
+ *
+ * If the string doesn't contain blocks, it returns 0.
+ *
+ * @since 2.8.0
+ * @see gutenberg_content_has_blocks()
+ *
+ * @param string $content Content to test.
+ * @return int The block format version.
+ */
+function gutenberg_content_block_version( $content ) {
+	return gutenberg_content_has_blocks( $content ) ? 1 : 0;
+}
+
+/**
  * Adds a "Gutenberg" post state for post tables, if the post contains blocks.
  *
  * @param  array   $post_states An array of post display states.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -235,6 +235,8 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 /**
  * Add the block format version to post content in the post REST API response.
  *
+ * @todo This will need to be registered to the schema too.
+ *
  * @param WP_REST_Response $response WP REST API response of a post.
  * @param WP_Post          $post The post being returned.
  * @param WP_REST_Request  $request WP REST API request.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -233,16 +233,37 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 }
 
 /**
+ * Add the block format version to post content in the post REST API response.
+ *
+ * @param WP_REST_Response $response WP REST API response of a post.
+ * @param WP_Post          $post The post being returned.
+ * @param WP_REST_Request  $request WP REST API request.
+ * @return WP_REST_Response Response containing the block_format.
+ */
+function gutenberg_add_block_format_to_post_content( $response, $post, $request ) {
+	if ( 'edit' !== $request['context'] ) {
+		return $response;
+	}
+
+	if ( isset( $response->data['content']['raw'] ) ) {
+		$response->data['content']['block_format'] = gutenberg_content_block_version( $response->data['content']['raw'] );
+	}
+
+	return $response;
+}
+
+/**
  * Whenever a post type is registered, ensure we're hooked into it's WP REST API response.
  *
  * @param string $post_type The newly registered post type.
  * @return string That same post type.
  */
-function gutenberg_register_permalink_template_function( $post_type ) {
+function gutenberg_register_post_prepare_functions( $post_type ) {
 	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_permalink_template_to_posts', 10, 3 );
+	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_block_format_to_post_content', 10, 3 );
 	return $post_type;
 }
-add_filter( 'registered_post_type', 'gutenberg_register_permalink_template_function' );
+add_filter( 'registered_post_type', 'gutenberg_register_post_prepare_functions' );
 
 /**
  * Includes the value for the 'viewable' attribute of a post type resource.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -247,8 +247,10 @@ function gutenberg_add_block_format_to_post_content( $response, $post, $request 
 		return $response;
 	}
 
-	if ( isset( $response->data['content']['raw'] ) ) {
-		$response->data['content']['block_format'] = gutenberg_content_block_version( $response->data['content']['raw'] );
+	$response_data = $response->get_data();
+	if ( isset( $response_data['content']['raw'] ) ) {
+		$response_data['content']['block_format'] = gutenberg_content_block_version( $response_data['content']['raw'] );
+		$response->set_data( $response_data );
 	}
 
 	return $response;

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -248,7 +248,7 @@ function gutenberg_add_block_format_to_post_content( $response, $post, $request 
 	}
 
 	$response_data = $response->get_data();
-	if ( isset( $response_data['content']['raw'] ) ) {
+	if ( is_array( $response_data['content'] ) && isset( $response_data['content']['raw'] ) ) {
 		$response_data['content']['block_format'] = gutenberg_content_block_version( $response_data['content']['raw'] );
 		$response->set_data( $response_data );
 	}


### PR DESCRIPTION
## Description

As described in #6435, it would be valuable to third party tools if we exposed a canonical block format version for the content of the current post, so they could decide how to handle the post.

For now, this is simply `0`, for "no blocks", or `1`, for "yes, there are blocks".

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
