### PR TITLE
Writing Flow: Consider tabbable edge if no adjacent tabbable

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -168,7 +168,7 @@ class WritingFlow extends Component {
 	 */
 	isTabbableEdge( target, isReverse ) {
 		const closestTabbable = this.getClosestTabbable( target, isReverse );
-		return ! isInSameBlock( target, closestTabbable );
+		return ! closestTabbable || ! isInSameBlock( target, closestTabbable );
 	}
 
 	onKeyDown( event ) {


### PR DESCRIPTION
This pull request seeks to resolve an error which occurs when making a forward shift selection in the last paragraph of a post, or a backward shift selection in the title. 

>[Uncaught TypeError: Cannot read property 'closest' of undefined](https://github.com/WordPress/gutenberg/blob/239de2e013c56ab306f4b58067104576997a1c5b/editor/utils/dom.js#L53)

__Implementation notes:__

`closestTabbable` may be `undefined` if there are no more tabbable fields in the desired direction. Since the intent of `isTabbableEdge` is to discern between there being other tabbables in the same block, it is reasonable to expect this should return `true` if there are no more tabbables. Where used, this may lead to `expandSelection`, but this already accounts for the case where there is no adjacent block.

__Testing instructions:__

Verify backward shift-selection from title results in no errors.
Verify forward shift-selection from last paragraph of content results in no errors.