### PR TITLE
Restore priority on embed block for raw transforming

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { find, flatMap, filter, compact } from 'lodash';
+import { flatMap, filter, compact } from 'lodash';
 // Also polyfills Element#matches.
 import 'element-closest';
 
 /**
  * Internal dependencies
  */
-import { createBlock, getBlockTransforms } from '../factory';
+import { createBlock, getBlockTransforms, findTransform } from '../factory';
 import { getBlockType } from '../registration';
 import { getBlockAttributes, parseWithGrammar } from '../parser';
 import normaliseBlocks from './normalise-blocks';
@@ -169,7 +169,7 @@ export default function rawHandler( { HTML = '', plainText = '', mode = 'AUTO', 
 		doc.body.innerHTML = piece;
 
 		return Array.from( doc.body.children ).map( ( node ) => {
-			const rawTransformation = find( rawTransformations, ( { isMatch } ) => isMatch( node ) );
+			const rawTransformation = findTransform( rawTransformations, ( { isMatch } ) => isMatch( node ) );
 
 			if ( ! rawTransformation ) {
 				warn(

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -271,6 +271,7 @@ export const settings = getEmbedBlockSettings( {
 		from: [
 			{
 				type: 'raw',
+				priority: 0,
 				isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ),
 				transform: ( node ) => {
 					return createBlock( 'core/embed', {

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -271,7 +271,6 @@ export const settings = getEmbedBlockSettings( {
 		from: [
 			{
 				type: 'raw',
-				priority: 0,
 				isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ),
 				transform: ( node ) => {
 					return createBlock( 'core/embed', {

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -344,6 +344,8 @@ export const settings = {
 		from: [
 			{
 				type: 'raw',
+				// Paragraph is a fallback and should be matched last.
+				priority: 20,
 				selector: 'p',
 				schema: {
 					p: {


### PR DESCRIPTION
## Description

In #5966 I was so stupid to remove the priority from the paragraph block and not testing embeds... This restores the priority and transform finder.

## How has this been tested?
Ensure pasting a URL in an empty paragraph embeds.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
