### PR TITLE
Tweak targetSchema Response

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -283,12 +283,11 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 			&& current_user_can( $post_type->cap->publish_posts ) ) {
 			$new_links['https://api.w.org/action-sticky'] = array(
 				array(
-					'title'        => __( 'Sticky Post', 'gutenberg' ),
+					'title'        => __( 'The current user can sticky this post.', 'gutenberg' ),
 					'href'         => $orig_links['self'][0]['href'],
 					'targetSchema' => array(
-						'type'        => 'object',
-						'description' => __( 'Whether or not the current user can sticky the post.', 'gutenberg' ),
-						'properties'  => array(
+						'type'       => 'object',
+						'properties' => array(
 							'sticky' => array(
 								'type' => 'boolean',
 							),


### PR DESCRIPTION
## Description

This is a PR against #6529.

It tweaks the response for the `wp:action-sticky` link, to more clearly state what it's used for:

- Move the `description` outside of the `targetSchema` object, to `wp:action-sticky`'s `title` attribute. This makes it clear that the text is referring to the link, not the `targetSchema`.
- Reword the text to more accurately reflect the nature of the `wp:action-sticky` link: if `wp:action-sticky` is present, then the current user has the ability to make the post sticky.