### PR TITLE
Treat autocompletions as tokens with editing boundaries

### DIFF
--- a/components/autocomplete/README.md
+++ b/components/autocomplete/README.md
@@ -14,7 +14,9 @@ Each completer declares:
 * Raw option data.
 * How to render an option's label.
 * An option's keywords, words that will be used to match an option with user input.
-* What the completion of an option looks like, including whether it should be inserted in the text or used to replace the current block.
+* What the completion of an option looks like, including:
+  * The kind of completion. Is it an editable, text-based completion or a non-editable completion containing HTML structure?
+  * How it should be inserted. Should it be inserted in the text or used to replace the current block?
 
 In addition, a completer may optionally declare:
 
@@ -77,6 +79,11 @@ There are currently two supported actions:
 * "insert-at-caret" - Insert the `value` into the text (the default completion action).
 * "replace" - Replace the current block with the block specified in the `value` property.
 
+An inserted completion is treated one of two ways, depending on its content:
+
+1. A text-only completion is inserted as a styled editable token. The purpose is to satisfy use cases like simple user mentions (e.g., "@username").
+2. A completion containing HTML is inserted as a non-editable token. This supports the creation of completers that insert arbitrary HTML content.
+
 #### allowNode
 
 A function that takes a text node and returns a boolean indicating whether the completer should be considered for that node.
@@ -107,7 +114,29 @@ Whether to apply debouncing for the autocompleter. Set to true to enable debounc
 
 ### Examples
 
-The following is a contrived completer for fresh fruit.
+#### Editable completions
+
+Here is a contrived completer for feelings. It yields editable tokens like "!resolute".
+
+```jsx
+const fruitCompleter = {
+	name: 'feeling',
+	// The prefix that triggers this completer
+	triggerPrefix: '!',
+	// The option data
+	options: [ 'happy', 'hopeful', 'resolute' ],
+	// Returns a simple, text-only label
+	getOptionLabel: option => option,
+	// Declares that options should be matched by their text
+	getOptionKeywords: option => [ option ],
+	// Declares completions should be inserted as text
+	getOptionCompletion: option => '!' + option,
+};
+```
+
+#### Structured, non-editable completions
+
+The following is a contrived completer for fresh fruit. It yields an `<abbr>` element with a `title` attribute.
 
 ```jsx
 const fruitCompleter = {

--- a/components/autocomplete/README.md
+++ b/components/autocomplete/README.md
@@ -119,7 +119,7 @@ Whether to apply debouncing for the autocompleter. Set to true to enable debounc
 Here is a contrived completer for feelings. It yields editable tokens like "!resolute".
 
 ```jsx
