### PR TITLE
Use nested blocks for quotes

### DIFF
--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -94,7 +94,7 @@ class AudioEdit extends Component {
 							placeholder={ __( 'Write caption…' ) }
 							value={ caption }
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
-							inlineToolbar
+							inlineToolbar="center"
 						/>
 					) }
 				</figure>

--- a/core-blocks/cover-image/index.js
+++ b/core-blocks/cover-image/index.js
@@ -221,7 +221,7 @@ export const settings = {
 							placeholder={ __( 'Write title…' ) }
 							value={ title }
 							onChange={ ( value ) => setAttributes( { title: value } ) }
-							inlineToolbar
+							inlineToolbar="center"
 						/>
 					) : null }
 				</div>

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -271,7 +271,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 									placeholder={ __( 'Write caption…' ) }
 									value={ caption }
 									onChange={ ( value ) => setAttributes( { caption: value } ) }
-									inlineToolbar
+									inlineToolbar="center"
 								/>
 							) : null }
 						</figure>

--- a/core-blocks/gallery/gallery-image.js
+++ b/core-blocks/gallery/gallery-image.js
@@ -136,7 +136,7 @@ class GalleryImage extends Component {
 						isSelected={ this.state.captionSelected }
 						onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
 						unstableOnFocus={ this.onSelectCaption }
-						inlineToolbar
+						inlineToolbar="center"
 					/>
 				) : null }
 			</figure>

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -393,7 +393,7 @@ class ImageEdit extends Component {
 							unstableOnFocus={ this.onFocusCaption }
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
 							isSelected={ this.state.captionFocused }
-							inlineToolbar
+							inlineToolbar="center"
 						/>
 					) : null }
 				</figure>

--- a/core-blocks/list/index.js
+++ b/core-blocks/list/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, compact, get, initial, last, isEmpty } from 'lodash';
+import { find, compact, get, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -81,21 +81,6 @@ export const settings = {
 				},
 			},
 			{
-				type: 'block',
-				blocks: [ 'core/quote' ],
-				transform: ( { value, citation } ) => {
-					const items = value.map( ( p ) => get( p, [ 'children', 'props', 'children' ] ) );
-					if ( ! isEmpty( citation ) ) {
-						items.push( citation );
-					}
-					const hasItems = ! items.every( isEmpty );
-					return createBlock( 'core/list', {
-						nodeName: 'UL',
-						values: hasItems ? items.map( ( content, index ) => <li key={ index }>{ content }</li> ) : [],
-					} );
-				},
-			},
-			{
 				type: 'raw',
 				selector: 'ol,ul',
 				schema: {
@@ -133,18 +118,6 @@ export const settings = {
 						.map( ( content ) => createBlock( 'core/paragraph', {
 							content: [ content ],
 						} ) ),
-			},
-			{
-				type: 'block',
-				blocks: [ 'core/quote' ],
-				transform: ( { values } ) => {
-					return createBlock( 'core/quote', {
-						value: compact( ( values.length === 1 ? values : initial( values ) )
-							.map( ( value ) => get( value, [ 'props', 'children' ], null ) ) )
-							.map( ( children ) => ( { children: <p>{ children }</p> } ) ),
-						citation: ( values.length === 1 ? undefined : [ get( last( values ), [ 'props', 'children' ] ) ] ),
-					} );
-				},
 			},
 		],
 	},
