### PR TITLE
Cover Image: Hide inspector controls if no image is selected

### DIFF
--- a/core-blocks/cover-image/index.js
+++ b/core-blocks/cover-image/index.js
@@ -146,23 +146,25 @@ export const settings = {
 						/>
 					</Toolbar>
 				</BlockControls>
-				<InspectorControls>
-					<PanelBody title={ __( 'Cover Image Settings' ) }>
-						<ToggleControl
-							label={ __( 'Fixed Background' ) }
-							checked={ !! hasParallax }
-							onChange={ toggleParallax }
-						/>
-						<RangeControl
-							label={ __( 'Background Dimness' ) }
-							value={ dimRatio }
-							onChange={ setDimRatio }
-							min={ 0 }
-							max={ 100 }
-							step={ 10 }
-						/>
-					</PanelBody>
-				</InspectorControls>
+				{ !! url && (
+					<InspectorControls>
+						<PanelBody title={ __( 'Cover Image Settings' ) }>
+							<ToggleControl
+								label={ __( 'Fixed Background' ) }
+								checked={ !! hasParallax }
+								onChange={ toggleParallax }
+							/>
+							<RangeControl
+								label={ __( 'Background Dimness' ) }
+								value={ dimRatio }
+								onChange={ setDimRatio }
+								min={ 0 }
+								max={ 100 }
+								step={ 10 }
+							/>
+						</PanelBody>
+					</InspectorControls>
+				) }
 			</Fragment>
 		);
 


### PR DESCRIPTION
This PR hides the cover image inspector controls if no image is selected to match other media blocks (image, audio, video, gallery)

closes #4433