### PR TITLE
Upgrade showdown to 1.8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2250,7 +2250,8 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
@@ -3105,6 +3106,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1",
@@ -3115,6 +3117,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -4499,6 +4502,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
 			}
@@ -6734,7 +6738,8 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"grouped-queue": {
 			"version": "0.3.3",
@@ -6988,7 +6993,8 @@
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"dev": true
 		},
 		"hpq": {
 			"version": "1.2.0",
@@ -7334,7 +7340,8 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -7361,6 +7368,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
@@ -9217,17 +9225,6 @@
 				}
 			}
 		},
-		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"strip-bom": "3.0.0"
-			}
-		},
 		"loader-runner": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
@@ -10399,6 +10396,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.5.0",
 				"is-builtin-module": "1.0.0",
@@ -10910,6 +10908,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
 			"requires": {
 				"error-ex": "1.3.1"
 			}
@@ -10978,14 +10977,6 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
 			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
 		},
-		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-			"requires": {
-				"pify": "2.3.0"
-			}
-		},
 		"pbkdf2": {
 			"version": "3.0.14",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
@@ -11049,7 +11040,8 @@
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
@@ -11949,7 +11941,7 @@
 		"react-onclickoutside": {
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
-			"integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg=="
+			"integrity": "sha1-altbi06ua3diWXEsiciis2sXvpM="
 		},
 		"react-popper": {
 			"version": "0.9.5",
@@ -12045,35 +12037,6 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
-				}
-			}
-		},
-		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-			"requires": {
-				"load-json-file": "2.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "2.0.0"
-			}
-		},
-		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-			"requires": {
-				"find-up": "2.1.0",
-				"read-pkg": "2.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "2.0.0"
-					}
 				}
 			}
 		},
@@ -13020,11 +12983,11 @@
 			"dev": true
 		},
 		"showdown": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.7.4.tgz",
-			"integrity": "sha1-a7yd0s2x5f3XSeza3GpHuFZZSuA=",
+			"version": "1.8.6",
+			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
+			"integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
 			"requires": {
-				"yargs": "8.0.2"
+				"yargs": "10.1.2"
 			}
 		},
 		"sigmund": {
@@ -13266,6 +13229,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"dev": true,
 			"requires": {
 				"spdx-license-ids": "1.2.2"
 			}
@@ -13273,12 +13237,14 @@
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
 		},
 		"split-string": {
 			"version": "3.1.0",
@@ -13560,7 +13526,8 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-bom-stream": {
 			"version": "2.0.0",
@@ -14446,6 +14413,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
@@ -15393,29 +15361,61 @@
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"requires": {
-				"camelcase": "4.1.0",
-				"cliui": "3.2.0",
+				"cliui": "4.1.0",
 				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
 				"get-caller-file": "1.0.2",
 				"os-locale": "2.1.0",
-				"read-pkg-up": "2.0.0",
 				"require-directory": "2.1.1",
 				"require-main-filename": "1.0.1",
 				"set-blocking": "2.0.0",
 				"string-width": "2.1.1",
 				"which-module": "2.0.0",
 				"y18n": "3.2.1",
-				"yargs-parser": "7.0.0"
+				"yargs-parser": "8.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
 			}
 		},
 		"yargs-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 			"requires": {
 				"camelcase": "4.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"redux-optimist": "1.0.0",
 		"refx": "3.0.0",
 		"rememo": "2.4.0",
-		"showdown": "1.7.4",
+		"showdown": "1.8.6",
 		"simple-html-tokenizer": "0.4.1",
 		"tinycolor2": "1.4.1",
 		"uuid": "3.1.0"


### PR DESCRIPTION
## Description

As part of #6508, the `showdown` component needs to be upgraded to a newer version, as the version we currently use includes dependences that have licenses incompatible with GPL2. Newer versions remove those dependencies.

## How has this been tested?

Pasting [this test file](https://raw.githubusercontent.com/mxstbr/markdown-test-file/master/TEST.md) into the editor, and observing if there was any changed behaviour before and after the upgrade.

