### PR TITLE
Add a license check for npm modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
     - stage: test
       script:
         - npm install || exit 1
-        - npm run license-check || exit 1
+        - ./bin/check-npm-licenses.sh || exit 1
         - npm run ci || exit 1
 
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
     - stage: test
       script:
         - npm install || exit 1
+        - npm run license-check || exit 1
         - npm run ci || exit 1
 
     - stage: test

--- a/bin/check-npm-licenses.sh
+++ b/bin/check-npm-licenses.sh
@@ -6,6 +6,7 @@
 ALLOWED_LICENSES=(
 	"GPL-2.0-or-later"
 	"GPL-2.0+"
+	"LGPL-2.1"
 	"(GPL-2.0 OR MIT)"
 	"MIT"
 	"ISC"

--- a/bin/check-npm-licenses.sh
+++ b/bin/check-npm-licenses.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Include useful functions
+. "$(dirname "$0")/includes.sh"
+
+ALLOWED_LICENSES=(
+	"GPL-2.0-or-later"
+	"GPL-2.0+"
+	"(GPL-2.0 OR MIT)"
+	"MIT"
+	"ISC"
+	"BSD"
+	"BSD-2-Clause"
+	"BSD-3-Clause"
+	"CC0-1.0"
+)
+
+FOUND_INCOMPATIBLE_MODULE=false
+
+
+for MODULE_DIR in $(npm ls --production --parseable); do
+	PACKAGE_JSON="${MODULE_DIR}/package.json"
+
+	PACKAGE_NAME=$(jq --raw-output '.name' $PACKAGE_JSON)
+	PACKAGE_LICENSE=$(jq --raw-output '( .license // .licenses[0].type )' $PACKAGE_JSON)
+
+	if ! in_array "${PACKAGE_LICENSE}" "${ALLOWED_LICENSES[@]}"; then
+		if ! $FOUND_INCOMPATIBLE_MODULE; then
+			FOUND_INCOMPATIBLE_MODULE=true;
+			echo "These modules have incompatible licences:"
+		fi
+		echo "${PACKAGE_NAME}: ${PACKAGE_LICENSE}"
+	fi
+done
+
+if ! $FOUND_INCOMPATIBLE_MODULE; then
+	echo "All module licenses are compatible."
+else
+	exit 1;
+fi

--- a/bin/includes.sh
+++ b/bin/includes.sh
@@ -132,3 +132,27 @@ action_format() {
 command_exists() {
 	type -t "$1" >/dev/null 2>&1
 }
+
+##
+# Checks if an array countains a particular value.
+#
+# @param {mixed} needle   The value to search for.
+# @param {array} haystack The array to search.
+#
+# @return bool Whether the haystack contains the needle or not.
+##
+in_array() {
+	local needle="$1";
+	shift;
+	local haystack=("$@");
+
+	local item;
+
+	for item in "${haystack[@]}"; do
+		if [ "$item" == "${needle}" ]; then
+			return 0;
+		fi
+	done
+
+	return 1;
+}

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 		"test": "npm run lint && npm run test-unit",
 		"test-php": "npm run lint-php && npm run test-unit-php",
 		"ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
-		"license-check": "! npm ls --production --parseable | xargs -I {} jq --raw-output '.name + \" \" + ( .license // .licenses[0].type )' '{}/package.json' | ag -v '^.* .*(MIT|GPL-2|ISC|BSD|CC0).*$'",
+		"license-check": "! npm ls --production --parseable | xargs -I {} jq --raw-output '.name + \" \" + ( .license // .licenses[0].type )' '{}/package.json' | grep -v -E '^.* .*(MIT|GPL-2|ISC|BSD|CC0).*$'",
 		"fixtures:clean": "rimraf \"core-blocks/test/fixtures/*.+(json|serialized.html)\"",
 		"fixtures:server-registered": "docker-compose run -w /var/www/html/wp-content/plugins/gutenberg --rm wordpress ./bin/get-server-blocks.php > core-blocks/test/server-registered.json",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 		"test": "npm run lint && npm run test-unit",
 		"test-php": "npm run lint-php && npm run test-unit-php",
 		"ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
-		"license-check": "! npm ls --production --parseable | xargs -I {} jq --raw-output '.name + \" \" + ( .license // .licenses[0].type )' '{}/package.json' | grep -v -E '^.* .*(MIT|GPL-2|ISC|BSD|CC0).*$'",
+		"check-licenses": "./bin/check-npm-licenses.sh",
 		"fixtures:clean": "rimraf \"core-blocks/test/fixtures/*.+(json|serialized.html)\"",
 		"fixtures:server-registered": "docker-compose run -w /var/www/html/wp-content/plugins/gutenberg --rm wordpress ./bin/get-server-blocks.php > core-blocks/test/server-registered.json",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 		"test": "npm run lint && npm run test-unit",
 		"test-php": "npm run lint-php && npm run test-unit-php",
 		"ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
-		"license-check": "! npm ls --production --parseable | xargs -I {} jq --raw-output '.name + \" \" + ( .license // .licenses[0].type )' '{}/package.json' | ack -v '^.* .*(MIT|GPL-2|ISC|BSD|CC0).*$'",
+		"license-check": "! npm ls --production --parseable | xargs -I {} jq --raw-output '.name + \" \" + ( .license // .licenses[0].type )' '{}/package.json' | ag -v '^.* .*(MIT|GPL-2|ISC|BSD|CC0).*$'",
 		"fixtures:clean": "rimraf \"core-blocks/test/fixtures/*.+(json|serialized.html)\"",
 		"fixtures:server-registered": "docker-compose run -w /var/www/html/wp-content/plugins/gutenberg --rm wordpress ./bin/get-server-blocks.php > core-blocks/test/server-registered.json",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
 		"test": "npm run lint && npm run test-unit",
 		"test-php": "npm run lint-php && npm run test-unit-php",
 		"ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
+		"license-check": "! npm ls --production --parseable | xargs -I {} jq --raw-output '.name + \" \" + ( .license // .licenses[0].type )' '{}/package.json' | ack -v '^.* .*(MIT|GPL-2|ISC|BSD|CC0).*$'",
 		"fixtures:clean": "rimraf \"core-blocks/test/fixtures/*.+(json|serialized.html)\"",
 		"fixtures:server-registered": "docker-compose run -w /var/www/html/wp-content/plugins/gutenberg --rm wordpress ./bin/get-server-blocks.php > core-blocks/test/server-registered.json",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",


### PR DESCRIPTION
## Description

As discussed in #6508, any modules we include must have a GPL2 compatible license. This PR adds a script and Travis check, to ensure that all modules are licensed correctly.

This PR can't be merged until the remaining issues associated with #6508 are resolved.

## How has this been tested?

- Running `npm run check-licenses` should exit with an error.
- To simulate a passing check, modify the `ALLOWED_LICENSES` array to add the failing licenses.
