### PR TITLE
Refactor withColors HOC.

### DIFF
--- a/blocks/colors/with-colors.js
+++ b/blocks/colors/with-colors.js
@@ -18,26 +18,26 @@ import { withEditorSettings } from '../editor-settings';
  * Higher-order component, which handles color logic for class generation
  * color value, retrieval and color attribute setting.
  *
- * @param {WPElement} WrappedComponent The wrapped component.
+ * @param {Function} mapGetSetColorToProps Function that receives getColor, setColor, and props,
+ *                                         and returns additional props to pass to the component.
  *
- * @return {Component} Component with a new colors prop.
+ * @return {Function} Higher-order component.
  */
-export default createHigherOrderComponent(
+export default ( mapGetSetColorToProps ) => createHigherOrderComponent(
 	withEditorSettings(
 		( settings, props ) => {
 			const colors = get( settings, [ 'colors' ], [] );
-			return {
-				initializeColor: ( { colorContext, colorAttribute, customColorAttribute } ) => ( {
-					value: getColorValue(
-						colors,
-						props.attributes[ colorAttribute ],
-						props.attributes[ customColorAttribute ]
-					),
-					name: props.attributes[ colorAttribute ],
-					class: getColorClass( colorContext, props.attributes[ colorAttribute ] ),
-					set: setColorValue( colors, colorAttribute, customColorAttribute, props.setAttributes ),
-				} ),
+			const getColor = ( colorName, customColorValue, colorContext ) => {
+				return {
+					name: colorName,
+					class: getColorClass( colorContext, colorName ),
+					value: getColorValue( colors, colorName, customColorValue ),
+				};
 			};
+			const setColor = ( colorNameAttribute, customColorAttribute, setAttributes ) => {
+				return setColorValue( colors, colorNameAttribute, customColorAttribute, setAttributes );
+			};
+			return mapGetSetColorToProps( getColor, setColor, props );
 		} ),
 	'withColors'
 );

--- a/core-blocks/button/index.js
+++ b/core-blocks/button/index.js
@@ -75,7 +75,10 @@ class ButtonBlock extends Component {
 	render() {
 		const {
 			attributes,
-			initializeColor,
+			backgroundColor,
+			textColor,
+			setBackgroundColor,
+			setTextColor,
 			setAttributes,
 			isSelected,
 			className,
@@ -88,17 +91,6 @@ class ButtonBlock extends Component {
 			align,
 			clear,
 		} = attributes;
-
-		const textColor = initializeColor( {
-			colorContext: 'color',
-			colorAttribute: 'textColor',
-			customColorAttribute: 'customTextColor',
-		} );
-		const backgroundColor = initializeColor( {
-			colorContext: 'background-color',
-			colorAttribute: 'backgroundColor',
-			customColorAttribute: 'customBackgroundColor',
-		} );
 
 		return (
 			<Fragment>
@@ -136,13 +128,13 @@ class ButtonBlock extends Component {
 							<PanelColor title={ __( 'Background Color' ) } colorValue={ backgroundColor.value } >
 								<ColorPalette
 									value={ backgroundColor.value }
-									onChange={ backgroundColor.set }
+									onChange={ setBackgroundColor }
 								/>
 							</PanelColor>
 							<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor.value } >
 								<ColorPalette
 									value={ textColor.value }
-									onChange={ textColor.set }
+									onChange={ setTextColor }
 								/>
 							</PanelColor>
 							{ this.nodeRef && <ContrastCheckerWithFallbackStyles
@@ -243,7 +235,14 @@ export const settings = {
 		return props;
 	},
 
-	edit: withColors( ButtonBlock ),
+	edit: withColors( ( getColor, setColor, { attributes, setAttributes } ) => {
+		return {
+			backgroundColor: getColor( attributes.backgroundColor, attributes.customBackgroundColor, 'background-color' ),
+			setBackgroundColor: setColor( 'backgroundColor', 'customBackgroundColor', setAttributes ),
+			textColor: getColor( attributes.textColor, attributes.customTextColor, 'color' ),
+			setTextColor: setColor( 'textColor', 'customTextColor', setAttributes ),
+		};
+	} )( ButtonBlock ),
 
 	save( { attributes } ) {
 		const {

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -131,7 +131,10 @@ class ParagraphBlock extends Component {
 			mergeBlocks,
 			onReplace,
 			className,
-			initializeColor,
+			backgroundColor,
+			textColor,
+			setBackgroundColor,
+			setTextColor,
 			fallbackBackgroundColor,
 			fallbackTextColor,
 			fallbackFontSize,
@@ -146,16 +149,6 @@ class ParagraphBlock extends Component {
 		} = attributes;
 
 		const fontSize = this.getFontSize();
-		const textColor = initializeColor( {
-			colorContext: 'color',
-			colorAttribute: 'textColor',
-			customColorAttribute: 'customTextColor',
-		} );
-		const backgroundColor = initializeColor( {
-			colorContext: 'background-color',
-			colorAttribute: 'backgroundColor',
-			customColorAttribute: 'customBackgroundColor',
-		} );
 
 		return (
 			<Fragment>
@@ -216,13 +209,13 @@ class ParagraphBlock extends Component {
 					<PanelColor title={ __( 'Background Color' ) } colorValue={ backgroundColor.value } colorName={ backgroundColor.name } initialOpen={ false }>
 						<ColorPalette
 							value={ backgroundColor.value }
-							onChange={ backgroundColor.set }
+							onChange={ setBackgroundColor }
 						/>
 					</PanelColor>
 					<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor.value } colorName={ textColor.name } initialOpen={ false }>
 						<ColorPalette
 							value={ textColor.value }
-							onChange={ textColor.set }
+							onChange={ setTextColor }
 						/>
 					</PanelColor>
 					<ContrastChecker
@@ -429,7 +422,14 @@ export const settings = {
 	},
 
 	edit: compose(
-		withColors,
+		withColors( ( getColor, setColor, { attributes, setAttributes } ) => {
+			return {
+				backgroundColor: getColor( attributes.backgroundColor, attributes.customBackgroundColor, 'background-color' ),
+				setBackgroundColor: setColor( 'backgroundColor', 'customBackgroundColor', setAttributes ),
+				textColor: getColor( attributes.textColor, attributes.customTextColor, 'color' ),
+				setTextColor: setColor( 'textColor', 'customTextColor', setAttributes ),
+			};
+		} ),
 		FallbackStyles,
 	)( ParagraphBlock ),
 


### PR DESCRIPTION
The component now instead of passing an initializeColor prop, allows the users of the component to configure the mapping when instantiating the component.

## How has this been tested?
No noticeable changes are expected, to test this changing colors in paragraph and button should be enough.
