### PR TITLE
Fix caretRangeFromPoint for Firefox

### DIFF
--- a/utils/dom.js
+++ b/utils/dom.js
@@ -252,7 +252,8 @@ function caretRangeFromPoint( doc, x, y ) {
 
 	const point = doc.caretPositionFromPoint( x, y );
 
-	// Happens when point is out of view.
+	// If x or y are negative, outside viewport, or there is no text entry node.
+	// https://developer.mozilla.org/en-US/docs/Web/API/Document/caretRangeFromPoint
 	if ( ! point ) {
 		return null;
 	}

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -251,6 +251,12 @@ function caretRangeFromPoint( doc, x, y ) {
 	}
 
 	const point = doc.caretPositionFromPoint( x, y );
+
+	// Happens when point is out of view.
+	if ( ! point ) {
+		return null;
+	}
+
 	const range = doc.createRange();
 
 	range.setStart( point.offsetNode, point.offset );


### PR DESCRIPTION
## Description

Currently there is an error in Firefox when moving the caret down with the arrow key, and the target block is outside of the viewport. In that case `caretPositionFromPoint` returns `null` and `range.setStart` fails. There will be no scrolling with a second attempt.  To fix this we have to return `null` to prevent the error, and a second attempt will be made by scrolling the page.

## How has this been tested?
See above.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->