### PR TITLE
Enable registering hooks in `registerPlugin`

### DIFF
--- a/plugins/api/index.js
+++ b/plugins/api/index.js
@@ -61,6 +61,27 @@ export function registerPlugin( name, settings ) {
 
 	settings = applyFilters( 'plugins.registerPlugin', settings, name );
 
+	if ( settings.hooks ) {
+		if ( settings.hooks.filters ) {
+			settings.hooks.filters.forEach( function( hook ) {
+				if ( hook.name && hook.callback ) {
+					var priority = hook.priority ? hook.priority : 10;
+					wp.hooks.addFilter( hook.name, name, hook.callback, proirity );
+				}
+			} );
+
+		}
+		if ( settings.hooks.actions ) {
+			settings.hooks.actions.forEach( function( hook ) {
+				if ( hook.name && hook.callback ) {
+					var priority = hook.priority ? hook.priority : 10;
+					wp.hooks.addAction( hook.name, name, hook.callback, proirity );
+				}
+			} );
+
+		}
+	}
+
 	plugins[ settings.name ] = settings;
 
 	doAction( 'plugins.pluginRegistered', settings, name );

--- a/plugins/api/index.js
+++ b/plugins/api/index.js
@@ -66,7 +66,7 @@ export function registerPlugin( name, settings ) {
 			settings.hooks.filters.forEach( function( hook ) {
 				if ( hook.name && hook.callback ) {
 					var priority = hook.priority ? hook.priority : 10;
-					wp.hooks.addFilter( hook.name, name, hook.callback, proirity );
+					wp.hooks.addFilter( hook.name, name, hook.callback, priority );
 				}
 			} );
 
@@ -75,7 +75,7 @@ export function registerPlugin( name, settings ) {
 			settings.hooks.actions.forEach( function( hook ) {
 				if ( hook.name && hook.callback ) {
 					var priority = hook.priority ? hook.priority : 10;
-					wp.hooks.addAction( hook.name, name, hook.callback, proirity );
+					wp.hooks.addAction( hook.name, name, hook.callback, priority );
 				}
 			} );
 

--- a/plugins/api/index.js
+++ b/plugins/api/index.js
@@ -65,20 +65,16 @@ export function registerPlugin( name, settings ) {
 		if ( settings.hooks.filters ) {
 			settings.hooks.filters.forEach( function( hook ) {
 				if ( hook.name && hook.callback ) {
-					var priority = hook.priority ? hook.priority : 10;
-					wp.hooks.addFilter( hook.name, name, hook.callback, priority );
+					wp.hooks.addFilter( hook.name, name, hook.callback, hook.priority ? hook.priority : 10 );
 				}
 			} );
-
 		}
 		if ( settings.hooks.actions ) {
 			settings.hooks.actions.forEach( function( hook ) {
 				if ( hook.name && hook.callback ) {
-					var priority = hook.priority ? hook.priority : 10;
-					wp.hooks.addAction( hook.name, name, hook.callback, priority );
+					wp.hooks.addAction( hook.name, name, hook.callback, hook.priority ? hook.priority : 10 );
 				}
 			} );
-
 		}
 	}
 


### PR DESCRIPTION
## Description
This is an experimental API exploring enable registering of action and filter hooks as part of the settings object passed to `registerPlugin`

* Enables plugins to easily add all of their hooks in one place.
* Uses the namespace from `registerPlugin` as the hook namespace.

## How has this been tested?
Added the following code to my theme based on the example from the [registerPlugin README](https://github.com/WordPress/gutenberg/blob/master/plugins/README.md):
```
function addBackgroundColorStyle( props ) {
	return Object.assign( props, { style: { backgroundColor: 'red' } } );
}
wp.plugins.registerPlugin( 'my-plugin',
	{
		render: renderFunction,
		hooks: {
			filters: [
				{
					name: 'blocks.getSaveContent.extraProps',
					callback: addBackgroundColorStyle
				}
			]
		}
	}
);
```
## Types of changes
* When handling `registerPlugin` look for a `hooks` settings object
* Inside `hooks` object, look for `actions` and `filters`arrays
* for each action/filter provided, perform addAction/addFilter with the passed name, callback and priority
* use a default priority of 10 if no priority is passed

## Todo
* Add some tests
* consider supporting an optional namespace for each hook in settings array that would be used instead of the plugin namespace.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
