### PR TITLE
Block API: Replace JSON-escaped quotation mark with unicode escape sequence

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -164,12 +164,29 @@ export function getCommentAttributes( allAttributes, blockType ) {
 	return attributes;
 }
 
-export function serializeAttributes( attrs ) {
-	return JSON.stringify( attrs )
-		.replace( /--/g, '\\u002d\\u002d' ) // don't break HTML comments
-		.replace( /</g, '\\u003c' ) // don't break standard-non-compliant tools
-		.replace( />/g, '\\u003e' ) // ibid
-		.replace( /&/g, '\\u0026' ); // ibid
+/**
+ * Given an attributes object, returns a string in the serialized attributes
+ * format prepared for post content.
+ *
+ * @param {Object} attributes Attributes object.
+ *
+ * @return {string} Serialized attributes.
+ */
+export function serializeAttributes( attributes ) {
+	return JSON.stringify( attributes )
+		// Don't break HTML comments.
+		.replace( /--/g, '\\u002d\\u002d' )
+
+		// Don't break non-standard-compliant tools.
+		.replace( /</g, '\\u003c' )
+		.replace( />/g, '\\u003e' )
+		.replace( /&/g, '\\u0026' )
+
+		// Bypass server stripslashes behavior which would unescape stringify's
+		// escaping of quotation mark.
+		//
+		// See: https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/
+		.replace( /\\"/g, '\\u0022' );
 }
 
 /**

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -16,6 +16,8 @@ import {
 	getBlockTypes,
 	setUnknownTypeHandlerName,
 } from '../registration';
+import { createBlock } from '../factory';
+import serialize from '../serializer';
 
 describe( 'block parser', () => {
 	const defaultBlockSettings = {
@@ -570,6 +572,25 @@ describe( 'block parser', () => {
 			expect( parsed.map( ( { name } ) => name ) ).toEqual( [
 				'core/test-block', 'core/void-block',
 			] );
+		} );
+
+		it( 'should parse with unicode escaped returned to original representation', () => {
+			registerBlockType( 'core/code', {
+				category: 'common',
+				title: 'Code Block',
+				attributes: {
+					content: {
+						type: 'string',
+					},
+				},
+				save: ( { attributes } ) => attributes.content,
+			} );
+
+			const content = '$foo = "My \"escaped\" text.";';
+			const block = createBlock( 'core/code', { content } );
+			const serialized = serialize( block );
+			const parsed = parse( serialized );
+			expect( parsed[ 0 ].attributes.content ).toBe( content );
 		} );
 	} );
 } );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -130,14 +130,21 @@ describe( 'block serializer', () => {
 		it( 'should not break HTML comments', () => {
 			expect( serializeAttributes( { a: '-- and --' } ) ).toBe( '{"a":"\\u002d\\u002d and \\u002d\\u002d"}' );
 		} );
+
 		it( 'should not break standard-non-compliant tools for "<"', () => {
 			expect( serializeAttributes( { a: '< and <' } ) ).toBe( '{"a":"\\u003c and \\u003c"}' );
 		} );
+
 		it( 'should not break standard-non-compliant tools for ">"', () => {
 			expect( serializeAttributes( { a: '> and >' } ) ).toBe( '{"a":"\\u003e and \\u003e"}' );
 		} );
+
 		it( 'should not break standard-non-compliant tools for "&"', () => {
 			expect( serializeAttributes( { a: '& and &' } ) ).toBe( '{"a":"\\u0026 and \\u0026"}' );
+		} );
+
+		it( 'should replace quotation marks', () => {
+			expect( serializeAttributes( { a: '" and "' } ) ).toBe( '{"a":"\\u0022 and \\u0022"}' );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #6181

This pull request seeks to resolve an issue where contributors who submit a block containing an (escaped) quotation mark in the serialized attributes would have the resulting post content become malformed. The specific behavior results during post sanitization, which for users without `unfiltered_html` capability includes a number more filters. In particular, the [`wp_kses_stripslashes` function](https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/) causes escaped JSON quotes to become unescaped, thus resulting in an invalid parse in the next editor session.

__Implementation notes:__

It was proposed at https://github.com/WordPress/gutenberg/issues/6181#issuecomment-387062185 to use entity-encoding on the quotation mark. However, this can result in a jarring end-user experience, where the encoded version would be displayed on next load:

![encoding](https://user-images.githubusercontent.com/1779930/39709818-ea14d99e-51e8-11e8-8907-c64613d3bed5.png)

__Testing instructions:__

Repeat steps to reproduce from https://github.com/WordPress/gutenberg/issues/6181#issuecomment-387057513 , verifying that the unicode escape sequence is saved to post content and that the post restores itself correctly upon refresh.