### PR TITLE
Writing Flow: Collapse range in horizontal edge check by selection direction

### DIFF
--- a/editor/components/rich-text/format.js
+++ b/editor/components/rich-text/format.js
@@ -7,7 +7,7 @@ import { nodeListToReact } from 'dom-react';
 /**
  * WordPress dependencies
  */
-import { Fragment, createElement, renderToString } from '@wordpress/element';
+import { createElement, renderToString } from '@wordpress/element';
 
 /**
  * Browser dependencies
@@ -88,10 +88,12 @@ export function tinyMCENodeToElement( node ) {
 		child = child.next;
 	}
 
-	const tagName = node.type === Node.DOCUMENT_FRAGMENT_NODE ? Fragment : node.name;
-	const attributes = get( node.attributes, [ 'map' ], {} );
+	if ( node.type === Node.DOCUMENT_FRAGMENT_NODE ) {
+		return children;
+	}
 
-	return createElement( tagName, attributes, ...children );
+	const attributes = get( node.attributes, [ 'map' ], {} );
+	return createElement( node.name, attributes, ...children );
 }
 
 /**

--- a/editor/components/rich-text/format.js
+++ b/editor/components/rich-text/format.js
@@ -1,13 +1,19 @@
 /**
  * External dependencies
  */
-import { omitBy } from 'lodash';
+import { omitBy, get } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 
 /**
  * WordPress dependencies
  */
