### PR TITLE
Build Tools: Fix the package plugin script

### DIFF
--- a/bin/get-vendor-scripts.php
+++ b/bin/get-vendor-scripts.php
@@ -11,10 +11,16 @@ define( 'SCRIPT_DEBUG', $argc > 1 && 'debug' === strtolower( $argv[1] ) );
 
 // Hacks to get lib/client-assets.php to load.
 define( 'ABSPATH', dirname( dirname( __FILE__ ) ) );
+
 /**
  * Hi, phpcs
  */
 function add_action() {}
+
+/**
+ * Hi, phpcs
+ */
+function wp_add_inline_script() {}
 
 // Instead of loading script files, just show how they need to be loaded.
 define( 'GUTENBERG_LIST_VENDOR_ASSETS', true );


### PR DESCRIPTION
I'm not certain this is the correct fix but there's already another polyfilled function `add_action` so to fix the package plugin script, I added a polyfill the newly used function `wp_add_inline_script`.

There's probably a better way to write this script but it would probably require fetching WordPress Core while the current script is independent.

**Testing instructions**

 - run `npm run package-plugin`
 - It should produce a correct gutenberg zip.

