### PR TITLE
Port the core/more block to ReactNative

### DIFF
--- a/core-blocks/code/edit.js
+++ b/core-blocks/code/edit.js
@@ -1,4 +1,3 @@
-
 /**
  * WordPress dependencies
  */

--- a/core-blocks/code/edit.js
+++ b/core-blocks/code/edit.js
@@ -1,3 +1,4 @@
+
 /**
  * WordPress dependencies
  */
@@ -9,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import { PlainText } from '@wordpress/editor';
 
-export default function edit( { attributes, setAttributes, className } ) {
+export default function CodeEdit( { attributes, setAttributes, className } ) {
 	return (
 		<div className={ className }>
 			<PlainText

--- a/core-blocks/code/edit.native.js
+++ b/core-blocks/code/edit.native.js
@@ -12,7 +12,7 @@ import { PlainText } from '@wordpress/editor';
 
 // Note: styling is applied directly to the (nested) PlainText component. Web-side components
 // apply it to the container 'div' but we don't have a proper proposal for cascading styling yet.
-export default function edit( { attributes, setAttributes, style } ) {
+export default function CodeEdit( { attributes, setAttributes, style } ) {
 	return (
 		<View>
 			<PlainText

--- a/core-blocks/index.native.js
+++ b/core-blocks/index.native.js
@@ -9,10 +9,12 @@ import {
  * Internal dependencies
  */
 import * as code from './code';
+import * as more from './more';
 
 export const registerCoreBlocks = () => {
 	[
 		code,
+		more,
 	].forEach( ( { name, settings } ) => {
 		registerBlockType( name, settings );
 	} );

--- a/core-blocks/more/edit.js
+++ b/core-blocks/more/edit.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+export default class edit extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onChangeInput = this.onChangeInput.bind( this );
+
+		this.state = {
+			defaultText: __( 'Read more' ),
+		};
+	}
+
+	onChangeInput( event ) {
+		// Set defaultText to an empty string, allowing the user to clear/replace the input field's text
+		this.setState( {
+			defaultText: '',
+		} );
+
+		const value = event.target.value.length === 0 ? undefined : event.target.value;
+		this.props.setAttributes( { customText: value } );
+	}
+
+	render() {
+		const { customText, noTeaser } = this.props.attributes;
+		const { setAttributes } = this.props;
+
+		const toggleNoTeaser = () => setAttributes( { noTeaser: ! noTeaser } );
+		const { defaultText } = this.state;
+		const value = customText !== undefined ? customText : defaultText;
+		const inputLength = value.length + 1;
+
+		return (
+			<Fragment>
+				<InspectorControls>
+					<PanelBody>
+						<ToggleControl
+							label={ __( 'Hide the teaser before the "More" tag' ) }
+							checked={ !! noTeaser }
+							onChange={ toggleNoTeaser }
+						/>
+					</PanelBody>
+				</InspectorControls>
+				<div className="wp-block-more">
+					<input
+						type="text"
+						value={ value }
+						size={ inputLength }
+						onChange={ this.onChangeInput }
+					/>
+				</div>
+			</Fragment>
+		);
+	}
+};

--- a/core-blocks/more/edit.js
+++ b/core-blocks/more/edit.js
@@ -62,4 +62,4 @@ export default class edit extends Component {
 			</Fragment>
 		);
 	}
-};
+}

--- a/core-blocks/more/edit.js
+++ b/core-blocks/more/edit.js
@@ -11,7 +11,7 @@ import { InspectorControls } from '@wordpress/editor';
  */
 import './editor.scss';
 
-export default class edit extends Component {
+export default class MoreEdit extends Component {
 	constructor() {
 		super( ...arguments );
 		this.onChangeInput = this.onChangeInput.bind( this );

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -8,9 +8,13 @@ import { View, Text } from 'react-native';
 import { __ } from '../../../i18n';
 
 export function edit( { attributes, setAttributes, isSelected } ) {
+  const { customText, noTeaser } = attributes;
+  const defaultText = __( 'Read more' );
+  const value = customText !== undefined ? customText : defaultText;
+
   return (
-    <View style={{ alignItems: 'center'}}>
-      <Text>&lt;!-- More --&gt;</Text>
+    <View style={{ alignItems: 'center', padding: 4}}>
+      <Text>&lt;!-- More: { value } --&gt;</Text>
     </View>
   );
 }

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -13,8 +13,8 @@ import { __ } from '@wordpress/i18n';
 import { PlainText } from '@wordpress/editor';
 import styles from './editor.scss';
 
-export default function edit( { attributes, setAttributes, isSelected } ) {
-	const { customText, noTeaser } = attributes;
+export default function edit( { attributes, setAttributes } ) {
+	const { customText } = attributes;
 	const defaultText = __( 'Read more' );
 	const value = customText !== undefined ? customText : defaultText;
 

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -19,18 +19,18 @@ export function edit( { attributes, setAttributes, isSelected } ) {
 	const value = customText !== undefined ? customText : defaultText;
 
 	return (
-		<View className={ styles.blocks_more_container }>
-			<View className={ styles.blocks_more_sub_container }>
-				<Text className={ styles.blocks_more_left_marker }>&lt;!--</Text>
+		<View className={ styles[ 'blocks-more-container' ] }>
+			<View className={ styles[ 'blocks-more-sub-container' ] }>
+				<Text className={ styles[ 'blocks-more-left-marker' ] }>&lt;!--</Text>
 				<PlainText
-					className={ styles.blocks_more_plain_text }
+					className={ styles[ 'blocks-more-plain-text' ] }
 					value={ value }
 					multiline={ true }
 					underlineColorAndroid="transparent"
 					onChange={ value => setAttributes( { customText: value } ) }
 					placeholder={ defaultText }
 				/>
-				<Text className={ styles.blocks_more_right_marker }>--&gt;</Text>
+				<Text className={ styles[ 'blocks-more-right-marker' ] }>--&gt;</Text>
 			</View>
 		</View> );
 }

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -13,22 +13,22 @@ import { __ } from '../../../i18n';
 import PlainText from '../../plain-text';
 
 export function edit( { attributes, setAttributes, isSelected } ) {
-  const { customText, noTeaser } = attributes;
-  const defaultText = __( 'Read more' );
-  const value = customText !== undefined ? customText : defaultText;
+	const { customText, noTeaser } = attributes;
+	const defaultText = __( 'Read more' );
+	const value = customText !== undefined ? customText : defaultText;
 
-  return (
-    <View style={{ padding: 4, alignItems: 'center' }}>
-      <View style={{ alignItems: 'center', flexDirection: "row"}}>
-        <Text style={{ fontFamily: 'monospace' }}>&lt;!--</Text>
-        <PlainText
-          value={ value }
-          multiline={ false }
-          underlineColorAndroid="transparent"
-          onChange={ content => setAttributes( { content } ) }
-          placeholder={ defaultText }
-        />
-        <Text style={{ fontFamily: 'monospace' }}>--&gt;</Text>
-      </View>
-    </View>);
+	return (
+		<View style={ { padding: 4, alignItems: 'center' } }>
+			<View style={ { alignItems: 'center', flexDirection: 'row' } }>
+				<Text style={ { fontFamily: 'monospace' } }>&lt;!--</Text>
+				<PlainText
+					value={ value }
+					multiline={ false }
+					underlineColorAndroid="transparent"
+					onChange={ content => setAttributes( { content } ) }
+					placeholder={ defaultText }
+				/>
+				<Text style={ { fontFamily: 'monospace' } }>--&gt;</Text>
+			</View>
+		</View> );
 }

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { PlainText } from '@wordpress/editor';
 import styles from './editor.scss';
 
-export default function edit( { attributes, setAttributes } ) {
+export default function MoreEdit( { attributes, setAttributes } ) {
 	const { customText } = attributes;
 	const defaultText = __( 'Read more' );
 	const value = customText !== undefined ? customText : defaultText;

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -1,0 +1,16 @@
+/** @format */
+
+import { View, Text } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '../../../i18n';
+
+export function edit( { attributes, setAttributes, isSelected } ) {
+  return (
+    <View style={{ alignItems: 'center'}}>
+      <Text>&lt;!-- More --&gt;</Text>
+    </View>
+  );
+}

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -7,14 +7,28 @@ import { View, Text } from 'react-native';
  */
 import { __ } from '../../../i18n';
 
+/**
+ * Internal dependencies
+ */
+import PlainText from '../../plain-text';
+
 export function edit( { attributes, setAttributes, isSelected } ) {
   const { customText, noTeaser } = attributes;
   const defaultText = __( 'Read more' );
   const value = customText !== undefined ? customText : defaultText;
 
   return (
-    <View style={{ alignItems: 'center', padding: 4}}>
-      <Text>&lt;!-- More: { value } --&gt;</Text>
-    </View>
-  );
+    <View style={{ padding: 4, alignItems: 'center' }}>
+      <View style={{ alignItems: 'center', flexDirection: "row"}}>
+        <Text style={{ fontFamily: 'monospace' }}>&lt;!--</Text>
+        <PlainText
+          value={ value }
+          multiline={ false }
+          underlineColorAndroid="transparent"
+          onChange={ content => setAttributes( { content } ) }
+          placeholder={ defaultText }
+        />
+        <Text style={{ fontFamily: 'monospace' }}>--&gt;</Text>
+      </View>
+    </View>);
 }

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -11,6 +11,7 @@ import { __ } from '../../../i18n';
  * Internal dependencies
  */
 import PlainText from '../../plain-text';
+import styles from './editor.scss';
 
 export function edit( { attributes, setAttributes, isSelected } ) {
 	const { customText, noTeaser } = attributes;
@@ -18,17 +19,18 @@ export function edit( { attributes, setAttributes, isSelected } ) {
 	const value = customText !== undefined ? customText : defaultText;
 
 	return (
-		<View style={ { padding: 4, alignItems: 'center' } }>
-			<View style={ { alignItems: 'center', flexDirection: 'row' } }>
-				<Text style={ { fontFamily: 'monospace' } }>&lt;!--</Text>
+		<View className={ styles.blocks_more_container }>
+			<View className={ styles.blocks_more_sub_container }>
+				<Text className={ styles.blocks_more_left_marker }>&lt;!--</Text>
 				<PlainText
+					className={ styles.blocks_more_plain_text }
 					value={ value }
-					multiline={ false }
+					multiline={ true }
 					underlineColorAndroid="transparent"
-					onChange={ content => setAttributes( { content } ) }
+					onChange={ value => setAttributes( { customText: value } ) }
 					placeholder={ defaultText }
 				/>
-				<Text style={ { fontFamily: 'monospace' } }>--&gt;</Text>
+				<Text className={ styles.blocks_more_right_marker }>--&gt;</Text>
 			</View>
 		</View> );
 }

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -10,10 +10,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import PlainText from '../../plain-text';
+import { PlainText } from '@wordpress/editor';
 import styles from './editor.scss';
 
-export function edit( { attributes, setAttributes, isSelected } ) {
+export default function edit( { attributes, setAttributes, isSelected } ) {
 	const { customText, noTeaser } = attributes;
 	const defaultText = __( 'Read more' );
 	const value = customText !== undefined ? customText : defaultText;
@@ -27,7 +27,7 @@ export function edit( { attributes, setAttributes, isSelected } ) {
 					value={ value }
 					multiline={ true }
 					underlineColorAndroid="transparent"
-					onChange={ value => setAttributes( { customText: value } ) }
+					onChange={ ( newValue ) => setAttributes( { customText: newValue } ) }
 					placeholder={ defaultText }
 				/>
 				<Text className={ styles[ 'blocks-more-right-marker' ] }>--&gt;</Text>

--- a/core-blocks/more/edit.native.js
+++ b/core-blocks/more/edit.native.js
@@ -5,7 +5,7 @@ import { View, Text } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { __ } from '../../../i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/core-blocks/more/editor.native.scss
+++ b/core-blocks/more/editor.native.scss
@@ -14,12 +14,10 @@
 }
 
 .blocks_more_left_marker	{
-	font-family: monospace;
 	padding-right: 4;
 }
 
 .blocks_more_right_marker	{
-	font-family: monospace;
 	padding-left: 4;
 }
 

--- a/core-blocks/more/editor.native.scss
+++ b/core-blocks/more/editor.native.scss
@@ -1,0 +1,25 @@
+// @format
+
+.blocks_more_container {
+	align-items: center;
+	padding-left: 4;
+	padding-right: 4;
+	padding-top: 4;
+	padding-bottom: 4;
+}
+
+.blocks_more_sub_container {
+	align-items: center;
+	flex-direction: row;
+}
+
+.blocks_more_left_marker	{
+	font-family: monospace;
+	padding-right: 4;
+}
+
+.blocks_more_right_marker	{
+	font-family: monospace;
+	padding-left: 4;
+}
+

--- a/core-blocks/more/editor.native.scss
+++ b/core-blocks/more/editor.native.scss
@@ -1,6 +1,6 @@
 // @format
 
-.blocks_more_container {
+.blocks-more-container {
 	align-items: center;
 	padding-left: 4;
 	padding-right: 4;
@@ -8,16 +8,15 @@
 	padding-bottom: 4;
 }
 
-.blocks_more_sub_container {
+.blocks-more-sub-container {
 	align-items: center;
 	flex-direction: row;
 }
 
-.blocks_more_left_marker	{
+.blocks-more-left-marker {
 	padding-right: 4;
 }
 
-.blocks_more_right_marker	{
+.blocks-more-right-marker {
 	padding-left: 4;
 }
-

--- a/core-blocks/more/index.js
+++ b/core-blocks/more/index.js
@@ -7,15 +7,13 @@ import { compact } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Component, Fragment, RawHTML } from '@wordpress/element';
+import { RawHTML } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import { InspectorControls } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import './editor.scss';
+import edit from './edit';
 
 export const name = 'core/more';
 
@@ -71,58 +69,7 @@ export const settings = {
 		],
 	},
 
-	edit: class extends Component {
-		constructor() {
-			super( ...arguments );
-			this.onChangeInput = this.onChangeInput.bind( this );
-
-			this.state = {
-				defaultText: __( 'Read more' ),
-			};
-		}
-
-		onChangeInput( event ) {
-			// Set defaultText to an empty string, allowing the user to clear/replace the input field's text
-			this.setState( {
-				defaultText: '',
-			} );
-
-			const value = event.target.value.length === 0 ? undefined : event.target.value;
-			this.props.setAttributes( { customText: value } );
-		}
-
-		render() {
-			const { customText, noTeaser } = this.props.attributes;
-			const { setAttributes } = this.props;
-
-			const toggleNoTeaser = () => setAttributes( { noTeaser: ! noTeaser } );
-			const { defaultText } = this.state;
-			const value = customText !== undefined ? customText : defaultText;
-			const inputLength = value.length + 1;
-
-			return (
-				<Fragment>
-					<InspectorControls>
-						<PanelBody>
-							<ToggleControl
-								label={ __( 'Hide the teaser before the "More" tag' ) }
-								checked={ !! noTeaser }
-								onChange={ toggleNoTeaser }
-							/>
-						</PanelBody>
-					</InspectorControls>
-					<div className="wp-block-more">
-						<input
-							type="text"
-							value={ value }
-							size={ inputLength }
-							onChange={ this.onChangeInput }
-						/>
-					</div>
-				</Fragment>
-			);
-		}
-	},
+	edit,
 
 	save( { attributes } ) {
 		const { customText, noTeaser } = attributes;

--- a/editor/components/plain-text/style.native.scss
+++ b/editor/components/plain-text/style.native.scss
@@ -5,5 +5,4 @@
 
 	padding: 0;
 	margin: 0;
-	width: 100%;
 }

--- a/editor/index.native.js
+++ b/editor/index.native.js
@@ -1,0 +1,1 @@
+export * from './components';


### PR DESCRIPTION
## Description
This PR ports the `more` block to the react-native app.

## How has this been tested?
* [PR on the RN side](https://github.com/wordpress-mobile/gutenberg-mobile/pull/43) builds, tests and runs fine
* `npm run test` succeeds

## Types of changes
* Introduces the `edit.js` module for the `more` block
* Native RN version of the `core-blocks/more/edit.js`
* Loads the `more` block styles from a `scss` file in this repo (`editor.native.scss`)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
