### PR TITLE
Add Hide teaser help text in More block

### DIFF
--- a/core-blocks/more/index.js
+++ b/core-blocks/more/index.js
@@ -110,6 +110,7 @@ export const settings = {
 								label={ __( 'Hide the teaser before the "More" tag' ) }
 								checked={ !! noTeaser }
 								onChange={ toggleNoTeaser }
+								help={ getHideTeaserHelp }
 							/>
 						</PanelBody>
 					</InspectorControls>
@@ -144,3 +145,7 @@ export const settings = {
 		);
 	},
 };
+
+function getHideTeaserHelp( checked ) {
+	return checked ? __( 'Hiding the content before the "More" tag in single post.' ) : __( 'Toggle to hide content before the "More" tag in single post.' );
+}

--- a/core-blocks/more/index.js
+++ b/core-blocks/more/index.js
@@ -107,7 +107,7 @@ export const settings = {
 					<InspectorControls>
 						<PanelBody>
 							<ToggleControl
-								label={ __( 'Hide the teaser before the "More" tag' ) }
+								label={ __( 'Hide intro content' ) }
 								checked={ !! noTeaser }
 								onChange={ toggleNoTeaser }
 								help={ getHideTeaserHelp }
@@ -147,5 +147,5 @@ export const settings = {
 };
 
 function getHideTeaserHelp( checked ) {
-	return checked ? __( 'Hiding the content before the "More" tag in single post.' ) : __( 'Toggle to hide content before the "More" tag in single post.' );
+	return checked ? __( 'Hiding the content before the "More" tag on single post.' ) : __( 'Toggle to hide content before the "More" tag on single post.' );
 }


### PR DESCRIPTION
## Description
Adds Hide teaser help text in More block as mentioned in #2146.

## How has this been tested?
- Run `npm test` without errors.
- Tested toggling the Hide teaser help in More block.

## Types of changes
Adds Hide teaser help text in More block.

## Screenshots

### Toggle off

<img width="265" alt="hide-teaser-toggle-off" src="https://user-images.githubusercontent.com/1820415/39580665-4ba2cff8-4ef2-11e8-9482-00430ac781a7.png">

### Toggle on

<img width="265" alt="hide-teaser-toggle-on" src="https://user-images.githubusercontent.com/1820415/39580672-507c2952-4ef2-11e8-9f0b-d4faf22daa7d.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
