### PR TITLE
fix: Remove block alignment from paragraph block (fix #6476)

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -29,7 +29,6 @@ import {
 	getColorClass,
 	withColors,
 	AlignmentToolbar,
-	BlockAlignmentToolbar,
 	BlockControls,
 	ColorPalette,
 	ContrastChecker,
@@ -142,7 +141,6 @@ class ParagraphBlock extends Component {
 			content,
 			dropCap,
 			placeholder,
-			width,
 		} = attributes;
 
 		const fontSize = this.getFontSize();
@@ -234,12 +232,6 @@ class ParagraphBlock extends Component {
 						} }
 						isLargeText={ fontSize >= 18 }
 					/>
-					<PanelBody title={ __( 'Block Alignment' ) }>
-						<BlockAlignmentToolbar
-							value={ width }
-							onChange={ ( nextWidth ) => setAttributes( { width: nextWidth } ) }
-						/>
-					</PanelBody>
 				</InspectorControls>
 				<div>
 					<RichText

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -279,14 +279,7 @@ const supports = {
 	className: false,
 };
 
-const deprecatedSchema = {
-	width: {
-		type: 'string',
-	},
-};
-
 const schema = {
-	...deprecatedSchema,
 	content: {
 		type: 'array',
 		source: 'children',
@@ -357,7 +350,12 @@ export const settings = {
 	deprecated: [
 		{
 			supports,
-			attributes: schema,
+			attributes: {
+				...schema,
+				width: {
+					type: 'string',
+				},
+			},
 			save( { attributes } ) {
 				const {
 					width,

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -280,15 +280,6 @@ const supports = {
 };
 
 const deprecatedSchema = {
-	customTextColor: {
-		type: 'string',
-	},
-	customBackgroundColor: {
-		type: 'string',
-	},
-	customFontSize: {
-		type: 'number',
-	},
 	width: {
 		type: 'string',
 	},
@@ -315,11 +306,20 @@ const schema = {
 	textColor: {
 		type: 'string',
 	},
+	customTextColor: {
+		type: 'string',
+	},
 	backgroundColor: {
+		type: 'string',
+	},
+	customBackgroundColor: {
 		type: 'string',
 	},
 	fontSize: {
 		type: 'string',
+	},
+	customFontSize: {
+		type: 'number',
 	},
 };
 

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -279,7 +279,23 @@ const supports = {
 	className: false,
 };
 
+const deprecatedSchema = {
+	customTextColor: {
+		type: 'string',
+	},
+	customBackgroundColor: {
+		type: 'string',
+	},
+	customFontSize: {
+		type: 'number',
+	},
+	width: {
+		type: 'string',
+	},
+};
+
 const schema = {
+	...deprecatedSchema,
 	content: {
 		type: 'array',
 		source: 'children',
@@ -296,26 +312,14 @@ const schema = {
 	placeholder: {
 		type: 'string',
 	},
-	width: {
-		type: 'string',
-	},
 	textColor: {
-		type: 'string',
-	},
-	customTextColor: {
 		type: 'string',
 	},
 	backgroundColor: {
 		type: 'string',
 	},
-	customBackgroundColor: {
-		type: 'string',
-	},
 	fontSize: {
 		type: 'string',
-	},
-	customFontSize: {
-		type: 'number',
 	},
 };
 
@@ -351,6 +355,53 @@ export const settings = {
 	},
 
 	deprecated: [
+		{
+			supports,
+			attributes: schema,
+			save( { attributes } ) {
+				const {
+					width,
+					align,
+					content,
+					dropCap,
+					backgroundColor,
+					textColor,
+					customBackgroundColor,
+					customTextColor,
+					fontSize,
+					customFontSize,
+				} = attributes;
+
+				const textClass = getColorClass( 'color', textColor );
+				const backgroundClass = getColorClass( 'background-color', backgroundColor );
+				const fontSizeClass = fontSize && FONT_SIZES[ fontSize ] && `is-${ fontSize }-text`;
+
+				const className = classnames( {
+					[ `align${ width }` ]: width,
+					'has-background': backgroundColor || customBackgroundColor,
+					'has-drop-cap': dropCap,
+					[ fontSizeClass ]: fontSizeClass,
+					[ textClass ]: textClass,
+					[ backgroundClass ]: backgroundClass,
+				} );
+
+				const styles = {
+					backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+					color: textClass ? undefined : customTextColor,
+					fontSize: fontSizeClass ? undefined : customFontSize,
+					textAlign: align,
+				};
+
+				return (
+					<RichText.Content
+						tagName="p"
+						style={ styles }
+						className={ className ? className : undefined }
+						value={ content }
+					/>
+				);
+			},
+		},
 		{
 			supports,
 			attributes: omit( {
@@ -427,7 +478,6 @@ export const settings = {
 
 	save( { attributes } ) {
 		const {
-			width,
 			align,
 			content,
 			dropCap,
@@ -444,7 +494,6 @@ export const settings = {
 		const fontSizeClass = fontSize && FONT_SIZES[ fontSize ] && `is-${ fontSize }-text`;
 
 		const className = classnames( {
-			[ `align${ width }` ]: width,
 			'has-background': backgroundColor || customBackgroundColor,
 			'has-drop-cap': dropCap,
 			[ fontSizeClass ]: fontSizeClass,


### PR DESCRIPTION
## Description
Remove the block alignment control for the paragraph block. This was requested in #6476.

## How has this been tested?
Ran locally on Firefox/Chrome thus far. This is my first PR and there didn't seem to be unit tests around this file I could find, so I suspect I need to edit e2e tests.
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots

### Before
<img width="1142" alt="screenshot 2018-05-01 00 32 32" src="https://user-images.githubusercontent.com/90871/39455298-960d072e-4cd7-11e8-9fd7-c3c08fb9f15c.png">

### After
<img width="1130" alt="screenshot 2018-05-01 00 32 52" src="https://user-images.githubusercontent.com/90871/39455304-9958001e-4cd7-11e8-85ee-ebab27127eb4.png">

## Types of changes
Removes the block alignment from the paragraph block completely. Simplifies alignment for the block but means it must rely on a container block for layout.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->