### PR TITLE
Fix 5919 in an alternate way

### DIFF
--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -21,22 +21,29 @@ $empty-paragraph-height: $text-editor-font-size * 4;
 	}
 
 	// Show quick insertion icons faded until hover
-	.editor-inserter-with-shortcuts,
-	.editor-inserter {
+	.editor-inserter-with-shortcuts {
 		.components-icon-button {
 			color: $light-gray-700;
 			transition: color 0.2s;
 		}
 	}
 
+	// Don't show inserter until mousing
+	.editor-inserter__toggle:not( [aria-expanded="true"] ) {
+		opacity: 0;
+	}
+
 	&:hover {
-		.editor-inserter-with-shortcuts,
-		.editor-inserter {
+		.editor-inserter-with-shortcuts {
 			opacity: 1;
 
 			.components-icon-button {
 				color: $dark-gray-500;
 			}
+		}
+
+		.editor-inserter__toggle {
+			opacity: 1;
 		}
 	}
 


### PR DESCRIPTION
In PR #6090 (much appreciated), #5919 was fixed. However this particular fix introduced a regression where the side plus was now visible right at the start, which it wasn't in 2.7.

This PR takes a different approach, fixing the same issue but without the regression.

GIF:

![hover regressions](https://user-images.githubusercontent.com/1204802/39470865-5b42052c-4d40-11e8-8788-d3d787ade453.gif)
