### PR TITLE
Add help texts for category block settings

### DIFF
--- a/core-blocks/categories/block.js
+++ b/core-blocks/categories/block.js
@@ -34,6 +34,10 @@ class CategoriesBlock extends Component {
 		setAttributes( { displayAsDropdown: ! displayAsDropdown } );
 	}
 
+	getDisplayAsDropdownHelp( checked ) {
+		return checked ? __( 'Showing as dropdown.' ) : __( 'Toggle to show as dropdown.' );
+	}
+
 	toggleShowPostCounts() {
 		const { attributes, setAttributes } = this.props;
 		const { showPostCounts } = attributes;
@@ -41,11 +45,19 @@ class CategoriesBlock extends Component {
 		setAttributes( { showPostCounts: ! showPostCounts } );
 	}
 
+	getShowPostCountsHelp( checked ) {
+		return checked ? __( 'Showing post counts.' ) : __( 'Toggle to show post counts.' );
+	}
+
 	toggleShowHierarchy() {
 		const { attributes, setAttributes } = this.props;
 		const { showHierarchy } = attributes;
 
 		setAttributes( { showHierarchy: ! showHierarchy } );
+	}
+
+	getShowHierarchyHelp( checked ) {
+		return checked ? __( 'Showing hierarchy.' ) : __( 'Toggle to show hierarchy.' );
 	}
 
 	getCategories( parentId = null ) {
@@ -155,16 +167,19 @@ class CategoriesBlock extends Component {
 						label={ __( 'Display as dropdown' ) }
 						checked={ displayAsDropdown }
 						onChange={ this.toggleDisplayAsDropdown }
+						help={ this.getDisplayAsDropdownHelp }
 					/>
 					<ToggleControl
-						label={ __( 'Show post counts' ) }
+						label={ __( 'Display post counts' ) }
 						checked={ showPostCounts }
 						onChange={ this.toggleShowPostCounts }
+						help={ this.getShowPostCountsHelp }
 					/>
 					<ToggleControl
 						label={ __( 'Show hierarchy' ) }
 						checked={ showHierarchy }
 						onChange={ this.toggleShowHierarchy }
+						help={ this.getShowHierarchyHelp }
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
## Description
Adds Display post date help text in Categories block as mentioned in #2146.

## How has this been tested?
- Run `npm test` without errors.
- Tested toggling toggle settings in Categories block.

## Types of changes
Adds help texts for category block settings.

## Screenshots

### Off state

<img width="268" alt="categories block toggle off texts" src="https://user-images.githubusercontent.com/1820415/39617213-73026b4a-4f87-11e8-9888-cfa31e267b59.png">

### On state

<img width="268" alt="categories block toggle on texts" src="https://user-images.githubusercontent.com/1820415/39617222-7c57c42e-4f87-11e8-9348-c4583c3abcbb.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
