### PR TITLE
Fix spelling error in post-featured-image/index.js

### DIFF
--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -18,7 +18,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import './style.scss';
 import PostFeaturedImageCheck from './check';
 
-//used when labels from post tyoe were not yet loaded or when they are not present.
+// Used when labels from post type were not yet loaded or when they are not present.
 const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
 const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove featured image' );
 


### PR DESCRIPTION
## Description

Change `tyoe` to `type` + minor formatting