### PR TITLE
Minor improvements for the permalink Copy to clipboard button

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -14,11 +14,11 @@
 		opacity: 0.3;
 	}
 
-	&:not( :disabled ) {
+	&:not( :disabled ):not( [aria-disabled="true"] ) {
 		cursor: pointer;
 	}
 
-	&:focus {
+	&:not( :disabled ):not( [aria-disabled="true"] ):focus {
 		@include button-style__focus-active;
 	}
 

--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -12,7 +12,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Button } from '../';
+import IconButton from '../icon-button';
 
 class ClipboardButton extends Component {
 	constructor() {
@@ -82,9 +82,9 @@ class ClipboardButton extends Component {
 
 		return (
 			<span ref={ this.bindContainer }>
-				<Button { ...buttonProps } className={ classes }>
+				<IconButton { ...buttonProps } icon="admin-links" className={ classes }>
 					{ children }
-				</Button>
+				</IconButton>
 			</span>
 		);
 	}

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -1,10 +1,15 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component, compose } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon, ClipboardButton, Button, Tooltip } from '@wordpress/components';
+import { ClipboardButton, Button } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -21,7 +26,7 @@ class PostPermalink extends Component {
 		this.onVisibilityChange = this.onVisibilityChange.bind( this );
 
 		this.state = {
-			iconClass: '',
+			isCopied: false,
 			isEditingPermalink: false,
 		};
 	}
@@ -52,7 +57,7 @@ class PostPermalink extends Component {
 
 	render() {
 		const { isNew, previewLink, isEditable, samplePermalink, isPublished } = this.props;
-		const { iconClass, isEditingPermalink } = this.state;
+		const { isCopied, isEditingPermalink } = this.state;
 
 		if ( isNew || ! previewLink ) {
 			return null;
@@ -60,15 +65,12 @@ class PostPermalink extends Component {
 
 		return (
 			<div className="editor-post-permalink">
-				<Tooltip text={ __( 'Copy the permalink to your clipboard' ) }>
-					<ClipboardButton
-						className="editor-post-permalink__copy"
-						text={ samplePermalink }
-						onCopy={ () => this.setState( { iconClass: 'is-copied' } ) }
-					>
-						<Dashicon icon="admin-links" className={ iconClass } />
-					</ClipboardButton>
-				</Tooltip>
+				<ClipboardButton
+					className={ classnames( 'editor-post-permalink__copy', { 'is-copied': isCopied } ) }
+					text={ samplePermalink }
+					label={ __( 'Copy the permalink' ) }
+					onCopy={ () => this.setState( { isCopied: true } ) }
+				/>
 
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>
 
@@ -132,4 +134,3 @@ export default compose( [
 		return { refreshPost };
 	} ),
 ] )( PostPermalink );
-

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -58,6 +58,7 @@ class PostPermalink extends Component {
 	render() {
 		const { isNew, previewLink, isEditable, samplePermalink, isPublished } = this.props;
 		const { isCopied, isEditingPermalink } = this.state;
+		const ariaLabel = isCopied ? __( 'Permalink copied' ) : __( 'Copy the permalink' );
 
 		if ( isNew || ! previewLink ) {
 			return null;
@@ -68,8 +69,9 @@ class PostPermalink extends Component {
 				<ClipboardButton
 					className={ classnames( 'editor-post-permalink__copy', { 'is-copied': isCopied } ) }
 					text={ samplePermalink }
-					label={ __( 'Copy the permalink' ) }
+					label={ ariaLabel }
 					onCopy={ () => this.setState( { isCopied: true } ) }
+					aria-disabled={ isCopied }
 				/>
 
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -19,15 +19,16 @@
 }
 
 .editor-post-permalink__copy {
-	margin-top: 4px;
+	border-radius: 4px;
+	padding: 6px;
 }
 
-.editor-post-permalink__copy .is-copied {
+.editor-post-permalink__copy.is-copied {
 	opacity: 0.3;
 }
 
 .editor-post-permalink__label {
-	margin: 0 10px;
+	margin: 0 10px 0 5px;
 }
 
 .editor-post-permalink__link {


### PR DESCRIPTION
Waiting for #5494, I'd like to propose a few minor improvements for the permalink "Copy" button.

This PR tries to re-use existing component and patterns. Specifically:
- uses an `IconButton` component instead of a `Button`
- uses `classnames()` to conditionally apply the `is-copied` CSS class 
- shortens the label to 'Copy the permalink'
- makes the button style more similar to default icon buttons (see border-radius)
- improves the button alignment

Screenshot before:

<img width="831" alt="before" src="https://user-images.githubusercontent.com/1682452/39377587-04d5d296-4a56-11e8-8896-2b74d998c835.png">

After:

<img width="835" alt="after" src="https://user-images.githubusercontent.com/1682452/39377597-0beff98a-4a56-11e8-8d0f-5feb17c3dc99.png">

<img width="829" alt="after2" src="https://user-images.githubusercontent.com/1682452/39377598-0c0b769c-4a56-11e8-8e1f-7d8e330cdd74.png">