-const fruitCompleter = {
+const feelingCompleter = {
 	name: 'feeling',
 	// The prefix that triggers this completer
 	triggerPrefix: '!',

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { escapeRegExp, find, filter, map, debounce } from 'lodash';
+import 'element-closest';
 
 /**
  * WordPress dependencies

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -658,19 +658,21 @@ export class Autocomplete extends Component {
 	}
 
 	handleKeyDown( event ) {
-		const { ctrlKey, shiftKey, altKey, metaKey } = event;
+		const { keyCode, ctrlKey, shiftKey, altKey, metaKey } = event;
 		const { open, suppress, query } = this.state;
-		if (
-			event.keyCode === SPACE &&
-			! ( ctrlKey || shiftKey || altKey || metaKey ) &&
-			open && suppress !== open.idx
-		) {
+		const completerIsOpenAndUnsuppressed = open && suppress !== open.idx;
+
+		if ( ! completerIsOpenAndUnsuppressed ) {
+			return;
+		}
+
+		if ( keyCode === SPACE && ! ( ctrlKey || shiftKey || altKey || metaKey ) ) {
 			// Insert a completion when the user spaces after typing an exact option match.
 			const exactMatchSearch = new RegExp( '^' + escapeRegExp( query ) + '$', 'i' );
-			const wasOptions = this.state[ 'options_' + open.idx ];
-			const [ firstMatchingOption ] = filterOptions( exactMatchSearch, wasOptions );
-			if ( firstMatchingOption ) {
-				this.select( firstMatchingOption );
+			const currentCompleterOptions = this.state[ 'options_' + open.idx ];
+			const [ exactMatch ] = filterOptions( exactMatchSearch, currentCompleterOptions );
+			if ( exactMatch ) {
+				this.select( exactMatch );
 			}
 		}
 	}

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -234,11 +234,14 @@ export class Autocomplete extends Component {
 	insertCompletion( range, replacement, completerName ) {
 		// Wrap completions so we can treat them as tokens with editing boundaries.
 		const tokenWrapper = document.createElement( 'span' );
+		tokenWrapper.innerHTML = renderToString( replacement );
+
+		// Remember the completer in case the user wants to edit the token.
 		tokenWrapper.dataset.autocompleter = completerName;
+
+		// Add classes for general and completer-specific styling.
 		tokenWrapper.classList.add( 'autocomplete-token' );
 		tokenWrapper.classList.add( `autocomplete-token-${ completerName }` );
-
-		tokenWrapper.innerHTML = renderToString( replacement );
 
 		const existingTokenWrapper = this.getTokenWrapperNode( range.startContainer );
 		if ( existingTokenWrapper ) {

--- a/components/autocomplete/style.scss
+++ b/components/autocomplete/style.scss
@@ -34,3 +34,7 @@
 		@include button-style__hover;
 	}
 }
+
+.autocomplete-token[data-mce-selected] {
+	background-color: $blue-medium-highlight;
+}

--- a/components/autocomplete/style.scss
+++ b/components/autocomplete/style.scss
@@ -35,6 +35,12 @@
 	}
 }
 
-.autocomplete-token[data-mce-selected] {
-	background-color: $blue-medium-highlight;
+.autocomplete-token {
+	border: 1px solid $light-gray-800;
+	background: $light-gray-300;
+	// Set the color since a some selected rich text colors
+	// may not look good against the token background color.
+	color: #444;
+	border-radius: 10px;
+	padding: 2px 4px;
 }

--- a/components/autocomplete/style.scss
+++ b/components/autocomplete/style.scss
@@ -35,7 +35,7 @@
 	}
 }
 
-.autocomplete-token {
+.autocomplete-token:not(.readonly-token) {
 	border: 1px solid $light-gray-800;
 	background: $light-gray-300;
 	// Set the color since a some selected rich text colors
@@ -43,4 +43,8 @@
 	color: #444;
 	border-radius: 10px;
 	padding: 2px 4px;
+}
+
+.readonly-token[data-mce-selected] {
+	background: $blue-medium-highlight;
 }

--- a/editor/components/autocompleters/style.scss
+++ b/editor/components/autocompleters/style.scss
@@ -33,3 +33,14 @@
 		color: $blue-medium-300;
 	}
 }
+
+.autocomplete-token-users {
+	border: 1px solid $light-gray-800;
+	border-radius: 10px;
+	padding: 1px 2px;
+
+	&,
+	&[data-mce-selected] {
+		background: $light-gray-300;
+	}
+}

--- a/editor/components/autocompleters/style.scss
+++ b/editor/components/autocompleters/style.scss
@@ -33,14 +33,3 @@
 		color: $blue-medium-300;
 	}
 }
-
-.autocomplete-token-users {
-	border: 1px solid $light-gray-800;
-	border-radius: 10px;
-	padding: 1px 2px;
-
-	&,
-	&[data-mce-selected] {
-		background: $light-gray-300;
-	}
-}

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -120,6 +120,7 @@ export class RichText extends Component {
 		this.onPaste = this.onPaste.bind( this );
 		this.onCreateUndoLevel = this.onCreateUndoLevel.bind( this );
 		this.setFocusedElement = this.setFocusedElement.bind( this );
+		this.transactAutocompletion = this.transactAutocompletion.bind( this );
 
 		this.state = {
 			formats: {},
@@ -536,6 +537,20 @@ export class RichText extends Component {
 		}
 	}
 
+	/**
+	 * Takes a function to insert an autocompletion and runs it as an undoable action.
+	 *
+	 * @param {Function} insertCompletion A function that inserts a completion.
+	 * @private
+	 */
+	transactAutocompletion( insertCompletion ) {
+		if ( this.editor ) {
+			this.editor.undoManager.transact( insertCompletion );
+		} else {
+			insertCompletion();
+		}
+	}
+
 	scrollToRect( rect ) {
 		const { top: caretTop } = rect;
 		const container = getScrollContainer( this.editor.getBody() );
@@ -892,7 +907,11 @@ export class RichText extends Component {
 						containerRef={ this.containerRef }
 					/>
 				}
-				<Autocomplete onReplace={ this.props.onReplace } completers={ autocompleters }>
+				<Autocomplete
+					completers={ autocompleters }
+					onReplace={ this.props.onReplace }
+					transactInsertion={ this.transactAutocompletion }
+				>
 					{ ( { isExpanded, listBoxId, activeId } ) => (
 						<Fragment>
 							<TinyMCE

--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -161,7 +161,7 @@ export default class TinyMCE extends Component {
 			browser_spellcheck: true,
 			entity_encoding: 'raw',
 			convert_urls: false,
-			inline_boundaries_selector: 'a[href],code,b,i,strong,em,del,ins,sup,sub',
+			inline_boundaries_selector: 'a[href],code,b,i,strong,em,del,ins,sup,sub,.autocomplete-token',
 			plugins: [],
 			formats: {
 				strikethrough: { inline: 'del' },

--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -168,7 +168,8 @@ export default class TinyMCE extends Component {
 			},
 		} );
 
-		settings.plugins.push( 'paste' );
+		settings.plugins.push( 'paste', 'noneditable' );
+		settings.noneditable_noneditable_class = 'readonly-token';
 
 		tinymce.init( {
 			...settings,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -325,6 +325,7 @@ function gutenberg_register_scripts_and_styles() {
 			'hr',
 			'lists',
 			'media',
+			'noneditable',
 			'paste',
 			'tabfocus',
 			'textcolor',
@@ -410,6 +411,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-viewport',
 			'wp-tinymce',
 			'tinymce-latest-lists',
+			'tinymce-latest-noneditable',
 			'tinymce-latest-paste',
 			'tinymce-latest-table',
 			'wp-nux',
@@ -626,6 +628,11 @@ function gutenberg_register_vendor_scripts() {
 	gutenberg_register_vendor_script(
 		'tinymce-latest-lists',
 		'https://unpkg.com/tinymce@' . $tinymce_version . '/plugins/lists/plugin' . $suffix . '.js',
+		array( 'wp-tinymce' )
+	);
+	gutenberg_register_vendor_script(
+		'tinymce-latest-noneditable',
+		'https://unpkg.com/tinymce@' . $tinymce_version . '/plugins/noneditable/plugin' . $suffix . '.js',
 		array( 'wp-tinymce' )
 	);
 	gutenberg_register_vendor_script(

--- a/test/e2e/specs/autocompletion.test.js
+++ b/test/e2e/specs/autocompletion.test.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage } from '../support/utils';
+
+describe( 'autocompletion', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+	} );
+
+	it( 'adds a token followed by a non-breaking space and the cursor', async () => {
+		await page.click( '.editor-default-block-appender' );
+
+		const contentEditableHandle = (
+			await page.evaluateHandle( () => document.activeElement )
+		);
+
+		await contentEditableHandle.asElement().type( '@' );
+		const optionNode = await page.waitForSelector( '.components-autocomplete__result', { timeout: 10000 } );
+		optionNode.click();
+
+		// Wait for content update.
+		await page.waitForFunction(
+			( contentEditableNode ) => contentEditableNode.textContent.length > 0,
+			{ timeout: 1000 },
+			contentEditableHandle
+		);
+
+		// Confirm we contain the selection.
+		expect( await page.evaluate(
+			( contentEditableNode ) => {
+				const { anchorNode, isCollapsed } = window.getSelection();
+				return contentEditableNode.contains( anchorNode ) && isCollapsed;
+			},
+			contentEditableHandle
+		) ).toBeTruthy();
+
+		// Confirm the expected content.
+		expect( await page.evaluate(
+			( contentEditableNode ) => contentEditableNode.textContent,
+			contentEditableHandle
+		) ).toMatch( /^@\w+\u00A0$/ );
+
+		// Selection is placed after a single-space text node.
+		const selectionAnchorHandle = await page.evaluateHandle( () => window.getSelection().anchorNode );
+		expect( await page.evaluate(
+			( anchorNode ) => anchorNode.nodeType === window.Node.TEXT_NODE,
+			selectionAnchorHandle
+		) ).toBeTruthy();
+		const nonBreakingSpace = '\u00A0';
+		expect( await page.evaluate(
+			( anchorNode ) => anchorNode.nodeValue,
+			selectionAnchorHandle
+		) ).toBe( nonBreakingSpace );
+		expect( await page.evaluate(
+			() => window.getSelection().anchorOffset
+		) ).toBe( nonBreakingSpace.length );
+
+		// The autocomplete token precedes the space.
+		const tokenHandle = await page.evaluateHandle(
+			( anchorNode ) => anchorNode.previousSibling,
+			selectionAnchorHandle
+		);
+		expect( await page.evaluate(
+			( tokenNode ) => tokenNode.nodeType === window.Node.ELEMENT_NODE,
+			tokenHandle
+		) ).toBeTruthy();
+		expect( await page.evaluate(
+			( tokenNode ) => tokenNode.classList.contains( 'autocomplete-token' ),
+			tokenHandle
+		) ).toBeTruthy();
+		expect( await page.evaluate(
+			( tokenNode ) => /^@\w+$/.test( tokenNode.textContent ),
+			tokenHandle
+		) ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
## Description
This PR updates the `<Autocomplete>` component to insert autocompletions as tokens.

Completions consisting entirely of text are inserted as styled, editable tokens. This satisfies the common completer use cases of user mentions (@-user), tags (#-tag), and cross posting site mentions (+site).

Here's an example of editable tokens:
![first-completer-type-example](https://user-images.githubusercontent.com/530877/42016409-44b5550a-7a60-11e8-91ec-f0e61745324a.gif)

Completions containing HTML are inserted as non-editable tokens. This supports the creation of completers that insert arbitrary HTML content.

Here's an example of a non-editable token created from [this completer](https://gist.github.com/brandonpayton/01b75c55ce4d329d534b1d3a68dc728f):
![second-completer-type-example](https://user-images.githubusercontent.com/530877/41986081-f3685830-79e9-11e8-833e-009499a51aed.gif)

Closes #6573.

## How has this been tested?
Tested manually in Chrome, Firefox, and Safari on macOS and in IE11 and Edge on Windows.

I also added an e2e test for basic token insertion.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
