### PR TITLE
Fix multi selection with arrows + shift

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { overEvery, find, findLast, reverse, get } from 'lodash';
+import { overEvery, find, findLast, reverse } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -137,19 +137,26 @@ class WritingFlow extends Component {
 		return find( focusableNodes, isTabCandidate );
 	}
 
-	expandSelection( currentStartUid, isReverse ) {
-		const { previousBlockUid, nextBlockUid } = this.props;
+	expandSelection( isReverse ) {
+		const {
+			selectedBlockUID,
+			selectionStartUID,
+			selectionBeforeEndUID,
+			selectionAfterEndUID,
+		} = this.props;
 
-		const expandedBlockUid = isReverse ? previousBlockUid : nextBlockUid;
-		if ( expandedBlockUid ) {
-			this.props.onMultiSelect( currentStartUid, expandedBlockUid );
+		const nextSelectionEndUID = isReverse ? selectionBeforeEndUID : selectionAfterEndUID;
+
+		if ( nextSelectionEndUID ) {
+			this.props.onMultiSelect( selectionStartUID || selectedBlockUID, nextSelectionEndUID );
 		}
 	}
 
 	moveSelection( isReverse ) {
-		const { previousBlockUid, nextBlockUid } = this.props;
+		const { selectedFirstUid, selectedLastUid } = this.props;
 
-		const focusedBlockUid = isReverse ? previousBlockUid : nextBlockUid;
+		const focusedBlockUid = isReverse ? selectedFirstUid : selectedLastUid;
+
 		if ( focusedBlockUid ) {
 			this.props.onSelectBlock( focusedBlockUid );
 		}
@@ -172,7 +179,7 @@ class WritingFlow extends Component {
 	}
 
 	onKeyDown( event ) {
-		const { selectedBlockUID, selectionStart, hasMultiSelection } = this.props;
+		const { hasMultiSelection } = this.props;
 
 		const { keyCode, target } = event;
 		const isUp = keyCode === UP;
@@ -193,20 +200,24 @@ class WritingFlow extends Component {
 			this.verticalRect = computeCaretRect( target );
 		}
 
-		if ( isNav && isShift && hasMultiSelection ) {
-			// Shift key is down and existing block multi-selection
+		if ( ! isNav ) {
+			return;
+		}
+
+		if ( isShift && ( hasMultiSelection || (
+			this.isTabbableEdge( target, isReverse ) &&
+			isNavEdge( target, isReverse, true )
+		) ) ) {
+			// Shift key is down, and there is multi selection or we're at the end of the current block.
+			this.expandSelection( isReverse );
 			event.preventDefault();
-			this.expandSelection( selectionStart, isReverse );
-		} else if ( isNav && isShift && this.isTabbableEdge( target, isReverse ) && isNavEdge( target, isReverse, true ) ) {
-			// Shift key is down, but no existing block multi-selection
-			event.preventDefault();
-			this.expandSelection( selectedBlockUID, isReverse );
-		} else if ( isNav && hasMultiSelection ) {
+		} else if ( hasMultiSelection ) {
 			// Moving from block multi-selection to single block selection
-			event.preventDefault();
 			this.moveSelection( isReverse );
+			event.preventDefault();
 		} else if ( isVertical && isVerticalEdge( target, isReverse, isShift ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
+
 			if ( closestTabbable ) {
 				placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
 				event.preventDefault();
@@ -259,18 +270,28 @@ class WritingFlow extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const {
+			getSelectedBlockUID,
+			getMultiSelectedBlocksStartUid,
+			getMultiSelectedBlocksEndUid,
 			getPreviousBlockUid,
 			getNextBlockUid,
-			getMultiSelectedBlocksStartUid,
-			getMultiSelectedBlocks,
-			getSelectedBlock,
+			getFirstMultiSelectedBlockUid,
+			getLastMultiSelectedBlockUid,
+			hasMultiSelection,
 		} = select( 'core/editor' );
+
+		const selectedBlockUID = getSelectedBlockUID();
+		const selectionStartUID = getMultiSelectedBlocksStartUid();
+		const selectionEndUID = getMultiSelectedBlocksEndUid();
+
 		return {
-			previousBlockUid: getPreviousBlockUid(),
-			nextBlockUid: getNextBlockUid(),
-			selectionStart: getMultiSelectedBlocksStartUid(),
-			hasMultiSelection: getMultiSelectedBlocks().length > 1,
-			selectedBlockUID: get( getSelectedBlock(), [ 'uid' ] ),
+			selectedBlockUID,
+			selectionStartUID,
+			selectionBeforeEndUID: getPreviousBlockUid( selectionEndUID || selectedBlockUID ),
+			selectionAfterEndUID: getNextBlockUid( selectionEndUID || selectedBlockUID ),
+			selectedFirstUid: getFirstMultiSelectedBlockUid(),
+			selectedLastUid: getLastMultiSelectedBlockUid(),
+			hasMultiSelection: hasMultiSelection(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -585,6 +585,19 @@ export function hasSelectedBlock( state ) {
 }
 
 /**
+ * Returns the currently selected block UID, or null if there is no selected
+ * block.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {?Object} Selected block UID.
+ */
+export function getSelectedBlockUID( state ) {
+	const { start, end } = state.blockSelection;
+	return start === end && start ? start : null;
+}
+
+/**
  * Returns the currently selected block, or null if there is no selected block.
  *
  * @param {Object} state Global application state.
@@ -592,12 +605,8 @@ export function hasSelectedBlock( state ) {
  * @return {?Object} Selected block.
  */
 export function getSelectedBlock( state ) {
-	const { start, end } = state.blockSelection;
-	if ( start !== end || ! start ) {
-		return null;
-	}
-
-	return getBlock( state, start );
+	const uid = getSelectedBlockUID( state );
+	return uid ? getBlock( state, uid ) : null;
 }
 
 /**

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -46,6 +46,7 @@ const {
 	getBlockCount,
 	hasSelectedBlock,
 	getSelectedBlock,
+	getSelectedBlockUID,
 	getBlockRootUID,
 	getEditedPostAttribute,
 	getGlobalBlockCount,
@@ -1606,6 +1607,33 @@ describe( 'selectors', () => {
 			expect( getGlobalBlockCount( state, 'core/heading' ) ).toBe( 0 );
 		} );
 	} );
+
+	describe( 'getSelectedBlockUID', () => {
+		it( 'should return null if no block is selected', () => {
+			const state = {
+				blockSelection: { start: null, end: null },
+			};
+
+			expect( getSelectedBlockUID( state ) ).toBe( null );
+		} );
+
+		it( 'should return null if there is multi selection', () => {
+			const state = {
+				blockSelection: { start: 23, end: 123 },
+			};
+
+			expect( getSelectedBlockUID( state ) ).toBe( null );
+		} );
+
+		it( 'should return the selected block UID', () => {
+			const state = {
+				blockSelection: { start: 23, end: 23 },
+			};
+
+			expect( getSelectedBlockUID( state ) ).toEqual( 23 );
+		} );
+	} );
+
 	describe( 'getSelectedBlock', () => {
 		it( 'should return null if no block is selected', () => {
 			const state = {


### PR DESCRIPTION
## Description
Fixes #5548.

## How has this been tested?
> 1. Select a block.
> 2. Use Shift+Arrow Down to trigger multi-selection. Select a few blocks.
> 3. Use Shift+Arrow Up to to go in the opposite direction again, i.e. deselect the last select block and so on. Instead the selection is reset and the start block + the block above are multi-selected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->