### PR TITLE
Components: Implement Button as assigning ref via forwardRef

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -6,67 +6,47 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, createElement } from '@wordpress/element';
+import { createElement, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-class Button extends Component {
-	constructor( props ) {
-		super( props );
-		this.setRef = this.setRef.bind( this );
-	}
+export function Button( props, ref ) {
+	const {
+		href,
+		target,
+		isPrimary,
+		isLarge,
+		isSmall,
+		isToggled,
+		isBusy,
+		className,
+		disabled,
+		focus,
+		...additionalProps
+	} = props;
 
-	componentDidMount() {
-		if ( this.props.focus ) {
-			this.ref.focus();
-		}
-	}
+	const classes = classnames( 'components-button', className, {
+		button: ( isPrimary || isLarge || isSmall ),
+		'button-primary': isPrimary,
+		'button-large': isLarge,
+		'button-small': isSmall,
+		'is-toggled': isToggled,
+		'is-busy': isBusy,
+	} );
 
-	setRef( ref ) {
-		this.ref = ref;
-	}
+	const tag = href !== undefined && ! disabled ? 'a' : 'button';
+	const tagProps = tag === 'a' ? { href, target } : { type: 'button', disabled };
 
-	focus() {
-		this.ref.focus();
-	}
-
-	render() {
-		const {
-			href,
-			target,
-			isPrimary,
-			isLarge,
-			isSmall,
-			isToggled,
-			isBusy,
-			className,
-			disabled,
-			...additionalProps
-		} = this.props;
-		const classes = classnames( 'components-button', className, {
-			button: ( isPrimary || isLarge || isSmall ),
-			'button-primary': isPrimary,
-			'button-large': isLarge,
-			'button-small': isSmall,
-			'is-toggled': isToggled,
-			'is-busy': isBusy,
-		} );
-
-		const tag = href !== undefined && ! disabled ? 'a' : 'button';
-		const tagProps = tag === 'a' ? { href, target } : { type: 'button', disabled };
-
-		delete additionalProps.focus;
-
-		return createElement( tag, {
-			...tagProps,
-			...additionalProps,
-			className: classes,
-			ref: this.setRef,
-		} );
-	}
+	return createElement( tag, {
+		...tagProps,
+		...additionalProps,
+		className: classes,
+		autoFocus: focus,
+		ref,
+	} );
 }
 
-export default Button;
+export default forwardRef( Button );

--- a/components/button/test/index.js
+++ b/components/button/test/index.js
@@ -1,12 +1,20 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { createRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import Button from '../';
+import ButtonWithForwardedRef, { Button } from '../';
+
+// [TEMPORARY]: Only needed so long as Enzyme does not support React.forwardRef
+jest.unmock( '../' );
 
 describe( 'Button', () => {
 	describe( 'basic rendering', () => {
@@ -91,6 +99,20 @@ describe( 'Button', () => {
 			const button = shallow( <Button href="https://wordpress.org/" disabled /> );
 
 			expect( button.type() ).toBe( 'button' );
+		} );
+	} );
+
+	// Disable reason: This test is desirable, but unsupported by Enzyme in
+	// the current version, as it depends on features new to React in 16.3.0.
+	//
+	// eslint-disable-next-line jest/no-disabled-tests
+	describe.skip( 'ref forwarding', () => {
+		it( 'should enable access to DOM element', () => {
+			const ref = createRef();
+
+			mount( <ButtonWithForwardedRef ref={ ref } /> );
+
+			expect( ref.current.nodeName ).toBe( 'button' );
 		} );
 	} );
 } );

--- a/element/index.js
+++ b/element/index.js
@@ -5,6 +5,7 @@ import {
 	createElement,
 	createContext,
 	createRef,
+	forwardRef,
 	Component,
 	cloneElement,
 	Children,
@@ -50,6 +51,19 @@ export { createElement };
  * @return {Object} Ref object.
  */
 export { createRef };
+
+/**
+ * Component enhancer used to enable passing a ref to its wrapped component.
+ * Pass a function argument which receives `props` and `ref` as its arguments,
+ * returning an element using the forwarded ref. The return value is a new
+ * component which forwards its ref.
+ *
+ * @param {Function} forwarder Function passed `props` and `ref`, expected to
+ *                             return an element.
+ *
+ * @return {WPComponent} Enhanced component.
+ */
+export { forwardRef };
 
 /**
  * Renders a given element into the target DOM node.

--- a/test/unit/jest.config.json
+++ b/test/unit/jest.config.json
@@ -10,7 +10,8 @@
 	"setupFiles": [
 		"core-js/fn/symbol/async-iterator",
 		"<rootDir>/test/unit/setup-blocks.js",
-		"<rootDir>/test/unit/setup-wp-aliases.js"
+		"<rootDir>/test/unit/setup-wp-aliases.js",
+		"<rootDir>/test/unit/setup-mocks.js"
 	],
 	"transform": {
 		"\\.pegjs$": "<rootDir>/test/unit/pegjs-transform.js"

--- a/test/unit/setup-mocks.js
+++ b/test/unit/setup-mocks.js
@@ -1,0 +1,16 @@
+// [TEMPORARY]: Button uses React.forwardRef, added in react@16.3.0 but not yet
+// supported by Enzyme as of enzyme-adapter-react-16@1.1.1 . This mock unwraps
+// the ref forwarding, so any tests relying on this behavior will fail.
+//
+// See: https://github.com/airbnb/enzyme/issues/1604
+// See: https://github.com/airbnb/enzyme/pull/1592/files
+jest.mock( '../../components/button', () => {
+	const { Button: RawButton } = require.requireActual( '../../components/button' );
+	const { Component } = require( 'react' );
+
+	return class Button extends Component {
+		render() {
+			return RawButton( this.props );
+		}
+	};
+} );


### PR DESCRIPTION
This pull request seeks to bring in React's (new as of 16.3.0) [`forwardRef`](https://reactjs.org/docs/forwarding-refs.html) as an alternative solution for components which need to expose its internal DOM representation. A `Button` abstraction is a perfect use case for this, where we expose an instance function `focus` to recreate the native DOM behavior. Instead, we can simply forward the `ref` so that any parent component which assigns a `ref` to `Button` will have its value assigned as the actual DOM node.

__Testing instructions:__

Verify that there are no regressions in the behavior of button, particularly in the two places where its `ref` is used for focus: Permalinks returning focus after pressing "OK" on an edit, and similarly for Shared Blocks pressing "OK" on an edit, returning focus to the permalink and Edit buttons respectively.