### PR TITLE
Remove wrap text setting in button block

### DIFF
--- a/core-blocks/button/index.js
+++ b/core-blocks/button/index.js
@@ -13,7 +13,6 @@ import {
 	Dashicon,
 	IconButton,
 	PanelBody,
-	ToggleControl,
 	withFallbackStyles,
 } from '@wordpress/components';
 import {
@@ -52,16 +51,10 @@ class ButtonBlock extends Component {
 		this.nodeRef = null;
 		this.bindRef = this.bindRef.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
-		this.toggleClear = this.toggleClear.bind( this );
 	}
 
 	updateAlignment( nextAlign ) {
 		this.props.setAttributes( { align: nextAlign } );
-	}
-
-	toggleClear() {
-		const { attributes, setAttributes } = this.props;
-		setAttributes( { clear: ! attributes.clear } );
 	}
 
 	bindRef( node ) {
@@ -88,7 +81,6 @@ class ButtonBlock extends Component {
 			url,
 			title,
 			align,
-			clear,
 		} = attributes;
 
 		return (
@@ -119,11 +111,6 @@ class ButtonBlock extends Component {
 					/>
 					<InspectorControls>
 						<PanelBody>
-							<ToggleControl
-								label={ __( 'Wrap text' ) }
-								checked={ !! clear }
-								onChange={ this.toggleClear }
-							/>
 							<PanelColor
 								colorName={ backgroundColor.name }
 								colorValue={ backgroundColor.value }


### PR DESCRIPTION
## Description
There is a Wrap text setting in Button block. However it doesn't do anything. It doesn’t add any classes and no visual change in the editor or front-end. See issue #6563.

## How has this been tested?
Tested changing other button settings.

## Screenshots <!-- if applicable -->

<img width="273" alt="button-block-settings" src="https://user-images.githubusercontent.com/1820415/39584149-62cbf36e-4efa-11e8-9609-c2e1ca144bb0.png">

Note from screenshot. There is kind of weird looking "double" border now.

## Types of changes
Remove wrap text setting in button block

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