-import { createElement, renderToString } from '@wordpress/element';
+import { Fragment, createElement, renderToString } from '@wordpress/element';
+
+/**
+ * Browser dependencies
+ */
+
+const { Node } = window;
 
 /**
  * Transforms a WP Element to its corresponding HTML string.
@@ -60,6 +66,32 @@ export function createTinyMCEElement( type, props, ...children ) {
 		omitBy( props, ( _, key ) => key.indexOf( 'data-mce-' ) === 0 ),
 		...children
 	);
+}
+
+/**
+ * Given a TinyMCE Node instance, returns an equivalent WordPress element.
+ *
+ * @param {tinyMCE.html.Node} node TinyMCE node
+ *
+ * @return {WPElement} WordPress element
+ */
+export function tinyMCENodeToElement( node ) {
+	if ( node.type === Node.TEXT_NODE ) {
+		return node.value;
+	}
+
+	const children = [];
+
+	let child = node.firstChild;
+	while ( child ) {
+		children.push( tinyMCENodeToElement( child ) );
+		child = child.next;
+	}
+
+	const tagName = node.type === Node.DOCUMENT_FRAGMENT_NODE ? Fragment : node.name;
+	const attributes = get( node.attributes, [ 'map' ], {} );
+
+	return createElement( tagName, attributes, ...children );
 }
 
 /**

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -18,7 +18,7 @@ import 'element-closest';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment, compose, RawHTML, createRef } from '@wordpress/element';
+import { Component, Fragment, compose, RawHTML, Children, createRef } from '@wordpress/element';
 import {
 	keycodes,
 	createBlobURL,
@@ -817,8 +817,15 @@ export class RichText extends Component {
 	 * @return {boolean} Whether field is empty.
 	 */
 	isEmpty() {
-		const { value } = this.props;
-		return ! value || ! value.length;
+		const { value, format } = this.props;
+		if ( ! value ) {
+			return true;
+		}
+
+		return (
+			format === 'string' ||
+			! Children.count( value )
+		);
 	}
 
 	isFormatActive( format ) {

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -43,7 +43,11 @@ import { pickAriaProps } from './aria';
 import patterns from './patterns';
 import { EVENTS } from './constants';
 import { withBlockEditContext } from '../block-edit/context';
-import { domToFormat, valueToString } from './format';
+import {
+	domToFormat,
+	valueToString,
+	tinyMCENodeToElement,
+} from './format';
 
 /**
  * Browser dependencies
@@ -820,9 +824,7 @@ export class RichText extends Component {
 			case 'string':
 				return this.editor.getContent();
 			default:
-				return this.editor.dom.isEmpty( this.editor.getBody() ) ?
-					[] :
-					domToFormat( this.editor.getBody().childNodes || [], 'element', this.editor );
+				return tinyMCENodeToElement( this.editor.getContent( { format: 'tree' } ) );
 		}
 	}
 

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -12,7 +12,6 @@ import {
 	focus,
 	isTextField,
 	computeCaretRect,
-	hasCollapsedSelection,
 	isHorizontalEdge,
 	isVerticalEdge,
 	placeCaretAtHorizontalEdge,
@@ -28,6 +27,12 @@ import {
 	isBlockFocusStop,
 	isInSameBlock,
 } from '../../utils/dom';
+
+/**
+ * Browser constants
+ */
+
+const { getSelection } = window;
 
 /**
  * Module Constants
@@ -223,7 +228,7 @@ class WritingFlow extends Component {
 				placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
 				event.preventDefault();
 			}
-		} else if ( isHorizontal && hasCollapsedSelection() && isHorizontalEdge( target, isReverse ) ) {
+		} else if ( isHorizontal && getSelection().isCollapsed && isHorizontalEdge( target, isReverse ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -12,6 +12,7 @@ import {
 	focus,
 	isTextField,
 	computeCaretRect,
+	hasCollapsedSelection,
 	isHorizontalEdge,
 	isVerticalEdge,
 	placeCaretAtHorizontalEdge,
@@ -206,7 +207,7 @@ class WritingFlow extends Component {
 
 		if ( isShift && ( hasMultiSelection || (
 			this.isTabbableEdge( target, isReverse ) &&
-			isNavEdge( target, isReverse, true )
+			isNavEdge( target, isReverse )
 		) ) ) {
 			// Shift key is down, and there is multi selection or we're at the end of the current block.
 			this.expandSelection( isReverse );
@@ -215,14 +216,14 @@ class WritingFlow extends Component {
 			// Moving from block multi-selection to single block selection
 			this.moveSelection( isReverse );
 			event.preventDefault();
-		} else if ( isVertical && isVerticalEdge( target, isReverse, isShift ) ) {
+		} else if ( isVertical && hasCollapsedSelection() && isVerticalEdge( target, isReverse ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 
 			if ( closestTabbable ) {
 				placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
 				event.preventDefault();
 			}
-		} else if ( isHorizontal && isHorizontalEdge( target, isReverse, isShift ) ) {
+		} else if ( isHorizontal && hasCollapsedSelection() && isHorizontalEdge( target, isReverse ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -216,7 +216,7 @@ class WritingFlow extends Component {
 			// Moving from block multi-selection to single block selection
 			this.moveSelection( isReverse );
 			event.preventDefault();
-		} else if ( isVertical && hasCollapsedSelection() && isVerticalEdge( target, isReverse ) ) {
+		} else if ( isVertical && isVerticalEdge( target, isReverse ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 
 			if ( closestTabbable ) {

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -53,41 +53,6 @@ const isTabbableTextField = overEvery( [
 	focus.tabbable.isTabbableIndex,
 ] );
 
-/**
- * Returns true if the given node is a TinyMCE inline boundary node.
- *
- * @param {Node} node Node to test.
- *
- * @return {boolean} Whether node is a TinyMCE inline boundary node.
- */
-function isInlineBoundary( node ) {
-	return node.getAttribute( 'data-mce-selected' ) === 'inline-boundary';
-}
-
-/**
- * Returns true if it can be inferred that horizontal navigation has already
- * been handled in the desired direction, or false otherwise. Specifically,
- * this accounts for TinyMCE's inline boundary traversal, where its keydown
- * event takes effect before the event propagates to WritingFlow. This avoids
- * the caret from being moved outside the block when inline boundary occurs at
- * the end of a RichText.
- *
- * @see tinymce/src/core/main/ts/keyboard/ArrowKeys.ts (executeKeydownOverride)
- *
- * @param {boolean} isReverse Whether to test in reverse.
- *
- * @return {boolean} Whether horizontal navigation has been handled.
- */
-function isHorizontalNavigationHandled( isReverse ) {
-	const { isCollapsed, focusNode } = getSelection();
-	if ( ! isCollapsed ) {
-		return false;
-	}
-
-	const siblingNode = focusNode[ isReverse ? 'nextSibling' : 'previousSibling' ];
-	return !! siblingNode && isInlineBoundary( siblingNode );
-}
-
 class WritingFlow extends Component {
 	constructor() {
 		super( ...arguments );
@@ -263,8 +228,7 @@ class WritingFlow extends Component {
 				placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
 				event.preventDefault();
 			}
-		} else if ( isHorizontal && getSelection().isCollapsed &&
-				! isHorizontalNavigationHandled( isReverse ) && isHorizontalEdge( target, isReverse ) ) {
+		} else if ( isHorizontal && getSelection().isCollapsed && isHorizontalEdge( target, isReverse ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();

--- a/element/serialize.js
+++ b/element/serialize.js
@@ -406,14 +406,14 @@ export function renderNativeComponent( type, props, context = {} ) {
 		// Textarea children can be assigned as value prop. If it is, render in
 		// place of children. Ensure to omit so it is not assigned as attribute
 		// as well.
-		content = renderChildren( [ props.value ], context );
+		content = renderChildren( props.value, context );
 		props = omit( props, 'value' );
 	} else if ( props.dangerouslySetInnerHTML &&
 			typeof props.dangerouslySetInnerHTML.__html === 'string' ) {
 		// Dangerous content is left unescaped.
 		content = props.dangerouslySetInnerHTML.__html;
 	} else if ( typeof props.children !== 'undefined' ) {
-		content = renderChildren( castArray( props.children ), context );
+		content = renderChildren( props.children, context );
 	}
 
 	if ( ! type ) {
@@ -464,6 +464,8 @@ export function renderComponent( Component, props, context = {} ) {
  */
 function renderChildren( children, context = {} ) {
 	let result = '';
+
+	children = castArray( children );
 
 	for ( let i = 0; i < children.length; i++ ) {
 		const child = children[ i ];

--- a/element/test/serialize.js
+++ b/element/test/serialize.js
@@ -199,6 +199,12 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( 'Hello' );
 	} );
 
+	it( 'renders Fragment with undefined children', () => {
+		const result = renderElement( <Fragment /> );
+
+		expect( result ).toBe( '' );
+	} );
+
 	it( 'renders RawHTML as its unescaped children', () => {
 		const result = renderElement( <RawHTML>{ '<img/>' }</RawHTML> );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -472,7 +472,7 @@ function gutenberg_register_vendor_scripts() {
 		'https://unpkg.com/moment@2.21.0/' . $moment_script,
 		array()
 	);
-	$tinymce_version = '4.7.2';
+	$tinymce_version = '4.7.12';
 	gutenberg_register_vendor_script(
 		'tinymce-latest',
 		'https://unpkg.com/tinymce@' . $tinymce_version . '/tinymce' . $suffix . '.js'

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -130,7 +130,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-utils',
 		gutenberg_url( 'build/utils/index.js' ),
-		array( 'tinymce-latest', 'lodash' ),
+		array( 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/utils/index.js' ),
 		true
 	);

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -9,3 +9,7 @@ exports[`adding blocks Should navigate with arrow keys 3`] = `"Hello to the Worl
 exports[`adding blocks Should navigate with arrow keys 4`] = `"Greeting: Hello to the World!"`;
 
 exports[`adding blocks Should navigate with arrow keys 5`] = `"The Greeting: <br>Hello to the World!"`;
+
+exports[`adding blocks Should navigate with arrow keys 6`] = `"Prefix: Hello"`;
+
+exports[`adding blocks Should navigate with arrow keys 7`] = `"The Greeting: <br>Hello to the World! (Suffix)"`;

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -13,3 +13,25 @@ exports[`adding blocks Should navigate with arrow keys 5`] = `"The Greeting: <br
 exports[`adding blocks Should navigate with arrow keys 6`] = `"Prefix: Hello"`;
 
 exports[`adding blocks Should navigate with arrow keys 7`] = `"The Greeting: <br>Hello to the World! (Suffix)"`;
+
+exports[`adding blocks Should navigate with arrow keys 8`] = `"<span id=\\"_mce_caret\\" data-mce-bogus=\\"1\\"><strong data-mce-selected=\\"inline-boundary\\">﻿Bolded</strong></span><br data-mce-bogus=\\"1\\">"`;
+
+exports[`adding blocks Should navigate with arrow keys 9`] = `"<strong data-mce-selected=\\"inline-boundary\\">Bolded Words﻿</strong><br data-mce-bogus=\\"1\\">"`;
+
+exports[`adding blocks Should navigate with arrow keys 10`] = `"<strong>Bolded Words</strong>After<br data-mce-bogus=\\"1\\">"`;
+
+exports[`adding blocks Should navigate with arrow keys 11`] = `"The Greeting: <br>Hello to the World! (Suffixed)"`;
+
+exports[`adding blocks Should navigate with arrow keys 12`] = `
+"<!-- wp:paragraph -->
+<p>The Greeting: <br/>Hello to the World! (Suffixed)</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>Bolded Words</strong>After</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Prefix: Hello</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`adding blocks Should navigate with arrow keys 1`] = `"Hello World!"`;
+
+exports[`adding blocks Should navigate with arrow keys 2`] = `"Hello"`;
+
+exports[`adding blocks Should navigate with arrow keys 3`] = `"Hello to the World!"`;
+
+exports[`adding blocks Should navigate with arrow keys 4`] = `"Greeting: Hello to the World!"`;
+
+exports[`adding blocks Should navigate with arrow keys 5`] = `"The Greeting: <br>Hello to the World!"`;

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -14,24 +14,30 @@ exports[`adding blocks Should navigate with arrow keys 6`] = `"Prefix: Hello"`;
 
 exports[`adding blocks Should navigate with arrow keys 7`] = `"The Greeting: <br>Hello to the World! (Suffix)"`;
 
-exports[`adding blocks Should navigate with arrow keys 8`] = `"<span id=\\"_mce_caret\\" data-mce-bogus=\\"1\\"><strong data-mce-selected=\\"inline-boundary\\">﻿Bolded</strong></span><br data-mce-bogus=\\"1\\">"`;
+exports[`adding blocks Should navigate with arrow keys 8`] = `"<span id=\\"_mce_caret\\" data-mce-bogus=\\"1\\" data-mce-type=\\"format-caret\\"><strong data-mce-selected=\\"inline-boundary\\">﻿Bolded</strong></span><br data-mce-bogus=\\"1\\">"`;
 
-exports[`adding blocks Should navigate with arrow keys 9`] = `"<strong data-mce-selected=\\"inline-boundary\\">Bolded Words﻿</strong><br data-mce-bogus=\\"1\\">"`;
+exports[`adding blocks Should navigate with arrow keys 9`] = `"<strong>Bolded</strong>&nbsp;After<br data-mce-bogus=\\"1\\">"`;
 
-exports[`adding blocks Should navigate with arrow keys 10`] = `"<strong>Bolded Words</strong>After<br data-mce-bogus=\\"1\\">"`;
+exports[`adding blocks Should navigate with arrow keys 10`] = `"The Greeting: <br>Hello to the World! (Suffixed)"`;
 
-exports[`adding blocks Should navigate with arrow keys 11`] = `"The Greeting: <br>Hello to the World! (Suffixed)"`;
+exports[`adding blocks Should navigate with arrow keys 11`] = `"<strong data-mce-selected=\\"inline-boundary\\">More Bolded (Still Bolded)﻿</strong><br data-mce-bogus=\\"1\\">"`;
 
-exports[`adding blocks Should navigate with arrow keys 12`] = `
+exports[`adding blocks Should navigate with arrow keys 12`] = `"The Prefix: Hello"`;
+
+exports[`adding blocks Should navigate with arrow keys 13`] = `
 "<!-- wp:paragraph -->
 <p>The Greeting: <br/>Hello to the World! (Suffixed)</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>Bolded Words</strong>After</p>
+<p><strong>Bolded</strong> After</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Prefix: Hello</p>
+<p><strong>More Bolded (Still Bolded)</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The Prefix: Hello</p>
 <!-- /wp:paragraph -->"
 `;

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { times } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage, pressWithModifier } from '../support/utils';
+
+describe( 'adding blocks', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+	} );
+
+	/**
+	 * Given an array of functions, each returning a promise, performs all
+	 * promises in sequence (waterfall) order.
+	 *
+	 * @param {Function[]} sequence Array of promise creators.
+	 *
+	 * @return {Promise} Promise resolving once all in the sequence complete.
+	 */
+	async function promiseSequence( sequence ) {
+		return sequence.reduce(
+			( current, next ) => current.then( next ),
+			Promise.resolve()
+		);
+	}
+
+	/**
+	 * Asserts that the nth paragraph matches expected snapshot content.
+	 *
+	 * @param {number} nthChild 1-based index of paragraph to assert against.
+	 */
+	async function expectParagraphToMatchSnapshot( nthChild ) {
+		const content = await page.$eval(
+			`.editor-block-list__block:nth-child( ${ nthChild } ) .wp-block-paragraph`,
+			( element ) => element.innerHTML
+		);
+
+		expect( content ).toMatchSnapshot();
+	}
+
+	it( 'Should navigate with arrow keys', async () => {
+		// Add demo content
+		await page.click( '.editor-default-block-appender__content' );
+		await page.keyboard.type( 'Hello World' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Hello World' );
+
+		// Traverse back to first paragraph. With identical content, assume
+		// caret will be at end of content. Append.
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( '!' );
+		await expectParagraphToMatchSnapshot( 1 );
+
+		// Likewise, pressing arrow down when subsequent paragraph is shorter
+		// should move caret to end of the paragraph. Remove second word.
+		await page.keyboard.press( 'ArrowDown' );
+		await promiseSequence( times( 6, () => () => page.keyboard.press( 'Backspace' ) ) );
+		await expectParagraphToMatchSnapshot( 2 );
+
+		// Arrow up should preserve caret X position. Add content to middle.
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( ' to the' );
+		await expectParagraphToMatchSnapshot( 1 );
+
+		// Arrow up from uncollapsed selection behaves same as collapsed.
+		// Highlight first word of second paragraph and prepend to first.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.down( 'Shift' );
+		await promiseSequence( times( 5, () => () => page.keyboard.press( 'ArrowLeft' ) ) );
+		await page.keyboard.up( 'Shift' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( 'Greeting: ' );
+		await expectParagraphToMatchSnapshot( 1 );
+
+		// Arrow up from second line of paragraph should _not_ place caret out
+		// of the current block.
+		await pressWithModifier( 'Shift', 'Enter' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( 'The ' );
+		await expectParagraphToMatchSnapshot( 1 );
+	} );
+} );

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -84,5 +84,32 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.type( 'The ' );
 		await expectParagraphToMatchSnapshot( 1 );
+
+		// Pressing down from last paragraph should move caret to end of the
+		// text of the last paragraph
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+
+		// Regression test: Ensure selection can be progressively collapsed at
+		// beginning and end of text while shift is held.
+		await promiseSequence( times( 5, () => () => page.keyboard.press( 'ArrowLeft' ) ) );
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.up( 'Shift' );
+		await page.keyboard.type( 'Prefix: ' );
+		await expectParagraphToMatchSnapshot( 2 );
+
+		// Likewise, ensure progressive collapse from previous block (previous
+		// to guard against multi-selection behavior). Asserts arrow left to
+		// traverse horizontally to previous.
+		await promiseSequence( times( 9, () => () => page.keyboard.press( 'ArrowLeft' ) ) );
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.up( 'Shift' );
+		await page.keyboard.type( ' (Suffix)' );
+		await expectParagraphToMatchSnapshot( 1 );
 	} );
 } );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -19,6 +19,13 @@ const {
  */
 const MOD_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
 
+/**
+ * Regular expression matching zero-width space characters.
+ *
+ * @type {RegExp}
+ */
+const REGEXP_ZWSP = /[\u200B\u200C\u200D\uFEFF]/;
+
 function getUrl( WPPath, query = '' ) {
 	const url = new URL( WP_BASE_URL );
 
@@ -78,6 +85,12 @@ export async function getHTMLFromCodeEditor() {
 	await switchToEditor( 'Code' );
 	const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
 	await switchToEditor( 'Visual' );
+
+	// Globally guard against zero-width characters.
+	if ( REGEXP_ZWSP.test( textEditorContent ) ) {
+		throw new Error( 'Unexpected zero-width space character in editor content.' );
+	}
+
 	return textEditorContent;
 }
 

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -11,7 +11,7 @@ const { getComputedStyle } = window;
 const { TEXT_NODE, ELEMENT_NODE } = window.Node;
 
 /**
- * Check whether the caret is horizontally at the edge of the container.
+ * Check whether the selection is horizontally at the edge of the container.
  *
  * @param {Element} container Focusable element.
  * @param {boolean} isReverse Set to true to check left, false for right.
@@ -35,7 +35,7 @@ export function isHorizontalEdge( container, isReverse ) {
 		return true;
 	}
 
-	// If the container is empty, the caret is always at the edge.
+	// If the container is empty, the selection is always at the edge.
 	if ( tinymce.DOM.isEmpty( container ) ) {
 		return true;
 	}
@@ -77,7 +77,7 @@ export function isHorizontalEdge( container, isReverse ) {
 }
 
 /**
- * Check whether the caret is vertically at the edge of the container.
+ * Check whether the selection is vertically at the edge of the container.
  *
  * @param {Element} container Focusable element.
  * @param {boolean} isReverse Set to true to check top, false for bottom.

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -11,15 +11,29 @@ const { getComputedStyle, DOMRect } = window;
 const { TEXT_NODE, ELEMENT_NODE } = window.Node;
 
 /**
+ * Returns true if there is a selection and if the selection is collapsed, or
+ * false otherwise.
+ *
+ * @return {boolean} Whether there is a collapsed selection.
+ */
+export function hasCollapsedSelection() {
+	const selection = window.getSelection();
+
+	return (
+		selection.rangeCount > 0 &&
+		selection.getRangeAt( 0 ).collapsed
+	);
+}
+
+/**
  * Check whether the caret is horizontally at the edge of the container.
  *
- * @param {Element} container             Focusable element.
- * @param {boolean} isReverse             Set to true to check left, false for right.
- * @param {boolean} requireCollapsedRange Whether or not to collapse the selection range before the check.
+ * @param {Element} container Focusable element.
+ * @param {boolean} isReverse Set to true to check left, false for right.
  *
  * @return {boolean} True if at the horizontal edge, false if not.
  */
-export function isHorizontalEdge( container, isReverse, requireCollapsedRange = false ) {
+export function isHorizontalEdge( container, isReverse ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		if ( container.selectionStart !== container.selectionEnd ) {
 			return false;
@@ -45,10 +59,6 @@ export function isHorizontalEdge( container, isReverse, requireCollapsedRange = 
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
 	if ( ! range ) {
-		return false;
-	}
-
-	if ( ! requireCollapsedRange && ! range.collapsed ) {
 		return false;
 	}
 
@@ -84,13 +94,12 @@ export function isHorizontalEdge( container, isReverse, requireCollapsedRange = 
 /**
  * Check whether the caret is vertically at the edge of the container.
  *
- * @param {Element} container      Focusable element.
- * @param {boolean} isReverse      Set to true to check top, false for bottom.
- * @param {boolean} collapseRanges Whether or not to collapse the selection range before the check.
+ * @param {Element} container Focusable element.
+ * @param {boolean} isReverse Set to true to check top, false for bottom.
  *
  * @return {boolean} True if at the edge, false if not.
  */
-export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
+export function isVerticalEdge( container, isReverse ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		return isHorizontalEdge( container, isReverse );
 	}
@@ -100,13 +109,9 @@ export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
 	}
 
 	const selection = window.getSelection();
-	let range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
-	if ( collapseRanges && range && ! range.collapsed ) {
-		const newRange = document.createRange();
-		// Get the end point of the selection (see focusNode vs. anchorNode)
-		newRange.setStart( selection.focusNode, selection.focusOffset );
-		newRange.collapse( true );
-		range = newRange;
+	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+	if ( ! range ) {
+		return false;
 	}
 
 	if ( ! range || ! range.collapsed ) {

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -8,37 +8,7 @@ import tinymce from 'tinymce';
  * Browser dependencies
  */
 const { getComputedStyle } = window;
-const { TEXT_NODE, ELEMENT_NODE, DOCUMENT_POSITION_PRECEDING } = window.Node;
-
-/**
- * Returns true if the given selection object is in the forward direction, or
- * false otherwise.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
- *
- * @param {Selection} selection Selection object to check.
- *
- * @return {boolean} Whether the selection is forward.
- */
-function isSelectionForward( selection ) {
-	const {
-		anchorNode,
-		focusNode,
-		anchorOffset,
-		focusOffset,
-	} = selection;
-
-	const position = anchorNode.compareDocumentPosition( focusNode );
-
-	return (
-		// Compare whether anchor node precedes focus node.
-		position !== DOCUMENT_POSITION_PRECEDING &&
-
-		// `compareDocumentPosition` returns 0 when passed the same node, in
-		// which case compare offsets.
-		! ( position === 0 && anchorOffset > focusOffset )
-	);
-}
+const { TEXT_NODE, ELEMENT_NODE } = window.Node;
 
 /**
  * Check whether the selection is horizontally at the edge of the container.
@@ -71,27 +41,15 @@ export function isHorizontalEdge( container, isReverse ) {
 	}
 
 	const selection = window.getSelection();
-	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
-	if ( ! range ) {
-		return false;
-	}
-
-	// Start and end offsets are always sorted small to large regardless of
-	// selection direction. If `isReverse` is does not align to selection
-	// being backward, invert the position.
-	let position = isReverse ? 'start' : 'end';
-	if ( isReverse === isSelectionForward( selection ) ) {
-		position = ( position === 'start' ) ? 'end' : 'start';
-	}
-
-	const offset = range[ `${ position }Offset` ];
+	const position = isReverse ? 'focus' : 'anchor';
+	const offset = selection[ `${ position }Offset` ];
 
 	if ( isReverse && offset !== 0 ) {
 		return false;
 	}
 
-	let node = range.startContainer;
+	let node = selection[ `${ position }Node` ];
 	const maxOffset = node.nodeType === TEXT_NODE ? node.nodeValue.length : node.childNodes.length;
 
 	if ( ! isReverse && offset !== maxOffset ) {
@@ -99,6 +57,7 @@ export function isHorizontalEdge( container, isReverse ) {
 	}
 
 	const order = isReverse ? 'first' : 'last';
+
 	while ( node !== container ) {
 		const parentNode = node.parentNode;
 

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -8,7 +8,37 @@ import tinymce from 'tinymce';
  * Browser dependencies
  */
 const { getComputedStyle } = window;
-const { TEXT_NODE, ELEMENT_NODE } = window.Node;
+const { TEXT_NODE, ELEMENT_NODE, DOCUMENT_POSITION_PRECEDING } = window.Node;
+
+/**
+ * Returns true if the given selection object is in the forward direction, or
+ * false otherwise.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
+ *
+ * @param {Selection} selection Selection object to check.
+ *
+ * @return {boolean} Whether the selection is forward.
+ */
+function isSelectionForward( selection ) {
+	const {
+		anchorNode,
+		focusNode,
+		anchorOffset,
+		focusOffset,
+	} = selection;
+
+	const position = anchorNode.compareDocumentPosition( focusNode );
+
+	return (
+		// Compare whether anchor node precedes focus node.
+		position !== DOCUMENT_POSITION_PRECEDING &&
+
+		// `compareDocumentPosition` returns 0 when passed the same node, in
+		// which case compare offsets.
+		! ( position === 0 && anchorOffset > focusOffset )
+	);
+}
 
 /**
  * Check whether the selection is horizontally at the edge of the container.
@@ -47,22 +77,28 @@ export function isHorizontalEdge( container, isReverse ) {
 		return false;
 	}
 
-	const position = isReverse ? 'start' : 'end';
-	const order = isReverse ? 'first' : 'last';
-	const offset = range[ `${ position }Offset` ];
+	// Start and end offsets are always sorted small to large regardless of
+	// selection direction. If `isReverse` is does not align to selection
+	// being backward, invert the position.
+	let position = isReverse ? 'start' : 'end';
+	if ( isReverse === isSelectionForward( selection ) ) {
+		position = ( position === 'start' ) ? 'end' : 'start';
+	}
 
-	let node = range.startContainer;
+	const offset = range[ `${ position }Offset` ];
 
 	if ( isReverse && offset !== 0 ) {
 		return false;
 	}
 
+	let node = range.startContainer;
 	const maxOffset = node.nodeType === TEXT_NODE ? node.nodeValue.length : node.childNodes.length;
 
 	if ( ! isReverse && offset !== maxOffset ) {
 		return false;
 	}
 
+	const order = isReverse ? 'first' : 'last';
 	while ( node !== container ) {
 		const parentNode = node.parentNode;
 

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -11,21 +11,6 @@ const { getComputedStyle, DOMRect } = window;
 const { TEXT_NODE, ELEMENT_NODE } = window.Node;
 
 /**
- * Returns true if there is a selection and if the selection is collapsed, or
- * false otherwise.
- *
- * @return {boolean} Whether there is a collapsed selection.
- */
-export function hasCollapsedSelection() {
-	const selection = window.getSelection();
-
-	return (
-		selection.rangeCount > 0 &&
-		selection.getRangeAt( 0 ).collapsed
-	);
-}
-
-/**
  * Check whether the caret is horizontally at the edge of the container.
  *
  * @param {Element} container Focusable element.

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -40,16 +40,13 @@ export function isHorizontalEdge( container, isReverse ) {
 		return true;
 	}
 
-	const selection = window.getSelection();
-
-	const position = isReverse ? 'focus' : 'anchor';
-	const offset = selection[ `${ position }Offset` ];
+	const { focusNode, focusOffset: offset } = window.getSelection();
 
 	if ( isReverse && offset !== 0 ) {
 		return false;
 	}
 
-	let node = selection[ `${ position }Node` ];
+	let node = focusNode;
 	const maxOffset = node.nodeType === TEXT_NODE ? node.nodeValue.length : node.childNodes.length;
 
 	if ( ! isReverse && offset !== maxOffset ) {

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -8,48 +8,18 @@ import tinymce from 'tinymce';
  * Browser dependencies
  */
 const { getComputedStyle, DOMRect } = window;
-const { TEXT_NODE, ELEMENT_NODE, DOCUMENT_POSITION_PRECEDING } = window.Node;
-
-/**
- * Returns true if the given selection object is in the forward direction, or
- * false otherwise.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
- *
- * @param {Selection} selection Selection object to check.
- *
- * @return {boolean} Whether the selection is forward.
- */
-function isSelectionForward( selection ) {
-	const {
-		anchorNode,
-		focusNode,
-		anchorOffset,
-		focusOffset,
-	} = selection;
-
-	const position = anchorNode.compareDocumentPosition( focusNode );
-
-	return (
-		// Compare whether anchor node precedes focus node.
-		position !== DOCUMENT_POSITION_PRECEDING &&
-
-		// `compareDocumentPosition` returns 0 when passed the same node, in
-		// which case compare offsets.
-		! ( position === 0 && anchorOffset > focusOffset )
-	);
-}
+const { TEXT_NODE, ELEMENT_NODE } = window.Node;
 
 /**
  * Check whether the caret is horizontally at the edge of the container.
  *
- * @param {Element} container      Focusable element.
- * @param {boolean} isReverse      Set to true to check left, false for right.
- * @param {boolean} collapseRanges Whether or not to collapse the selection range before the check.
+ * @param {Element} container             Focusable element.
+ * @param {boolean} isReverse             Set to true to check left, false for right.
+ * @param {boolean} requireCollapsedRange Whether or not to collapse the selection range before the check.
  *
  * @return {boolean} True if at the horizontal edge, false if not.
  */
-export function isHorizontalEdge( container, isReverse, collapseRanges = false ) {
+export function isHorizontalEdge( container, isReverse, requireCollapsedRange = false ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		if ( container.selectionStart !== container.selectionEnd ) {
 			return false;
@@ -72,15 +42,13 @@ export function isHorizontalEdge( container, isReverse, collapseRanges = false )
 	}
 
 	const selection = window.getSelection();
-	let range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
-	if ( collapseRanges ) {
-		range = range.cloneRange();
+	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
-		// Collapse to the extent of the selection by direction.
-		range.collapse( ! isSelectionForward( selection ) );
+	if ( ! range ) {
+		return false;
 	}
 
-	if ( ! range || ! range.collapsed ) {
+	if ( ! requireCollapsedRange && ! range.collapsed ) {
 		return false;
 	}
 

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -114,10 +114,6 @@ export function isVerticalEdge( container, isReverse ) {
 		return false;
 	}
 
-	if ( ! range || ! range.collapsed ) {
-		return false;
-	}
-
 	const rangeRect = getRectangleFromRange( range );
 
 	if ( ! rangeRect ) {
@@ -187,7 +183,7 @@ export function computeCaretRect( container ) {
 	const selection = window.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
-	if ( ! range || ! range.collapsed ) {
+	if ( ! range ) {
 		return;
 	}
 
@@ -319,7 +315,7 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 	// equivalent to a point at half the height of a line of text.
 	const buffer = rect.height / 2;
 	const editableRect = container.getBoundingClientRect();
-	const x = rect.left + ( rect.width / 2 );
+	const x = rect.left;
 	const y = isReverse ? ( editableRect.bottom - buffer ) : ( editableRect.top + buffer );
 	const selection = window.getSelection();
 

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -40,16 +40,17 @@ export function isHorizontalEdge( container, isReverse ) {
 		return true;
 	}
 
-	const { focusNode, focusOffset: offset } = window.getSelection();
-
-	if ( isReverse && offset !== 0 ) {
+	// Focus offset accounts for direction of selection (offset where selection
+	// ends).
+	const { focusNode, focusOffset } = window.getSelection();
+	if ( isReverse && focusOffset !== 0 ) {
 		return false;
 	}
 
 	let node = focusNode;
 	const maxOffset = node.nodeType === TEXT_NODE ? node.nodeValue.length : node.childNodes.length;
 
-	if ( ! isReverse && offset !== maxOffset ) {
+	if ( ! isReverse && focusOffset !== maxOffset ) {
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #5095

This pull request seeks to resolve an issue where it is not possible to unexpand a selection from the beginning of a paragraph block. I'm not entirely clear the intent with collapsing range in the `isHorizontalEdge` function, though it would seem that it should be based on the direction of the current selection itself, not necessarily the direction being considered as the edge.

__Testing instructions:__

Verify that various shift-selection within and across blocks works as expected, particularly the previously failing behavior:

1. Insert a new paragraph block with some text
2. Make a selection of the text from the beginning of the block
3. Press Shift+ArrowLeft to unexpand the selection
4. Note that the selection becomes unexpanded as expected