### PR TITLE
Only display featured image UI when theme supports it too

### DIFF
--- a/editor/components/post-featured-image/check.js
+++ b/editor/components/post-featured-image/check.js
@@ -5,9 +5,11 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import ThemeSupportCheck from '../theme-support-check';
 
 function PostFeaturedImageCheck( props ) {
-	return <ThemeSupportCheck supportKeys="post-thumbnails">
-		<PostTypeSupportCheck { ...props } supportKeys="thumbnail" />
-	</ThemeSupportCheck>;
+	return (
+		<ThemeSupportCheck supportKeys="post-thumbnails">
+			<PostTypeSupportCheck { ...props } supportKeys="thumbnail" />
+		</ThemeSupportCheck>
+	);
 }
 
 export default PostFeaturedImageCheck;

--- a/editor/components/post-featured-image/check.js
+++ b/editor/components/post-featured-image/check.js
@@ -2,9 +2,12 @@
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
+import ThemeSupportCheck from '../theme-support-check';
 
 function PostFeaturedImageCheck( props ) {
-	return <PostTypeSupportCheck { ...props } supportKeys="thumbnail" />;
+	return <ThemeSupportCheck supportKeys="post-thumbnails">
+		<PostTypeSupportCheck { ...props } supportKeys="thumbnail" />
+	</ThemeSupportCheck>;
 }
 
 export default PostFeaturedImageCheck;

--- a/editor/components/theme-support-check/index.js
+++ b/editor/components/theme-support-check/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { get, some, castArray } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+
+export function ThemeSupportCheck( { themeSupports, children, supportKeys } ) {
+	const isSupported = some(
+		castArray( supportKeys ), ( key ) => get( themeSupports, [ key ], false )
+	);
+
+	if ( ! isSupported ) {
+		return null;
+	}
+
+	return children;
+}
+
+export default withSelect( ( select ) => {
+	const { getThemeSupports } = select( 'core' );
+	return {
+		themeSupports: getThemeSupports(),
+	};
+} )( ThemeSupportCheck );

--- a/editor/components/theme-support-check/test/index.js
+++ b/editor/components/theme-support-check/test/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { ThemeSupportCheck } from '../index';
+
+describe( 'ThemeSupportCheck', () => {
+	it( 'should not render if there\'s no support check provided', () => {
+		const wrapper = shallow( <ThemeSupportCheck>foobar</ThemeSupportCheck> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should render if post-thumbnails are supported', () => {
+		const themeSupports = {
+			'post-thumbnails': true,
+		};
+		const supportKeys = 'post-thumbnails';
+		const wrapper = shallow( <ThemeSupportCheck
+			supportKeys={ supportKeys }
+			themeSupports={ themeSupports }>foobar</ThemeSupportCheck> );
+		expect( wrapper.type() ).not.toBe( null );
+	} );
+
+	it( 'should not render if theme doesn\'t support post-thumbnails', () => {
+		const themeSupports = {
+			'post-thumbnails': false,
+		};
+		const supportKeys = 'post-thumbnails';
+		const wrapper = shallow( <ThemeSupportCheck
+			supportKeys={ supportKeys }
+			themeSupports={ themeSupports }>foobar</ThemeSupportCheck> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+} );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -370,6 +370,11 @@ function gutenberg_ensure_wp_json_has_theme_supports( $response ) {
 
 		$site_info['theme_supports']['formats'] = $formats;
 	}
+	if ( ! array_key_exists( 'post-thumbnails', $site_info['theme_supports'] ) ) {
+		if ( get_theme_support( 'post-thumbnails' ) ) {
+			$site_info['theme_supports']['post-thumbnails'] = true;
+		}
+	}
 	$response->set_data( $site_info );
 	return $response;
 }


### PR DESCRIPTION
## Description

Ensures the "Featured Image" UI only displays when the theme supports `post-thumbnails` too.

Fixes #2523
Previously #6510 
## Types of changes

My code introduces a new `ThemeSupportCheck` component to inspect the theme's `post-thumbnails` setting. If the theme doesn't support post thumbnails, then the featured image UI doesn't render.

The code also introduces `post-thumbnails=true` on the site index for exposure through the REST API.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->


## How has this been tested?

Using Twenty Seventeen, here's the UI that normally displays:

<img width="415" alt="image" src="https://user-images.githubusercontent.com/36432/39454257-1e9c82e8-4c8f-11e8-9980-9ed6d5b35e08.png">

Then, add the following code snippet to a `wp-content/mu-plugins/local.php` file:

```
add_action( 'after_setup_theme', function(){
	remove_theme_support( 'post-thumbnails' );
}, 100 );
```

The "Featured Image" will no longer display:

<img width="339" alt="image" src="https://user-images.githubusercontent.com/36432/39454273-3f082f46-4c8f-11e8-9a20-981063ebf6e3.png">