### PR TITLE
Fix gallery width to match with other elements width

### DIFF
--- a/core-blocks/gallery/editor.scss
+++ b/core-blocks/gallery/editor.scss
@@ -1,3 +1,6 @@
+.wp-block-gallery.components-placeholder {
+	margin: 0px;
+}
 .gutenberg .wp-block-gallery:not( .components-placeholder ) {
 	// allow gallery items to go edge to edge
 	margin-left: -8px;

--- a/core-blocks/gallery/style.scss
+++ b/core-blocks/gallery/style.scss
@@ -2,8 +2,9 @@
 	display: flex;
 	flex-wrap: wrap;
 	list-style-type: none;
-	margin: 0px;
 	padding: 0px;
+	// allow gallery items to go edge to edge
+	margin: 0 -8px 0 -8px;
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {


### PR DESCRIPTION
Gallery width should match the width of other elements in the editor and in the frontend. We had a rule in the backend for that but not on the frontend. This rule was added to the frontend.
Fixes: https://github.com/WordPress/gutenberg/issues/4548

<img width="250" alt="screen shot 2018-05-04 at 08 40 55" src="https://user-images.githubusercontent.com/11271197/39617272-f77a2842-4f76-11e8-951d-cf99ca2a5c46.png">
<img width="250" alt="screen shot 2018-05-04 at 08 33 10" src="https://user-images.githubusercontent.com/11271197/39617273-f79d2432-4f76-11e8-9eb3-8c39a07bfdf3.png">



## How has this been tested?
Verify the gallery block width matches exactly the width of other blocks in frontend and backend as shown in the screenshots.
