### PR TITLE
Framework: Make sure block assets are always registered before wp-edit-post script

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -834,6 +834,18 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// to disable it outright.
 	wp_enqueue_script( 'heartbeat' );
 
+	/**
+	 * Fires after block assets have been enqueued for the editing interface.
+	 *
+	 * Call `add_action` on any hook before 'admin_enqueue_scripts'.
+	 *
+	 * In the function call you supply, simply use `wp_enqueue_script` and
+	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
+	 *
+	 * @since 0.4.0
+	 */
+	do_action( 'enqueue_block_editor_assets' );
+
 	// Ignore Classic Editor's `rich_editing` user option, aka "Disable visual
 	// editor". Forcing this to be true guarantees that TinyMCE and its plugins
 	// are available in Gutenberg. Fixes
@@ -999,16 +1011,4 @@ JS;
 	 * Styles
 	 */
 	wp_enqueue_style( 'wp-edit-post' );
-
-	/**
-	 * Fires after block assets have been enqueued for the editing interface.
-	 *
-	 * Call `add_action` on any hook before 'admin_enqueue_scripts'.
-	 *
-	 * In the function call you supply, simply use `wp_enqueue_script` and
-	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
-	 *
-	 * @since 0.4.0
-	 */
-	do_action( 'enqueue_block_editor_assets' );
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -834,18 +834,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// to disable it outright.
 	wp_enqueue_script( 'heartbeat' );
 
-	/**
-	 * Fires after block assets have been enqueued for the editing interface.
-	 *
-	 * Call `add_action` on any hook before 'admin_enqueue_scripts'.
-	 *
-	 * In the function call you supply, simply use `wp_enqueue_script` and
-	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
-	 *
-	 * @since 0.4.0
-	 */
-	do_action( 'enqueue_block_editor_assets' );
-
 	// Ignore Classic Editor's `rich_editing` user option, aka "Disable visual
 	// editor". Forcing this to be true guarantees that TinyMCE and its plugins
 	// are available in Gutenberg. Fixes
@@ -991,8 +979,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$script  = '( function() {';
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
 	$script .= <<<JS
-		window._wpLoadGutenbergEditor = wp.api.init().then( function() {
-			wp.coreBlocks.registerCoreBlocks();
+		window._wpLoadGutenbergEditor = new Promise( function( resolve ) {
+			wp.api.init().then( resolve );
+		} ).then( function() {
 			return wp.editPost.initializeEditor( 'editor', window._wpGutenbergPost, editorSettings );
 		} );
 JS;
@@ -1011,4 +1000,16 @@ JS;
 	 * Styles
 	 */
 	wp_enqueue_style( 'wp-edit-post' );
+
+	/**
+	 * Fires after block assets have been enqueued for the editing interface.
+	 *
+	 * Call `add_action` on any hook before 'admin_enqueue_scripts'.
+	 *
+	 * In the function call you supply, simply use `wp_enqueue_script` and
+	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
+	 *
+	 * @since 0.4.0
+	 */
+	do_action( 'enqueue_block_editor_assets' );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -259,7 +259,7 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-1.0.6.tgz",
 			"integrity": "sha512-IyL7KzYGzMEg+FFyTrQzD/CUfABYCXOvmnm29vBZBA3JMER1ep3/+NFDe6CpWVEEMCw94oj2gUOSQ4YKVgDjUQ==",
 			"requires": {
-				"@wordpress/dom-ready": "1.0.3"
+				"@wordpress/dom-ready": "1.0.4"
 			}
 		},
 		"@wordpress/autop": {
@@ -324,9 +324,9 @@
 			}
 		},
 		"@wordpress/dom-ready": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-1.0.3.tgz",
-			"integrity": "sha512-1tmJLO2NDc45wxnUWv6F/4q8/00qSgqLvBXBKl7IayLvJbG25vt7lMQkdSfiY2gTwsujAqOgOuJdO5VOGuqQNg=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-1.0.4.tgz",
+			"integrity": "sha512-FxSH0A23Xs0t/ZcvfiQly7P1V3pKsHQGjja+oISKV2NosfIcWjc3JTDFZYLcKjmSREozKqMoqVIPY+h1CP2ehw=="
 		},
 		"@wordpress/hooks": {
 			"version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"dependencies": {
 		"@wordpress/a11y": "1.0.6",
 		"@wordpress/autop": "1.0.4",
+		"@wordpress/dom-ready": "1.0.4",
 		"@wordpress/hooks": "1.1.6",
 		"@wordpress/i18n": "1.1.0",
 		"@wordpress/url": "1.0.3",


### PR DESCRIPTION
## Description
Fixes #6443 and #5661.

Raised by @korobochkin:
> You can register your new Guten block with wp.blocks.registerBlockType function call. But it won’t work after page reloading

Raised by @theleemon:
> Everything seems to work as expected: at first glance the block is rendered correctly both on the editor and the frontend. But, if I save the post, then preview it and at the end I come back to edit it again, the custom block is automatically rendered in the editor as a classic editor block, although the HTML code beneath it shows that it's still a custom block. The console shows no errors.

In my tests it turned out that all blocks related assets are loaded too late when their are forced to be included in the footer. It works perfectly fine when they are included in the header. This patch moves those assets to be include before `wp-edit-post` which moves them in the flow to be always included first regardless where there are located.

## How has this been tested?
Manually. I registered the plugin with block using the code snippet generated with WP-CLI as explained in https://wordpress.org/gutenberg/handbook/blocks/generate-blocks-with-wp-cli/. I also updated:
```diff
    wp_register_script(
        'movie-block-editor',
        plugins_url( $block_js, __FILE__ ),
        array(
            'wp-blocks',
            'wp-i18n',
            'wp-element',
        ),
-        filemtime( "$dir/$block_js" )
+        filemtime( "$dir/$block_js" ),
+        true
    );
```
to ensure it works also when the script is loaded in footer.

I added the test block and made sure it still loads properly when I refreshed the page.

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
