### PR TITLE
 Feature: Markdown support as a Jetpack Markdown-specific Gutenberg Block

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -852,7 +852,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	/**
 	 * Apply filter to modify WP_Post prior to sending it to Gutenberg.
 	 */
-	$post_to_edit = apply_filters( 'after_gutenberg_gets_post_to_edit',  $post_to_edit);
+	$post_to_edit = apply_filters( 'after_gutenberg_gets_post_to_edit',  $post_to_edit );
 
 	// Set initial title to empty string for auto draft for duration of edit.
 	// Otherwise, title defaults to and displays as "Auto Draft".

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -850,16 +850,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	}
 
 	/**
-	 * Naive implementation of Jetpack's post_content <--> post_content_filtered swap on post edit.
-	 *
-	 * Todo: find out if a filter like rest_request_after_callbacks can solve this in Jetpack
+	 * Apply filter to modify WP_Post prior to sending it to Gutenberg.
 	 */
-	if ( $post instanceof WP_Post && class_exists( 'WPCom_Markdown' ) ) {
-		$jetpack_markdown = WPCom_Markdown::get_instance();
-		if ( $jetpack_markdown->is_markdown( $post->ID ) ) {
-			$post_to_edit['content']['raw'] = $jetpack_markdown->edit_post_content( $post->post_content, $post->ID );
-		}
-	}
+	$post_to_edit = apply_filters( 'after_gutenberg_gets_post_to_edit',  $post_to_edit);
 
 	// Set initial title to empty string for auto draft for duration of edit.
 	// Otherwise, title defaults to and displays as "Auto Draft".

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -852,7 +852,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	/**
 	 * Apply filter to modify WP_Post prior to sending it to Gutenberg.
 	 */
-	$post_to_edit = apply_filters( 'after_gutenberg_gets_post_to_edit',  $post_to_edit );
+	$post_to_edit = apply_filters( 'after_gutenberg_gets_post_to_edit', $post_to_edit );
 
 	// Set initial title to empty string for auto draft for duration of edit.
 	// Otherwise, title defaults to and displays as "Auto Draft".

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -852,7 +852,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	/**
 	 * Apply filter to modify WP_Post prior to sending it to Gutenberg.
 	 */
-	$post_to_edit = apply_filters( 'after_gutenberg_gets_post_to_edit', $post_to_edit );
+	$post_to_edit = apply_filters( 'after_block_editor_gets_post_to_edit', $post_to_edit );
 
 	// Set initial title to empty string for auto draft for duration of edit.
 	// Otherwise, title defaults to and displays as "Auto Draft".

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -850,14 +850,13 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	}
 
 	/**
-	 * Naive implementation of Jetpack's post_content <--> post_content_filtered swap
-	 * on post edit.
+	 * Naive implementation of Jetpack's post_content <--> post_content_filtered swap on post edit.
 	 *
-	 * todo: find out if a filter like rest_request_after_callbacks can solve this in Jetpack
+	 * Todo: find out if a filter like rest_request_after_callbacks can solve this in Jetpack
 	 */
 	if ( $post instanceof WP_Post && class_exists( 'WPCom_Markdown' ) ) {
 		$jetpack_markdown = WPCom_Markdown::get_instance();
-		if($jetpack_markdown->is_markdown( $post->ID )) {
+		if ( $jetpack_markdown->is_markdown( $post->ID ) ) {
 			$post_to_edit['content']['raw'] = $jetpack_markdown->edit_post_content($post->post_content, $post->ID);
 		}
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -849,6 +849,19 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		wp_die( $post_to_edit->get_error_message() );
 	}
 
+	/**
+	 * Naive implementation of Jetpack's post_content <--> post_content_filtered swap
+	 * on post edit.
+	 *
+	 * todo: find out if a filter like rest_request_after_callbacks can solve this in Jetpack
+	 */
+	if ( $post instanceof WP_Post && class_exists( 'WPCom_Markdown' ) ) {
+		$jetpack_markdown = WPCom_Markdown::get_instance();
+		if($jetpack_markdown->is_markdown( $post->ID )) {
+			$post_to_edit['content']['raw'] = $jetpack_markdown->edit_post_content($post->post_content, $post->ID);
+		}
+	}
+
 	// Set initial title to empty string for auto draft for duration of edit.
 	// Otherwise, title defaults to and displays as "Auto Draft".
 	$is_new_post = 'auto-draft' === $post_to_edit['status'];

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -857,7 +857,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	if ( $post instanceof WP_Post && class_exists( 'WPCom_Markdown' ) ) {
 		$jetpack_markdown = WPCom_Markdown::get_instance();
 		if ( $jetpack_markdown->is_markdown( $post->ID ) ) {
-			$post_to_edit['content']['raw'] = $jetpack_markdown->edit_post_content($post->post_content, $post->ID);
+			$post_to_edit['content']['raw'] = $jetpack_markdown->edit_post_content( $post->post_content, $post->ID );
 		}
 	}
 

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -22,18 +22,21 @@
  *
  * @since 1.3.0
  *
- * @param  array $post      Post object which contains content to check for block.
+ * @param  array $post Post object which contains content to check for block.
  * @return array $post      Post object.
  */
 function gutenberg_remove_wpcom_markdown_support( $post ) {
-	if ( class_exists( 'WPCom_Markdown' ) && gutenberg_content_has_blocks( $post['post_content'] ) ) {
-		if (
-			! isset( WPCom_Markdown::$is_gutenberg_compatible )
-			|| true !== WPCom_Markdown::$is_gutenberg_compatible
-		) {
-			WPCom_Markdown::get_instance()->unload_markdown_for_posts();
-		}
+	if (
+		class_exists( 'WPCom_Markdown' )
+		&& gutenberg_content_has_blocks( $post['post_content'] )
+		&& (
+			! isset( WPCom_Markdown::$is_block_editor_compatible )
+			|| true !== WPCom_Markdown::$is_block_editor_compatible
+		)
+	) {
+		WPCom_Markdown::get_instance()->unload_markdown_for_posts();
 	}
 	return $post;
 }
+
 add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -31,4 +31,4 @@ function gutenberg_remove_wpcom_markdown_support( $post ) {
 	}
 	return $post;
 }
-// add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );
+// add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 ); tmp fix.

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -31,4 +31,4 @@ function gutenberg_remove_wpcom_markdown_support( $post ) {
 	}
 	return $post;
 }
