### PR TITLE
Refactor blocks->PanelColor, to avoid the need for the colorName prop

### DIFF
--- a/blocks/colors/index.js
+++ b/blocks/colors/index.js
@@ -1,2 +1,2 @@
-export { getColorClass } from './utils';
+export { getColorClass, getColorName } from './utils';
 export { default as withColors } from './with-colors';

--- a/blocks/colors/utils.js
+++ b/blocks/colors/utils.js
@@ -24,6 +24,19 @@ export const getColorValue = ( colors, namedColor, customColor ) => {
 };
 
 /**
+* Provided an array of named colors and a color value returns the color name.
+*
+* @param {Array}   colors      Array of color objects containing the "name" and "color" value as properties.
+* @param {?string} colorValue  A string containing the color value.
+*
+* @return {?string} If colorValue is defined and matches a color part of the colors array, it returns the color name for that color.
+*/
+export const getColorName = ( colors, colorValue ) => {
+	const colorObj = find( colors, { color: colorValue } );
+	return colorObj ? colorObj.name : undefined;
+};
+
+/**
  * Returns a function that receives the color value and sets it using the attribute for named colors or for custom colors.
  *
  * @param {Array}  colors                   Array of color objects containing the "name" and "color" value as properties.

--- a/blocks/panel-color/index.js
+++ b/blocks/panel-color/index.js
@@ -14,13 +14,15 @@ import { compose } from '@wordpress/element';
  */
 import ColorPalette from '../color-palette';
 import withColorContext from '../with-color-context';
+import { getColorName } from '../colors';
 
-function PanelColor( { title, colorName, colorValue, initialOpen, ...props } ) {
+function PanelColor( { colors, title, colorValue, initialOpen, ...props } ) {
+	const colorName = getColorName( colors, colorValue );
 	return (
 		<PanelColorComponent { ...{ title, colorName, colorValue, initialOpen } } >
 			<ColorPalette
 				value={ colorValue }
-				{ ...omit( props, [ 'disableCustomColors', 'colors' ] ) }
+				{ ...omit( props, [ 'disableCustomColors' ] ) }
 			/>
 		</PanelColorComponent>
 	);

--- a/core-blocks/button/index.js
+++ b/core-blocks/button/index.js
@@ -125,13 +125,11 @@ class ButtonBlock extends Component {
 								onChange={ this.toggleClear }
 							/>
 							<PanelColor
-								colorName={ backgroundColor.name }
 								colorValue={ backgroundColor.value }
 								title={ __( 'Background Color' ) }
 								onChange={ setBackgroundColor }
 							/>
 							<PanelColor
-								colorName={ textColor.name }
 								colorValue={ textColor.value }
 								title={ __( 'Text Color' ) }
 								onChange={ setTextColor }

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -207,19 +207,16 @@ class ParagraphBlock extends Component {
 						/>
 					</PanelBody>
 					<PanelColor
-						colorName={ backgroundColor.name }
 						colorValue={ backgroundColor.value }
 						initialOpen={ false }
 						title={ __( 'Background Color' ) }
 						onChange={ setBackgroundColor }
 					/>
 					<PanelColor
-						colorName={ textColor.name }
 						colorValue={ textColor.value }
 						initialOpen={ false }
 						title={ __( 'Text Color' ) }
 						onChange={ setTextColor }
-						value={ textColor.value }
 					/>
 					<ContrastChecker
 						textColor={ textColor.value }


### PR DESCRIPTION
With the creation of a PanelColor in blocks, there is no need to receive the colorName anymore as the component already has the color context available and can get the colorName from it.
This change makes the usage of the component easier. Existing core blocks that make use of the component were updated.

## How has this been tested?
Verify that when we set a named color (e.g., a color from the default palette in themes that don't change it), the aria-label of the panel contains the color indication, e.g.:`(current color: luminous vivid amber)´.