### PR TITLE
Avoid change in RichText when possible

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -422,9 +422,10 @@ export class RichText extends Component {
 			return;
 		}
 
-		// Always ensure the content is up-to-date, but avoid dispatching an
-		// action if the original event is blur because the content will already
-		// be up-to-date.
+		// Always ensure the content is up-to-date. This is needed because e.g.
+		// making something bold will trigger a TinyMCE change event but no
+		// input event. Avoid dispatching an action if the original event is
+		// blur because the content will already be up-to-date.
 		if ( ! event || ! event.originalEvent || event.originalEvent.type !== 'blur' ) {
 			this.onChange();
 		}

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -411,9 +411,24 @@ export class RichText extends Component {
 		this.props.onChange( this.savedContent );
 	}
 
-	onCreateUndoLevel() {
-		// Always ensure the content is up-to-date.
-		this.onChange();
+	onCreateUndoLevel( event ) {
+		// TinyMCE fires a `change` event when the first letter in an instance
+		// is typed. This should not create a history record in Gutenberg.
+		// https://github.com/tinymce/tinymce/blob/4.7.11/src/core/main/ts/api/UndoManager.ts#L116-L125
+		// In other cases TinyMCE won't fire a `change` with at least a previous
+		// record present, so this is a reliable check.
+		// https://github.com/tinymce/tinymce/blob/4.7.11/src/core/main/ts/api/UndoManager.ts#L272-L275
+		if ( event && event.lastLevel === null ) {
+			return;
+		}
+
+		// Always ensure the content is up-to-date, but avoid dispatching an
+		// action if the original event is blur because the content will already
+		// be up-to-date.
+		if ( ! event || ! event.originalEvent || event.originalEvent.type !== 'blur' ) {
+			this.onChange();
+		}
+
 		this.context.onCreateUndoLevel();
 	}
 


### PR DESCRIPTION
## Description

Fixes #5103.

1. Don't create a history record when TinyMCE fires a change event on typing the first character.
2. Avoid updating the content on a change event when the content is the same. ~~This introduces a deep equality check, but the change event does not fire often (only MCE commands and internal undo levels). I don't like this check much; the alternative is to just let it dispatch an action.~~ This happens when the source event was blurs, so we can filter that out.

## How has this been tested?

Follow the steps in #5103 and ensure only one action is dispatched.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->