### PR TITLE
Add Fixed background help text in Cover image block

### DIFF
--- a/core-blocks/cover-image/index.js
+++ b/core-blocks/cover-image/index.js
@@ -153,6 +153,7 @@ export const settings = {
 								label={ __( 'Fixed Background' ) }
 								checked={ !! hasParallax }
 								onChange={ toggleParallax }
+								help={ getFixedBackgroundHelp }
 							/>
 							<RangeControl
 								label={ __( 'Background Dimness' ) }
@@ -278,4 +279,8 @@ function backgroundImageStyles( url ) {
 	return url ?
 		{ backgroundImage: `url(${ url })` } :
 		undefined;
+}
+
+function getFixedBackgroundHelp( checked ) {
+	return checked ? __( 'The background does not move with the element' ) : __( 'The background scrolls with the element.' );
 }


### PR DESCRIPTION
## Description
Adds Fixed background help text as mentioned in #2146.

## How has this been tested?
- Run `npm test` without errors.
- Tested toggling the Fixed backgroundp in several Cover image blocks.

## Types of changes
Adds help text under Fixed background in Cover image block. 

## Screenshots

### Toggle off

<img width="265" alt="fixed-background-toggle-off" src="https://user-images.githubusercontent.com/1820415/39578272-65eb3c0c-4eec-11e8-8a8a-605888460cad.png">

### Toggle on

<img width="261" alt="fixed-background-toggle-on" src="https://user-images.githubusercontent.com/1820415/39578289-6e3894f4-4eec-11e8-827f-2a74fd7ce216.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