@@ -253,7 +226,6 @@ export const settings = {
 			const {
 				attributes,
 				insertBlocksAfter,
-				setAttributes,
 				mergeBlocks,
 				onReplace,
 				className,
@@ -301,7 +273,7 @@ export const settings = {
 						onMerge={ mergeBlocks }
 						onSplit={
 							insertBlocksAfter ?
-								( before, after, ...blocks ) => {
+								( unused, after, ...blocks ) => {
 									if ( ! blocks.length ) {
 										blocks.push( createBlock( 'core/paragraph' ) );
 									}
@@ -313,7 +285,6 @@ export const settings = {
 										} ) );
 									}
 
-									setAttributes( { values: before } );
 									insertBlocksAfter( blocks );
 								} :
 								undefined

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -238,9 +238,7 @@ class ParagraphBlock extends Component {
 
 							insertBlocksAfter( blocks );
 
-							if ( before ) {
-								setAttributes( { content: before } );
-							} else {
+							if ( ! before ) {
 								onReplace( [] );
 							}
 						} :

--- a/core-blocks/pullquote/test/__snapshots__/index.js.snap
+++ b/core-blocks/pullquote/test/__snapshots__/index.js.snap
@@ -5,29 +5,149 @@ exports[`core/pullquote block edit matches snapshot 1`] = `
   class="wp-block-pullquote"
 >
   <div
-    class="core-blocks-pullquote__content editor-rich-text"
+    class="editor-inner-blocks"
   >
-    <div>
+    <div
+      class="editor-block-list__layout"
+    >
       <div>
         <div
-          class="components-autocomplete"
+          class="editor-default-block-appender has-tip"
+          data-root-uid=""
         >
           <div
-            aria-autocomplete="list"
-            aria-expanded="false"
-            aria-label="Write quote…"
-            aria-multiline="true"
-            class="editor-rich-text__tinymce"
-            contenteditable="true"
-            data-is-placeholder-visible="true"
-            role="textbox"
+            class="components-drop-zone editor-block-drop-zone is-appender"
+          >
+            <div
+              class="components-drop-zone__content"
+            >
+              <svg
+                aria-hidden="true"
+                class="dashicon dashicons-upload components-drop-zone__content-icon"
+                focusable="false"
+                height="40"
+                role="img"
+                viewBox="0 0 20 20"
+                width="40"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+                />
+              </svg>
+              <span
+                class="components-drop-zone__content-text"
+              >
+                Drop files to upload
+              </span>
+            </div>
+          </div>
+          <input
+            aria-label="Add block"
+            class="editor-default-block-appender__content"
+            readonly=""
+            role="button"
+            type="text"
+            value="Write your story"
           />
           <div
-            class="editor-rich-text__tinymce"
+            class="editor-inserter-with-shortcuts"
           >
-            <p>
-              Write quote…
-            </p>
+            <button
+              aria-label="Add Pullquote"
+              class="components-button components-icon-button editor-inserter-with-shortcuts__block"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="dashicon dashicons-format-quote"
+                focusable="false"
+                height="20"
+                role="img"
+                viewBox="0 0 20 20"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8.54 12.74c0-.87-.24-1.61-.72-2.22-.73-.92-2.14-1.03-2.96-.85-.34-1.93 1.3-4.39 3.42-5.45L6.65 1.94C3.45 3.46.31 6.96.85 11.37 1.19 14.16 2.8 16 5.08 16c1 0 1.83-.29 2.48-.88.66-.59.98-1.38.98-2.38zm9.43 0c0-.87-.24-1.61-.72-2.22-.73-.92-2.14-1.03-2.96-.85-.34-1.93 1.3-4.39 3.42-5.45l-1.63-2.28c-3.2 1.52-6.34 5.02-5.8 9.43.34 2.79 1.95 4.63 4.23 4.63 1 0 1.83-.29 2.48-.88.66-.59.98-1.38.98-2.38z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="editor-inserter"
+          >
+            <div>
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Add block"
+                class="components-button components-icon-button editor-inserter__toggle"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="dashicon dashicons-insert"
+                  focusable="false"
+                  height="20"
+                  role="img"
+                  viewBox="0 0 20 20"
+                  width="20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7zm1-11H9v3H6v2h3v3h2v-3h3V9h-3V6z"
+                  />
+                </svg>
+                <span>
+                  <div>
+                    <div
+                      aria-label="Gutenberg tips"
+                      class="components-popover nux-dot-tip is-top is-center no-arrow"
+                      role="dialog"
+                      style="visibility:hidden"
+                    >
+                      <div
+                        class="components-popover__content"
+                        tabindex="-1"
+                      >
+                        <p>
+                          Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.
+                        </p>
+                        <p />
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </button>
+              <button
+                class="components-button is-link"
+                type="button"
+              >
+                Got it
+              </button>
+              <p />
+              <button
+                aria-label="Disable tips"
+                class="components-button components-icon-button nux-dot-tip__disable"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="dashicon dashicons-no-alt"
+                  focusable="false"
+                  height="20"
+                  role="img"
+                  viewBox="0 0 20 20"
+                  width="20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14.95 6.46L11.41 10l3.54 3.54-1.41 1.41L10 11.42l-3.53 3.53-1.42-1.42L8.58 10 5.05 6.47l1.42-1.42L10 8.58l3.54-3.53z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, get, isString, isEmpty } from 'lodash';
+import { castArray } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -10,11 +10,12 @@ import classnames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { Toolbar } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
+import { createBlock, rawHandler } from '@wordpress/blocks';
 import {
 	BlockControls,
 	AlignmentToolbar,
 	RichText,
+	InnerBlocks,
 } from '@wordpress/editor';
 
 /**
@@ -24,23 +25,7 @@ import './style.scss';
 import './editor.scss';
 import './theme.scss';
 
-const toRichTextValue = ( value ) => value.map( ( ( subValue ) => subValue.children ) );
-const fromRichTextValue = ( value ) => value.map( ( subValue ) => ( {
-	children: subValue,
-} ) );
-
 const blockAttributes = {
-	value: {
-		type: 'array',
-		source: 'query',
-		selector: 'blockquote > p',
-		query: {
-			children: {
-				source: 'node',
-			},
-		},
-		default: [],
-	},
 	citation: {
 		type: 'array',
 		source: 'children',
@@ -67,119 +52,40 @@ export const settings = {
 
 	transforms: {
 		from: [
-			{
+			...[ 'core/paragraph', 'core/heading' ].map( ( fromName ) => ( {
 				type: 'block',
-				isMultiBlock: true,
-				blocks: [ 'core/paragraph' ],
-				transform: ( attributes ) => {
-					const items = attributes.map( ( { content } ) => content );
-					const hasItems = ! items.every( isEmpty );
-					return createBlock( 'core/quote', {
-						value: hasItems ?
-							items.map( ( content, index ) => ( { children: <p key={ index }>{ content }</p> } ) ) :
-							[],
-					} );
-				},
-			},
-			{
-				type: 'block',
-				blocks: [ 'core/heading' ],
-				transform: ( { content } ) => {
-					return createBlock( 'core/quote', {
-						value: [
-							{ children: <p key="1">{ content }</p> },
-						],
-					} );
-				},
-			},
+				blocks: [ fromName ],
+				transform: ( attributes ) => createBlock( name, {}, [
+					createBlock( fromName, attributes ),
+				] ),
+			} ) ),
 			{
 				type: 'pattern',
 				regExp: /^>\s/,
-				transform: ( { content } ) => {
-					return createBlock( 'core/quote', {
-						value: [
-							{ children: <p key="1">{ content }</p> },
-						],
-					} );
-				},
+				transform: ( attributes ) => createBlock( name, {}, [
+					createBlock( 'core/paragraph', attributes ),
+				] ),
 			},
 			{
 				type: 'raw',
 				selector: 'blockquote',
 				schema: {
 					blockquote: {
-						children: {
-							p: {
-								children: getPhrasingContentSchema(),
-							},
-						},
+						children: '*',
 					},
 				},
-			},
-		],
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/paragraph' ],
-				transform: ( { value, citation } ) => {
-					// transforming an empty quote
-					if ( ( ! value || ! value.length ) && ! citation ) {
-						return createBlock( 'core/paragraph' );
-					}
-					// transforming a quote with content
-					return ( value || [] ).map( ( item ) => createBlock( 'core/paragraph', {
-						content: [ get( item, [ 'children', 'props', 'children' ], '' ) ],
-					} ) ).concat( citation ? createBlock( 'core/paragraph', {
-						content: citation,
-					} ) : [] );
-				},
-			},
-			{
-				type: 'block',
-				blocks: [ 'core/heading' ],
-				transform: ( { value, citation, ...attrs } ) => {
-					// if no text content exist just transform the quote into an heading block
-					// using citation as the content, it may be empty creating an empty heading block.
-					if ( ( ! value || ! value.length ) ) {
-						return createBlock( 'core/heading', {
-							content: citation,
-						} );
-					}
-
-					const firstValue = get( value, [ 0, 'children' ] );
-					const headingContent = castArray( isString( firstValue ) ?
-						firstValue :
-						get( firstValue, [ 'props', 'children' ], '' )
-					);
-
-					// if the quote content just contains a paragraph and no citation exist
-					// convert the quote content into and heading block.
-					if ( ! citation && value.length === 1 ) {
-						return createBlock( 'core/heading', {
-							content: headingContent,
-						} );
-					}
-
-					// In the normal case convert the first paragraph of quote into an heading
-					// and create a new quote block equal tl what we had excluding the first paragraph
-					const heading = createBlock( 'core/heading', {
-						content: headingContent,
-					} );
-
-					const quote = createBlock( 'core/quote', {
-						...attrs,
-						citation,
-						value: value.slice( 1 ),
-					} );
-
-					return [ heading, quote ];
+				transform( node ) {
+					return createBlock( name, {}, rawHandler( {
+						HTML: node.innerHTML,
+						mode: 'BLOCKS',
+					} ) );
 				},
 			},
 		],
 	},
 
-	edit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
-		const { align, value, citation, style } = attributes;
+	edit( { attributes, setAttributes, isSelected, className, hasSelectedBlock } ) {
+		const { align, citation, style } = attributes;
 		const containerClassname = classnames( className, style === 2 ? 'is-large' : '' );
 
 		return (
@@ -204,25 +110,9 @@ export const settings = {
 					className={ containerClassname }
 					style={ { textAlign: align } }
 				>
-					<RichText
-						multiline="p"
-						value={ toRichTextValue( value ) }
-						onChange={
-							( nextValue ) => setAttributes( {
-								value: fromRichTextValue( nextValue ),
-							} )
-						}
-						onMerge={ mergeBlocks }
-						onRemove={ ( forward ) => {
-							const hasEmptyCitation = ! citation || citation.length === 0;
-							if ( ! forward && hasEmptyCitation ) {
-								onReplace( [] );
-							}
-						} }
-						/* translators: the text of the quotation */
-						placeholder={ __( 'Write quote…' ) }
-					/>
-					{ ( ( citation && citation.length > 0 ) || isSelected ) && (
+
+					<InnerBlocks />
+					{ ( ( citation && citation.length > 0 ) || isSelected || hasSelectedBlock ) && (
 						<RichText
 							tagName="cite"
 							value={ citation }
@@ -233,6 +123,7 @@ export const settings = {
 							}
 							/* translators: the individual or entity quoted */
 							placeholder={ __( 'Write citation…' ) }
+							inlineToolbar="left"
 						/>
 					) }
 				</blockquote>
@@ -241,14 +132,14 @@ export const settings = {
 	},
 
 	save( { attributes } ) {
-		const { align, value, citation, style } = attributes;
+		const { align, citation, style } = attributes;
 
 		return (
 			<blockquote
 				className={ style === 2 ? 'is-large' : '' }
 				style={ { textAlign: align ? align : null } }
 			>
-				<RichText.Content value={ toRichTextValue( value ) } />
+				<InnerBlocks.Content />
 				{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>
 		);
@@ -258,6 +149,60 @@ export const settings = {
 		{
 			attributes: {
 				...blockAttributes,
+				value: {
+					type: 'array',
+					source: 'query',
+					selector: 'blockquote > p',
+					query: {
+						children: {
+							source: 'node',
+						},
+					},
+					default: [],
+				},
+			},
+
+			migrate( { value = [], ...attributes } ) {
+				return [
+					attributes,
+					value.map( ( { children: paragraph } ) =>
+						createBlock( 'core/paragraph', {
+							content: castArray( paragraph.props.children ),
+						} )
+					),
+				];
+			},
+
+			save( { attributes } ) {
+				const { align, value, citation, style } = attributes;
+
+				return (
+					<blockquote
+						className={ style === 2 ? 'is-large' : '' }
+						style={ { textAlign: align ? align : null } }
+					>
+						{ value.map( ( paragraph, i ) => (
+							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
+						) ) }
+						{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				);
+			},
+		},
+		{
+			attributes: {
+				...blockAttributes,
+				value: {
+					type: 'array',
+					source: 'query',
+					selector: 'blockquote > p',
+					query: {
+						children: {
+							source: 'node',
+						},
+					},
+					default: [],
+				},
 				citation: {
 					type: 'array',
 					source: 'children',
@@ -273,7 +218,9 @@ export const settings = {
 						className={ `blocks-quote-style-${ style }` }
 						style={ { textAlign: align ? align : null } }
 					>
-						<RichText.Content value={ toRichTextValue( value ) } />
+						{ value.map( ( paragraph, i ) => (
+							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
+						) ) }
 						{ citation && citation.length > 0 && <RichText.Content tagName="footer" value={ citation } /> }
 					</blockquote>
 				);

--- a/core-blocks/quote/test/__snapshots__/index.js.snap
+++ b/core-blocks/quote/test/__snapshots__/index.js.snap
@@ -5,29 +5,149 @@ exports[`core/quote block edit matches snapshot 1`] = `
   class="wp-block-quote"
 >
   <div
-    class="editor-rich-text"
+    class="editor-inner-blocks"
   >
-    <div>
+    <div
+      class="editor-block-list__layout"
+    >
       <div>
         <div
-          class="components-autocomplete"
+          class="editor-default-block-appender has-tip"
+          data-root-uid=""
         >
           <div
-            aria-autocomplete="list"
-            aria-expanded="false"
-            aria-label="Write quote…"
-            aria-multiline="true"
-            class="editor-rich-text__tinymce"
-            contenteditable="true"
-            data-is-placeholder-visible="true"
-            role="textbox"
+            class="components-drop-zone editor-block-drop-zone is-appender"
+          >
+            <div
+              class="components-drop-zone__content"
+            >
+              <svg
+                aria-hidden="true"
+                class="dashicon dashicons-upload components-drop-zone__content-icon"
+                focusable="false"
+                height="40"
+                role="img"
+                viewBox="0 0 20 20"
+                width="40"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+                />
+              </svg>
+              <span
+                class="components-drop-zone__content-text"
+              >
+                Drop files to upload
+              </span>
+            </div>
+          </div>
+          <input
+            aria-label="Add block"
+            class="editor-default-block-appender__content"
+            readonly=""
+            role="button"
+            type="text"
+            value="Write your story"
           />
           <div
-            class="editor-rich-text__tinymce"
+            class="editor-inserter-with-shortcuts"
           >
-            <p>
-              Write quote…
-            </p>
+            <button
+              aria-label="Add Quote"
+              class="components-button components-icon-button editor-inserter-with-shortcuts__block"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="dashicon dashicons-format-quote"
+                focusable="false"
+                height="20"
+                role="img"
+                viewBox="0 0 20 20"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8.54 12.74c0-.87-.24-1.61-.72-2.22-.73-.92-2.14-1.03-2.96-.85-.34-1.93 1.3-4.39 3.42-5.45L6.65 1.94C3.45 3.46.31 6.96.85 11.37 1.19 14.16 2.8 16 5.08 16c1 0 1.83-.29 2.48-.88.66-.59.98-1.38.98-2.38zm9.43 0c0-.87-.24-1.61-.72-2.22-.73-.92-2.14-1.03-2.96-.85-.34-1.93 1.3-4.39 3.42-5.45l-1.63-2.28c-3.2 1.52-6.34 5.02-5.8 9.43.34 2.79 1.95 4.63 4.23 4.63 1 0 1.83-.29 2.48-.88.66-.59.98-1.38.98-2.38z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="editor-inserter"
+          >
+            <div>
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Add block"
+                class="components-button components-icon-button editor-inserter__toggle"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="dashicon dashicons-insert"
+                  focusable="false"
+                  height="20"
+                  role="img"
+                  viewBox="0 0 20 20"
+                  width="20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7zm1-11H9v3H6v2h3v3h2v-3h3V9h-3V6z"
+                  />
+                </svg>
+                <span>
+                  <div>
+                    <div
+                      aria-label="Gutenberg tips"
+                      class="components-popover nux-dot-tip is-top is-center no-arrow"
+                      role="dialog"
+                      style="visibility:hidden"
+                    >
+                      <div
+                        class="components-popover__content"
+                        tabindex="-1"
+                      >
+                        <p>
+                          Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.
+                        </p>
+                        <p />
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </button>
+              <button
+                class="components-button is-link"
+                type="button"
+              >
+                Got it
+              </button>
+              <p />
+              <button
+                aria-label="Disable tips"
+                class="components-button components-icon-button nux-dot-tip__disable"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="dashicon dashicons-no-alt"
+                  focusable="false"
+                  height="20"
+                  role="img"
+                  viewBox="0 0 20 20"
+                  width="20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14.95 6.46L11.41 10l3.54 3.54-1.41 1.41L10 11.42l-3.53 3.53-1.42-1.42L8.58 10 5.05 6.47l1.42-1.42L10 8.58l3.54-3.53z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/core-blocks/test/fixtures/core__pullquote.html
+++ b/core-blocks/test/fixtures/core__pullquote.html
@@ -1,5 +1,8 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-<p>Testing pullquote block...</p><cite>...with a caption</cite>
+	<!-- wp:core/paragraph -->
+	<p>Testing pullquote block...</p>
+	<!-- /wp:core/paragraph -->
+	<cite>...with a caption</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/core-blocks/test/fixtures/core__pullquote.json
+++ b/core-blocks/test/fixtures/core__pullquote.json
@@ -4,26 +4,26 @@
         "name": "core/pullquote",
         "isValid": true,
         "attributes": {
-            "value": [
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "Testing pullquote block..."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                }
-            ],
             "citation": [
                 "...with a caption"
             ],
             "align": "none"
         },
-        "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>"
+        "innerBlocks": [
+            {
+                "name": "core/paragraph",
+                "uid": "_uid_0",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Testing pullquote block..."
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Testing pullquote block...</p>"
+            }
+        ],
+        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n\t\n\t<cite>...with a caption</cite>\n</blockquote>"
     }
 ]

