### PR TITLE
Switch `post-author` component to use `/wp/v2/users/?who=authors`

### DIFF
--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -40,14 +40,16 @@ export function receiveTerms( taxonomy, terms ) {
 /**
  * Returns an action object used in signalling that authors have been received.
  *
- * @param {Array|Object} authors Authors received.
+ * @param {string}       queryID Query ID.
+ * @param {Array|Object} users   Users received.
  *
  * @return {Object} Action object.
  */
-export function receiveAuthors( authors ) {
+export function receiveUserQuery( queryID, users ) {
 	return {
-		type: 'RECEIVE_AUTHORS',
-		authors: castArray( authors ),
+		type: 'RECEIVE_USER_QUERY',
+		users: castArray( users ),
+		queryID,
 	};
 }
 

--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -38,6 +38,20 @@ export function receiveTerms( taxonomy, terms ) {
 }
 
 /**
+ * Returns an action object used in signalling that authors have been received.
+ *
+ * @param {Array|Object} authors Authors received.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveAuthors( authors ) {
+	return {
+		type: 'RECEIVE_AUTHORS',
+		authors: castArray( authors ),
+	};
+}
+
+/**
  * Returns an action object used in signalling that media have been received.
  *
  * @param {Array|Object} media Media received.

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -43,6 +43,26 @@ export function terms( state = {}, action ) {
 }
 
 /**
+ * Reducer managing authors state. Keyed by id.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function authors( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_AUTHORS':
+			return {
+				...state,
+				...action.authors,
+			};
+	}
+
+	return state;
+}
+
+/**
  * Reducer managing media state. Keyed by id.
  *
  * @param {Object} state  Current state.
@@ -104,6 +124,7 @@ export function themeSupports( state = {}, action ) {
 
 export default combineReducers( {
 	terms,
+	authors,
 	media,
 	postTypes,
 	themeSupports,

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -50,13 +50,13 @@ export function terms( state = {}, action ) {
  *
  * @return {Object} Updated state.
  */
-export function authors( state = {}, action ) {
+export function authors( state = [], action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_AUTHORS':
-			return {
+			return [
 				...state,
 				...action.authors,
-			};
+			];
 	}
 
 	return state;

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, uniqBy } from 'lodash';
+import { keyBy, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -50,13 +50,19 @@ export function terms( state = {}, action ) {
  *
  * @return {Object} Updated state.
  */
-export function authors( state = [], action ) {
+export function users( state = { byId: {}, queries: {} }, action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_AUTHORS':
-			return [
-				...state,
-				...uniqBy( action.authors, 'id' ),
-			];
+		case 'RECEIVE_USER_QUERY':
+			return {
+				byId: {
+					...state.byId,
+					...keyBy( action.users, 'id' ),
+				},
+				queries: {
+					...state.queries,
+					[ action.queryID ]: map( action.users, ( user ) => user.id ),
+				},
+			};
 	}
 
 	return state;
@@ -124,7 +130,7 @@ export function themeSupports( state = {}, action ) {
 
 export default combineReducers( {
 	terms,
-	authors,
+	users,
 	media,
 	postTypes,
 	themeSupports,

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy } from 'lodash';
+import { keyBy, uniqBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -55,7 +55,7 @@ export function authors( state = [], action ) {
 		case 'RECEIVE_AUTHORS':
 			return [
 				...state,
-				...action.authors,
+				...uniqBy( action.authors, 'id' ),
 			];
 	}
 

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -9,6 +9,7 @@ import apiRequest from '@wordpress/api-request';
 import {
 	setRequested,
 	receiveTerms,
+	receiveAuthors,
 	receiveMedia,
 	receivePostTypes,
 	receiveThemeSupportsFromIndex,
@@ -22,6 +23,14 @@ export async function* getCategories() {
 	yield setRequested( 'terms', 'categories' );
 	const categories = await apiRequest( { path: '/wp/v2/categories' } );
 	yield receiveTerms( 'categories', categories );
+}
+
+/**
+ * Requests authors from the REST API.
+ */
+export async function* getAuthors() {
+	const authors = await apiRequest( { path: '/wp/v2/users/?who=authors' } );
+	yield receiveAuthors( authors );
 }
 
 /**

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -9,7 +9,7 @@ import apiRequest from '@wordpress/api-request';
 import {
 	setRequested,
 	receiveTerms,
-	receiveAuthors,
+	receiveUserQuery,
 	receiveMedia,
 	receivePostTypes,
 	receiveThemeSupportsFromIndex,
@@ -29,8 +29,8 @@ export async function* getCategories() {
  * Requests authors from the REST API.
  */
 export async function* getAuthors() {
-	const authors = await apiRequest( { path: '/wp/v2/users/?who=authors' } );
-	yield receiveAuthors( authors );
+	const users = await apiRequest( { path: '/wp/v2/users/?who=authors' } );
+	yield receiveUserQuery( 'authors', users );
 }
 
 /**

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -59,6 +59,17 @@ export function getMedia( state, id ) {
 }
 
 /**
+ * Returns all available authors.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Array} Authors list.
+ */
+export function getAuthors( state ) {
+	return state.authors;
+}
+
+/**
  * Returns the Post Type object by slug.
  *
  * @param {Object} state Data state.

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
+/**
  * Returns all the available terms for the given taxonomy.
  *
  * @param {Object} state    Data state.
@@ -66,7 +71,21 @@ export function getMedia( state, id ) {
  * @return {Array} Authors list.
  */
 export function getAuthors( state ) {
-	return state.authors;
+	return getUserQueryResults( state, 'authors' );
+}
+
+/**
+ * Returns all the users returned by a query ID.
+ *
+ * @param {Object} state   Data state.
+ * @param {string} queryID Query ID.
+ *
+ * @return {Array} Users list.
+ */
+export function getUserQueryResults( state, queryID ) {
+	const queryResults = state.users.queries[ queryID ];
+
+	return map( queryResults, ( id ) => state.users.byId[ id ] );
 }
 
 /**

--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -33,10 +33,9 @@ export default compose( [
 		};
 	} ),
 	withAPIData( ( props ) => {
-		const { postType, authors } = props;
+		const { postType } = props;
 
 		return {
-			authors,
 			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} ),

--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, get } from 'lodash';
+import { castArray, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,9 +15,9 @@ import { withSelect } from '@wordpress/data';
  */
 import PostTypeSupportCheck from '../post-type-support-check';
 
-export function PostAuthorCheck( { user, users, children } ) {
-	const authors = filter( users.data, ( { capabilities } ) => get( capabilities, [ 'level_1' ], false ) );
+export function PostAuthorCheck( { user, authors, children } ) {
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
+	authors = castArray( authors );
 
 	if ( ! userCanPublishPosts || authors.length < 2 ) {
 		return null;
@@ -30,13 +30,14 @@ export default compose( [
 	withSelect( ( select ) => {
 		return {
 			postType: select( 'core/editor' ).getCurrentPostType(),
+			authors: select( 'core' ).getAuthors(),
 		};
 	} ),
 	withAPIData( ( props ) => {
-		const { postType } = props;
+		const { postType, authors } = props;
 
 		return {
-			users: '/wp/v2/users?context=edit&per_page=100',
+			authors,
 			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} ),

--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -17,7 +17,6 @@ import PostTypeSupportCheck from '../post-type-support-check';
 
 export function PostAuthorCheck( { user, authors, children } ) {
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-	authors = castArray( authors );
 
 	if ( ! userCanPublishPosts || authors.length < 2 ) {
 		return null;

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { get, filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withAPIData, withInstanceId } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/components';
 import { Component, compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -29,21 +24,8 @@ export class PostAuthor extends Component {
 		onUpdateAuthor( Number( value ) );
 	}
 
-	getAuthors() {
-		// While User Levels are officially deprecated, the behavior of the
-		// existing users dropdown on `who=authors` tests `user_level != 0`
-		//
-		// See: https://github.com/WordPress/WordPress/blob/a193916/wp-includes/class-wp-user-query.php#L322-L327
-		// See: https://codex.wordpress.org/Roles_and_Capabilities#User_Levels
-		const { users } = this.props;
-		return filter( users.data, ( user ) => {
-			return get( user, [ 'capabilities', 'level_1' ], false );
-		} );
-	}
-
 	render() {
-		const { postAuthor, instanceId } = this.props;
-		const authors = this.getAuthors();
+		const { postAuthor, instanceId, authors } = this.props;
 		const selectId = 'post-author-selector-' + instanceId;
 
 		// Disable reason: A select with an onchange throws a warning
@@ -72,6 +54,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		return {
 			postAuthor: select( 'core/editor' ).getEditedPostAttribute( 'author' ),
+			authors: select( 'core' ).getAuthors(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
@@ -79,10 +62,5 @@ export default compose( [
 			dispatch( 'core/editor' ).editPost( { author } );
 		},
 	} ) ),
-	withAPIData( () => {
-		return {
-			users: '/wp/v2/users?context=edit&per_page=100',
-		};
-	} ),
 	withInstanceId,
 ] )( PostAuthor );

--- a/editor/components/post-author/test/check.js
+++ b/editor/components/post-author/test/check.js
@@ -44,13 +44,13 @@ describe( 'PostAuthorCheck', () => {
 	};
 
 	it( 'should not render anything if users unknown', () => {
-		const wrapper = shallow( <PostAuthorCheck authors={ {} } user={ user }>authors</PostAuthorCheck> );
+		const wrapper = shallow( <PostAuthorCheck authors={ [] } user={ user }>authors</PostAuthorCheck> );
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'should not render anything if single user', () => {
 		const wrapper = shallow(
-			<PostAuthorCheck authors={ { data: users.data.slice( 0, 1 ) } } user={ user }>
+			<PostAuthorCheck authors={ users.data.slice( 0, 1 ) } user={ user }>
 				authors
 			</PostAuthorCheck>
 		);

--- a/editor/components/post-author/test/check.js
+++ b/editor/components/post-author/test/check.js
@@ -43,36 +43,14 @@ describe( 'PostAuthorCheck', () => {
 		},
 	};
 
-	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
-		let wrapper = shallow( <PostAuthorCheck users={ users } user={ {} }>authors</PostAuthorCheck> );
-		expect( wrapper.type() ).toBe( null );
-		wrapper = shallow(
-			<PostAuthorCheck users={ users } user={
-				{ data: { post_type_capabilities: { publish_posts: false } } }
-			}>
-				authors
-			</PostAuthorCheck>
-		);
-		expect( wrapper.type() ).toBe( null );
-	} );
-
 	it( 'should not render anything if users unknown', () => {
-		const wrapper = shallow( <PostAuthorCheck users={ {} } user={ user }>authors</PostAuthorCheck> );
+		const wrapper = shallow( <PostAuthorCheck authors={ {} } user={ user }>authors</PostAuthorCheck> );
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'should not render anything if single user', () => {
 		const wrapper = shallow(
-			<PostAuthorCheck users={ { data: users.data.slice( 0, 1 ) } } user={ user }>
-				authors
-			</PostAuthorCheck>
-		);
-		expect( wrapper.type() ).toBe( null );
-	} );
-
-	it( 'should not render anything if single filtered user', () => {
-		const wrapper = shallow(
-			<PostAuthorCheck users={ { data: users.data.slice( 0, 2 ) } } user={ user }>
+			<PostAuthorCheck authors={ { data: users.data.slice( 0, 1 ) } } user={ user }>
 				authors
 			</PostAuthorCheck>
 		);
@@ -81,7 +59,7 @@ describe( 'PostAuthorCheck', () => {
 
 	it( 'should render  control', () => {
 		const wrapper = shallow(
-			<PostAuthorCheck users={ users } user={ user }>
+			<PostAuthorCheck authors={ users } user={ user }>
 				authors
 			</PostAuthorCheck>
 		);

--- a/editor/components/post-author/test/index.js
+++ b/editor/components/post-author/test/index.js
@@ -43,30 +43,12 @@ describe( 'PostAuthor', () => {
 		},
 	};
 
-	describe( '#getAuthors()', () => {
-		it( 'returns empty array on unknown users', () => {
-			const wrapper = shallow( <PostAuthor users={ {} } user={ user } /> );
-
-			const authors = wrapper.instance().getAuthors();
-
-			expect( authors ).toEqual( [] );
-		} );
-
-		it( 'filters users to authors', () => {
-			const wrapper = shallow( <PostAuthor users={ users } user={ user } /> );
-
-			const authors = wrapper.instance().getAuthors();
-
-			expect( authors.map( ( author ) => author.id ).sort() ).toEqual( [ 1, 3 ] );
-		} );
-	} );
-
 	describe( '#render()', () => {
 		it( 'should update author', () => {
 			const onUpdateAuthor = jest.fn();
 			const wrapper = shallow(
 				<PostAuthor
-					users={ users }
+					authors={ users }
 					user={ user }
 					onUpdateAuthor={ onUpdateAuthor } />
 			);

--- a/editor/components/post-author/test/index.js
+++ b/editor/components/post-author/test/index.js
@@ -9,31 +9,29 @@ import { shallow } from 'enzyme';
 import { PostAuthor } from '../';
 
 describe( 'PostAuthor', () => {
-	const users = {
-		data: [
-			{
-				id: 1,
-				name: 'admin',
-				capabilities: {
-					level_1: true,
-				},
+	const authors = [
+		{
+			id: 1,
+			name: 'admin',
+			capabilities: {
+				level_1: true,
 			},
-			{
-				id: 2,
-				name: 'subscriber',
-				capabilities: {
-					level_0: true,
-				},
+		},
+		{
+			id: 2,
+			name: 'subscriber',
+			capabilities: {
+				level_0: true,
 			},
-			{
-				id: 3,
-				name: 'andrew',
-				capabilities: {
-					level_1: true,
-				},
+		},
+		{
+			id: 3,
+			name: 'andrew',
+			capabilities: {
+				level_1: true,
 			},
-		],
-	};
+		},
+	];
 
 	const user = {
 		data: {
@@ -48,7 +46,7 @@ describe( 'PostAuthor', () => {
 			const onUpdateAuthor = jest.fn();
 			const wrapper = shallow(
 				<PostAuthor
-					authors={ users }
+					authors={ authors }
 					user={ user }
 					onUpdateAuthor={ onUpdateAuthor } />
 			);

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -374,3 +374,69 @@ function gutenberg_ensure_wp_json_has_theme_supports( $response ) {
 	return $response;
 }
 add_filter( 'rest_index', 'gutenberg_ensure_wp_json_has_theme_supports' );
+
+/**
+ * Handle any necessary checks early.
+ *
+ * @param WP_HTTP_Response $response Result to send to the client. Usually a WP_REST_Response.
+ * @param WP_REST_Server   $handler  ResponseHandler instance (usually WP_REST_Server).
+ * @param WP_REST_Request  $request  Request used to generate the response.
+ */
+function gutenberg_handle_early_callback_checks( $response, $handler, $request ) {
+	if ( '/wp/v2/users' === $request->get_route() ) {
+		if ( ! empty( $request['who'] ) && 'authors' === $request['who'] ) {
+			$can_view = false;
+			$types    = get_post_types( array( 'show_in_rest' => true ), 'objects' );
+			foreach ( $types as $type ) {
+				if ( current_user_can( $type->cap->edit_posts ) ) {
+					$can_view = true;
+				}
+			}
+			if ( ! $can_view ) {
+				return new WP_Error( 'rest_forbidden_who', __( 'Sorry, you are not allowed to query users by this parameter.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+		}
+	}
+	return $response;
+}
+add_filter( 'rest_request_before_callbacks', 'gutenberg_handle_early_callback_checks', 10, 3 );
+
+/**
+ * Include additional query parameters on the user query endpoint.
+ *
+ * @see https://core.trac.wordpress.org/ticket/42202
+ *
+ * @param array $query_params JSON Schema-formatted collection parameters.
+ * @return array
+ */
+function gutenberg_filter_user_collection_parameters( $query_params ) {
+	$query_params['who'] = array(
+		'description' => __( 'Limit result set to users who are considered authors.', 'gutenberg' ),
+		'type'        => 'string',
+		'enum'        => array(
+			'authors',
+		),
+	);
+	return $query_params;
+}
+add_filter( 'rest_user_collection_params', 'gutenberg_filter_user_collection_parameters' );
+
+/**
+ * Filter user collection query parameters to include specific behavior.
+ *
+ * @see https://core.trac.wordpress.org/ticket/42202
+ *
+ * @param array           $prepared_args Array of arguments for WP_User_Query.
+ * @param WP_REST_Request $request       The current request.
+ * @return array
+ */
+function gutenberg_filter_user_query_arguments( $prepared_args, $request ) {
+	if ( ! empty( $request['who'] ) && 'authors' === $request['who'] ) {
+		$prepared_args['who'] = 'authors';
+		if ( isset( $prepared_args['has_published_posts'] ) ) {
+			unset( $prepared_args['has_published_posts'] );
+		}
+	}
+	return $prepared_args;
+}
+add_filter( 'rest_user_query', 'gutenberg_filter_user_query_arguments', 10, 2 );


### PR DESCRIPTION
## Description

Switches the `post-author` component to use `/wp/v2/users/?who=authors` and its underling REST API query parameters.

See https://core.trac.wordpress.org/ticket/42202
See #3010, #6361

## Screenshots

<img width="331" alt="image" src="https://user-images.githubusercontent.com/36432/39458779-e2a8a4f2-4cab-11e8-9347-2a996d96ed59.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
