### PR TITLE
Raw handling: preserve image ID

### DIFF
--- a/blocks/api/raw-handling/test/integration/one-image-out.html
+++ b/blocks/api/raw-handling/test/integration/one-image-out.html
@@ -1,3 +1,3 @@
-<!-- wp:image -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" /></figure>
+<!-- wp:image {"id":5114} -->
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" /></figure>
 <!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/two-images-out.html
+++ b/blocks/api/raw-handling/test/integration/two-images-out.html
@@ -1,7 +1,7 @@
-<!-- wp:image -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" /></figure>
+<!-- wp:image {"id":5114} -->
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" /></figure>
+<!-- wp:image {"id":5109} -->
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109" /></figure>
 <!-- /wp:image -->

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, mergeWith, includes, find } from 'lodash';
+import { omit, mergeWith, includes, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -204,14 +204,20 @@ function cleanNodeList( nodeList, doc, schema, inline ) {
 
 					// Strip invalid classes.
 					if ( node.classList.length ) {
-						Array.from( node.classList ).forEach( ( name ) => {
-							if ( find( classes, ( item ) => {
-								return typeof item === 'string' ? item === name : item.test( name );
-							} ) ) {
-								return;
+						const mattchers = classes.map( ( item ) => {
+							if ( typeof item === 'string' ) {
+								return ( className ) => className === item;
+							} else if ( item instanceof RegExp ) {
+								return ( className ) => item.test( className );
 							}
 
-							node.classList.remove( name );
+							return noop;
+						} );
+
+						Array.from( node.classList ).forEach( ( name ) => {
+							if ( ! mattchers.some( ( isMatch ) => isMatch( name ) ) ) {
+								node.classList.remove( name );
+							}
 						} );
 
 						if ( ! node.classList.length ) {

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, mergeWith, includes } from 'lodash';
+import { omit, mergeWith, includes, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -204,13 +204,17 @@ function cleanNodeList( nodeList, doc, schema, inline ) {
 
 					// Strip invalid classes.
 					if ( node.classList.length ) {
-						const newClasses = classes.filter( ( name ) =>
-							node.classList.contains( name )
-						);
+						Array.from( node.classList ).forEach( ( name ) => {
+							if ( find( classes, ( item ) => {
+								return typeof item === 'string' ? item === name : item.test( name );
+							} ) ) {
+								return;
+							}
 
-						if ( newClasses.length ) {
-							node.setAttribute( 'class', newClasses.join( ' ' ) );
-						} else {
+							node.classList.remove( name );
+						} );
+
+						if ( ! node.classList.length ) {
 							node.removeAttribute( 'class' );
 						}
 					}

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -61,7 +61,7 @@ const blockAttributes = {
 const imageSchema = {
 	img: {
 		attributes: [ 'src', 'alt' ],
-		classes: [ 'alignleft', 'aligncenter', 'alignright', 'alignnone', /wp-image-\d+/ ],
+		classes: [ 'alignleft', 'aligncenter', 'alignright', 'alignnone', /^wp-image-\d+$/ ],
 	},
 };
 
@@ -101,10 +101,12 @@ export const settings = {
 				isMatch: ( node ) => node.nodeName === 'FIGURE' && !! node.querySelector( 'img' ),
 				schema,
 				transform: ( node ) => {
+					// Search both figure and image classes. Alignment could be
+					// set on either. ID is set on the image.
 					const className = node.className + ' ' + node.querySelector( 'img' ).className;
-					const alignMatches = /align(left|center|right)/.exec( className );
+					const alignMatches = /(?:^|\s)align(left|center|right)(?:$|\s)/.exec( className );
 					const align = alignMatches ? alignMatches[ 1 ] : undefined;
-					const idMatches = /wp-image-(\d+)/.exec( className );
+					const idMatches = /(?:^|\s)wp-image-(\d+)(?:$|\s)/.exec( className );
 					const id = idMatches ? idMatches[ 1 ] : undefined;
 					const blockType = getBlockType( 'core/image' );
 					const attributes = getBlockAttributes( blockType, node.outerHTML, { align, id } );

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -61,7 +61,7 @@ const blockAttributes = {
 const imageSchema = {
 	img: {
 		attributes: [ 'src', 'alt' ],
-		classes: [ 'alignleft', 'aligncenter', 'alignright', 'alignnone' ],
+		classes: [ 'alignleft', 'aligncenter', 'alignright', 'alignnone', /wp-image-\d+/ ],
 	},
 };
 
@@ -101,10 +101,13 @@ export const settings = {
 				isMatch: ( node ) => node.nodeName === 'FIGURE' && !! node.querySelector( 'img' ),
 				schema,
 				transform: ( node ) => {
-					const matches = /align(left|center|right)/.exec( node.className );
-					const align = matches ? matches[ 1 ] : undefined;
+					const className = node.className + ' ' + node.querySelector( 'img' ).className;
+					const alignMatches = /align(left|center|right)/.exec( className );
+					const align = alignMatches ? alignMatches[ 1 ] : undefined;
+					const idMatches = /wp-image-(\d+)/.exec( className );
+					const id = idMatches ? idMatches[ 1 ] : undefined;
 					const blockType = getBlockType( 'core/image' );
-					const attributes = getBlockAttributes( blockType, node.outerHTML, { align } );
+					const attributes = getBlockAttributes( blockType, node.outerHTML, { align, id } );
 					return createBlock( 'core/image', attributes );
 				},
 			},


### PR DESCRIPTION
## Description

When copy pasting an image from the old editor, or converting a classic block to blocks, image IDs are dropped. We should preserve this information so the the correct image is selected in the media library on editing the image, and so that the image is made responsive on the front-end.

## How has this been tested?
Convert some old WP content to blocks.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->