--- a/core-blocks/test/fixtures/core__pullquote.parsed.json
+++ b/core-blocks/test/fixtures/core__pullquote.parsed.json
@@ -2,8 +2,15 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>Testing pullquote block...</p>\n\t"
+            }
+        ],
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n\t\n\t<cite>...with a caption</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__pullquote.serialized.html
+++ b/core-blocks/test/fixtures/core__pullquote.serialized.html
@@ -1,4 +1,6 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-	<p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote>
+	<!-- wp:paragraph -->
+	<p>Testing pullquote block...</p>
+	<!-- /wp:paragraph --><cite>...with a caption</cite></blockquote>
 <!-- /wp:pullquote -->

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.html
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.html
@@ -1,7 +1,11 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
+	<!-- wp:core/paragraph -->
     <p>Paragraph <strong>one</strong></p>
+    <!-- /wp:core/paragraph -->
+    <!-- wp:core/paragraph -->
     <p>Paragraph two</p>
+    <!-- /wp:core/paragraph -->
     <cite>by whomever</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -4,50 +4,43 @@
         "name": "core/pullquote",
         "isValid": true,
         "attributes": {
-            "value": [
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": [
-                                "Paragraph ",
-                                {
-                                    "type": "strong",
-                                    "key": "_domReact71",
-                                    "ref": null,
-                                    "props": {
-                                        "children": "one"
-                                    },
-                                    "_owner": null,
-                                    "_store": {}
-                                }
-                            ]
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                },
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "Paragraph two"
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                }
-            ],
             "citation": [
                 "by whomever"
             ],
             "align": "none"
         },
