### PR TITLE
New User Experience (NUX)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,6 +99,10 @@ module.exports = {
 				"message": "Use @wordpress/core-blocks as import path instead."
 			},
 			{
+				"selector": "ImportDeclaration[source.value=/^nux$/]",
+				"message": "Use @wordpress/nux as import path instead."
+			},
+			{
 				selector: 'CallExpression[callee.name="deprecated"] Property[key.name="version"][value.value=/' + majorMinorRegExp + '/]',
 				message: 'Deprecated functions must be removed before releasing this version.',
 			},

--- a/components/popover/utils.js
+++ b/components/popover/utils.js
@@ -11,26 +11,32 @@ const isMobileViewport = () => window.innerWidth < 782;
  * @param {Object} anchorRect       Anchor Rect.
  * @param {Object} contentSize      Content Size.
  * @param {string} xAxis            Desired xAxis.
+ * @param {string} chosenYAxis      yAxis to be used.
  * @param {boolean} expandOnMobile  Whether to expand the popover on mobile or not.
  *
  * @return {Object} Popover xAxis position and constraints.
  */
-export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis ) {
+export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, chosenYAxis ) {
 	const { width } = contentSize;
-	const popoverLeft = Math.round( anchorRect.left + ( anchorRect.width / 2 ) );
 
 	// x axis alignment choices
+	const anchorMidPoint = Math.round( anchorRect.left + ( anchorRect.width / 2 ) );
 	const centerAlignment = {
+		popoverLeft: anchorMidPoint,
 		contentWidth: (
-			( popoverLeft - ( width / 2 ) > 0 ? ( width / 2 ) : popoverLeft ) +
-			( popoverLeft + ( width / 2 ) > window.innerWidth ? window.innerWidth - popoverLeft : ( width / 2 ) )
+			( anchorMidPoint - ( width / 2 ) > 0 ? ( width / 2 ) : anchorMidPoint ) +
+			( anchorMidPoint + ( width / 2 ) > window.innerWidth ? window.innerWidth - anchorMidPoint : ( width / 2 ) )
 		),
 	};
+	const leftAlignmentX = chosenYAxis === 'middle' ? anchorRect.left : anchorMidPoint;
 	const leftAlignment = {
-		contentWidth: popoverLeft - width > 0 ? width : popoverLeft,
+		popoverLeft: leftAlignmentX,
+		contentWidth: leftAlignmentX - width > 0 ? width : leftAlignmentX,
 	};
+	const rightAlignmentX = chosenYAxis === 'middle' ? anchorRect.right : anchorMidPoint;
 	const rightAlignment = {
-		contentWidth: popoverLeft + width > window.innerWidth ? window.innerWidth - popoverLeft : width,
+		popoverLeft: rightAlignmentX,
+		contentWidth: rightAlignmentX + width > window.innerWidth ? window.innerWidth - rightAlignmentX : width,
 	};
 
 	// Choosing the x axis
@@ -46,6 +52,15 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis ) {
 		chosenXAxis = leftAlignment.contentWidth > rightAlignment.contentWidth ? 'left' : 'right';
 		const chosenWidth = chosenXAxis === 'left' ? leftAlignment.contentWidth : rightAlignment.contentWidth;
 		contentWidth = chosenWidth !== width ? chosenWidth : null;
+	}
+
+	let popoverLeft;
+	if ( chosenXAxis === 'center' ) {
+		popoverLeft = centerAlignment.popoverLeft;
+	} else if ( chosenXAxis === 'left' ) {
+		popoverLeft = leftAlignment.popoverLeft;
+	} else {
+		popoverLeft = rightAlignment.popoverLeft;
 	}
 
 	return {
@@ -131,8 +146,8 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis ) {
 export function computePopoverPosition( anchorRect, contentSize, position = 'top', expandOnMobile = false ) {
 	const [ yAxis, xAxis = 'center' ] = position.split( ' ' );
 
-	const xAxisPosition = computePopoverXAxisPosition( anchorRect, contentSize, xAxis );
 	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis );
+	const xAxisPosition = computePopoverXAxisPosition( anchorRect, contentSize, xAxis, yAxisPosition.yAxis );
 
 	return {
 		isMobile: isMobileViewport() && expandOnMobile,

--- a/components/tooltip/style.scss
+++ b/components/tooltip/style.scss
@@ -1,5 +1,6 @@
 .components-tooltip.components-popover {
 	pointer-events: none;
+	z-index: z-index( '.components-tooltip' );
 
 	&:before {
 		border-color: transparent;

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -77,6 +77,9 @@ $z-layers: (
 	'.components-autocomplete__results': 1000000,
 
 	'.skip-to-selected-block': 100000,
+
+	// Show NUX tips above popovers, wp-admin menus, submenus, and sidebar:
+	'.nux-dot-tip': 1000001,
 );
 
 @function z-index( $key ) {

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -80,6 +80,9 @@ $z-layers: (
 
 	// Show NUX tips above popovers, wp-admin menus, submenus, and sidebar:
 	'.nux-dot-tip': 1000001,
+
+	// Show tooltips above NUX tips, wp-admin menus, submenus, and sidebar:
+	'.components-tooltip': 1000002
 );
 
 @function z-index( $key ) {

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/element';
+import { DotTip } from '@wordpress/nux';
 
 /**
  * Internal dependencies
@@ -57,7 +58,11 @@ function Header( {
 						onClick={ toggleGeneralSidebar }
 						isToggled={ isEditorSidebarOpened }
 						aria-expanded={ isEditorSidebarOpened }
-					/>
+					>
+						<DotTip id="core/editor.settings">
+							{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click ‘Settings’ to open it.' ) }
+						</DotTip>
+					</IconButton>
 					<PinnedPlugins.Slot />
 					<MoreMenu />
 				</div>

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -3,6 +3,7 @@
  */
 import { registerCoreBlocks } from '@wordpress/core-blocks';
 import { render, unmountComponentAtNode } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -72,6 +73,13 @@ export function initializeEditor( id, postType, postId, settings, overridePost )
 	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, overridePost );
 
 	registerCoreBlocks();
+
+	dispatch( 'core/nux' ).triggerGuide( [
+		'core/editor.inserter',
+		'core/editor.settings',
+		'core/editor.preview',
+		'core/editor.publish',
+	] );
 
 	render(
 		<Editor settings={ settings } onError={ reboot } postId={ postId } postType={ postType } overridePost={ overridePost } />,

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -28,6 +28,7 @@ import { withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
+import { DotTip } from '@wordpress/nux';
 
 /**
  * Internal dependencies
@@ -414,6 +415,7 @@ export class BlockListBlock extends Component {
 			isEmptyDefaultBlock,
 			isPreviousBlockADefaultEmptyBlock,
 			hasSelectedInnerBlock,
+			hasTip,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -426,7 +428,7 @@ export class BlockListBlock extends Component {
 		// If the block is selected and we're typing the block should not appear.
 		// Empty paragraph blocks should always show up as unselected.
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
-		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
+		const showSideInserter = ( isSelected || isHovered || hasTip ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showSideInserter && ( isSelected || hasSelectedInnerBlock ) && ! isTypingWithinBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isMultiSelected && ! isTypingWithinBlock;
@@ -595,7 +597,11 @@ export class BlockListBlock extends Component {
 							<Inserter
 								position="top right"
 								onToggle={ this.selectOnOpen }
-							/>
+							>
+								<DotTip id="core/editor.inserter">
+									{ __( 'Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.' ) }
+								</DotTip>
+							</Inserter>
 						</div>
 					</Fragment>
 				) }
@@ -623,6 +629,9 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		getEditorSettings,
 		hasSelectedInnerBlock,
 	} = select( 'core/editor' );
+
+	const { isTipVisible } = select( 'core/nux' );
+
 	const isSelected = isBlockSelected( uid );
 	const isParentOfSelectedBlock = hasSelectedInnerBlock( uid );
 	const { templateLock, hasFixedToolbar } = getEditorSettings();
@@ -651,6 +660,7 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		block,
 		isSelected,
 		hasFixedToolbar,
+		hasTip: isTipVisible( 'core/editor.inserter' ),
 	};
 } );
 

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -28,7 +28,6 @@ import { withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
-import { DotTip } from '@wordpress/nux';
 
 /**
  * Internal dependencies
@@ -415,7 +414,6 @@ export class BlockListBlock extends Component {
 			isEmptyDefaultBlock,
 			isPreviousBlockADefaultEmptyBlock,
 			hasSelectedInnerBlock,
-			hasTip,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -428,7 +426,7 @@ export class BlockListBlock extends Component {
 		// If the block is selected and we're typing the block should not appear.
 		// Empty paragraph blocks should always show up as unselected.
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
-		const showSideInserter = ( isSelected || isHovered || hasTip ) && isEmptyDefaultBlock;
+		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showSideInserter && ( isSelected || hasSelectedInnerBlock ) && ! isTypingWithinBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isMultiSelected && ! isTypingWithinBlock;
@@ -597,11 +595,7 @@ export class BlockListBlock extends Component {
 							<Inserter
 								position="top right"
 								onToggle={ this.selectOnOpen }
-							>
-								<DotTip id="core/editor.inserter">
-									{ __( 'Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.' ) }
-								</DotTip>
-							</Inserter>
+							/>
 						</div>
 					</Fragment>
 				) }
@@ -629,9 +623,6 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		getEditorSettings,
 		hasSelectedInnerBlock,
 	} = select( 'core/editor' );
-
-	const { isTipVisible } = select( 'core/nux' );
-
 	const isSelected = isBlockSelected( uid );
 	const isParentOfSelectedBlock = hasSelectedInnerBlock( uid );
 	const { templateLock, hasFixedToolbar } = getEditorSettings();
@@ -660,7 +651,6 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		block,
 		isSelected,
 		hasFixedToolbar,
-		hasTip: isTipVisible( 'core/editor.inserter' ),
 	};
 } );
 

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { get } from 'lodash';
 
 /**
@@ -11,6 +12,7 @@ import { compose } from '@wordpress/element';
 import { getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { DotTip } from '@wordpress/nux';
 
 /**
  * Internal dependencies
@@ -28,6 +30,7 @@ export function DefaultBlockAppender( {
 	placeholder,
 	layout,
 	rootUID,
+	hasTip,
 } ) {
 	if ( isLocked || ! isVisible ) {
 		return null;
@@ -38,7 +41,9 @@ export function DefaultBlockAppender( {
 	return (
 		<div
 			data-root-uid={ rootUID || '' }
-			className="editor-default-block-appender">
+			className={ classnames( 'editor-default-block-appender', {
+				'has-tip': hasTip,
+			} ) }>
 			<BlockDropZone rootUID={ rootUID } layout={ layout } />
 			<input
 				role="button"
@@ -52,17 +57,19 @@ export function DefaultBlockAppender( {
 				value={ showPrompt ? value : '' }
 			/>
 			<InserterWithShortcuts rootUID={ rootUID } layout={ layout } />
-			<Inserter position="top right" />
+			<Inserter position="top right">
+				<DotTip id="core/editor.inserter">
+					{ __( 'Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.' ) }
+				</DotTip>
+			</Inserter>
 		</div>
 	);
 }
 export default compose(
 	withSelect( ( select, ownProps ) => {
-		const {
-			getBlockCount,
-			getBlock,
-			getEditorSettings,
-		} = select( 'core/editor' );
+		const { getBlockCount, getBlock, getEditorSettings } = select( 'core/editor' );
+		const { isTipVisible } = select( 'core/nux' );
+
 		const isEmpty = ! getBlockCount( ownProps.rootUID );
 		const lastBlock = getBlock( ownProps.lastBlockUID );
 		const isLastBlockDefault = get( lastBlock, [ 'name' ] ) === getDefaultBlockName();
@@ -73,6 +80,7 @@ export default compose(
 			showPrompt: isEmpty,
 			isLocked: !! templateLock,
 			placeholder: bodyPlaceholder,
+			hasTip: isTipVisible( 'core/editor.inserter' ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -88,9 +88,12 @@ export default compose(
 			insertDefaultBlock,
 			startTyping,
 		} = dispatch( 'core/editor' );
+
+		const { dismissTip } = dispatch( 'core/nux' );
+
 		return {
 			onAppend() {
-				const { layout, rootUID } = ownProps;
+				const { layout, rootUID, hasTip } = ownProps;
 
 				let attributes;
 				if ( layout ) {
@@ -99,6 +102,10 @@ export default compose(
 
 				insertDefaultBlock( attributes, rootUID );
 				startTyping();
+
+				if ( hasTip ) {
+					dismissTip( 'core/editor.inserter' );
+				}
 			},
 		};
 	} ),

--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -45,17 +45,17 @@ $empty-paragraph-height: $text-editor-font-size * 4;
 		}
 	}
 
-	// Don't show inserter until mousing
-	.editor-inserter__toggle:not( [aria-expanded="true"] ) {
-		opacity: 0;
+	&:hover .editor-inserter-with-shortcuts {
+		opacity: 1;
 	}
 
-	&:hover {
-		.editor-inserter-with-shortcuts {
-			opacity: 1;
+	// Show the inserter if mousing over or there is a tip
+	&:not( .has-tip ) {
+		.editor-inserter__toggle:not( [aria-expanded="true"] ) {
+			opacity: 0;
 		}
 
-		.editor-inserter__toggle {
+		&:hover .editor-inserter__toggle {
 			opacity: 1;
 		}
 	}

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -38,7 +38,13 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(WithDispatch(Inserter))
     position="top right"
-  />
+  >
+    <WithSelect(WithDispatch(DotTip))
+      id="core/editor.inserter"
+    >
+      Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.
+    </WithSelect(WithDispatch(DotTip))>
+  </WithSelect(WithDispatch(Inserter))>
 </div>
 `;
 
@@ -62,7 +68,13 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(WithDispatch(Inserter))
     position="top right"
-  />
+  >
+    <WithSelect(WithDispatch(DotTip))
+      id="core/editor.inserter"
+    >
+      Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.
+    </WithSelect(WithDispatch(DotTip))>
+  </WithSelect(WithDispatch(Inserter))>
 </div>
 `;
 
@@ -86,6 +98,12 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(WithDispatch(Inserter))
     position="top right"
-  />
+  >
+    <WithSelect(WithDispatch(DotTip))
+      id="core/editor.inserter"
+    >
+      Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.
+    </WithSelect(WithDispatch(DotTip))>
+  </WithSelect(WithDispatch(Inserter))>
 </div>
 `;

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -8,8 +8,9 @@ import { get } from 'lodash';
  */
 import { Component, compose } from '@wordpress/element';
 import { Button, ifCondition } from '@wordpress/components';
-import { _x } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { DotTip } from '@wordpress/nux';
 
 export class PostPreviewButton extends Component {
 	constructor() {
@@ -107,6 +108,9 @@ export class PostPreviewButton extends Component {
 				disabled={ ! isSaveable }
 			>
 				{ _x( 'Preview', 'imperative verb' ) }
+				<DotTip id="core/editor.preview">
+					{ __( 'Click ‘Preview’ to load a preview of this page, so you can make sure you’re happy with your blocks.' ) }
+				</DotTip>
 			</Button>
 		);
 	}

--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -10,6 +10,7 @@ import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
+import { DotTip } from '@wordpress/nux';
 
 /**
  * Internal Dependencies
@@ -50,6 +51,9 @@ function PostPublishPanelToggle( {
 			isBusy={ isSaving && isPublished }
 		>
 			{ isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' ) }
+			<DotTip id="core/editor.publish">
+				{ __( 'Finished writing? That’s great, let’s get this published right now. Just click ‘Publish’ and you’re good to go.' ) }
+			</DotTip>
 		</Button>
 	);
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -424,7 +424,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_style(
 		'wp-edit-post',
 		gutenberg_url( 'build/edit-post/style.css' ),
-		array( 'wp-components', 'wp-editor', 'wp-edit-blocks', 'wp-core-blocks' ),
+		array( 'wp-components', 'wp-editor', 'wp-edit-blocks', 'wp-core-blocks', 'wp-nux' ),
 		filemtime( gutenberg_dir_path() . 'build/edit-post/style.css' )
 	);
 	wp_style_add_data( 'wp-edit-post', 'rtl', 'replace' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -265,6 +265,13 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/core-blocks/index.js' ),
 		true
 	);
+	wp_register_script(
+		'wp-nux',
+		gutenberg_url( 'build/nux/index.js' ),
+		array( 'wp-element', 'wp-components', 'wp-data', 'wp-i18n', 'lodash' ),
+		filemtime( gutenberg_dir_path() . 'build/nux/index.js' ),
+		true
+	);
 	// Loading the old editor and its config to ensure the classic block works as expected.
 	wp_add_inline_script(
 		'editor', 'window.wp.oldEditor = window.wp.editor;', 'after'
@@ -361,6 +368,7 @@ function gutenberg_register_scripts_and_styles() {
 			'tinymce-latest-lists',
 			'tinymce-latest-paste',
 			'tinymce-latest-table',
+			'wp-nux',
 		),
 		filemtime( gutenberg_dir_path() . 'build/editor/index.js' )
 	);
@@ -408,7 +416,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_style(
 		'wp-editor',
 		gutenberg_url( 'build/editor/style.css' ),
-		array( 'wp-components', 'wp-editor-font' ),
+		array( 'wp-components', 'wp-editor-font', 'wp-nux' ),
 		filemtime( gutenberg_dir_path() . 'build/editor/style.css' )
 	);
 	wp_style_add_data( 'wp-editor', 'rtl', 'replace' );
@@ -449,6 +457,14 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/core-blocks/edit-blocks.css' )
 	);
 	wp_style_add_data( 'wp-edit-blocks', 'rtl', 'replace' );
+
+	wp_register_style(
+		'wp-nux',
+		gutenberg_url( 'build/nux/style.css' ),
+		array( 'wp-components' ),
+		filemtime( gutenberg_dir_path() . 'build/nux/style.css' )
+	);
+	wp_style_add_data( 'wp-nux', 'rtl', 'replace' );
 
 	wp_register_style(
 		'wp-core-blocks-theme',

--- a/nux/README.md
+++ b/nux/README.md
@@ -1,0 +1,86 @@
+NUX (New User eXperience)
+=========================
+
+The NUX module exposes components, and `wp.data` methods useful for onboarding a new user to the WordPress admin interface. Specifically, it exposes _tips_ and _guides_.
+
+A _tip_ is a component that points to an element in the UI and contains text that explains the element's functionality. The user can dismiss a tip, in which case it never shows again. The user can also disable tips entirely. Information about tips is persisted between sessions using `localStorage`.
+
+A _guide_ allows a series of of tips to be presented to the user one by one. When a user dismisses a tip that is in a guide, the next tip in the guide is shown.
+
+## DotTip
+
+`DotTip` is a React component that renders a single _tip_ on the screen. The tip will point to the React element that `DotTip` is nested within. Each tip is uniquely identified by a string passed to `id`.
+
+See [the component's README][dot-tip-readme] for more information.
+
+[dot-tip-readme]: https://github.com/WordPress/gutenberg/tree/master/nux/components/dot-tip/README.md
+
+```jsx
+<button onClick={ ... }>
+	Add to Cart
+	<DotTip id="acme/add-to-cart">
+		Click here to add the product to your shopping cart.
+	</DotTip>
+</button>
+}
+```
+
+## Determining if a tip is visible
+
+You can programmatically determine if a tip is visible using the `isTipVisible` select method.
+
+```jsx
+const isVisible = select( 'core/nux' ).isTipVisible( 'acme/add-to-cart' );
+console.log( isVisible ); // true or false
+```
+
+## Manually dismissing a tip
+
+`dismissTip` is a dispatch method that allows you to programmatically dismiss a tip.
+
+```jsx
+<button
+	onClick={ () => {
+		dispatch( 'core/nux' ).dismissTip( 'acme/add-to-cart' );
+	}
+>
+	Dismiss tip
+</button>
+```
+
+## Manually disabling tips
+
+`disableTips` is a dispatch method that allows you to programmatically disable all tips.
+
+```jsx
+<button
+	onClick={ () => {
+		dispatch( 'core/nux' ).disableTips();
+	}
+>
+	Disable tips
+</button>
+```
+
+## Triggering a guide
+
+You can group a series of tips into a guide by calling the `triggerGuide` dispatch method. The given tips will then appear one by one.
+
+A tip cannot be added to more than one guide.
+
+```jsx
+domReady(() => {
+	dispatch( 'core/nux' ).triggerGuide( [ 'acme/product-info', 'acme/add-to-cart', 'acme/checkout' ] );
+} );
+```
+
+## Getting information about a guide
+
+`getAssociatedGuide` is a select method that returns useful information about the state of the guide that a tip is associated with.
+
+```jsx
+const guide = select( 'core/nux' ).getAssociatedGuide( 'acme/add-to-cart' );
+console.log( 'Tips in this guide:', guide.tipIDs );
+console.log( 'Currently showing:', guide.currentTipID );
+console.log( 'Next to show:', guide.nextTipID );
+```

--- a/nux/README.md
+++ b/nux/README.md
@@ -69,9 +69,7 @@ You can group a series of tips into a guide by calling the `triggerGuide` dispat
 A tip cannot be added to more than one guide.
 
 ```jsx
-domReady(() => {
-	dispatch( 'core/nux' ).triggerGuide( [ 'acme/product-info', 'acme/add-to-cart', 'acme/checkout' ] );
-} );
+dispatch( 'core/nux' ).triggerGuide( [ 'acme/product-info', 'acme/add-to-cart', 'acme/checkout' ] );
 ```
 
 ## Getting information about a guide

--- a/nux/README.md
+++ b/nux/README.md
@@ -78,7 +78,7 @@ dispatch( 'core/nux' ).triggerGuide( [ 'acme/product-info', 'acme/add-to-cart', 
 
 ```jsx
 const guide = select( 'core/nux' ).getAssociatedGuide( 'acme/add-to-cart' );
-console.log( 'Tips in this guide:', guide.tipIDs );
-console.log( 'Currently showing:', guide.currentTipID );
-console.log( 'Next to show:', guide.nextTipID );
+console.log( 'Tips in this guide:', guide.tipIds );
+console.log( 'Currently showing:', guide.currentTipId );
+console.log( 'Next to show:', guide.nextTipId );
 ```

--- a/nux/components/dot-tip/README.md
+++ b/nux/components/dot-tip/README.md
@@ -1,0 +1,31 @@
+DotTip
+========
+
+`DotTip` is a React component that renders a single _tip_ on the screen. The tip will point to the React element that `DotTip` is nested within. Each tip is uniquely identified by a string passed to `id`.
+
+## Usage
+
+```jsx
+<button onClick={ ... }>
+	Add to Cart
+	<DotTip id="acme/add-to-cart">
+		Click here to add the product to your shopping cart.
+	</DotTip>
+</button>
+}
+```
+
+## Props
+
+The component accepts the following props:
+
+### id
+
+An identifier that uniquely identifies the tip.
+
+- Type: `string`
+- Required: Yes
+
+### children
+
+Any React element or elements can be passed as children. They will be rendered within the tip bubble.

--- a/nux/components/dot-tip/README.md
+++ b/nux/components/dot-tip/README.md
@@ -21,7 +21,7 @@ The component accepts the following props:
 
 ### id
 
-An identifier that uniquely identifies the tip.
+A string that uniquely identifies the tip. Identifiers should be prefixed with the name of the plugin, followed by a `/`. For example, `acme/add-to-cart`.
 
 - Type: `string`
 - Required: Yes

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { defer, partial } from 'lodash';
+import { defer } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -83,8 +83,12 @@ export default compose(
 	withDispatch( ( dispatch, { id } ) => {
 		const { dismissTip, disableTips } = dispatch( 'core/nux' );
 		return {
-			onDismiss: partial( dismissTip, id ),
-			onDisable: disableTips,
+			onDismiss() {
+				dismissTip( id );
+			},
+			onDisable() {
+				disableTips();
+			},
 		};
 	} ),
 )( DotTip );

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -36,7 +36,7 @@ export class DotTip extends Component {
 	}
 
 	render() {
-		const { children, isVisible, hasNextTip, onDismiss, onDisable } = this.props;
+		const { children, isVisible, hasNextTip, onDismiss } = this.props;
 
 		if ( ! isVisible ) {
 			return null;
@@ -57,8 +57,8 @@ export class DotTip extends Component {
 				<IconButton
 					className="nux-dot-tip__disable"
 					icon="no-alt"
-					label={ __( 'Disable tips' ) }
-					onClick={ onDisable }
+					label={ __( 'Dismiss tip' ) }
+					onClick={ onDismiss }
 				/>
 				<p>{ children }</p>
 				<p>
@@ -81,13 +81,10 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch, { id } ) => {
-		const { dismissTip, disableTips } = dispatch( 'core/nux' );
+		const { dismissTip } = dispatch( 'core/nux' );
 		return {
 			onDismiss() {
 				dismissTip( id );
-			},
-			onDisable() {
-				disableTips();
 			},
 		};
 	} ),

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -6,7 +6,7 @@ import { defer, partial } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, createRef, Fragment, compose } from '@wordpress/element';
+import { Component, createRef, compose } from '@wordpress/element';
 import { Popover, Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -43,32 +43,30 @@ export class DotTip extends Component {
 		}
 
 		return (
-			<Fragment>
-				<Popover
-					ref={ this.popoverRef }
-					className="nux-dot-tip"
-					position="middle right"
-					noArrow
-					focusOnMount
-					role="dialog"
-					aria-modal="true"
-					aria-label={ __( 'New user tip' ) }
-					onClick={ ( event ) => event.stopPropagation() }
-				>
-					<p>{ children }</p>
-					<p>
-						<Button isLink onClick={ onDismiss }>
-							{ hasNextTip ? __( 'See next' ) : __( 'Got it' ) }
-						</Button>
-					</p>
-					<IconButton
-						className="nux-dot-tip__disable"
-						icon="no-alt"
-						label={ __( 'Disable guide' ) }
-						onClick={ onDisable }
-					/>
-				</Popover>
-			</Fragment>
+			<Popover
+				ref={ this.popoverRef }
+				className="nux-dot-tip"
+				position="middle right"
+				noArrow
+				focusOnMount
+				role="dialog"
+				aria-modal="true"
+				aria-label={ __( 'New user tip' ) }
+				onClick={ ( event ) => event.stopPropagation() }
+			>
+				<p>{ children }</p>
+				<p>
+					<Button isLink onClick={ onDismiss }>
+						{ hasNextTip ? __( 'See next' ) : __( 'Got it' ) }
+					</Button>
+				</p>
+				<IconButton
+					className="nux-dot-tip__disable"
+					icon="no-alt"
+					label={ __( 'Disable guide' ) }
+					onClick={ onDisable }
+				/>
+			</Popover>
 		);
 	}
 }

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { defer, partial } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, createRef, Fragment, compose } from '@wordpress/element';
+import { Popover, Button, IconButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { withSelect, withDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+export class DotTip extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.popoverRef = createRef();
+	}
+
+	componentDidMount() {
+		if ( this.props.isVisible ) {
+			// Fix the tip not appearing next to the inserter toggle by forcing Popover
+			// to recalculate its size and position on the next frame
+			defer( () => {
+				const popover = this.popoverRef.current;
+				const popoverSize = popover.updatePopoverSize();
+				popover.computePopoverPosition( popoverSize );
+			} );
+		}
+	}
+
+	render() {
+		const { children, isVisible, hasNextTip, onDismiss, onDisable } = this.props;
+
+		if ( ! isVisible ) {
+			return null;
+		}
+
+		return (
+			<Fragment>
+				<Popover
+					ref={ this.popoverRef }
+					className="nux-dot-tip"
+					position="middle right"
+					noArrow
+					focusOnMount
+					role="dialog"
+					aria-modal="true"
+					aria-label={ __( 'New user tip' ) }
+					onClick={ ( event ) => event.stopPropagation() }
+				>
+					<p>{ children }</p>
+					<p>
+						<Button isLink onClick={ onDismiss }>
+							{ hasNextTip ? __( 'See next' ) : __( 'Got it' ) }
+						</Button>
+					</p>
+					<IconButton
+						className="nux-dot-tip__disable"
+						icon="no-alt"
+						label={ __( 'Disable guide' ) }
+						onClick={ onDisable }
+					/>
+				</Popover>
+			</Fragment>
+		);
+	}
+}
+
+export default compose(
+	withSelect( ( select, { id } ) => {
+		const { isTipVisible, getAssociatedGuide } = select( 'core/nux' );
+		const associatedGuide = getAssociatedGuide( id );
+		return {
+			isVisible: isTipVisible( id ),
+			hasNextTip: !! ( associatedGuide && associatedGuide.nextTipID ),
+		};
+	} ),
+	withDispatch( ( dispatch, { id } ) => {
+		const { dismissTip, disableTips } = dispatch( 'core/nux' );
+		return {
+			onDismiss: partial( dismissTip, id ),
+			onDisable: disableTips,
+		};
+	} ),
+)( DotTip );

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -52,6 +52,7 @@ export class DotTip extends Component {
 				role="dialog"
 				aria-modal="true"
 				aria-label={ __( 'New user tip' ) }
+				onClose={ onDismiss }
 				onClick={ ( event ) => event.stopPropagation() }
 			>
 				<p>{ children }</p>

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -50,20 +50,20 @@ export class DotTip extends Component {
 				noArrow
 				focusOnMount
 				role="dialog"
-				aria-label={ __( 'New user tip' ) }
+				aria-label={ __( 'Gutenberg tips' ) }
 				onClose={ onDismiss }
 				onClick={ ( event ) => event.stopPropagation() }
 			>
 				<IconButton
 					className="nux-dot-tip__disable"
 					icon="no-alt"
-					label={ __( 'Disable guide' ) }
+					label={ __( 'Disable tips' ) }
 					onClick={ onDisable }
 				/>
 				<p>{ children }</p>
 				<p>
 					<Button isLink onClick={ onDismiss }>
-						{ hasNextTip ? __( 'See next' ) : __( 'Got it' ) }
+						{ hasNextTip ? __( 'See next tip' ) : __( 'Got it' ) }
 					</Button>
 				</p>
 			</Popover>

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -77,7 +77,7 @@ export default compose(
 		const associatedGuide = getAssociatedGuide( id );
 		return {
 			isVisible: isTipVisible( id ),
-			hasNextTip: !! ( associatedGuide && associatedGuide.nextTipID ),
+			hasNextTip: !! ( associatedGuide && associatedGuide.nextTipId ),
 		};
 	} ),
 	withDispatch( ( dispatch, { id } ) => {

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -54,18 +54,18 @@ export class DotTip extends Component {
 				onClose={ onDismiss }
 				onClick={ ( event ) => event.stopPropagation() }
 			>
-				<p>{ children }</p>
-				<p>
-					<Button isLink onClick={ onDismiss }>
-						{ hasNextTip ? __( 'See next' ) : __( 'Got it' ) }
-					</Button>
-				</p>
 				<IconButton
 					className="nux-dot-tip__disable"
 					icon="no-alt"
 					label={ __( 'Disable guide' ) }
 					onClick={ onDisable }
 				/>
+				<p>{ children }</p>
+				<p>
+					<Button isLink onClick={ onDismiss }>
+						{ hasNextTip ? __( 'See next' ) : __( 'Got it' ) }
+					</Button>
+				</p>
 			</Popover>
 		);
 	}

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -25,12 +25,16 @@ export class DotTip extends Component {
 
 	componentDidMount() {
 		if ( this.props.isVisible ) {
-			// Fix the tip not appearing next to the inserter toggle by forcing Popover
-			// to recalculate its size and position on the next frame
+			// Force the popover to recalculate its position on the next frame. This is a
+			// Temporary workaround to fix the tip not appearing next to the inserter
+			// toggle on page load. This happens because the popover calculates its
+			// position before <PostTitle> is made visible, resulting in the position
+			// being too high on the page.
 			defer( () => {
 				const popover = this.popoverRef.current;
 				const popoverSize = popover.updatePopoverSize();
 				popover.computePopoverPosition( popoverSize );
+				popover.focus();
 			} );
 		}
 	}
@@ -54,18 +58,18 @@ export class DotTip extends Component {
 				onClose={ onDismiss }
 				onClick={ ( event ) => event.stopPropagation() }
 			>
-				<IconButton
-					className="nux-dot-tip__disable"
-					icon="no-alt"
-					label={ __( 'Dismiss tip' ) }
-					onClick={ onDismiss }
-				/>
 				<p>{ children }</p>
 				<p>
 					<Button isLink onClick={ onDismiss }>
 						{ hasNextTip ? __( 'See next tip' ) : __( 'Got it' ) }
 					</Button>
 				</p>
+				<IconButton
+					className="nux-dot-tip__disable"
+					icon="no-alt"
+					label={ __( 'Dismiss tip' ) }
+					onClick={ onDismiss }
+				/>
 			</Popover>
 		);
 	}

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -50,7 +50,6 @@ export class DotTip extends Component {
 				noArrow
 				focusOnMount
 				role="dialog"
-				aria-modal="true"
 				aria-label={ __( 'New user tip' ) }
 				onClose={ onDismiss }
 				onClick={ ( event ) => event.stopPropagation() }

--- a/nux/components/dot-tip/style.scss
+++ b/nux/components/dot-tip/style.scss
@@ -1,0 +1,74 @@
+$dot-size: 8px; // Size of the indicator dot
+$dot-scale: 3;  // How much the pulse animation should scale up by in size
+
+.nux-dot-tip {
+	&:before,
+	&:after {
+		border-radius: 100%;
+		content: ' ';
+		pointer-events: none;
+		position: absolute;
+	}
+
+	&:before {
+		animation: nux-pulse 1.6s infinite cubic-bezier( 0.17, 0.67, 0.92, 0.62 );
+		background: rgba( $blue-medium-800, 0.9 );
+		height: $dot-size * $dot-scale;
+		left: -( $dot-size * $dot-scale ) / 2;
+		top: -( $dot-size * $dot-scale ) / 2;
+		transform: scale( ( 1 / $dot-scale ) );
+		width: $dot-size * $dot-scale
+	}
+		
+	&:after {
+		background: $blue-medium-800;
+		height: $dot-size;
+		left: -$dot-size / 2;
+		top: -$dot-size / 2;
+		width: $dot-size;
+	}
+
+	@keyframes nux-pulse {
+		100% {
+			background: rgba( $blue-medium-800, 0 );
+			transform: scale( 1 );
+		}
+	}
+
+	.components-popover__content {
+		padding: 5px ( 36px + 5px ) 5px 10px;
+		width: 350px;
+
+		@include break-small {
+			width: 450px;
+		}
+
+		.nux-dot-tip__disable {
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
+	}
+
+	&.is-left {
+		margin-left: -25px;
+
+		.components-popover__content {
+			margin-right: 20px;
+		}
+	}
+
+	&.is-right {
+		margin-left: 25px;
+
+		.components-popover__content {
+			margin-left: 20px;
+		}
+	}
+}
+
+// Need extra specificity to override the z-index set by .component-popover
+.nux-dot-tip,
+.nux-dot-tip:not( .is-mobile ).is-bottom {
+	z-index: z-index( '.nux-dot-tip' );
+}

--- a/nux/components/dot-tip/style.scss
+++ b/nux/components/dot-tip/style.scss
@@ -36,7 +36,7 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 	}
 
 	.components-popover__content {
-		padding: 5px ( 36px + 5px ) 5px 10px;
+		padding: 5px ( 36px + 5px ) 5px 20px;
 		width: 350px;
 
 		@include break-small {

--- a/nux/components/dot-tip/style.scss
+++ b/nux/components/dot-tip/style.scss
@@ -50,25 +50,46 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 		}
 	}
 
+	// Position the dot 25px away from the button
 	&.is-left {
 		margin-left: -25px;
-
-		.components-popover__content {
-			margin-right: 20px;
-		}
 	}
-
 	&.is-right {
 		margin-left: 25px;
+	}
 
-		.components-popover__content {
-			margin-left: 20px;
+	// Position the tip content 20px away from the dot
+	&.is-top .components-popover__content {
+		margin-bottom: 20px;
+	}
+	&.is-bottom .components-popover__content {
+		margin-top: 20px;
+	}
+	&.is-middle.is-left .components-popover__content {
+		margin-right: 20px;
+	}
+	&.is-middle.is-right .components-popover__content {
+		margin-left: 20px;
+	}
+
+	// Extra specificity so that we can override the styles in .component-popover
+	&:not( .is-mobile ).is-left,
+	&:not( .is-mobile ).is-center,
+	&:not( .is-mobile ).is-right {
+
+		// Position tips above popovers
+		z-index: z-index( '.nux-dot-tip' );
+
+		// On mobile, always position the tip below the dot and fill the width of the viewport
+		@media ( max-width: $break-small ) {
+			.components-popover__content {
+				align-self: end;
+				left: 0;
+				margin: 20px 0 0 0;
+				max-width: none !important; // Override the inline style set by <Popover>
+				position: fixed;
+				width: 100%;
+			}
 		}
 	}
-}
-
-// Need extra specificity to override the z-index set by .component-popover
-.nux-dot-tip,
-.nux-dot-tip:not( .is-mobile ).is-bottom {
-	z-index: z-index( '.nux-dot-tip' );
 }

--- a/nux/components/dot-tip/style.scss
+++ b/nux/components/dot-tip/style.scss
@@ -50,15 +50,15 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 		}
 	}
 
-	// Position the dot 25px away from the button
+	// Position the dot right next to the edge of the button
 	&.is-left {
-		margin-left: -25px;
+		margin-left: -$dot-size / 2;
 	}
 	&.is-right {
-		margin-left: 25px;
+		margin-left: $dot-size / 2;
 	}
 
-	// Position the tip content 20px away from the dot
+	// Position the tip content away from the dot
 	&.is-top .components-popover__content {
 		margin-bottom: 20px;
 	}

--- a/nux/components/dot-tip/style.scss
+++ b/nux/components/dot-tip/style.scss
@@ -84,11 +84,12 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 		@media ( max-width: $break-small ) {
 			.components-popover__content {
 				align-self: end;
-				left: 0;
+				left: 5px;
 				margin: 20px 0 0 0;
 				max-width: none !important; // Override the inline style set by <Popover>
 				position: fixed;
-				width: 100%;
+				right: 5px;
+				width: auto;
 			}
 		}
 	}

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -10,6 +10,11 @@ exports[`DotTip should render correctly 1`] = `
   position="middle right"
   role="dialog"
 >
+  <IconButton
+    className="nux-dot-tip__disable"
+    icon="no-alt"
+    label="Disable guide"
+  />
   <p>
     It looks like you’re writing a letter. Would you like help?
   </p>
@@ -20,10 +25,5 @@ exports[`DotTip should render correctly 1`] = `
       Got it
     </Button>
   </p>
-  <IconButton
-    className="nux-dot-tip__disable"
-    icon="no-alt"
-    label="Disable guide"
-  />
 </Popover>
 `;

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -1,32 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DotTip should render correctly 1`] = `
-<React.Fragment>
-  <Popover
-    aria-label="New user tip"
-    aria-modal="true"
-    className="nux-dot-tip"
-    focusOnMount={true}
-    noArrow={true}
-    onClick={[Function]}
-    position="middle right"
-    role="dialog"
-  >
-    <p>
-      It looks like you’re writing a letter. Would you like help?
-    </p>
-    <p>
-      <Button
-        isLink={true}
-      >
-        Got it
-      </Button>
-    </p>
-    <IconButton
-      className="nux-dot-tip__disable"
-      icon="no-alt"
-      label="Disable guide"
-    />
-  </Popover>
-</React.Fragment>
+<Popover
+  aria-label="New user tip"
+  aria-modal="true"
+  className="nux-dot-tip"
+  focusOnMount={true}
+  noArrow={true}
+  onClick={[Function]}
+  position="middle right"
+  role="dialog"
+>
+  <p>
+    It looks like you’re writing a letter. Would you like help?
+  </p>
+  <p>
+    <Button
+      isLink={true}
+    >
+      Got it
+    </Button>
+  </p>
+  <IconButton
+    className="nux-dot-tip__disable"
+    icon="no-alt"
+    label="Disable guide"
+  />
+</Popover>
 `;

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DotTip should render correctly 1`] = `
+<React.Fragment>
+  <Popover
+    aria-label="New user tip"
+    aria-modal="true"
+    className="nux-dot-tip"
+    focusOnMount={true}
+    noArrow={true}
+    onClick={[Function]}
+    position="middle right"
+    role="dialog"
+  >
+    <p>
+      It looks like you’re writing a letter. Would you like help?
+    </p>
+    <p>
+      <Button
+        isLink={true}
+      >
+        Got it
+      </Button>
+    </p>
+    <IconButton
+      className="nux-dot-tip__disable"
+      icon="no-alt"
+      label="Disable guide"
+    />
+  </Popover>
+</React.Fragment>
+`;

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -10,11 +10,6 @@ exports[`DotTip should render correctly 1`] = `
   position="middle right"
   role="dialog"
 >
-  <IconButton
-    className="nux-dot-tip__disable"
-    icon="no-alt"
-    label="Dismiss tip"
-  />
   <p>
     It looks like you’re writing a letter. Would you like help?
   </p>
@@ -25,5 +20,10 @@ exports[`DotTip should render correctly 1`] = `
       Got it
     </Button>
   </p>
+  <IconButton
+    className="nux-dot-tip__disable"
+    icon="no-alt"
+    label="Dismiss tip"
+  />
 </Popover>
 `;

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -13,7 +13,7 @@ exports[`DotTip should render correctly 1`] = `
   <IconButton
     className="nux-dot-tip__disable"
     icon="no-alt"
-    label="Disable tips"
+    label="Dismiss tip"
   />
   <p>
     It looks like you’re writing a letter. Would you like help?

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -3,7 +3,6 @@
 exports[`DotTip should render correctly 1`] = `
 <Popover
   aria-label="New user tip"
-  aria-modal="true"
   className="nux-dot-tip"
   focusOnMount={true}
   noArrow={true}

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DotTip should render correctly 1`] = `
 <Popover
-  aria-label="New user tip"
+  aria-label="Gutenberg tips"
   className="nux-dot-tip"
   focusOnMount={true}
   noArrow={true}
@@ -13,7 +13,7 @@ exports[`DotTip should render correctly 1`] = `
   <IconButton
     className="nux-dot-tip__disable"
     icon="no-alt"
-    label="Disable guide"
+    label="Disable tips"
   />
   <p>
     It looks like you’re writing a letter. Would you like help?

--- a/nux/components/dot-tip/test/index.js
+++ b/nux/components/dot-tip/test/index.js
@@ -38,14 +38,14 @@ describe( 'DotTip', () => {
 		expect( onDismiss ).toHaveBeenCalled();
 	} );
 
-	it( 'should call onDisable when the disable button is clicked', () => {
-		const onDisable = jest.fn();
+	it( 'should call onDismiss when the X button is clicked', () => {
+		const onDismiss = jest.fn();
 		const wrapper = shallow(
-			<DotTip isVisible onDisable={ onDisable }>
+			<DotTip isVisible onDismiss={ onDismiss }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
-		wrapper.find( 'IconButton[label="Disable tips"]' ).first().simulate( 'click' );
-		expect( onDisable ).toHaveBeenCalled();
+		wrapper.find( 'IconButton[label="Dismiss tip"]' ).first().simulate( 'click' );
+		expect( onDismiss ).toHaveBeenCalled();
 	} );
 } );

--- a/nux/components/dot-tip/test/index.js
+++ b/nux/components/dot-tip/test/index.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { DotTip } from '..';
+
+describe( 'DotTip', () => {
+	it( 'should not render anything if invisible', () => {
+		const wrapper = shallow(
+			<DotTip>
+				It looks like you’re writing a letter. Would you like help?
+			</DotTip>
+		);
+		expect( wrapper.isEmptyRender() ).toBe( true );
+	} );
+
+	it( 'should render correctly', () => {
+		const wrapper = shallow(
+			<DotTip isVisible>
+				It looks like you’re writing a letter. Would you like help?
+			</DotTip>
+		);
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'should call onDismiss when the dismiss button is clicked', () => {
+		const onDismiss = jest.fn();
+		const wrapper = shallow(
+			<DotTip isVisible onDismiss={ onDismiss }>
+				It looks like you’re writing a letter. Would you like help?
+			</DotTip>
+		);
+		wrapper.find( 'Button[children="Got it"]' ).first().simulate( 'click' );
+		expect( onDismiss ).toHaveBeenCalled();
+	} );
+
+	it( 'should call onDisable when the disable button is clicked', () => {
+		const onDisable = jest.fn();
+		const wrapper = shallow(
+			<DotTip isVisible onDisable={ onDisable }>
+				It looks like you’re writing a letter. Would you like help?
+			</DotTip>
+		);
+		wrapper.find( 'IconButton[label="Disable guide"]' ).first().simulate( 'click' );
+		expect( onDisable ).toHaveBeenCalled();
+	} );
+} );

--- a/nux/components/dot-tip/test/index.js
+++ b/nux/components/dot-tip/test/index.js
@@ -45,7 +45,7 @@ describe( 'DotTip', () => {
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
-		wrapper.find( 'IconButton[label="Disable guide"]' ).first().simulate( 'click' );
+		wrapper.find( 'IconButton[label="Disable tips"]' ).first().simulate( 'click' );
 		expect( onDisable ).toHaveBeenCalled();
 	} );
 } );

--- a/nux/index.js
+++ b/nux/index.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import './store';
+
+export { default as DotTip } from './components/dot-tip';

--- a/nux/store/actions.js
+++ b/nux/store/actions.js
@@ -2,14 +2,14 @@
  * Returns an action object that, when dispatched, presents a guide that takes
  * the user through a series of tips step by step.
  *
- * @param {string[]} tipIDs Which tips to show in the guide.
+ * @param {string[]} tipIds Which tips to show in the guide.
  *
  * @return {Object} Action object.
  */
-export function triggerGuide( tipIDs ) {
+export function triggerGuide( tipIds ) {
 	return {
 		type: 'TRIGGER_GUIDE',
-		tipIDs,
+		tipIds,
 	};
 }
 

--- a/nux/store/actions.js
+++ b/nux/store/actions.js
@@ -1,0 +1,41 @@
+/**
+ * Returns an action object that, when dispatched, presents a guide that takes
+ * the user through a series of tips step by step.
+ *
+ * @param {string[]} tipIDs Which tips to show in the guide.
+ *
+ * @return {Object} Action object.
+ */
+export function triggerGuide( tipIDs ) {
+	return {
+		type: 'TRIGGER_GUIDE',
+		tipIDs,
+	};
+}
+
+/**
+ * Returns an action object that, when dispatched, dismisses the given tip. A
+ * dismissed tip will not show again.
+ *
+ * @param {string} id The tip to dismiss.
+ *
+ * @return {Object} Action object.
+ */
+export function dismissTip( id ) {
+	return {
+		type: 'DISMISS_TIP',
+		id,
+	};
+}
+
+/**
+ * Returns an action object that, when dispatched, prevents all tips from
+ * showing again.
+ *
+ * @return {Object} Action object.
+ */
+export function disableTips() {
+	return {
+		type: 'DISABLE_TIPS',
+	};
+}

--- a/nux/store/index.js
+++ b/nux/store/index.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore, withRehydration, loadAndPersist } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+const REDUCER_KEY = 'preferences';
+const STORAGE_KEY = `GUTENBERG_NUX_${ window.userSettings.uid }`;
+
+const store = registerStore( 'core/nux', {
+	reducer: withRehydration( reducer, REDUCER_KEY, STORAGE_KEY ),
+	actions,
+	selectors,
+} );
+
+loadAndPersist( store, reducer, REDUCER_KEY, STORAGE_KEY );
+
+export default store;

--- a/nux/store/reducer.js
+++ b/nux/store/reducer.js
@@ -3,6 +3,15 @@
  */
 import { combineReducers } from '@wordpress/data';
 
+/**
+ * Reducer that tracks which tips are in a guide. Each guide is represented by
+ * an array which contains the tip identifiers contained within that guide.
+ *
+ * @param {Array} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Array} Updated state.
+ */
 export function guides( state = [], action ) {
 	switch ( action.type ) {
 		case 'TRIGGER_GUIDE':
@@ -15,6 +24,14 @@ export function guides( state = [], action ) {
 	return state;
 }
 
+/**
+ * Reducer that tracks whether or not tips are globally disabled.
+ *
+ * @param {boolean} state Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
 export function areTipsDisabled( state = false, action ) {
 	switch ( action.type ) {
 		case 'DISABLE_TIPS':
@@ -24,6 +41,15 @@ export function areTipsDisabled( state = false, action ) {
 	return state;
 }
 
+/**
+ * Reducer that tracks which tips have been dismissed. If the state object
+ * contains a tip identifier, then that tip is dismissed.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
 export function dismissedTips( state = {}, action ) {
 	switch ( action.type ) {
 		case 'DISMISS_TIP':

--- a/nux/store/reducer.js
+++ b/nux/store/reducer.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+export function guides( state = [], action ) {
+	switch ( action.type ) {
+		case 'TRIGGER_GUIDE':
+			return [
+				...state,
+				action.tipIDs,
+			];
+	}
+
+	return state;
+}
+
+export function areTipsDisabled( state = false, action ) {
+	switch ( action.type ) {
+		case 'DISABLE_TIPS':
+			return true;
+	}
+
+	return state;
+}
+
+export function dismissedTips( state = {}, action ) {
+	switch ( action.type ) {
+		case 'DISMISS_TIP':
+			return {
+				...state,
+				[ action.id ]: true,
+			};
+	}
+
+	return state;
+}
+
+const preferences = combineReducers( { areTipsDisabled, dismissedTips } );
+
+export default combineReducers( { guides, preferences } );

--- a/nux/store/reducer.js
+++ b/nux/store/reducer.js
@@ -8,7 +8,7 @@ export function guides( state = [], action ) {
 		case 'TRIGGER_GUIDE':
 			return [
 				...state,
-				action.tipIDs,
+				action.tipIds,
 			];
 	}
 

--- a/nux/store/selectors.js
+++ b/nux/store/selectors.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { includes, difference, keys } from 'lodash';
+
+/**
+ * Returns an object describing the guide, if any, that the given tip is a part
+ * of.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} tipID The tip to query.
+ *
+ * @typedef {Object} NUX.GuideInfo
+ * @property {string[]} tipIDs       Which tips the guide contains.
+ * @property {?string}  currentTipID The guide's currently showing tip.
+ * @property {?string}  nextTipID    The guide's next tip to show.
+ *
+ * @return {?NUX.GuideInfo} Information about the associated guide.
+ */
+export function getAssociatedGuide( state, tipID ) {
+	for ( const tipIDs of state.guides ) {
+		if ( includes( tipIDs, tipID ) ) {
+			const nonDismissedTips = difference( tipIDs, keys( state.preferences.dismissedTips ) );
+			const [ currentTipID = null, nextTipID = null ] = nonDismissedTips;
+			return { tipIDs, currentTipID, nextTipID };
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Determines whether or not the given tip is showing. Tips are hidden if they
+ * are disabled, have been dismissed, or are not the current tip in any
+ * guide that they have been added to.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} id    The tip to query.
+ *
+ * @return {boolean} Whether or not the given tip is showing.
+ */
+export function isTipVisible( state, id ) {
+	if ( state.preferences.areTipsDisabled ) {
+		return false;
+	}
+
+	if ( state.preferences.dismissedTips[ id ] ) {
+		return false;
+	}
+
+	const associatedGuide = getAssociatedGuide( state, id );
+	if ( associatedGuide && associatedGuide.currentTipID !== id ) {
+		return false;
+	}
+
+	return true;
+}

--- a/nux/store/selectors.js
+++ b/nux/store/selectors.js
@@ -8,21 +8,21 @@ import { includes, difference, keys } from 'lodash';
  * of.
  *
  * @param {Object} state Global application state.
- * @param {string} tipID The tip to query.
+ * @param {string} tipId The tip to query.
  *
  * @typedef {Object} NUX.GuideInfo
- * @property {string[]} tipIDs       Which tips the guide contains.
- * @property {?string}  currentTipID The guide's currently showing tip.
- * @property {?string}  nextTipID    The guide's next tip to show.
+ * @property {string[]} tipIds       Which tips the guide contains.
+ * @property {?string}  currentTipId The guide's currently showing tip.
+ * @property {?string}  nextTipId    The guide's next tip to show.
  *
  * @return {?NUX.GuideInfo} Information about the associated guide.
  */
-export function getAssociatedGuide( state, tipID ) {
-	for ( const tipIDs of state.guides ) {
-		if ( includes( tipIDs, tipID ) ) {
-			const nonDismissedTips = difference( tipIDs, keys( state.preferences.dismissedTips ) );
-			const [ currentTipID = null, nextTipID = null ] = nonDismissedTips;
-			return { tipIDs, currentTipID, nextTipID };
+export function getAssociatedGuide( state, tipId ) {
+	for ( const tipIds of state.guides ) {
+		if ( includes( tipIds, tipId ) ) {
+			const nonDismissedTips = difference( tipIds, keys( state.preferences.dismissedTips ) );
+			const [ currentTipId = null, nextTipId = null ] = nonDismissedTips;
+			return { tipIds, currentTipId, nextTipId };
 		}
 	}
 
@@ -49,7 +49,7 @@ export function isTipVisible( state, id ) {
 	}
 
 	const associatedGuide = getAssociatedGuide( state, id );
-	if ( associatedGuide && associatedGuide.currentTipID !== id ) {
+	if ( associatedGuide && associatedGuide.currentTipId !== id ) {
 		return false;
 	}
 

--- a/nux/store/selectors.js
+++ b/nux/store/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import createSelector from 'rememo';
 import { includes, difference, keys } from 'lodash';
 
 /**
@@ -21,17 +22,23 @@ import { includes, difference, keys } from 'lodash';
  *
  * @return {?NUX.GuideInfo} Information about the associated guide.
  */
-export function getAssociatedGuide( state, tipId ) {
-	for ( const tipIds of state.guides ) {
-		if ( includes( tipIds, tipId ) ) {
-			const nonDismissedTips = difference( tipIds, keys( state.preferences.dismissedTips ) );
-			const [ currentTipId = null, nextTipId = null ] = nonDismissedTips;
-			return { tipIds, currentTipId, nextTipId };
+export const getAssociatedGuide = createSelector(
+	( state, tipId ) => {
+		for ( const tipIds of state.guides ) {
+			if ( includes( tipIds, tipId ) ) {
+				const nonDismissedTips = difference( tipIds, keys( state.preferences.dismissedTips ) );
+				const [ currentTipId = null, nextTipId = null ] = nonDismissedTips;
+				return { tipIds, currentTipId, nextTipId };
+			}
 		}
-	}
 
-	return null;
-}
+		return null;
+	},
+	( state ) => [
+		state.guides,
+		state.preferences.dismissedTips,
+	],
+);
 
 /**
  * Determines whether or not the given tip is showing. Tips are hidden if they

--- a/nux/store/selectors.js
+++ b/nux/store/selectors.js
@@ -4,16 +4,20 @@
 import { includes, difference, keys } from 'lodash';
 
 /**
- * Returns an object describing the guide, if any, that the given tip is a part
- * of.
- *
- * @param {Object} state Global application state.
- * @param {string} tipId The tip to query.
+ * An object containing information about a guide.
  *
  * @typedef {Object} NUX.GuideInfo
  * @property {string[]} tipIds       Which tips the guide contains.
  * @property {?string}  currentTipId The guide's currently showing tip.
  * @property {?string}  nextTipId    The guide's next tip to show.
+ */
+
+/**
+ * Returns an object describing the guide, if any, that the given tip is a part
+ * of.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} tipId The tip to query.
  *
  * @return {?NUX.GuideInfo} Information about the associated guide.
  */

--- a/nux/store/test/actions.js
+++ b/nux/store/test/actions.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { triggerGuide, dismissTip, disableTips } from '../actions';
+
+describe( 'actions', () => {
+	describe( 'triggerGuide', () => {
+		it( 'should return a TRIGGER_GUIDE action', () => {
+			expect( triggerGuide( [ 'test/tip-1', 'test/tip-2' ] ) ).toEqual( {
+				type: 'TRIGGER_GUIDE',
+				tipIDs: [ 'test/tip-1', 'test/tip-2' ],
+			} );
+		} );
+	} );
+
+	describe( 'dismissTip', () => {
+		it( 'should return an DISMISS_TIP action', () => {
+			expect( dismissTip( 'test/tip' ) ).toEqual( {
+				type: 'DISMISS_TIP',
+				id: 'test/tip',
+			} );
+		} );
+	} );
+
+	describe( 'disableTips', () => {
+		it( 'should return an DISABLE_TIPS action', () => {
+			expect( disableTips() ).toEqual( {
+				type: 'DISABLE_TIPS',
+			} );
+		} );
+	} );
+} );

--- a/nux/store/test/actions.js
+++ b/nux/store/test/actions.js
@@ -8,7 +8,7 @@ describe( 'actions', () => {
 		it( 'should return a TRIGGER_GUIDE action', () => {
 			expect( triggerGuide( [ 'test/tip-1', 'test/tip-2' ] ) ).toEqual( {
 				type: 'TRIGGER_GUIDE',
-				tipIDs: [ 'test/tip-1', 'test/tip-2' ],
+				tipIds: [ 'test/tip-1', 'test/tip-2' ],
 			} );
 		} );
 	} );

--- a/nux/store/test/reducer.js
+++ b/nux/store/test/reducer.js
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+import { guides, areTipsDisabled, dismissedTips } from '../reducer';
+
+describe( 'reducer', () => {
+	describe( 'guides', () => {
+		it( 'should start out empty', () => {
+			expect( guides( undefined, {} ) ).toEqual( [] );
+		} );
+
+		it( 'should add a guide when it is triggered', () => {
+			const state = guides( [], {
+				type: 'TRIGGER_GUIDE',
+				tipIDs: [ 'test/tip-1', 'test/tip-2' ],
+			} );
+			expect( state ).toEqual( [
+				[ 'test/tip-1', 'test/tip-2' ],
+			] );
+		} );
+	} );
+
+	describe( 'areTipsDisabled', () => {
+		it( 'should default to false', () => {
+			expect( areTipsDisabled( undefined, {} ) ).toBe( false );
+		} );
+
+		it( 'should flip when tips are disabled', () => {
+			const state = areTipsDisabled( false, {
+				type: 'DISABLE_TIPS',
+			} );
+			expect( state ).toBe( true );
+		} );
+	} );
+
+	describe( 'dismissedTips', () => {
+		it( 'should start out empty', () => {
+			expect( dismissedTips( undefined, {} ) ).toEqual( {} );
+		} );
+
+		it( 'should mark tips as dismissed', () => {
+			const state = dismissedTips( {}, {
+				type: 'DISMISS_TIP',
+				id: 'test/tip',
+			} );
+			expect( state ).toEqual( {
+				'test/tip': true,
+			} );
+		} );
+	} );
+} );

--- a/nux/store/test/reducer.js
+++ b/nux/store/test/reducer.js
@@ -12,7 +12,7 @@ describe( 'reducer', () => {
 		it( 'should add a guide when it is triggered', () => {
 			const state = guides( [], {
 				type: 'TRIGGER_GUIDE',
-				tipIDs: [ 'test/tip-1', 'test/tip-2' ],
+				tipIds: [ 'test/tip-1', 'test/tip-2' ],
 			} );
 			expect( state ).toEqual( [
 				[ 'test/tip-1', 'test/tip-2' ],

--- a/nux/store/test/selectors.js
+++ b/nux/store/test/selectors.js
@@ -1,0 +1,104 @@
+/**
+ * Internal dependencies
+ */
+import { getAssociatedGuide, isTipVisible } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'getAssociatedGuide', () => {
+		const state = {
+			guides: [
+				[ 'test/tip-1', 'test/tip-2', 'test/tip-3' ],
+				[ 'test/tip-a', 'test/tip-b', 'test/tip-c' ],
+				[ 'test/tip-α', 'test/tip-β', 'test/tip-γ' ],
+			],
+			preferences: {
+				dismissedTips: {
+					'test/tip-1': true,
+					'test/tip-a': true,
+					'test/tip-b': true,
+					'test/tip-α': true,
+					'test/tip-β': true,
+					'test/tip-γ': true,
+				},
+			},
+		};
+
+		it( 'should return null when there is no associated guide', () => {
+			expect( getAssociatedGuide( state, 'test/unknown' ) ).toBeNull();
+		} );
+
+		it( 'should return the associated guide', () => {
+			expect( getAssociatedGuide( state, 'test/tip-2' ) ).toEqual( {
+				tipIDs: [ 'test/tip-1', 'test/tip-2', 'test/tip-3' ],
+				currentTipID: 'test/tip-2',
+				nextTipID: 'test/tip-3',
+			} );
+		} );
+
+		it( 'should indicate when there is no next tip', () => {
+			expect( getAssociatedGuide( state, 'test/tip-b' ) ).toEqual( {
+				tipIDs: [ 'test/tip-a', 'test/tip-b', 'test/tip-c' ],
+				currentTipID: 'test/tip-c',
+				nextTipID: null,
+			} );
+		} );
+
+		it( 'should indicate when there is no current or next tip', () => {
+			expect( getAssociatedGuide( state, 'test/tip-β' ) ).toEqual( {
+				tipIDs: [ 'test/tip-α', 'test/tip-β', 'test/tip-γ' ],
+				currentTipID: null,
+				nextTipID: null,
+			} );
+		} );
+	} );
+
+	describe( 'isTipVisible', () => {
+		it( 'should return true by default', () => {
+			const state = {
+				guides: [],
+				preferences: {
+					areTipsDisabled: false,
+					dismissedTips: {},
+				},
+			};
+			expect( isTipVisible( state, 'test/tip' ) ).toBe( true );
+		} );
+
+		it( 'should return false if tips are disabled', () => {
+			const state = {
+				guides: [],
+				preferences: {
+					areTipsDisabled: true,
+					dismissedTips: {},
+				},
+			};
+			expect( isTipVisible( state, 'test/tip' ) ).toBe( false );
+		} );
+
+		it( 'should return false if the tip is dismissed', () => {
+			const state = {
+				guides: [],
+				preferences: {
+					areTipsDisabled: false,
+					dismissedTips: {
+						'test/tip': true,
+					},
+				},
+			};
+			expect( isTipVisible( state, 'test/tip' ) ).toBe( false );
+		} );
+
+		it( 'should return false if the tip is in a guide and it is not the current tip', () => {
+			const state = {
+				guides: [
+					[ 'test/tip-1', 'test/tip-2', 'test/tip-3' ],
+				],
+				preferences: {
+					areTipsDisabled: false,
+					dismissedTips: {},
+				},
+			};
+			expect( isTipVisible( state, 'test/tip-2' ) ).toBe( false );
+		} );
+	} );
+} );

--- a/nux/store/test/selectors.js
+++ b/nux/store/test/selectors.js
@@ -29,25 +29,25 @@ describe( 'selectors', () => {
 
 		it( 'should return the associated guide', () => {
 			expect( getAssociatedGuide( state, 'test/tip-2' ) ).toEqual( {
-				tipIDs: [ 'test/tip-1', 'test/tip-2', 'test/tip-3' ],
-				currentTipID: 'test/tip-2',
-				nextTipID: 'test/tip-3',
+				tipIds: [ 'test/tip-1', 'test/tip-2', 'test/tip-3' ],
+				currentTipId: 'test/tip-2',
+				nextTipId: 'test/tip-3',
 			} );
 		} );
 
 		it( 'should indicate when there is no next tip', () => {
 			expect( getAssociatedGuide( state, 'test/tip-b' ) ).toEqual( {
-				tipIDs: [ 'test/tip-a', 'test/tip-b', 'test/tip-c' ],
-				currentTipID: 'test/tip-c',
-				nextTipID: null,
+				tipIds: [ 'test/tip-a', 'test/tip-b', 'test/tip-c' ],
+				currentTipId: 'test/tip-c',
+				nextTipId: null,
 			} );
 		} );
 
 		it( 'should indicate when there is no current or next tip', () => {
 			expect( getAssociatedGuide( state, 'test/tip-β' ) ).toEqual( {
-				tipIDs: [ 'test/tip-α', 'test/tip-β', 'test/tip-γ' ],
-				currentTipID: null,
-				nextTipID: null,
+				tipIds: [ 'test/tip-α', 'test/tip-β', 'test/tip-γ' ],
+				currentTipId: null,
+				nextTipId: null,
 			} );
 		} );
 	} );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -68,6 +68,11 @@ export async function visitAdmin( adminPath, query ) {
 
 export async function newPost( postType ) {
 	await visitAdmin( 'post-new.php', postType ? 'post_type=' + postType : '' );
+
+	// Disable new user tips so that their UI doesn't get in the way
+	await page.evaluate( () => {
+		wp.data.dispatch( 'core/nux' ).disableTips();
+	} );
 }
 
 export async function newDesktopBrowserPage() {

--- a/test/unit/jest.config.json
+++ b/test/unit/jest.config.json
@@ -1,11 +1,11 @@
 {
 	"rootDir": "../../",
 	"collectCoverageFrom": [
-		"(blocks|components|editor|utils|edit-post|viewport|plugins|core-data|core-blocks)/**/*.js",
+		"(blocks|components|editor|utils|edit-post|viewport|plugins|core-data|core-blocks|nux)/**/*.js",
 		"packages/**/*.js"
 	],
 	"moduleNameMapper": {
-		"@wordpress\\/(blocks|components|editor|utils|edit-post|viewport|plugins|core-data|core-blocks)$": "$1",
+		"@wordpress\\/(blocks|components|editor|utils|edit-post|viewport|plugins|core-data|core-blocks|nux)$": "$1",
 		"@wordpress\\/(blob|data|date|dom|deprecated|element|postcss-themes)$": "packages/$1/src"
 	},
 	"preset": "@wordpress/jest-preset-default",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,6 +146,7 @@ const entryPointNames = [
 	'plugins',
 	'edit-post',
 	'core-blocks',
+	'nux',
 ];
 
 const gutenbergPackages = [


### PR DESCRIPTION
### 🕺 What this is

Closes #3670. Blocked by https://github.com/WordPress/gutenberg/pull/7038.

This implements the NUX flow outlined by @karmatosed in https://github.com/WordPress/gutenberg/issues/3670#issuecomment-384595696:

When a new user opens Gutenberg, they're presented with a guide that points out some useful page elements:

![nux](https://user-images.githubusercontent.com/612155/40633279-0d4e915c-6332-11e8-80e2-39f10f2c838e.gif)

If they dismiss the guide, it won't ever show again:

![nux-dismiss](https://user-images.githubusercontent.com/612155/40633389-ccc2127a-6332-11e8-991b-004f5f0da523.gif)

### 🤔 How it works

- A `DotTip` component renders a tip bubble independently of anything else
  - This uses `Popover`, which now supports having its `yAxis` set to `middle`
- The `triggerGuide()` action lets you associate a series of tips into a single guide
- The `isTipVisible()` and `getAssociatedGuide()` selectors return information about which step in a guide the user is in
- The `dismissTip()` and `disableTips()` actions control dismissing a single tip (and stepping through the guide) and disabling tips entirely
- All of this functionality is contained within a new `nux` module with the intention that these components should be made available in other areas of the WP Admin

### 📋 Testing

There's unit tests included. Manual testing can be done by:

1. Create a new post
2. View and step through the tips
3. Refresh the page—the current step should be maintained 
3. Dismiss the tips
4. Refresh the page—the tips should no longer appear

### ✍️ Copy

I'm still waiting on the final copy for each tip. There was some discussion about this in https://github.com/WordPress/gutenberg/issues/3670.