### PR TITLE
Revert "Removed block transforms from the toolbars. #6473"

### DIFF
--- a/edit-post/components/header/header-toolbar/index.js
+++ b/edit-post/components/header/header-toolbar/index.js
@@ -15,6 +15,7 @@ import {
 	TableOfContents,
 	EditorHistoryRedo,
 	EditorHistoryUndo,
+	MultiBlocksSwitcher,
 	NavigableToolbar,
 } from '@wordpress/editor';
 
@@ -33,6 +34,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport } ) {
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents />
+			<MultiBlocksSwitcher />
 			{ hasFixedToolbar && isLargeViewport && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar />

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu } from '@wordpress/components';
+import { getBlockType, getPossibleBlockTransformations, switchToBlockType, BlockIcon, withEditorSettings } from '@wordpress/blocks';
+import { compose } from '@wordpress/element';
+import { keycodes } from '@wordpress/utils';
+import { withSelect, withDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Module Constants
+ */
+const { DOWN } = keycodes;
+
+export function BlockSwitcher( { blocks, onTransform, isLocked } ) {
+	const allowedBlocks = getPossibleBlockTransformations( blocks );
+
+	if ( isLocked || ! allowedBlocks.length ) {
+		return null;
+	}
+
+	const sourceBlockName = blocks[ 0 ].name;
+	const blockType = getBlockType( sourceBlockName );
+
+	return (
+		<Dropdown
+			className="editor-block-switcher"
+			contentClassName="editor-block-switcher__popover"
+			renderToggle={ ( { onToggle, isOpen } ) => {
+				const openOnArrowDown = ( event ) => {
+					if ( ! isOpen && event.keyCode === DOWN ) {
+						event.preventDefault();
+						event.stopPropagation();
+						onToggle();
+					}
+				};
+				const label = __( 'Change block type' );
+
+				return (
+					<Toolbar>
+						<IconButton
+							className="editor-block-switcher__toggle"
+							icon={ <BlockIcon icon={ blockType.icon } /> }
+							onClick={ onToggle }
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							label={ label }
+							tooltip={ label }
+							onKeyDown={ openOnArrowDown }
+						>
+							<Dashicon icon="arrow-down" />
+						</IconButton>
+					</Toolbar>
+				);
+			} }
+			renderContent={ ( { onClose } ) => (
+				<div>
+					<span
+						className="editor-block-switcher__menu-title"
+					>
+						{ __( 'Transform into:' ) }
+					</span>
+					<NavigableMenu
+						role="menu"
+						aria-label={ __( 'Block types' ) }
+					>
+						{ allowedBlocks.map( ( { name, title, icon } ) => (
+							<IconButton
+								key={ name }
+								onClick={ () => {
+									onTransform( blocks, name );
+									onClose();
+								} }
+								className="editor-block-switcher__menu-item"
+								icon={ (
+									<span className="editor-block-switcher__block-icon">
+										<BlockIcon icon={ icon } />
+									</span>
+								) }
+								role="menuitem"
+							>
+								{ title }
+							</IconButton>
+						) ) }
+					</NavigableMenu>
+				</div>
+			) }
+		/>
+	);
+}
+
+export default compose(
+	withSelect( ( select, ownProps ) => {
+		return {
+			blocks: ownProps.uids.map( ( uid ) => select( 'core/editor' ).getBlock( uid ) ),
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => ( {
+		onTransform( blocks, name ) {
+			dispatch( 'core/editor' ).replaceBlocks(
+				ownProps.uids,
+				switchToBlockType( blocks, name )
+			);
+		},
+	} ) ),
+	withEditorSettings( ( settings ) => {
+		const { templateLock } = settings;
+
+		return {
+			isLocked: !! templateLock,
+		};
+	} ),
+)( BlockSwitcher );

--- a/editor/components/block-switcher/multi-blocks-switcher.js
+++ b/editor/components/block-switcher/multi-blocks-switcher.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import BlockSwitcher from './';
+
+export function MultiBlocksSwitcher( { isMultiBlockSelection, selectedBlockUids } ) {
+	if ( ! isMultiBlockSelection ) {
+		return null;
+	}
+	return (
+		<BlockSwitcher key="switcher" uids={ selectedBlockUids } />
+	);
+}
+
+export default withSelect(
+	( select ) => {
+		const selectedBlockUids = select( 'core/editor' ).getMultiSelectedBlockUids();
+		return {
+			isMultiBlockSelection: selectedBlockUids.length > 1,
+			selectedBlockUids,
+		};
+	}
+)( MultiBlocksSwitcher );

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -1,0 +1,52 @@
+.editor-block-switcher {
+	position: relative;
+
+	.components-toolbar {
+		border-left: none;
+	}
+}
+
+.editor-block-switcher__toggle {
+	width: auto;
+	margin: 0;
+	padding: 8px;
+	border-radius: 0;
+
+	&:focus:before {
+		top: -3px;
+		right: -3px;
+		bottom: -3px;
+		left: -3px;
+	}
+}
+
+.editor-block-switcher__popover .components-popover__content {
+	width: 200px;
+}
+
+.editor-block-switcher__menu {
+	box-shadow: $shadow-popover;
+	border: 1px solid $light-gray-500;
+	background: $white;
+	padding: 3px 3px 0;
+}
+
+.editor-block-switcher__menu-title {
+	display: block;
+	padding: 6px;
+	color: $dark-gray-300;
+}
+
+.editor-block-switcher__menu-item {
+	color: $dark-gray-500;
+	display: flex;
+	align-items: center;
+	width: 100%;
+	padding: 6px;
+	text-align: left;
+
+	.editor-block-switcher__block-icon {
+		margin-right: 8px;
+		height: 20px;
+	}
+}

--- a/editor/components/block-switcher/test/__snapshots__/index.js.snap
+++ b/editor/components/block-switcher/test/__snapshots__/index.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BlockSwitcher should render switcher with blocks 1`] = `
+<Dropdown
+  className="editor-block-switcher"
+  contentClassName="editor-block-switcher__popover"
+  renderContent={[Function]}
+  renderToggle={[Function]}
+/>
+`;

--- a/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
+++ b/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MultiBlocksSwitcher should return a BlockSwitcher element matching the snapshot. 1`] = `
+<WithSelect(WithDispatch(WithEditorSettings(BlockSwitcher)))
+  key="switcher"
+  uids={
+    Array [
+      "an-uid",
+      "another-uid",
+    ]
+  }
+/>
+`;

--- a/editor/components/block-switcher/test/index.js
+++ b/editor/components/block-switcher/test/index.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/core-blocks';
+import { keycodes } from '@wordpress/utils';
+
+/**
+ * Internal dependencies
+ */
+import { BlockSwitcher } from '../';
+
+const { DOWN } = keycodes;
+
+describe( 'BlockSwitcher', () => {
+	const headingBlock1 = {
+		attributes: {
+			content: [ 'How are you?' ],
+			nodeName: 'H2',
+		},
+		isValid: true,
+		name: 'core/heading',
+		originalContent: '<h2>How are you?</h2>',
+		uid: 'a1303fd6-3e60-4fff-a770-0e0ea656c5b9',
+	};
+
+	const textBlock = {
+		attributes: {
+			content: [ 'I am great!' ],
+			nodeName: 'P',
+		},
+		isValid: true,
+		name: 'core/text',
+		originalContent: '<p>I am great!</p>',
+		uid: 'b1303fdb-3e60-43faf-a770-2e1ea656c5b8',
+	};
+
+	const headingBlock2 = {
+		attributes: {
+			content: [ 'I am the greatest!' ],
+			nodeName: 'H3',
+		},
+		isValid: true,
+		name: 'core/text',
+		originalContent: '<h3>I am the greatest!</h3>',
+		uid: 'c2403fd2-4e63-5ffa-b71c-1e0ea656c5b0',
+	};
+
+	beforeAll( () => {
+		registerCoreBlocks();
+	} );
+
+	test( 'should not render block switcher without blocks', () => {
+		const wrapper = shallow( <BlockSwitcher /> );
+
+		expect( wrapper.html() ).toBeNull();
+	} );
+
+	test( 'should render switcher with blocks', () => {
+		const blocks = [
+			headingBlock1,
+		];
+		const wrapper = shallow( <BlockSwitcher blocks={ blocks } /> );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should not render block switcher with multi block of different types.', () => {
+		const blocks = [
+			headingBlock1,
+			textBlock,
+		];
+		const wrapper = shallow( <BlockSwitcher blocks={ blocks } /> );
+
+		expect( wrapper.html() ).toBeNull();
+	} );
+
+	test( 'should not render a component when the multi selected types of blocks match.', () => {
+		const blocks = [
+			headingBlock1,
+			headingBlock2,
+		];
+		const wrapper = shallow( <BlockSwitcher blocks={ blocks } /> );
+
+		expect( wrapper.html() ).toBeNull();
+	} );
+
+	describe( 'Dropdown', () => {
+		const blocks = [
+			headingBlock1,
+		];
+
+		const onTransformStub = jest.fn();
+		const getDropdown = () => {
+			const blockSwitcher = shallow( <BlockSwitcher blocks={ blocks } onTransform={ onTransformStub } /> );
+			return blockSwitcher.find( 'Dropdown' );
+		};
+
+		test( 'should dropdown exist', () => {
+			expect( getDropdown() ).toHaveLength( 1 );
+		} );
+
+		describe( '.renderToggle', () => {
+			const onToggleStub = jest.fn();
+			const mockKeyDown = {
+				preventDefault: () => {},
+				stopPropagation: () => {},
+				keyCode: DOWN,
+			};
+
+			afterEach( () => {
+				onToggleStub.mockReset();
+			} );
+
+			test( 'should simulate a keydown event, which should call onToggle and open transform toggle.', () => {
+				const toggleClosed = shallow( getDropdown().props().renderToggle( { onToggle: onToggleStub, isOpen: false } ) );
+				const iconButtonClosed = toggleClosed.find( 'IconButton' );
+
+				iconButtonClosed.simulate( 'keydown', mockKeyDown );
+
+				expect( onToggleStub ).toHaveBeenCalledTimes( 1 );
+			} );
+
+			test( 'should simulate a click event, which should call onToggle.', () => {
+				const toggleOpen = shallow( getDropdown().props().renderToggle( { onToggle: onToggleStub, isOpen: true } ) );
+				const iconButtonOpen = toggleOpen.find( 'IconButton' );
+
+				iconButtonOpen.simulate( 'keydown', mockKeyDown );
+
+				expect( onToggleStub ).toHaveBeenCalledTimes( 0 );
+			} );
+		} );
+
+		describe( '.renderContent', () => {
+			const onCloseStub = jest.fn();
+
+			const getIconButtons = () => {
+				const content = shallow( getDropdown().props().renderContent( { onClose: onCloseStub } ) );
+				return content.find( 'IconButton' );
+			};
+
+			test( 'should create the iconButtons for the chosen block. A heading block will have 3 items', () => {
+				expect( getIconButtons() ).toHaveLength( 3 );
+			} );
+
+			test( 'should simulate the click event by closing the switcher and causing a block transform on iconButtons.', () => {
+				getIconButtons().first().simulate( 'click' );
+
+				expect( onCloseStub ).toHaveBeenCalledTimes( 1 );
+				expect( onTransformStub ).toHaveBeenCalledTimes( 1 );
+			} );
+		} );
+	} );
+} );

--- a/editor/components/block-switcher/test/multi-blocks-switcher.js
+++ b/editor/components/block-switcher/test/multi-blocks-switcher.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { MultiBlocksSwitcher } from '../multi-blocks-switcher';
+
+describe( 'MultiBlocksSwitcher', () => {
+	test( 'should return null when the selection is not a multi block selection.', () => {
+		const isMultiBlockSelection = false;
+		const selectedBlockUids = [
+			'an-uid',
+		];
+		const wrapper = shallow(
+			<MultiBlocksSwitcher
+				isMultiBlockSelection={ isMultiBlockSelection }
+				selectedBlockUids={ selectedBlockUids }
+			/>
+		);
+
+		expect( wrapper.html() ).toBeNull();
+	} );
+
+	test( 'should return a BlockSwitcher element matching the snapshot.', () => {
+		const isMultiBlockSelection = true;
+		const selectedBlockUids = [
+			'an-uid',
+			'another-uid',
+		];
+		const wrapper = shallow(
+			<MultiBlocksSwitcher
+				isMultiBlockSelection={ isMultiBlockSelection }
+				selectedBlockUids={ selectedBlockUids }
+			/>
+		);
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -8,6 +8,7 @@ import { withSelect } from '@wordpress/data';
  * Internal Dependencies
  */
 import './style.scss';
+import BlockSwitcher from '../block-switcher';
 
 function BlockToolbar( { block, mode } ) {
 	if ( ! block || ! block.isValid || mode !== 'visual' ) {
@@ -16,6 +17,7 @@ function BlockToolbar( { block, mode } ) {
 
 	return (
 		<div className="editor-block-toolbar">
+			<BlockSwitcher uids={ [ block.uid ] } />
 			<BlockControls.Slot />
 			<BlockFormatControls.Slot />
 		</div>

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -63,6 +63,7 @@ export { default as CopyHandler } from './copy-handler';
 export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as Inserter } from './inserter';
+export { default as MultiBlocksSwitcher } from './block-switcher/multi-blocks-switcher';
 export { default as MultiSelectScrollIntoView } from './multi-select-scroll-into-view';
 export { default as NavigableToolbar } from './navigable-toolbar';
 export { default as ObserveTyping } from './observe-typing';


### PR DESCRIPTION
We decided that transforms should be a primary action, and we will iterate further to have transforms fit nicely in the toolbars.

Reverts: https://github.com/WordPress/gutenberg/pull/6473

## How has this been tested?
Verify that single and multiple blocks transforms, still, work as expected. 