-        "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>"
+        "innerBlocks": [
+            {
+                "uid": "_uid_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Paragraph ",
+                        {
+                            "type": "strong",
+                            "children": "one"
+                        }
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Paragraph <strong>one</strong></p>"
+            },
+            {
+                "uid": "_uid_1",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Paragraph two"
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Paragraph two</p>"
+            }
+        ],
+        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n\t\n    \n    <cite>by whomever</cite>\n</blockquote>"
     }
 ]

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -2,8 +2,21 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n    <p>Paragraph <strong>one</strong></p>\n    "
+            },
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n    <p>Paragraph two</p>\n    "
+            }
+        ],
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n\t\n    \n    <cite>by whomever</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,5 +1,10 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
+	<!-- wp:paragraph -->
 	<p>Paragraph <strong>one</strong></p>
-	<p>Paragraph two</p><cite>by whomever</cite></blockquote>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Paragraph two</p>
+	<!-- /wp:paragraph --><cite>by whomever</cite></blockquote>
 <!-- /wp:pullquote -->

--- a/core-blocks/test/fixtures/core__quote__style-1.html
+++ b/core-blocks/test/fixtures/core__quote__style-1.html
@@ -1,3 +1,8 @@
 <!-- wp:core/quote {"style":"1"} -->
-<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote">
+	<!-- wp:core/paragraph -->
+	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
+	<!-- /wp:core/paragraph -->
+	<cite>Matt Mullenweg, 2017</cite>
+</blockquote>
 <!-- /wp:core/quote -->

