### PR TITLE
Fix regression with formatting button hover/focus style

### DIFF
--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -47,8 +47,8 @@ div.components-toolbar {
 
 	// unset icon button styles
 	&:active,
-	&:hover,
-	&:focus {
+	&:not( [aria-disabled="true"] ):hover,
+	&:not( [aria-disabled="true"] ):focus {
 		outline: none;
 		box-shadow: none;
 		background: none;


### PR DESCRIPTION
A recent fix to aria-disabled buttons (up mover on first block) caused a regression in formatting buttons. This PR fixes that.

Screenshot, after:

<img width="403" alt="screen shot 2018-04-30 at 08 58 30" src="https://user-images.githubusercontent.com/1204802/39417493-e430ffb0-4c54-11e8-8d0a-c3863035e24c.png">

Don't mind the background color, that's from the theme and unrelated to this PR. 