### PR TITLE
Use npm v6 is the minimum required version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
 
 before_install:
   - nvm install && nvm use
+  - npm install npm -g
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	],
 	"engines": {
 		"node": ">=8.0.0",
-		"npm": ">=5.0.0"
+		"npm": ">=6.0.0"
 	},
 	"dependencies": {
 		"@wordpress/a11y": "1.0.6",


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Updates the minimum required version of npm to version `6.0.0` or greater.

This is a follow up to https://github.com/WordPress/gutenberg/pull/6610#issuecomment-386858400 where npm v6.0.0 was used to generate the `package-lock.json` file, everyone should be using the same version of npm otherwise there will be unnecessary and potentially troublesome pull requests submitted due to the differences in how npm v5 and v6 handle `package-lock.json` files.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Build tool update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
