### PR TITLE
Fix a PHP Notice in REST API responses

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -257,7 +257,7 @@ function gutenberg_add_block_format_to_post_content( $response, $post, $request 
 	}
 
 	$response_data = $response->get_data();
-	if ( isset( $response_data['content']['raw'] ) ) {
+	if ( isset( $response_data['content'] ) && is_array( $response_data['content'] ) && isset( $response_data['content']['raw'] ) ) {
 		$response_data['content']['block_format'] = gutenberg_content_block_version( $response_data['content']['raw'] );
 		$response->set_data( $response_data );
 	}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -257,7 +257,7 @@ function gutenberg_add_block_format_to_post_content( $response, $post, $request 
 	}
 
 	$response_data = $response->get_data();
-	if ( is_array( $response_data['content'] ) && isset( $response_data['content']['raw'] ) ) {
+	if ( isset( $response_data['content']['raw'] ) ) {
 		$response_data['content']['block_format'] = gutenberg_content_block_version( $response_data['content']['raw'] );
 		$response->set_data( $response_data );
 	}


### PR DESCRIPTION
## Description

As described in #6575, there's a PHP notice when adding the `block_format` to post responses.

We can fix this by removing the `is_array()` check, is `isset()` can check multi-dimensional arrays correctly.