### PR TITLE
Try fixing captions on resized images

### DIFF
--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -196,12 +196,32 @@ export const settings = {
 		{
 			attributes: blockAttributes,
 			save( { attributes } ) {
+				const { url, alt, caption, align, href, width, height, id } = attributes;
+
+				const image = (
+					<img
+						src={ url }
+						alt={ alt }
+						className={ id ? `wp-image-${ id }` : null }
+						width={ width }
+						height={ height }
+					/>
+				);
+
+				return (
+					<figure className={ align ? `align${ align }` : null } >
+						{ href ? <a href={ href }>{ image }</a> : image }
+						{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
+					</figure>
+				);
+			},
+		},
+		{
+			attributes: blockAttributes,
+			save( { attributes } ) {
 				const { url, alt, caption, align, href, width, height } = attributes;
 				const extraImageProps = width || height ? { width, height } : {};
 				const image = <img src={ url } alt={ alt } { ...extraImageProps } />;
-				const classes = classnames( align ? `align${ align }` : null, {
-					'is-resized': !! width || !! height,
-				} );
 
 				let figureStyle = {};
 
@@ -212,7 +232,7 @@ export const settings = {
 				}
 
 				return (
-					<figure className={ classes } style={ figureStyle }>
+					<figure className={ align ? `align${ align }` : null } style={ figureStyle }>
 						{ href ? <a href={ href }>{ image }</a> : image }
 						{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 					</figure>

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -165,6 +170,10 @@ export const settings = {
 	save( { attributes } ) {
 		const { url, alt, caption, align, href, width, height, id } = attributes;
 
+		const classes = classnames( align ? `align${ align }` : null, {
+			'is-resized': !! width || !! height,
+		} );
+
 		const image = (
 			<img
 				src={ url }
@@ -176,7 +185,7 @@ export const settings = {
 		);
 
 		return (
-			<figure className={ align ? `align${ align }` : null }>
+			<figure className={ classes }>
 				{ href ? <a href={ href }>{ image }</a> : image }
 				{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 			</figure>

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -199,6 +199,9 @@ export const settings = {
 				const { url, alt, caption, align, href, width, height } = attributes;
 				const extraImageProps = width || height ? { width, height } : {};
 				const image = <img src={ url } alt={ alt } { ...extraImageProps } />;
+				const classes = classnames( align ? `align${ align }` : null, {
+					'is-resized': !! width || !! height,
+				} );
 
 				let figureStyle = {};
 
@@ -209,7 +212,7 @@ export const settings = {
 				}
 
 				return (
-					<figure className={ align ? `align${ align }` : null } style={ figureStyle }>
+					<figure className={ classes } style={ figureStyle }>
 						{ href ? <a href={ href }>{ image }</a> : image }
 						{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 					</figure>

--- a/core-blocks/image/style.scss
+++ b/core-blocks/image/style.scss
@@ -18,6 +18,15 @@
 	&.is-resized {
 		width: min-content;
 
+		// Emulate min-content for Edge and IE11
+		display: -ms-inline-grid;
+		-ms-grid-columns: min-content;
+
+		> :nth-child(2) {
+			-ms-grid-row: 2;
+			display: inline-block;
+		}
+
 		img {
 			max-width: none;
 		}

--- a/core-blocks/image/style.scss
+++ b/core-blocks/image/style.scss
@@ -1,5 +1,6 @@
 .wp-block-image {
 	width: fit-content;
+
 	figcaption {
 		margin-top: 0.5em;
 		color: $dark-gray-300;
@@ -12,5 +13,13 @@
 		margin-left: auto;
 		margin-right: auto;
 		text-align: center;
+	}
+
+	&.is-resized {
+		width: min-content;
+
+		img {
+			max-width: none;
+		}
 	}
 }

--- a/core-blocks/image/style.scss
+++ b/core-blocks/image/style.scss
@@ -22,9 +22,8 @@
 		display: -ms-inline-grid;
 		-ms-grid-columns: min-content;
 
-		> :nth-child(2) {
+		figcaption {
 			-ms-grid-row: 2;
-			display: inline-block;
 		}
 
 		img {


### PR DESCRIPTION
This is an alternative, and probably better approach, than the one explored in https://github.com/WordPress/gutenberg/pull/6304.

Both branches try and fix the same issue — ensuring that the caption inside a `figure` is only ever as wide as the adjecent image. This is only ah issue when that image is resized.

This branch fixes that, in a fairly clean way. See the details in https://css-tricks.com/almanac/properties/w/width/

The figure now uses both `fit-content`, and `min-content`, both rather magical. Fit-content uses the maximum width available, and is applied to images that are not resized. Min-content uses the _minimum_ width available, and is applied when images _are_ resized. In effect this means that the image in a figure with a caption will define the width of the caption itself.