### PR TITLE
Used editorMediaUpload in Gallery files transform (images drag&drop)

### DIFF
--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -7,9 +7,9 @@ import { filter, every } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { mediaUpload } from '@wordpress/utils';
 import {
 	createBlock,
+	editorMediaUpload,
 	RichText,
 } from '@wordpress/blocks';
 
@@ -135,7 +135,7 @@ export const settings = {
 				},
 				transform( files, onChange ) {
 					const block = createBlock( 'core/gallery' );
-					mediaUpload(
+					editorMediaUpload(
 						files,
 						( images ) => onChange( block.uid, { images } ),
 						'image'


### PR DESCRIPTION
Before we used mediaUpload directly this created a bug. The images uploaded did not contain the reference to the current post where they were uploaded.


## How has this been tested?
Create a new post, drag & drop multiple images to the post. Go to media, select the images that were uploaded (one by one) and verify the "Uploaded To" field references the post where we uploaded the images.

