### PR TITLE
Table of content: Add a max-height

### DIFF
--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -9,6 +9,7 @@
 		@include break-small {
 			max-height: calc(100vh - 120px);
 			overflow-y: auto;
+			box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
 		}
 	}
 

--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -5,6 +5,11 @@
 .table-of-contents__popover {
 	.components-popover__content {
 		padding: 16px;
+
+		@include break-small {
+			max-height: calc(100vh - 120px);
+			overflow-y: auto;
+		}
 	}
 
 	hr {


### PR DESCRIPTION
closes #6538

On posts with a lot of headings, the table of content popover can be partially hidden. This PR fixes it by adding a max-height and scrollbars.

**Testing instructions**

 - Add a lot of headings
 - Ensure the popover is scrollable when it hits the threshold. 