--- a/core-blocks/test/fixtures/core__quote__style-1.json
+++ b/core-blocks/test/fixtures/core__quote__style-1.json
@@ -4,26 +4,26 @@
         "name": "core/quote",
         "isValid": true,
         "attributes": {
-            "value": [
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                }
-            ],
             "citation": [
                 "Matt Mullenweg, 2017"
             ],
             "style": 1
         },
-        "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
+        "innerBlocks": [
+            {
+                "uid": "_uid_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>"
+            }
+        ],
+        "originalContent": "<blockquote class=\"wp-block-quote\">\n\t\n\t<cite>Matt Mullenweg, 2017</cite>\n</blockquote>"
     }
 ]

--- a/core-blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/core-blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -4,8 +4,15 @@
         "attrs": {
             "style": "1"
         },
-        "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>\n\t"
+            }
+        ],
+        "innerHTML": "\n<blockquote class=\"wp-block-quote\">\n\t\n\t<cite>Matt Mullenweg, 2017</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/core-blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,4 +1,6 @@
 <!-- wp:quote -->
 <blockquote class="wp-block-quote">
-	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+	<!-- wp:paragraph -->
+	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
+	<!-- /wp:paragraph --><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:quote -->

--- a/core-blocks/test/fixtures/core__quote__style-2.html
+++ b/core-blocks/test/fixtures/core__quote__style-2.html
@@ -1,3 +1,8 @@
 <!-- wp:core/quote {"style":"2"} -->
