### PR TITLE
Inserter: Leverage provisional block deletion for unmodified default

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -18,7 +18,6 @@ import {
 } from '@wordpress/utils';
 import {
 	BlockEdit,
-	createBlock,
 	cloneBlock,
 	getBlockType,
 	getSaveElement,
@@ -351,9 +350,7 @@ export class BlockListBlock extends Component {
 			case ENTER:
 				// Insert default block after current block if enter and event
 				// not already handled by descendant.
-				this.props.onInsertBlocks( [
-					createBlock( 'core/paragraph' ),
-				], this.props.order + 1 );
+				this.props.onInsertDefaultBlock( this.props.order + 1 );
 				event.preventDefault();
 				break;
 
@@ -647,6 +644,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		updateBlockAttributes,
 		selectBlock,
 		insertBlocks,
+		insertDefaultBlock,
 		removeBlock,
 		mergeBlocks,
 		replaceBlocks,
@@ -666,6 +664,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 			blocks = blocks.map( ( block ) => cloneBlock( block, { layout } ) );
 			insertBlocks( blocks, index, rootUID );
 		},
+		onInsertDefaultBlock: insertDefaultBlock,
 		onRemove( uid ) {
 			removeBlock( uid );
 		},

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -8,7 +8,7 @@ import { isEmpty } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton } from '@wordpress/components';
-import { createBlock, isUnmodifiedDefaultBlock, withEditorSettings } from '@wordpress/blocks';
+import { createBlock, withEditorSettings } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -90,20 +90,16 @@ export default compose( [
 	withSelect( ( select ) => ( {
 		title: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
 		insertionPoint: select( 'core/editor' ).getBlockInsertionPoint(),
-		selectedBlock: select( 'core/editor' ).getSelectedBlock(),
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		showInsertionPoint: dispatch( 'core/editor' ).showInsertionPoint,
 		hideInsertionPoint: dispatch( 'core/editor' ).hideInsertionPoint,
 		onInsertBlock: ( item ) => {
-			const { insertionPoint, selectedBlock } = ownProps;
+			const { insertionPoint } = ownProps;
 			const { index, rootUID, layout } = insertionPoint;
 			const { name, initialAttributes } = item;
 			const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
-			if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
-				return dispatch( 'core/editor' ).replaceBlocks( selectedBlock.uid, insertedBlock );
-			}
-			return dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootUID );
+			dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootUID );
 		},
 	} ) ),
 	withEditorSettings( ( settings ) => {

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -660,9 +660,5 @@ export function convertBlockToShared( uid ) {
  */
 export function insertDefaultBlock( attributes, rootUID, index ) {
 	const block = createBlock( getDefaultBlockName(), attributes );
-
-	return {
-		...insertBlock( block, index, rootUID ),
-		isProvisional: true,
-	};
+	return insertBlock( block, index, rootUID );
 }

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -589,6 +589,8 @@ export default {
 
 	MULTI_SELECT: removeProvisionalBlock,
 
+	INSERT_BLOCKS: removeProvisionalBlock,
+
 	REMOVE_BLOCKS( action, { getState, dispatch } ) {
 		// if the action says previous block should not be selected don't do anything.
 		if ( ! action.selectPrevious ) {

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -23,7 +23,7 @@ import {
 /**
  * WordPress dependencies
  */
-import { isSharedBlock } from '@wordpress/blocks';
+import { isSharedBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { combineReducers } from '@wordpress/data';
 
 /**
@@ -707,8 +707,9 @@ export function blockSelection( state = {
 export function provisionalBlockUID( state = null, action ) {
 	switch ( action.type ) {
 		case 'INSERT_BLOCKS':
-			if ( action.isProvisional ) {
-				return first( action.blocks ).uid;
+			const { blocks } = action;
+			if ( blocks.length === 1 && isUnmodifiedDefaultBlock( blocks[ 0 ] ) ) {
+				return blocks[ 0 ].uid;
 			}
 			break;
 

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -37,6 +37,11 @@ import {
 	template,
 } from '../reducer';
 
+jest.mock( '@wordpress/blocks', () => ( {
+	...require.requireActual( '@wordpress/blocks' ),
+	isUnmodifiedDefaultBlock: jest.fn().mockReturnValue( false ),
+} ) );
+
 describe( 'state', () => {
 	describe( 'hasSameKeys()', () => {
 		it( 'returns false if two objects do not have the same keys', () => {
@@ -1812,9 +1817,10 @@ describe( 'state', () => {
 		} );
 
 		it( 'returns the uid of the first inserted provisional block', () => {
+			require( '@wordpress/blocks' ).isUnmodifiedDefaultBlock.mockReturnValueOnce( true );
+
 			const state = provisionalBlockUID( null, {
 				type: 'INSERT_BLOCKS',
-				isProvisional: true,
 				blocks: [
 					{ uid: 'chicken' },
 				],

--- a/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`adding blocks Should insert content using the placeholder and the regular inserter 1`] = `
-"<!-- wp:paragraph -->
+"<!-- wp:code -->
+<pre class=\\"wp-block-code\\"><code>Code block</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:paragraph -->
 <p>Paragraph block</p>
 <!-- /wp:paragraph -->
 
@@ -13,9 +17,5 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 <blockquote class=\\"wp-block-quote\\">
 	<p>Quote block</p>
 </blockquote>
-<!-- /wp:quote -->
-
-<!-- wp:code -->
-<pre class=\\"wp-block-code\\"><code>Code block</code></pre>
-<!-- /wp:code -->"
+<!-- /wp:quote -->"
 `;

--- a/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
@@ -1,13 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`adding blocks Should insert content using the placeholder and the regular inserter 1`] = `
-"<!-- wp:code -->
-<pre class=\\"wp-block-code\\"><code>Code block</code></pre>
-<!-- /wp:code -->
+"<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\" /></figure>
+<!-- /wp:image -->
 
 <!-- wp:paragraph -->
 <p>Paragraph block</p>
 <!-- /wp:paragraph -->
+
+<!-- wp:code -->
+<pre class=\\"wp-block-code\\"><code>Code block</code></pre>
+<!-- /wp:code -->
 
 <!-- wp:paragraph -->
 <p>Second paragraph</p>
@@ -16,6 +20,6 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 <!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\">
 	<p>Quote block</p>
-</blockquote>
+	<p>Can have multiple paragraphs</p><cite>CiteCan have line breaks as well<br/></cite></blockquote>
 <!-- /wp:quote -->"
 `;

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -61,6 +61,17 @@ describe( 'adding blocks', () => {
 		// out because default block is provisional.
 		expect( await page.$( '[data-type="core/paragraph"]' ) ).toBeNull();
 
+		// Enter from title creates new default block.
+		await page.keyboard.press( 'Enter' );
+
+		// Using the regular inserter. Should replace the default unmodified
+		// (provisional) block.
+		await page.click( '.edit-post-header [aria-label="Add block"]' );
+		await page.keyboard.type( 'code' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Code block' );
+
 		// Using the placeholder
 		await page.click( '.editor-default-block-appender' );
 		await page.keyboard.type( 'Paragraph block' );
@@ -70,13 +81,6 @@ describe( 'adding blocks', () => {
 		await page.keyboard.type( '/quote' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Quote block' );
-
-		// Using the regular inserter
-		await page.click( '.edit-post-header [aria-label="Add block"]' );
-		await page.keyboard.type( 'code' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Code block' );
 
 		// Using the between inserter
 		await page.mouse.move( 200, 300 );

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -63,24 +63,34 @@ describe( 'adding blocks', () => {
 
 		// Enter from title creates new default block.
 		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '/image' );
+		await page.keyboard.press( 'Enter' );
+
+		// Using the placeholder (works only below non-default blocks)
+		await page.click( '.editor-default-block-appender' );
+		await page.keyboard.type( 'Paragraph block' );
 
 		// Using the regular inserter. Should replace the default unmodified
 		// (provisional) block.
+		await page.keyboard.press( 'Enter' );
 		await page.click( '.edit-post-header [aria-label="Add block"]' );
 		await page.keyboard.type( 'code' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Code block' );
 
-		// Using the placeholder
-		await page.click( '.editor-default-block-appender' );
-		await page.keyboard.type( 'Paragraph block' );
-
 		// Using the slash command
-		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.type( '/quote' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Quote block' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Can have multiple paragraphs' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.type( 'Cite' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Can have line breaks as well' );
+		await page.keyboard.press( 'ArrowDown' );
 
 		// Using the between inserter
 		await page.mouse.move( 200, 300 );


### PR DESCRIPTION
This pull request seeks to simplify the inserter's `onInsertBlock` implementation to take advantage of existing provisional block deletion (#5417). The intended behavior is preserved: When inserting a block via an inserter and the selected block is an unmodified default block, the act of insertion should trigger the deletion of the default block.

Notably, this avoids the need for `selectedBlock` to be passed to the Inserter, which is a source of frequent renders for the component.

__Implementation notes:__

Block selection state tracks from an `INSERT_BLOCKS` action type, so it was necessary to add `INSERT_BLOCKS` as the triggering action for the `removeProvisionalBlock` effect handler. Alternatively, we could consider selection from insert a side-effect of the insert itself, removing handling of insertion from the `blockSelection` state and leveraging the existing `SELECT_BLOCK` effect handler for provisional block deletion.

In future iterations, it might be worth exploring whether we can collapse the concepts of "unmodified default block" with "provisional block", as on the surface they appear to be referring to the same type of block.

__Testing instructions:__

Verify that when inserting a block after having created a new default block (paragraph), the unmodified default block is removed.

The "Adding Blocks" end-to-end test has been revised to test for this behavior:

```
npm run test-e2e
```