### PR TITLE
Data: Refactor resolver fulfillment / request progress as data state

### DIFF
--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -4,23 +4,6 @@
 import { castArray } from 'lodash';
 
 /**
- * Returns an action object used in signalling that the request for a given
- * data type has been made.
- *
- * @param {string}  dataType Data type requested.
- * @param {?string} subType  Optional data sub-type.
- *
- * @return {Object} Action object.
- */
-export function setRequested( dataType, subType ) {
-	return {
-		type: 'SET_REQUESTED',
-		dataType,
-		subType,
-	};
-}
-
-/**
  * Returns an action object used in signalling that terms have been received
  * for a given taxonomy.
  *

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -12,6 +12,13 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import { default as entities, getMethodName } from './entities';
 
+/**
+ * The reducer key used by core data in store registration.
+ *
+ * @type {string}
+ */
+export const REDUCER_KEY = 'core';
+
 const createEntityRecordGetter = ( source ) => entities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	const methodName = getMethodName( kind, name );
@@ -22,7 +29,7 @@ const createEntityRecordGetter = ( source ) => entities.reduce( ( result, entity
 const entityResolvers = createEntityRecordGetter( resolvers );
 const entitySelectors = createEntityRecordGetter( selectors );
 
-const store = registerStore( 'core', {
+const store = registerStore( REDUCER_KEY, {
 	reducer,
 	actions,
 	selectors: { ...selectors, ...entitySelectors },

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -31,17 +31,6 @@ export function terms( state = {}, action ) {
 				...state,
 				[ action.taxonomy ]: action.terms,
 			};
-
-		case 'SET_REQUESTED':
-			const { dataType, subType: taxonomy } = action;
-			if ( dataType !== 'terms' || state.hasOwnProperty( taxonomy ) ) {
-				return state;
-			}
-
-			return {
-				...state,
-				[ taxonomy ]: null,
-			};
 	}
 
 	return state;

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -7,7 +7,6 @@ import apiRequest from '@wordpress/api-request';
  * Internal dependencies
  */
 import {
-	setRequested,
 	receiveTerms,
 	receiveUserQuery,
 	receiveEntityRecords,
@@ -21,7 +20,6 @@ import { getEntity } from './entities';
  * progress.
  */
 export async function* getCategories() {
-	yield setRequested( 'terms', 'categories' );
 	const categories = await apiRequest( { path: '/wp/v2/categories?per_page=-1' } );
 	yield receiveTerms( 'categories', categories );
 }

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -4,6 +4,29 @@
 import { map } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { REDUCER_KEY } from './';
+
+/**
+ * Returns true if resolution is in progress for the core selector of the given
+ * name and arguments.
+ *
+ * @param {string} selectorName Core data selector name.
+ * @param {...*}   args         Arguments passed to selector.
+ *
+ * @return {boolean} Whether resolution is in progress.
+ */
+function isResolving( selectorName, ...args ) {
+	return select( 'core/data' ).isResolving( REDUCER_KEY, selectorName, ...args );
+}
+
+/**
  * Returns all the available terms for the given taxonomy.
  *
  * @param {Object} state    Data state.
@@ -36,7 +59,7 @@ export function getCategories( state ) {
  * @return {boolean} Whether a request is in progress for taxonomy's terms.
  */
 export function isRequestingTerms( state, taxonomy ) {
-	return state.terms[ taxonomy ] === null;
+	return isResolving( 'getTerms', taxonomy );
 }
 
 /**
@@ -47,8 +70,8 @@ export function isRequestingTerms( state, taxonomy ) {
  *
  * @return {boolean} Whether a request is in progress for categories.
  */
-export function isRequestingCategories( state ) {
-	return isRequestingTerms( state, 'categories' );
+export function isRequestingCategories() {
+	return isResolving( 'getCategories' );
 }
 
 /**

--- a/core-data/test/reducer.js
+++ b/core-data/test/reducer.js
@@ -27,45 +27,6 @@ describe( 'terms()', () => {
 			categories: [ { id: 1 } ],
 		} );
 	} );
-
-	it( 'assigns requested taxonomy to null', () => {
-		const originalState = deepFreeze( {} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'terms',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {
-			categories: null,
-		} );
-	} );
-
-	it( 'does not assign requested taxonomy to null if received', () => {
-		const originalState = deepFreeze( {
-			categories: [ { id: 1 } ],
-		} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'terms',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {
-			categories: [ { id: 1 } ],
-		} );
-	} );
-
-	it( 'does not assign requested taxonomy if not terms data type', () => {
-		const originalState = deepFreeze( {} );
-		const state = terms( originalState, {
-			type: 'SET_REQUESTED',
-			dataType: 'foo',
-			subType: 'categories',
-		} );
-
-		expect( state ).toEqual( {} );
-	} );
 } );
 
 describe( 'entities', () => {

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -7,7 +7,7 @@ import apiRequest from '@wordpress/api-request';
  * Internal dependencies
  */
 import { getCategories, getEntityRecord } from '../resolvers';
-import { setRequested, receiveTerms, receiveEntityRecords } from '../actions';
+import { receiveTerms, receiveEntityRecords } from '../actions';
 
 jest.mock( '@wordpress/api-request' );
 
@@ -24,8 +24,6 @@ describe( 'getCategories', () => {
 
 	it( 'yields with requested terms', async () => {
 		const fulfillment = getCategories();
-		const requested = ( await fulfillment.next() ).value;
-		expect( requested.type ).toBe( setRequested().type );
 		const received = ( await fulfillment.next() ).value;
 		expect( received ).toEqual( receiveTerms( 'categories', CATEGORIES ) );
 	} );

--- a/core-data/test/selectors.js
+++ b/core-data/test/selectors.js
@@ -6,7 +6,13 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getTerms, isRequestingTerms, getEntityRecord } from '../selectors';
+import { getTerms, isRequestingCategories, getEntityRecord } from '../selectors';
+import { select } from '@wordpress/data';
+
+jest.mock( '@wordpress/data', () => ( {
+	...require.requireActual( '@wordpress/data' ),
+	select: jest.fn().mockReturnValue( {} ),
+} ) );
 
 describe( 'getTerms()', () => {
 	it( 'returns value of terms by taxonomy', () => {
@@ -24,35 +30,39 @@ describe( 'getTerms()', () => {
 	} );
 } );
 
-describe( 'isRequestingTerms()', () => {
+describe( 'isRequestingCategories()', () => {
+	beforeAll( () => {
+		select( 'core/data' ).isResolving = jest.fn().mockReturnValue( false );
+	} );
+
+	afterAll( () => {
+		select( 'core/data' ).isResolving.mockRestore();
+	} );
+
+	function setIsResolving( isResolving ) {
+		select( 'core/data' ).isResolving.mockImplementation(
+			( reducerKey, selectorName ) => (
+				isResolving &&
+				reducerKey === 'core' &&
+				selectorName === 'getCategories'
+			)
+		);
+	}
+
 	it( 'returns false if never requested', () => {
-		const state = deepFreeze( {
-			terms: {},
-		} );
-
-		const result = isRequestingTerms( state, 'categories' );
+		const result = isRequestingCategories();
 		expect( result ).toBe( false );
 	} );
 
-	it( 'returns false if terms received', () => {
-		const state = deepFreeze( {
-			terms: {
-				categories: [ { id: 1 } ],
-			},
-		} );
-
-		const result = isRequestingTerms( state, 'categories' );
+	it( 'returns false if categories resolution finished', () => {
+		setIsResolving( false );
+		const result = isRequestingCategories();
 		expect( result ).toBe( false );
 	} );
 
-	it( 'returns true if requesting', () => {
-		const state = deepFreeze( {
-			terms: {
-				categories: null,
-			},
-		} );
-
-		const result = isRequestingTerms( state, 'categories' );
+	it( 'returns true if categories resolution started', () => {
+		setIsResolving( true );
+		const result = isRequestingCategories();
 		expect( result ).toBe( true );
 	} );
 } );

--- a/data/index.js
+++ b/data/index.js
@@ -3,7 +3,6 @@
  */
 import { combineReducers, createStore } from 'redux';
 import { flowRight, without, mapValues, overEvery } from 'lodash';
-import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
  * WordPress dependencies
@@ -14,6 +13,8 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 /**
  * Internal dependencies
  */
+import registerDataStore from './store';
+
 export { loadAndPersist, withRehydratation } from './persist';
 
 /**
@@ -130,50 +131,29 @@ export function registerSelectors( reducerKey, newSelectors ) {
  * @param {Object} newResolvers Resolvers to register.
  */
 export function registerResolvers( reducerKey, newResolvers ) {
-	const createResolver = ( selector, key ) => {
+	const { hasStartedResolution } = select( 'core/data' );
+	const { startResolution, finishResolution } = dispatch( 'core/data' );
+
+	const createResolver = ( selector, selectorName ) => {
 		// Don't modify selector behavior if no resolver exists.
-		if ( ! newResolvers.hasOwnProperty( key ) ) {
+		if ( ! newResolvers.hasOwnProperty( selectorName ) ) {
 			return selector;
 		}
 
 		const store = stores[ reducerKey ];
 
 		// Normalize resolver shape to object.
-		let resolver = newResolvers[ key ];
+		let resolver = newResolvers[ selectorName ];
 		if ( ! resolver.fulfill ) {
 			resolver = { fulfill: resolver };
 		}
 
-		/**
-		 * To ensure that fulfillment occurs only once per arguments set
-		 * (even for deeply "equivalent" arguments), track calls.
-		 *
-		 * @type {EquivalentKeyMap}
-		 */
-		const fulfilledByEquivalentArgs = new EquivalentKeyMap();
-
-		/**
-		 * Returns true if resolver fulfillment has already occurred for an
-		 * equivalent set of arguments. Includes side effect when returning
-		 * false to ensure the next invocation returns true.
-		 *
-		 * @param {Array} args Arguments set.
-		 *
-		 * @return {boolean} Whether fulfillment has already occurred.
-		 */
-		function hasBeenFulfilled( args ) {
-			const hasArguments = fulfilledByEquivalentArgs.has( args );
-			if ( ! hasArguments ) {
-				fulfilledByEquivalentArgs.set( args, true );
-			}
-
-			return hasArguments;
-		}
-
 		async function fulfill( ...args ) {
-			if ( hasBeenFulfilled( args ) ) {
+			if ( hasStartedResolution( reducerKey, selectorName, args ) ) {
 				return;
 			}
+
+			startResolution( reducerKey, selectorName, args );
 
 			// At this point, selectors have already been pre-bound to inject
 			// state, it would not be otherwise provided to fulfill.
@@ -193,6 +173,8 @@ export function registerResolvers( reducerKey, newResolvers ) {
 					store.dispatch( maybeAction );
 				}
 			}
+
+			finishResolution( reducerKey, selectorName, args );
 		}
 
 		if ( typeof resolver.isFulfilled === 'function' ) {
@@ -485,3 +467,5 @@ export function toAsyncIterable( object ) {
 		}
 	}() );
 }
+
+registerDataStore();

--- a/data/store/actions.js
+++ b/data/store/actions.js
@@ -1,0 +1,37 @@
+/**
+ * Returns an action object used in signalling that selector resolution has
+ * started.
+ *
+ * @param {string} reducerKey   Registered store reducer key.
+ * @param {string} selectorName Name of selector for which resolver triggered.
+ * @param {...*}   args         Arguments to associate for uniqueness.
+ *
+ * @return {Object} Action object.
+ */
+export function startResolution( reducerKey, selectorName, args ) {
+	return {
+		type: 'START_RESOLUTION',
+		reducerKey,
+		selectorName,
+		args,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that selector resolution has
+ * completed.
+ *
+ * @param {string} reducerKey   Registered store reducer key.
+ * @param {string} selectorName Name of selector for which resolver triggered.
+ * @param {...*}   args         Arguments to associate for uniqueness.
+ *
+ * @return {Object} Action object.
+ */
+export function finishResolution( reducerKey, selectorName, args ) {
+	return {
+		type: 'FINISH_RESOLUTION',
+		reducerKey,
+		selectorName,
+		args,
+	};
+}

--- a/data/store/index.js
+++ b/data/store/index.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { registerStore } from '../';
+
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+
+export default function registerDataStore() {
+	registerStore( 'core/data', {
+		reducer,
+		actions,
+		selectors,
+	} );
+}

--- a/data/store/reducer.js
+++ b/data/store/reducer.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { flowRight } from 'lodash';
+import EquivalentKeyMap from 'equivalent-key-map';
+
+/**
+ * Internal dependencies
+ */
+import { onSubKey } from './utils';
+
+/**
+ * Reducer function returning next state for selector resolution, object form:
+ *
+ *  reducerKey -> selectorName -> EquivalentKeyMap<Array,boolean>
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @returns {Object} Next state.
+ */
+const isResolved = flowRight( [
+	onSubKey( 'reducerKey' ),
+	onSubKey( 'selectorName' ),
+] )( ( state = new EquivalentKeyMap(), action ) => {
+	switch ( action.type ) {
+		case 'START_RESOLUTION':
+		case 'FINISH_RESOLUTION':
+			const isStarting = action.type === 'START_RESOLUTION';
+			const nextState = new EquivalentKeyMap( state );
+			nextState.set( action.args, isStarting );
+			return nextState;
+	}
+
+	return state;
+} );
+
+export default isResolved;

--- a/data/store/selectors.js
+++ b/data/store/selectors.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the raw `isResolving` value for a given reducer key, selector name,
+ * and arguments set. May be undefined if the selector has never been resolved
+ * or not resolved for the given set of arguments, otherwise true or false for
+ * resolution started and completed respectively.
+ *
+ * @param {Object} state        Data state.
+ * @param {string} reducerKey   Registered store reducer key.
+ * @param {string} selectorName Selector name.
+ * @param {Array}  args         Arguments passed to selector.
+ *
+ * @return {?boolean} isResolving value.
+ */
+export function getIsResolving( state, reducerKey, selectorName, args ) {
+	const map = get( state, [ reducerKey, selectorName ] );
+	if ( ! map ) {
+		return;
+	}
+
+	return map.get( args );
+}
+
+/**
+ * Returns true if resolution has already been triggered for a given reducer
+ * key, selector name, and arguments set.
+ *
+ * @param {Object} state        Data state.
+ * @param {string} reducerKey   Registered store reducer key.
+ * @param {string} selectorName Selector name.
+ * @param {?Array} args         Arguments passed to selector (default `[]`).
+ *
+ * @return {boolean} Whether resolution has been triggered.
+ */
+export function hasStartedResolution( state, reducerKey, selectorName, args = [] ) {
+	return getIsResolving( state, reducerKey, selectorName, args ) !== undefined;
+}
+
+/**
+ * Returns true if resolution has completed for a given reducer key, selector
+ * name, and arguments set.
+ *
+ * @param {Object} state        Data state.
+ * @param {string} reducerKey   Registered store reducer key.
+ * @param {string} selectorName Selector name.
+ * @param {?Array} args         Arguments passed to selector.
+ *
+ * @return {boolean} Whether resolution has completed.
+ */
+export function hasFinishedResolution( state, reducerKey, selectorName, args = [] ) {
+	return getIsResolving( state, reducerKey, selectorName, args ) === false;
+}
+
+/**
+ * Returns true if resolution has been triggered but has not yet completed for
+ * a given reducer key, selector name, and arguments set.
+ *
+ * @param {Object} state        Data state.
+ * @param {string} reducerKey   Registered store reducer key.
+ * @param {string} selectorName Selector name.
+ * @param {?Array} args         Arguments passed to selector.
+ *
+ * @return {boolean} Whether resolution is in progress.
+ */
+export function isResolving( state, reducerKey, selectorName, args = [] ) {
+	return getIsResolving( state, reducerKey, selectorName, args ) === true;
+}

--- a/data/store/test/reducer.js
+++ b/data/store/test/reducer.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+
+describe( 'reducer', () => {
+	it( 'should default to an empty object', () => {
+		const state = reducer( undefined, {} );
+
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'should return with started resolution', () => {
+		const state = reducer( undefined, {
+			type: 'START_RESOLUTION',
+			reducerKey: 'test',
+			selectorName: 'getFoo',
+			args: [],
+		} );
+
+		// { test: { getFoo: EquivalentKeyMap( [] => true ) } }
+		expect( state.test.getFoo.get( [] ) ).toBe( true );
+	} );
+
+	it( 'should return with finished resolution', () => {
+		const original = reducer( undefined, {
+			type: 'START_RESOLUTION',
+			reducerKey: 'test',
+			selectorName: 'getFoo',
+			args: [],
+		} );
+		const state = reducer( deepFreeze( original ), {
+			type: 'FINISH_RESOLUTION',
+			reducerKey: 'test',
+			selectorName: 'getFoo',
+			args: [],
+		} );
+
+		// { test: { getFoo: EquivalentKeyMap( [] => false ) } }
+		expect( state.test.getFoo.get( [] ) ).toBe( false );
+	} );
+} );

--- a/data/store/test/selectors.js
+++ b/data/store/test/selectors.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import EquivalentKeyMap from 'equivalent-key-map';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getIsResolving,
+	hasStartedResolution,
+	hasFinishedResolution,
+	isResolving,
+} from '../selectors';
+
+describe( 'getIsResolving', () => {
+	it( 'should return undefined if no state by reducerKey, selectorName', () => {
+		const state = {};
+		const result = getIsResolving( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( undefined );
+	} );
+
+	it( 'should return undefined if state by reducerKey, selectorName, but not args', () => {
+		const state = {
+			test: {
+				getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			},
+		};
+		const result = getIsResolving( state, 'test', 'getFoo', [ 'bar' ] );
+
+		expect( result ).toBe( undefined );
+	} );
+
+	it( 'should return value by reducerKey, selectorName', () => {
+		const state = {
+			test: {
+				getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			},
+		};
+		const result = getIsResolving( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'hasStartedResolution', () => {
+	it( 'returns false if not has started', () => {
+		const state = {};
+		const result = hasStartedResolution( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if has started', () => {
+		const state = {
+			test: {
+				getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			},
+		};
+		const result = hasStartedResolution( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'hasFinishedResolution', () => {
+	it( 'returns false if not has finished', () => {
+		const state = {
+			test: {
+				getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			},
+		};
+		const result = hasFinishedResolution( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if has finished', () => {
+		const state = {
+			test: {
+				getFoo: new EquivalentKeyMap( [ [ [], false ] ] ),
+			},
+		};
+		const result = hasFinishedResolution( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'isResolving', () => {
+	it( 'returns false if not has started', () => {
+		const state = {};
+		const result = isResolving( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false if has finished', () => {
+		const state = {
+			test: {
+				getFoo: new EquivalentKeyMap( [ [ [], false ] ] ),
+			},
+		};
+		const result = isResolving( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if has started but not finished', () => {
+		const state = {
+			test: {
+				getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			},
+		};
+		const result = isResolving( state, 'test', 'getFoo', [] );
+
+		expect( result ).toBe( true );
+	} );
+} );

--- a/data/store/test/utils.js
+++ b/data/store/test/utils.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { onSubKey } from '../utils';
+
+describe( 'onSubKey', () => {
+	function createEnhancedReducer( actionProperty ) {
+		const enhanceReducer = onSubKey( actionProperty );
+		return enhanceReducer( ( state, action ) => 'Called by ' + action.caller );
+	}
+
+	it( 'should default to an empty object', () => {
+		const reducer = createEnhancedReducer( 'caller' );
+		const nextState = reducer( undefined, { type: '@@INIT' } );
+
+		expect( nextState ).toEqual( {} );
+	} );
+
+	it( 'should ignore actions where property not present', () => {
+		const state = {};
+		const reducer = createEnhancedReducer( 'caller' );
+		const nextState = reducer( state, { type: 'DO_FOO' } );
+
+		expect( nextState ).toBe( state );
+	} );
+
+	it( 'should key by action property', () => {
+		const reducer = createEnhancedReducer( 'caller' );
+
+		let state = Object.freeze( {} );
+		state = reducer( state, { type: 'DO_FOO', caller: 1 } );
+		state = reducer( state, { type: 'DO_FOO', caller: 2 } );
+
+		expect( state ).toEqual( {
+			1: 'Called by 1',
+			2: 'Called by 2',
+		} );
+	} );
+} );

--- a/data/store/utils.js
+++ b/data/store/utils.js
@@ -1,0 +1,28 @@
+/**
+ * Higher-order reducer creator which creates a combined reducer object, keyed
+ * by a property on the action object.
+ *
+ * @param {string} actionProperty Action property by which to key object.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+export const onSubKey = ( actionProperty ) => ( reducer ) => ( state = {}, action ) => {
+	// Retrieve subkey from action. Do not track if undefined; useful for cases
+	// where reducer is scoped by action shape.
+	const key = action[ actionProperty ];
+	if ( key === undefined ) {
+		return state;
+	}
+
+	// Avoid updating state if unchanged. Note that this also accounts for a
+	// reducer which returns undefined on a key which is not yet tracked.
+	const nextKeyState = reducer( state[ key ], action );
+	if ( nextKeyState === state[ key ] ) {
+		return state;
+	}
+
+	return {
+		...state,
+		[ key ]: nextKeyState,
+	};
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4589,9 +4589,9 @@
 			}
 		},
 		"equivalent-key-map": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.1.1.tgz",
-			"integrity": "sha512-VfHxntFFcApMyX3TTEQg+nuDPoiGgs1WfYm1JN+d9HUM6Shxp2d7LrMrDmdiybYZVs7U8HM9mqAHpwE9/X8pSQ=="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.0.tgz",
+			"integrity": "sha512-F6m+4Th/DEUexGY+OGZoMsq33u8CfLzW9kCuryIugZS4sO4niQIBjVUM3yvWy4oaBUB0hM7uVDBlZhreVAPfcg=="
 		},
 		"errno": {
 			"version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"dom-react": "2.2.1",
 		"dom-scroll-into-view": "1.2.1",
 		"element-closest": "2.0.2",
-		"equivalent-key-map": "0.1.1",
+		"equivalent-key-map": "0.2.0",
 		"escape-string-regexp": "1.0.5",
 		"eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
 		"hpq": "1.2.0",


### PR DESCRIPTION
Related: #6395

This pull request seeks to implement a new resolver state in the data module itself. This is used for...

- ... Tracking whether fulfillment for a resolver has already occurred for a given set of arguments.
- ... Replacing the need for dedicated requests state in other modules.

Specifically, this should help simplify implementation of `core-data`, both in master and as proposed in #6395, as we'd not need to track whether a request is in progress, as it can be determined from the current progress of the selector resolver.

__Implementation notes:__

- This is the first instance of using `select` within a selector, which may be subject to debate or at least a decision on consistent approach. While it feels less "pure", it does enable (albeit currently awkward) [selector stubbing](https://github.com/WordPress/gutenberg/blob/245947c6a3f3041b072fbd2db8ee4371067f13b2/core-data/test/selectors.js#L35) which can alleviate some existing issues with providing a state shape to a selector satisfying the implicit dependencies of its composed selectors ([example](https://github.com/WordPress/gutenberg/pull/6209/files#diff-d2493f48caf3f95c74d6ec017e507ced) of how these revisions can require cascading changes to many dependent selectors).
- `EquivalentKeyMap` was updated to 0.2.0 to take advantage of the need for cloning the state value ([see changelog](https://github.com/aduth/equivalent-key-map/blob/master/CHANGELOG.md))

__Testing instructions:__

Only the Categories block makes use of the impacted data. Verify there are no regressions in the load and display of categories in the block. The "load" stage is particularly affected, and a spinner should be shown while the request is in progress.