-<blockquote class="wp-block-quote is-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-large">
+	<!-- wp:core/paragraph -->
+	<p>There is no greater agony than bearing an untold story inside you.</p>
+	<!-- /wp:core/paragraph -->
+	<cite>Maya Angelou</cite>
+</blockquote>
 <!-- /wp:core/quote -->

--- a/core-blocks/test/fixtures/core__quote__style-2.json
+++ b/core-blocks/test/fixtures/core__quote__style-2.json
@@ -4,26 +4,26 @@
         "name": "core/quote",
         "isValid": true,
         "attributes": {
-            "value": [
-                {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "There is no greater agony than bearing an untold story inside you."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
-                }
-            ],
             "citation": [
                 "Maya Angelou"
             ],
             "style": 2
         },
-        "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote is-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
+        "innerBlocks": [
+            {
+                "uid": "_uid_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "There is no greater agony than bearing an untold story inside you."
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>There is no greater agony than bearing an untold story inside you.</p>"
+            }
+        ],
+        "originalContent": "<blockquote class=\"wp-block-quote is-large\">\n\t\n\t<cite>Maya Angelou</cite>\n</blockquote>"
     }
 ]

--- a/core-blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/core-blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -4,8 +4,15 @@
         "attrs": {
             "style": "2"
         },
-        "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote is-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>There is no greater agony than bearing an untold story inside you.</p>\n\t"
+            }
+        ],
+        "innerHTML": "\n<blockquote class=\"wp-block-quote is-large\">\n\t\n\t<cite>Maya Angelou</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/core-blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,4 +1,6 @@
 <!-- wp:quote {"style":2} -->
 <blockquote class="wp-block-quote is-large">
