### PR TITLE
Improve consistency of Shared and Permalink blocks UI.

### DIFF
--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -18,6 +18,7 @@ class ReusableBlockEditPanel extends Component {
 
 		this.titleField = createRef();
 		this.editButton = createRef();
+		this.editForm = createRef();
 		this.handleFormSubmit = this.handleFormSubmit.bind( this );
 		this.handleTitleChange = this.handleTitleChange.bind( this );
 		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
@@ -35,7 +36,7 @@ class ReusableBlockEditPanel extends Component {
 		if ( ! prevProps.isEditing && this.props.isEditing ) {
 			this.titleField.current.select();
 		}
-		// Move focus back to the Edit button after pressing the Escape key, Cancel, or Save.
+		// Move focus back to the Edit button after pressing the Escape key or after saving.
 		if ( ( prevProps.isEditing || prevProps.isSaving ) && ! this.props.isEditing && ! this.props.isSaving ) {
 			this.editButton.current.focus();
 		}
@@ -58,7 +59,7 @@ class ReusableBlockEditPanel extends Component {
 	}
 
 	render() {
-		const { isEditing, title, isSaving, onEdit, onCancel, instanceId } = this.props;
+		const { isEditing, title, isSaving, onEdit, instanceId } = this.props;
 
 		return (
 			<Fragment>
@@ -78,7 +79,11 @@ class ReusableBlockEditPanel extends Component {
 					</div>
 				) }
 				{ ( isEditing || isSaving ) && (
-					<form className="reusable-block-edit-panel" onSubmit={ this.handleFormSubmit }>
+					<form
+						className="reusable-block-edit-panel"
+						ref={ this.editForm }
+						onSubmit={ this.handleFormSubmit }
+					>
 						<label
 							htmlFor={ `reusable-block-edit-panel__title-${ instanceId }` }
 							className="reusable-block-edit-panel__label"
@@ -97,21 +102,12 @@ class ReusableBlockEditPanel extends Component {
 						/>
 						<Button
 							type="submit"
-							isPrimary
 							isLarge
 							isBusy={ isSaving }
 							disabled={ ! title || isSaving }
 							className="reusable-block-edit-panel__button"
 						>
 							{ __( 'Save' ) }
-						</Button>
-						<Button
-							isLarge
-							disabled={ isSaving }
-							className="reusable-block-edit-panel__button"
-							onClick={ onCancel }
-						>
-							{ __( 'Cancel' ) }
 						</Button>
 					</form>
 				) }

--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -25,10 +25,11 @@ class ReusableBlockEditPanel extends Component {
 	}
 
 	componentDidMount() {
-		// Select the input text when the form opens.
-		if ( this.props.isEditing && this.titleField.current ) {
-			this.titleField.current.select();
-		}
+		document.addEventListener( 'click', this.handleClickOutside, true );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'click', this.handleClickOutside, true );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -24,6 +24,13 @@ class ReusableBlockEditPanel extends Component {
 		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
 	}
 
+	componentDidMount() {
+		// Select the input text when the form opens.
+		if ( this.props.isEditing && this.titleField.current ) {
+			this.titleField.current.select();
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		// Select the input text only once when the form opens.
 		if ( ! prevProps.isEditing && this.props.isEditing ) {

--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -24,14 +24,6 @@ class ReusableBlockEditPanel extends Component {
 		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
 	}
 
-	componentDidMount() {
-		document.addEventListener( 'click', this.handleClickOutside, true );
-	}
-
-	componentWillUnmount() {
-		document.removeEventListener( 'click', this.handleClickOutside, true );
-	}
-
 	componentDidUpdate( prevProps ) {
 		// Select the input text only once when the form opens.
 		if ( ! prevProps.isEditing && this.props.isEditing ) {

--- a/core-blocks/block/edit-panel/style.scss
+++ b/core-blocks/block/edit-panel/style.scss
@@ -38,10 +38,6 @@
 		margin: #{ $item-spacing / 2 } 0 $item-spacing;
 	}
 
-	.components-button.reusable-block-edit-panel__button {
-		margin: 0 5px 0 0;
-	}
-
 	@include break-large() {
 		flex-wrap: nowrap;
 

--- a/packages/editor/src/components/post-permalink/editor.js
+++ b/packages/editor/src/components/post-permalink/editor.js
@@ -71,7 +71,7 @@ class PostPermalinkEditor extends Component {
 					isLarge
 					onClick={ this.onSavePermalink }
 				>
-					{ __( 'OK' ) }
+					{ __( 'Save' ) }
 				</Button>
 			</form>
 		);
@@ -91,4 +91,3 @@ export default compose( [
 		return { editPost };
 	} ),
 ] )( PostPermalinkEditor );
-

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -33,6 +33,7 @@
 
 .editor-post-permalink__label {
 	margin: 0 10px 0 5px;
+	font-weight: 600;
 }
 
 .editor-post-permalink__link {


### PR DESCRIPTION
This PR tries to improve consistency of the Post Permalink and Shared Block UIs, specifically about buttons and interaction.

- post permalink: changes "OK" to "Save"
- shared block:
  - removes primary style from the Save button
  - removes the "Cancel" button
  - closes the edit form when clicking outside of it, inspired by what [react-click-outside](https://github.com/kentor/react-click-outside/blob/e3e133799c51f896c1f65a799f0007827dd48248/index.js) does
  - (for keyboard users, it already closes when pressing Escape)

Screenshot:

<img width="716" alt="screen shot 2018-04-28 at 14 11 17" src="https://user-images.githubusercontent.com/1682452/39396430-35cbe1a4-4aee-11e8-8863-9dca8d56500a.png">

Fixes #6469 