### PR TITLE
Add Display post date help text in Latest posts block

### DIFF
--- a/core-blocks/latest-posts/block.js
+++ b/core-blocks/latest-posts/block.js
@@ -50,6 +50,10 @@ class LatestPostsBlock extends Component {
 		setAttributes( { displayPostDate: ! displayPostDate } );
 	}
 
+	getDisplayPostDateHelp( checked ) {
+		return checked ? __( 'Showing post date.' ) : __( 'Toggle to show post date.' );
+	}
+
 	render() {
 		const latestPosts = this.props.latestPosts.data;
 		const { attributes, categoriesList, setAttributes } = this.props;
@@ -72,6 +76,7 @@ class LatestPostsBlock extends Component {
 						label={ __( 'Display post date' ) }
 						checked={ displayPostDate }
 						onChange={ this.toggleDisplayPostDate }
+						help={ this.getDisplayPostDateHelp }
 					/>
 					{ postLayout === 'grid' &&
 						<RangeControl


### PR DESCRIPTION
## Description
Adds Display post date help text in Latest posts block as mentioned in #2146.

## How has this been tested?
- Run `npm test` without errors.
- Tested toggling the Display post date help text in several Latest posts blocks.

## Types of changes
Adds Display post date help text in Latest posts block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
