### PR TITLE
Fix: Text custom size number input not showing on load or reset

### DIFF
--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -32,6 +32,7 @@ function RangeControl( {
 	const id = `inspector-range-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 	const initialSliderValue = isFinite( value ) ? value : initialPosition || '';
+	const initialNumberValue = isFinite( value ) ? value : initialPosition || '';
 
 	return (
 		<BaseControl
@@ -55,7 +56,7 @@ function RangeControl( {
 				type="number"
 				onChange={ onChangeValue }
 				aria-label={ label }
-				value={ value }
+				value={ initialNumberValue }
 				{ ...props }
 			/>
 			{ allowReset &&


### PR DESCRIPTION
## Description
This PR fixes the issue that @GaryJones described in #6479 which included the custom text size number input not showing the default value (`16`) when Gutenberg is loaded, i.e. before selecting any custom size or when the size is reset.

## How has this been tested?
This PR has been tested in the Gutenberg Editor for both posts and pages, specifically in the “Text Settings” for the “Paragraph” block. This was tested in WP 4.9.5, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots
This is how the text size number input behaves after merging this PR. Please compare with the screencast shared in #6479 .
![gutenberg-min](https://user-images.githubusercontent.com/20284937/39416448-ce9ee13e-4c6e-11e8-96d8-3f9e04a6cdee.gif)



## Types of changes
The PR just replicates the custom text size slider’s initial position property and implements the same to the number input.
It introduces a new `initialNumberValue` constant variable which replicates the constant variable `initialSliderValue` and implements it into the `value` attribute of the `input` element.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->