### PR TITLE
Show caption and description settings in Gutenberg post featured image modal

### DIFF
--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -31,9 +31,3 @@
 	margin: 10px 0;
 }
 
-// Should be replaced with a config in media modal.
-.editor-post-featured-image__media-modal {
-	.setting[data-setting="caption"], .setting[data-setting="description"] {
-		display: none;
-	}
-}


### PR DESCRIPTION
## Description
This PR addresses #6383 which requested to bring back the caption and description setting in the post featured image selection modal. It was initially hidden in [#4197(PR)](https://github.com/WordPress/gutenberg/pull/4197) as requested in #2330.


## How has this been tested?
This PR has been tested by confirming that the caption and description setting fields show up in the featured image selection modal in the Gutenberg editor. This was tested in WP 4.9.5, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.


## Screenshots
![gutenberg](https://user-images.githubusercontent.com/20284937/39539137-b42a1bf4-4e60-11e8-8fcd-3621bea46f24.gif)


## Types of changes
This PR just removes the CSS code added in [this commit](https://github.com/WordPress/gutenberg/commit/d931e5f7bbe2a4dc19bec8deb178368b23a81de4) which made the caption and description setting fields to be hidden.