### PR TITLE
Upgrade react-datepicker to 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 		"@babel/helper-function-name": {
 			"version": "7.0.0-beta.31",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
-			"integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
+			"integrity": "sha1-r+Y615kgmYk0ixEJtE/rZqokX1c=",
 			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "7.0.0-beta.31",
@@ -28,7 +28,7 @@
 		"@babel/helper-get-function-arity": {
 			"version": "7.0.0-beta.31",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
-			"integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
+			"integrity": "sha1-EXbXklJ0EhjgrshyraB++ys3pJM=",
 			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.31"
@@ -85,7 +85,7 @@
 		"@babel/template": {
 			"version": "7.0.0-beta.31",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
-			"integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
+			"integrity": "sha1-V3uyk4n2xJfD59AUYX59ZxP2i9o=",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.31",
@@ -97,7 +97,7 @@
 				"@babel/code-frame": {
 					"version": "7.0.0-beta.31",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
-					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+					"integrity": "sha1-Rz0CHsxXOizOHAfVtQnVIV9GujU=",
 					"dev": true,
 					"requires": {
 						"chalk": "2.3.0",
@@ -117,7 +117,7 @@
 				"babylon": {
 					"version": "7.0.0-beta.31",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+					"integrity": "sha1-fsEPgeDkVv0PhVrWD6MMKsRUKD8=",
 					"dev": true
 				},
 				"chalk": {
@@ -145,7 +145,7 @@
 		"@babel/traverse": {
 			"version": "7.0.0-beta.31",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
-			"integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
+			"integrity": "sha1-2zmUma10rv2gFPDBAyGrJVE0sd8=",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.31",
@@ -161,7 +161,7 @@
 				"@babel/code-frame": {
 					"version": "7.0.0-beta.31",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
-					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+					"integrity": "sha1-Rz0CHsxXOizOHAfVtQnVIV9GujU=",
 					"dev": true,
 					"requires": {
 						"chalk": "2.3.0",
@@ -181,7 +181,7 @@
 				"babylon": {
 					"version": "7.0.0-beta.31",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+					"integrity": "sha1-fsEPgeDkVv0PhVrWD6MMKsRUKD8=",
 					"dev": true
 				},
 				"chalk": {
@@ -198,7 +198,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -207,7 +207,7 @@
 				"globals": {
 					"version": "10.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
-					"integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+					"integrity": "sha1-XEdziLEoqeTFxdAceirKaMaLLac=",
 					"dev": true
 				},
 				"supports-color": {
@@ -224,7 +224,7 @@
 		"@babel/types": {
 			"version": "7.0.0-beta.31",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
-			"integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
+			"integrity": "sha1-QsnIZ4T2dMFz+yGILKlkMzQCneQ=",
 			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
@@ -245,7 +245,7 @@
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+			"integrity": "sha1-mgb08TfuhNffBGDB/bETX/psUP0=",
 			"dev": true
 		},
 		"@types/node": {
@@ -257,7 +257,7 @@
 		"@wordpress/a11y": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-1.0.6.tgz",
-			"integrity": "sha512-IyL7KzYGzMEg+FFyTrQzD/CUfABYCXOvmnm29vBZBA3JMER1ep3/+NFDe6CpWVEEMCw94oj2gUOSQ4YKVgDjUQ==",
+			"integrity": "sha1-lReTgTZPdGgsjTWM3ZuEllldc/g=",
 			"requires": {
 				"@wordpress/dom-ready": "1.0.4"
 			}
@@ -265,12 +265,12 @@
 		"@wordpress/autop": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-1.0.4.tgz",
-			"integrity": "sha512-nqm/gP+ipeUMvEngh4Sp4k5umph8SPqfc5aCd9Ge03mz4JSWAIE4z36pPQwId0a1B3hGqri5Wo40O1hQ851ZnA=="
+			"integrity": "sha1-ocOfDQrw7Y04vMCgtguNVsAjMJE="
 		},
 		"@wordpress/babel-plugin-makepot": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-1.0.0.tgz",
-			"integrity": "sha512-YNcXr33fUUHg9HncNhUNkG2jnCAtnvC5hN0ZdDdTVe7r7aR4l+gCTCZXvM/0SHqikrNhRNjSrE5ZM/3u2zsOyw==",
+			"integrity": "sha1-alpyCXqfnlhq7sIUDQIMGQU0x1Y=",
 			"dev": true,
 			"requires": {
 				"gettext-parser": "1.3.1",
@@ -298,7 +298,7 @@
 		"@wordpress/babel-preset-default": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-1.2.0.tgz",
-			"integrity": "sha512-DJ4P3gwj8gUQy94GeaVdHTh2JVKQ8eNFwCQi4GDhCcq78KDAJjRO497ZwoJWJR0MVq5a3XfsrJ6fVf7S8APfUw==",
+			"integrity": "sha1-M+QG+QoY4lNSRugtoiyfE+ZfeEg=",
 			"dev": true,
 			"requires": {
 				"@wordpress/browserslist-config": "2.1.3",
@@ -311,13 +311,13 @@
 		"@wordpress/browserslist-config": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.1.3.tgz",
-			"integrity": "sha512-I8xUK/oqxI0LYoTar2U/vvQS78pWnEXWqClyhzmQ53NfWWaGydYgNdH3X2+oCGZjNUtdEkXuhjnyAwSZ12h0HQ==",
+			"integrity": "sha1-MiTFj4u+ydn9iAecbtMZRwgObFc=",
 			"dev": true
 		},
 		"@wordpress/custom-templated-path-webpack-plugin": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/custom-templated-path-webpack-plugin/-/custom-templated-path-webpack-plugin-1.0.0.tgz",
-			"integrity": "sha512-7GDENg5juXusGye4JqKAjfAr1EcKNNmJ6GUnnUrdOkXgjnT5CoAw2ADJxvtALtl4vx6o/nqzJxp9YQ/bZi85Dg==",
+			"integrity": "sha1-zlUVV81C02eCQ26hAr0sKqGIsHo=",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
@@ -331,12 +331,12 @@
 		"@wordpress/hooks": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-1.1.6.tgz",
-			"integrity": "sha512-+7s5j296RTXRabaubvNK35ED/+WUYJgM8oeiHWP6RvPGd/2rkei3cI0SNwjBdaRrlNQ22vtzvCfhdDCyb9W1xQ=="
+			"integrity": "sha1-E60RWSZI1pQTAactKpJHC4qSzaU="
 		},
 		"@wordpress/i18n": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-1.1.0.tgz",
-			"integrity": "sha512-zzpyhSaVOv5iLIwkJ4nrPt7FO+50xHlGDSJljfGdS+ypvFAnEHpCkkJ84F3NhHaYIIZqMEn5lC4k1edIaIqAbA==",
+			"integrity": "sha1-BcyubrIgGXp1n7vk6UsBCqafGf4=",
 			"requires": {
 				"gettext-parser": "1.3.1",
 				"jed": "1.1.1",
@@ -369,7 +369,7 @@
 		"@wordpress/jest-preset-default": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-1.0.3.tgz",
-			"integrity": "sha512-1+uREUyhMWBanX4qceevrFEuaFm/gRKIKiDb36Wc5X02ODEaUaQ6qjIvrD6fariYtvxQpjC8TBjKapsvSaqHHw==",
+			"integrity": "sha1-mVokUppjnGbWul9nbKkbAT9qeG4=",
 			"dev": true,
 			"requires": {
 				"@wordpress/jest-console": "1.0.5",
@@ -383,7 +383,7 @@
 		"@wordpress/scripts": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-1.1.0.tgz",
-			"integrity": "sha512-gbtpV6i4SKi7Pya8qeB6N9FGyWAMBtyAsRnFg6Lv6Ejh0Pk9R2Aa71GjX4ZAMzq1LFuVNdhciIybdxDPSsP8sQ==",
+			"integrity": "sha1-aq6psjfQ3d+dyjBDFp0aSrT2Mgc=",
 			"dev": true,
 			"requires": {
 				"@wordpress/babel-preset-default": "1.2.0",
@@ -427,7 +427,7 @@
 				"path-type": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
 					"dev": true,
 					"requires": {
 						"pify": "3.0.0"
@@ -484,7 +484,7 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+			"integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
 		},
 		"acorn": {
 			"version": "5.4.1",
@@ -495,7 +495,7 @@
 		"acorn-dynamic-import": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+			"integrity": "sha1-kBzu5Mf6rvfgetKkfokGddpQong=",
 			"dev": true,
 			"requires": {
 				"acorn": "5.4.1"
@@ -504,7 +504,7 @@
 		"acorn-globals": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"integrity": "sha1-q3FgJdvhfFTT74HTLs4rLZn+JTg=",
 			"dev": true,
 			"requires": {
 				"acorn": "5.4.1"
@@ -530,7 +530,7 @@
 		"agent-base": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-			"integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+			"integrity": "sha1-mDi1wzkrliutAx5qTF4QJKvsRc4=",
 			"dev": true,
 			"requires": {
 				"es6-promisify": "5.0.0"
@@ -622,7 +622,7 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
 			"dev": true
 		},
 		"are-we-there-yet": {
@@ -680,7 +680,7 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
 			"dev": true
 		},
 		"arr-union": {
@@ -758,7 +758,7 @@
 		"asn1.js": {
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
 			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
@@ -790,7 +790,7 @@
 		"ast-types": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
-			"integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+			"integrity": "sha1-wgdX/nLucSeOoP89h+XCyjDZ7fg=",
 			"dev": true
 		},
 		"ast-types-flow": {
@@ -802,13 +802,13 @@
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
 			"dev": true
 		},
 		"async": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
 			"dev": true,
 			"requires": {
 				"lodash": "4.17.5"
@@ -829,7 +829,7 @@
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
 			"dev": true
 		},
 		"asynckit": {
@@ -847,7 +847,7 @@
 		"autoprefixer": {
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.2.0.tgz",
-			"integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
+			"integrity": "sha1-Hkm2EbMaUlm4a3prKxuPrwkavio=",
 			"dev": true,
 			"requires": {
 				"browserslist": "3.2.4",
@@ -937,7 +937,7 @@
 		"autosize": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.1.tgz",
-			"integrity": "sha512-Sapd3XwNqZin0VW0DFiAGfgr9s2d1Sudj2+hnE/jj6aJUKXvlaimkY+FFB2Xzm3nfD7tCaMSC2jo4sVB2EOqpw=="
+			"integrity": "sha1-Ti+J0A4pDdmOH5VVWozLkenHpBo="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -1001,7 +1001,7 @@
 		"babel-eslint": {
 			"version": "8.0.3",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
-			"integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
+			"integrity": "sha1-8p7PAjNr5DgZUyXNR8Ro2oHuTpg=",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.31",
@@ -1013,7 +1013,7 @@
 				"@babel/code-frame": {
 					"version": "7.0.0-beta.31",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
-					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+					"integrity": "sha1-Rz0CHsxXOizOHAfVtQnVIV9GujU=",
 					"dev": true,
 					"requires": {
 						"chalk": "2.3.0",
@@ -1033,7 +1033,7 @@
 				"babylon": {
 					"version": "7.0.0-beta.31",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+					"integrity": "sha1-fsEPgeDkVv0PhVrWD6MMKsRUKD8=",
 					"dev": true
 				},
 				"chalk": {
@@ -1061,7 +1061,7 @@
 		"babel-generator": {
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
 			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
@@ -1266,7 +1266,7 @@
 		"babel-loader": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
-			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+			"integrity": "sha1-40Y5OL1ObVXRwXTFSF1AahiO0BU=",
 			"dev": true,
 			"requires": {
 				"find-cache-dir": "1.0.0",
@@ -1767,7 +1767,7 @@
 		"babel-preset-env": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+			"integrity": "sha1-oYtWTMm5r99KrleuPBsNmRiOb0g=",
 			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
@@ -1904,7 +1904,7 @@
 				"source-map-support": {
 					"version": "0.4.18",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
 					"dev": true,
 					"requires": {
 						"source-map": "0.5.7"
@@ -1983,7 +1983,7 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
 			"dev": true
 		},
 		"balanced-match": {
@@ -1994,7 +1994,7 @@
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
 			"dev": true,
 			"requires": {
 				"cache-base": "1.0.1",
@@ -2042,7 +2042,7 @@
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+			"integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
 			"dev": true
 		},
 		"binary-extensions": {
@@ -2054,7 +2054,7 @@
 		"binaryextensions": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
+			"integrity": "sha1-MgmlHKSkrVQaO409am1bg6JIWTU=",
 			"dev": true
 		},
 		"block-stream": {
@@ -2069,12 +2069,12 @@
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+			"integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
 		},
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+			"integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
 			"dev": true
 		},
 		"boolbase": {
@@ -2205,7 +2205,7 @@
 		"browserify-zlib": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+			"integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
 			"dev": true,
 			"requires": {
 				"pako": "1.0.6"
@@ -2214,7 +2214,7 @@
 		"browserslist": {
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"integrity": "sha1-/jYWeu0bvN5IJ+v+cTR6LMcLmbI=",
 			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000828",
@@ -2261,7 +2261,7 @@
 		"cacache": {
 			"version": "10.0.4",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"integrity": "sha1-ZFI2eZnv+dQYiu/ZoU6dfGomNGA=",
 			"dev": true,
 			"requires": {
 				"bluebird": "3.5.1",
@@ -2282,7 +2282,7 @@
 				"lru-cache": {
 					"version": "4.1.2",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-					"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+					"integrity": "sha1-RSNLLm4vKzPaElYkxGZJKaAiTD8=",
 					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
@@ -2292,7 +2292,7 @@
 				"y18n": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
 					"dev": true
 				}
 			}
@@ -2300,7 +2300,7 @@
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
 			"dev": true,
 			"requires": {
 				"collection-visit": "1.0.0",
@@ -2503,7 +2503,7 @@
 		"check-node-version": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.1.1.tgz",
-			"integrity": "sha512-52fHDe/0pbidY3InI33Beyb/oarySfLANlXxLGBl9lLVrLIW88XWIwu4jGJrQ1imuWzX5ukNGWXUyCgmgVUD8A==",
+			"integrity": "sha1-dIx0I0/2f+s3K8EjLv2x34afppg=",
 			"dev": true,
 			"requires": {
 				"chalk": "2.3.0",
@@ -2569,7 +2569,7 @@
 		"chokidar": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+			"integrity": "sha1-3L1PbLsqVbR5m6ioQKxSfl9LEXY=",
 			"dev": true,
 			"requires": {
 				"anymatch": "2.0.0",
@@ -2911,7 +2911,7 @@
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
 			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
@@ -2921,19 +2921,19 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
 			"dev": true
 		},
 		"circular-json-es6": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/circular-json-es6/-/circular-json-es6-2.0.2.tgz",
-			"integrity": "sha512-ODYONMMNb3p658Zv+Pp+/XPa5s6q7afhz3Tzyvo+VRh9WIrJ64J76ZC4GQxnlye/NesTn09jvOiuE8+xxfpwhQ==",
+			"integrity": "sha1-5PSgk+SftLaroRVzZXRhEqeL00Q=",
 			"dev": true
 		},
 		"clap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+			"integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
 			"dev": true,
 			"requires": {
 				"chalk": "1.1.3"
@@ -2942,7 +2942,7 @@
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
 			"dev": true,
 			"requires": {
 				"arr-union": "3.1.0",
@@ -3138,7 +3138,7 @@
 		"clone-deep": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
-			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+			"integrity": "sha1-ANs6Hhc2VnMNEYjD1qztbX6pdxM=",
 			"dev": true,
 			"requires": {
 				"for-own": "1.0.0",
@@ -3182,7 +3182,7 @@
 		"cloneable-readable": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+			"integrity": "sha1-1ZHe5Kj4vBXaQ86X3O66E9Q+KmU=",
 			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
@@ -3417,7 +3417,7 @@
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
 			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
@@ -3630,11 +3630,6 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
-		},
 		"content-type-parser": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
@@ -3650,7 +3645,7 @@
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
 			"dev": true,
 			"requires": {
 				"aproba": "1.2.0",
@@ -3681,7 +3676,7 @@
 		"cosmiconfig": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+			"integrity": "sha1-YXPOvVb6wELB9DkO33r2wHx8uJI=",
 			"dev": true,
 			"requires": {
 				"is-directory": "0.3.1",
@@ -3780,7 +3775,7 @@
 				"boom": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
 					"dev": true,
 					"requires": {
 						"hoek": "4.2.0"
@@ -3791,7 +3786,7 @@
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+			"integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
 			"dev": true,
 			"requires": {
 				"browserify-cipher": "1.0.0",
@@ -3961,7 +3956,7 @@
 		"date-fns": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+			"integrity": "sha1-EuYJzcuTUScxHQTTMzTilgoqVOY=",
 			"dev": true
 		},
 		"date-now": {
@@ -3973,13 +3968,14 @@
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+			"integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4=",
 			"dev": true
 		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -4064,7 +4060,7 @@
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
 			"dev": true,
 			"requires": {
 				"is-descriptor": "1.0.2",
@@ -4109,7 +4105,7 @@
 		"delegate": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
+			"integrity": "sha1-tmtxwxWFIuirV0T3INjKDCr1kWY="
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -4171,15 +4167,6 @@
 			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
 			"dev": true
 		},
-		"doctrine": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-			"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-			"requires": {
-				"esutils": "2.0.2",
-				"isarray": "1.0.0"
-			}
-		},
 		"dom-react": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/dom-react/-/dom-react-2.2.0.tgz",
@@ -4211,7 +4198,7 @@
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+			"integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
 			"dev": true
 		},
 		"domelementtype": {
@@ -4223,7 +4210,7 @@
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
 			"dev": true,
 			"requires": {
 				"webidl-conversions": "4.0.2"
@@ -4257,7 +4244,7 @@
 		"duplexify": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+			"integrity": "sha1-S7RsF5bqvr7sTKmi5muAjLej2LQ=",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "1.4.1",
@@ -4279,13 +4266,13 @@
 		"editions": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+			"integrity": "sha1-NmLLWSNHwxaOuOSYoP9zJx1n9Qs=",
 			"dev": true
 		},
 		"editorconfig": {
 			"version": "0.13.3",
 			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
-			"integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+			"integrity": "sha1-5SGeWHlR1glY/ZTqmpoAjN7/GzQ=",
 			"requires": {
 				"bluebird": "3.5.1",
 				"commander": "2.14.1",
@@ -4335,7 +4322,7 @@
 		"emoji-regex": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+			"integrity": "sha1-m66pKbFVVlwR6kHGYm6qZc75ksI=",
 			"dev": true
 		},
 		"emojis-list": {
@@ -4355,7 +4342,7 @@
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
 			"dev": true,
 			"requires": {
 				"once": "1.4.0"
@@ -4364,7 +4351,7 @@
 		"enhanced-resolve": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
-			"integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
+			"integrity": "sha1-40puqnkPYvzNcdk5WfVrK0MtsQo=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4381,7 +4368,7 @@
 		"enzyme": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
-			"integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
+			"integrity": "sha1-CXGr0Wfy1L8/W9UIIp4cS23FBHk=",
 			"dev": true,
 			"requires": {
 				"cheerio": "1.0.0-rc.2",
@@ -4405,7 +4392,7 @@
 		"enzyme-adapter-react-16": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz",
-			"integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
+			"integrity": "sha1-qPQni0fggvvKFPW/se5Q7mUHF7Q=",
 			"dev": true,
 			"requires": {
 				"enzyme-adapter-utils": "1.3.0",
@@ -4444,7 +4431,7 @@
 		"enzyme-adapter-utils": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
-			"integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
+			"integrity": "sha1-1shXVoJsJXqFRNNizHpn6X6mmMc=",
 			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
@@ -4468,7 +4455,7 @@
 		"enzyme-matchers": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-4.2.0.tgz",
-			"integrity": "sha512-5Gf/mAVYx6KPAUuxuDhAGt/gu9ndPd6duFcVnH2rbEad2clgTpHZL4Df49FHFukrjEEubX9rhfeAKx0/sbfVkQ==",
+			"integrity": "sha1-ODM4gyWNqQ5UFLWsB9OIrst1In8=",
 			"dev": true,
 			"requires": {
 				"circular-json-es6": "2.0.2",
@@ -4492,7 +4479,7 @@
 		"errno": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
 			"dev": true,
 			"requires": {
 				"prr": "1.0.1"
@@ -4543,7 +4530,7 @@
 		"es6-promise": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-			"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+			"integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk=",
 			"dev": true
 		},
 		"es6-promisify": {
@@ -4584,7 +4571,7 @@
 		"eslint": {
 			"version": "4.16.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
-			"integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
+			"integrity": "sha1-k0ranphxXh17v9b28FGe0vqzXME=",
 			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
@@ -4655,7 +4642,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -4664,7 +4651,7 @@
 				"doctrine": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 					"dev": true,
 					"requires": {
 						"esutils": "2.0.2"
@@ -4708,56 +4695,21 @@
 			"integrity": "sha1-UgEgbGlk1kgxUjLt9t+9LpJeTNY=",
 			"dev": true
 		},
-		"eslint-import-resolver-node": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
-			"requires": {
-				"debug": "2.6.9",
-				"resolve": "1.5.0"
-			}
-		},
-		"eslint-module-utils": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-			"integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
-			"requires": {
-				"debug": "2.6.9",
-				"pkg-dir": "1.0.0"
-			}
-		},
 		"eslint-plugin-i18n": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-i18n/-/eslint-plugin-i18n-1.2.0.tgz",
 			"integrity": "sha1-SfP0OA7e/oyHbwyXlh9lw6w3zao="
 		},
-		"eslint-plugin-import": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-			"integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
-			"requires": {
-				"builtin-modules": "1.1.1",
-				"contains-path": "0.1.0",
-				"debug": "2.6.9",
-				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "0.3.2",
-				"eslint-module-utils": "2.1.1",
-				"has": "1.0.1",
-				"lodash.cond": "4.5.2",
-				"minimatch": "3.0.4",
-				"read-pkg-up": "2.0.0"
-			}
-		},
 		"eslint-plugin-jest": {
 			"version": "21.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.5.0.tgz",
-			"integrity": "sha512-4fxfe2RcqzU+IVNQL5n4pqibLcUhKKxihYsA510+6kC/FTdGInszDDHgO4ntBzPWu8mcHAvKJLs8o3AQw6eHTg==",
+			"integrity": "sha1-x6O9LunRyDK04x3sifatk+CNSFM=",
 			"dev": true
 		},
 		"eslint-plugin-jsdoc": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.5.0.tgz",
-			"integrity": "sha512-qoNpVicVWGjGBXAJsqRoqVuAnajgX7PWtSa2Men36XKRiXe3RS/QmRv215PXZwo4OHskYOsUoJUeiPiWtS9ULA==",
+			"integrity": "sha1-yxu7lBxJn6wWxpmlhWozK1F4l94=",
 			"requires": {
 				"comment-parser": "0.4.2",
 				"lodash": "4.17.5"
@@ -4781,7 +4733,7 @@
 		"eslint-plugin-node": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+			"integrity": "sha1-vxlkIpgGQ3kxXXpLKnWTc3b6BeQ=",
 			"requires": {
 				"ignore": "3.3.7",
 				"minimatch": "3.0.4",
@@ -4799,7 +4751,7 @@
 		"eslint-plugin-react": {
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+			"integrity": "sha1-9gbHGdvYoaKz0lwWKZgTh4zKAWA=",
 			"dev": true,
 			"requires": {
 				"doctrine": "2.1.0",
@@ -4811,7 +4763,7 @@
 				"doctrine": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 					"dev": true,
 					"requires": {
 						"esutils": "2.0.2"
@@ -4829,7 +4781,7 @@
 				"prop-types": {
 					"version": "15.6.1",
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+					"integrity": "sha1-NmREU1ZCVd3aORGR+zoSXL32VMo=",
 					"dev": true,
 					"requires": {
 						"fbjs": "0.8.16",
@@ -4852,7 +4804,7 @@
 		"eslint-plugin-wpcalypso": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-wpcalypso/-/eslint-plugin-wpcalypso-4.0.1.tgz",
-			"integrity": "sha512-fU5NSc0XGdel/tlEIUoESOdqphBWQN2FfSgXXNHpXKX7ftTcqXacqgzXU8OVziyhXz6s2RUzK0+JSJaNxhZ+Mw==",
+			"integrity": "sha1-dszuXOT7zHdgq9HnbBISDj4Aa/c=",
 			"requires": {
 				"requireindex": "1.2.0"
 			}
@@ -4870,7 +4822,7 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
 			"dev": true
 		},
 		"espree": {
@@ -4886,7 +4838,7 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
 			"dev": true
 		},
 		"esquery": {
@@ -4917,7 +4869,8 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"events": {
 			"version": "1.1.1",
@@ -4928,7 +4881,7 @@
 		"evp_bytestokey": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
 			"dev": true,
 			"requires": {
 				"md5.js": "1.3.4",
@@ -4938,7 +4891,7 @@
 		"exec-sh": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+			"integrity": "sha1-FjuYpuiea2W0fCoo0hW8H2OYnDg=",
 			"dev": true,
 			"requires": {
 				"merge": "1.2.0"
@@ -5041,7 +4994,7 @@
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
@@ -5083,7 +5036,7 @@
 		"extract-text-webpack-plugin": {
 			"version": "4.0.0-beta.0",
 			"resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-4.0.0-beta.0.tgz",
-			"integrity": "sha512-Hypkn9jUTnFr0DpekNam53X47tXn3ucY08BQumv7kdGgeVUBLq3DJHJTi6HNxv4jl9W+Skxjz9+RnK0sJyqqjA==",
+			"integrity": "sha1-9zYdf/QwtClh+NEyG6jBdXtdTEI=",
 			"dev": true,
 			"requires": {
 				"async": "2.6.0",
@@ -5261,6 +5214,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
 			"requires": {
 				"path-exists": "2.1.0",
 				"pinkie-promise": "2.0.1"
@@ -5326,7 +5280,7 @@
 		"flush-write-stream": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"integrity": "sha1-xdWG7zivYJdlC0m8QbVfq7GfNb0=",
 			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
@@ -6441,12 +6395,13 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+			"dev": true
 		},
 		"function.prototype.name": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
-			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+			"integrity": "sha1-i9djzAr4YKhZzF1JOE10uTLNIyc=",
 			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
@@ -6547,7 +6502,7 @@
 		"gettext-parser": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
-			"integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
+			"integrity": "sha1-dLepnktfqNqrEfpRXopYJIBEihI=",
 			"requires": {
 				"encoding": "0.1.12",
 				"safe-buffer": "5.1.1"
@@ -6556,7 +6511,7 @@
 		"gh-got": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
-			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+			"integrity": "sha1-10NTAExuxGZkdSChC9RvcpnSaNA=",
 			"dev": true,
 			"requires": {
 				"got": "7.1.0",
@@ -6566,7 +6521,7 @@
 				"got": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+					"integrity": "sha1-BUUP2ECU5rvqVvRRpDqcKJFmOFo=",
 					"dev": true,
 					"requires": {
 						"decompress-response": "3.3.0",
@@ -6588,7 +6543,7 @@
 				"p-cancelable": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+					"integrity": "sha1-ueEjgAvOu3rBOkeb4ZW1B7mNMPo=",
 					"dev": true
 				},
 				"p-timeout": {
@@ -6623,7 +6578,7 @@
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
@@ -6683,7 +6638,7 @@
 		"global-modules": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
 			"dev": true,
 			"requires": {
 				"global-prefix": "1.0.2",
@@ -6707,7 +6662,7 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
 			"dev": true
 		},
 		"globby": {
@@ -6746,7 +6701,7 @@
 		"got": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
-			"integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
+			"integrity": "sha1-a6JudfimzExrPrH+fOT+x6ushTM=",
 			"dev": true,
 			"requires": {
 				"@sindresorhus/is": "0.7.0",
@@ -6845,6 +6800,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
 			}
@@ -6873,7 +6829,7 @@
 		"has-symbol-support-x": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+			"integrity": "sha1-FAn5i8ACR9pF2mfO4KNvKC/yZFU=",
 			"dev": true
 		},
 		"has-symbols": {
@@ -6885,7 +6841,7 @@
 		"has-to-string-tag-x": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+			"integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
 			"dev": true,
 			"requires": {
 				"has-symbol-support-x": "1.4.2"
@@ -6969,7 +6925,7 @@
 		"hash.js": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
 			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
@@ -6979,7 +6935,7 @@
 		"hawk": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
 			"dev": true,
 			"requires": {
 				"boom": "4.3.1",
@@ -7048,7 +7004,7 @@
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
 			"dev": true,
 			"requires": {
 				"whatwg-encoding": "1.0.3"
@@ -7071,7 +7027,7 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+			"integrity": "sha1-ObDhat2bYFvwqe89nar0hDtMrNI=",
 			"dev": true
 		},
 		"http-signature": {
@@ -7104,7 +7060,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7120,7 +7076,7 @@
 		"ieee754": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-			"integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+			"integrity": "sha1-wWOE/+APW3g1gk5ntvK9RKUilFU=",
 			"dev": true
 		},
 		"iferr": {
@@ -7137,7 +7093,7 @@
 		"import-local": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"integrity": "sha1-Xk/9wD9P5sAJxnKb6yljHC+CJ7w=",
 			"dev": true,
 			"requires": {
 				"pkg-dir": "2.0.0",
@@ -7215,12 +7171,12 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.0.0",
@@ -7398,7 +7354,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
 			"dev": true
 		},
 		"is-builtin-module": {
@@ -7418,7 +7374,7 @@
 		"is-ci": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"integrity": "sha1-JH5BYueGDOu9rzC3dNawrH3P56U=",
 			"dev": true,
 			"requires": {
 				"ci-info": "1.1.2"
@@ -7584,7 +7540,7 @@
 		"is-odd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
 			"dev": true,
 			"requires": {
 				"is-number": "4.0.0"
@@ -7593,7 +7549,7 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
 					"dev": true
 				}
 			}
@@ -7631,7 +7587,7 @@
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
 			"dev": true,
 			"requires": {
 				"isobject": "3.0.1"
@@ -7681,7 +7637,7 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
 			"dev": true
 		},
 		"is-retry-allowed": {
@@ -7864,7 +7820,7 @@
 		"istanbul-lib-source-maps": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"integrity": "sha1-IPtUsU4Us/tu22rKNXH9IUPbROY=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
@@ -7877,7 +7833,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7897,7 +7853,7 @@
 		"istextorbinary": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
-			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
+			"integrity": "sha1-pSMaCO9t0ismjQiVCEz41Ytb7FM=",
 			"dev": true,
 			"requires": {
 				"binaryextensions": "2.1.1",
@@ -7908,7 +7864,7 @@
 		"isurl": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+			"integrity": "sha1-sn9PSfPNqj6kSgpbfzRi5u3DnWc=",
 			"dev": true,
 			"requires": {
 				"has-to-string-tag-x": "1.4.1",
@@ -8045,7 +8001,7 @@
 				"yargs": {
 					"version": "10.1.2",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+					"integrity": "sha1-RU0HTCsWpRpD4vt4B+T53mnMtcU=",
 					"dev": true,
 					"requires": {
 						"cliui": "4.0.0",
@@ -8065,7 +8021,7 @@
 				"yargs-parser": {
 					"version": "8.1.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
 					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
@@ -8220,7 +8176,7 @@
 		"jest-enzyme": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/jest-enzyme/-/jest-enzyme-4.2.0.tgz",
-			"integrity": "sha512-nna99NnU6sDbWqVX0153c81RUuxI/spTgw4Xobh049NcKihu0OAtAawbuSzZUnlCqdZOoXlKMudfjUPm0sCTsg==",
+			"integrity": "sha1-0oRQa22H4HK/bSeGWElwu0LqWWk=",
 			"dev": true,
 			"requires": {
 				"enzyme-matchers": "4.2.0",
@@ -8599,7 +8555,7 @@
 				"yargs": {
 					"version": "10.1.2",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+					"integrity": "sha1-RU0HTCsWpRpD4vt4B+T53mnMtcU=",
 					"dev": true,
 					"requires": {
 						"cliui": "4.0.0",
@@ -8619,7 +8575,7 @@
 				"yargs-parser": {
 					"version": "8.1.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
 					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
@@ -8802,7 +8758,7 @@
 		"js-base64": {
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+			"integrity": "sha1-LlRewrDylX9BNWUQIFIU6Y+tZYI=",
 			"dev": true
 		},
 		"js-beautify": {
@@ -8841,7 +8797,7 @@
 		"jscodeshift": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.0.tgz",
-			"integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
+			"integrity": "sha1-vbe2zCDdYsFqpyjD+i0v5mynx0g=",
 			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0",
@@ -8887,7 +8843,7 @@
 				"colors": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-					"integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+					"integrity": "sha1-9KPTApdqrwQjVroa3jsaLGLZ15Q=",
 					"dev": true
 				},
 				"nomnom": {
@@ -8962,7 +8918,7 @@
 				"parse5": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+					"integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
 					"dev": true
 				}
 			}
@@ -9057,7 +9013,7 @@
 		"keyv": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+			"integrity": "sha1-RJI7o55osSp87H32wyaMAx8u83M=",
 			"dev": true,
 			"requires": {
 				"json-buffer": "3.0.0"
@@ -9308,7 +9264,7 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+			"integrity": "sha1-maktZcAnLevoyWtgV7yPv6O+1RE="
 		},
 		"lodash-es": {
 			"version": "4.17.5",
@@ -9349,11 +9305,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
-		},
-		"lodash.cond": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
@@ -9409,13 +9360,13 @@
 		"lodash.merge": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+			"integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ=",
 			"dev": true
 		},
 		"lodash.mergewith": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+			"integrity": "sha1-Y5BX5ybDr72z59QnQcqo1uQzWSc=",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -9439,7 +9390,7 @@
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
 			"dev": true,
 			"requires": {
 				"chalk": "2.3.2"
@@ -9448,7 +9399,7 @@
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
@@ -9552,7 +9503,7 @@
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
 			"dev": true
 		},
 		"lru-cache": {
@@ -9572,7 +9523,7 @@
 		"make-dir": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"integrity": "sha1-bWpJ7q1KrilsU7vzoaAIvWyJRps=",
 			"dev": true,
 			"requires": {
 				"pify": "3.0.0"
@@ -9742,7 +9693,7 @@
 		"memize": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/memize/-/memize-1.0.5.tgz",
-			"integrity": "sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg=="
+			"integrity": "sha1-UdiehAdkPbyMq5jG1WuIn5o5VOM="
 		},
 		"memory-fs": {
 			"version": "0.4.1",
@@ -9872,7 +9823,7 @@
 		"miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
 			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
@@ -9882,7 +9833,7 @@
 		"mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
 			"dev": true
 		},
 		"mime-db": {
@@ -9903,7 +9854,7 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
 		},
 		"mimic-response": {
 			"version": "1.0.0",
@@ -9926,7 +9877,7 @@
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"requires": {
 				"brace-expansion": "1.1.8"
 			}
@@ -9939,7 +9890,7 @@
 		"mississippi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"integrity": "sha1-NEKlCPr8KFAEhv7qmUCWduTuWm8=",
 			"dev": true,
 			"requires": {
 				"concat-stream": "1.6.0",
@@ -9957,7 +9908,7 @@
 		"mixin-deep": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
 			"dev": true,
 			"requires": {
 				"for-in": "1.0.2",
@@ -9967,7 +9918,7 @@
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
@@ -10004,7 +9955,7 @@
 		"moment": {
 			"version": "2.21.0",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+			"integrity": "sha1-KhFLUdKm7J5tg8+AP4OKh42KAjo="
 		},
 		"moment-timezone": {
 			"version": "0.5.13",
@@ -10036,7 +9987,8 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"multimatch": {
 			"version": "2.1.0",
@@ -10065,7 +10017,7 @@
 		"nanomatch": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
 			"dev": true,
 			"requires": {
 				"arr-diff": "4.0.0",
@@ -10143,7 +10095,7 @@
 		"nice-try": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+			"integrity": "sha1-2Tli9sUvLBVYwPvabVEoGfHv4cQ=",
 			"dev": true
 		},
 		"node-dir": {
@@ -10155,7 +10107,7 @@
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
 			"requires": {
 				"encoding": "0.1.12",
 				"is-stream": "1.1.0"
@@ -10191,7 +10143,7 @@
 		"node-libs-browser": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+			"integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
 			"dev": true,
 			"requires": {
 				"assert": "1.4.1",
@@ -10222,7 +10174,7 @@
 		"node-notifier": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"integrity": "sha1-+jE90I9VF9sOJQLldY1mSsafneo=",
 			"dev": true,
 			"requires": {
 				"growly": "1.3.0",
@@ -10242,7 +10194,7 @@
 		"node-sass": {
 			"version": "4.7.2",
 			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-			"integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
+			"integrity": "sha1-k2Z3i6FGnrAUOKnoWS9CYry2eU4=",
 			"dev": true,
 			"requires": {
 				"async-foreach": "0.1.3",
@@ -10446,7 +10398,7 @@
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
 			"requires": {
 				"hosted-git-info": "2.5.0",
 				"is-builtin-module": "1.0.0",
@@ -10492,7 +10444,7 @@
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
 			"dev": true,
 			"requires": {
 				"are-we-there-yet": "1.1.4",
@@ -10606,7 +10558,7 @@
 		"object-inspect": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
-			"integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
+			"integrity": "sha1-nYdsEeQPSFx5IVZwKBt2dIj5v+M=",
 			"dev": true
 		},
 		"object-is": {
@@ -10641,7 +10593,7 @@
 		"object.assign": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
 			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
@@ -10815,7 +10767,7 @@
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
 			"requires": {
 				"execa": "0.7.0",
 				"lcid": "1.0.0",
@@ -10873,7 +10825,7 @@
 		"p-limit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
 			"requires": {
 				"p-try": "1.0.0"
 			}
@@ -10889,7 +10841,7 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
 			"dev": true
 		},
 		"p-reduce": {
@@ -10901,7 +10853,7 @@
 		"p-timeout": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"integrity": "sha1-2N0ZeVldLcATnh/ka4tkbLPN8Dg=",
 			"dev": true,
 			"requires": {
 				"p-finally": "1.0.0"
@@ -10915,7 +10867,7 @@
 		"pako": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+			"integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg=",
 			"dev": true
 		},
 		"parallel-transform": {
@@ -10971,7 +10923,7 @@
 		"parse5": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+			"integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
 			"dev": true,
 			"requires": {
 				"@types/node": "9.4.6"
@@ -10999,6 +10951,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
 			"requires": {
 				"pinkie-promise": "2.0.1"
 			}
@@ -11055,7 +11008,7 @@
 		"pegjs-loader": {
 			"version": "0.5.4",
 			"resolved": "https://registry.npmjs.org/pegjs-loader/-/pegjs-loader-0.5.4.tgz",
-			"integrity": "sha512-ViH8WwUkc/N8H59zuarORrgCi7uxn+gDIq+Ydriw1GFJi/oUg2xvhsgDDujO6dAxRsxXMgqWESx6TKYIqHorqA==",
+			"integrity": "sha1-OSHta0VOgtNgKbiWzsb4psL2sJg=",
 			"dev": true,
 			"requires": {
 				"loader-utils": "0.2.17"
@@ -11101,40 +11054,34 @@
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
-			}
-		},
-		"pkg-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-			"requires": {
-				"find-up": "1.1.2"
 			}
 		},
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
 			"dev": true
 		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
 			"dev": true
 		},
 		"popper.js": {
-			"version": "1.12.9",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
-			"integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+			"integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -11294,7 +11241,7 @@
 		"postcss-loader": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.3.tgz",
-			"integrity": "sha512-RuBcNE8rjCkIB0IsbmkGFRmQJTeQJfCI88E0VTarPNTvaNSv9OFv1DvTwgtAN/qlzyiELsmmmtX/tEzKp/cdug==",
+			"integrity": "sha1-6yENpzTkdaJE92zNYfmGD1uz7gk=",
 			"dev": true,
 			"requires": {
 				"loader-utils": "1.1.0",
@@ -11625,7 +11572,7 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
 			"dev": true
 		},
 		"process": {
@@ -11648,7 +11595,7 @@
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -11706,7 +11653,7 @@
 		"pump": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "1.4.1",
@@ -11716,7 +11663,7 @@
 		"pumpify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
-			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"integrity": "sha1-gLfF334kFT0D8OesigWl0Gi9B/s=",
 			"dev": true,
 			"requires": {
 				"duplexify": "3.5.4",
@@ -11733,7 +11680,7 @@
 		"puppeteer": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.2.0.tgz",
-			"integrity": "sha512-4sY/6mB7+kNPGAzPGKq65tH0VG3ohUEkXHuOReB9K/tw3m1TqifYmxnMR/uDeci/UPwyk5K1gWYh8rw0U0Zscw==",
+			"integrity": "sha1-aoocYYrwc9/Pb8fH48EuVBKf+pg=",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -11749,7 +11696,7 @@
 				"ws": {
 					"version": "3.3.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+					"integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
 					"dev": true,
 					"requires": {
 						"async-limiter": "1.0.0",
@@ -11768,7 +11715,7 @@
 		"qs": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+			"integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
 			"dev": true
 		},
 		"query-string": {
@@ -11801,7 +11748,7 @@
 		"raf": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-			"integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+			"integrity": "sha1-ooh2iBtLwsqRF9QTgWPduA94FXU=",
 			"dev": true,
 			"requires": {
 				"performance-now": "2.1.0"
@@ -11816,7 +11763,7 @@
 		"randexp": {
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
 			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
@@ -11826,7 +11773,7 @@
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
 			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
@@ -11867,7 +11814,7 @@
 		"randombytes": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"integrity": "sha1-0wLFIpSFiISKjTAMkytEwkIx2oA=",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
@@ -11876,7 +11823,7 @@
 		"randomfill": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
 			"dev": true,
 			"requires": {
 				"randombytes": "2.0.6",
@@ -11892,7 +11839,7 @@
 		"re-resizable": {
 			"version": "4.4.8",
 			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.4.8.tgz",
-			"integrity": "sha512-5Nm4FL5wz41/5SYz8yJIM1kCcftxNPXxv3Yfa5qhkrGasHPgYzmzbbu1pcYM9vuCHog79EVwKWuz7zxDH52Gfw=="
+			"integrity": "sha1-HH7t/Zue0fg7Ot+nqXzadogeTlc="
 		},
 		"react": {
 			"version": "16.3.0",
@@ -11908,7 +11855,7 @@
 				"prop-types": {
 					"version": "15.6.1",
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+					"integrity": "sha1-NmREU1ZCVd3aORGR+zoSXL32VMo=",
 					"requires": {
 						"fbjs": "0.8.16",
 						"loose-envify": "1.3.1",
@@ -11938,7 +11885,7 @@
 		"react-color": {
 			"version": "2.13.4",
 			"resolved": "https://registry.npmjs.org/react-color/-/react-color-2.13.4.tgz",
-			"integrity": "sha512-rNJTTxMPTImI1NpFaKLggDIvHgKOYRXj0krVh8c+Mo1YNsrLko8O94yiFqqdnSQgtIPteiAcGEJgBo9V5+uqaw==",
+			"integrity": "sha1-Q/HMXgtjrDfJuxkqO9zmWxUfbDU=",
 			"requires": {
 				"lodash": "4.17.5",
 				"material-colors": "1.2.5",
@@ -11948,39 +11895,20 @@
 			}
 		},
 		"react-datepicker": {
-			"version": "0.61.0",
-			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-0.61.0.tgz",
-			"integrity": "sha512-FJnqJCbYaU1ca7Jn9LaJ7iKTYHKAskVkVHCsOBDQd8vJZrESLAu3rtPbj3T6IB++dQO7qb0IlcCXtmC0geIAGA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-1.4.1.tgz",
+			"integrity": "sha512-O/ExTWLS81pyWJWLFg1BRQEr9S/BDd6iMEkGctxQmVrRw2srW8DNdnQm5UgFNu8LoSZGMDvI55OghYZvDpWJhw==",
 			"requires": {
 				"classnames": "2.2.5",
-				"eslint-plugin-import": "2.8.0",
-				"eslint-plugin-node": "5.2.1",
-				"moment": "2.20.1",
-				"prop-types": "15.6.0",
+				"prop-types": "15.6.1",
 				"react-onclickoutside": "6.7.1",
-				"react-popper": "0.7.5"
+				"react-popper": "0.9.5"
 			},
 			"dependencies": {
-				"eslint-plugin-node": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
-					"integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
-					"requires": {
-						"ignore": "3.3.7",
-						"minimatch": "3.0.4",
-						"resolve": "1.5.0",
-						"semver": "5.3.0"
-					}
-				},
-				"moment": {
-					"version": "2.20.1",
-					"resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-					"integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
-				},
 				"prop-types": {
-					"version": "15.6.0",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+					"version": "15.6.1",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
 						"fbjs": "0.8.16",
 						"loose-envify": "1.3.1",
@@ -12003,7 +11931,7 @@
 				"prop-types": {
 					"version": "15.6.1",
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+					"integrity": "sha1-NmREU1ZCVd3aORGR+zoSXL32VMo=",
 					"requires": {
 						"fbjs": "0.8.16",
 						"loose-envify": "1.3.1",
@@ -12024,18 +11952,30 @@
 			"integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg=="
 		},
 		"react-popper": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
-			"integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
+			"version": "0.9.5",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.9.5.tgz",
+			"integrity": "sha1-AqJO8+7DOvnlToNYq3DrDjMe3QU=",
 			"requires": {
-				"popper.js": "1.12.9",
-				"prop-types": "15.5.10"
+				"popper.js": "1.14.3",
+				"prop-types": "15.6.1"
+			},
+			"dependencies": {
+				"prop-types": {
+					"version": "15.6.1",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+					"requires": {
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
+					}
+				}
 			}
 		},
 		"react-reconciler": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.7.0.tgz",
-			"integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
+			"integrity": "sha1-lhSJQQPl8Tje7rXquvPugOsdAm0=",
 			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
@@ -12072,7 +12012,7 @@
 				"prop-types": {
 					"version": "15.6.1",
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+					"integrity": "sha1-NmREU1ZCVd3aORGR+zoSXL32VMo=",
 					"dev": true,
 					"requires": {
 						"fbjs": "0.8.16",
@@ -12085,7 +12025,7 @@
 		"reactcss": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-			"integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+			"integrity": "sha1-wAATh15Vexzw39mjaKHD2rO1SN0=",
 			"requires": {
 				"lodash": "4.17.5"
 			}
@@ -12166,7 +12106,7 @@
 		"realpath-native": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
-			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"integrity": "sha1-eIVyGoO0O9Uydgnw3eyySCMF/fA=",
 			"dev": true,
 			"requires": {
 				"util.promisify": "1.0.0"
@@ -12175,7 +12115,7 @@
 		"recast": {
 			"version": "0.14.7",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.14.7.tgz",
-			"integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
+			"integrity": "sha1-TxSXwrWCbUKmbo48nYDFEpg/9h0=",
 			"dev": true,
 			"requires": {
 				"ast-types": "0.11.3",
@@ -12187,7 +12127,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				}
 			}
@@ -12250,7 +12190,7 @@
 		"redux": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"integrity": "sha1-BrcxIyFZAdJdBlvjQusCa8HIU3s=",
 			"requires": {
 				"lodash": "4.17.5",
 				"lodash-es": "4.17.5",
@@ -12266,29 +12206,29 @@
 		"redux-optimist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/redux-optimist/-/redux-optimist-1.0.0.tgz",
-			"integrity": "sha512-AG1v8o6UZcGXTEH2jVcWG6KD+gEix+Cj9JXAAzln9MPkauSVd98H7N7EOOyT/v4c9N1mJB4sm1zfspGlLDkUEw=="
+			"integrity": "sha1-Hz1P+80RVzFZu5DpbGjjXjuHWBg="
 		},
 		"refx": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/refx/-/refx-3.0.0.tgz",
-			"integrity": "sha512-qmd73YvYiVWfKPECtE90ujmPwwtAnmtEOkBKgfNEuqJ4trTeKbqFV2UY878yFvHBvU7BBu4/w/Q8pk/t0zDpYA=="
+			"integrity": "sha1-tlj0lcvYQibY+plOQiTq2aex37U="
 		},
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"integrity": "sha1-DDNtOYBVPXVcObWGrjsgqknIK38=",
 			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
 			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
 			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
@@ -12299,7 +12239,7 @@
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
 			"dev": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
@@ -12308,7 +12248,7 @@
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "3.0.2",
@@ -12344,7 +12284,7 @@
 		"rememo": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/rememo/-/rememo-2.4.0.tgz",
-			"integrity": "sha512-4rqlLATPcha9lfdvylUWqSbceiTlYiBJvEJAyUiT/68cYPlNG1zXf7ABeve7s4YPrT6o3Q6zfN6n38ecAL71lw==",
+			"integrity": "sha1-t1AohRQ1znBKAf4kQpx0Ai+GmYc=",
 			"requires": {
 				"shallow-equal": "1.0.0"
 			}
@@ -12469,7 +12409,7 @@
 		"requireindex": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
+			"integrity": "sha1-NGPNsi7hUZAmNapslTXU3pwu8e8="
 		},
 		"resolve": {
 			"version": "1.5.0",
@@ -12532,7 +12472,7 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
 			"dev": true
 		},
 		"right-align": {
@@ -12548,7 +12488,7 @@
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
 			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
@@ -12577,7 +12517,7 @@
 		"rtlcss": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.2.1.tgz",
-			"integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
+			"integrity": "sha1-+FN+QVUggWawXhiYAhMZNvzv0p4=",
 			"dev": true,
 			"requires": {
 				"chalk": "2.3.0",
@@ -12879,7 +12819,7 @@
 		"sass-loader": {
 			"version": "6.0.7",
 			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
-			"integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
+			"integrity": "sha1-3S/bPn7v9KU/NbpqxAhxVIg1PQA=",
 			"dev": true,
 			"requires": {
 				"clone-deep": "2.0.2",
@@ -12900,13 +12840,13 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
 			"dev": true
 		},
 		"schema-utils": {
 			"version": "0.4.5",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
-			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+			"integrity": "sha1-IYNvBgiqwXt4+ePiTa/xSlyhOj4=",
 			"dev": true,
 			"requires": {
 				"ajv": "6.4.0",
@@ -12990,7 +12930,7 @@
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "2.0.1",
@@ -13018,7 +12958,7 @@
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
 			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
@@ -13028,7 +12968,7 @@
 		"shallow-clone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
-			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
+			"integrity": "sha1-RIDNBuiC72iyrYij6lSDLixItXE=",
 			"dev": true,
 			"requires": {
 				"is-extendable": "0.1.1",
@@ -13039,7 +12979,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
 					"dev": true
 				}
 			}
@@ -13065,7 +13005,7 @@
 		"shelljs": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-			"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+			"integrity": "sha1-cp4DjEE6IlTEB4uV7UbgOXFUqfE=",
 			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
@@ -13076,7 +13016,7 @@
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
 			"dev": true
 		},
 		"showdown": {
@@ -13123,7 +13063,7 @@
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
 			"dev": true,
 			"requires": {
 				"base": "0.11.2",
@@ -13216,7 +13156,7 @@
 		"snapdragon-node": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
 			"dev": true,
 			"requires": {
 				"define-property": "1.0.0",
@@ -13244,7 +13184,7 @@
 		"snapdragon-util": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
 			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
@@ -13253,7 +13193,7 @@
 		"sntp": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
 			"dev": true,
 			"requires": {
 				"hoek": "4.2.0"
@@ -13271,7 +13211,7 @@
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+			"integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU=",
 			"dev": true
 		},
 		"source-map": {
@@ -13283,7 +13223,7 @@
 		"source-map-resolve": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+			"integrity": "sha1-etD1k/IoFZjoVN+A8ZquS5LXoRo=",
 			"dev": true,
 			"requires": {
 				"atob": "2.1.0",
@@ -13305,7 +13245,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				}
 			}
@@ -13343,7 +13283,7 @@
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "3.0.2"
@@ -13374,7 +13314,7 @@
 		"ssri": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"integrity": "sha1-ujhyycbTOgcEp9cf8EXl7EiZnQY=",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
@@ -13492,7 +13432,7 @@
 		"stream-each": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+			"integrity": "sha1-joxGP5HaiZF3h2WHP+TZYNj2Fr0=",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "1.4.1",
@@ -13502,7 +13442,7 @@
 		"stream-http": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-			"integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+			"integrity": "sha1-0EQb4aRXpzpzOop7U1cL69nvZqQ=",
 			"dev": true,
 			"requires": {
 				"builtin-status-codes": "3.0.0",
@@ -13569,7 +13509,7 @@
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -13666,7 +13606,7 @@
 		"style-loader": {
 			"version": "0.20.3",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
-			"integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
+			"integrity": "sha1-6+8GuJ3sSRvLH9s0UukTpv0cEMQ=",
 			"dev": true,
 			"requires": {
 				"loader-utils": "1.1.0",
@@ -13721,7 +13661,7 @@
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+			"integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ="
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
@@ -13792,7 +13732,7 @@
 		"tapable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
-			"integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
+			"integrity": "sha1-y7Y52QAu7ZxrWXXrIFmNeTbx+fI=",
 			"dev": true
 		},
 		"tar": {
@@ -13902,7 +13842,7 @@
 		"textextensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA==",
+			"integrity": "sha1-OKxnYVEoW2WGVFgZh6DOGkSQ0oY=",
 			"dev": true
 		},
 		"throat": {
@@ -13945,7 +13885,7 @@
 		"tiny-emitter": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-			"integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
+			"integrity": "sha1-gtJ0aKylrejl/R5tIrV91D69+3w="
 		},
 		"tinycolor2": {
 			"version": "1.4.1",
@@ -13988,7 +13928,7 @@
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
 			"dev": true,
 			"requires": {
 				"define-property": "2.0.2",
@@ -14047,7 +13987,7 @@
 		"tree-kill": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-			"integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
+			"integrity": "sha1-WEZ4Yje0I5AU8F2xVrZDIS1MbzY=",
 			"dev": true
 		},
 		"trim-newlines": {
@@ -14126,7 +14066,7 @@
 		"ua-parser-js": {
 			"version": "0.7.17",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+			"integrity": "sha1-6exflJi57JEOeuOsYmqAXE0J7Kw="
 		},
 		"uglify-js": {
 			"version": "2.8.29",
@@ -14207,19 +14147,19 @@
 				"commander": {
 					"version": "2.13.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+					"integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w=",
 					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				},
 				"uglify-es": {
 					"version": "3.3.9",
 					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+					"integrity": "sha1-DBxPBwC+2NvBJM2zBNJZLKID5nc=",
 					"dev": true,
 					"requires": {
 						"commander": "2.13.0",
@@ -14231,7 +14171,7 @@
 		"ultron": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+			"integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=",
 			"dev": true
 		},
 		"underscore": {
@@ -14445,7 +14385,7 @@
 		"use": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+			"integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
 			"dev": true,
 			"requires": {
 				"kind-of": "6.0.2"
@@ -14484,7 +14424,7 @@
 		"util.promisify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
 			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
@@ -14494,12 +14434,12 @@
 		"uuid": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+			"integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
 		},
 		"v8-compile-cache": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz",
-			"integrity": "sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA==",
+			"integrity": "sha1-jTLk8Wl0ZUZX5nbg5GejSOibDcQ=",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -14623,13 +14563,13 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
 			"dev": true
 		},
 		"webpack": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.4.1.tgz",
-			"integrity": "sha512-iLUJcsEAjaPKWbB32ADr29Pg9fPUVfFEMPK4VXyZGftzhSEFg2BLjHLoBYZ14wdTEA8xqG/hjpuX8qOmabRYvw==",
+			"integrity": "sha1-sBBXiYkMKL/OnzkmI+9YUCVDKKQ=",
 			"dev": true,
 			"requires": {
 				"acorn": "5.4.1",
@@ -14932,7 +14872,7 @@
 		"webpack-addons": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
-			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
+			"integrity": "sha1-KxeN/oc/tudeQKgZ+lwm5Km8g3o=",
 			"dev": true,
 			"requires": {
 				"jscodeshift": "0.4.1"
@@ -14947,7 +14887,7 @@
 				"ast-types": {
 					"version": "0.10.1",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
+					"integrity": "sha1-9S/KlxVXmhT4QdZ9f40lQyq2o90=",
 					"dev": true
 				},
 				"async": {
@@ -14970,13 +14910,13 @@
 				"colors": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-					"integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+					"integrity": "sha1-9KPTApdqrwQjVroa3jsaLGLZ15Q=",
 					"dev": true
 				},
 				"jscodeshift": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
-					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
+					"integrity": "sha1-2pGhwuzPoDozh6IdOZSOJRztREo=",
 					"dev": true,
 					"requires": {
 						"async": "1.5.2",
@@ -15009,7 +14949,7 @@
 				"recast": {
 					"version": "0.12.9",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
-					"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+					"integrity": "sha1-6OUr25aRr0Ysy9fBXVpRE2R6FfE=",
 					"dev": true,
 					"requires": {
 						"ast-types": "0.10.1",
@@ -15022,7 +14962,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				},
 				"strip-ansi": {
@@ -15053,7 +14993,7 @@
 		"webpack-cli": {
 			"version": "2.0.13",
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.13.tgz",
-			"integrity": "sha512-0lnOi3yla8FsZVuMsbfnNRB/8DlfuDugKdekC+4ykydZG0+UOidMi5J5LLWN4c0VJ8PqC19yMXXkYyCq78OuqA==",
+			"integrity": "sha1-bivZ75E0U0RzchfiLikAGthTdRg=",
 			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
@@ -15092,7 +15032,7 @@
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
@@ -15123,7 +15063,7 @@
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
 					"dev": true,
 					"requires": {
 						"nice-try": "1.0.4",
@@ -15157,7 +15097,7 @@
 				"inquirer": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+					"integrity": "sha1-2zUMK3Paynf/EkOWLp8i8JloVyY=",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "3.0.0",
@@ -15208,7 +15148,7 @@
 				"yargs": {
 					"version": "11.0.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+					"integrity": "sha1-wFKTEAbF7udGEOX8A1S+39CKIBs=",
 					"dev": true,
 					"requires": {
 						"cliui": "4.0.0",
@@ -15269,7 +15209,7 @@
 		"webpack-sources": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+			"integrity": "sha1-oQHrrlnWUHNU1x2AE5UKOot6WlQ=",
 			"dev": true,
 			"requires": {
 				"source-list-map": "2.0.0",
@@ -15279,7 +15219,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				}
 			}
@@ -15287,7 +15227,7 @@
 		"whatwg-encoding": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"integrity": "sha1-V8I1vIZX6RTSTho5fTyC2u4Ka6M=",
 			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
@@ -15318,7 +15258,7 @@
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -15331,7 +15271,7 @@
 		"wide-align": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+			"integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
 			"dev": true,
 			"requires": {
 				"string-width": "1.0.2"
@@ -15366,7 +15306,7 @@
 		"worker-farm": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"integrity": "sha1-rsxAWXb6talVJhgIRvDboojzpKA=",
 			"dev": true,
 			"requires": {
 				"errno": "0.1.7"
@@ -15411,7 +15351,7 @@
 		"write-file-atomic": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -15433,7 +15373,7 @@
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
 			"dev": true
 		},
 		"xtend": {
@@ -15513,7 +15453,7 @@
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
@@ -15533,7 +15473,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -15605,7 +15545,7 @@
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
@@ -15625,7 +15565,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -15677,7 +15617,7 @@
 				"path-type": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
 					"dev": true,
 					"requires": {
 						"pify": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"react-autosize-textarea": "3.0.2",
 		"react-click-outside": "2.3.1",
 		"react-color": "2.13.4",
-		"react-datepicker": "0.61.0",
+		"react-datepicker": "1.4.1",
 		"react-dom": "16.3.0",
 		"redux": "3.7.2",
 		"redux-multi": "0.1.12",


### PR DESCRIPTION
## Description

As part of #6508, the `react-datepicker` component needs to be upgraded to a newer version, as the version we currently use includes dependences that have licenses incompatible with GPL2. Newer versions remove those dependencies.

## How has this been tested?

Manually in browser: comparing appearance and behaviour before and after upgrading. No differences were observed.
