### PR TITLE
Core blocks: Refactor blocks to use edit file - part 2

### DIFF
--- a/core-blocks/freeform/edit.js
+++ b/core-blocks/freeform/edit.js
@@ -5,6 +5,11 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { keycodes } from '@wordpress/utils';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
 const { BACKSPACE, DELETE, F10 } = keycodes;
 
 function isTmceEmpty( editor ) {
@@ -23,7 +28,7 @@ function isTmceEmpty( editor ) {
 	return /^\n?$/.test( body.innerText || body.textContent );
 }
 
-export default class OldEditor extends Component {
+export default class FreeformEdit extends Component {
 	constructor( props ) {
 		super( props );
 		this.initialize = this.initialize.bind( this );

--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -7,8 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './editor.scss';
-import OldEditor from './old-editor';
+import edit from './edit';
 
 export const name = 'core/freeform';
 
@@ -33,7 +32,7 @@ export const settings = {
 		customClassName: false,
 	},
 
-	edit: OldEditor,
+	edit,
 
 	save( { attributes } ) {
 		const { content } = attributes;

--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -30,6 +30,7 @@ import {
 /**
  * Internal dependencies
  */
+import './editor.scss';
 import GalleryImage from './gallery-image';
 
 const MAX_COLUMNS = 8;
@@ -43,7 +44,7 @@ export function defaultColumnsNumber( attributes ) {
 	return Math.min( 3, attributes.images.length );
 }
 
-class GalleryBlock extends Component {
+export default class GalleryEdit extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -270,5 +271,3 @@ class GalleryBlock extends Component {
 		);
 	}
 }
-
-export default GalleryBlock;

--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -16,9 +16,8 @@ import { RichText } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
-import './editor.scss';
 import './style.scss';
-import { default as GalleryBlock, defaultColumnsNumber } from './block';
+import { default as edit, defaultColumnsNumber } from './edit';
 
 const blockAttributes = {
 	align: {
@@ -165,7 +164,7 @@ export const settings = {
 		}
 	},
 
-	edit: GalleryBlock,
+	edit,
 
 	save( { attributes } ) {
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -45,6 +45,7 @@ import {
 /**
  * Internal dependencies
  */
+import './editor.scss';
 import ImageSize from './image-size';
 
 /**
@@ -52,7 +53,7 @@ import ImageSize from './image-size';
  */
 const MIN_SIZE = 20;
 
-class ImageBlock extends Component {
+class ImageEdit extends Component {
 	constructor() {
 		super( ...arguments );
 		this.updateAlt = this.updateAlt.bind( this );
@@ -399,4 +400,4 @@ export default compose( [
 			image: id ? getMedia( id ) : null,
 		};
 	} ),
-] )( ImageBlock );
+] )( ImageEdit );

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -14,8 +14,7 @@ import { RichText } from '@wordpress/editor';
  * Internal dependencies
  */
 import './style.scss';
-import './editor.scss';
-import ImageBlock from './block';
+import edit from './edit';
 
 export const name = 'core/image';
 
@@ -180,7 +179,7 @@ export const settings = {
 		}
 	},
 
-	edit: ImageBlock,
+	edit,
 
 	save( { attributes } ) {
 		const { url, alt, caption, align, href, width, height, id } = attributes;

--- a/core-blocks/latest-posts/edit.js
+++ b/core-blocks/latest-posts/edit.js
@@ -32,11 +32,10 @@ import {
  * Internal dependencies
  */
 import './editor.scss';
-import './style.scss';
 
 const MAX_POSTS_COLUMNS = 6;
 
-class LatestPostsBlock extends Component {
+class LatestPostsEdit extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -176,4 +175,4 @@ export default withAPIData( ( props ) => {
 		latestPosts: `/wp/v2/posts?${ latestPostsQuery }`,
 		categoriesList: `/wp/v2/categories?${ categoriesListQuery }`,
 	};
-} )( LatestPostsBlock );
+} )( LatestPostsEdit );

--- a/core-blocks/latest-posts/index.js
+++ b/core-blocks/latest-posts/index.js
@@ -6,9 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './editor.scss';
 import './style.scss';
-import LatestPostsBlock from './block';
+import edit from './edit';
 
 export const name = 'core/latest-posts';
 
@@ -34,7 +33,7 @@ export const settings = {
 		}
 	},
 
-	edit: LatestPostsBlock,
+	edit,
 
 	save() {
 		return null;


### PR DESCRIPTION
## Description
This PR follows the work started by @hypest in #5816, #6626 and continued in #6637 by me, to have `edit` component in a separate file. This helps to speed up exploration how to make Gutenberg work with mobile apps using React Native implementation.

There are no changes in the logic. This PR contains only extract and move code refactoring.

## How has this been tested?
Manually. The following blocks should still work as before:
- `Freeform`
- `Gallery`
- `Image`
- `Latest Posts`

## Types of changes
Refactoring

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->