### PR TITLE
Build: Introduce the common `build` folder to be used by all modules

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -91,7 +91,7 @@ rm -f gutenberg.zip
 php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
-build_files=$(ls **/build/*.{js,css})
+build_files=$(ls build/*/*.{js,css})
 
 # Generate the plugin zip file
 status "Creating archive..."

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -7,7 +7,6 @@ import { get, isString, some } from 'lodash';
  * WordPress dependencies
  */
 import { registerCoreBlocks } from '@wordpress/core-blocks';
-import domReady from '@wordpress/dom-ready';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { deprecated } from '@wordpress/utils';
 

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -83,25 +83,21 @@ export function initializeEditor( id, post, settings ) {
 		);
 	}
 
-	return new Promise( ( resolve ) => {
-		domReady( () => {
-			const target = document.getElementById( id );
-			const reboot = reinitializeEditor.bind( null, target, settings );
+	const target = document.getElementById( id );
+	const reboot = reinitializeEditor.bind( null, target, settings );
 
-			registerCoreBlocks();
+	registerCoreBlocks();
 
-			render(
-				<Editor settings={ migratedSettings || settings } onError={ reboot } post={ post } />,
-				target
-			);
+	render(
+		<Editor settings={ migratedSettings || settings } onError={ reboot } post={ post } />,
+		target
+	);
 
-			resolve( {
-				initializeMetaBoxes( metaBoxes ) {
-					store.dispatch( initializeMetaBoxState( metaBoxes ) );
-				},
-			} );
-		} );
-	} );
+	return {
+		initializeMetaBoxes( metaBoxes ) {
+			store.dispatch( initializeMetaBoxState( metaBoxes ) );
+		},
+	};
 }
 
 export { default as PluginSidebar } from './components/sidebar/plugin-sidebar';

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -109,7 +109,7 @@ function gutenberg_build_files_notice() {
  * @since 1.5.0
  */
 function gutenberg_pre_init() {
-	if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE && ! file_exists( dirname( __FILE__ ) . '/blocks/build' ) ) {
+	if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE && ! file_exists( dirname( __FILE__ ) . '/build/blocks' ) ) {
 		add_action( 'admin_notices', 'gutenberg_build_files_notice' );
 		return;
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -75,7 +75,35 @@ function gutenberg_get_script_polyfill( $tests ) {
 function gutenberg_register_scripts_and_styles() {
 	gutenberg_register_vendor_scripts();
 
-	// Editor Scripts.
+	// WordPress packages
+	wp_register_script(
+		'wp-dom-ready',
+		gutenberg_url( 'build/dom-ready/index.js' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/dom-ready/index.js' ),
+		true
+	);
+	wp_register_script(
+		'wp-a11y',
+		gutenberg_url( 'build/a11y/index.js' ),
+		array( 'wp-dom-ready' ),
+		filemtime( gutenberg_dir_path() . 'build/a11y/index.js' ),
+		true
+	);
+	wp_register_script(
+		'wp-hooks',
+		gutenberg_url( 'build/hooks/index.js' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/hooks/index.js' ),
+		true
+	);
+	wp_register_script(
+		'wp-i18n',
+		gutenberg_url( 'build/i18n/index.js' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/i18n/index.js' ),
+		true
+	);
 	wp_register_script(
 		'wp-is-shallow-equal',
 		gutenberg_url( 'build/is-shallow-equal/index.js' ),
@@ -83,6 +111,8 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/is-shallow-equal/index.js' ),
 		true
 	);
+
+	// Editor Scripts.
 	wp_register_script(
 		'wp-data',
 		gutenberg_url( 'build/data/index.js' ),
@@ -106,13 +136,6 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_add_inline_script( 'wp-utils', 'var originalUtils = window.wp && window.wp.utils ? window.wp.utils : {};', 'before' );
 	wp_add_inline_script( 'wp-utils', 'for ( var key in originalUtils ) wp.utils[ key ] = originalUtils[ key ];' );
-	wp_register_script(
-		'wp-hooks',
-		gutenberg_url( 'build/hooks/index.js' ),
-		array(),
-		filemtime( gutenberg_dir_path() . 'build/hooks/index.js' ),
-		true
-	);
 	wp_register_script(
 		'wp-date',
 		gutenberg_url( 'build/date/index.js' ),
@@ -147,13 +170,6 @@ function gutenberg_register_scripts_and_styles() {
 		),
 	) ), 'before' );
 	wp_register_script(
-		'wp-i18n',
-		gutenberg_url( 'build/i18n/index.js' ),
-		array(),
-		filemtime( gutenberg_dir_path() . 'build/i18n/index.js' ),
-		true
-	);
-	wp_register_script(
 		'wp-element',
 		gutenberg_url( 'build/element/index.js' ),
 		array( 'react', 'react-dom', 'wp-utils', 'wp-is-shallow-equal', 'lodash' ),
@@ -163,7 +179,17 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-components',
 		gutenberg_url( 'build/components/index.js' ),
-		array( 'wp-element', 'wp-i18n', 'wp-utils', 'wp-hooks', 'wp-api-request', 'wp-is-shallow-equal', 'moment', 'lodash' ),
+		array(
+			'lodash',
+			'moment',
+			'wp-a11y',
+			'wp-api-request',
+			'wp-element',
+			'wp-hooks',
+			'wp-i18n',
+			'wp-is-shallow-equal',
+			'wp-utils',
+		),
 		filemtime( gutenberg_dir_path() . 'build/components/index.js' ),
 		true
 	);
@@ -283,21 +309,22 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-editor',
 		gutenberg_url( 'build/editor/index.js' ),
 		array(
-			'postbox',
+			'editor',
 			'jquery',
+			'lodash',
+			'postbox',
+			'wp-a11y',
 			'wp-api',
+			'wp-blocks',
+			'wp-components',
+			'wp-core-data',
 			'wp-data',
 			'wp-date',
 			'wp-i18n',
-			'wp-blocks',
 			'wp-element',
-			'wp-components',
+			'wp-plugins',
 			'wp-utils',
 			'wp-viewport',
-			'wp-plugins',
-			'wp-core-data',
-			'editor',
-			'lodash',
 		),
 		filemtime( gutenberg_dir_path() . 'build/editor/index.js' ),
 		true
@@ -306,7 +333,25 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-edit-post',
 		gutenberg_url( 'build/edit-post/index.js' ),
-		array( 'jquery', 'media-views', 'media-models', 'wp-element', 'wp-components', 'wp-editor', 'wp-i18n', 'wp-date', 'wp-utils', 'wp-data', 'wp-embed', 'wp-viewport', 'wp-plugins', 'wp-core-blocks', 'lodash' ),
+		array(
+			'jquery',
+			'lodash',
+			'media-models',
+			'media-views',
+			'wp-a11y',
+			'wp-components',
+			'wp-core-blocks',
+			'wp-date',
+			'wp-data',
+			'wp-dom-ready',
+			'wp-editor',
+			'wp-element',
+			'wp-embed',
+			'wp-i18n',
+			'wp-plugins',
+			'wp-viewport',
+			'wp-utils',
+		),
 		filemtime( gutenberg_dir_path() . 'build/edit-post/index.js' ),
 		true
 	);

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -75,7 +75,7 @@ function gutenberg_get_script_polyfill( $tests ) {
 function gutenberg_register_scripts_and_styles() {
 	gutenberg_register_vendor_scripts();
 
-	// WordPress packages
+	// WordPress packages.
 	wp_register_script(
 		'wp-dom-ready',
 		gutenberg_url( 'build/dom-ready/index.js' ),

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1047,9 +1047,11 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
 	$script .= <<<JS
 		window._wpLoadGutenbergEditor = new Promise( function( resolve ) {
-			wp.api.init().then( resolve );
-		} ).then( function() {
-			return wp.editPost.initializeEditor( 'editor', window._wpGutenbergPost, editorSettings );
+			wp.api.init().then( function() {
+				wp.domReady.default( function() {
+					resolve( wp.editPost.initializeEditor( 'editor', window._wpGutenbergPost, editorSettings ) );
+				} );
+			} );
 		} );
 JS;
 	$script .= '} )();';

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -78,46 +78,46 @@ function gutenberg_register_scripts_and_styles() {
 	// Editor Scripts.
 	wp_register_script(
 		'wp-is-shallow-equal',
-		gutenberg_url( 'is-shallow-equal/build/index.js' ),
+		gutenberg_url( 'build/is-shallow-equal/index.js' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'is-shallow-equal/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/is-shallow-equal/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-data',
-		gutenberg_url( 'data/build/index.js' ),
+		gutenberg_url( 'build/data/index.js' ),
 		array( 'wp-element', 'wp-utils', 'wp-is-shallow-equal', 'lodash' ),
-		filemtime( gutenberg_dir_path() . 'data/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/data/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-core-data',
-		gutenberg_url( 'core-data/build/index.js' ),
+		gutenberg_url( 'build/core-data/index.js' ),
 		array( 'wp-data', 'wp-api-request', 'lodash' ),
-		filemtime( gutenberg_dir_path() . 'core-data/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/core-data/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-utils',
-		gutenberg_url( 'utils/build/index.js' ),
+		gutenberg_url( 'build/utils/index.js' ),
 		array( 'tinymce-latest', 'lodash' ),
-		filemtime( gutenberg_dir_path() . 'utils/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/utils/index.js' ),
 		true
 	);
 	wp_add_inline_script( 'wp-utils', 'var originalUtils = window.wp && window.wp.utils ? window.wp.utils : {};', 'before' );
 	wp_add_inline_script( 'wp-utils', 'for ( var key in originalUtils ) wp.utils[ key ] = originalUtils[ key ];' );
 	wp_register_script(
 		'wp-hooks',
-		gutenberg_url( 'hooks/build/index.js' ),
+		gutenberg_url( 'build/hooks/index.js' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'hooks/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/hooks/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-date',
-		gutenberg_url( 'date/build/index.js' ),
+		gutenberg_url( 'build/date/index.js' ),
 		array( 'moment' ),
-		filemtime( gutenberg_dir_path() . 'date/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/date/index.js' ),
 		true
 	);
 	global $wp_locale;
@@ -148,28 +148,28 @@ function gutenberg_register_scripts_and_styles() {
 	) ), 'before' );
 	wp_register_script(
 		'wp-i18n',
-		gutenberg_url( 'i18n/build/index.js' ),
+		gutenberg_url( 'build/i18n/index.js' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'i18n/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/i18n/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-element',
-		gutenberg_url( 'element/build/index.js' ),
+		gutenberg_url( 'build/element/index.js' ),
 		array( 'react', 'react-dom', 'wp-utils', 'wp-is-shallow-equal', 'lodash' ),
-		filemtime( gutenberg_dir_path() . 'element/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/element/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-components',
-		gutenberg_url( 'components/build/index.js' ),
+		gutenberg_url( 'build/components/index.js' ),
 		array( 'wp-element', 'wp-i18n', 'wp-utils', 'wp-hooks', 'wp-api-request', 'wp-is-shallow-equal', 'moment', 'lodash' ),
-		filemtime( gutenberg_dir_path() . 'components/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/components/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-blocks',
-		gutenberg_url( 'blocks/build/index.js' ),
+		gutenberg_url( 'build/blocks/index.js' ),
 		array(
 			'wp-element',
 			'wp-components',
@@ -185,7 +185,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-core-data',
 			'lodash',
 		),
-		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/blocks/index.js' ),
 		true
 	);
 	wp_add_inline_script(
@@ -198,16 +198,16 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_register_script(
 		'wp-viewport',
-		gutenberg_url( 'viewport/build/index.js' ),
+		gutenberg_url( 'build/viewport/index.js' ),
 		array( 'wp-element', 'wp-data', 'wp-components', 'lodash' ),
-		filemtime( gutenberg_dir_path() . 'viewport/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/viewport/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-core-blocks',
-		gutenberg_url( 'core-blocks/build/index.js' ),
+		gutenberg_url( 'build/core-blocks/index.js' ),
 		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-blocks', 'wp-i18n', 'editor', 'wp-core-data', 'lodash' ),
-		filemtime( gutenberg_dir_path() . 'core-blocks/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/core-blocks/index.js' ),
 		true
 	);
 	// Loading the old editor and its config to ensure the classic block works as expected.
@@ -281,7 +281,7 @@ function gutenberg_register_scripts_and_styles() {
 
 	wp_register_script(
 		'wp-editor',
-		gutenberg_url( 'editor/build/index.js' ),
+		gutenberg_url( 'build/editor/index.js' ),
 		array(
 			'postbox',
 			'jquery',
@@ -299,15 +299,15 @@ function gutenberg_register_scripts_and_styles() {
 			'editor',
 			'lodash',
 		),
-		filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/editor/index.js' ),
 		true
 	);
 
 	wp_register_script(
 		'wp-edit-post',
-		gutenberg_url( 'edit-post/build/index.js' ),
+		gutenberg_url( 'build/edit-post/index.js' ),
 		array( 'jquery', 'media-views', 'media-models', 'wp-element', 'wp-components', 'wp-editor', 'wp-i18n', 'wp-date', 'wp-utils', 'wp-data', 'wp-embed', 'wp-viewport', 'wp-plugins', 'wp-core-blocks', 'lodash' ),
-		filemtime( gutenberg_dir_path() . 'edit-post/build/index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/edit-post/index.js' ),
 		true
 	);
 	wp_add_inline_script(
@@ -324,57 +324,57 @@ function gutenberg_register_scripts_and_styles() {
 
 	wp_register_style(
 		'wp-editor',
-		gutenberg_url( 'editor/build/style.css' ),
+		gutenberg_url( 'build/editor/style.css' ),
 		array( 'wp-components', 'wp-blocks', 'wp-editor-font' ),
-		filemtime( gutenberg_dir_path() . 'editor/build/style.css' )
+		filemtime( gutenberg_dir_path() . 'build/editor/style.css' )
 	);
 	wp_style_add_data( 'wp-editor', 'rtl', 'replace' );
 
 	wp_register_style(
 		'wp-edit-post',
-		gutenberg_url( 'edit-post/build/style.css' ),
+		gutenberg_url( 'build/edit-post/style.css' ),
 		array( 'wp-components', 'wp-editor', 'wp-edit-blocks', 'wp-core-blocks' ),
-		filemtime( gutenberg_dir_path() . 'edit-post/build/style.css' )
+		filemtime( gutenberg_dir_path() . 'build/edit-post/style.css' )
 	);
 	wp_style_add_data( 'wp-edit-post', 'rtl', 'replace' );
 
 	wp_register_style(
 		'wp-components',
-		gutenberg_url( 'components/build/style.css' ),
+		gutenberg_url( 'build/components/style.css' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'components/build/style.css' )
+		filemtime( gutenberg_dir_path() . 'build/components/style.css' )
 	);
 	wp_style_add_data( 'wp-components', 'rtl', 'replace' );
 
 	wp_register_style(
 		'wp-blocks',
-		gutenberg_url( 'blocks/build/style.css' ),
+		gutenberg_url( 'build/blocks/style.css' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'blocks/build/style.css' )
+		filemtime( gutenberg_dir_path() . 'build/blocks/style.css' )
 	);
 	wp_style_add_data( 'wp-blocks', 'rtl', 'replace' );
 
 	wp_register_style(
 		'wp-core-blocks',
-		gutenberg_url( 'core-blocks/build/style.css' ),
+		gutenberg_url( 'build/core-blocks/style.css' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'core-blocks/build/style.css' )
+		filemtime( gutenberg_dir_path() . 'build/core-blocks/style.css' )
 	);
 	wp_style_add_data( 'wp-core-blocks', 'rtl', 'replace' );
 
 	wp_register_style(
 		'wp-edit-blocks',
-		gutenberg_url( 'core-blocks/build/edit-blocks.css' ),
+		gutenberg_url( 'build/core-blocks/edit-blocks.css' ),
 		array( 'wp-components', 'wp-blocks' ),
-		filemtime( gutenberg_dir_path() . 'core-blocks/build/edit-blocks.css' )
+		filemtime( gutenberg_dir_path() . 'build/core-blocks/edit-blocks.css' )
 	);
 	wp_style_add_data( 'wp-edit-blocks', 'rtl', 'replace' );
 
 	wp_register_script(
 		'wp-plugins',
-		gutenberg_url( 'plugins/build/index.js' ),
+		gutenberg_url( 'build/plugins/index.js' ),
 		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-data' ),
-		filemtime( gutenberg_dir_path() . 'plugins/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'build/plugins/index.js' )
 	);
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,6 +83,8 @@ const entryPointNames = [
 ];
 
 const packageNames = [
+	'a11y',
+	'dom-ready',
 	'hooks',
 	'i18n',
 	'is-shallow-equal',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,17 +13,17 @@ const CustomTemplatedPathPlugin = require( '@wordpress/custom-templated-path-web
 
 // Main CSS loader for everything but blocks..
 const mainCSSExtractTextPlugin = new ExtractTextPlugin( {
-	filename: './[basename]/build/style.css',
+	filename: './build/[basename]/style.css',
 } );
 
 // CSS loader for styles specific to block editing.
 const editBlocksCSSPlugin = new ExtractTextPlugin( {
-	filename: './core-blocks/build/edit-blocks.css',
+	filename: './build/core-blocks/edit-blocks.css',
 } );
 
 // CSS loader for styles specific to blocks in general.
 const blocksCSSPlugin = new ExtractTextPlugin( {
-	filename: './core-blocks/build/style.css',
+	filename: './build/core-blocks/style.css',
 } );
 
 // Configuration for the ExtractTextPlugin.
@@ -128,7 +128,7 @@ const config = {
 		}, {} )
 	),
 	output: {
-		filename: '[basename]/build/index.js',
+		filename: './build/[basename]/index.js',
 		path: __dirname,
 		library: [ 'wp', '[name]' ],
 		libraryTarget: 'this',


### PR DESCRIPTION
## Description
This PR changes the way we manage `build` folders. Instead of having a subfolder for each module, the changes proposed cause to have one common `build` folder. It should make it easier to reason which folders contain the source code and which are external ones. This will also make easier to exclude `build` folders from search results in your IDEs.

As part of this PR I also extracted `a11y` and `dom-ready` to be served as external packages. This allowed to move `domReady` call from `editPost` module to `client-assets.php` file as suggested by @aduth in https://github.com/WordPress/gutenberg/pull/6448#discussion_r185822297:

> Should it be up to the editor to decide the specific time it should be initialized? Or should the prerequisite of the initialization be considered by that which is initializing it (thinking outside the specific "WP + Plugins" context).

Having `dom-ready` and `a11y` extracted was also discussed in https://github.com/WordPress/gutenberg/pull/6526#discussion_r185455493:

> I expect for compatibility's sake we'd not want to remove any of the existing scripts, though my preference moving forward would be that there is a corresponding script handle for every single NPM package under the WordPress scope. 

## How has this been tested?
Manually made sure there are no regressions.

All commands should work as before, in particular, the following must be double checked:
- `npm test`
- `npm run build`
- `npm run dev`
- `npm run package-plugin`

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
