### PR TITLE
Use `wp:action-assign-author` to indicate if user can assign authors

### DIFF
--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withAPIData, withInstanceId } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
@@ -15,10 +15,8 @@ import { withSelect } from '@wordpress/data';
  */
 import PostTypeSupportCheck from '../post-type-support-check';
 
-export function PostAuthorCheck( { user, authors, children } ) {
-	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-
-	if ( ! userCanPublishPosts || authors.length < 2 ) {
+export function PostAuthorCheck( { hasAssignAuthorAction, authors, children } ) {
+	if ( ! hasAssignAuthorAction || authors.length < 2 ) {
 		return null;
 	}
 
@@ -27,16 +25,11 @@ export function PostAuthorCheck( { user, authors, children } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
+		const post = select( 'core/editor' ).getCurrentPost();
 		return {
+			hasAssignAuthorAction: get( post, [ '_links', 'wp:action-assign-author' ], false ),
 			postType: select( 'core/editor' ).getCurrentPostType(),
 			authors: select( 'core' ).getAuthors(),
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} ),
 	withInstanceId,

--- a/editor/components/post-author/test/check.js
+++ b/editor/components/post-author/test/check.js
@@ -35,22 +35,23 @@ describe( 'PostAuthorCheck', () => {
 		],
 	};
 
-	const user = {
-		data: {
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
 	it( 'should not render anything if users unknown', () => {
-		const wrapper = shallow( <PostAuthorCheck authors={ [] } user={ user }>authors</PostAuthorCheck> );
+		const wrapper = shallow( <PostAuthorCheck authors={ [] } hasAssignAuthorAction={ true }>authors</PostAuthorCheck> );
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'should not render anything if single user', () => {
 		const wrapper = shallow(
-			<PostAuthorCheck authors={ users.data.slice( 0, 1 ) } user={ user }>
+			<PostAuthorCheck authors={ users.data.slice( 0, 1 ) } hasAssignAuthorAction={ true }>
+				authors
+			</PostAuthorCheck>
+		);
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should not render anything if doesn\'t have author action', () => {
+		const wrapper = shallow(
+			<PostAuthorCheck authors={ users } hasAssignAuthorAction={ false }>
 				authors
 			</PostAuthorCheck>
 		);
@@ -59,7 +60,7 @@ describe( 'PostAuthorCheck', () => {
 
 	it( 'should render  control', () => {
 		const wrapper = shallow(
-			<PostAuthorCheck authors={ users } user={ user }>
+			<PostAuthorCheck authors={ users } hasAssignAuthorAction={ true }>
 				authors
 			</PostAuthorCheck>
 		);

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -281,7 +281,7 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 		if ( current_user_can( $post_type->cap->edit_others_posts ) ) {
 			$new_links['https://api.w.org/action-assign-author'] = array(
 				array(
-					'title'        => __( 'The current user change author on this post.', 'gutenberg' ),
+					'title'        => __( 'The current user can change the author on this post.', 'gutenberg' ),
 					'href'         => $orig_links['self'][0]['href'],
 					'targetSchema' => array(
 						'type'       => 'object',

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -277,6 +277,24 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 	$new_links  = array();
 	$orig_links = $response->get_links();
 	$post_type  = get_post_type_object( $post->post_type );
+	if ( 'edit' === $request['context'] && post_type_supports( $post_type->name, 'author' ) ) {
+		if ( current_user_can( $post_type->cap->edit_others_posts ) ) {
+			$new_links['https://api.w.org/action-assign-author'] = array(
+				array(
+					'title'        => __( 'The current user change author on this post.', 'gutenberg' ),
+					'href'         => $orig_links['self'][0]['href'],
+					'targetSchema' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'author' => array(
+								'type' => 'integer',
+							),
+						),
+					),
+				),
+			);
+		}
+	}
 	// Only Posts can be sticky.
 	if ( 'post' === $post->post_type && 'edit' === $request['context'] ) {
 		if ( current_user_can( $post_type->cap->edit_others_posts )

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -128,6 +128,35 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Only returns wp:action-assign-author when current user can assign author.
+	 */
+	function test_link_assign_author_only_appears_for_editor() {
+		$post_id   = $this->factory->post->create();
+		$check_key = 'https://api.w.org/action-assign-author';
+		// authors cannot assign author.
+		wp_set_current_user( $this->author );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertFalse( isset( $links[ $check_key ] ) );
+		// editors can assign author.
+		wp_set_current_user( $this->editor );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertTrue( isset( $links[ $check_key ] ) );
+		// editors can assign author but not included for context != edit.
+		wp_set_current_user( $this->editor );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'view' );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertFalse( isset( $links[ $check_key ] ) );
+	}
+
+	/**
 	 * Only returns wp:action-sticky when current user can sticky.
 	 */
 	function test_link_sticky_only_appears_for_editor() {


### PR DESCRIPTION
## Description

Introduces a `wp:action-assign-author` action (see conversation in #6529) to indicate whether the current user can assign authors.

See #6361
Fixes #3010

## How has this been tested?

As a WordPress user with role `author`, I cannot modify the post author:

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/36432/39730324-cee4f9a6-5215-11e8-96de-ca8fed8bf583.png">

However, I can modify the post author as a WordPress user with role `editor`:

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/36432/39730353-f9d37322-5215-11e8-8e89-a47a35c6fc6a.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
