### PR TITLE
Use `targetSchema` of JSON Hyper Schema to communicate sticky action

### DIFF
--- a/editor/components/post-sticky/check.js
+++ b/editor/components/post-sticky/check.js
@@ -6,17 +6,13 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
-export function PostStickyCheck( { postType, children, user } ) {
-	const userCan = get( user.data, [ 'post_type_capabilities' ], false );
-
+export function PostStickyCheck( { post, postType, children } ) {
 	if (
 		postType !== 'post' ||
-		! userCan.publish_posts ||
-		! userCan.edit_others_posts
+		! get( post, [ '_links', 'wp:action-sticky' ], false )
 	) {
 		return null;
 	}
@@ -27,14 +23,8 @@ export function PostStickyCheck( { postType, children, user } ) {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
+			post: select( 'core/editor' ).getCurrentPost(),
 			postType: select( 'core/editor' ).getCurrentPostType(),
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} ),
 ] )( PostStickyCheck );

--- a/editor/components/post-sticky/check.js
+++ b/editor/components/post-sticky/check.js
@@ -9,10 +9,10 @@ import { get } from 'lodash';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
-export function PostStickyCheck( { post, postType, children } ) {
+export function PostStickyCheck( { hasStickyAction, postType, children } ) {
 	if (
 		postType !== 'post' ||
-		! get( post, [ '_links', 'wp:action-sticky' ], false )
+		! hasStickyAction
 	) {
 		return null;
 	}
@@ -22,8 +22,9 @@ export function PostStickyCheck( { post, postType, children } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
+		const post = select( 'core/editor' ).getCurrentPost();
 		return {
-			post: select( 'core/editor' ).getCurrentPost(),
+			hasStickyAction: get( post, [ '_links', 'wp:action-sticky' ], false ),
 			postType: select( 'core/editor' ).getCurrentPostType(),
 		};
 	} ),

--- a/editor/components/post-sticky/test/index.js
+++ b/editor/components/post-sticky/test/index.js
@@ -11,14 +11,7 @@ import { PostStickyCheck } from '../check';
 describe( 'PostSticky', () => {
 	it( 'should not render anything if the post type is not "post"', () => {
 		const wrapper = shallow(
-			<PostStickyCheck postType="page" post={ {
-				_links: {
-					self: [ {
-						href: 'https://w.org/wp-json/wp/v2/pages/5',
-					} ],
-				},
-				title: 'Not a stickyable post',
-			} }>
+			<PostStickyCheck postType="page" hasStickyAction={ true }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
@@ -27,14 +20,7 @@ describe( 'PostSticky', () => {
 
 	it( 'should not render anything if post doesn\'t support stickying', () => {
 		const wrapper = shallow(
-			<PostStickyCheck postType="post" post={ {
-				_links: {
-					self: [ {
-						href: 'https://w.org/wp-json/wp/v2/posts/5',
-					} ],
-				},
-				title: 'Not a stickyable post',
-			} }>
+			<PostStickyCheck postType="post" hasStickyAction={ false }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
@@ -43,17 +29,7 @@ describe( 'PostSticky', () => {
 
 	it( 'should render if the post supports stickying', () => {
 		const wrapper = shallow(
-			<PostStickyCheck postType="post" post={ {
-				_links: {
-					self: [ {
-						href: 'https://w.org/wp-json/wp/v2/posts/5',
-					} ],
-					'wp:action-sticky': [ {
-						href: 'https://w.org/wp-json/wp/v2/posts/5',
-					} ],
-				},
-				title: 'A stickyable post',
-			} }>
+			<PostStickyCheck postType="post" hasStickyAction={ true }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);

--- a/editor/components/post-sticky/test/index.js
+++ b/editor/components/post-sticky/test/index.js
@@ -9,54 +9,51 @@ import { shallow } from 'enzyme';
 import { PostStickyCheck } from '../check';
 
 describe( 'PostSticky', () => {
-	const user = {
-		data: {
-			post_type_capabilities: {
-				edit_others_posts: true,
-				publish_posts: true,
-			},
-		},
-	};
-
 	it( 'should not render anything if the post type is not "post"', () => {
 		const wrapper = shallow(
-			<PostStickyCheck postType="page" user={ user }>
+			<PostStickyCheck postType="page" post={ {
+				_links: {
+					self: {
+						href: 'https://w.org/wp-json/wp/v2/posts/5',
+					},
+				},
+				title: 'Not a stickyable post',
+			} }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
 		expect( wrapper.type() ).toBe( null );
 	} );
 
-	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
-		let wrapper = shallow(
-			<PostStickyCheck postType="post" user={ {} }>
-				Can Toggle Sticky
-			</PostStickyCheck>
-		);
-		expect( wrapper.type() ).toBe( null );
-
-		wrapper = shallow(
-			<PostStickyCheck postType="post" user={
-				{ data: { post_type_capabilities: { edit_others_posts: false, publish_posts: true } } }
-			}>
-				Can Toggle Sticky
-			</PostStickyCheck>
-		);
-		expect( wrapper.type() ).toBe( null );
-
-		wrapper = shallow(
-			<PostStickyCheck postType="post" user={
-				{ data: { post_type_capabilities: { edit_others_posts: true, publish_posts: false } } }
-			}>
-				Can Toggle Sticky
-			</PostStickyCheck>
-		);
-		expect( wrapper.type() ).toBe( null );
-	} );
-
-	it( 'should render if the user has the correct capability', () => {
+	it( 'should not render anything if post doesn\'t support stickying', () => {
 		const wrapper = shallow(
-			<PostStickyCheck postType="post" user={ user }>
+			<PostStickyCheck postType="post" post={ {
+				_links: {
+					self: {
+						href: 'https://w.org/wp-json/wp/v2/posts/5',
+					},
+				},
+				title: 'Not a stickyable post',
+			} }>
+				Can Toggle Sticky
+			</PostStickyCheck>
+		);
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should render if the post supports stickying', () => {
+		const wrapper = shallow(
+			<PostStickyCheck postType="post" post={ {
+				_links: {
+					self: {
+						href: 'https://w.org/wp-json/wp/v2/posts/5',
+					},
+					'wp:action-sticky': {
+						href: 'https://w.org/wp-json/wp/v2/posts/5',
+					},
+				},
+				title: 'A stickyable post',
+			} }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);

--- a/editor/components/post-sticky/test/index.js
+++ b/editor/components/post-sticky/test/index.js
@@ -14,7 +14,7 @@ describe( 'PostSticky', () => {
 			<PostStickyCheck postType="page" post={ {
 				_links: {
 					self: [ {
-						href: 'https://w.org/wp-json/wp/v2/posts/5',
+						href: 'https://w.org/wp-json/wp/v2/pages/5',
 					} ],
 				},
 				title: 'Not a stickyable post',

--- a/editor/components/post-sticky/test/index.js
+++ b/editor/components/post-sticky/test/index.js
@@ -13,9 +13,9 @@ describe( 'PostSticky', () => {
 		const wrapper = shallow(
 			<PostStickyCheck postType="page" post={ {
 				_links: {
-					self: {
+					self: [ {
 						href: 'https://w.org/wp-json/wp/v2/posts/5',
-					},
+					} ],
 				},
 				title: 'Not a stickyable post',
 			} }>
@@ -29,9 +29,9 @@ describe( 'PostSticky', () => {
 		const wrapper = shallow(
 			<PostStickyCheck postType="post" post={ {
 				_links: {
-					self: {
+					self: [ {
 						href: 'https://w.org/wp-json/wp/v2/posts/5',
-					},
+					} ],
 				},
 				title: 'Not a stickyable post',
 			} }>
@@ -45,12 +45,12 @@ describe( 'PostSticky', () => {
 		const wrapper = shallow(
 			<PostStickyCheck postType="post" post={ {
 				_links: {
-					self: {
+					self: [ {
 						href: 'https://w.org/wp-json/wp/v2/posts/5',
-					},
-					'wp:action-sticky': {
+					} ],
+					'wp:action-sticky': [ {
 						href: 'https://w.org/wp-json/wp/v2/posts/5',
-					},
+					} ],
 				},
 				title: 'A stickyable post',
 			} }>

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -278,7 +278,7 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 	$orig_links = $response->get_links();
 	$post_type  = get_post_type_object( $post->post_type );
 	// Only Posts can be sticky.
-	if ( 'post' === $post->post_type ) {
+	if ( 'post' === $post->post_type && 'edit' === $request['context'] ) {
 		if ( current_user_can( $post_type->cap->edit_others_posts )
 			&& current_user_can( $post_type->cap->publish_posts ) ) {
 			$new_links['https://api.w.org/action-sticky'] = array(
@@ -286,11 +286,11 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 					'title'        => __( 'Sticky Post', 'gutenberg' ),
 					'href'         => $orig_links['self'][0]['href'],
 					'targetSchema' => array(
-						'type'       => 'object',
-						'properties' => array(
+						'type'        => 'object',
+						'description' => __( 'Whether or not the current user can sticky the post.', 'gutenberg' ),
+						'properties'  => array(
 							'sticky' => array(
-								'type'        => 'boolean',
-								'description' => __( 'Whether or not the object should be treated as sticky.', 'gutenberg' ),
+								'type' => 'boolean',
 							),
 						),
 					),

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -266,6 +266,44 @@ function gutenberg_add_block_format_to_post_content( $response, $post, $request 
 }
 
 /**
+ * Include target schema attributes to links, based on whether the user can.
+ *
+ * @param WP_REST_Response $response WP REST API response of a post.
+ * @param WP_Post          $post The post being returned.
+ * @param WP_REST_Request  $request WP REST API request.
+ * @return WP_REST_Response Response containing the new links.
+ */
+function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
+	$new_links  = array();
+	$orig_links = $response->get_links();
+	$post_type  = get_post_type_object( $post->post_type );
+	// Only Posts can be sticky.
+	if ( 'post' === $post->post_type ) {
+		if ( current_user_can( $post_type->cap->edit_others_posts )
+			&& current_user_can( $post_type->cap->publish_posts ) ) {
+			$new_links['https://api.w.org/action-sticky'] = array(
+				array(
+					'title'        => __( 'Sticky Post', 'gutenberg' ),
+					'href'         => $orig_links['self'][0]['href'],
+					'targetSchema' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'sticky' => array(
+								'type'        => 'boolean',
+								'description' => __( 'Whether or not the object should be treated as sticky.', 'gutenberg' ),
+							),
+						),
+					),
+				),
+			);
+		}
+	}
+
+	$response->add_links( $new_links );
+	return $response;
+}
+
+/**
  * Whenever a post type is registered, ensure we're hooked into it's WP REST API response.
  *
  * @param string $post_type The newly registered post type.
@@ -274,6 +312,7 @@ function gutenberg_add_block_format_to_post_content( $response, $post, $request 
 function gutenberg_register_post_prepare_functions( $post_type ) {
 	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_permalink_template_to_posts', 10, 3 );
 	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_block_format_to_post_content', 10, 3 );
+	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_target_schema_to_links', 10, 3 );
 	return $post_type;
 }
 add_filter( 'registered_post_type', 'gutenberg_register_post_prepare_functions' );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -283,12 +283,11 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 			&& current_user_can( $post_type->cap->publish_posts ) ) {
 			$new_links['https://api.w.org/action-sticky'] = array(
 				array(
-					'title'        => __( 'Sticky Post', 'gutenberg' ),
+					'title'        => __( 'The current user can sticky this post.', 'gutenberg' ),
 					'href'         => $orig_links['self'][0]['href'],
 					'targetSchema' => array(
-						'type'        => 'object',
-						'description' => __( 'Whether or not the current user can sticky the post.', 'gutenberg' ),
-						'properties'  => array(
+						'type'       => 'object',
+						'properties' => array(
 							'sticky' => array(
 								'type' => 'boolean',
 							),

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -128,16 +128,25 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$check_key = 'https://api.w.org/action-sticky';
 		// authors cannot sticky.
 		wp_set_current_user( $this->author );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'edit' );
 		$response = rest_do_request( $request );
 		$links    = $response->get_links();
 		$this->assertFalse( isset( $links[ $check_key ] ) );
 		// editors can sticky.
 		wp_set_current_user( $this->editor );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'edit' );
 		$response = rest_do_request( $request );
 		$links    = $response->get_links();
 		$this->assertTrue( isset( $links[ $check_key ] ) );
+		// editors can sticky but not included for context != edit.
+		wp_set_current_user( $this->editor );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'view' );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertFalse( isset( $links[ $check_key ] ) );
 	}
 
 	/**

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -121,6 +121,26 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Only returns wp:action-sticky when current user can sticky.
+	 */
+	function test_link_sticky_only_appears_for_editor() {
+		$post_id   = $this->factory->post->create();
+		$check_key = 'https://api.w.org/action-sticky';
+		// authors cannot sticky.
+		wp_set_current_user( $this->author );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertFalse( isset( $links[ $check_key ] ) );
+		// editors can sticky.
+		wp_set_current_user( $this->editor );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertTrue( isset( $links[ $check_key ] ) );
+	}
+
+	/**
 	 * Should include relevant data in the 'theme_supports' key of index.
 	 */
 	function test_theme_supports_index() {


### PR DESCRIPTION
## Description

Updates the `post-sticky` check to use presence of `wp:action-sticky` in `_links` to determine whether the sticky UI should display. This system is called `targetSchema`. It allows us to compute whether a user can perform an action server-side, and then communicate it to the client.

See https://github.com/WordPress/gutenberg/issues/6361#issuecomment-385769046

## How has this been tested?

For editors and above, the "Stick to the Front Page" UI should display:

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/36432/39495245-61c11f24-4d4e-11e8-8553-e05d357c2e33.png">

For authors and below, it should not:

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/36432/39495280-7c4a7a7a-4d4e-11e8-9c43-e4acab457ad7.png">

[User Switching](https://wordpress.org/plugins/user-switching/) is a helpful plugin for quickly testing this.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
