### PR TITLE
Query for all authors with an unbounded `per_page=-1` request

### DIFF
--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -29,7 +29,7 @@ export async function* getCategories() {
  * Requests authors from the REST API.
  */
 export async function* getAuthors() {
-	const users = await apiRequest( { path: '/wp/v2/users/?who=authors' } );
+	const users = await apiRequest( { path: '/wp/v2/users/?who=authors&per_page=-1' } );
 	yield receiveUserQuery( 'authors', users );
 }
 

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -198,4 +198,22 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$data = $response->get_data();
 		$this->assertEquals( 'rest_forbidden_who', $data['code'] );
 	}
+
+	public function test_get_items_unbounded_per_page() {
+		wp_set_current_user( $this->author );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'per_page', '-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_items_unbounded_per_page_unauthorized() {
+		wp_set_current_user( $this->subscriber );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'per_page', '-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 403, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
+	}
 }


### PR DESCRIPTION
## Description

Queries for all potential authors with an unbounded `GET /wp/v2/users?who=authors&per_page=-1` request.

Fixes #4622
See https://github.com/WordPress/gutenberg/issues/6180#issuecomment-384511059

## How has this been tested?

Generate a bunch of authors programmatically with WP-CLI:

```
wp user generate --role=author --count=150
```

See them all appear in the post author dropdown:

<img width="633" alt="image" src="https://user-images.githubusercontent.com/36432/39729210-896c4c40-520f-11e8-80d0-8091a635393b.png">

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
