### PR TITLE
Allow resetting the permalink by saving it as empty

### DIFF
--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -29,7 +29,7 @@ class PostPermalinkEditor extends Component {
 
 		this.props.onSave();
 
-		if ( ! postName || postName === this.props.postName ) {
+		if ( postName === this.props.postName ) {
 			return;
 		}
 
@@ -63,7 +63,6 @@ class PostPermalinkEditor extends Component {
 						value={ editedPostName }
 						onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
 						type="text"
-						required
 						autoFocus
 					/>
 					<span className="editor-post-permalink-editor__suffix">

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1540,7 +1540,7 @@ export function getPermalink( state ) {
  */
 export function getPermalinkParts( state ) {
 	const permalinkTemplate = getEditedPostAttribute( state, 'permalink_template' );
-	const postName = getEditedPostAttribute( state, 'slug' ) || getEditedPostAttribute( state, 'draft_slug' );
+	const postName = getEditedPostAttribute( state, 'slug' ) || getEditedPostAttribute( state, 'generated_slug' );
 
 	const [ prefix, suffix ] = permalinkTemplate.split( PERMALINK_POSTNAME_REGEX );
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -230,13 +230,10 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 		require_once ABSPATH . '/wp-admin/includes/post.php';
 	}
 
-	$sample_permalink = get_sample_permalink( $post->ID );
+	$sample_permalink = get_sample_permalink( $post->ID, $post->post_title, '' );
 
 	$response->data['permalink_template'] = $sample_permalink[0];
-
-	if ( 'draft' === $post->post_status && ! $post->post_name ) {
-		$response->data['draft_slug'] = $sample_permalink[1];
-	}
+	$response->data['generated_slug'] = $sample_permalink[1];
 
 	return $response;
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -233,7 +233,7 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 	$sample_permalink = get_sample_permalink( $post->ID, $post->post_title, '' );
 
 	$response->data['permalink_template'] = $sample_permalink[0];
-	$response->data['generated_slug'] = $sample_permalink[1];
+	$response->data['generated_slug']     = $sample_permalink[1];
 
 	return $response;
 }


### PR DESCRIPTION
## Description

#6603 reports a permalink workflow from the classic editor that doesn't work in the block editor:

- Create a post, save it.
- Change the permalink, save it again.
- Edit the permalink to be empty, and save it again.

The permalink should be reset to the auto-generated permalink: this should work for both draft and published posts.

This PR makes a few change to support this flow:
- On post responses from the REST API, rename the `draft_slug` property to `generated_slug`, and make it available on all posts, not just drafts.
- Ensure `generated_slug` is the generated slug, rather than defaulting to the `slug`, when that's set.
- Allow the `PostPermalinkEditor` to be saved with an empty permalink.

## How has this been tested?

To test, run through the workflow with a few variations:

- With draft and published posts.
- With hierarchical and non-hierarchical post types (eg, pages and posts).
- With CPTs.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.