-	<p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+	<!-- wp:paragraph -->
+	<p>There is no greater agony than bearing an untold story inside you.</p>
+	<!-- /wp:paragraph --><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:quote -->

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -94,7 +94,7 @@ class VideoEdit extends Component {
 							placeholder={ __( 'Write caption…' ) }
 							value={ caption }
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
-							inlineToolbar
+							inlineToolbar="center"
 						/>
 					) }
 				</figure>

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -46,7 +46,13 @@ export class BlockMover extends Component {
 		const { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked, instanceId, isHidden } = this.props;
 		const { isFocused } = this.state;
 		const blocksCount = castArray( uids ).length;
+
 		if ( isLocked ) {
+			return null;
+		}
+
+		// Don't render if there's only one block in the list.
+		if ( isFirst && isLast ) {
 			return null;
 		}
 

--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -33,7 +33,7 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 ### `onSplit( before: Array|String, after: Array|String, ...blocks: Object ): Function`
 
-*Optional.* Called when the content can be split with `before` and `after`. There might be blocks present, which should be inserted in between.
+*Optional.* Called when the content can be split with `after` as the split off value. There might be blocks present, which should be inserted before the `after` value. Note: the `before` value should no longer be used.
 
 ### `onReplace( blocks: Array ): Function`
 
@@ -62,6 +62,10 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 ### `autocompleters: Array<Completer>`
 
 *Optional.* A list of autocompleters to use instead of the default.
+
+### `inlineToolbar: String`
+
+*Optional.* Render the formatting toolbar inline, next to the rich text field.  Needs to be a string that can be used with the `justify-content` CSS property.
 
 ## RichText.Content
 

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -691,6 +691,25 @@ export function getSelectedBlockUID( state ) {
 }
 
 /**
+ * Returns true if there is a selected block inside a given block, or false
+ * otherwise.
+ *
+ * @param {Object} state Editor state.
+ * @param {string} uid   Block in which to find a selected block.
+ *
+ * @return {boolean} Whether a the block contains a selected block.
+ */
+export function hasBlockSelectedBlock( state, uid ) {
+	const { start, end } = state.blockSelection;
+
+	if ( ! start || start !== end ) {
+		return false;
+	}
+
+	return getBlockRootUID( state, start ) === uid;
+}
+
+/**
  * Returns the currently selected block, or null if there is no selected block.
  *
  * @param {Object} state Global application state.

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -97,6 +97,7 @@ const {
 	INSERTER_UTILITY_HIGH,
 	INSERTER_UTILITY_MEDIUM,
 	INSERTER_UTILITY_LOW,
+	hasBlockSelectedBlock,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -1823,6 +1824,44 @@ describe( 'selectors', () => {
 			};
 
 			expect( hasSelectedBlock( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'hasBlockSelectedBlock', () => {
+		it( 'should return true if the block has selected blocks', () => {
+			const state = {
+				editor: {
+					present: {
+						blockOrder: {
+							1: [ '2' ],
+						},
+					},
+				},
+				blockSelection: {
+					start: '2',
+					end: '2',
+				},
+			};
+
+			expect( hasBlockSelectedBlock( state, '1' ) ).toBe( true );
+		} );
+
+		it( 'should return false if the block does not have selected blocks', () => {
+			const state = {
+				editor: {
+					present: {
+						blockOrder: {
+							1: [ '2' ],
+						},
+					},
+				},
+				blockSelection: {
+					start: '1',
+					end: '1',
+				},
+			};
+
+			expect( hasBlockSelectedBlock( state, '1' ) ).toBe( false );
 		} );
 	} );
 

--- a/post-content.js
+++ b/post-content.js
@@ -70,7 +70,14 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:quote {"style":1} -->',
-			'<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>',
+			'<blockquote class="wp-block-quote">',
+
+			'<!-- wp:paragraph -->',
+			'<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>',
+			'<!-- /wp:paragraph -->',
+
+			'<cite>Matt Mullenweg, 2017</cite>',
+			'</blockquote>',
 			'<!-- /wp:quote -->',
 
 			'<!-- wp:paragraph -->',
@@ -133,7 +140,14 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:pullquote -->',
-			'<blockquote class="wp-block-pullquote alignnone"><p>Code is Poetry</p><cite>The WordPress community</cite></blockquote>',
+			'<blockquote class="wp-block-pullquote alignnone">',
+
+			'<!-- wp:paragraph -->',
+			'<p>Code is Poetry</p>',
+			'<!-- /wp:paragraph -->',
+
+			'<cite>The WordPress community</cite>',
+			'</blockquote>',
 			'<!-- /wp:pullquote -->',
 
 			'<!-- wp:paragraph {"align":"center"} -->',

--- a/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
@@ -5,15 +5,17 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 <p>Paragraph block</p>
 <!-- /wp:paragraph -->
 
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\">
+	<!-- wp:paragraph -->
+	<p>Quote block</p>
+	<!-- /wp:paragraph -->
+</blockquote>
+<!-- /wp:quote -->
+
 <!-- wp:paragraph -->
 <p>Second paragraph</p>
 <!-- /wp:paragraph -->
-
-<!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\">
-	<p>Quote block</p>
-</blockquote>
-<!-- /wp:quote -->
 
 <!-- wp:code -->
 <pre class=\\"wp-block-code\\"><code>Code block</code></pre>

--- a/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
@@ -15,3 +15,17 @@ exports[`splitting and merging blocks Should split and merge paragraph blocks us
 <p>FirstSecond</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`splitting and merging blocks should split out of quote block using enter 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\">
+	<!-- wp:paragraph -->
+	<p>test</p>
+	<!-- /wp:paragraph -->
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage, insertBlock } from '../support/utils';
+import { newPost, newDesktopBrowserPage, insertBlock, getHTMLFromCodeEditor } from '../support/utils';
 
 describe( 'adding blocks', () => {
 	beforeAll( async () => {
@@ -48,6 +48,10 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Quote block' );
 
+		// Leave nested area.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
 		// Using the regular inserter
 		await insertBlock( 'code' );
 		await page.keyboard.type( 'Code block' );
@@ -56,20 +60,12 @@ describe( 'adding blocks', () => {
 		await page.click( '.editor-post-title__input' );
 
 		// Using the between inserter
-		const insertionPoint = await page.$( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
+		const insertionPoint = await page.$( '[data-type="core/code"] .editor-block-list__insertion-point-button' );
 		const rect = await insertionPoint.boundingBox();
 		await page.mouse.move( rect.x + ( rect.width / 2 ), rect.y + ( rect.height / 2 ) );
-		await page.click( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
+		await page.click( '[data-type="core/code"] .editor-block-list__insertion-point-button' );
 		await page.keyboard.type( 'Second paragraph' );
 
-		// Switch to Text Mode to check HTML Output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
-
-		// Assertions
-		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-
-		expect( textEditorContent ).toMatchSnapshot();
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/multi-block-selection.test.js
+++ b/test/e2e/specs/multi-block-selection.test.js
@@ -13,15 +13,15 @@ describe( 'Multi-block selection', () => {
 	it( 'Should select/unselect multiple blocks', async () => {
 		const firstBlockSelector = '[data-type="core/paragraph"]';
 		const secondBlockSelector = '[data-type="core/image"]';
-		const thirdBlockSelector = '[data-type="core/quote"]';
+		const thirdBlockSelector = '[data-type="core/list"]';
 		const multiSelectedCssClass = 'is-multi-selected';
 
 		// Creating test blocks
 		await page.click( '.editor-default-block-appender' );
 		await page.keyboard.type( 'First Paragraph' );
 		await insertBlock( 'Image' );
-		await insertBlock( 'Quote' );
-		await page.keyboard.type( 'Quote Block' );
+		await insertBlock( 'List' );
+		await page.keyboard.type( 'List Block' );
 
 		const blocks = [ firstBlockSelector, secondBlockSelector, thirdBlockSelector ];
 		const expectMultiSelected = async ( selectors, areMultiSelected ) => {

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage, insertBlock } from '../support/utils';
+import { newPost, newDesktopBrowserPage, insertBlock, getHTMLFromCodeEditor } from '../support/utils';
 
 describe( 'splitting and merging blocks', () => {
-	beforeAll( async () => {
+	beforeEach( async () => {
 		await newDesktopBrowserPage();
 		await newPost();
 	} );
@@ -21,32 +21,23 @@ describe( 'splitting and merging blocks', () => {
 		}
 		await page.keyboard.press( 'Enter' );
 
-		//Switch to Code Editor to check HTML output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
-
-		//Assert that there are now two paragraph blocks with correct content
-		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-		expect( textEditorContent ).toMatchSnapshot();
-
-		//Switch to Visual Editor to continue testing
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		const visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
-		await visualEditorButton.click( 'button' );
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
 
 		//Press Backspace to merge paragraph blocks
 		await page.click( '.is-selected' );
 		await page.keyboard.press( 'Home' );
 		await page.keyboard.press( 'Backspace' );
 
-		//Switch to Code Editor to check HTML output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
+	} );
 
-		//Assert that there is now one paragraph with correct content
-		textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-		expect( textEditorContent ).toMatchSnapshot();
+	it( 'should split out of quote block using enter', async () => {
+		//Use regular inserter to add paragraph block and text
+		await insertBlock( 'quote' );
+		await page.keyboard.type( 'test' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
 	} );
 } );

--- a/test/integration/fixtures/markdown-out.html
+++ b/test/integration/fixtures/markdown-out.html
@@ -65,8 +65,13 @@
 
 <!-- wp:quote -->
 <blockquote class="wp-block-quote">
+	<!-- wp:paragraph -->
 	<p>First</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
 	<p>Second</p>
+	<!-- /wp:paragraph -->
 </blockquote>
 <!-- /wp:quote -->
 


### PR DESCRIPTION
Revert "Revert "Use nested blocks for quotes (#6054)" (#6501)"
This reverts commit 230ad0d1b9743ca7dcae9f3f53800b182a765b1e.

## Description

Redo of #6054.

Things to fix:

* ~~Formatting toolbar for cite.~~
* ~~Cite placeholder is hard to discover.~~
* ~~There should be no arrows if there is only one block.~~

## How has this been tested?

Create a quote and pull quote block.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->