### PR TITLE
Rich text formatting filter

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -23,7 +23,7 @@ import PositionedAtSelection from './positioned-at-selection';
 import URLInput from '../../url-input';
 import { filterURLForDisplay } from '../../../utils/url';
 
-const FORMATTING_CONTROLS = applyFilters( 'editor.RichText.formattingControls', [
+const getFormattingControls = () => applyFilters( 'editor.RichText.formattingControls', [
 	{
 		icon: 'editor-bold',
 		title: __( 'Bold' ),
@@ -181,7 +181,7 @@ class FormatToolbar extends Component {
 		const { linkValue, settingsVisible, opensInNewWindow } = this.state;
 		const isAddingLink = formats.link && formats.link.isAdding;
 
-		const toolbarControls = FORMATTING_CONTROLS.concat( customControls )
+		const toolbarControls = getFormattingControls().concat( customControls )
 			.filter( ( control ) => enabledControls.indexOf( control.format ) !== -1 )
 			.map( ( control ) => {
 				if ( control.format === 'link' ) {

--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/components';
 import { ESCAPE, LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER, displayShortcut } from '@wordpress/keycodes';
 import { prependHTTP } from '@wordpress/url';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ import PositionedAtSelection from './positioned-at-selection';
 import URLInput from '../../url-input';
 import { filterURLForDisplay } from '../../../utils/url';
 
-const FORMATTING_CONTROLS = [
+const FORMATTING_CONTROLS = applyFilters( 'editor.RichText.formattingControls', [
 	{
 		icon: 'editor-bold',
 		title: __( 'Bold' ),
@@ -47,7 +48,7 @@ const FORMATTING_CONTROLS = [
 		shortcut: displayShortcut.access( 'd' ),
 		format: 'strikethrough',
 	},
-];
+] );
 
 // Default controls shown if no `enabledControls` prop provided
 const DEFAULT_CONTROLS = [ 'bold', 'italic', 'strikethrough', 'link' ];


### PR DESCRIPTION
## Description

See also #4658.

Related PRs: #9192.

This small change makes the formatting controls for all rich text instances extensible. E.g. a plugin wants to add an extra button to add a "code" tag:

```js
addFilter( 'editor.richText.formattingControls', 'core/test', ( controls ) => {
	return [
		...controls,
		{
			icon: 'editor-code',
			title: __( 'Code' ),
			shortcut: displayShortcut.primary( 'x' ),
			format: 'code',
		},
	];
} );
```

For the moment it's limited to adding formats, but I could imagine an option to insert custom HTML as well. Let's start simple. :)

Questions:

* What's the right place to call `applyFilters`? At the top level, plugins will need to add the filter before the Gutenberg scripts run. At render it will be run too many times. Should it be run on constructing `FormatToolbar`?
* If we keep `DEFAULT_CONTROLS`, we this might need a filter too, but it does not make sense without context. `RichText` is not aware of the block using it. It could also be the tag, but not sure if this makes any sense. Alternatively we could get rid of `DEFAULT_CONTROLS` or invert the behaviour, e.g. a button would declare controls to omit rather then the ones to display.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->