### PR TITLE
Simplify the BlockBreadcrumb component

### DIFF
--- a/editor/components/block-list/breadcrumb.js
+++ b/editor/components/block-list/breadcrumb.js
@@ -55,7 +55,6 @@ export class BlockBreadcrumb extends Component {
 	render( ) {
 		const { uid, rootUID, selectRootBlock, isHidden } = this.props;
 		const { isFocused } = this.state;
-		const selectParentLabel = __( 'Select parent block' );
 
 		return (
 			<div className={ classnames( 'editor-block-list__breadcrumb', {
@@ -67,7 +66,7 @@ export class BlockBreadcrumb extends Component {
 							onClick={ selectRootBlock }
 							onFocus={ this.onFocus }
 							onBlur={ this.onBlur }
-							label={ selectParentLabel }
+							label={ __( 'Select parent block' ) }
 							icon="arrow-left-alt"
 						/>
 					) }

--- a/editor/components/block-list/breadcrumb.js
+++ b/editor/components/block-list/breadcrumb.js
@@ -7,14 +7,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { compose, Component } from '@wordpress/element';
-import { IconButton, Tooltip, Toolbar } from '@wordpress/components';
+import { IconButton, Toolbar } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import NavigableToolbar from '../navigable-toolbar';
 import BlockTitle from '../block-title';
 
 /**
@@ -59,24 +58,22 @@ export class BlockBreadcrumb extends Component {
 		const selectParentLabel = __( 'Select parent block' );
 
 		return (
-			<NavigableToolbar className={ classnames( 'editor-block-list__breadcrumb', {
+			<div className={ classnames( 'editor-block-list__breadcrumb', {
 				'is-visible': ! isHidden || isFocused,
 			} ) }>
 				<Toolbar>
 					{ rootUID && (
-						<Tooltip text={ selectParentLabel }>
-							<IconButton
-								onClick={ selectRootBlock }
-								onFocus={ this.onFocus }
-								onBlur={ this.onBlur }
-								label={ selectParentLabel }
-								icon="arrow-left-alt"
-							/>
-						</Tooltip>
+						<IconButton
+							onClick={ selectRootBlock }
+							onFocus={ this.onFocus }
+							onBlur={ this.onBlur }
+							label={ selectParentLabel }
+							icon="arrow-left-alt"
+						/>
 					) }
 					<BlockTitle uid={ uid } />
 				</Toolbar>
-			</NavigableToolbar>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
This PR aims to simplify the BlockBreadcrumb component and remove some semantics and features that are not needed in this case. For more details, please refer to the related issue #6337

- there's. no need for a `role="toolbar"` (added by NavigableToolbar via NavigableMenu)
- there's no need for arrows navigation (added by NavigableToolbar via NavigableMenu)
- IconButton already uses Tooltip

No visual changes:

<img width="384" alt="screen shot 2018-04-30 at 17 33 44" src="https://user-images.githubusercontent.com/1682452/39435843-b813a502-4c9c-11e8-91cc-6cabe7e21027.png">

Fixes #6337 