### PR TITLE
Plugins: Add pinning support for sidebar plugins

### DIFF
--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -53,6 +53,22 @@ Title displayed at the top of the sidebar.
 - Type: `String`
 - Required: Yes
 
+##### pinnable
+
+Whether to allow to pin sidebar to toolbar.
+
+- Type: `Boolean`
+- Required: No
+- Default: `true`
+
+##### icon
+
+The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+
+- Type: `String` | `Element`
+- Required: No
+- Default: `admin-plugins`
+
 
 ### `PluginSidebarMoreMenuItem`
 

--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -29,6 +29,7 @@ const MyPluginSidebar = () => (
 	<PluginSidebar
 		name="my-sidebar"
 		title="My sidebar title"
+		icon="smiley"
 	>
 		<PanelBody>
 			{ __( 'My sidebar content' ) }
@@ -53,7 +54,7 @@ Title displayed at the top of the sidebar.
 - Type: `String`
 - Required: Yes
 
-##### pinnable
+##### isPinnable
 
 Whether to allow to pin sidebar to toolbar.
 

--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -68,7 +68,7 @@ The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug st
 
 - Type: `String` | `Element`
 - Required: No
-- Default: `admin-plugins`
+- Default: _inherits from the plugin_
 
 
 ### `PluginSidebarMoreMenuItem`
@@ -85,7 +85,7 @@ const { PluginSidebarMoreMenuItem } = wp.editPost;
 const MySidebarMoreMenuItem = () => (
 	<PluginSidebarMoreMenuItem
 		target="my-sidebar"
-		icon="yes"
+		icon="smiley"
 	>
 		{ __( 'My sidebar title' ) }
 	</PluginSidebarMoreMenuItem>
@@ -107,7 +107,7 @@ The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug st
 
 - Type: `String` | `Element`
 - Required: No
-
+- Default: _inherits from the plugin_
 
 ### `PluginPostStatusInfo`
 

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -51,15 +51,13 @@ function Header( {
 						forceIsDirty={ hasActiveMetaboxes }
 						forceIsSaving={ isSaving }
 					/>
-					<PinnedPlugins>
-						<IconButton
-							icon="admin-generic"
-							onClick={ toggleGeneralSidebar }
-							isToggled={ isEditorSidebarOpened }
-							label={ __( 'Settings' ) }
-							aria-expanded={ isEditorSidebarOpened }
-						/>
-					</PinnedPlugins>
+					<IconButton
+						icon="admin-generic"
+						onClick={ toggleGeneralSidebar }
+						isToggled={ isEditorSidebarOpened }
+						label={ __( 'Settings' ) }
+						aria-expanded={ isEditorSidebarOpened }
+					/>
 					<PinnedPlugins.Slot />
 					<MoreMenu />
 				</div>

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -17,6 +17,7 @@ import { compose } from '@wordpress/element';
 import './style.scss';
 import MoreMenu from './more-menu';
 import HeaderToolbar from './header-toolbar';
+import PinnedPlugins from './pinned-plugins';
 
 function Header( {
 	isEditorSidebarOpened,
@@ -50,14 +51,17 @@ function Header( {
 						forceIsDirty={ hasActiveMetaboxes }
 						forceIsSaving={ isSaving }
 					/>
-					<IconButton
-						icon="admin-generic"
-						onClick={ toggleGeneralSidebar }
-						isToggled={ isEditorSidebarOpened }
-						label={ __( 'Settings' ) }
-						aria-expanded={ isEditorSidebarOpened }
-					/>
-					<MoreMenu key="more-menu" />
+					<PinnedPlugins>
+						<IconButton
+							icon="admin-generic"
+							onClick={ toggleGeneralSidebar }
+							isToggled={ isEditorSidebarOpened }
+							label={ __( 'Settings' ) }
+							aria-expanded={ isEditorSidebarOpened }
+						/>
+					</PinnedPlugins>
+					<PinnedPlugins.Slot />
+					<MoreMenu />
 				</div>
 			) }
 		</div>

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -53,9 +53,9 @@ function Header( {
 					/>
 					<IconButton
 						icon="admin-generic"
+						label={ __( 'Settings' ) }
 						onClick={ toggleGeneralSidebar }
 						isToggled={ isEditorSidebarOpened }
-						label={ __( 'Settings' ) }
 						aria-expanded={ isEditorSidebarOpened }
 					/>
 					<PinnedPlugins.Slot />

--- a/edit-post/components/header/pinned-plugins/index.js
+++ b/edit-post/components/header/pinned-plugins/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const { Fill: PinnedPlugins, Slot } = createSlotFill( 'PinnedPlugins' );
+
+PinnedPlugins.Slot = ( { fillProps } ) => (
+	<Slot fillProps={ fillProps }>
+		{ ( fills ) => ! isEmpty( fills ) && (
+			<div className="edit-post-pinned-plugins">
+				{ fills }
+			</div>
+		) }
+	</Slot>
+);
+
+export default PinnedPlugins;

--- a/edit-post/components/header/pinned-plugins/index.js
+++ b/edit-post/components/header/pinned-plugins/index.js
@@ -15,8 +15,8 @@ import './style.scss';
 
 const { Fill: PinnedPlugins, Slot } = createSlotFill( 'PinnedPlugins' );
 
-PinnedPlugins.Slot = ( { fillProps } ) => (
-	<Slot fillProps={ fillProps }>
+PinnedPlugins.Slot = ( props ) => (
+	<Slot { ...props }>
 		{ ( fills ) => ! isEmpty( fills ) && (
 			<div className="edit-post-pinned-plugins">
 				{ fills }

--- a/edit-post/components/header/pinned-plugins/style.scss
+++ b/edit-post/components/header/pinned-plugins/style.scss
@@ -1,3 +1,7 @@
 .edit-post-pinned-plugins {
 	display: flex;
+
+	.components-icon-button {
+		margin-left: 4px;
+	}
 }

--- a/edit-post/components/header/pinned-plugins/style.scss
+++ b/edit-post/components/header/pinned-plugins/style.scss
@@ -1,0 +1,3 @@
+.edit-post-pinned-plugins {
+	display: flex;
+}

--- a/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
@@ -14,9 +14,9 @@ import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
 const PluginSidebarMoreMenuItem = ( { children, icon, isPinned, isSelected, onClick } ) => (
 	<Fragment>
-		{ isPinned && icon && (
+		{ icon && (
 			<PinnedPlugins>
-				{ <IconButton
+				{ isPinned && <IconButton
 					icon={ icon }
 					label={ children }
 					onClick={ onClick }
@@ -50,7 +50,7 @@ export default compose(
 		const sidebarName = `${ pluginContext.name }/${ target }`;
 
 		return {
-			isPinned: isPluginItemPinned( `sidebar/${ sidebarName }` ),
+			isPinned: isPluginItemPinned( sidebarName ),
 			isSelected: getActiveGeneralSidebarName() === sidebarName,
 			sidebarName,
 		};

--- a/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
@@ -16,13 +16,13 @@ const PluginSidebarMoreMenuItem = ( { children, icon, isPinned, isSelected, onCl
 	<Fragment>
 		{ isPinned && icon && (
 			<PinnedPlugins>
-				<IconButton
+				{ <IconButton
 					icon={ icon }
 					label={ children }
 					onClick={ onClick }
 					isToggled={ isSelected }
 					aria-expanded={ isSelected }
-				/>
+				/> }
 			</PinnedPlugins>
 		) }
 		<PluginsMoreMenuGroup>

--- a/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
@@ -1,42 +1,28 @@
 /**
  * WordPress dependencies
  */
-import { compose, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { IconButton, MenuItem } from '@wordpress/components';
+import { MenuItem } from '@wordpress/components';
 import { withPluginContext } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
  */
-import PinnedPlugins from '../pinned-plugins';
 import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
-const PluginSidebarMoreMenuItem = ( { children, icon, isPinned, isSelected, onClick } ) => (
-	<Fragment>
-		{ icon && (
-			<PinnedPlugins>
-				{ isPinned && <IconButton
-					icon={ icon }
-					label={ children }
-					onClick={ onClick }
-					isToggled={ isSelected }
-					aria-expanded={ isSelected }
-				/> }
-			</PinnedPlugins>
+const PluginSidebarMoreMenuItem = ( { children, icon, isSelected, onClick } ) => (
+	<PluginsMoreMenuGroup>
+		{ ( fillProps ) => (
+			<MenuItem
+				icon={ isSelected ? 'yes' : icon }
+				isSelected={ isSelected }
+				onClick={ compose( onClick, fillProps.onClose ) }
+			>
+				{ children }
+			</MenuItem>
 		) }
-		<PluginsMoreMenuGroup>
-			{ ( fillProps ) => (
-				<MenuItem
-					icon={ isSelected ? 'yes' : icon }
-					isSelected={ isSelected }
-					onClick={ compose( onClick, fillProps.onClose ) }
-				>
-					{ children }
-				</MenuItem>
-			) }
-		</PluginsMoreMenuGroup>
-	</Fragment>
+	</PluginsMoreMenuGroup>
 );
 
 export default compose(
@@ -44,13 +30,11 @@ export default compose(
 	withSelect( ( select, ownProps ) => {
 		const {
 			getActiveGeneralSidebarName,
-			isPluginItemPinned,
 		} = select( 'core/edit-post' );
 		const { pluginContext, target } = ownProps;
 		const sidebarName = `${ pluginContext.name }/${ target }`;
 
 		return {
-			isPinned: isPluginItemPinned( sidebarName ),
 			isSelected: getActiveGeneralSidebarName() === sidebarName,
 			sidebarName,
 		};

--- a/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
@@ -12,9 +12,9 @@ import { withPluginContext } from '@wordpress/plugins';
 import PinnedPlugins from '../pinned-plugins';
 import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
-const PluginSidebarMoreMenuItem = ( { children, isSelected, icon, onClick } ) => (
+const PluginSidebarMoreMenuItem = ( { children, icon, isPinned, isSelected, onClick } ) => (
 	<Fragment>
-		{ icon && (
+		{ isPinned && icon && (
 			<PinnedPlugins>
 				<IconButton
 					icon={ icon }
@@ -42,11 +42,16 @@ const PluginSidebarMoreMenuItem = ( { children, isSelected, icon, onClick } ) =>
 export default compose(
 	withPluginContext,
 	withSelect( ( select, ownProps ) => {
+		const {
+			getActiveGeneralSidebarName,
+			isPluginItemPinned,
+		} = select( 'core/edit-post' );
 		const { pluginContext, target } = ownProps;
 		const sidebarName = `${ pluginContext.name }/${ target }`;
 
 		return {
-			isSelected: select( 'core/edit-post' ).getActiveGeneralSidebarName() === sidebarName,
+			isPinned: isPluginItemPinned( `sidebar/${ sidebarName }` ),
+			isSelected: getActiveGeneralSidebarName() === sidebarName,
 			sidebarName,
 		};
 	} ),

--- a/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
@@ -27,14 +27,14 @@ const PluginSidebarMoreMenuItem = ( { children, icon, isSelected, onClick } ) =>
 
 export default compose(
 	withPluginContext,
-	withSelect( ( select, ownProps ) => {
+	withSelect( ( select, { icon, pluginContext, target } ) => {
 		const {
 			getActiveGeneralSidebarName,
 		} = select( 'core/edit-post' );
-		const { pluginContext, target } = ownProps;
 		const sidebarName = `${ pluginContext.name }/${ target }`;
 
 		return {
+			icon: icon || pluginContext.icon,
 			isSelected: getActiveGeneralSidebarName() === sidebarName,
 			sidebarName,
 		};

--- a/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
@@ -26,17 +26,19 @@ const PluginSidebarMoreMenuItem = ( { children, icon, isSelected, onClick } ) =>
 );
 
 export default compose(
-	withPluginContext,
-	withSelect( ( select, { icon, pluginContext, target } ) => {
+	withPluginContext( ( context, ownProps ) => {
+		return {
+			icon: ownProps.icon || context.icon,
+			sidebarName: `${ context.name }/${ ownProps.target }`,
+		};
+	} ),
+	withSelect( ( select, { sidebarName } ) => {
 		const {
 			getActiveGeneralSidebarName,
 		} = select( 'core/edit-post' );
-		const sidebarName = `${ pluginContext.name }/${ target }`;
 
 		return {
-			icon: icon || pluginContext.icon,
 			isSelected: getActiveGeneralSidebarName() === sidebarName,
-			sidebarName,
 		};
 	} ),
 	withDispatch( ( dispatch, { isSelected, sidebarName } ) => {

--- a/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
@@ -1,28 +1,42 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/element';
+import { compose, Fragment } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { MenuItem } from '@wordpress/components';
+import { IconButton, MenuItem } from '@wordpress/components';
 import { withPluginContext } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
  */
+import PinnedPlugins from '../pinned-plugins';
 import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
 const PluginSidebarMoreMenuItem = ( { children, isSelected, icon, onClick } ) => (
-	<PluginsMoreMenuGroup>
-		{ ( fillProps ) => (
-			<MenuItem
-				icon={ isSelected ? 'yes' : icon }
-				isSelected={ isSelected }
-				onClick={ compose( onClick, fillProps.onClose ) }
-			>
-				{ children }
-			</MenuItem>
+	<Fragment>
+		{ icon && (
+			<PinnedPlugins>
+				<IconButton
+					icon={ icon }
+					label={ children }
+					onClick={ onClick }
+					isToggled={ isSelected }
+					aria-expanded={ isSelected }
+				/>
+			</PinnedPlugins>
 		) }
-	</PluginsMoreMenuGroup>
+		<PluginsMoreMenuGroup>
+			{ ( fillProps ) => (
+				<MenuItem
+					icon={ isSelected ? 'yes' : icon }
+					isSelected={ isSelected }
+					onClick={ compose( onClick, fillProps.onClose ) }
+				>
+					{ children }
+				</MenuItem>
+			) }
+		</PluginsMoreMenuGroup>
+	</Fragment>
 );
 
 export default compose(

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -25,8 +25,8 @@ function PluginSidebar( props ) {
 		children,
 		icon = 'admin-plugins',
 		isActive,
+		isPinnable = true,
 		isPinned,
-		pinnable = true,
 		sidebarName,
 		title,
 		togglePin,
@@ -35,7 +35,7 @@ function PluginSidebar( props ) {
 
 	return (
 		<Fragment>
-			{ pinnable && (
+			{ isPinnable && (
 				<PinnedPlugins>
 					{ isPinned && <IconButton
 						icon={ icon }
@@ -54,11 +54,11 @@ function PluginSidebar( props ) {
 					closeLabel={ __( 'Close plugin' ) }
 				>
 					<strong>{ title }</strong>
-					{ pinnable && (
+					{ isPinnable && (
 						<IconButton
-							onClick={ togglePin }
 							icon={ isPinned ? 'star-filled' : 'star-empty' }
 							label={ isPinned ? __( 'Unpin from toolbar' ) : __( 'Pin to toolbar' ) }
+							onClick={ togglePin }
 							isToggled={ isPinned }
 							aria-expanded={ isPinned }
 						/>

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -3,45 +3,72 @@
  */
 import { IconButton, Panel } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { compose } from '@wordpress/element';
+import { compose, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withPluginContext } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
  */
+import PinnedPlugins from '../../header/pinned-plugins';
 import Sidebar from '../';
 import SidebarHeader from '../sidebar-header';
 
 /**
  * Renders the plugin sidebar component.
  *
+ * @param {Object} props Element props.
  * @return {WPElement} Plugin sidebar component.
  */
-function PluginSidebar( { children, isPinned, sidebarName, title, togglePin, pinnable = true } ) {
+function PluginSidebar( props ) {
+	const {
+		children,
+		icon = 'admin-plugins',
+		isActive,
+		isPinned,
+		pinnable = true,
+		sidebarName,
+		title,
+		togglePin,
+		toggleSidebar,
+	} = props;
+
 	return (
-		<Sidebar
-			name={ sidebarName }
-			label={ __( 'Editor plugins' ) }
-		>
-			<SidebarHeader
-				closeLabel={ __( 'Close plugin' ) }
+		<Fragment>
+			{ pinnable && (
+				<PinnedPlugins>
+					{ isPinned && <IconButton
+						icon={ icon }
+						label={ title }
+						onClick={ toggleSidebar }
+						isToggled={ isActive }
+						aria-expanded={ isActive }
+					/> }
+				</PinnedPlugins>
+			) }
+			<Sidebar
+				name={ sidebarName }
+				label={ __( 'Editor plugins' ) }
 			>
-				<strong>{ title }</strong>
-				{ pinnable && (
-					<IconButton
-						onClick={ togglePin }
-						icon={ isPinned ? 'star-filled' : 'star-empty' }
-						label={ isPinned ? __( 'Unpin from toolbar' ) : __( 'Pin to toolbar' ) }
-						isToggled={ isPinned }
-						aria-expanded={ isPinned }
-					/>
-				) }
-			</SidebarHeader>
-			<Panel>
-				{ children }
-			</Panel>
-		</Sidebar>
+				<SidebarHeader
+					closeLabel={ __( 'Close plugin' ) }
+				>
+					<strong>{ title }</strong>
+					{ pinnable && (
+						<IconButton
+							onClick={ togglePin }
+							icon={ isPinned ? 'star-filled' : 'star-empty' }
+							label={ isPinned ? __( 'Unpin from toolbar' ) : __( 'Pin to toolbar' ) }
+							isToggled={ isPinned }
+							aria-expanded={ isPinned }
+						/>
+					) }
+				</SidebarHeader>
+				<Panel>
+					{ children }
+				</Panel>
+			</Sidebar>
+		</Fragment>
 	);
 }
 
@@ -49,23 +76,31 @@ export default compose(
 	withPluginContext,
 	withSelect( ( select, { name, pluginContext } ) => {
 		const {
+			getActiveGeneralSidebarName,
 			isPluginItemPinned,
 		} = select( 'core/edit-post' );
 		const sidebarName = `${ pluginContext.name }/${ name }`;
 
 		return {
+			isActive: getActiveGeneralSidebarName() === sidebarName,
 			isPinned: isPluginItemPinned( sidebarName ),
 			sidebarName,
 		};
 	} ),
-	withDispatch( ( dispatch, { sidebarName } ) => {
+	withDispatch( ( dispatch, { isActive, sidebarName } ) => {
 		const {
+			closeGeneralSidebar,
 			togglePinnedPluginItem,
 		} = dispatch( 'core/edit-post' );
 
 		return {
 			togglePin() {
 				togglePinnedPluginItem( sidebarName );
+			},
+			toggleSidebar() {
+				if ( isActive ) {
+					closeGeneralSidebar();
+				}
 			},
 		};
 	} ),

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -90,6 +90,7 @@ export default compose(
 	withDispatch( ( dispatch, { isActive, sidebarName } ) => {
 		const {
 			closeGeneralSidebar,
+			openGeneralSidebar,
 			togglePinnedPluginItem,
 		} = dispatch( 'core/edit-post' );
 
@@ -100,6 +101,8 @@ export default compose(
 			toggleSidebar() {
 				if ( isActive ) {
 					closeGeneralSidebar();
+				} else {
+					openGeneralSidebar( sidebarName );
 				}
 			},
 		};

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -73,19 +73,21 @@ function PluginSidebar( props ) {
 }
 
 export default compose(
-	withPluginContext,
-	withSelect( ( select, { icon, name, pluginContext } ) => {
+	withPluginContext( ( context, ownProps ) => {
+		return {
+			icon: ownProps.icon || context.icon,
+			sidebarName: `${ context.name }/${ ownProps.name }`,
+		};
+	} ),
+	withSelect( ( select, { sidebarName } ) => {
 		const {
 			getActiveGeneralSidebarName,
 			isPluginItemPinned,
 		} = select( 'core/edit-post' );
-		const sidebarName = `${ pluginContext.name }/${ name }`;
 
 		return {
-			icon: icon || pluginContext.icon,
 			isActive: getActiveGeneralSidebarName() === sidebarName,
 			isPinned: isPluginItemPinned( sidebarName ),
-			sidebarName,
 		};
 	} ),
 	withDispatch( ( dispatch, { isActive, sidebarName } ) => {

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -32,7 +32,7 @@ function PluginSidebar( { children, isPinned, sidebarName, title, togglePin, pin
 					<IconButton
 						onClick={ togglePin }
 						icon={ isPinned ? 'star-filled' : 'star-empty' }
-						label={ isPinned ? __( 'Unpin plugin' ) : __( 'Pin plugin' ) }
+						label={ isPinned ? __( 'Unpin from toolbar' ) : __( 'Pin to toolbar' ) }
 						isToggled={ isPinned }
 						aria-expanded={ isPinned }
 					/>

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -23,7 +23,7 @@ import SidebarHeader from '../sidebar-header';
 function PluginSidebar( props ) {
 	const {
 		children,
-		icon = 'admin-plugins',
+		icon,
 		isActive,
 		isPinnable = true,
 		isPinned,
@@ -74,7 +74,7 @@ function PluginSidebar( props ) {
 
 export default compose(
 	withPluginContext,
-	withSelect( ( select, { name, pluginContext } ) => {
+	withSelect( ( select, { icon, name, pluginContext } ) => {
 		const {
 			getActiveGeneralSidebarName,
 			isPluginItemPinned,
@@ -82,6 +82,7 @@ export default compose(
 		const sidebarName = `${ pluginContext.name }/${ name }`;
 
 		return {
+			icon: icon || pluginContext.icon,
 			isActive: getActiveGeneralSidebarName() === sidebarName,
 			isPinned: isPluginItemPinned( sidebarName ),
 			sidebarName,

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -18,6 +18,7 @@ import SidebarHeader from '../sidebar-header';
  * Renders the plugin sidebar component.
  *
  * @param {Object} props Element props.
+ *
  * @return {WPElement} Plugin sidebar component.
  */
 function PluginSidebar( props ) {

--- a/edit-post/components/sidebar/sidebar-header/style.scss
+++ b/edit-post/components/sidebar/sidebar-header/style.scss
@@ -20,7 +20,11 @@
 
 	.components-icon-button {
 		display: none;
-		margin-left: auto;
+		margin-left: 0;
+
+		&:first-of-type {
+			margin-left: auto;
+		}
 
 		@include break-medium() {
 			display: flex;

--- a/edit-post/components/sidebar/sidebar-header/style.scss
+++ b/edit-post/components/sidebar/sidebar-header/style.scss
@@ -20,10 +20,10 @@
 
 	.components-icon-button {
 		display: none;
-		margin-left: 0;
+		margin-left: auto;
 
-		&:first-of-type {
-			margin-left: auto;
+		~ .components-icon-button {
+			margin-left: 0;
 		}
 
 		@include break-medium() {

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -73,7 +73,7 @@ export function toggleGeneralSidebarEditorPanel( panel ) {
 /**
  * Returns an action object used to toggle a feature flag.
  *
- * @param {string} feature Featurre name.
+ * @param {string} feature Feature name.
  *
  * @return {Object} Action object.
  */
@@ -88,6 +88,20 @@ export function switchEditorMode( mode ) {
 	return {
 		type: 'SWITCH_MODE',
 		mode,
+	};
+}
+
+/**
+ * Returns an action object used to toggle a plugin name flag.
+ *
+ * @param {string} pluginName Plugin name.
+ *
+ * @return {Object} Action object.
+ */
+export function togglePinnedPluginItem( pluginName ) {
+	return {
+		type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+		pluginName,
 	};
 }
 

--- a/edit-post/store/defaults.js
+++ b/edit-post/store/defaults.js
@@ -5,4 +5,5 @@ export const PREFERENCES_DEFAULTS = {
 	features: {
 		fixedToolbar: false,
 	},
+	pinnedPluginItems: {},
 };

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -63,6 +63,15 @@ export const preferences = combineReducers( {
 
 		return state;
 	},
+	pinnedPluginItems( state = PREFERENCES_DEFAULTS.pinnedPluginItems, action ) {
+		if ( action.type === 'TOGGLE_PINNED_PLUGIN_ITEM' ) {
+			return {
+				...state,
+				[ action.pluginName ]: ! state[ action.pluginName ],
+			};
+		}
+		return state;
+	},
 } );
 
 export function panel( state = 'document', action ) {

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isUndefined } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -67,7 +72,9 @@ export const preferences = combineReducers( {
 		if ( action.type === 'TOGGLE_PINNED_PLUGIN_ITEM' ) {
 			return {
 				...state,
-				[ action.pluginName ]: ! state[ action.pluginName ],
+				[ action.pluginName ]: isUndefined( state[ action.pluginName ] ) ?
+					false :
+					! state[ action.pluginName ],
 			};
 		}
 		return state;

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isUndefined } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -72,9 +72,7 @@ export const preferences = combineReducers( {
 		if ( action.type === 'TOGGLE_PINNED_PLUGIN_ITEM' ) {
 			return {
 				...state,
-				[ action.pluginName ]: isUndefined( state[ action.pluginName ] ) ?
-					false :
-					! state[ action.pluginName ],
+				[ action.pluginName ]: ! get( state, [ action.pluginName ], true ),
 			};
 		}
 		return state;

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -154,3 +154,13 @@ export const hasMetaBoxes = createSelector(
 export function isSavingMetaBoxes( state ) {
 	return state.isSavingMetaBoxes;
 }
+
+/**
+ * Returns true if the the plugin item is pinned to the header.
+ *
+ * @param   {Object}  state Global application state.
+ * @return {boolean}       Whether the plugin item is pinned.
+ */
+export function isPluginItemPinned( state ) {
+	return Boolean( state );
+}

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -109,6 +109,18 @@ export function isFeatureActive( state, feature ) {
 }
 
 /**
+ * Returns true if the the plugin item is pinned to the header.
+ *
+ * @param  {Object}  state      Global application state.
+ * @param  {string}  pluginName Plugin item name.
+ * @return {boolean}            Whether the plugin item is pinned.
+ */
+export function isPluginItemPinned( state, pluginName ) {
+	const pinnedPluginItems = getPreference( state, 'pinnedPluginItems', {} );
+	return Boolean( pinnedPluginItems[ pluginName ] );
+}
+
+/**
  * Returns the state of legacy meta boxes.
  *
  * @param   {Object} state Global application state.
@@ -153,14 +165,4 @@ export const hasMetaBoxes = createSelector(
  */
 export function isSavingMetaBoxes( state ) {
 	return state.isSavingMetaBoxes;
-}
-
-/**
- * Returns true if the the plugin item is pinned to the header.
- *
- * @param   {Object}  state Global application state.
- * @return {boolean}       Whether the plugin item is pinned.
- */
-export function isPluginItemPinned( state ) {
-	return Boolean( state );
 }

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { includes, some } from 'lodash';
+import { includes, isUndefined, some } from 'lodash';
 
 /**
  * Returns the current editing mode.
@@ -110,14 +110,19 @@ export function isFeatureActive( state, feature ) {
 
 /**
  * Returns true if the the plugin item is pinned to the header.
+ * When the value is not set it defaults to true.
  *
  * @param  {Object}  state      Global application state.
  * @param  {string}  pluginName Plugin item name.
  * @return {boolean}            Whether the plugin item is pinned.
  */
 export function isPluginItemPinned( state, pluginName ) {
+	const defaultValue = true;
 	const pinnedPluginItems = getPreference( state, 'pinnedPluginItems', {} );
-	return Boolean( pinnedPluginItems[ pluginName ] );
+
+	return isUndefined( pinnedPluginItems[ pluginName ] ) ?
+		defaultValue :
+		Boolean( pinnedPluginItems[ pluginName ] );
 }
 
 /**

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { includes, isUndefined, some } from 'lodash';
+import { get, includes, some } from 'lodash';
 
 /**
  * Returns the current editing mode.
@@ -117,12 +117,9 @@ export function isFeatureActive( state, feature ) {
  * @return {boolean}            Whether the plugin item is pinned.
  */
 export function isPluginItemPinned( state, pluginName ) {
-	const defaultValue = true;
 	const pinnedPluginItems = getPreference( state, 'pinnedPluginItems', {} );
 
-	return isUndefined( pinnedPluginItems[ pluginName ] ) ?
-		defaultValue :
-		Boolean( pinnedPluginItems[ pluginName ] );
+	return get( pinnedPluginItems, [ pluginName ], true );
 }
 
 /**

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -114,7 +114,8 @@ export function isFeatureActive( state, feature ) {
  *
  * @param  {Object}  state      Global application state.
  * @param  {string}  pluginName Plugin item name.
- * @return {boolean}            Whether the plugin item is pinned.
+ *
+ * @return {boolean} Whether the plugin item is pinned.
  */
 export function isPluginItemPinned( state, pluginName ) {
 	const pinnedPluginItems = getPreference( state, 'pinnedPluginItems', {} );

--- a/edit-post/store/test/actions.js
+++ b/edit-post/store/test/actions.js
@@ -9,6 +9,7 @@ import {
 	closePublishSidebar,
 	togglePublishSidebar,
 	toggleFeature,
+	togglePinnedPluginItem,
 	requestMetaBoxUpdates,
 	initializeMetaBoxState,
 } from '../actions';
@@ -72,6 +73,17 @@ describe( 'actions', () => {
 			expect( toggleFeature( feature ) ).toEqual( {
 				type: 'TOGGLE_FEATURE',
 				feature,
+			} );
+		} );
+	} );
+
+	describe( 'togglePinnedPluginItem', () => {
+		it( 'should return TOGGLE_PINNED_PLUGIN_ITEM action', () => {
+			const pluginName = 'foo/bar';
+
+			expect( togglePinnedPluginItem( pluginName ) ).toEqual( {
+				type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+				pluginName,
 			} );
 		} );
 	} );

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -22,6 +22,7 @@ describe( 'state', () => {
 				editorMode: 'visual',
 				panels: { 'post-status': true },
 				features: { fixedToolbar: false },
+				pinnedPluginItems: {},
 			} );
 		} );
 
@@ -50,6 +51,7 @@ describe( 'state', () => {
 				editorMode: 'visual',
 				panels: { 'post-status': true },
 				features: { fixedToolbar: false },
+				pinnedPluginItems: {},
 			} );
 		} );
 
@@ -112,6 +114,37 @@ describe( 'state', () => {
 			} );
 
 			expect( state.features ).toEqual( { chicken: false } );
+		} );
+
+		describe( 'pinnedPluginItems', () => {
+			const initialState = deepFreeze( {
+				pinnedPluginItems: {
+					'foo/enabled': true,
+				},
+			} );
+
+			it( 'should enable a pinned plugin flag when the value does not exist', () => {
+				const state = preferences( initialState, {
+					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+					pluginName: 'foo/does-not-exist',
+				} );
+
+				expect( state.pinnedPluginItems ).toEqual( {
+					'foo/enabled': true,
+					'foo/does-not-exist': true,
+				} );
+			} );
+
+			it( 'should disable a pinned plugin flag when it is enabled', () => {
+				const state = preferences( initialState, {
+					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+					pluginName: 'foo/enabled',
+				} );
+
+				expect( state.pinnedPluginItems ).toEqual( {
+					'foo/enabled': false,
+				} );
+			} );
 		} );
 	} );
 

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -120,19 +120,17 @@ describe( 'state', () => {
 			const initialState = deepFreeze( {
 				pinnedPluginItems: {
 					'foo/enabled': true,
+					'foo/disabled': false,
 				},
 			} );
 
-			it( 'should enable a pinned plugin flag when the value does not exist', () => {
+			it( 'should disable a pinned plugin flag when the value does not exist', () => {
 				const state = preferences( initialState, {
 					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
 					pluginName: 'foo/does-not-exist',
 				} );
 
-				expect( state.pinnedPluginItems ).toEqual( {
-					'foo/enabled': true,
-					'foo/does-not-exist': true,
-				} );
+				expect( state.pinnedPluginItems[ 'foo/does-not-exist' ] ).toBe( false );
 			} );
 
 			it( 'should disable a pinned plugin flag when it is enabled', () => {
@@ -141,9 +139,16 @@ describe( 'state', () => {
 					pluginName: 'foo/enabled',
 				} );
 
-				expect( state.pinnedPluginItems ).toEqual( {
-					'foo/enabled': false,
+				expect( state.pinnedPluginItems[ 'foo/enabled' ] ).toBe( false );
+			} );
+
+			it( 'should enable a pinned plugin flag when it is disabled', () => {
+				const state = preferences( initialState, {
+					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+					pluginName: 'foo/disabled',
 				} );
+
+				expect( state.pinnedPluginItems[ 'foo/disabled' ] ).toBe( true );
 			} );
 		} );
 	} );

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -192,17 +192,22 @@ describe( 'selectors', () => {
 		const state = {
 			preferences: {
 				pinnedPluginItems: {
-					'foo/bar': true,
+					'foo/pinned': true,
+					'foo/unpinned': false,
 				},
 			},
 		};
 
-		it( 'should return false if plugin item is not pinned', () => {
+		it( 'should return false if the flag is not set for the plugin item', () => {
 			expect( isPluginItemPinned( state, 'foo/unknown' ) ).toBe( false );
 		} );
 
-		it( 'should return true if plugin item item is pinned', () => {
-			expect( isPluginItemPinned( state, 'foo/bar' ) ).toBe( true );
+		it( 'should return true if plugin item is not pinned', () => {
+			expect( isPluginItemPinned( state, 'foo/pinned' ) ).toBe( true );
+		} );
+
+		it( 'should return false if plugin item item is unpinned', () => {
+			expect( isPluginItemPinned( state, 'foo/unpinned' ) ).toBe( false );
 		} );
 	} );
 

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -198,8 +198,8 @@ describe( 'selectors', () => {
 			},
 		};
 
-		it( 'should return false if the flag is not set for the plugin item', () => {
-			expect( isPluginItemPinned( state, 'foo/unknown' ) ).toBe( false );
+		it( 'should return true if the flag is not set for the plugin item', () => {
+			expect( isPluginItemPinned( state, 'foo/unknown' ) ).toBe( true );
 		} );
 
 		it( 'should return true if plugin item is not pinned', () => {

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -8,6 +8,7 @@ import {
 	isEditorSidebarPanelOpened,
 	isFeatureActive,
 	isPluginSidebarOpened,
+	isPluginItemPinned,
 	getMetaBoxes,
 	hasMetaBoxes,
 	isSavingMetaBoxes,
@@ -186,6 +187,25 @@ describe( 'selectors', () => {
 			expect( isFeatureActive( state, 'chicken' ) ).toBe( false );
 		} );
 	} );
+
+	describe( 'isPluginItemPinned', () => {
+		const state = {
+			preferences: {
+				pinnedPluginItems: {
+					'foo/bar': true,
+				},
+			},
+		};
+
+		it( 'should return false if plugin item is not pinned', () => {
+			expect( isPluginItemPinned( state, 'foo/unknown' ) ).toBe( false );
+		} );
+
+		it( 'should return true if plugin item item is pinned', () => {
+			expect( isPluginItemPinned( state, 'foo/bar' ) ).toBe( true );
+		} );
+	} );
+
 	describe( 'hasMetaBoxes', () => {
 		it( 'should return true if there are active meta boxes', () => {
 			const state = {

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -12,7 +12,10 @@ This method takes two arguments:
 
 1. `name`: A string identifying the plugin. Must be unique across all registered plugins.
 2. `settings`: An object containing the following data:
-   - `render`: A component containing the UI elements to be rendered.
+    - `icon: string | WPElement | Function` - An icon to be shown in the UI. It can be a slug
+      of the [Dashicon](https://developer.wordpress.org/resource/dashicons/#awards),
+      or an element (or function returning an element) if you choose to render your own SVG.
+    - `render`: A component containing the UI elements to be rendered.
 
 See [the edit-post module documentation](../edit-post/) for available components.
 
@@ -27,7 +30,6 @@ const Component = () => (
 	<Fragment>
 		<PluginSidebarMoreMenuItem
 			target="sidebar-name"
-			icon="smiley"
 		>
 			My Sidebar
 		</PluginSidebarMoreMenuItem>
@@ -41,6 +43,7 @@ const Component = () => (
 );
 
 registerPlugin( 'plugin-name', {
+	icon: 'smiley',
 	render: Component,
 } );
 ```

--- a/plugins/api/index.js
+++ b/plugins/api/index.js
@@ -23,6 +23,7 @@ const plugins = {};
  * @param {string}   name   The name of the plugin.
  * @param {Object}   settings        The settings for this plugin.
  * @param {Function} settings.render The function that renders the plugin.
+ * @param {string}   settings.icon   An icon to be shown in the UI.
  *
  * @return {Object} The final plugin settings object.
  */
@@ -50,6 +51,9 @@ export function registerPlugin( name, settings ) {
 			`Plugin "${ name }" is already registered.`
 		);
 	}
+
+	settings = applyFilters( 'plugins.registerPlugin', settings, name );
+
 	if ( ! isFunction( settings.render ) ) {
 		console.error(
 			'The "render" property must be specified and must be a valid function.'
@@ -57,11 +61,11 @@ export function registerPlugin( name, settings ) {
 		return null;
 	}
 
-	settings.name = name;
-
-	settings = applyFilters( 'plugins.registerPlugin', settings, name );
-
-	plugins[ settings.name ] = settings;
+	plugins[ name ] = {
+		name,
+		icon: 'admin-plugins',
+		...settings,
+	};
 
 	doAction( 'plugins.pluginRegistered', settings, name );
 

--- a/plugins/api/index.js
+++ b/plugins/api/index.js
@@ -20,10 +20,10 @@ const plugins = {};
 /**
  * Registers a plugin to the editor.
  *
- * @param {string}   name   The name of the plugin.
- * @param {Object}   settings        The settings for this plugin.
- * @param {Function} settings.render The function that renders the plugin.
- * @param {string}   settings.icon   An icon to be shown in the UI.
+ * @param {string}                    name            The name of the plugin.
+ * @param {Object}                    settings        The settings for this plugin.
+ * @param {Function}                  settings.render The function that renders the plugin.
+ * @param {string|WPElement|Function} settings.icon   An icon to be shown in the UI.
  *
  * @return {Object} The final plugin settings object.
  */

--- a/plugins/api/test/index.js
+++ b/plugins/api/test/index.js
@@ -4,6 +4,7 @@
 import {
 	registerPlugin,
 	unregisterPlugin,
+	getPlugin,
 	getPlugins,
 } from '../';
 
@@ -15,8 +16,19 @@ describe( 'registerPlugin', () => {
 	} );
 
 	it( 'successfully registers a plugin', () => {
-		registerPlugin( 'plugin', {
-			render: () => 'plugin content',
+		const name = 'plugin';
+		const icon = 'smiley';
+		const Component = () => 'plugin content';
+
+		registerPlugin( name, {
+			render: Component,
+			icon,
+		} );
+
+		expect( getPlugin( name ) ).toEqual( {
+			name,
+			render: Component,
+			icon,
 		} );
 	} );
 
@@ -51,7 +63,6 @@ describe( 'registerPlugin', () => {
 		registerPlugin( 'plugin', {
 			render: () => 'plugin content',
 		} );
-		console.log( console ); // eslint-disable-line
 		expect( console ).toHaveErroredWith( 'Plugin "plugin" is already registered.' );
 	} );
 } );

--- a/plugins/components/plugin-area/index.js
+++ b/plugins/components/plugin-area/index.js
@@ -30,12 +30,13 @@ class PluginArea extends Component {
 
 	getCurrentPluginsState() {
 		return {
-			plugins: map( getPlugins(), ( { name, render } ) => {
+			plugins: map( getPlugins(), ( { icon, name, render } ) => {
 				return {
 					name,
 					Plugin: render,
 					context: {
 						name,
+						icon,
 					},
 				};
 			} ),

--- a/plugins/components/plugin-area/index.js
+++ b/plugins/components/plugin-area/index.js
@@ -32,7 +32,6 @@ class PluginArea extends Component {
 		return {
 			plugins: map( getPlugins(), ( { icon, name, render } ) => {
 				return {
-					name,
 					Plugin: render,
 					context: {
 						name,
@@ -60,9 +59,9 @@ class PluginArea extends Component {
 	render() {
 		return (
 			<div style={ { display: 'none' } }>
-				{ map( this.state.plugins, ( { context, name, Plugin } ) => (
+				{ map( this.state.plugins, ( { context, Plugin } ) => (
 					<PluginContextProvider
-						key={ name }
+						key={ context.name }
 						value={ context }
 					>
 						<Plugin />

--- a/plugins/components/plugin-context/index.js
+++ b/plugins/components/plugin-context/index.js
@@ -11,23 +11,24 @@ const { Consumer, Provider } = createContext( {
 export { Provider as PluginContextProvider };
 
 /**
- * A Higher-order Component used to inject Plugin context into the wrapped
- * component.
+ * A Higher Order Component used to inject Plugin context to the
+ * wrapped component.
  *
- * @param {Component} OriginalComponent Component to wrap.
+ * @param {Function} mapContextToProps Function called on every context change,
+ *                                     expected to return object of props to
+ *                                     merge with the component's own props.
  *
- * @return {Component} Component with Plugin context injected.
+ * @return {Component} Enhanced component with injected context as props.
  */
-export const withPluginContext = createHigherOrderComponent(
-	( OriginalComponent ) => ( props ) => (
+export const withPluginContext = ( mapContextToProps ) => createHigherOrderComponent( ( OriginalComponent ) => {
+	return ( props ) => (
 		<Consumer>
-			{ ( pluginContext ) => (
+			{ ( context ) => (
 				<OriginalComponent
 					{ ...props }
-					pluginContext={ pluginContext }
+					{ ...mapContextToProps( context, props ) }
 				/>
 			) }
 		</Consumer>
-	),
-	'withPluginContext'
-);
+	);
+}, 'withPluginContext' );

--- a/plugins/components/plugin-context/index.js
+++ b/plugins/components/plugin-context/index.js
@@ -5,6 +5,7 @@ import { createContext, createHigherOrderComponent } from '@wordpress/element';
 
 const { Consumer, Provider } = createContext( {
 	name: null,
+	icon: null,
 } );
 
 export { Provider as PluginContextProvider };


### PR DESCRIPTION
## Description

This PR adds pinning support for sidebar plugins as described by @jasmussen in https://github.com/WordPress/gutenberg/issues/4287#issuecomment-382367609:

> ![screen shot 2018-04-18 at 14 19 18](https://user-images.githubusercontent.com/1204802/38931464-868a26ce-4313-11e8-941d-8ff8a6f4b8d2.png)
> 
> ☝️ this features a "pin" icon, allowing you to pin or unpin this. It's quick and dirty, would like to polish it more, but it conveys the point. 
> 
> To recap the ideas for this kind of extensibility right now, they are:
> 
> - Every plugin that extends the editor gets a menu item in the more menu. Invoking this item invokes the plugins primary action.
> - Plugin actions could be to open a sidebar, or to open a screen takeover, or to run an action (such as spell check) directly.
> - Plugins can register a pinned extension icon next to the cog but before the more menu. These are plain svg icons that are recolored to be solid gray.
> - A user can unpin any extension icon that a plugin has pinned. The user can always use an unpinned plugin because the action will always be available in the more menu.
> - The way to unpin (or pin) an extension icon is currently the weakest aspect of the mockups, but right now they have you tap a star to toggle pinning, hollow for unpinned, solid for pinned.

and also in https://github.com/WordPress/gutenberg/issues/3330#issuecomment-345677753:

> Here are some mockups for how pinning extensions to the toolbar could work. This is inspired by Chrome and Firefox. 
> 
> 1. You open it from the ellipsis, where all editor extensions register themselves
> 
> ![wolframalpha open from ellipsis](https://user-images.githubusercontent.com/1204802/33017752-d0fcbd9c-cdf3-11e7-8555-a6a1c587d1cd.png)
> 
> 2. This immediately opens a sidebar, because this is a "editor sidebar extension":
> 
> ![wolframalpha sidebar open](https://user-images.githubusercontent.com/1204802/33017767-e00be1d2-cdf3-11e7-8997-82665943ea2c.png)
> 
> 3. All sidebar extensions have a "Star" icon in their heading. 
> 
> ![wolframalpha pin to toolbar](https://user-images.githubusercontent.com/1204802/33017789-f93c2054-cdf3-11e7-89d0-17eaecc70b9c.png)
> 
> 4. Click it to pin the icon to the toolbar:
> 
> ![wolframalpha extension pinned](https://user-images.githubusercontent.com/1204802/33017791-fe9fe6d4-cdf3-11e7-9edd-95d26f15f953.png)
> 
> 5. Even if you close the sidebar, the extension icon still sits there for quick access:
> 
> ![pinned](https://user-images.githubusercontent.com/1204802/33018007-e6ad2cde-cdf4-11e7-83ed-3fc142f1093e.png)
> 
> Repeat these steps in reverse to unpin it. 

## How has this been tested?

It was tested manually using a test plugin. The easiest way to apply the plugin is to copy ES5 version from this gist: https://gist.github.com/gziolo/e2954aa83aa1f823b2b05ca1660c2223.


## Screenshots <!-- if applicable -->

#### Version ~1 - always present 2 - unpinned by default~ 3 - pinned by default

![pinned plugins](https://user-images.githubusercontent.com/699132/39771866-d981e32c-52f3-11e8-9b40-1a4ed2a03553.gif)


## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
