### PR TITLE
Add withAllowedBlockTypes HOC and simplify existing code using it

### DIFF
--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -35,8 +35,8 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     type="text"
     value="Write your story"
   />
-  <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
-  <WithEditorSettings(WithSelect(WithDispatch(Inserter)))
+  <WithAllowedBlockTypes(IfCondition(WithSelect(WithDispatch(InserterWithShortcuts)))) />
+  <WithSelect(WithAllowedBlockTypes(IfCondition(WithDispatch(Inserter))))
     position="top right"
   />
 </div>
@@ -59,8 +59,8 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     type="text"
     value="Write your story"
   />
-  <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
-  <WithEditorSettings(WithSelect(WithDispatch(Inserter)))
+  <WithAllowedBlockTypes(IfCondition(WithSelect(WithDispatch(InserterWithShortcuts)))) />
+  <WithSelect(WithAllowedBlockTypes(IfCondition(WithDispatch(Inserter))))
     position="top right"
   />
 </div>
@@ -83,8 +83,8 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     type="text"
     value=""
   />
-  <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
-  <WithEditorSettings(WithSelect(WithDispatch(Inserter)))
+  <WithAllowedBlockTypes(IfCondition(WithSelect(WithDispatch(InserterWithShortcuts)))) />
+  <WithSelect(WithAllowedBlockTypes(IfCondition(WithDispatch(Inserter))))
     position="top right"
   />
 </div>

--- a/editor/components/higher-order/with-allowed-block-types/index.js
+++ b/editor/components/higher-order/with-allowed-block-types/index.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+import { compose, createHigherOrderComponent } from '@wordpress/element';
+import { withEditorSettings } from '@wordpress/blocks';
+
+/**
+ * Higher-order component, which computes allowedBlockTypes.
+ *
+ * @param {?Function} getRootBlockUid Function that receives props and select
+ *                                    and returns the rootBlock whose allowedBlockTypes we want to retrieve.
+ *                                    If the function is not provided we query the state to know the Block Insertion Point.
+ *
+ * @return {Function} Higher-order component.
+ */
+export default ( getRootBlockUid ) => createHigherOrderComponent( compose( [
+	withEditorSettings( ( settings ) => {
+		const { allowedBlockTypes = true, templateLock } = settings;
+		const isLocked = !! templateLock;
+		return {
+			allowedBlockTypes: isLocked || ( allowedBlockTypes && allowedBlockTypes.length === 0 ) ? false : allowedBlockTypes,
+		};
+	} ),
+	withSelect( ( select, props ) => {
+		const {
+			getBlockInsertionPoint,
+			getSupportedBlocks,
+		} = select( 'core/editor' );
+		const rootUID = getRootBlockUid ?
+			getRootBlockUid( props, select ) :
+			getBlockInsertionPoint().rootUID;
+		const allowedBlockTypes = getSupportedBlocks( rootUID, props.allowedBlockTypes );
+		// Todo: move false if empty logic to selector getSupportedBlocks.
+		return {
+			allowedBlockTypes: allowedBlockTypes && allowedBlockTypes.length === 0 ? false : allowedBlockTypes,
+		};
+	} ),
+] ),
+'withAllowedBlockTypes'
+);

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -72,5 +72,8 @@ export { default as SkipToSelectedBlock } from './skip-to-selected-block';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
 
+// Higher order components
+export { default as withAllowedBlockTypes } from './higher-order/with-allowed-block-types';
+
 // State Related Components
 export { default as EditorProvider } from './provider';

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -24,7 +24,7 @@ import {
 	withInstanceId,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { getCategories, isSharedBlock, withEditorSettings } from '@wordpress/blocks';
+import { getCategories, isSharedBlock } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -35,6 +35,7 @@ import './style.scss';
 import NoBlocks from './no-blocks';
 import InserterGroup from './group';
 import BlockPreview from '../block-preview';
+import withAllowedBlockTypes from './../higher-order/with-allowed-block-types';
 
 export const searchItems = ( items, searchTerm ) => {
 	const normalizedSearchTerm = searchTerm.toLowerCase().trim();
@@ -336,25 +337,15 @@ export class InserterMenu extends Component {
 }
 
 export default compose(
-	withEditorSettings( ( settings ) => {
-		const { allowedBlockTypes } = settings;
-
-		return {
-			allowedBlockTypes,
-		};
-	} ),
+	withAllowedBlockTypes(),
 	withSelect( ( select, { allowedBlockTypes } ) => {
 		const {
-			getBlockInsertionPoint,
 			getInserterItems,
 			getFrecentInserterItems,
-			getSupportedBlocks,
 		} = select( 'core/editor' );
-		const { rootUID } = getBlockInsertionPoint();
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
 		return {
-			items: getInserterItems( supportedBlocks ),
-			frecentItems: getFrecentInserterItems( supportedBlocks ),
+			items: getInserterItems( allowedBlockTypes ),
+			frecentItems: getFrecentInserterItems( allowedBlockTypes ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {


### PR DESCRIPTION
## Description
The logic to compute allowed blocks is complex and evolves querying both the state and using context information.
With a HOC we can provide a simple component that checks all the sources of information and computes the desired final result, making the code simpler and reducing duplicate code.
This change also allows us in the future to change how we store allowed blocks information (e.g., save allowed nested blocks in context instead of the global state) without changing other places besides this component.

## How has this been tested?
Verify the global inserter, the inserter, and the shortcuts inserter all work as expected.
Temporarily change the columns block to restrict allowed block types:
e.g:
```
<InnerBlocks layouts={ getColumnLayouts( columns ) } allowedBlocks={ [ 'core/button' ] } />
```

Verify the restriction is correctly applied and in the inserter only core/button is available.
