### PR TITLE
Tag selector: Don't add terms when tabbing away from the field

### DIFF
--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -94,7 +94,7 @@ class FormTokenField extends Component {
 
 	onBlur() {
 		if ( this.inputHasValidValue() ) {
-			this.setState( { isActive: false }, this.addCurrentToken );
+			this.setState( { isActive: false } );
 		} else {
 			this.setState( initialState );
 		}
@@ -106,9 +106,6 @@ class FormTokenField extends Component {
 		switch ( event.keyCode ) {
 			case 8: // backspace (delete to left)
 				preventDefault = this.handleDeleteKey( this.deleteTokenBeforeInput );
-				break;
-			case 9: // tab
-				preventDefault = this.addCurrentToken();
 				break;
 			case 13: // enter/return
 				preventDefault = this.addCurrentToken();


### PR DESCRIPTION
This PR aims to implement a safer interaction with the tags input field. Currently, tags (or better, non-hierarchical terms) are added or new ones created when simply tabbing away from the field.

While operating with the keyboard, tabbing away from a field is pretty common and it's certainly not a confirmation that the user's intent is to create/add a new tag. As mentioned in the related issue, after a while this leads to dozens of unwanted terms being created.

Also, there are at least other two cases where a tag gets created non-intentionally, to reproduce:
- enter some random string in the field
- press Cmd+Tab (or Alt+Tab on Windows) to switch to another application window open in yout operating system
- switch back to your browser's window
- a new tag has been created and added

or

- instead of switching to a different application window, just open a new browser's tab
- switch back to the previous tab (the Gutentab)
- a new tag has been created and added

By avoiding creation/addition of new tags on blur and when tabbing away, the new behavior should be more respectful of the real users intent.

Fixes #1339 

There's one remaining point in the related issue, not strictly related to a11y. Will split in separate issue for consideration.