### PR TITLE
Only display featured image UI when theme supports it too

### DIFF
--- a/editor/components/post-type-support-check/index.js
+++ b/editor/components/post-type-support-check/index.js
@@ -1,19 +1,26 @@
 /**
  * External dependencies
  */
-import { get, some, castArray } from 'lodash';
+import { get, includes, some, castArray } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
 
-function PostTypeSupportCheck( { postType, children, supportKeys } ) {
+function PostTypeSupportCheck( { postType, children, supportKeys, themeSupports } ) {
+	supportKeys = castArray( supportKeys );
 	const isSupported = some(
-		castArray( supportKeys ), ( key ) => get( postType, [ 'supports', key ], false )
+		supportKeys, ( key ) => get( postType, [ 'supports', key ], false )
 	);
 
 	if ( ! isSupported ) {
+		return null;
+	}
+
+	// 'thumbnail' and 'post-thumbnails' are intentionally different.
+	if ( includes( supportKeys, 'thumbnail' )
+		&& ! get( themeSupports, 'post-thumbnails', false ) ) {
 		return null;
 	}
 
@@ -22,8 +29,9 @@ function PostTypeSupportCheck( { postType, children, supportKeys } ) {
 
 export default withSelect( ( select ) => {
 	const { getEditedPostAttribute } = select( 'core/editor' );
-	const { getPostType } = select( 'core' );
+	const { getPostType, getThemeSupports } = select( 'core' );
 	return {
+		themeSupports: getThemeSupports(),
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 	};
 } )( PostTypeSupportCheck );

--- a/editor/components/post-type-support-check/index.js
+++ b/editor/components/post-type-support-check/index.js
@@ -8,7 +8,7 @@ import { get, includes, some, castArray } from 'lodash';
  */
 import { withSelect } from '@wordpress/data';
 
-function PostTypeSupportCheck( { postType, children, supportKeys, themeSupports } ) {
+export function PostTypeSupportCheck( { postType, children, supportKeys, themeSupports } ) {
 	supportKeys = castArray( supportKeys );
 	const isSupported = some(
 		supportKeys, ( key ) => get( postType, [ 'supports', key ], false )

--- a/editor/components/post-type-support-check/index.js
+++ b/editor/components/post-type-support-check/index.js
@@ -19,8 +19,8 @@ function PostTypeSupportCheck( { postType, children, supportKeys, themeSupports 
 	}
 
 	// 'thumbnail' and 'post-thumbnails' are intentionally different.
-	if ( includes( supportKeys, 'thumbnail' )
-		&& ! get( themeSupports, 'post-thumbnails', false ) ) {
+	if ( includes( supportKeys, 'thumbnail' ) &&
+		! get( themeSupports, 'post-thumbnails', false ) ) {
 		return null;
 	}
 

--- a/editor/components/post-type-support-check/test/index.js
+++ b/editor/components/post-type-support-check/test/index.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostTypeSupportCheck } from '../index';
+
+describe( 'PostTypeSupportCheck', () => {
+	it( 'should not render if there\'s no support check provided', () => {
+		const wrapper = shallow( <PostTypeSupportCheck>foobar</PostTypeSupportCheck> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should render if both thumbnail and post-thumbnails are supported', () => {
+		const themeSupports = {
+			'post-thumbnails': true,
+		};
+		const postType = {
+			supports: {
+				thumbnail: true,
+			},
+		};
+		const supportKeys = 'thumbnail';
+		const wrapper = shallow( <PostTypeSupportCheck
+			supportKeys={ supportKeys }
+			postType={ postType }
+			themeSupports={ themeSupports }>foobar</PostTypeSupportCheck> );
+		expect( wrapper.type() ).not.toBe( null );
+	} );
+
+	it( 'should not render if theme doesn\'t support thumbnails', () => {
+		const themeSupports = {
+			'post-thumbnails': false,
+		};
+		const postType = {
+			supports: {
+				thumbnail: true,
+			},
+		};
+		const supportKeys = 'thumbnail';
+		const wrapper = shallow( <PostTypeSupportCheck
+			supportKeys={ supportKeys }
+			postType={ postType }
+			themeSupports={ themeSupports }>foobar</PostTypeSupportCheck> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+} );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -370,6 +370,11 @@ function gutenberg_ensure_wp_json_has_theme_supports( $response ) {
 
 		$site_info['theme_supports']['formats'] = $formats;
 	}
+	if ( ! array_key_exists( 'post-thumbnails', $site_info['theme_supports'] ) ) {
+		if ( get_theme_support( 'post-thumbnails' ) ) {
+			$site_info['theme_supports']['post-thumbnails'] = true;
+		}
+	}
 	$response->set_data( $site_info );
 	return $response;
 }


### PR DESCRIPTION
## Description

Ensures the "Featured Image" UI only displays when the theme supports `post-thumbnails` too.

Fixes #2523

## How has this been tested?

Using Twenty Seventeen, here's the UI that normally displays:

<img width="415" alt="image" src="https://user-images.githubusercontent.com/36432/39454257-1e9c82e8-4c8f-11e8-9980-9ed6d5b35e08.png">

Then, add the following code snippet to a `wp-content/mu-plugins/local.php` file:

```
add_action( 'after_setup_theme', function(){
	remove_theme_support( 'post-thumbnails' );
}, 100 );
```

The "Featured Image" will no longer display:

<img width="339" alt="image" src="https://user-images.githubusercontent.com/36432/39454273-3f082f46-4c8f-11e8-9a20-981063ebf6e3.png">

## Types of changes

My code ensures `PostTypeSupportCheck` also respects the theme's `post-thumbnails` setting. It introduces `post-thumbnails=>true` on the site index for exposure through the REST API.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
