### PR TITLE
Add ability to set custom placeholder in lists

### DIFF
--- a/core-blocks/list/index.js
+++ b/core-blocks/list/index.js
@@ -42,6 +42,9 @@ export const settings = {
 			selector: 'ol,ul',
 			default: [],
 		},
+		placeholder: {
+			type: 'string',
+		},
 	},
 
 	supports: {
@@ -209,7 +212,7 @@ export const settings = {
 				onReplace,
 				className,
 			} = this.props;
-			const { nodeName, values } = attributes;
+			const { nodeName, values, placeholder } = attributes;
 
 			return (
 				<Fragment>
@@ -248,7 +251,7 @@ export const settings = {
 						value={ values }
 						wrapperClassName="blocks-list"
 						className={ className }
-						placeholder={ __( 'Write list…' ) }
+						placeholder={ placeholder || __( 'Write list…' ) }
 						onMerge={ mergeBlocks }
 						onSplit={
 							insertBlocksAfter ?


### PR DESCRIPTION
Following #1891 for text and headings, this adds `placeholder` as an attribute to `core/list` to make the placeholder customizable when the block is used in a template.