### PR TITLE
Cover Image Block: Remove the text alignment from the block inspector

### DIFF
--- a/core-blocks/cover-image/index.js
+++ b/core-blocks/cover-image/index.js
@@ -117,14 +117,6 @@ export const settings = {
 			}
 		);
 
-		const alignmentToolbar	= (
-			<AlignmentToolbar
-				value={ contentAlign }
-				onChange={ ( nextAlign ) => {
-					setAttributes( { contentAlign: nextAlign } );
-				} }
-			/>
-		);
 		const controls = (
 			<Fragment>
 				<BlockControls>
@@ -132,8 +124,12 @@ export const settings = {
 						value={ align }
 						onChange={ updateAlignment }
 					/>
-
-					{ alignmentToolbar }
+					<AlignmentToolbar
+						value={ contentAlign }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { contentAlign: nextAlign } );
+						} }
+					/>
 					<Toolbar>
 						<MediaUpload
 							onSelect={ onSelectImage }
@@ -165,9 +161,6 @@ export const settings = {
 							max={ 100 }
 							step={ 10 }
 						/>
-					</PanelBody>
-					<PanelBody title={ __( 'Text Alignment' ) }>
-						{ alignmentToolbar }
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>


### PR DESCRIPTION
closes #6477

Tiny PR removing the text alignment from the inspector controls leaving the toolbar visible in the block toolbar.