### PR TITLE
Removed Edit and Link for Image Block

### DIFF
--- a/core-blocks/image/block.js
+++ b/core-blocks/image/block.js
@@ -166,6 +166,10 @@ class ImageBlock extends Component {
 		return get( this.props.image, [ 'media_details', 'sizes' ], {} );
 	}
 
+	isPlaceholder() {
+		return ( ! isEmpty( this.props.image ) );
+	}
+
 	render() {
 		const { attributes, setAttributes, isSelected, className, settings, toggleSelection } = this.props;
 		const { url, alt, caption, align, id, href, width, height } = attributes;
@@ -188,10 +192,12 @@ class ImageBlock extends Component {
 								label={ __( 'Edit image' ) }
 								icon="edit"
 								onClick={ open }
-							/>
-						) }
+								disabled={ ! this.isPlaceholder() }
+							/> ) }
 					/>
+
 					<UrlInputButton onChange={ this.onSetHref } url={ href } />
+
 				</Toolbar>
 			</BlockControls>
 		);


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/issues/5246

Signed-off-by: Lewis Cowles <lewiscowles@me.com>

## Description

Image block does not have edit or link button in placeholder mode

## How has this been tested?

Upload to a wordpress site & test suite

## Screenshots 

![Image selected](https://user-images.githubusercontent.com/2605791/39396615-22cb33de-4ae9-11e8-90b9-5f17bf2ef5d8.png)

![empty placeholder](https://user-images.githubusercontent.com/2605791/39396623-371327de-4ae9-11e8-876a-3403fcd1295b.png)

## Types of changes

Visual & UI

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [?] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
