### PR TITLE
Try: Data: Cache selector results by state via WeakMap

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -128,7 +128,7 @@ export function registerSelectors( reducerKey, newSelectors ) {
 			cacheByState.set( state, cache );
 		}
 
-		const key = { [ selectorName ]: args };
+		const key = [ selectorName, args ];
 		if ( ! cache.has( key ) ) {
 			cache.set( key, selector( state, ...args ) );
 		}


### PR DESCRIPTION
This pull request seeks to explore an option for aggressive selector caching on every selector when called with the same state. It does so by tracking an `EquivalentKeyMap` per state object by `WeakMap` (meaning unreferenced states are garbage collected), where each entry is a combination of selector name and arguments set.

This particularly optimizes for repeated calls to the same selector with the same state value, without requiring explicit memoization by `createSelector`. The latter may still be useful for more granular caching across distinct state values.