### PR TITLE
Fix arrow navigation in the Shared Block more options menu.

### DIFF
--- a/editor/components/block-settings-menu/shared-block-settings.js
+++ b/editor/components/block-settings-menu/shared-block-settings.js
@@ -26,7 +26,7 @@ export function SharedBlockSettings( { sharedBlock, onConvertToStatic, onConvert
 				</IconButton>
 			) }
 			{ sharedBlock && (
-				<div className="editor-block-settings-menu__section">
+				<Fragment>
 					<IconButton
 						className="editor-block-settings-menu__control"
 						icon="controls-repeat"
@@ -44,7 +44,7 @@ export function SharedBlockSettings( { sharedBlock, onConvertToStatic, onConvert
 					>
 						{ __( 'Delete Shared Block' ) }
 					</IconButton>
-				</div>
+				</Fragment>
 			) }
 		</Fragment>
 	);


### PR DESCRIPTION
Fixes arrow navigation in the Shared Block more options menu, by making all buttons direct children of the menu as done for a similar case, see #5442.

Fixes #6482