-add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );
+//add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -29,7 +29,7 @@ function gutenberg_remove_wpcom_markdown_support( $post ) {
 	if ( class_exists( 'WPCom_Markdown' ) && gutenberg_content_has_blocks( $post['post_content'] ) ) {
 		if (
 			! isset( WPCom_Markdown::$is_gutenberg_compatible )
-			|| WPCom_Markdown::$is_gutenberg_compatible !== true
+			|| true !== WPCom_Markdown::$is_gutenberg_compatible
 		) {
 			WPCom_Markdown::get_instance()->unload_markdown_for_posts();
 		}

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -27,9 +27,9 @@
  */
 function gutenberg_remove_wpcom_markdown_support( $post ) {
 	if ( class_exists( 'WPCom_Markdown' ) && gutenberg_content_has_blocks( $post['post_content'] ) ) {
-		if(
-			! isset(WPCom_Markdown::$is_gutenberg_compatible) ||
-			WPCom_Markdown::$is_gutenberg_compatible !== true
+		if (
+			! isset( WPCom_Markdown::$is_gutenberg_compatible )
+			|| WPCom_Markdown::$is_gutenberg_compatible !== true
 		) {
 			WPCom_Markdown::get_instance()->unload_markdown_for_posts();
 		}

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -31,4 +31,4 @@ function gutenberg_remove_wpcom_markdown_support( $post ) {
 	}
 	return $post;
 }
-//add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );
+// add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -27,8 +27,13 @@
  */
 function gutenberg_remove_wpcom_markdown_support( $post ) {
 	if ( class_exists( 'WPCom_Markdown' ) && gutenberg_content_has_blocks( $post['post_content'] ) ) {
-		WPCom_Markdown::get_instance()->unload_markdown_for_posts();
+		if(
+			! isset(WPCom_Markdown::$is_gutenberg_compatible) ||
+			WPCom_Markdown::$is_gutenberg_compatible !== true
+		) {
+			WPCom_Markdown::get_instance()->unload_markdown_for_posts();
+		}
 	}
 	return $post;
 }
-// add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 ); tmp fix.
+add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR will contain any supporting code for the [Automattic/Jetpack](https://github.com/Automattic/jetpack) PR [Feature: Markdown support as a Markdown-specific Gutenberg Block](https://github.com/Automattic/jetpack/pull/9357).

My Goal is to minimize this PR to one change, and move all functionality to Jetpack.

## Issues

- [x] Move "Read Markdown for Editing Post" functionality to Jetpack.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

There are two changes:

1. Breaking change: re-enable Markdown functionality in Jetpack and let Jetpack preserve non-markdown Gutenberg blocks here: https://github.com/Automattic/jetpack/pull/9357/commits/a1c661172672c2f0986c53ccc1bab1581f0edbdf

2. Breaking change: ~~Naive implementation which does some "filtering" the result of the REST `dispatch` request, in order to serve the Markdown content to Gutenberg on New/Edit post. This change should be moved to Jetpack as a proper filter triggered by an event of the `dispatch` flow of the `WP_REST_Server`~~. This has been changed to apply filters on the `after_gutenberg_gets_post_to_edit ` event https://github.com/WordPress/gutenberg/pull/6491/commits/36cd43caf3d2c051596b1aa6be3eebb74f0b399e



## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->