### PR TITLE
fix: Update wordcount package to prevent crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
 			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -51,7 +51,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -60,9 +60,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -77,7 +77,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -91,7 +91,7 @@
 				"@babel/code-frame": "7.0.0-beta.31",
 				"@babel/types": "7.0.0-beta.31",
 				"babylon": "7.0.0-beta.31",
-				"lodash": "4.17.5"
+				"lodash": "^4.2.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -100,9 +100,9 @@
 					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"ansi-styles": {
@@ -111,7 +111,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"babylon": {
@@ -126,9 +126,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"supports-color": {
@@ -137,7 +137,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -152,10 +152,10 @@
 				"@babel/helper-function-name": "7.0.0-beta.31",
 				"@babel/types": "7.0.0-beta.31",
 				"babylon": "7.0.0-beta.31",
-				"debug": "3.1.0",
-				"globals": "10.4.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.5"
+				"debug": "^3.0.1",
+				"globals": "^10.0.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.2.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -164,9 +164,9 @@
 					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"ansi-styles": {
@@ -175,7 +175,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"babylon": {
@@ -190,9 +190,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"debug": {
@@ -216,7 +216,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -227,9 +227,9 @@
 			"integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2",
-				"lodash": "4.17.5",
-				"to-fast-properties": "2.0.0"
+				"esutils": "^2.0.2",
+				"lodash": "^4.2.0",
+				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@romainberger/css-diff": {
@@ -238,8 +238,8 @@
 			"integrity": "sha1-ztOHU11PQqQqwf4TwJ3pf1rhNEw=",
 			"dev": true,
 			"requires": {
-				"lodash.merge": "4.6.1",
-				"postcss": "5.2.18"
+				"lodash.merge": "^4.4.0",
+				"postcss": "^5.0.21"
 			}
 		},
 		"@sindresorhus/is": {
@@ -259,7 +259,7 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-1.0.6.tgz",
 			"integrity": "sha512-IyL7KzYGzMEg+FFyTrQzD/CUfABYCXOvmnm29vBZBA3JMER1ep3/+NFDe6CpWVEEMCw94oj2gUOSQ4YKVgDjUQ==",
 			"requires": {
-				"@wordpress/dom-ready": "1.0.4"
+				"@wordpress/dom-ready": "^1.0.3"
 			}
 		},
 		"@wordpress/autop": {
@@ -273,8 +273,8 @@
 			"integrity": "sha512-YNcXr33fUUHg9HncNhUNkG2jnCAtnvC5hN0ZdDdTVe7r7aR4l+gCTCZXvM/0SHqikrNhRNjSrE5ZM/3u2zsOyw==",
 			"dev": true,
 			"requires": {
-				"gettext-parser": "1.3.1",
-				"lodash": "4.17.5"
+				"gettext-parser": "^1.3.1",
+				"lodash": "^4.17.5"
 			},
 			"dependencies": {
 				"gettext-parser": {
@@ -283,8 +283,8 @@
 					"integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
 					"dev": true,
 					"requires": {
-						"encoding": "0.1.12",
-						"safe-buffer": "5.1.1"
+						"encoding": "^0.1.12",
+						"safe-buffer": "^5.1.1"
 					}
 				},
 				"lodash": {
@@ -301,11 +301,11 @@
 			"integrity": "sha512-DJ4P3gwj8gUQy94GeaVdHTh2JVKQ8eNFwCQi4GDhCcq78KDAJjRO497ZwoJWJR0MVq5a3XfsrJ6fVf7S8APfUw==",
 			"dev": true,
 			"requires": {
-				"@wordpress/browserslist-config": "2.1.3",
-				"babel-plugin-transform-object-rest-spread": "6.26.0",
-				"babel-plugin-transform-react-jsx": "6.24.1",
-				"babel-plugin-transform-runtime": "6.23.0",
-				"babel-preset-env": "1.6.1"
+				"@wordpress/browserslist-config": "^2.1.3",
+				"babel-plugin-transform-object-rest-spread": "^6.23.0",
+				"babel-plugin-transform-react-jsx": "^6.24.1",
+				"babel-plugin-transform-runtime": "^6.23.0",
+				"babel-preset-env": "^1.6.1"
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -320,7 +320,7 @@
 			"integrity": "sha512-7GDENg5juXusGye4JqKAjfAr1EcKNNmJ6GUnnUrdOkXgjnT5CoAw2ADJxvtALtl4vx6o/nqzJxp9YQ/bZi85Dg==",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"@wordpress/dom-ready": {
@@ -338,10 +338,10 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-1.1.0.tgz",
 			"integrity": "sha512-zzpyhSaVOv5iLIwkJ4nrPt7FO+50xHlGDSJljfGdS+ypvFAnEHpCkkJ84F3NhHaYIIZqMEn5lC4k1edIaIqAbA==",
 			"requires": {
-				"gettext-parser": "1.3.1",
-				"jed": "1.1.1",
-				"lodash": "4.17.5",
-				"memize": "1.0.5"
+				"gettext-parser": "^1.3.1",
+				"jed": "^1.1.1",
+				"lodash": "^4.17.5",
+				"memize": "^1.0.5"
 			},
 			"dependencies": {
 				"lodash": {
@@ -362,8 +362,8 @@
 			"integrity": "sha512-PwhDL2H4EI6adnGyQo0v4p8zRokjNu4DJ3EDZpH9dmNK0/G9hKuuIAwGN2e9RGyAiqipddCkt5y4qzH1mx8PJw==",
 			"dev": true,
 			"requires": {
-				"jest-matcher-utils": "22.4.0",
-				"lodash": "4.17.5"
+				"jest-matcher-utils": "^22.4.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"@wordpress/jest-preset-default": {
@@ -372,12 +372,12 @@
 			"integrity": "sha512-1+uREUyhMWBanX4qceevrFEuaFm/gRKIKiDb36Wc5X02ODEaUaQ6qjIvrD6fariYtvxQpjC8TBjKapsvSaqHHw==",
 			"dev": true,
 			"requires": {
-				"@wordpress/jest-console": "1.0.5",
-				"babel-jest": "22.4.0",
-				"enzyme": "3.3.0",
-				"enzyme-adapter-react-16": "1.1.1",
-				"jest-enzyme": "4.2.0",
-				"pegjs": "0.10.0"
+				"@wordpress/jest-console": "^1.0.5",
+				"babel-jest": "^22.1.0",
+				"enzyme": "^3.3.0",
+				"enzyme-adapter-react-16": "^1.1.1",
+				"jest-enzyme": "^4.0.2",
+				"pegjs": "^0.10.0"
 			}
 		},
 		"@wordpress/scripts": {
@@ -386,11 +386,11 @@
 			"integrity": "sha512-gbtpV6i4SKi7Pya8qeB6N9FGyWAMBtyAsRnFg6Lv6Ejh0Pk9R2Aa71GjX4ZAMzq1LFuVNdhciIybdxDPSsP8sQ==",
 			"dev": true,
 			"requires": {
-				"@wordpress/babel-preset-default": "1.2.0",
-				"@wordpress/jest-preset-default": "1.0.3",
-				"cross-spawn": "5.1.0",
-				"jest": "22.4.0",
-				"read-pkg-up": "3.0.0"
+				"@wordpress/babel-preset-default": "^1.1.1",
+				"@wordpress/jest-preset-default": "^1.0.3",
+				"cross-spawn": "^5.1.0",
+				"jest": "^22.4.0",
+				"read-pkg-up": "^3.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -399,7 +399,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -408,10 +408,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"parse-json": {
@@ -420,8 +420,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -430,7 +430,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -445,9 +445,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -456,8 +456,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				}
 			}
@@ -472,7 +472,7 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-1.0.2.tgz",
 			"integrity": "sha512-UZGVjKvyTWJuTCEhbgZj0Ilmv/Ufj+dsit0nxawPz5+1m54fbqy8/hpfCH9RiS9JmMWfE3TB6rB4U/Bd0NmFZg==",
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.17.4"
 			}
 		},
 		"abab": {
@@ -498,7 +498,7 @@
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.4.1"
+				"acorn": "^5.0.0"
 			}
 		},
 		"acorn-globals": {
@@ -507,7 +507,7 @@
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.4.1"
+				"acorn": "^5.0.0"
 			}
 		},
 		"acorn-jsx": {
@@ -516,7 +516,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "3.3.0"
+				"acorn": "^3.0.4"
 			},
 			"dependencies": {
 				"acorn": {
@@ -533,7 +533,7 @@
 			"integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
 			"dev": true,
 			"requires": {
-				"es6-promisify": "5.0.0"
+				"es6-promisify": "^5.0.0"
 			}
 		},
 		"ajv": {
@@ -542,10 +542,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ajv-keywords": {
@@ -560,9 +560,9 @@
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"alphanum-sort": {
@@ -606,8 +606,8 @@
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 			"dev": true,
 			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
+				"micromatch": "^2.1.5",
+				"normalize-path": "^2.0.0"
 			}
 		},
 		"append-transform": {
@@ -616,7 +616,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "1.0.0"
+				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"aproba": {
@@ -631,8 +631,8 @@
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"dev": true,
 			"requires": {
-				"delegates": "1.0.0",
-				"readable-stream": "2.3.3"
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
 			}
 		},
 		"argparse": {
@@ -641,7 +641,7 @@
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			},
 			"dependencies": {
 				"sprintf-js": {
@@ -665,7 +665,7 @@
 			"dev": true,
 			"requires": {
 				"ast-types-flow": "0.0.7",
-				"commander": "2.14.1"
+				"commander": "^2.11.0"
 			}
 		},
 		"arr-diff": {
@@ -674,7 +674,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
@@ -713,8 +713,8 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.7.0"
 			}
 		},
 		"array-union": {
@@ -723,7 +723,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -761,9 +761,9 @@
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"assert": {
@@ -811,7 +811,7 @@
 			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.14.0"
 			}
 		},
 		"async-each": {
@@ -850,12 +850,12 @@
 			"integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "3.2.4",
-				"caniuse-lite": "1.0.30000821",
-				"normalize-range": "0.1.2",
-				"num2fraction": "1.2.2",
-				"postcss": "6.0.21",
-				"postcss-value-parser": "3.3.0"
+				"browserslist": "^3.2.0",
+				"caniuse-lite": "^1.0.30000817",
+				"normalize-range": "^0.1.2",
+				"num2fraction": "^1.2.2",
+				"postcss": "^6.0.20",
+				"postcss-value-parser": "^3.2.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -864,7 +864,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"browserslist": {
@@ -873,8 +873,8 @@
 					"integrity": "sha512-Dwe62y/fNAcMfknzGJnkh7feISrrN0SmRvMFozb+Y2+qg7rfTIH5MS8yHzaIXcEWl8fPeIcdhZNQi1Lux+7dlg==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "1.0.30000821",
-						"electron-to-chromium": "1.3.41"
+						"caniuse-lite": "^1.0.30000821",
+						"electron-to-chromium": "^1.3.41"
 					}
 				},
 				"caniuse-lite": {
@@ -889,9 +889,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"electron-to-chromium": {
@@ -912,9 +912,9 @@
 					"integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.2",
-						"source-map": "0.6.1",
-						"supports-color": "5.3.0"
+						"chalk": "^2.3.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"source-map": {
@@ -929,7 +929,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -966,9 +966,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			}
 		},
 		"babel-core": {
@@ -977,25 +977,25 @@
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.1",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.1",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.5",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
+				"babel-code-frame": "^6.26.0",
+				"babel-generator": "^6.26.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"convert-source-map": "^1.5.0",
+				"debug": "^2.6.8",
+				"json5": "^0.5.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"path-is-absolute": "^1.0.1",
+				"private": "^0.1.7",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.6"
 			}
 		},
 		"babel-eslint": {
@@ -1016,9 +1016,9 @@
 					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"ansi-styles": {
@@ -1027,7 +1027,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"babylon": {
@@ -1042,9 +1042,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"supports-color": {
@@ -1053,7 +1053,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -1064,14 +1064,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.5",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -1088,9 +1088,9 @@
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1099,9 +1099,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-assignable-expression": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -1110,9 +1110,9 @@
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"esutils": "2.0.2"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"esutils": "^2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -1121,10 +1121,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-define-map": {
@@ -1133,10 +1133,10 @@
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.5"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -1145,9 +1145,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-explode-class": {
@@ -1156,10 +1156,10 @@
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
 			"dev": true,
 			"requires": {
-				"babel-helper-bindify-decorators": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-bindify-decorators": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-function-name": {
@@ -1168,11 +1168,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -1181,8 +1181,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -1191,8 +1191,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -1201,8 +1201,8 @@
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-regex": {
@@ -1211,9 +1211,9 @@
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.5"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -1222,11 +1222,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -1235,12 +1235,12 @@
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -1249,8 +1249,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-jest": {
@@ -1259,8 +1259,8 @@
 			"integrity": "sha512-A/safCd5jSf1D98XoHCN3YYuGurtUPntuPh8b7UxsLNfEp/QC8UwdL+VEGSLN5Fk3+tS/Jdbf5NK/T2it8RGYw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "4.1.5",
-				"babel-preset-jest": "22.2.0"
+				"babel-plugin-istanbul": "^4.1.5",
+				"babel-preset-jest": "^22.2.0"
 			}
 		},
 		"babel-loader": {
@@ -1269,9 +1269,9 @@
 			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "1.0.0",
-				"loader-utils": "1.1.0",
-				"mkdirp": "0.5.1"
+				"find-cache-dir": "^1.0.0",
+				"loader-utils": "^1.0.2",
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"babel-messages": {
@@ -1280,7 +1280,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -1289,7 +1289,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -1298,9 +1298,9 @@
 			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.9.2",
-				"test-exclude": "4.2.0"
+				"find-up": "^2.1.0",
+				"istanbul-lib-instrument": "^1.7.5",
+				"test-exclude": "^4.1.1"
 			},
 			"dependencies": {
 				"find-up": {
@@ -1309,7 +1309,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				}
 			}
@@ -1398,9 +1398,9 @@
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-generators": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-generators": "^6.5.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-async-to-generator": {
@@ -1409,9 +1409,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-functions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-class-constructor-call": {
@@ -1420,9 +1420,9 @@
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "6.18.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -1431,10 +1431,10 @@
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-plugin-syntax-class-properties": "^6.8.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-decorators": {
@@ -1443,11 +1443,11 @@
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-class": "6.24.1",
-				"babel-plugin-syntax-decorators": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-class": "^6.24.1",
+				"babel-plugin-syntax-decorators": "^6.13.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1456,7 +1456,7 @@
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1465,7 +1465,7 @@
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1474,11 +1474,11 @@
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.5"
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1487,15 +1487,15 @@
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "6.26.0",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1504,8 +1504,8 @@
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1514,7 +1514,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -1523,8 +1523,8 @@
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1533,7 +1533,7 @@
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1542,9 +1542,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1553,7 +1553,7 @@
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -1562,9 +1562,9 @@
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1573,10 +1573,10 @@
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-types": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -1585,9 +1585,9 @@
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -1596,9 +1596,9 @@
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1607,8 +1607,8 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.26.0"
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1617,12 +1617,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1631,8 +1631,8 @@
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1641,7 +1641,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1650,9 +1650,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1661,7 +1661,7 @@
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -1670,7 +1670,7 @@
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1679,9 +1679,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"regexpu-core": "^2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1690,9 +1690,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-export-extensions": {
@@ -1701,8 +1701,8 @@
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-export-extensions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-export-extensions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1711,8 +1711,8 @@
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-flow": "^6.18.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1721,8 +1721,8 @@
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -1731,9 +1731,9 @@
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-react-jsx": "6.26.0",
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-builder-react-jsx": "^6.24.1",
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1742,7 +1742,7 @@
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "0.10.1"
+				"regenerator-transform": "^0.10.0"
 			}
 		},
 		"babel-plugin-transform-runtime": {
@@ -1751,7 +1751,7 @@
 			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -1760,8 +1760,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-preset-env": {
@@ -1770,36 +1770,36 @@
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0",
-				"browserslist": "2.11.3",
-				"invariant": "2.2.2",
-				"semver": "5.3.0"
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+				"babel-plugin-transform-async-to-generator": "^6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+				"babel-plugin-transform-es2015-classes": "^6.23.0",
+				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+				"babel-plugin-transform-es2015-for-of": "^6.23.0",
+				"babel-plugin-transform-es2015-function-name": "^6.22.0",
+				"babel-plugin-transform-es2015-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+				"babel-plugin-transform-es2015-object-super": "^6.22.0",
+				"babel-plugin-transform-es2015-parameters": "^6.23.0",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
+				"babel-plugin-transform-regenerator": "^6.22.0",
+				"browserslist": "^2.1.2",
+				"invariant": "^2.2.2",
+				"semver": "^5.3.0"
 			}
 		},
 		"babel-preset-es2015": {
@@ -1808,30 +1808,30 @@
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0"
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+				"babel-plugin-transform-es2015-classes": "^6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+				"babel-plugin-transform-es2015-for-of": "^6.22.0",
+				"babel-plugin-transform-es2015-function-name": "^6.24.1",
+				"babel-plugin-transform-es2015-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+				"babel-plugin-transform-es2015-object-super": "^6.24.1",
+				"babel-plugin-transform-es2015-parameters": "^6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+				"babel-plugin-transform-regenerator": "^6.24.1"
 			}
 		},
 		"babel-preset-jest": {
@@ -1840,8 +1840,8 @@
 			"integrity": "sha512-p61cPMGYlSgfNScn1yQuVnLguWE4bjhB/br4KQDMbYZG+v6ryE5Ch7TKukjA6mRuIQj1zhyou7Sbpqrh4/N6Pg==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "22.2.0",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0"
+				"babel-plugin-jest-hoist": "^22.2.0",
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
 		"babel-preset-stage-1": {
@@ -1850,9 +1850,9 @@
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-class-constructor-call": "6.24.1",
-				"babel-plugin-transform-export-extensions": "6.22.0",
-				"babel-preset-stage-2": "6.24.1"
+				"babel-plugin-transform-class-constructor-call": "^6.24.1",
+				"babel-plugin-transform-export-extensions": "^6.22.0",
+				"babel-preset-stage-2": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-2": {
@@ -1861,10 +1861,10 @@
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "6.18.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-decorators": "6.24.1",
-				"babel-preset-stage-3": "6.24.1"
+				"babel-plugin-syntax-dynamic-import": "^6.18.0",
+				"babel-plugin-transform-class-properties": "^6.24.1",
+				"babel-plugin-transform-decorators": "^6.24.1",
+				"babel-preset-stage-3": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-3": {
@@ -1873,11 +1873,11 @@
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-generator-functions": "6.24.1",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-object-rest-spread": "6.26.0"
+				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+				"babel-plugin-transform-async-generator-functions": "^6.24.1",
+				"babel-plugin-transform-async-to-generator": "^6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
+				"babel-plugin-transform-object-rest-spread": "^6.22.0"
 			}
 		},
 		"babel-register": {
@@ -1886,13 +1886,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.3",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.5",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1907,7 +1907,7 @@
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"dev": true,
 					"requires": {
-						"source-map": "0.5.7"
+						"source-map": "^0.5.6"
 					}
 				}
 			}
@@ -1918,8 +1918,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.3",
-				"regenerator-runtime": "0.11.1"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1936,11 +1936,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.5"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1949,15 +1949,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.5"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-types": {
@@ -1966,10 +1966,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.5",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -1997,13 +1997,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2012,7 +2012,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"isobject": {
@@ -2036,7 +2036,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"big.js": {
@@ -2063,7 +2063,7 @@
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.0"
 			}
 		},
 		"bluebird": {
@@ -2089,7 +2089,7 @@
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"dev": true,
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"brace-expansion": {
@@ -2097,7 +2097,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -2107,9 +2107,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"brorand": {
@@ -2147,12 +2147,12 @@
 			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"browserify-cipher": {
@@ -2161,9 +2161,9 @@
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "1.1.1",
-				"browserify-des": "1.0.0",
-				"evp_bytestokey": "1.0.3"
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
 			}
 		},
 		"browserify-des": {
@@ -2172,9 +2172,9 @@
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3"
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"browserify-rsa": {
@@ -2183,8 +2183,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"randombytes": "2.0.6"
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"browserify-sign": {
@@ -2193,13 +2193,13 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"elliptic": "6.4.0",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.0"
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
 			}
 		},
 		"browserify-zlib": {
@@ -2208,7 +2208,7 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"dev": true,
 			"requires": {
-				"pako": "1.0.6"
+				"pako": "~1.0.5"
 			}
 		},
 		"browserslist": {
@@ -2217,8 +2217,8 @@
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "1.0.30000828",
-				"electron-to-chromium": "1.3.33"
+				"caniuse-lite": "^1.0.30000792",
+				"electron-to-chromium": "^1.3.30"
 			}
 		},
 		"bser": {
@@ -2227,7 +2227,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "0.4.0"
+				"node-int64": "^0.4.0"
 			}
 		},
 		"buffer": {
@@ -2236,9 +2236,9 @@
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
-				"base64-js": "1.2.3",
-				"ieee754": "1.1.11",
-				"isarray": "1.0.0"
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4",
+				"isarray": "^1.0.0"
 			}
 		},
 		"buffer-xor": {
@@ -2265,19 +2265,19 @@
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"dev": true,
 			"requires": {
-				"bluebird": "3.5.1",
-				"chownr": "1.0.1",
-				"glob": "7.1.2",
-				"graceful-fs": "4.1.11",
-				"lru-cache": "4.1.2",
-				"mississippi": "2.0.0",
-				"mkdirp": "0.5.1",
-				"move-concurrently": "1.0.1",
-				"promise-inflight": "1.0.1",
-				"rimraf": "2.6.2",
-				"ssri": "5.3.0",
-				"unique-filename": "1.1.0",
-				"y18n": "4.0.0"
+				"bluebird": "^3.5.1",
+				"chownr": "^1.0.1",
+				"glob": "^7.1.2",
+				"graceful-fs": "^4.1.11",
+				"lru-cache": "^4.1.1",
+				"mississippi": "^2.0.0",
+				"mkdirp": "^0.5.1",
+				"move-concurrently": "^1.0.1",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"ssri": "^5.2.4",
+				"unique-filename": "^1.1.0",
+				"y18n": "^4.0.0"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -2286,8 +2286,8 @@
 					"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 					"dev": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"y18n": {
@@ -2304,15 +2304,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -2350,9 +2350,9 @@
 					"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
 					"dev": true,
 					"requires": {
-						"prepend-http": "2.0.0",
-						"query-string": "5.1.1",
-						"sort-keys": "2.0.0"
+						"prepend-http": "^2.0.0",
+						"query-string": "^5.0.1",
+						"sort-keys": "^2.0.0"
 					}
 				},
 				"prepend-http": {
@@ -2367,9 +2367,9 @@
 					"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 					"dev": true,
 					"requires": {
-						"decode-uri-component": "0.2.0",
-						"object-assign": "4.1.1",
-						"strict-uri-encode": "1.1.0"
+						"decode-uri-component": "^0.2.0",
+						"object-assign": "^4.1.0",
+						"strict-uri-encode": "^1.0.0"
 					}
 				},
 				"sort-keys": {
@@ -2378,7 +2378,7 @@
 					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 					"dev": true,
 					"requires": {
-						"is-plain-obj": "1.1.0"
+						"is-plain-obj": "^1.0.0"
 					}
 				}
 			}
@@ -2389,7 +2389,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "0.2.0"
+				"callsites": "^0.2.0"
 			},
 			"dependencies": {
 				"callsites": {
@@ -2417,8 +2417,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
+				"camelcase": "^2.0.0",
+				"map-obj": "^1.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -2435,10 +2435,10 @@
 			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
 			"dev": true,
 			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-db": "1.0.30000804",
-				"lodash.memoize": "4.1.2",
-				"lodash.uniq": "4.5.0"
+				"browserslist": "^1.3.6",
+				"caniuse-db": "^1.0.30000529",
+				"lodash.memoize": "^4.1.2",
+				"lodash.uniq": "^4.5.0"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -2447,8 +2447,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000804",
-						"electron-to-chromium": "1.3.33"
+						"caniuse-db": "^1.0.30000639",
+						"electron-to-chromium": "^1.2.7"
 					}
 				}
 			}
@@ -2478,8 +2478,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chalk": {
@@ -2488,11 +2488,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
 			}
 		},
 		"chardet": {
@@ -2507,13 +2507,13 @@
 			"integrity": "sha512-52fHDe/0pbidY3InI33Beyb/oarySfLANlXxLGBl9lLVrLIW88XWIwu4jGJrQ1imuWzX5ukNGWXUyCgmgVUD8A==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.0",
-				"map-values": "1.0.1",
-				"minimist": "1.2.0",
-				"object-filter": "1.0.2",
-				"object.assign": "4.1.0",
-				"run-parallel": "1.1.6",
-				"semver": "5.3.0"
+				"chalk": "^2.3.0",
+				"map-values": "^1.0.1",
+				"minimist": "^1.2.0",
+				"object-filter": "^1.0.2",
+				"object.assign": "^4.0.4",
+				"run-parallel": "^1.1.4",
+				"semver": "^5.0.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -2522,7 +2522,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -2531,9 +2531,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"minimist": {
@@ -2548,7 +2548,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -2559,12 +2559,12 @@
 			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
 			"dev": true,
 			"requires": {
-				"css-select": "1.2.0",
-				"dom-serializer": "0.1.0",
-				"entities": "1.1.1",
-				"htmlparser2": "3.9.2",
-				"lodash": "4.17.5",
-				"parse5": "3.0.3"
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.0",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash": "^4.15.0",
+				"parse5": "^3.0.1"
 			}
 		},
 		"chokidar": {
@@ -2573,18 +2573,18 @@
 			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 			"dev": true,
 			"requires": {
-				"anymatch": "2.0.0",
-				"async-each": "1.0.1",
-				"braces": "2.3.1",
-				"fsevents": "1.1.3",
-				"glob-parent": "3.1.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "4.0.0",
-				"normalize-path": "2.1.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0",
-				"upath": "1.0.4"
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.1.2",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^2.1.1",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.0"
 			},
 			"dependencies": {
 				"anymatch": {
@@ -2593,8 +2593,8 @@
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 					"dev": true,
 					"requires": {
-						"micromatch": "3.1.10",
-						"normalize-path": "2.1.1"
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
 					}
 				},
 				"arr-diff": {
@@ -2615,18 +2615,18 @@
 					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"kind-of": "^6.0.2",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2635,7 +2635,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -2644,7 +2644,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2655,13 +2655,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2670,7 +2670,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -2679,7 +2679,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-descriptor": {
@@ -2688,9 +2688,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -2707,14 +2707,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2723,7 +2723,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -2732,7 +2732,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2743,10 +2743,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2755,7 +2755,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2766,8 +2766,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -2776,7 +2776,7 @@
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"dev": true,
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						}
 					}
@@ -2787,7 +2787,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2796,7 +2796,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2807,7 +2807,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2816,7 +2816,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2833,7 +2833,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-number": {
@@ -2842,7 +2842,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2851,7 +2851,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2874,19 +2874,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.1",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				}
 			}
@@ -2915,8 +2915,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"circular-json": {
@@ -2937,7 +2937,7 @@
 			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3"
+				"chalk": "^1.1.3"
 			}
 		},
 		"class-utils": {
@@ -2946,10 +2946,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2958,7 +2958,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2967,7 +2967,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2976,7 +2976,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2987,7 +2987,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2996,7 +2996,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -3007,9 +3007,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					}
 				},
 				"isobject": {
@@ -3037,7 +3037,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -3070,7 +3070,7 @@
 			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
-				"string-width": "1.0.2"
+				"string-width": "^1.0.1"
 			},
 			"dependencies": {
 				"string-width": {
@@ -3079,9 +3079,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -3097,9 +3097,9 @@
 			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
 			"integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
 			"requires": {
-				"good-listener": "1.2.2",
-				"select": "1.1.2",
-				"tiny-emitter": "2.0.2"
+				"good-listener": "^1.2.2",
+				"select": "^1.1.2",
+				"tiny-emitter": "^2.0.0"
 			}
 		},
 		"cliui": {
@@ -3108,9 +3108,9 @@
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wrap-ansi": "2.1.0"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wrap-ansi": "^2.0.0"
 			},
 			"dependencies": {
 				"string-width": {
@@ -3119,9 +3119,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -3144,10 +3144,10 @@
 			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
 			"dev": true,
 			"requires": {
-				"for-own": "1.0.0",
-				"is-plain-object": "2.0.4",
-				"kind-of": "6.0.2",
-				"shallow-clone": "1.0.0"
+				"for-own": "^1.0.0",
+				"is-plain-object": "^2.0.4",
+				"kind-of": "^6.0.0",
+				"shallow-clone": "^1.0.0"
 			},
 			"dependencies": {
 				"for-own": {
@@ -3156,7 +3156,7 @@
 					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
 					"dev": true,
 					"requires": {
-						"for-in": "1.0.2"
+						"for-in": "^1.0.1"
 					}
 				},
 				"kind-of": {
@@ -3173,7 +3173,7 @@
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"dev": true,
 			"requires": {
-				"mimic-response": "1.0.0"
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"clone-stats": {
@@ -3188,9 +3188,9 @@
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"process-nextick-args": "2.0.0",
-				"readable-stream": "2.3.5"
+				"inherits": "^2.0.1",
+				"process-nextick-args": "^2.0.0",
+				"readable-stream": "^2.3.5"
 			},
 			"dependencies": {
 				"process-nextick-args": {
@@ -3205,13 +3205,13 @@
 					"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.0.3",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.0.3",
+						"util-deprecate": "~1.0.1"
 					}
 				}
 			}
@@ -3228,7 +3228,7 @@
 			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.1.2"
 			}
 		},
 		"code-point-at": {
@@ -3253,8 +3253,8 @@
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"dev": true,
 					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
 					}
 				},
 				"assert-plus": {
@@ -3275,7 +3275,7 @@
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"cryptiles": {
@@ -3284,7 +3284,7 @@
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
 					"requires": {
-						"boom": "2.10.1"
+						"boom": "2.x.x"
 					}
 				},
 				"form-data": {
@@ -3293,9 +3293,9 @@
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
 					"dev": true,
 					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.17"
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
 					}
 				},
 				"har-schema": {
@@ -3310,8 +3310,8 @@
 					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
 					"dev": true,
 					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
+						"ajv": "^4.9.1",
+						"har-schema": "^1.0.5"
 					}
 				},
 				"hawk": {
@@ -3320,10 +3320,10 @@
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
 					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
+						"boom": "2.x.x",
+						"cryptiles": "2.x.x",
+						"hoek": "2.x.x",
+						"sntp": "1.x.x"
 					}
 				},
 				"hoek": {
@@ -3338,9 +3338,9 @@
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"dev": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.1",
-						"sshpk": "1.13.1"
+						"assert-plus": "^0.2.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
 					}
 				},
 				"performance-now": {
@@ -3361,28 +3361,28 @@
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
 					"dev": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.17",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.1.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.3",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.1.0"
+						"aws-sign2": "~0.6.0",
+						"aws4": "^1.2.1",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.0",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~4.2.1",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.7",
+						"oauth-sign": "~0.8.1",
+						"performance-now": "^0.2.0",
+						"qs": "~6.4.0",
+						"safe-buffer": "^5.0.1",
+						"stringstream": "~0.0.4",
+						"tough-cookie": "~2.3.0",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.0.0"
 					}
 				},
 				"sntp": {
@@ -3391,7 +3391,7 @@
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				}
 			}
@@ -3402,8 +3402,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color": {
@@ -3412,9 +3412,9 @@
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
 			"dev": true,
 			"requires": {
-				"clone": "1.0.3",
-				"color-convert": "1.9.1",
-				"color-string": "0.3.0"
+				"clone": "^1.0.2",
+				"color-convert": "^1.3.0",
+				"color-string": "^0.3.0"
 			}
 		},
 		"color-convert": {
@@ -3423,7 +3423,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -3438,7 +3438,7 @@
 			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.0.0"
 			}
 		},
 		"colormin": {
@@ -3447,9 +3447,9 @@
 			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
 			"dev": true,
 			"requires": {
-				"color": "0.11.4",
+				"color": "^0.11.0",
 				"css-color-names": "0.0.4",
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"colors": {
@@ -3464,7 +3464,7 @@
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -3477,7 +3477,7 @@
 			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
 			"integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.4"
 			}
 		},
 		"commondir": {
@@ -3508,9 +3508,9 @@
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"concurrently": {
@@ -3521,12 +3521,12 @@
 			"requires": {
 				"chalk": "0.5.1",
 				"commander": "2.6.0",
-				"date-fns": "1.29.0",
-				"lodash": "4.17.5",
+				"date-fns": "^1.23.0",
+				"lodash": "^4.5.1",
 				"rx": "2.3.24",
-				"spawn-command": "0.0.2-1",
-				"supports-color": "3.2.3",
-				"tree-kill": "1.2.0"
+				"spawn-command": "^0.0.2-1",
+				"supports-color": "^3.2.3",
+				"tree-kill": "^1.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3547,11 +3547,11 @@
 					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "1.1.0",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "0.1.0",
-						"strip-ansi": "0.3.0",
-						"supports-color": "0.2.0"
+						"ansi-styles": "^1.1.0",
+						"escape-string-regexp": "^1.0.0",
+						"has-ansi": "^0.1.0",
+						"strip-ansi": "^0.3.0",
+						"supports-color": "^0.2.0"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -3574,7 +3574,7 @@
 					"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "0.2.1"
+						"ansi-regex": "^0.2.0"
 					}
 				},
 				"has-flag": {
@@ -3589,7 +3589,7 @@
 					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "0.2.1"
+						"ansi-regex": "^0.2.1"
 					}
 				},
 				"supports-color": {
@@ -3598,7 +3598,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -3608,8 +3608,8 @@
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
 			"integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
 			"requires": {
-				"ini": "1.3.5",
-				"proto-list": "1.2.4"
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
 			}
 		},
 		"console-browserify": {
@@ -3618,7 +3618,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "0.1.4"
+				"date-now": "^0.1.4"
 			}
 		},
 		"console-control-strings": {
@@ -3651,12 +3651,12 @@
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"fs-write-stream-atomic": "1.0.10",
-				"iferr": "0.1.5",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"run-queue": "1.0.3"
+				"aproba": "^1.1.1",
+				"fs-write-stream-atomic": "^1.0.8",
+				"iferr": "^0.1.5",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.0"
 			}
 		},
 		"copy-descriptor": {
@@ -3682,13 +3682,13 @@
 			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
 			"dev": true,
 			"requires": {
-				"is-directory": "0.3.1",
-				"js-yaml": "3.10.0",
-				"minimist": "1.2.0",
-				"object-assign": "4.1.1",
-				"os-homedir": "1.0.2",
-				"parse-json": "2.2.0",
-				"require-from-string": "1.2.1"
+				"is-directory": "^0.3.1",
+				"js-yaml": "^3.4.3",
+				"minimist": "^1.2.0",
+				"object-assign": "^4.1.0",
+				"os-homedir": "^1.0.1",
+				"parse-json": "^2.2.0",
+				"require-from-string": "^1.1.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -3705,8 +3705,8 @@
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0"
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
 			}
 		},
 		"create-hash": {
@@ -3715,10 +3715,10 @@
 			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"sha.js": "2.4.11"
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
@@ -3727,12 +3727,12 @@
 			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.11"
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"cross-env": {
@@ -3741,8 +3741,8 @@
 			"integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"is-windows": "1.0.1"
+				"cross-spawn": "^5.1.0",
+				"is-windows": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -3750,9 +3750,9 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -3760,8 +3760,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				}
 			}
@@ -3772,7 +3772,7 @@
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"dev": true,
 			"requires": {
-				"boom": "5.2.0"
+				"boom": "5.x.x"
 			},
 			"dependencies": {
 				"boom": {
@@ -3781,7 +3781,7 @@
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"dev": true,
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.x.x"
 					}
 				}
 			}
@@ -3792,17 +3792,17 @@
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "1.0.0",
-				"browserify-sign": "4.0.4",
-				"create-ecdh": "4.0.0",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"diffie-hellman": "5.0.2",
-				"inherits": "2.0.3",
-				"pbkdf2": "3.0.14",
-				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.6",
-				"randomfill": "1.0.4"
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
 			}
 		},
 		"css-color-names": {
@@ -3817,10 +3817,10 @@
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"dev": true,
 			"requires": {
-				"boolbase": "1.0.0",
-				"css-what": "2.1.0",
+				"boolbase": "~1.0.0",
+				"css-what": "2.1",
 				"domutils": "1.5.1",
-				"nth-check": "1.0.1"
+				"nth-check": "~1.0.1"
 			}
 		},
 		"css-what": {
@@ -3835,38 +3835,38 @@
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
 			"dev": true,
 			"requires": {
-				"autoprefixer": "6.7.7",
-				"decamelize": "1.2.0",
-				"defined": "1.0.0",
-				"has": "1.0.1",
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-calc": "5.3.1",
-				"postcss-colormin": "2.2.2",
-				"postcss-convert-values": "2.6.1",
-				"postcss-discard-comments": "2.0.4",
-				"postcss-discard-duplicates": "2.1.0",
-				"postcss-discard-empty": "2.1.0",
-				"postcss-discard-overridden": "0.1.1",
-				"postcss-discard-unused": "2.2.3",
-				"postcss-filter-plugins": "2.0.2",
-				"postcss-merge-idents": "2.1.7",
-				"postcss-merge-longhand": "2.0.2",
-				"postcss-merge-rules": "2.1.2",
-				"postcss-minify-font-values": "1.0.5",
-				"postcss-minify-gradients": "1.0.5",
-				"postcss-minify-params": "1.2.2",
-				"postcss-minify-selectors": "2.1.1",
-				"postcss-normalize-charset": "1.1.1",
-				"postcss-normalize-url": "3.0.8",
-				"postcss-ordered-values": "2.2.3",
-				"postcss-reduce-idents": "2.4.0",
-				"postcss-reduce-initial": "1.0.1",
-				"postcss-reduce-transforms": "1.0.4",
-				"postcss-svgo": "2.1.6",
-				"postcss-unique-selectors": "2.0.2",
-				"postcss-value-parser": "3.3.0",
-				"postcss-zindex": "2.2.0"
+				"autoprefixer": "^6.3.1",
+				"decamelize": "^1.1.2",
+				"defined": "^1.0.0",
+				"has": "^1.0.1",
+				"object-assign": "^4.0.1",
+				"postcss": "^5.0.14",
+				"postcss-calc": "^5.2.0",
+				"postcss-colormin": "^2.1.8",
+				"postcss-convert-values": "^2.3.4",
+				"postcss-discard-comments": "^2.0.4",
+				"postcss-discard-duplicates": "^2.0.1",
+				"postcss-discard-empty": "^2.0.1",
+				"postcss-discard-overridden": "^0.1.1",
+				"postcss-discard-unused": "^2.2.1",
+				"postcss-filter-plugins": "^2.0.0",
+				"postcss-merge-idents": "^2.1.5",
+				"postcss-merge-longhand": "^2.0.1",
+				"postcss-merge-rules": "^2.0.3",
+				"postcss-minify-font-values": "^1.0.2",
+				"postcss-minify-gradients": "^1.0.1",
+				"postcss-minify-params": "^1.0.4",
+				"postcss-minify-selectors": "^2.0.4",
+				"postcss-normalize-charset": "^1.1.0",
+				"postcss-normalize-url": "^3.0.7",
+				"postcss-ordered-values": "^2.1.0",
+				"postcss-reduce-idents": "^2.2.2",
+				"postcss-reduce-initial": "^1.0.0",
+				"postcss-reduce-transforms": "^1.0.3",
+				"postcss-svgo": "^2.1.1",
+				"postcss-unique-selectors": "^2.0.2",
+				"postcss-value-parser": "^3.2.3",
+				"postcss-zindex": "^2.0.1"
 			},
 			"dependencies": {
 				"autoprefixer": {
@@ -3875,12 +3875,12 @@
 					"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
 					"dev": true,
 					"requires": {
-						"browserslist": "1.7.7",
-						"caniuse-db": "1.0.30000804",
-						"normalize-range": "0.1.2",
-						"num2fraction": "1.2.2",
-						"postcss": "5.2.18",
-						"postcss-value-parser": "3.3.0"
+						"browserslist": "^1.7.6",
+						"caniuse-db": "^1.0.30000634",
+						"normalize-range": "^0.1.2",
+						"num2fraction": "^1.2.2",
+						"postcss": "^5.2.16",
+						"postcss-value-parser": "^3.2.3"
 					}
 				},
 				"browserslist": {
@@ -3889,8 +3889,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000804",
-						"electron-to-chromium": "1.3.33"
+						"caniuse-db": "^1.0.30000639",
+						"electron-to-chromium": "^1.2.7"
 					}
 				}
 			}
@@ -3901,8 +3901,8 @@
 			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
 			"dev": true,
 			"requires": {
-				"clap": "1.2.3",
-				"source-map": "0.5.7"
+				"clap": "^1.0.9",
+				"source-map": "^0.5.3"
 			}
 		},
 		"cssom": {
@@ -3917,7 +3917,7 @@
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.2"
+				"cssom": "0.3.x"
 			}
 		},
 		"currently-unhandled": {
@@ -3926,7 +3926,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"cyclist": {
@@ -3953,7 +3953,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"date-fns": {
@@ -4000,7 +4000,7 @@
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 			"dev": true,
 			"requires": {
-				"mimic-response": "1.0.0"
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"deep-equal-ident": {
@@ -4009,7 +4009,7 @@
 			"integrity": "sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=",
 			"dev": true,
 			"requires": {
-				"lodash.isequal": "3.0.4"
+				"lodash.isequal": "^3.0"
 			}
 		},
 		"deep-extend": {
@@ -4036,7 +4036,7 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "2.0.0"
+				"strip-bom": "^2.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -4045,7 +4045,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -4056,8 +4056,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			}
 		},
 		"define-property": {
@@ -4066,8 +4066,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4090,13 +4090,13 @@
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"dev": true,
 			"requires": {
-				"globby": "5.0.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"rimraf": "2.6.2"
+				"globby": "^5.0.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"rimraf": "^2.2.8"
 			}
 		},
 		"delayed-stream": {
@@ -4122,8 +4122,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"detect-conflict": {
@@ -4138,7 +4138,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"detect-newline": {
@@ -4159,9 +4159,9 @@
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"miller-rabin": "4.0.1",
-				"randombytes": "2.0.6"
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
 			}
 		},
 		"discontinuous-range": {
@@ -4186,8 +4186,8 @@
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.1.3",
-				"entities": "1.1.1"
+				"domelementtype": "~1.1.1",
+				"entities": "~1.1.1"
 			},
 			"dependencies": {
 				"domelementtype": {
@@ -4216,7 +4216,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "4.0.2"
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"domhandler": {
@@ -4225,7 +4225,7 @@
 			"integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.3.0"
+				"domelementtype": "1"
 			}
 		},
 		"domutils": {
@@ -4234,8 +4234,8 @@
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
 			"dev": true,
 			"requires": {
-				"dom-serializer": "0.1.0",
-				"domelementtype": "1.3.0"
+				"dom-serializer": "0",
+				"domelementtype": "1"
 			}
 		},
 		"duplexer3": {
@@ -4250,10 +4250,10 @@
 			"integrity": "sha1-S7RsF5bqvr7sTKmi5muAjLej2LQ=",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"stream-shift": "1.0.0"
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"ecc-jsbn": {
@@ -4263,7 +4263,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"editions": {
@@ -4277,11 +4277,11 @@
 			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
 			"integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
 			"requires": {
-				"bluebird": "3.5.1",
-				"commander": "2.14.1",
-				"lru-cache": "3.2.0",
-				"semver": "5.3.0",
-				"sigmund": "1.0.1"
+				"bluebird": "^3.0.5",
+				"commander": "^2.9.0",
+				"lru-cache": "^3.2.0",
+				"semver": "^5.1.0",
+				"sigmund": "^1.0.1"
 			}
 		},
 		"ejs": {
@@ -4313,13 +4313,13 @@
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"emoji-regex": {
@@ -4339,7 +4339,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "0.4.19"
+				"iconv-lite": "~0.4.13"
 			}
 		},
 		"end-of-stream": {
@@ -4348,7 +4348,7 @@
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -4357,9 +4357,9 @@
 			"integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"memory-fs": "0.4.1",
-				"tapable": "1.0.0"
+				"graceful-fs": "^4.1.2",
+				"memory-fs": "^0.4.0",
+				"tapable": "^1.0.0"
 			}
 		},
 		"entities": {
@@ -4374,22 +4374,22 @@
 			"integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
 			"dev": true,
 			"requires": {
-				"cheerio": "1.0.0-rc.2",
-				"function.prototype.name": "1.1.0",
-				"has": "1.0.1",
-				"is-boolean-object": "1.0.0",
-				"is-callable": "1.1.3",
-				"is-number-object": "1.0.3",
-				"is-string": "1.0.4",
-				"is-subset": "0.1.1",
-				"lodash": "4.17.5",
-				"object-inspect": "1.5.0",
-				"object-is": "1.0.1",
-				"object.assign": "4.1.0",
-				"object.entries": "1.0.4",
-				"object.values": "1.0.4",
-				"raf": "3.4.0",
-				"rst-selector-parser": "2.2.3"
+				"cheerio": "^1.0.0-rc.2",
+				"function.prototype.name": "^1.0.3",
+				"has": "^1.0.1",
+				"is-boolean-object": "^1.0.0",
+				"is-callable": "^1.1.3",
+				"is-number-object": "^1.0.3",
+				"is-string": "^1.0.4",
+				"is-subset": "^0.1.1",
+				"lodash": "^4.17.4",
+				"object-inspect": "^1.5.0",
+				"object-is": "^1.0.1",
+				"object.assign": "^4.1.0",
+				"object.entries": "^1.0.4",
+				"object.values": "^1.0.4",
+				"raf": "^3.4.0",
+				"rst-selector-parser": "^2.2.3"
 			}
 		},
 		"enzyme-adapter-react-16": {
@@ -4398,13 +4398,13 @@
 			"integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
 			"dev": true,
 			"requires": {
-				"enzyme-adapter-utils": "1.3.0",
-				"lodash": "4.17.5",
-				"object.assign": "4.1.0",
-				"object.values": "1.0.4",
-				"prop-types": "15.6.0",
-				"react-reconciler": "0.7.0",
-				"react-test-renderer": "16.2.0"
+				"enzyme-adapter-utils": "^1.3.0",
+				"lodash": "^4.17.4",
+				"object.assign": "^4.0.4",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.0",
+				"react-reconciler": "^0.7.0",
+				"react-test-renderer": "^16.0.0-0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -4413,9 +4413,9 @@
 					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				},
 				"react-test-renderer": {
@@ -4424,9 +4424,9 @@
 					"integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"object-assign": "4.1.1",
-						"prop-types": "15.6.0"
+						"fbjs": "^0.8.16",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.0"
 					}
 				}
 			}
@@ -4437,9 +4437,9 @@
 			"integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5",
-				"object.assign": "4.1.0",
-				"prop-types": "15.6.0"
+				"lodash": "^4.17.4",
+				"object.assign": "^4.0.4",
+				"prop-types": "^15.6.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -4448,9 +4448,9 @@
 					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -4461,8 +4461,8 @@
 			"integrity": "sha512-5Gf/mAVYx6KPAUuxuDhAGt/gu9ndPd6duFcVnH2rbEad2clgTpHZL4Df49FHFukrjEEubX9rhfeAKx0/sbfVkQ==",
 			"dev": true,
 			"requires": {
-				"circular-json-es6": "2.0.2",
-				"deep-equal-ident": "1.1.1"
+				"circular-json-es6": "^2.0.1",
+				"deep-equal-ident": "^1.1.1"
 			}
 		},
 		"enzyme-to-json": {
@@ -4471,7 +4471,7 @@
 			"integrity": "sha512-PrgRyZAgEwOrh5/8BtBWrwGcv1mC7yNohytIciAX6SUqDaXg1BlU8CepYQ9BgnDP1i1jTB65qJJITMMCph+T6A==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.17.4"
 			}
 		},
 		"equivalent-key-map": {
@@ -4485,7 +4485,7 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"dev": true,
 			"requires": {
-				"prr": "1.0.1"
+				"prr": "~1.0.1"
 			}
 		},
 		"error": {
@@ -4494,8 +4494,8 @@
 			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
 			"dev": true,
 			"requires": {
-				"string-template": "0.2.1",
-				"xtend": "4.0.1"
+				"string-template": "~0.2.1",
+				"xtend": "~4.0.0"
 			}
 		},
 		"error-ex": {
@@ -4504,7 +4504,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -4513,11 +4513,11 @@
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.1",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -4526,9 +4526,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"es6-promise": {
@@ -4543,7 +4543,7 @@
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"dev": true,
 			"requires": {
-				"es6-promise": "4.2.4"
+				"es6-promise": "^4.0.3"
 			}
 		},
 		"escape-string-regexp": {
@@ -4557,11 +4557,11 @@
 			"integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
 			"dev": true,
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.5.7"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.5.6"
 			},
 			"dependencies": {
 				"esprima": {
@@ -4578,43 +4578,43 @@
 			"integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"babel-code-frame": "6.26.0",
-				"chalk": "2.3.0",
-				"concat-stream": "1.6.0",
-				"cross-spawn": "5.1.0",
-				"debug": "3.1.0",
-				"doctrine": "2.1.0",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "1.0.0",
-				"espree": "3.5.3",
-				"esquery": "1.0.0",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"functional-red-black-tree": "1.0.1",
-				"glob": "7.1.2",
-				"globals": "11.3.0",
-				"ignore": "3.3.7",
-				"imurmurhash": "0.1.4",
-				"inquirer": "3.3.0",
-				"is-resolvable": "1.1.0",
-				"js-yaml": "3.10.0",
-				"json-stable-stringify-without-jsonify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.5",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "7.0.0",
-				"progress": "2.0.0",
-				"require-uncached": "1.0.3",
-				"semver": "5.3.0",
-				"strip-ansi": "4.0.0",
-				"strip-json-comments": "2.0.1",
-				"table": "4.0.2",
-				"text-table": "0.2.0"
+				"ajv": "^5.3.0",
+				"babel-code-frame": "^6.22.0",
+				"chalk": "^2.1.0",
+				"concat-stream": "^1.6.0",
+				"cross-spawn": "^5.1.0",
+				"debug": "^3.1.0",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^3.7.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^3.5.2",
+				"esquery": "^1.0.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.0.1",
+				"ignore": "^3.3.3",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^3.0.6",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.9.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"require-uncached": "^1.0.3",
+				"semver": "^5.3.0",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "~2.0.1",
+				"table": "^4.0.1",
+				"text-table": "~0.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4629,7 +4629,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -4638,9 +4638,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"debug": {
@@ -4658,7 +4658,7 @@
 					"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 					"dev": true,
 					"requires": {
-						"esutils": "2.0.2"
+						"esutils": "^2.0.2"
 					}
 				},
 				"globals": {
@@ -4679,7 +4679,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -4688,7 +4688,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -4715,8 +4715,8 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.5.0.tgz",
 			"integrity": "sha512-qoNpVicVWGjGBXAJsqRoqVuAnajgX7PWtSa2Men36XKRiXe3RS/QmRv215PXZwo4OHskYOsUoJUeiPiWtS9ULA==",
 			"requires": {
-				"comment-parser": "0.4.2",
-				"lodash": "4.17.5"
+				"comment-parser": "^0.4.2",
+				"lodash": "^4.17.4"
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
@@ -4725,13 +4725,13 @@
 			"integrity": "sha1-ZZJ3p1iwNsMFp+ShMFfDAc075z8=",
 			"dev": true,
 			"requires": {
-				"aria-query": "0.7.1",
-				"array-includes": "3.0.3",
+				"aria-query": "^0.7.0",
+				"array-includes": "^3.0.3",
 				"ast-types-flow": "0.0.7",
-				"axobject-query": "0.1.0",
-				"damerau-levenshtein": "1.0.4",
-				"emoji-regex": "6.5.1",
-				"jsx-ast-utils": "1.4.1"
+				"axobject-query": "^0.1.0",
+				"damerau-levenshtein": "^1.0.0",
+				"emoji-regex": "^6.1.0",
+				"jsx-ast-utils": "^1.4.0"
 			}
 		},
 		"eslint-plugin-node": {
@@ -4739,10 +4739,10 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
 			"requires": {
-				"ignore": "3.3.7",
-				"minimatch": "3.0.4",
-				"resolve": "1.5.0",
-				"semver": "5.5.0"
+				"ignore": "^3.3.6",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.3",
+				"semver": "^5.4.1"
 			},
 			"dependencies": {
 				"semver": {
@@ -4758,10 +4758,10 @@
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
 			"dev": true,
 			"requires": {
-				"doctrine": "2.1.0",
-				"has": "1.0.1",
-				"jsx-ast-utils": "2.0.1",
-				"prop-types": "15.6.1"
+				"doctrine": "^2.0.2",
+				"has": "^1.0.1",
+				"jsx-ast-utils": "^2.0.1",
+				"prop-types": "^15.6.0"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -4770,7 +4770,7 @@
 					"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 					"dev": true,
 					"requires": {
-						"esutils": "2.0.2"
+						"esutils": "^2.0.2"
 					}
 				},
 				"jsx-ast-utils": {
@@ -4779,7 +4779,7 @@
 					"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
 					"dev": true,
 					"requires": {
-						"array-includes": "3.0.3"
+						"array-includes": "^3.0.3"
 					}
 				},
 				"prop-types": {
@@ -4788,21 +4788,22 @@
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
 		},
 		"eslint-plugin-wordpress": {
 			"version": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
+			"from": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
 			"requires": {
-				"eslint-plugin-i18n": "1.2.0",
-				"eslint-plugin-jsdoc": "3.5.0",
-				"eslint-plugin-node": "6.0.1",
-				"eslint-plugin-wpcalypso": "4.0.1",
-				"merge": "1.2.0"
+				"eslint-plugin-i18n": "~1.2.0",
+				"eslint-plugin-jsdoc": "~3.5.0",
+				"eslint-plugin-node": "~6.0.1",
+				"eslint-plugin-wpcalypso": "~4.0.1",
+				"merge": "~1.2.0"
 			}
 		},
 		"eslint-plugin-wpcalypso": {
@@ -4810,7 +4811,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-wpcalypso/-/eslint-plugin-wpcalypso-4.0.1.tgz",
 			"integrity": "sha512-fU5NSc0XGdel/tlEIUoESOdqphBWQN2FfSgXXNHpXKX7ftTcqXacqgzXU8OVziyhXz6s2RUzK0+JSJaNxhZ+Mw==",
 			"requires": {
-				"requireindex": "1.2.0"
+				"requireindex": "^1.1.0"
 			}
 		},
 		"eslint-scope": {
@@ -4819,8 +4820,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -4835,8 +4836,8 @@
 			"integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.4.1",
-				"acorn-jsx": "3.0.1"
+				"acorn": "^5.4.0",
+				"acorn-jsx": "^3.0.0"
 			}
 		},
 		"esprima": {
@@ -4851,7 +4852,7 @@
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -4860,8 +4861,8 @@
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0",
-				"object-assign": "4.1.1"
+				"estraverse": "^4.1.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"estraverse": {
@@ -4888,8 +4889,8 @@
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"dev": true,
 			"requires": {
-				"md5.js": "1.3.4",
-				"safe-buffer": "5.1.1"
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"exec-sh": {
@@ -4898,7 +4899,7 @@
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"dev": true,
 			"requires": {
-				"merge": "1.2.0"
+				"merge": "^1.1.3"
 			}
 		},
 		"execa": {
@@ -4906,13 +4907,13 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit": {
@@ -4933,7 +4934,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -4942,7 +4943,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"expand-tilde": {
@@ -4951,7 +4952,7 @@
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
-				"homedir-polyfill": "1.0.1"
+				"homedir-polyfill": "^1.0.1"
 			}
 		},
 		"expect": {
@@ -4960,12 +4961,12 @@
 			"integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.0",
-				"jest-diff": "22.4.0",
-				"jest-get-type": "22.1.0",
-				"jest-matcher-utils": "22.4.0",
-				"jest-message-util": "22.4.0",
-				"jest-regex-util": "22.1.0"
+				"ansi-styles": "^3.2.0",
+				"jest-diff": "^22.4.0",
+				"jest-get-type": "^22.1.0",
+				"jest-matcher-utils": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-regex-util": "^22.1.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4974,7 +4975,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				}
 			}
@@ -4991,8 +4992,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5001,7 +5002,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -5012,9 +5013,9 @@
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
 			"dev": true,
 			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.19",
-				"tmp": "0.0.33"
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
 			},
 			"dependencies": {
 				"tmp": {
@@ -5023,7 +5024,7 @@
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				}
 			}
@@ -5034,7 +5035,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"extract-text-webpack-plugin": {
@@ -5043,10 +5044,10 @@
 			"integrity": "sha512-Hypkn9jUTnFr0DpekNam53X47tXn3ucY08BQumv7kdGgeVUBLq3DJHJTi6HNxv4jl9W+Skxjz9+RnK0sJyqqjA==",
 			"dev": true,
 			"requires": {
-				"async": "2.6.0",
-				"loader-utils": "1.1.0",
-				"schema-utils": "0.4.5",
-				"webpack-sources": "1.1.0"
+				"async": "^2.4.1",
+				"loader-utils": "^1.1.0",
+				"schema-utils": "^0.4.5",
+				"webpack-sources": "^1.1.0"
 			}
 		},
 		"extract-zip": {
@@ -5102,7 +5103,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "2.0.0"
+				"bser": "^2.0.0"
 			}
 		},
 		"fbjs": {
@@ -5110,13 +5111,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.17"
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.9"
 			},
 			"dependencies": {
 				"core-js": {
@@ -5132,7 +5133,7 @@
 			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
 			"dev": true,
 			"requires": {
-				"pend": "1.2.0"
+				"pend": "~1.2.0"
 			}
 		},
 		"figures": {
@@ -5141,7 +5142,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -5150,8 +5151,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "1.3.0",
-				"object-assign": "4.1.1"
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"filename-regex": {
@@ -5166,8 +5167,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"minimatch": "3.0.4"
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
 			}
 		},
 		"fill-range": {
@@ -5176,11 +5177,11 @@
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^1.1.3",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"find-cache-dir": {
@@ -5189,9 +5190,9 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"dev": true,
 			"requires": {
-				"commondir": "1.0.1",
-				"make-dir": "1.2.0",
-				"pkg-dir": "2.0.0"
+				"commondir": "^1.0.1",
+				"make-dir": "^1.0.0",
+				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -5200,7 +5201,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -5209,7 +5210,7 @@
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				}
 			}
@@ -5220,8 +5221,8 @@
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 			"dev": true,
 			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
+				"path-exists": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"findup": {
@@ -5230,8 +5231,8 @@
 			"integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
 			"dev": true,
 			"requires": {
-				"colors": "0.6.2",
-				"commander": "2.1.0"
+				"colors": "~0.6.0-1",
+				"commander": "~2.1.0"
 			},
 			"dependencies": {
 				"colors": {
@@ -5254,7 +5255,7 @@
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"flat-cache": {
@@ -5263,10 +5264,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
+				"circular-json": "^0.3.1",
+				"del": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"write": "^0.2.1"
 			}
 		},
 		"flatten": {
@@ -5287,8 +5288,8 @@
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.4"
 			}
 		},
 		"for-in": {
@@ -5303,7 +5304,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"foreach": {
@@ -5324,9 +5325,9 @@
 			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
 			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.5",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fragment-cache": {
@@ -5335,7 +5336,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
 			}
 		},
 		"from2": {
@@ -5344,8 +5345,8 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -5354,10 +5355,10 @@
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"iferr": "0.1.5",
-				"imurmurhash": "0.1.4",
-				"readable-stream": "2.3.3"
+				"graceful-fs": "^4.1.2",
+				"iferr": "^0.1.5",
+				"imurmurhash": "^0.1.4",
+				"readable-stream": "1 || 2"
 			}
 		},
 		"fs.realpath": {
@@ -5373,8 +5374,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.8.0",
-				"node-pre-gyp": "0.6.39"
+				"nan": "^2.3.0",
+				"node-pre-gyp": "^0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -5391,8 +5392,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
 					}
 				},
 				"ansi-regex": {
@@ -5467,7 +5468,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"tweetnacl": "0.14.5"
+						"tweetnacl": "^0.14.3"
 					}
 				},
 				"block-stream": {
@@ -5476,7 +5477,7 @@
 					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 					"dev": true,
 					"requires": {
-						"inherits": "2.0.3"
+						"inherits": "~2.0.0"
 					}
 				},
 				"boom": {
@@ -5485,7 +5486,7 @@
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"brace-expansion": {
@@ -5494,7 +5495,7 @@
 					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
 					"dev": true,
 					"requires": {
-						"balanced-match": "0.4.2",
+						"balanced-match": "^0.4.1",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -5530,7 +5531,7 @@
 					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 					"dev": true,
 					"requires": {
-						"delayed-stream": "1.0.0"
+						"delayed-stream": "~1.0.0"
 					}
 				},
 				"concat-map": {
@@ -5557,7 +5558,7 @@
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
 					"requires": {
-						"boom": "2.10.1"
+						"boom": "2.x.x"
 					}
 				},
 				"dashdash": {
@@ -5567,7 +5568,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "1.0.0"
+						"assert-plus": "^1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -5623,7 +5624,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
+						"jsbn": "~0.1.0"
 					}
 				},
 				"extend": {
@@ -5653,9 +5654,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
 					}
 				},
 				"fs.realpath": {
@@ -5670,10 +5671,10 @@
 					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
+						"graceful-fs": "^4.1.2",
+						"inherits": "~2.0.0",
+						"mkdirp": ">=0.5 0",
+						"rimraf": "2"
 					}
 				},
 				"fstream-ignore": {
@@ -5683,9 +5684,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
+						"fstream": "^1.0.0",
+						"inherits": "2",
+						"minimatch": "^3.0.0"
 					}
 				},
 				"gauge": {
@@ -5712,7 +5713,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "1.0.0"
+						"assert-plus": "^1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -5758,8 +5759,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
+						"ajv": "^4.9.1",
+						"har-schema": "^1.0.5"
 					}
 				},
 				"has-unicode": {
@@ -5775,10 +5776,10 @@
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
 					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
+						"boom": "2.x.x",
+						"cryptiles": "2.x.x",
+						"hoek": "2.x.x",
+						"sntp": "1.x.x"
 					}
 				},
 				"hoek": {
@@ -5794,9 +5795,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
+						"assert-plus": "^0.2.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
 					}
 				},
 				"inflight": {
@@ -5858,7 +5859,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
+						"jsbn": "~0.1.0"
 					}
 				},
 				"jsbn": {
@@ -5882,7 +5883,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsonify": "0.0.0"
+						"jsonify": "~0.0.0"
 					}
 				},
 				"json-stringify-safe": {
@@ -5933,7 +5934,7 @@
 					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.27.0"
+						"mime-db": "~1.27.0"
 					}
 				},
 				"minimatch": {
@@ -5974,17 +5975,17 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.2",
+						"detect-libc": "^1.0.2",
 						"hawk": "3.1.3",
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
+						"mkdirp": "^0.5.1",
+						"nopt": "^4.0.1",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
 						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^2.2.1",
+						"tar-pack": "^3.4.0"
 					}
 				},
 				"nopt": {
@@ -6005,10 +6006,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -6061,8 +6062,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -6105,10 +6106,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "~0.4.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -6126,13 +6127,13 @@
 					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
 					"dev": true,
 					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
+						"buffer-shims": "~1.0.0",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~1.0.6",
+						"string_decoder": "~1.0.0",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"request": {
@@ -6142,28 +6143,28 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
+						"aws-sign2": "~0.6.0",
+						"aws4": "^1.2.1",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.0",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~4.2.1",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.7",
+						"oauth-sign": "~0.8.1",
+						"performance-now": "^0.2.0",
+						"qs": "~6.4.0",
+						"safe-buffer": "^5.0.1",
+						"stringstream": "~0.0.4",
+						"tough-cookie": "~2.3.0",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.0.0"
 					}
 				},
 				"rimraf": {
@@ -6172,7 +6173,7 @@
 					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 					"dev": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
@@ -6208,7 +6209,7 @@
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"sshpk": {
@@ -6218,15 +6219,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jodid25519": "^1.0.0",
+						"jsbn": "~0.1.0",
+						"tweetnacl": "~0.14.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -6255,7 +6256,7 @@
 					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"stringstream": {
@@ -6287,9 +6288,9 @@
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 					"dev": true,
 					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
+						"block-stream": "*",
+						"fstream": "^1.0.2",
+						"inherits": "2"
 					}
 				},
 				"tar-pack": {
@@ -6299,14 +6300,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
+						"debug": "^2.2.0",
+						"fstream": "^1.0.10",
+						"fstream-ignore": "^1.0.5",
+						"once": "^1.3.3",
+						"readable-stream": "^2.1.4",
+						"rimraf": "^2.5.1",
+						"tar": "^2.2.1",
+						"uid-number": "^0.0.6"
 					}
 				},
 				"tough-cookie": {
@@ -6316,7 +6317,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"punycode": "1.4.1"
+						"punycode": "^1.4.1"
 					}
 				},
 				"tunnel-agent": {
@@ -6326,7 +6327,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"tweetnacl": {
@@ -6390,10 +6391,10 @@
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"inherits": "2.0.3",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
 			}
 		},
 		"function-bind": {
@@ -6408,9 +6409,9 @@
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"function-bind": "1.1.1",
-				"is-callable": "1.1.3"
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"is-callable": "^1.1.3"
 			}
 		},
 		"functional-red-black-tree": {
@@ -6425,14 +6426,14 @@
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"console-control-strings": "1.1.0",
-				"has-unicode": "2.0.1",
-				"object-assign": "4.1.1",
-				"signal-exit": "3.0.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wide-align": "1.1.2"
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
 			},
 			"dependencies": {
 				"string-width": {
@@ -6441,9 +6442,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -6454,7 +6455,7 @@
 			"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
 			"dev": true,
 			"requires": {
-				"globule": "1.2.0"
+				"globule": "^1.0.0"
 			}
 		},
 		"generate-function": {
@@ -6469,7 +6470,7 @@
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
 			"dev": true,
 			"requires": {
-				"is-property": "1.0.2"
+				"is-property": "^1.0.0"
 			}
 		},
 		"get-caller-file": {
@@ -6500,7 +6501,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"gettext-parser": {
@@ -6508,8 +6509,8 @@
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
 			"integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
 			"requires": {
-				"encoding": "0.1.12",
-				"safe-buffer": "5.1.1"
+				"encoding": "^0.1.12",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"gh-got": {
@@ -6518,8 +6519,8 @@
 			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
 			"dev": true,
 			"requires": {
-				"got": "7.1.0",
-				"is-plain-obj": "1.1.0"
+				"got": "^7.0.0",
+				"is-plain-obj": "^1.1.0"
 			},
 			"dependencies": {
 				"got": {
@@ -6528,20 +6529,20 @@
 					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
 					"dev": true,
 					"requires": {
-						"decompress-response": "3.3.0",
-						"duplexer3": "0.1.4",
-						"get-stream": "3.0.0",
-						"is-plain-obj": "1.1.0",
-						"is-retry-allowed": "1.1.0",
-						"is-stream": "1.1.0",
-						"isurl": "1.0.0",
-						"lowercase-keys": "1.0.1",
-						"p-cancelable": "0.3.0",
-						"p-timeout": "1.2.1",
-						"safe-buffer": "5.1.1",
-						"timed-out": "4.0.1",
-						"url-parse-lax": "1.0.0",
-						"url-to-options": "1.0.1"
+						"decompress-response": "^3.2.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-plain-obj": "^1.1.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"isurl": "^1.0.0-alpha5",
+						"lowercase-keys": "^1.0.0",
+						"p-cancelable": "^0.3.0",
+						"p-timeout": "^1.1.1",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"url-parse-lax": "^1.0.0",
+						"url-to-options": "^1.0.1"
 					}
 				},
 				"p-cancelable": {
@@ -6556,7 +6557,7 @@
 					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
 					"dev": true,
 					"requires": {
-						"p-finally": "1.0.0"
+						"p-finally": "^1.0.0"
 					}
 				},
 				"url-parse-lax": {
@@ -6565,7 +6566,7 @@
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"dev": true,
 					"requires": {
-						"prepend-http": "1.0.4"
+						"prepend-http": "^1.0.1"
 					}
 				}
 			}
@@ -6576,7 +6577,7 @@
 			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
 			"dev": true,
 			"requires": {
-				"gh-got": "6.0.0"
+				"gh-got": "^6.0.0"
 			}
 		},
 		"glob": {
@@ -6585,12 +6586,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-all": {
@@ -6599,8 +6600,8 @@
 			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"yargs": "1.2.6"
+				"glob": "^7.0.5",
+				"yargs": "~1.2.6"
 			},
 			"dependencies": {
 				"minimist": {
@@ -6615,7 +6616,7 @@
 					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
 					"dev": true,
 					"requires": {
-						"minimist": "0.1.0"
+						"minimist": "^0.1.0"
 					}
 				}
 			}
@@ -6626,8 +6627,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-parent": {
@@ -6636,7 +6637,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^2.0.0"
 			}
 		},
 		"global-modules": {
@@ -6645,9 +6646,9 @@
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
 			"dev": true,
 			"requires": {
-				"global-prefix": "1.0.2",
-				"is-windows": "1.0.1",
-				"resolve-dir": "1.0.1"
+				"global-prefix": "^1.0.1",
+				"is-windows": "^1.0.1",
+				"resolve-dir": "^1.0.0"
 			}
 		},
 		"global-prefix": {
@@ -6656,11 +6657,11 @@
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "2.0.2",
-				"homedir-polyfill": "1.0.1",
-				"ini": "1.3.5",
-				"is-windows": "1.0.1",
-				"which": "1.3.0"
+				"expand-tilde": "^2.0.2",
+				"homedir-polyfill": "^1.0.1",
+				"ini": "^1.3.4",
+				"is-windows": "^1.0.1",
+				"which": "^1.2.14"
 			}
 		},
 		"globals": {
@@ -6675,12 +6676,12 @@
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 			"dev": true,
 			"requires": {
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"glob": "^7.0.3",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"globule": {
@@ -6689,9 +6690,9 @@
 			"integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"lodash": "4.17.5",
-				"minimatch": "3.0.4"
+				"glob": "~7.1.1",
+				"lodash": "~4.17.4",
+				"minimatch": "~3.0.2"
 			}
 		},
 		"good-listener": {
@@ -6699,7 +6700,7 @@
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
 			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
 			"requires": {
-				"delegate": "3.2.0"
+				"delegate": "^3.1.2"
 			}
 		},
 		"got": {
@@ -6708,23 +6709,23 @@
 			"integrity": "sha1-a6JudfimzExrPrH+fOT+x6ushTM=",
 			"dev": true,
 			"requires": {
-				"@sindresorhus/is": "0.7.0",
-				"cacheable-request": "2.1.4",
-				"decompress-response": "3.3.0",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"into-stream": "3.1.0",
-				"is-retry-allowed": "1.1.0",
-				"isurl": "1.0.0",
-				"lowercase-keys": "1.0.1",
-				"mimic-response": "1.0.0",
-				"p-cancelable": "0.4.0",
-				"p-timeout": "2.0.1",
-				"pify": "3.0.0",
-				"safe-buffer": "5.1.1",
-				"timed-out": "4.0.1",
-				"url-parse-lax": "3.0.0",
-				"url-to-options": "1.0.1"
+				"@sindresorhus/is": "^0.7.0",
+				"cacheable-request": "^2.1.1",
+				"decompress-response": "^3.3.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"into-stream": "^3.1.0",
+				"is-retry-allowed": "^1.1.0",
+				"isurl": "^1.0.0-alpha5",
+				"lowercase-keys": "^1.0.0",
+				"mimic-response": "^1.0.0",
+				"p-cancelable": "^0.4.0",
+				"p-timeout": "^2.0.1",
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.1.1",
+				"timed-out": "^4.0.1",
+				"url-parse-lax": "^3.0.0",
+				"url-to-options": "^1.0.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -6747,7 +6748,7 @@
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.17.2"
 			}
 		},
 		"growly": {
@@ -6762,10 +6763,10 @@
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"async": "^1.4.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.4.4",
+				"uglify-js": "^2.6"
 			},
 			"dependencies": {
 				"async": {
@@ -6780,7 +6781,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -6797,8 +6798,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
@@ -6807,7 +6808,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.0.2"
 			}
 		},
 		"has-ansi": {
@@ -6816,7 +6817,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-color": {
@@ -6849,7 +6850,7 @@
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
 			"dev": true,
 			"requires": {
-				"has-symbol-support-x": "1.4.2"
+				"has-symbol-support-x": "^1.4.1"
 			}
 		},
 		"has-unicode": {
@@ -6864,9 +6865,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -6883,8 +6884,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6893,7 +6894,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6902,7 +6903,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -6913,7 +6914,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -6924,7 +6925,7 @@
 			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "^2.0.1"
 			}
 		},
 		"hash.js": {
@@ -6933,8 +6934,8 @@
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"hawk": {
@@ -6943,10 +6944,10 @@
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"dev": true,
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
-				"sntp": "2.1.0"
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
 			}
 		},
 		"hmac-drbg": {
@@ -6955,9 +6956,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "1.1.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"hoek": {
@@ -6977,8 +6978,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"homedir-polyfill": {
@@ -6987,7 +6988,7 @@
 			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
 			"dev": true,
 			"requires": {
-				"parse-passwd": "1.0.0"
+				"parse-passwd": "^1.0.0"
 			}
 		},
 		"hosted-git-info": {
@@ -7013,7 +7014,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "1.0.3"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"htmlparser2": {
@@ -7022,12 +7023,12 @@
 			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.3.0",
-				"domhandler": "2.4.1",
-				"domutils": "1.5.1",
-				"entities": "1.1.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"domelementtype": "^1.3.0",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"http-cache-semantics": {
@@ -7042,9 +7043,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"https-browserify": {
@@ -7059,8 +7060,8 @@
 			"integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
 			"dev": true,
 			"requires": {
-				"agent-base": "4.2.0",
-				"debug": "3.1.0"
+				"agent-base": "^4.1.0",
+				"debug": "^3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -7102,8 +7103,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -7112,7 +7113,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -7121,7 +7122,7 @@
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				}
 			}
@@ -7144,7 +7145,7 @@
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"indexes-of": {
@@ -7165,8 +7166,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -7185,20 +7186,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "3.0.0",
-				"chalk": "2.3.0",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.1.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.5",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.0.4",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rx-lite": "4.0.8",
-				"rx-lite-aggregates": "4.0.8",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rx-lite": "^4.0.8",
+				"rx-lite-aggregates": "^4.0.8",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7213,7 +7214,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -7222,9 +7223,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"cli-cursor": {
@@ -7233,7 +7234,7 @@
 					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "2.0.0"
+						"restore-cursor": "^2.0.0"
 					}
 				},
 				"figures": {
@@ -7242,7 +7243,7 @@
 					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5"
+						"escape-string-regexp": "^1.0.5"
 					}
 				},
 				"onetime": {
@@ -7251,7 +7252,7 @@
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"restore-cursor": {
@@ -7260,8 +7261,8 @@
 					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 					"dev": true,
 					"requires": {
-						"onetime": "2.0.1",
-						"signal-exit": "3.0.2"
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"strip-ansi": {
@@ -7270,7 +7271,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -7279,7 +7280,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -7296,8 +7297,8 @@
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
 			"dev": true,
 			"requires": {
-				"from2": "2.3.0",
-				"p-is-promise": "1.1.0"
+				"from2": "^2.1.1",
+				"p-is-promise": "^1.1.0"
 			}
 		},
 		"invariant": {
@@ -7306,7 +7307,7 @@
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
@@ -7326,7 +7327,7 @@
 			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7349,7 +7350,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "1.11.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-boolean-object": {
@@ -7370,7 +7371,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -7385,7 +7386,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.1.2"
+				"ci-info": "^1.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -7394,7 +7395,7 @@
 			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7417,9 +7418,9 @@
 			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "1.0.0",
-				"is-data-descriptor": "1.0.0",
-				"kind-of": "6.0.2"
+				"is-accessor-descriptor": "^1.0.0",
+				"is-data-descriptor": "^1.0.0",
+				"kind-of": "^6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7448,7 +7449,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -7469,7 +7470,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -7477,7 +7478,7 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-generator-fn": {
@@ -7492,7 +7493,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-my-json-valid": {
@@ -7501,10 +7502,10 @@
 			"integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
 			"dev": true,
 			"requires": {
-				"generate-function": "2.0.0",
-				"generate-object-property": "1.2.0",
-				"jsonpointer": "4.0.1",
-				"xtend": "4.0.1"
+				"generate-function": "^2.0.0",
+				"generate-object-property": "^1.1.0",
+				"jsonpointer": "^4.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"is-number": {
@@ -7513,7 +7514,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-number-object": {
@@ -7534,7 +7535,7 @@
 			"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "0.2.4"
+				"symbol-observable": "^0.2.2"
 			},
 			"dependencies": {
 				"symbol-observable": {
@@ -7551,7 +7552,7 @@
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "4.0.0"
+				"is-number": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -7574,7 +7575,7 @@
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "1.0.1"
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-path-inside": {
@@ -7583,7 +7584,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "1.0.2"
+				"path-is-inside": "^1.0.1"
 			}
 		},
 		"is-plain-obj": {
@@ -7598,7 +7599,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -7639,7 +7640,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"is-resolvable": {
@@ -7660,7 +7661,7 @@
 			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
 			"dev": true,
 			"requires": {
-				"scoped-regex": "1.0.0"
+				"scoped-regex": "^1.0.0"
 			}
 		},
 		"is-stream": {
@@ -7686,7 +7687,7 @@
 			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
 			"dev": true,
 			"requires": {
-				"html-comment-regex": "1.1.1"
+				"html-comment-regex": "^1.1.0"
 			}
 		},
 		"is-symbol": {
@@ -7737,8 +7738,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.3"
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -7753,17 +7754,17 @@
 			"integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
 			"dev": true,
 			"requires": {
-				"async": "2.6.0",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.1.2",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.9.2",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.1.4",
-				"js-yaml": "3.10.0",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
+				"async": "^2.1.4",
+				"fileset": "^2.0.2",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.9.2",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.1.4",
+				"js-yaml": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"once": "^1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -7778,7 +7779,7 @@
 			"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
 			"dev": true,
 			"requires": {
-				"append-transform": "0.4.0"
+				"append-transform": "^0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -7787,13 +7788,13 @@
 			"integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.1.2",
-				"semver": "5.3.0"
+				"babel-generator": "^6.18.0",
+				"babel-template": "^6.16.0",
+				"babel-traverse": "^6.18.0",
+				"babel-types": "^6.18.0",
+				"babylon": "^6.18.0",
+				"istanbul-lib-coverage": "^1.1.2",
+				"semver": "^5.3.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -7802,10 +7803,10 @@
 			"integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "1.1.2",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.5",
-				"supports-color": "3.2.3"
+				"istanbul-lib-coverage": "^1.1.2",
+				"mkdirp": "^0.5.1",
+				"path-parse": "^1.0.5",
+				"supports-color": "^3.1.2"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -7831,11 +7832,11 @@
 			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
 			"dev": true,
 			"requires": {
-				"debug": "3.1.0",
-				"istanbul-lib-coverage": "1.1.2",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"source-map": "0.5.7"
+				"debug": "^3.1.0",
+				"istanbul-lib-coverage": "^1.1.2",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.1",
+				"source-map": "^0.5.3"
 			},
 			"dependencies": {
 				"debug": {
@@ -7855,7 +7856,7 @@
 			"integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
 			"dev": true,
 			"requires": {
-				"handlebars": "4.0.11"
+				"handlebars": "^4.0.3"
 			}
 		},
 		"istextorbinary": {
@@ -7864,9 +7865,9 @@
 			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
 			"dev": true,
 			"requires": {
-				"binaryextensions": "2.1.1",
-				"editions": "1.3.4",
-				"textextensions": "2.2.0"
+				"binaryextensions": "2",
+				"editions": "^1.3.3",
+				"textextensions": "2"
 			}
 		},
 		"isurl": {
@@ -7875,8 +7876,8 @@
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
 			"dev": true,
 			"requires": {
-				"has-to-string-tag-x": "1.4.1",
-				"is-object": "1.0.1"
+				"has-to-string-tag-x": "^1.2.0",
+				"is-object": "^1.0.1"
 			}
 		},
 		"jed": {
@@ -7890,8 +7891,8 @@
 			"integrity": "sha512-eze1JLbBDkrbZMnE6xIlBxHkqPAmuHbz4GQbED8qRVtnpea3o6Tt/Dc3SBs3qnlTo7svema8Ho5bqLfdHyabyQ==",
 			"dev": true,
 			"requires": {
-				"import-local": "1.0.0",
-				"jest-cli": "22.4.0"
+				"import-local": "^1.0.0",
+				"jest-cli": "^22.4.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7906,7 +7907,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -7915,9 +7916,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"cliui": {
@@ -7926,9 +7927,9 @@
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 					"dev": true,
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -7937,7 +7938,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -7952,40 +7953,40 @@
 					"integrity": "sha512-0JlBb/PvHGQZR2I9GZwsycHgWHhriBmvBWPaaPYUT186oiIIDY4ezDxFOFt2Ts0yNTRg3iY9mTyHsfWbT5VRWA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.0.0",
-						"chalk": "2.3.1",
-						"exit": "0.1.2",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"import-local": "1.0.0",
-						"is-ci": "1.1.0",
-						"istanbul-api": "1.2.2",
-						"istanbul-lib-coverage": "1.1.2",
-						"istanbul-lib-instrument": "1.9.2",
-						"istanbul-lib-source-maps": "1.2.3",
-						"jest-changed-files": "22.2.0",
-						"jest-config": "22.4.0",
-						"jest-environment-jsdom": "22.4.0",
-						"jest-get-type": "22.1.0",
-						"jest-haste-map": "22.4.0",
-						"jest-message-util": "22.4.0",
-						"jest-regex-util": "22.1.0",
-						"jest-resolve-dependencies": "22.1.0",
-						"jest-runner": "22.4.0",
-						"jest-runtime": "22.4.0",
-						"jest-snapshot": "22.4.0",
-						"jest-util": "22.4.0",
-						"jest-validate": "22.4.0",
-						"jest-worker": "22.2.2",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.2.1",
-						"realpath-native": "1.0.0",
-						"rimraf": "2.6.2",
-						"slash": "1.0.0",
-						"string-length": "2.0.0",
-						"strip-ansi": "4.0.0",
-						"which": "1.3.0",
-						"yargs": "10.1.2"
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
+						"is-ci": "^1.0.10",
+						"istanbul-api": "^1.1.14",
+						"istanbul-lib-coverage": "^1.1.1",
+						"istanbul-lib-instrument": "^1.8.0",
+						"istanbul-lib-source-maps": "^1.2.1",
+						"jest-changed-files": "^22.2.0",
+						"jest-config": "^22.4.0",
+						"jest-environment-jsdom": "^22.4.0",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^22.4.0",
+						"jest-message-util": "^22.4.0",
+						"jest-regex-util": "^22.1.0",
+						"jest-resolve-dependencies": "^22.1.0",
+						"jest-runner": "^22.4.0",
+						"jest-runtime": "^22.4.0",
+						"jest-snapshot": "^22.4.0",
+						"jest-util": "^22.4.0",
+						"jest-validate": "^22.4.0",
+						"jest-worker": "^22.2.2",
+						"micromatch": "^2.3.11",
+						"node-notifier": "^5.2.1",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
+						"slash": "^1.0.0",
+						"string-length": "^2.0.0",
+						"strip-ansi": "^4.0.0",
+						"which": "^1.2.12",
+						"yargs": "^10.0.3"
 					}
 				},
 				"strip-ansi": {
@@ -7994,7 +7995,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -8003,7 +8004,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"yargs": {
@@ -8012,18 +8013,18 @@
 					"integrity": "sha1-RU0HTCsWpRpD4vt4B+T53mnMtcU=",
 					"dev": true,
 					"requires": {
-						"cliui": "4.0.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.1.0"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -8032,7 +8033,7 @@
 					"integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -8043,7 +8044,7 @@
 			"integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
 			"dev": true,
 			"requires": {
-				"throat": "4.1.0"
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
@@ -8052,17 +8053,17 @@
 			"integrity": "sha512-hZs8qHjCybOpqni0Kwt40eAavYN/3KnJJwYxSJsBRedJ98IgGSiI18SjybCSccKayA7eHgw1A+dLkHcfI4LItQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"glob": "7.1.2",
-				"jest-environment-jsdom": "22.4.0",
-				"jest-environment-node": "22.4.0",
-				"jest-get-type": "22.1.0",
-				"jest-jasmine2": "22.4.0",
-				"jest-regex-util": "22.1.0",
-				"jest-resolve": "22.4.0",
-				"jest-util": "22.4.0",
-				"jest-validate": "22.4.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^22.4.0",
+				"jest-environment-node": "^22.4.0",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^22.4.0",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.0",
+				"jest-util": "^22.4.0",
+				"jest-validate": "^22.4.0",
+				"pretty-format": "^22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8071,7 +8072,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8080,9 +8081,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8097,7 +8098,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8108,10 +8109,10 @@
 			"integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"diff": "3.4.0",
-				"jest-get-type": "22.1.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"diff": "^3.2.0",
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8120,7 +8121,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8129,9 +8130,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8146,7 +8147,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8157,7 +8158,7 @@
 			"integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "2.1.0"
+				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -8166,9 +8167,9 @@
 			"integrity": "sha512-SAUCte4KFLaD2YhYwHFVEI2GkR4BHqHJsnbFgmQMGgHnZ2CfjSZE8Bnb+jlarbxIG4GXl31+2e9rjBpzbY9gKQ==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "22.2.0",
-				"jest-util": "22.4.0",
-				"jsdom": "11.6.2"
+				"jest-mock": "^22.2.0",
+				"jest-util": "^22.4.0",
+				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
@@ -8177,8 +8178,8 @@
 			"integrity": "sha512-ihSKa2MU5jkAhmRJ17FU4nisbbfW6spvl6Jtwmm5W9kmTVa2sa9UoHWbOWAb7HXuLi3PGGjzTfEt5o3uIzisnQ==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "22.2.0",
-				"jest-util": "22.4.0"
+				"jest-mock": "^22.2.0",
+				"jest-util": "^22.4.0"
 			}
 		},
 		"jest-enzyme": {
@@ -8187,8 +8188,8 @@
 			"integrity": "sha512-nna99NnU6sDbWqVX0153c81RUuxI/spTgw4Xobh049NcKihu0OAtAawbuSzZUnlCqdZOoXlKMudfjUPm0sCTsg==",
 			"dev": true,
 			"requires": {
-				"enzyme-matchers": "4.2.0",
-				"enzyme-to-json": "3.3.1"
+				"enzyme-matchers": "^4.2.0",
+				"enzyme-to-json": "^3.3.0"
 			}
 		},
 		"jest-get-type": {
@@ -8203,13 +8204,13 @@
 			"integrity": "sha512-znYomZ+GaRcuFLQz7hmwQOfLkHY2Y2Aoyd29ZcXLrwBEWts5U/c7lFsqo54XUJUlMhrM5M2IOaAUWjZ1CRqAOQ==",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "2.0.0",
-				"graceful-fs": "4.1.11",
-				"jest-docblock": "22.4.0",
-				"jest-serializer": "22.4.0",
-				"jest-worker": "22.2.2",
-				"micromatch": "2.3.11",
-				"sane": "2.4.1"
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"jest-docblock": "^22.4.0",
+				"jest-serializer": "^22.4.0",
+				"jest-worker": "^22.2.2",
+				"micromatch": "^2.3.11",
+				"sane": "^2.0.0"
 			}
 		},
 		"jest-jasmine2": {
@@ -8218,17 +8219,17 @@
 			"integrity": "sha512-oL7bNLfEL9jPVjmiwqQuwrAJ/5ddmKHSpns0kCpAmv1uQ47Q5aC9zBTXZbDWP5GVbVHj2hbYtNbkwTiXJr0e8w==",
 			"dev": true,
 			"requires": {
-				"callsites": "2.0.0",
-				"chalk": "2.3.1",
-				"co": "4.6.0",
-				"expect": "22.4.0",
-				"graceful-fs": "4.1.11",
-				"is-generator-fn": "1.0.0",
-				"jest-diff": "22.4.0",
-				"jest-matcher-utils": "22.4.0",
-				"jest-message-util": "22.4.0",
-				"jest-snapshot": "22.4.0",
-				"source-map-support": "0.5.3"
+				"callsites": "^2.0.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^22.4.0",
+				"graceful-fs": "^4.1.11",
+				"is-generator-fn": "^1.0.0",
+				"jest-diff": "^22.4.0",
+				"jest-matcher-utils": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-snapshot": "^22.4.0",
+				"source-map-support": "^0.5.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8237,7 +8238,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8246,9 +8247,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8263,7 +8264,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8274,7 +8275,7 @@
 			"integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "22.4.0"
+				"pretty-format": "^22.4.0"
 			}
 		},
 		"jest-matcher-utils": {
@@ -8283,9 +8284,9 @@
 			"integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"jest-get-type": "22.1.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8294,7 +8295,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8303,9 +8304,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8320,7 +8321,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8331,11 +8332,11 @@
 			"integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.40",
-				"chalk": "2.3.1",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0",
-				"stack-utils": "1.0.1"
+				"@babel/code-frame": "^7.0.0-beta.35",
+				"chalk": "^2.0.1",
+				"micromatch": "^2.3.11",
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8344,7 +8345,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8353,9 +8354,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8370,7 +8371,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8393,8 +8394,8 @@
 			"integrity": "sha512-Vs/5VeJEHLpB0ubpYuU9QpBjcCUZRHoHnoV58ZC+N3EXyMJr/MgoqUNpo4OHGQERWlUpvl4YLAAO5uxSMF2VIg==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "1.11.2",
-				"chalk": "2.3.1"
+				"browser-resolve": "^1.11.2",
+				"chalk": "^2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8403,7 +8404,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8412,9 +8413,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8429,7 +8430,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8440,7 +8441,7 @@
 			"integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "22.1.0"
+				"jest-regex-util": "^22.1.0"
 			}
 		},
 		"jest-runner": {
@@ -8449,17 +8450,17 @@
 			"integrity": "sha512-x5QJQrSQs/oaZq2UxtKJxCjGq3fNF7guKRLxAIS39QIaRSAynS4agniMyvHMnLaYsBh6yzUea2SDeNHayQh+TQ==",
 			"dev": true,
 			"requires": {
-				"exit": "0.1.2",
-				"jest-config": "22.4.0",
-				"jest-docblock": "22.4.0",
-				"jest-haste-map": "22.4.0",
-				"jest-jasmine2": "22.4.0",
-				"jest-leak-detector": "22.4.0",
-				"jest-message-util": "22.4.0",
-				"jest-runtime": "22.4.0",
-				"jest-util": "22.4.0",
-				"jest-worker": "22.2.2",
-				"throat": "4.1.0"
+				"exit": "^0.1.2",
+				"jest-config": "^22.4.0",
+				"jest-docblock": "^22.4.0",
+				"jest-haste-map": "^22.4.0",
+				"jest-jasmine2": "^22.4.0",
+				"jest-leak-detector": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-runtime": "^22.4.0",
+				"jest-util": "^22.4.0",
+				"jest-worker": "^22.2.2",
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-runtime": {
@@ -8468,26 +8469,26 @@
 			"integrity": "sha512-aixL2DIXoFQ2ubnurzK4kbNXLl3+m0m7wIBb5VWaJdl1/3nV1UCSjZ9/dJZzpWGGfXsoGw2RZd8sS0nS5s+tdw==",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-jest": "22.4.0",
-				"babel-plugin-istanbul": "4.1.5",
-				"chalk": "2.3.1",
-				"convert-source-map": "1.5.1",
-				"exit": "0.1.2",
-				"graceful-fs": "4.1.11",
-				"jest-config": "22.4.0",
-				"jest-haste-map": "22.4.0",
-				"jest-regex-util": "22.1.0",
-				"jest-resolve": "22.4.0",
-				"jest-util": "22.4.0",
-				"jest-validate": "22.4.0",
-				"json-stable-stringify": "1.0.1",
-				"micromatch": "2.3.11",
-				"realpath-native": "1.0.0",
-				"slash": "1.0.0",
+				"babel-core": "^6.0.0",
+				"babel-jest": "^22.4.0",
+				"babel-plugin-istanbul": "^4.1.5",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^22.4.0",
+				"jest-haste-map": "^22.4.0",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.0",
+				"jest-util": "^22.4.0",
+				"jest-validate": "^22.4.0",
+				"json-stable-stringify": "^1.0.1",
+				"micromatch": "^2.3.11",
+				"realpath-native": "^1.0.0",
+				"slash": "^1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "2.3.0",
-				"yargs": "10.1.2"
+				"write-file-atomic": "^2.1.0",
+				"yargs": "^10.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8502,7 +8503,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8511,9 +8512,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"cliui": {
@@ -8522,9 +8523,9 @@
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 					"dev": true,
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -8533,7 +8534,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -8548,7 +8549,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -8557,7 +8558,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"yargs": {
@@ -8566,18 +8567,18 @@
 					"integrity": "sha1-RU0HTCsWpRpD4vt4B+T53mnMtcU=",
 					"dev": true,
 					"requires": {
-						"cliui": "4.0.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.1.0"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -8586,7 +8587,7 @@
 					"integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -8603,12 +8604,12 @@
 			"integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"jest-diff": "22.4.0",
-				"jest-matcher-utils": "22.4.0",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"jest-diff": "^22.4.0",
+				"jest-matcher-utils": "^22.4.0",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8617,7 +8618,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8626,9 +8627,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8643,7 +8644,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8654,12 +8655,12 @@
 			"integrity": "sha512-652EArz3XScAGAUMhbny7FrFGlmJkp+56CO+9RTrKPtGfbtVDF2WB2D8G+6D6zorDmDW5hNtKNIGNdGfG2kj1g==",
 			"dev": true,
 			"requires": {
-				"callsites": "2.0.0",
-				"chalk": "2.3.1",
-				"graceful-fs": "4.1.11",
-				"is-ci": "1.1.0",
-				"jest-message-util": "22.4.0",
-				"mkdirp": "0.5.1"
+				"callsites": "^2.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.11",
+				"is-ci": "^1.0.10",
+				"jest-message-util": "^22.4.0",
+				"mkdirp": "^0.5.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8668,7 +8669,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8677,9 +8678,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8694,7 +8695,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8705,11 +8706,11 @@
 			"integrity": "sha512-l5JwbIAso8jGp/5/Dy86BCVjOra/Rb81wyXcFTGa4VxbtIh4AEOp2WixgprHLwp+YlUrHugZwaGyuagjB+iB+A==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"jest-config": "22.4.0",
-				"jest-get-type": "22.1.0",
-				"leven": "2.1.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"jest-config": "^22.4.0",
+				"jest-get-type": "^22.1.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8718,7 +8719,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8727,9 +8728,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.2.0"
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8744,7 +8745,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8755,7 +8756,7 @@
 			"integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "1.0.1"
+				"merge-stream": "^1.0.1"
 			}
 		},
 		"jquery": {
@@ -8774,10 +8775,10 @@
 			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.14.tgz",
 			"integrity": "sha1-07j3Mi0CuSd9WL0jgmTDJ+WARM0=",
 			"requires": {
-				"config-chain": "1.1.11",
-				"editorconfig": "0.13.3",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6"
+				"config-chain": "~1.1.5",
+				"editorconfig": "^0.13.2",
+				"mkdirp": "~0.5.0",
+				"nopt": "~3.0.1"
 			}
 		},
 		"js-tokens": {
@@ -8791,8 +8792,8 @@
 			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.9",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -8808,21 +8809,21 @@
 			"integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "6.22.0",
-				"babel-preset-es2015": "6.24.1",
-				"babel-preset-stage-1": "6.24.1",
-				"babel-register": "6.26.0",
-				"babylon": "7.0.0-beta.42",
-				"colors": "1.2.1",
-				"flow-parser": "0.69.0",
-				"lodash": "4.17.5",
-				"micromatch": "2.3.11",
-				"neo-async": "2.5.0",
+				"babel-plugin-transform-flow-strip-types": "^6.8.0",
+				"babel-preset-es2015": "^6.9.0",
+				"babel-preset-stage-1": "^6.5.0",
+				"babel-register": "^6.9.0",
+				"babylon": "^7.0.0-beta.30",
+				"colors": "^1.1.2",
+				"flow-parser": "^0.*",
+				"lodash": "^4.13.1",
+				"micromatch": "^2.3.7",
+				"neo-async": "^2.5.0",
 				"node-dir": "0.1.8",
-				"nomnom": "1.8.1",
-				"recast": "0.14.7",
-				"temp": "0.8.3",
-				"write-file-atomic": "1.3.4"
+				"nomnom": "^1.8.1",
+				"recast": "^0.14.1",
+				"temp": "^0.8.1",
+				"write-file-atomic": "^1.2.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8843,9 +8844,9 @@
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "1.0.0",
-						"has-color": "0.1.7",
-						"strip-ansi": "0.1.1"
+						"ansi-styles": "~1.0.0",
+						"has-color": "~0.1.0",
+						"strip-ansi": "~0.1.0"
 					}
 				},
 				"colors": {
@@ -8860,8 +8861,8 @@
 					"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
 					"dev": true,
 					"requires": {
-						"chalk": "0.4.0",
-						"underscore": "1.6.0"
+						"chalk": "~0.4.0",
+						"underscore": "~1.6.0"
 					}
 				},
 				"strip-ansi": {
@@ -8882,9 +8883,9 @@
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				}
 			}
@@ -8895,32 +8896,32 @@
 			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
 			"dev": true,
 			"requires": {
-				"abab": "1.0.4",
-				"acorn": "5.4.1",
-				"acorn-globals": "4.1.0",
-				"array-equal": "1.0.0",
-				"browser-process-hrtime": "0.1.2",
-				"content-type-parser": "1.0.2",
-				"cssom": "0.3.2",
-				"cssstyle": "0.2.37",
-				"domexception": "1.0.1",
-				"escodegen": "1.9.0",
-				"html-encoding-sniffer": "1.0.2",
-				"left-pad": "1.2.0",
-				"nwmatcher": "1.4.3",
+				"abab": "^1.0.4",
+				"acorn": "^5.3.0",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"browser-process-hrtime": "^0.1.2",
+				"content-type-parser": "^1.0.2",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": ">= 0.2.37 < 0.3.0",
+				"domexception": "^1.0.0",
+				"escodegen": "^1.9.0",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.2.0",
+				"nwmatcher": "^1.4.3",
 				"parse5": "4.0.0",
-				"pn": "1.1.0",
-				"request": "2.83.0",
-				"request-promise-native": "1.0.5",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.3",
-				"w3c-hr-time": "1.0.1",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-url": "6.4.0",
-				"ws": "4.0.0",
-				"xml-name-validator": "3.0.0"
+				"pn": "^1.1.0",
+				"request": "^2.83.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.3",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-url": "^6.4.0",
+				"ws": "^4.0.0",
+				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
 				"parse5": {
@@ -8967,7 +8968,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -9033,7 +9034,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"lazy-cache": {
@@ -9048,7 +9049,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"left-pad": {
@@ -9069,8 +9070,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"line-height": {
@@ -9078,7 +9079,7 @@
 			"resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
 			"integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
 			"requires": {
-				"computed-style": "0.1.4"
+				"computed-style": "~0.1.3"
 			}
 		},
 		"listr": {
@@ -9087,23 +9088,23 @@
 			"integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"figures": "1.7.0",
-				"indent-string": "2.1.0",
-				"is-observable": "0.2.0",
-				"is-promise": "2.1.0",
-				"is-stream": "1.1.0",
-				"listr-silent-renderer": "1.1.1",
-				"listr-update-renderer": "0.4.0",
-				"listr-verbose-renderer": "0.4.1",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"ora": "0.2.3",
-				"p-map": "1.2.0",
-				"rxjs": "5.5.8",
-				"stream-to-observable": "0.2.0",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"figures": "^1.7.0",
+				"indent-string": "^2.1.0",
+				"is-observable": "^0.2.0",
+				"is-promise": "^2.1.0",
+				"is-stream": "^1.1.0",
+				"listr-silent-renderer": "^1.1.1",
+				"listr-update-renderer": "^0.4.0",
+				"listr-verbose-renderer": "^0.4.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"ora": "^0.2.3",
+				"p-map": "^1.1.1",
+				"rxjs": "^5.4.2",
+				"stream-to-observable": "^0.2.0",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"figures": {
@@ -9112,8 +9113,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"log-symbols": {
@@ -9122,7 +9123,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
 				}
 			}
@@ -9139,14 +9140,14 @@
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"elegant-spinner": "1.0.1",
-				"figures": "1.7.0",
-				"indent-string": "3.2.0",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"elegant-spinner": "^1.0.1",
+				"figures": "^1.7.0",
+				"indent-string": "^3.0.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"figures": {
@@ -9155,8 +9156,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"indent-string": {
@@ -9171,7 +9172,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
 				}
 			}
@@ -9182,10 +9183,10 @@
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"date-fns": "1.29.0",
-				"figures": "1.7.0"
+				"chalk": "^1.1.3",
+				"cli-cursor": "^1.0.2",
+				"date-fns": "^1.27.2",
+				"figures": "^1.7.0"
 			},
 			"dependencies": {
 				"cli-cursor": {
@@ -9194,7 +9195,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"figures": {
@@ -9203,8 +9204,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"onetime": {
@@ -9219,8 +9220,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -9237,9 +9238,9 @@
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"dev": true,
 			"requires": {
-				"big.js": "3.2.0",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1"
+				"big.js": "^3.1.3",
+				"emojis-list": "^2.0.0",
+				"json5": "^0.5.0"
 			}
 		},
 		"locate-path": {
@@ -9247,8 +9248,8 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			},
 			"dependencies": {
 				"path-exists": {
@@ -9274,9 +9275,9 @@
 			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
 			"dev": true,
 			"requires": {
-				"lodash.isarray": "3.0.4",
-				"lodash.istypedarray": "3.0.6",
-				"lodash.keys": "3.1.2"
+				"lodash.isarray": "^3.0.0",
+				"lodash.istypedarray": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash._bindcallback": {
@@ -9327,8 +9328,8 @@
 			"integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
 			"dev": true,
 			"requires": {
-				"lodash._baseisequal": "3.0.7",
-				"lodash._bindcallback": "3.0.1"
+				"lodash._baseisequal": "^3.0.0",
+				"lodash._bindcallback": "^3.0.0"
 			}
 		},
 		"lodash.istypedarray": {
@@ -9343,9 +9344,9 @@
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"dev": true,
 			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
 			}
 		},
 		"lodash.memoize": {
@@ -9390,7 +9391,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2"
+				"chalk": "^2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -9399,7 +9400,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -9408,9 +9409,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -9425,7 +9426,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -9436,8 +9437,8 @@
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"cli-cursor": "1.0.2"
+				"ansi-escapes": "^1.0.0",
+				"cli-cursor": "^1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -9452,7 +9453,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
@@ -9467,8 +9468,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -9484,7 +9485,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"loud-rejection": {
@@ -9493,8 +9494,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
@@ -9508,7 +9509,7 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
 			"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
 			"requires": {
-				"pseudomap": "1.0.2"
+				"pseudomap": "^1.0.1"
 			}
 		},
 		"macaddress": {
@@ -9523,7 +9524,7 @@
 			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -9540,7 +9541,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.4"
+				"tmpl": "1.0.x"
 			}
 		},
 		"map-cache": {
@@ -9567,7 +9568,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
 		},
 		"material-colors": {
@@ -9587,8 +9588,8 @@
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"dev": true,
 			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			},
 			"dependencies": {
 				"hash-base": {
@@ -9597,8 +9598,8 @@
 					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 					"dev": true,
 					"requires": {
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.1"
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
 					}
 				}
 			}
@@ -9608,7 +9609,7 @@
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"mem-fs": {
@@ -9617,9 +9618,9 @@
 			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
 			"dev": true,
 			"requires": {
-				"through2": "2.0.3",
-				"vinyl": "1.2.0",
-				"vinyl-file": "2.0.0"
+				"through2": "^2.0.0",
+				"vinyl": "^1.1.0",
+				"vinyl-file": "^2.0.0"
 			}
 		},
 		"mem-fs-editor": {
@@ -9628,16 +9629,16 @@
 			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
 			"dev": true,
 			"requires": {
-				"commondir": "1.0.1",
-				"deep-extend": "0.4.2",
-				"ejs": "2.5.8",
-				"glob": "7.1.2",
-				"globby": "6.1.0",
-				"mkdirp": "0.5.1",
-				"multimatch": "2.1.0",
-				"rimraf": "2.6.2",
-				"through2": "2.0.3",
-				"vinyl": "2.1.0"
+				"commondir": "^1.0.1",
+				"deep-extend": "^0.4.0",
+				"ejs": "^2.3.1",
+				"glob": "^7.0.3",
+				"globby": "^6.1.0",
+				"mkdirp": "^0.5.0",
+				"multimatch": "^2.0.0",
+				"rimraf": "^2.2.8",
+				"through2": "^2.0.0",
+				"vinyl": "^2.0.1"
 			},
 			"dependencies": {
 				"clone": {
@@ -9658,11 +9659,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"replace-ext": {
@@ -9698,8 +9699,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.7",
-				"readable-stream": "2.3.3"
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"meow": {
@@ -9708,16 +9709,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
+				"camelcase-keys": "^2.0.0",
+				"decamelize": "^1.1.2",
+				"loud-rejection": "^1.0.0",
+				"map-obj": "^1.0.1",
+				"minimist": "^1.1.3",
+				"normalize-package-data": "^2.3.4",
+				"object-assign": "^4.0.1",
+				"read-pkg-up": "^1.0.1",
+				"redent": "^1.0.0",
+				"trim-newlines": "^1.0.0"
 			},
 			"dependencies": {
 				"load-json-file": {
@@ -9726,11 +9727,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"minimist": {
@@ -9745,9 +9746,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -9756,9 +9757,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -9767,8 +9768,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"strip-bom": {
@@ -9777,7 +9778,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -9793,7 +9794,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"micromatch": {
@@ -9802,19 +9803,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			}
 		},
 		"miller-rabin": {
@@ -9823,8 +9824,8 @@
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0"
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
 			}
 		},
 		"mime": {
@@ -9845,7 +9846,7 @@
 			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "~1.30.0"
 			}
 		},
 		"mimic-fn": {
@@ -9876,7 +9877,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -9890,16 +9891,16 @@
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "1.6.0",
-				"duplexify": "3.5.4",
-				"end-of-stream": "1.4.1",
-				"flush-write-stream": "1.0.3",
-				"from2": "2.3.0",
-				"parallel-transform": "1.1.0",
-				"pump": "2.0.1",
-				"pumpify": "1.4.0",
-				"stream-each": "1.2.2",
-				"through2": "2.0.3"
+				"concat-stream": "^1.5.0",
+				"duplexify": "^3.4.2",
+				"end-of-stream": "^1.1.0",
+				"flush-write-stream": "^1.0.0",
+				"from2": "^2.1.0",
+				"parallel-transform": "^1.1.0",
+				"pump": "^2.0.1",
+				"pumpify": "^1.3.3",
+				"stream-each": "^1.1.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"mixin-deep": {
@@ -9908,8 +9909,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -9918,7 +9919,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -9929,8 +9930,8 @@
 			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
 			"dev": true,
 			"requires": {
-				"for-in": "0.1.8",
-				"is-extendable": "0.1.1"
+				"for-in": "^0.1.3",
+				"is-extendable": "^0.1.1"
 			},
 			"dependencies": {
 				"for-in": {
@@ -9959,7 +9960,7 @@
 			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
 			"integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
 			"requires": {
-				"moment": "2.21.0"
+				"moment": ">= 2.9.0"
 			}
 		},
 		"mousetrap": {
@@ -9973,12 +9974,12 @@
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"copy-concurrently": "1.0.5",
-				"fs-write-stream-atomic": "1.0.10",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"run-queue": "1.0.3"
+				"aproba": "^1.1.1",
+				"copy-concurrently": "^1.0.0",
+				"fs-write-stream-atomic": "^1.0.8",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.3"
 			}
 		},
 		"ms": {
@@ -9993,10 +9994,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
 			}
 		},
 		"mute-stream": {
@@ -10017,18 +10018,18 @@
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-odd": "2.0.0",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-odd": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -10069,10 +10070,10 @@
 			"integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
 			"dev": true,
 			"requires": {
-				"nomnom": "1.6.2",
-				"railroad-diagrams": "1.0.0",
+				"nomnom": "~1.6.2",
+				"railroad-diagrams": "^1.0.0",
 				"randexp": "0.4.6",
-				"semver": "5.5.0"
+				"semver": "^5.4.1"
 			},
 			"dependencies": {
 				"semver": {
@@ -10106,8 +10107,8 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-gyp": {
@@ -10116,19 +10117,19 @@
 			"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
 			"dev": true,
 			"requires": {
-				"fstream": "1.0.11",
-				"glob": "7.1.2",
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6",
-				"npmlog": "4.1.2",
-				"osenv": "0.1.4",
-				"request": "2.83.0",
-				"rimraf": "2.6.2",
-				"semver": "5.3.0",
-				"tar": "2.2.1",
-				"which": "1.3.0"
+				"fstream": "^1.0.0",
+				"glob": "^7.0.3",
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.0",
+				"nopt": "2 || 3",
+				"npmlog": "0 || 1 || 2 || 3 || 4",
+				"osenv": "0",
+				"request": "2",
+				"rimraf": "2",
+				"semver": "~5.3.0",
+				"tar": "^2.0.0",
+				"which": "1"
 			}
 		},
 		"node-int64": {
@@ -10143,28 +10144,28 @@
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"dev": true,
 			"requires": {
-				"assert": "1.4.1",
-				"browserify-zlib": "0.2.0",
-				"buffer": "4.9.1",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.12.0",
-				"domain-browser": "1.2.0",
-				"events": "1.1.1",
-				"https-browserify": "1.0.0",
-				"os-browserify": "0.3.0",
+				"assert": "^1.1.1",
+				"browserify-zlib": "^0.2.0",
+				"buffer": "^4.3.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "^1.0.0",
+				"crypto-browserify": "^3.11.0",
+				"domain-browser": "^1.1.1",
+				"events": "^1.0.0",
+				"https-browserify": "^1.0.0",
+				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"readable-stream": "2.3.3",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.8.1",
-				"string_decoder": "1.0.3",
-				"timers-browserify": "2.0.6",
+				"process": "^0.11.10",
+				"punycode": "^1.2.4",
+				"querystring-es3": "^0.2.0",
+				"readable-stream": "^2.3.3",
+				"stream-browserify": "^2.0.1",
+				"stream-http": "^2.7.2",
+				"string_decoder": "^1.0.0",
+				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
+				"url": "^0.11.0",
+				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			}
 		},
@@ -10174,10 +10175,10 @@
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"dev": true,
 			"requires": {
-				"growly": "1.3.0",
-				"semver": "5.5.0",
-				"shellwords": "0.1.1",
-				"which": "1.3.0"
+				"growly": "^1.3.0",
+				"semver": "^5.4.1",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -10194,25 +10195,25 @@
 			"integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
 			"dev": true,
 			"requires": {
-				"async-foreach": "0.1.3",
-				"chalk": "1.1.3",
-				"cross-spawn": "3.0.1",
-				"gaze": "1.1.2",
-				"get-stdin": "4.0.1",
-				"glob": "7.1.2",
-				"in-publish": "2.0.0",
-				"lodash.assign": "4.2.0",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.mergewith": "4.6.1",
-				"meow": "3.7.0",
-				"mkdirp": "0.5.1",
-				"nan": "2.8.0",
-				"node-gyp": "3.6.2",
-				"npmlog": "4.1.2",
-				"request": "2.79.0",
-				"sass-graph": "2.2.4",
-				"stdout-stream": "1.4.0",
-				"true-case-path": "1.0.2"
+				"async-foreach": "^0.1.3",
+				"chalk": "^1.1.1",
+				"cross-spawn": "^3.0.0",
+				"gaze": "^1.0.0",
+				"get-stdin": "^4.0.1",
+				"glob": "^7.0.3",
+				"in-publish": "^2.0.0",
+				"lodash.assign": "^4.2.0",
+				"lodash.clonedeep": "^4.3.2",
+				"lodash.mergewith": "^4.6.0",
+				"meow": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"nan": "^2.3.2",
+				"node-gyp": "^3.3.1",
+				"npmlog": "^4.0.0",
+				"request": "~2.79.0",
+				"sass-graph": "^2.2.4",
+				"stdout-stream": "^1.4.0",
+				"true-case-path": "^1.0.2"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -10233,7 +10234,7 @@
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"caseless": {
@@ -10248,8 +10249,8 @@
 					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.1",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"cryptiles": {
@@ -10258,7 +10259,7 @@
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
 					"requires": {
-						"boom": "2.10.1"
+						"boom": "2.x.x"
 					}
 				},
 				"form-data": {
@@ -10267,9 +10268,9 @@
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
 					"dev": true,
 					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.17"
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
 					}
 				},
 				"har-validator": {
@@ -10278,10 +10279,10 @@
 					"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
 					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"commander": "2.14.1",
-						"is-my-json-valid": "2.17.1",
-						"pinkie-promise": "2.0.1"
+						"chalk": "^1.1.1",
+						"commander": "^2.9.0",
+						"is-my-json-valid": "^2.12.4",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"hawk": {
@@ -10290,10 +10291,10 @@
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
 					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
+						"boom": "2.x.x",
+						"cryptiles": "2.x.x",
+						"hoek": "2.x.x",
+						"sntp": "1.x.x"
 					}
 				},
 				"hoek": {
@@ -10308,9 +10309,9 @@
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"dev": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.1",
-						"sshpk": "1.13.1"
+						"assert-plus": "^0.2.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
 					}
 				},
 				"lru-cache": {
@@ -10319,8 +10320,8 @@
 					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 					"dev": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"qs": {
@@ -10335,26 +10336,26 @@
 					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
 					"dev": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.11.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "2.0.6",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.17",
-						"oauth-sign": "0.8.2",
-						"qs": "6.3.2",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.3",
-						"tunnel-agent": "0.4.3",
-						"uuid": "3.1.0"
+						"aws-sign2": "~0.6.0",
+						"aws4": "^1.2.1",
+						"caseless": "~0.11.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.0",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~2.0.6",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.7",
+						"oauth-sign": "~0.8.1",
+						"qs": "~6.3.0",
+						"stringstream": "~0.0.4",
+						"tough-cookie": "~2.3.0",
+						"tunnel-agent": "~0.4.1",
+						"uuid": "^3.0.0"
 					}
 				},
 				"sntp": {
@@ -10363,7 +10364,7 @@
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"tunnel-agent": {
@@ -10380,8 +10381,8 @@
 			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
 			"dev": true,
 			"requires": {
-				"colors": "0.5.1",
-				"underscore": "1.4.4"
+				"colors": "0.5.x",
+				"underscore": "~1.4.4"
 			}
 		},
 		"nopt": {
@@ -10389,7 +10390,7 @@
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 			"requires": {
-				"abbrev": "1.1.1"
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -10398,10 +10399,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.3.0",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -10410,7 +10411,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"normalize-range": {
@@ -10425,10 +10426,10 @@
 			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
 			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"prepend-http": "1.0.4",
-				"query-string": "4.3.4",
-				"sort-keys": "1.1.2"
+				"object-assign": "^4.0.1",
+				"prepend-http": "^1.0.0",
+				"query-string": "^4.1.0",
+				"sort-keys": "^1.0.0"
 			}
 		},
 		"npm-run-path": {
@@ -10436,7 +10437,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"npmlog": {
@@ -10445,10 +10446,10 @@
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
 			"requires": {
-				"are-we-there-yet": "1.1.4",
-				"console-control-strings": "1.1.0",
-				"gauge": "2.7.4",
-				"set-blocking": "2.0.0"
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
 			}
 		},
 		"nth-check": {
@@ -10457,7 +10458,7 @@
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
 			"dev": true,
 			"requires": {
-				"boolbase": "1.0.0"
+				"boolbase": "~1.0.0"
 			}
 		},
 		"num2fraction": {
@@ -10494,9 +10495,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
@@ -10505,7 +10506,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -10514,7 +10515,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -10523,7 +10524,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -10532,9 +10533,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -10577,7 +10578,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -10594,10 +10595,10 @@
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"function-bind": "1.1.1",
-				"has-symbols": "1.0.0",
-				"object-keys": "1.0.11"
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"object.entries": {
@@ -10606,10 +10607,10 @@
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0",
-				"function-bind": "1.1.1",
-				"has": "1.0.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.6.1",
+				"function-bind": "^1.1.0",
+				"has": "^1.0.1"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -10618,8 +10619,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.omit": {
@@ -10628,8 +10629,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -10638,7 +10639,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -10655,10 +10656,10 @@
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0",
-				"function-bind": "1.1.1",
-				"has": "1.0.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.6.1",
+				"function-bind": "^1.1.0",
+				"has": "^1.0.1"
 			}
 		},
 		"once": {
@@ -10667,7 +10668,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -10676,7 +10677,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"optimist": {
@@ -10685,8 +10686,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			}
 		},
 		"optionator": {
@@ -10695,12 +10696,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -10717,10 +10718,10 @@
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-spinners": "0.1.2",
-				"object-assign": "4.1.1"
+				"chalk": "^1.1.1",
+				"cli-cursor": "^1.0.2",
+				"cli-spinners": "^0.1.2",
+				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
 				"cli-cursor": {
@@ -10729,7 +10730,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
@@ -10744,8 +10745,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -10767,9 +10768,9 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -10784,8 +10785,8 @@
 			"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
 			}
 		},
 		"p-cancelable": {
@@ -10800,7 +10801,7 @@
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
 			"dev": true,
 			"requires": {
-				"p-reduce": "1.0.0"
+				"p-reduce": "^1.0.0"
 			}
 		},
 		"p-finally": {
@@ -10825,7 +10826,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -10833,7 +10834,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "1.2.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
@@ -10854,7 +10855,7 @@
 			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
 			"dev": true,
 			"requires": {
-				"p-finally": "1.0.0"
+				"p-finally": "^1.0.0"
 			}
 		},
 		"p-try": {
@@ -10874,9 +10875,9 @@
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 			"dev": true,
 			"requires": {
-				"cyclist": "0.2.2",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"cyclist": "~0.2.2",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.1.5"
 			}
 		},
 		"parse-asn1": {
@@ -10885,11 +10886,11 @@
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"dev": true,
 			"requires": {
-				"asn1.js": "4.10.1",
-				"browserify-aes": "1.1.1",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"pbkdf2": "3.0.14"
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3"
 			}
 		},
 		"parse-glob": {
@@ -10898,10 +10899,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"parse-json": {
@@ -10910,7 +10911,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parse-passwd": {
@@ -10925,7 +10926,7 @@
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
 			"dev": true,
 			"requires": {
-				"@types/node": "9.4.6"
+				"@types/node": "*"
 			}
 		},
 		"pascalcase": {
@@ -10952,7 +10953,7 @@
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 			"dev": true,
 			"requires": {
-				"pinkie-promise": "2.0.1"
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -10983,11 +10984,11 @@
 			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
 			"dev": true,
 			"requires": {
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.11"
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"pegjs": {
@@ -11002,7 +11003,7 @@
 			"integrity": "sha512-ViH8WwUkc/N8H59zuarORrgCi7uxn+gDIq+Ydriw1GFJi/oUg2xvhsgDDujO6dAxRsxXMgqWESx6TKYIqHorqA==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "0.2.17"
+				"loader-utils": "^0.2.5"
 			},
 			"dependencies": {
 				"loader-utils": {
@@ -11011,10 +11012,10 @@
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"dev": true,
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0",
+						"object-assign": "^4.0.1"
 					}
 				}
 			}
@@ -11055,7 +11056,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pluralize": {
@@ -11087,10 +11088,10 @@
 			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"js-base64": "2.4.3",
-				"source-map": "0.5.7",
-				"supports-color": "3.2.3"
+				"chalk": "^1.1.3",
+				"js-base64": "^2.1.9",
+				"source-map": "^0.5.6",
+				"supports-color": "^3.2.3"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -11105,7 +11106,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -11116,9 +11117,9 @@
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-message-helpers": "2.0.0",
-				"reduce-css-calc": "1.3.0"
+				"postcss": "^5.0.2",
+				"postcss-message-helpers": "^2.0.0",
+				"reduce-css-calc": "^1.2.6"
 			}
 		},
 		"postcss-colormin": {
@@ -11127,9 +11128,9 @@
 			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
 			"dev": true,
 			"requires": {
-				"colormin": "1.1.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"colormin": "^1.0.5",
+				"postcss": "^5.0.13",
+				"postcss-value-parser": "^3.2.3"
 			}
 		},
 		"postcss-convert-values": {
@@ -11138,8 +11139,8 @@
 			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.11",
+				"postcss-value-parser": "^3.1.2"
 			}
 		},
 		"postcss-discard-comments": {
@@ -11148,7 +11149,7 @@
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.14"
 			}
 		},
 		"postcss-discard-duplicates": {
@@ -11157,7 +11158,7 @@
 			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			}
 		},
 		"postcss-discard-empty": {
@@ -11166,7 +11167,7 @@
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.14"
 			}
 		},
 		"postcss-discard-overridden": {
@@ -11175,7 +11176,7 @@
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.16"
 			}
 		},
 		"postcss-discard-unused": {
@@ -11184,8 +11185,8 @@
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"postcss": "^5.0.14",
+				"uniqs": "^2.0.0"
 			}
 		},
 		"postcss-filter-plugins": {
@@ -11194,8 +11195,8 @@
 			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"uniqid": "4.1.1"
+				"postcss": "^5.0.4",
+				"uniqid": "^4.0.0"
 			}
 		},
 		"postcss-load-config": {
@@ -11204,10 +11205,10 @@
 			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1",
-				"postcss-load-options": "1.2.0",
-				"postcss-load-plugins": "2.3.0"
+				"cosmiconfig": "^2.1.0",
+				"object-assign": "^4.1.0",
+				"postcss-load-options": "^1.2.0",
+				"postcss-load-plugins": "^2.3.0"
 			}
 		},
 		"postcss-load-options": {
@@ -11216,8 +11217,8 @@
 			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1"
+				"cosmiconfig": "^2.1.0",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"postcss-load-plugins": {
@@ -11226,8 +11227,8 @@
 			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1"
+				"cosmiconfig": "^2.1.1",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"postcss-loader": {
@@ -11236,10 +11237,10 @@
 			"integrity": "sha512-RuBcNE8rjCkIB0IsbmkGFRmQJTeQJfCI88E0VTarPNTvaNSv9OFv1DvTwgtAN/qlzyiELsmmmtX/tEzKp/cdug==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "1.1.0",
-				"postcss": "6.0.21",
-				"postcss-load-config": "1.2.0",
-				"schema-utils": "0.4.5"
+				"loader-utils": "^1.1.0",
+				"postcss": "^6.0.0",
+				"postcss-load-config": "^1.2.0",
+				"schema-utils": "^0.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -11248,7 +11249,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -11257,9 +11258,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -11274,9 +11275,9 @@
 					"integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.2",
-						"source-map": "0.6.1",
-						"supports-color": "5.3.0"
+						"chalk": "^2.3.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"source-map": {
@@ -11291,7 +11292,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -11302,9 +11303,9 @@
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.10",
+				"postcss-value-parser": "^3.1.1"
 			}
 		},
 		"postcss-merge-longhand": {
@@ -11313,7 +11314,7 @@
 			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			}
 		},
 		"postcss-merge-rules": {
@@ -11322,11 +11323,11 @@
 			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
 			"dev": true,
 			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-api": "1.6.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3",
-				"vendors": "1.0.1"
+				"browserslist": "^1.5.2",
+				"caniuse-api": "^1.5.2",
+				"postcss": "^5.0.4",
+				"postcss-selector-parser": "^2.2.2",
+				"vendors": "^1.0.0"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -11335,8 +11336,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000804",
-						"electron-to-chromium": "1.3.33"
+						"caniuse-db": "^1.0.30000639",
+						"electron-to-chromium": "^1.2.7"
 					}
 				}
 			}
@@ -11353,9 +11354,9 @@
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
 			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"object-assign": "^4.0.1",
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.2"
 			}
 		},
 		"postcss-minify-gradients": {
@@ -11364,8 +11365,8 @@
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.12",
+				"postcss-value-parser": "^3.3.0"
 			}
 		},
 		"postcss-minify-params": {
@@ -11374,10 +11375,10 @@
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"uniqs": "2.0.0"
+				"alphanum-sort": "^1.0.1",
+				"postcss": "^5.0.2",
+				"postcss-value-parser": "^3.0.2",
+				"uniqs": "^2.0.0"
 			}
 		},
 		"postcss-minify-selectors": {
@@ -11386,10 +11387,10 @@
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3"
+				"alphanum-sort": "^1.0.2",
+				"has": "^1.0.1",
+				"postcss": "^5.0.14",
+				"postcss-selector-parser": "^2.0.0"
 			}
 		},
 		"postcss-normalize-charset": {
@@ -11398,7 +11399,7 @@
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.5"
 			}
 		},
 		"postcss-normalize-url": {
@@ -11407,10 +11408,10 @@
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
 			"dev": true,
 			"requires": {
-				"is-absolute-url": "2.1.0",
-				"normalize-url": "1.9.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"is-absolute-url": "^2.0.0",
+				"normalize-url": "^1.4.0",
+				"postcss": "^5.0.14",
+				"postcss-value-parser": "^3.2.3"
 			}
 		},
 		"postcss-ordered-values": {
@@ -11419,8 +11420,8 @@
 			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.1"
 			}
 		},
 		"postcss-reduce-idents": {
@@ -11429,8 +11430,8 @@
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.2"
 			}
 		},
 		"postcss-reduce-initial": {
@@ -11439,7 +11440,7 @@
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			}
 		},
 		"postcss-reduce-transforms": {
@@ -11448,9 +11449,9 @@
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.8",
+				"postcss-value-parser": "^3.0.1"
 			}
 		},
 		"postcss-selector-parser": {
@@ -11459,9 +11460,9 @@
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
 			"dev": true,
 			"requires": {
-				"flatten": "1.0.2",
-				"indexes-of": "1.0.1",
-				"uniq": "1.0.1"
+				"flatten": "^1.0.2",
+				"indexes-of": "^1.0.1",
+				"uniq": "^1.0.1"
 			}
 		},
 		"postcss-svgo": {
@@ -11470,10 +11471,10 @@
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
 			"dev": true,
 			"requires": {
-				"is-svg": "2.1.0",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"svgo": "0.7.2"
+				"is-svg": "^2.0.0",
+				"postcss": "^5.0.14",
+				"postcss-value-parser": "^3.2.3",
+				"svgo": "^0.7.0"
 			}
 		},
 		"postcss-unique-selectors": {
@@ -11482,9 +11483,9 @@
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"alphanum-sort": "^1.0.1",
+				"postcss": "^5.0.4",
+				"uniqs": "^2.0.0"
 			}
 		},
 		"postcss-value-parser": {
@@ -11499,9 +11500,9 @@
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.4",
+				"uniqs": "^2.0.0"
 			}
 		},
 		"prelude-ls": {
@@ -11540,8 +11541,8 @@
 			"integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0",
-				"ansi-styles": "3.2.0"
+				"ansi-regex": "^3.0.0",
+				"ansi-styles": "^3.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11556,7 +11557,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				}
 			}
@@ -11589,7 +11590,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "2.0.6"
+				"asap": "~2.0.3"
 			}
 		},
 		"promise-inflight": {
@@ -11603,8 +11604,8 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
 			"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1"
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.3.1"
 			}
 		},
 		"proto-list": {
@@ -11635,11 +11636,11 @@
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"parse-asn1": "5.1.0",
-				"randombytes": "2.0.6"
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"pump": {
@@ -11648,8 +11649,8 @@
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"once": "1.4.0"
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"pumpify": {
@@ -11658,9 +11659,9 @@
 			"integrity": "sha1-gLfF334kFT0D8OesigWl0Gi9B/s=",
 			"dev": true,
 			"requires": {
-				"duplexify": "3.5.4",
-				"inherits": "2.0.3",
-				"pump": "2.0.1"
+				"duplexify": "^3.5.3",
+				"inherits": "^2.0.3",
+				"pump": "^2.0.0"
 			}
 		},
 		"punycode": {
@@ -11675,14 +11676,14 @@
 			"integrity": "sha512-4sY/6mB7+kNPGAzPGKq65tH0VG3ohUEkXHuOReB9K/tw3m1TqifYmxnMR/uDeci/UPwyk5K1gWYh8rw0U0Zscw==",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"extract-zip": "1.6.6",
-				"https-proxy-agent": "2.2.0",
-				"mime": "1.6.0",
-				"progress": "2.0.0",
-				"proxy-from-env": "1.0.0",
-				"rimraf": "2.6.2",
-				"ws": "3.3.3"
+				"debug": "^2.6.8",
+				"extract-zip": "^1.6.5",
+				"https-proxy-agent": "^2.1.0",
+				"mime": "^1.3.4",
+				"progress": "^2.0.0",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^2.6.1",
+				"ws": "^3.0.0"
 			},
 			"dependencies": {
 				"ws": {
@@ -11691,9 +11692,9 @@
 					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
 					"dev": true,
 					"requires": {
-						"async-limiter": "1.0.0",
-						"safe-buffer": "5.1.1",
-						"ultron": "1.1.1"
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
+						"ultron": "~1.1.0"
 					}
 				}
 			}
@@ -11716,8 +11717,8 @@
 			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
 			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
 			}
 		},
 		"querystring": {
@@ -11743,7 +11744,7 @@
 			"integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
 			"dev": true,
 			"requires": {
-				"performance-now": "2.1.0"
+				"performance-now": "^2.1.0"
 			}
 		},
 		"railroad-diagrams": {
@@ -11759,7 +11760,7 @@
 			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"randomatic": {
@@ -11768,8 +11769,8 @@
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -11778,7 +11779,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11787,7 +11788,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -11798,7 +11799,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -11809,7 +11810,7 @@
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomfill": {
@@ -11818,8 +11819,8 @@
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"dev": true,
 			"requires": {
-				"randombytes": "2.0.6",
-				"safe-buffer": "5.1.1"
+				"randombytes": "^2.0.5",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"raw-loader": {
@@ -11838,10 +11839,10 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-16.3.0.tgz",
 			"integrity": "sha512-Qh35tNbwY8SLFELkN3PCLO16EARV+lgcmNkQnoZXfzAF1ASRpeucZYUwBlBzsRAzTb7KyfBaLQ4/K/DLC6MYeA==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11849,9 +11850,9 @@
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -11861,9 +11862,9 @@
 			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.2.tgz",
 			"integrity": "sha1-K2hApp9xOHGavOpaQp7PcwF2jAc=",
 			"requires": {
-				"autosize": "4.0.1",
-				"line-height": "0.3.1",
-				"prop-types": "15.5.10"
+				"autosize": "^4.0.0",
+				"line-height": "^0.3.1",
+				"prop-types": "^15.5.6"
 			}
 		},
 		"react-click-outside": {
@@ -11871,7 +11872,7 @@
 			"resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.3.1.tgz",
 			"integrity": "sha1-MYc3698IGko7zUaCVmNnTL6YNus=",
 			"requires": {
-				"hoist-non-react-statics": "1.2.0"
+				"hoist-non-react-statics": "^1.2.0"
 			}
 		},
 		"react-color": {
@@ -11879,11 +11880,11 @@
 			"resolved": "https://registry.npmjs.org/react-color/-/react-color-2.13.4.tgz",
 			"integrity": "sha512-rNJTTxMPTImI1NpFaKLggDIvHgKOYRXj0krVh8c+Mo1YNsrLko8O94yiFqqdnSQgtIPteiAcGEJgBo9V5+uqaw==",
 			"requires": {
-				"lodash": "4.17.5",
-				"material-colors": "1.2.5",
-				"prop-types": "15.5.10",
-				"reactcss": "1.2.3",
-				"tinycolor2": "1.4.1"
+				"lodash": "^4.0.1",
+				"material-colors": "^1.2.1",
+				"prop-types": "^15.5.4",
+				"reactcss": "^1.2.0",
+				"tinycolor2": "^1.1.2"
 			}
 		},
 		"react-datepicker": {
@@ -11891,10 +11892,10 @@
 			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-1.4.1.tgz",
 			"integrity": "sha512-O/ExTWLS81pyWJWLFg1BRQEr9S/BDd6iMEkGctxQmVrRw2srW8DNdnQm5UgFNu8LoSZGMDvI55OghYZvDpWJhw==",
 			"requires": {
-				"classnames": "2.2.5",
-				"prop-types": "15.6.1",
-				"react-onclickoutside": "6.7.1",
-				"react-popper": "0.9.5"
+				"classnames": "^2.2.5",
+				"prop-types": "^15.6.0",
+				"react-onclickoutside": "^6.7.1",
+				"react-popper": "^0.9.1"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11902,9 +11903,9 @@
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -11914,10 +11915,10 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.0.tgz",
 			"integrity": "sha512-xT/FxawAurL6AV8YtAP7LkdDJFFX2vvv17AqFLQRF81ZtWLXkV/0dcAaiFIy0lmoQEFT931TU9aaH+5dBUxTcw==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11925,9 +11926,9 @@
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -11948,8 +11949,8 @@
 			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.9.5.tgz",
 			"integrity": "sha1-AqJO8+7DOvnlToNYq3DrDjMe3QU=",
 			"requires": {
-				"popper.js": "1.14.3",
-				"prop-types": "15.6.1"
+				"popper.js": "^1.14.1",
+				"prop-types": "^15.6.1"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11957,9 +11958,9 @@
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -11970,10 +11971,10 @@
 			"integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
 			"dev": true,
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11982,9 +11983,9 @@
 					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -11995,10 +11996,10 @@
 			"integrity": "sha512-7FAfgIT8Kvew36b2VFXnhMxjKkwAnicD1dyopq7Ot19WAhfJkyhYNwPzM1AnCfYccvEhO0x4FbqJETyMGQwgIg==",
 			"dev": true,
 			"requires": {
-				"fbjs": "0.8.16",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1",
-				"react-is": "16.3.0"
+				"fbjs": "^0.8.16",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0",
+				"react-is": "^16.3.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -12007,9 +12008,9 @@
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -12019,7 +12020,7 @@
 			"resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
 			"integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.0.1"
 			}
 		},
 		"read-chunk": {
@@ -12028,8 +12029,8 @@
 			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0",
-				"safe-buffer": "5.1.1"
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.1.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -12045,13 +12046,13 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.0.3",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
@@ -12060,10 +12061,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -12072,7 +12073,7 @@
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "1.0.0"
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"recast": {
@@ -12082,9 +12083,9 @@
 			"dev": true,
 			"requires": {
 				"ast-types": "0.11.3",
-				"esprima": "4.0.0",
-				"private": "0.1.8",
-				"source-map": "0.6.1"
+				"esprima": "~4.0.0",
+				"private": "~0.1.5",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12101,7 +12102,7 @@
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dev": true,
 			"requires": {
-				"resolve": "1.5.0"
+				"resolve": "^1.1.6"
 			}
 		},
 		"redent": {
@@ -12110,8 +12111,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
+				"indent-string": "^2.1.0",
+				"strip-indent": "^1.0.1"
 			}
 		},
 		"reduce-css-calc": {
@@ -12120,9 +12121,9 @@
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "0.4.2",
-				"math-expression-evaluator": "1.2.17",
-				"reduce-function-call": "1.0.2"
+				"balanced-match": "^0.4.2",
+				"math-expression-evaluator": "^1.2.14",
+				"reduce-function-call": "^1.0.1"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -12139,7 +12140,7 @@
 			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "0.4.2"
+				"balanced-match": "^0.4.2"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -12155,10 +12156,10 @@
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
-				"lodash": "4.17.5",
-				"lodash-es": "4.17.5",
-				"loose-envify": "1.3.1",
-				"symbol-observable": "1.2.0"
+				"lodash": "^4.2.1",
+				"lodash-es": "^4.2.1",
+				"loose-envify": "^1.1.0",
+				"symbol-observable": "^1.0.3"
 			}
 		},
 		"redux-multi": {
@@ -12194,9 +12195,9 @@
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"private": "0.1.8"
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
@@ -12205,7 +12206,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -12214,8 +12215,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -12224,9 +12225,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "1.3.3",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"regjsgen": {
@@ -12241,7 +12242,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			}
 		},
 		"rememo": {
@@ -12249,7 +12250,7 @@
 			"resolved": "https://registry.npmjs.org/rememo/-/rememo-2.4.0.tgz",
 			"integrity": "sha512-4rqlLATPcha9lfdvylUWqSbceiTlYiBJvEJAyUiT/68cYPlNG1zXf7ABeve7s4YPrT6o3Q6zfN6n38ecAL71lw==",
 			"requires": {
-				"shallow-equal": "1.0.0"
+				"shallow-equal": "^1.0.0"
 			}
 		},
 		"remove-trailing-separator": {
@@ -12276,7 +12277,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"replace-ext": {
@@ -12291,28 +12292,28 @@
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.1.0"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			}
 		},
 		"request-promise-core": {
@@ -12321,7 +12322,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.13.1"
 			}
 		},
 		"request-promise-native": {
@@ -12331,8 +12332,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.3"
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-directory": {
@@ -12357,8 +12358,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -12379,7 +12380,7 @@
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -12388,7 +12389,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"resolve-dir": {
@@ -12397,8 +12398,8 @@
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "2.0.2",
-				"global-modules": "1.0.0"
+				"expand-tilde": "^2.0.0",
+				"global-modules": "^1.0.0"
 			}
 		},
 		"resolve-from": {
@@ -12419,7 +12420,7 @@
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "1.0.1"
+				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"restore-cursor": {
@@ -12428,8 +12429,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ret": {
@@ -12445,7 +12446,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
 		},
 		"rimraf": {
@@ -12454,7 +12455,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"ripemd160": {
@@ -12463,8 +12464,8 @@
 			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
 			"dev": true,
 			"requires": {
-				"hash-base": "2.0.2",
-				"inherits": "2.0.3"
+				"hash-base": "^2.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"rst-selector-parser": {
@@ -12473,8 +12474,8 @@
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
 			"dev": true,
 			"requires": {
-				"lodash.flattendeep": "4.4.0",
-				"nearley": "2.11.1"
+				"lodash.flattendeep": "^4.4.0",
+				"nearley": "^2.7.10"
 			}
 		},
 		"rtlcss": {
@@ -12483,11 +12484,11 @@
 			"integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.0",
-				"findup": "0.1.5",
-				"mkdirp": "0.5.1",
-				"postcss": "6.0.17",
-				"strip-json-comments": "2.0.1"
+				"chalk": "^2.3.0",
+				"findup": "^0.1.5",
+				"mkdirp": "^0.5.1",
+				"postcss": "^6.0.14",
+				"strip-json-comments": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -12496,7 +12497,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -12505,9 +12506,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"postcss": {
@@ -12516,9 +12517,9 @@
 					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"source-map": "0.6.1",
-						"supports-color": "5.1.0"
+						"chalk": "^2.3.0",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.1.0"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -12527,7 +12528,7 @@
 							"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
 							"dev": true,
 							"requires": {
-								"has-flag": "2.0.0"
+								"has-flag": "^2.0.0"
 							}
 						}
 					}
@@ -12544,7 +12545,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -12555,7 +12556,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			}
 		},
 		"run-parallel": {
@@ -12570,7 +12571,7 @@
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0"
+				"aproba": "^1.1.1"
 			}
 		},
 		"rx": {
@@ -12591,7 +12592,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "4.0.8"
+				"rx-lite": "*"
 			}
 		},
 		"rxjs": {
@@ -12622,7 +12623,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"sane": {
@@ -12631,14 +12632,14 @@
 			"integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
 			"dev": true,
 			"requires": {
-				"anymatch": "1.3.2",
-				"exec-sh": "0.2.1",
-				"fb-watchman": "2.0.0",
-				"fsevents": "1.1.3",
-				"minimatch": "3.0.4",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.18.0"
+				"anymatch": "^1.3.0",
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.1.1",
+				"minimatch": "^3.0.2",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.18.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -12655,10 +12656,10 @@
 			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"lodash": "4.17.5",
-				"scss-tokenizer": "0.2.3",
-				"yargs": "7.1.0"
+				"glob": "^7.0.0",
+				"lodash": "^4.0.0",
+				"scss-tokenizer": "^0.2.3",
+				"yargs": "^7.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -12673,11 +12674,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"os-locale": {
@@ -12686,7 +12687,7 @@
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"dev": true,
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-type": {
@@ -12695,9 +12696,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -12706,9 +12707,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -12717,8 +12718,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -12727,9 +12728,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -12738,7 +12739,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"which-module": {
@@ -12753,19 +12754,19 @@
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
 					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "5.0.0"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^5.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -12774,7 +12775,7 @@
 					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -12785,11 +12786,11 @@
 			"integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
 			"dev": true,
 			"requires": {
-				"clone-deep": "2.0.2",
-				"loader-utils": "1.1.0",
-				"lodash.tail": "4.1.1",
-				"neo-async": "2.5.0",
-				"pify": "3.0.0"
+				"clone-deep": "^2.0.1",
+				"loader-utils": "^1.0.1",
+				"lodash.tail": "^4.1.1",
+				"neo-async": "^2.5.0",
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -12812,8 +12813,8 @@
 			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
 			"dev": true,
 			"requires": {
-				"ajv": "6.4.0",
-				"ajv-keywords": "3.1.0"
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -12822,10 +12823,10 @@
 					"integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "1.0.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1",
-						"uri-js": "3.0.2"
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0",
+						"uri-js": "^3.0.2"
 					}
 				},
 				"ajv-keywords": {
@@ -12848,8 +12849,8 @@
 			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
 			"dev": true,
 			"requires": {
-				"js-base64": "2.4.3",
-				"source-map": "0.4.4"
+				"js-base64": "^2.1.8",
+				"source-map": "^0.4.2"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12858,7 +12859,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -12896,10 +12897,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -12908,7 +12909,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -12924,8 +12925,8 @@
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"shallow-clone": {
@@ -12934,9 +12935,9 @@
 			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
 			"dev": true,
 			"requires": {
-				"is-extendable": "0.1.1",
-				"kind-of": "5.1.0",
-				"mixin-object": "2.0.1"
+				"is-extendable": "^0.1.1",
+				"kind-of": "^5.0.0",
+				"mixin-object": "^2.0.1"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -12957,7 +12958,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -12971,9 +12972,9 @@
 			"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"interpret": "1.1.0",
-				"rechoir": "0.6.2"
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
 			}
 		},
 		"shellwords": {
@@ -12987,7 +12988,7 @@
 			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
 			"integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
 			"requires": {
-				"yargs": "10.1.2"
+				"yargs": "^10.0.3"
 			}
 		},
 		"sigmund": {
@@ -13029,14 +13030,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.1",
-				"use": "3.1.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -13045,7 +13046,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
@@ -13054,7 +13055,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -13063,7 +13064,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13072,7 +13073,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -13083,7 +13084,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13092,7 +13093,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -13103,9 +13104,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					}
 				},
 				"kind-of": {
@@ -13122,9 +13123,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -13133,7 +13134,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"isobject": {
@@ -13150,7 +13151,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.2.0"
 			}
 		},
 		"sntp": {
@@ -13159,7 +13160,7 @@
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"dev": true,
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"sort-keys": {
@@ -13168,7 +13169,7 @@
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-list-map": {
@@ -13189,11 +13190,11 @@
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 			"dev": true,
 			"requires": {
-				"atob": "2.1.0",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.0.0",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -13202,7 +13203,7 @@
 			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
 			"dev": true,
 			"requires": {
-				"source-map": "0.6.1"
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -13231,7 +13232,7 @@
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"dev": true,
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-license-ids": "^1.0.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -13252,7 +13253,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"sprintf-js": {
@@ -13267,14 +13268,14 @@
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"ssri": {
@@ -13283,7 +13284,7 @@
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"stack-utils": {
@@ -13298,8 +13299,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -13308,7 +13309,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -13317,7 +13318,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13326,7 +13327,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -13337,7 +13338,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13346,7 +13347,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -13357,9 +13358,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					}
 				},
 				"kind-of": {
@@ -13376,7 +13377,7 @@
 			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"stealthy-require": {
@@ -13391,8 +13392,8 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-each": {
@@ -13401,8 +13402,8 @@
 			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"stream-shift": "1.0.0"
+				"end-of-stream": "^1.1.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"stream-http": {
@@ -13411,11 +13412,11 @@
 			"integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.3.3",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"stream-shift": {
@@ -13430,7 +13431,7 @@
 			"integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
 			"dev": true,
 			"requires": {
-				"any-observable": "0.2.0"
+				"any-observable": "^0.2.0"
 			}
 		},
 		"strict-uri-encode": {
@@ -13445,8 +13446,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "1.0.0",
-				"strip-ansi": "4.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -13461,7 +13462,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -13477,8 +13478,8 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -13496,7 +13497,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -13506,7 +13507,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"stringstream": {
@@ -13520,7 +13521,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -13535,8 +13536,8 @@
 			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
 			"dev": true,
 			"requires": {
-				"first-chunk-stream": "2.0.0",
-				"strip-bom": "2.0.0"
+				"first-chunk-stream": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -13545,7 +13546,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -13561,7 +13562,7 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "4.0.1"
+				"get-stdin": "^4.0.1"
 			}
 		},
 		"strip-json-comments": {
@@ -13576,8 +13577,8 @@
 			"integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "1.1.0",
-				"schema-utils": "0.4.5"
+				"loader-utils": "^1.1.0",
+				"schema-utils": "^0.4.5"
 			}
 		},
 		"supports-color": {
@@ -13592,13 +13593,13 @@
 			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
 			"dev": true,
 			"requires": {
-				"coa": "1.0.4",
-				"colors": "1.1.2",
-				"csso": "2.3.2",
-				"js-yaml": "3.7.0",
-				"mkdirp": "0.5.1",
-				"sax": "1.2.4",
-				"whet.extend": "0.9.9"
+				"coa": "~1.0.1",
+				"colors": "~1.1.2",
+				"csso": "~2.3.1",
+				"js-yaml": "~3.7.0",
+				"mkdirp": "~0.5.1",
+				"sax": "~1.2.1",
+				"whet.extend": "~0.9.9"
 			},
 			"dependencies": {
 				"colors": {
@@ -13619,8 +13620,8 @@
 					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
 					"dev": true,
 					"requires": {
-						"argparse": "1.0.9",
-						"esprima": "2.7.3"
+						"argparse": "^1.0.7",
+						"esprima": "^2.6.0"
 					}
 				}
 			}
@@ -13642,12 +13643,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"ajv-keywords": "2.1.1",
-				"chalk": "2.3.0",
-				"lodash": "4.17.5",
+				"ajv": "^5.2.3",
+				"ajv-keywords": "^2.1.0",
+				"chalk": "^2.1.0",
+				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
+				"string-width": "^2.1.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -13656,7 +13657,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -13665,9 +13666,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -13682,7 +13683,7 @@
 					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0"
+						"is-fullwidth-code-point": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -13691,7 +13692,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -13708,9 +13709,9 @@
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"dev": true,
 			"requires": {
-				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
-				"inherits": "2.0.3"
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
 			}
 		},
 		"temp": {
@@ -13719,8 +13720,8 @@
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "1.0.2",
-				"rimraf": "2.2.8"
+				"os-tmpdir": "^1.0.0",
+				"rimraf": "~2.2.6"
 			},
 			"dependencies": {
 				"rimraf": {
@@ -13737,11 +13738,11 @@
 			"integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "2.3.11",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
+				"arrify": "^1.0.1",
+				"micromatch": "^2.3.11",
+				"object-assign": "^4.1.0",
+				"read-pkg-up": "^1.0.1",
+				"require-main-filename": "^1.0.1"
 			},
 			"dependencies": {
 				"load-json-file": {
@@ -13750,11 +13751,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -13763,9 +13764,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -13774,9 +13775,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -13785,8 +13786,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"strip-bom": {
@@ -13795,7 +13796,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -13830,8 +13831,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"timed-out": {
@@ -13846,7 +13847,7 @@
 			"integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
 			"dev": true,
 			"requires": {
-				"setimmediate": "1.0.5"
+				"setimmediate": "^1.0.4"
 			}
 		},
 		"tiny-emitter": {
@@ -13889,7 +13890,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"to-regex": {
@@ -13898,10 +13899,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -13910,8 +13911,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -13920,7 +13921,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				}
 			}
@@ -13931,7 +13932,7 @@
 			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
 			"dev": true,
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			}
 		},
 		"tr46": {
@@ -13940,7 +13941,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.0"
+				"punycode": "^2.1.0"
 			},
 			"dependencies": {
 				"punycode": {
@@ -13975,7 +13976,7 @@
 			"integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
 			"dev": true,
 			"requires": {
-				"glob": "6.0.4"
+				"glob": "^6.0.4"
 			},
 			"dependencies": {
 				"glob": {
@@ -13984,11 +13985,11 @@
 					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
 					"dev": true,
 					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -14005,7 +14006,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -14021,7 +14022,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"typedarray": {
@@ -14042,9 +14043,9 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -14061,8 +14062,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					}
 				},
@@ -14080,9 +14081,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -14101,14 +14102,14 @@
 			"integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
 			"dev": true,
 			"requires": {
-				"cacache": "10.0.4",
-				"find-cache-dir": "1.0.0",
-				"schema-utils": "0.4.5",
-				"serialize-javascript": "1.4.0",
-				"source-map": "0.6.1",
-				"uglify-es": "3.3.9",
-				"webpack-sources": "1.1.0",
-				"worker-farm": "1.6.0"
+				"cacache": "^10.0.4",
+				"find-cache-dir": "^1.0.0",
+				"schema-utils": "^0.4.5",
+				"serialize-javascript": "^1.4.0",
+				"source-map": "^0.6.1",
+				"uglify-es": "^3.3.4",
+				"webpack-sources": "^1.1.0",
+				"worker-farm": "^1.5.2"
 			},
 			"dependencies": {
 				"commander": {
@@ -14129,8 +14130,8 @@
 					"integrity": "sha1-DBxPBwC+2NvBJM2zBNJZLKID5nc=",
 					"dev": true,
 					"requires": {
-						"commander": "2.13.0",
-						"source-map": "0.6.1"
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
 					}
 				}
 			}
@@ -14153,10 +14154,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -14165,7 +14166,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
@@ -14174,10 +14175,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
@@ -14194,7 +14195,7 @@
 			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
 			"dev": true,
 			"requires": {
-				"macaddress": "0.2.8"
+				"macaddress": "^0.2.8"
 			}
 		},
 		"uniqs": {
@@ -14209,7 +14210,7 @@
 			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 			"dev": true,
 			"requires": {
-				"unique-slug": "2.0.0"
+				"unique-slug": "^2.0.0"
 			}
 		},
 		"unique-slug": {
@@ -14218,7 +14219,7 @@
 			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 			"dev": true,
 			"requires": {
-				"imurmurhash": "0.1.4"
+				"imurmurhash": "^0.1.4"
 			}
 		},
 		"unset-value": {
@@ -14227,8 +14228,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
@@ -14237,9 +14238,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -14285,7 +14286,7 @@
 			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.0"
+				"punycode": "^2.1.0"
 			},
 			"dependencies": {
 				"punycode": {
@@ -14326,7 +14327,7 @@
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "2.0.0"
+				"prepend-http": "^2.0.0"
 			},
 			"dependencies": {
 				"prepend-http": {
@@ -14355,7 +14356,7 @@
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -14394,8 +14395,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"object.getownpropertydescriptors": "2.0.3"
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
 		"uuid": {
@@ -14415,8 +14416,8 @@
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
 			}
 		},
 		"vendors": {
@@ -14431,9 +14432,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vinyl": {
@@ -14442,8 +14443,8 @@
 			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 			"dev": true,
 			"requires": {
-				"clone": "1.0.3",
-				"clone-stats": "0.0.1",
+				"clone": "^1.0.0",
+				"clone-stats": "^0.0.1",
 				"replace-ext": "0.0.1"
 			}
 		},
@@ -14453,12 +14454,12 @@
 			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0",
-				"strip-bom-stream": "2.0.0",
-				"vinyl": "1.2.0"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.3.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0",
+				"strip-bom-stream": "^2.0.0",
+				"vinyl": "^1.1.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -14467,7 +14468,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -14487,7 +14488,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "0.1.2"
+				"browser-process-hrtime": "^0.1.2"
 			}
 		},
 		"walker": {
@@ -14496,7 +14497,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.11"
+				"makeerror": "1.0.x"
 			}
 		},
 		"watch": {
@@ -14505,8 +14506,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "0.2.1",
-				"minimist": "1.2.0"
+				"exec-sh": "^0.2.0",
+				"minimist": "^1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -14523,9 +14524,9 @@
 			"integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
 			"dev": true,
 			"requires": {
-				"chokidar": "2.0.3",
-				"graceful-fs": "4.1.11",
-				"neo-async": "2.5.0"
+				"chokidar": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"neo-async": "^2.5.0"
 			}
 		},
 		"webidl-conversions": {
@@ -14540,25 +14541,25 @@
 			"integrity": "sha512-iLUJcsEAjaPKWbB32ADr29Pg9fPUVfFEMPK4VXyZGftzhSEFg2BLjHLoBYZ14wdTEA8xqG/hjpuX8qOmabRYvw==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.4.1",
-				"acorn-dynamic-import": "3.0.0",
-				"ajv": "6.4.0",
-				"ajv-keywords": "3.1.0",
-				"chrome-trace-event": "0.1.2",
-				"enhanced-resolve": "4.0.0",
-				"eslint-scope": "3.7.1",
-				"loader-runner": "2.3.0",
-				"loader-utils": "1.1.0",
-				"memory-fs": "0.4.1",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"neo-async": "2.5.0",
-				"node-libs-browser": "2.1.0",
-				"schema-utils": "0.4.5",
-				"tapable": "1.0.0",
-				"uglifyjs-webpack-plugin": "1.2.4",
-				"watchpack": "1.5.0",
-				"webpack-sources": "1.1.0"
+				"acorn": "^5.0.0",
+				"acorn-dynamic-import": "^3.0.0",
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0",
+				"chrome-trace-event": "^0.1.1",
+				"enhanced-resolve": "^4.0.0",
+				"eslint-scope": "^3.7.1",
+				"loader-runner": "^2.3.0",
+				"loader-utils": "^1.1.0",
+				"memory-fs": "~0.4.1",
+				"micromatch": "^3.1.8",
+				"mkdirp": "~0.5.0",
+				"neo-async": "^2.5.0",
+				"node-libs-browser": "^2.0.0",
+				"schema-utils": "^0.4.2",
+				"tapable": "^1.0.0",
+				"uglifyjs-webpack-plugin": "^1.2.4",
+				"watchpack": "^1.5.0",
+				"webpack-sources": "^1.0.1"
 			},
 			"dependencies": {
 				"ajv": {
@@ -14567,10 +14568,10 @@
 					"integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "1.0.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1",
-						"uri-js": "3.0.2"
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0",
+						"uri-js": "^3.0.2"
 					}
 				},
 				"ajv-keywords": {
@@ -14597,18 +14598,18 @@
 					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"kind-of": "^6.0.2",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -14617,7 +14618,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -14626,7 +14627,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -14637,13 +14638,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -14652,7 +14653,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -14661,7 +14662,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-descriptor": {
@@ -14670,9 +14671,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -14689,14 +14690,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -14705,7 +14706,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -14714,7 +14715,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -14725,10 +14726,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -14737,7 +14738,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -14748,7 +14749,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -14757,7 +14758,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -14768,7 +14769,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -14777,7 +14778,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -14788,7 +14789,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -14797,7 +14798,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -14820,19 +14821,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.1",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				}
 			}
@@ -14843,7 +14844,7 @@
 			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
 			"dev": true,
 			"requires": {
-				"jscodeshift": "0.4.1"
+				"jscodeshift": "^0.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -14870,9 +14871,9 @@
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "1.0.0",
-						"has-color": "0.1.7",
-						"strip-ansi": "0.1.1"
+						"ansi-styles": "~1.0.0",
+						"has-color": "~0.1.0",
+						"strip-ansi": "~0.1.0"
 					}
 				},
 				"colors": {
@@ -14887,21 +14888,21 @@
 					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
 					"dev": true,
 					"requires": {
-						"async": "1.5.2",
-						"babel-plugin-transform-flow-strip-types": "6.22.0",
-						"babel-preset-es2015": "6.24.1",
-						"babel-preset-stage-1": "6.24.1",
-						"babel-register": "6.26.0",
-						"babylon": "6.18.0",
-						"colors": "1.2.1",
-						"flow-parser": "0.69.0",
-						"lodash": "4.17.5",
-						"micromatch": "2.3.11",
+						"async": "^1.5.0",
+						"babel-plugin-transform-flow-strip-types": "^6.8.0",
+						"babel-preset-es2015": "^6.9.0",
+						"babel-preset-stage-1": "^6.5.0",
+						"babel-register": "^6.9.0",
+						"babylon": "^6.17.3",
+						"colors": "^1.1.2",
+						"flow-parser": "^0.*",
+						"lodash": "^4.13.1",
+						"micromatch": "^2.3.7",
 						"node-dir": "0.1.8",
-						"nomnom": "1.8.1",
-						"recast": "0.12.9",
-						"temp": "0.8.3",
-						"write-file-atomic": "1.3.4"
+						"nomnom": "^1.8.1",
+						"recast": "^0.12.5",
+						"temp": "^0.8.1",
+						"write-file-atomic": "^1.2.0"
 					}
 				},
 				"nomnom": {
@@ -14910,8 +14911,8 @@
 					"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
 					"dev": true,
 					"requires": {
-						"chalk": "0.4.0",
-						"underscore": "1.6.0"
+						"chalk": "~0.4.0",
+						"underscore": "~1.6.0"
 					}
 				},
 				"recast": {
@@ -14921,10 +14922,10 @@
 					"dev": true,
 					"requires": {
 						"ast-types": "0.10.1",
-						"core-js": "2.5.3",
-						"esprima": "4.0.0",
-						"private": "0.1.8",
-						"source-map": "0.6.1"
+						"core-js": "^2.4.1",
+						"esprima": "~4.0.0",
+						"private": "~0.1.5",
+						"source-map": "~0.6.1"
 					}
 				},
 				"source-map": {
@@ -14951,9 +14952,9 @@
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				}
 			}
@@ -14964,31 +14965,31 @@
 			"integrity": "sha512-0lnOi3yla8FsZVuMsbfnNRB/8DlfuDugKdekC+4ykydZG0+UOidMi5J5LLWN4c0VJ8PqC19yMXXkYyCq78OuqA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"cross-spawn": "6.0.5",
-				"diff": "3.5.0",
-				"enhanced-resolve": "4.0.0",
-				"glob-all": "3.1.0",
-				"global-modules": "1.0.0",
-				"got": "8.3.0",
-				"inquirer": "5.2.0",
-				"interpret": "1.1.0",
-				"jscodeshift": "0.5.0",
-				"listr": "0.13.0",
-				"loader-utils": "1.1.0",
-				"lodash": "4.17.5",
-				"log-symbols": "2.2.0",
-				"mkdirp": "0.5.1",
-				"p-each-series": "1.0.0",
-				"p-lazy": "1.0.0",
-				"prettier": "1.11.1",
-				"resolve-cwd": "2.0.0",
-				"supports-color": "5.3.0",
-				"v8-compile-cache": "1.1.2",
-				"webpack-addons": "1.1.5",
-				"yargs": "11.0.0",
-				"yeoman-environment": "2.0.5",
-				"yeoman-generator": "2.0.3"
+				"chalk": "^2.3.2",
+				"cross-spawn": "^6.0.5",
+				"diff": "^3.5.0",
+				"enhanced-resolve": "^4.0.0",
+				"glob-all": "^3.1.0",
+				"global-modules": "^1.0.0",
+				"got": "^8.2.0",
+				"inquirer": "^5.1.0",
+				"interpret": "^1.0.4",
+				"jscodeshift": "^0.5.0",
+				"listr": "^0.13.0",
+				"loader-utils": "^1.1.0",
+				"lodash": "^4.17.5",
+				"log-symbols": "^2.2.0",
+				"mkdirp": "^0.5.1",
+				"p-each-series": "^1.0.0",
+				"p-lazy": "^1.0.0",
+				"prettier": "^1.5.3",
+				"resolve-cwd": "^2.0.0",
+				"supports-color": "^5.3.0",
+				"v8-compile-cache": "^1.1.2",
+				"webpack-addons": "^1.1.5",
+				"yargs": "^11.0.0",
+				"yeoman-environment": "^2.0.0",
+				"yeoman-generator": "^2.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -15003,7 +15004,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -15012,9 +15013,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cliui": {
@@ -15023,9 +15024,9 @@
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 					"dev": true,
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -15034,11 +15035,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "1.0.4",
-						"path-key": "2.0.1",
-						"semver": "5.5.0",
-						"shebang-command": "1.2.0",
-						"which": "1.3.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"diff": {
@@ -15053,7 +15054,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -15068,19 +15069,19 @@
 					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.0.0",
-						"chalk": "2.3.2",
-						"cli-cursor": "2.1.0",
-						"cli-width": "2.2.0",
-						"external-editor": "2.1.0",
-						"figures": "2.0.0",
-						"lodash": "4.17.5",
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.1.0",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
 						"mute-stream": "0.0.7",
-						"run-async": "2.3.0",
-						"rxjs": "5.5.8",
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"through": "2.3.8"
+						"run-async": "^2.2.0",
+						"rxjs": "^5.5.2",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
 					}
 				},
 				"lodash": {
@@ -15101,7 +15102,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -15110,7 +15111,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"yargs": {
@@ -15119,18 +15120,18 @@
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
-						"cliui": "4.0.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					}
 				},
 				"yargs-parser": {
@@ -15139,21 +15140,22 @@
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
 		},
 		"webpack-rtl-plugin": {
 			"version": "github:yoavf/webpack-rtl-plugin#fc5a2f20dd99fde8f86f297844aefde601780fa3",
+			"from": "github:yoavf/webpack-rtl-plugin#develop",
 			"dev": true,
 			"requires": {
-				"@romainberger/css-diff": "1.0.3",
-				"async": "2.6.0",
-				"cssnano": "3.10.0",
-				"postcss": "5.2.18",
-				"rtlcss": "2.2.1",
-				"webpack-sources": "0.1.5"
+				"@romainberger/css-diff": "^1.0.3",
+				"async": "^2.0.0-rc.6",
+				"cssnano": "^3.7.1",
+				"postcss": "^5.0.21",
+				"rtlcss": "^2.0.4",
+				"webpack-sources": "^0.1.2"
 			},
 			"dependencies": {
 				"source-list-map": {
@@ -15180,8 +15182,8 @@
 			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "2.0.0",
-				"source-map": "0.6.1"
+				"source-list-map": "^2.0.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -15212,9 +15214,9 @@
 			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "4.7.0",
-				"tr46": "1.0.1",
-				"webidl-conversions": "4.0.2"
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.0",
+				"webidl-conversions": "^4.0.1"
 			}
 		},
 		"whet.extend": {
@@ -15228,7 +15230,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -15242,7 +15244,7 @@
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2"
+				"string-width": "^1.0.2"
 			},
 			"dependencies": {
 				"string-width": {
@@ -15251,9 +15253,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -15277,7 +15279,7 @@
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.7"
+				"errno": "~0.1.7"
 			}
 		},
 		"wrap-ansi": {
@@ -15285,8 +15287,8 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"string-width": {
@@ -15294,9 +15296,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -15313,7 +15315,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -15322,9 +15324,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ws": {
@@ -15333,9 +15335,9 @@
 			"integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1",
-				"ultron": "1.1.1"
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0",
+				"ultron": "~1.1.0"
 			}
 		},
 		"xml-name-validator": {
@@ -15365,18 +15367,18 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
 			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"requires": {
-				"cliui": "4.1.0",
-				"decamelize": "1.2.0",
-				"find-up": "2.1.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "8.1.0"
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^8.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -15389,9 +15391,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -15399,7 +15401,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -15407,7 +15409,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -15417,7 +15419,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
 			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			}
 		},
 		"yauzl": {
@@ -15426,7 +15428,7 @@
 			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
 			"dev": true,
 			"requires": {
-				"fd-slicer": "1.0.1"
+				"fd-slicer": "~1.0.1"
 			}
 		},
 		"yeoman-environment": {
@@ -15435,19 +15437,19 @@
 			"integrity": "sha512-6/W7/B54OPHJXob0n0+pmkwFsirC8cokuQkPSmT/D0lCcSxkKtg/BA6ZnjUBIwjuGqmw3DTrT4en++htaUju5g==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"debug": "3.1.0",
-				"diff": "3.4.0",
-				"escape-string-regexp": "1.0.5",
-				"globby": "6.1.0",
-				"grouped-queue": "0.3.3",
-				"inquirer": "3.3.0",
-				"is-scoped": "1.0.0",
-				"lodash": "4.17.5",
-				"log-symbols": "2.2.0",
-				"mem-fs": "1.1.3",
-				"text-table": "0.2.0",
-				"untildify": "3.0.2"
+				"chalk": "^2.1.0",
+				"debug": "^3.1.0",
+				"diff": "^3.3.1",
+				"escape-string-regexp": "^1.0.2",
+				"globby": "^6.1.0",
+				"grouped-queue": "^0.3.3",
+				"inquirer": "^3.3.0",
+				"is-scoped": "^1.0.0",
+				"lodash": "^4.17.4",
+				"log-symbols": "^2.1.0",
+				"mem-fs": "^1.1.0",
+				"text-table": "^0.2.0",
+				"untildify": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15456,7 +15458,7 @@
 					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -15465,9 +15467,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -15504,7 +15506,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -15515,31 +15517,31 @@
 			"integrity": "sha512-mODmrZ26a94djmGZZuIiomSGlN4wULdou29ZwcySupb2e9FdvoCl7Ps2FqHFjEHio3kOl/iBeaNqrnx3C3NwWg==",
 			"dev": true,
 			"requires": {
-				"async": "2.6.0",
-				"chalk": "2.3.2",
-				"cli-table": "0.3.1",
-				"cross-spawn": "5.1.0",
-				"dargs": "5.1.0",
-				"dateformat": "3.0.3",
-				"debug": "3.1.0",
-				"detect-conflict": "1.0.1",
-				"error": "7.0.2",
-				"find-up": "2.1.0",
-				"github-username": "4.1.0",
-				"istextorbinary": "2.2.1",
-				"lodash": "4.17.5",
-				"make-dir": "1.2.0",
-				"mem-fs-editor": "3.0.2",
-				"minimist": "1.2.0",
-				"pretty-bytes": "4.0.2",
-				"read-chunk": "2.1.0",
-				"read-pkg-up": "3.0.0",
-				"rimraf": "2.6.2",
-				"run-async": "2.3.0",
-				"shelljs": "0.8.1",
-				"text-table": "0.2.0",
-				"through2": "2.0.3",
-				"yeoman-environment": "2.0.5"
+				"async": "^2.6.0",
+				"chalk": "^2.3.0",
+				"cli-table": "^0.3.1",
+				"cross-spawn": "^5.1.0",
+				"dargs": "^5.1.0",
+				"dateformat": "^3.0.2",
+				"debug": "^3.1.0",
+				"detect-conflict": "^1.0.0",
+				"error": "^7.0.2",
+				"find-up": "^2.1.0",
+				"github-username": "^4.0.0",
+				"istextorbinary": "^2.1.0",
+				"lodash": "^4.17.4",
+				"make-dir": "^1.1.0",
+				"mem-fs-editor": "^3.0.2",
+				"minimist": "^1.2.0",
+				"pretty-bytes": "^4.0.2",
+				"read-chunk": "^2.1.0",
+				"read-pkg-up": "^3.0.0",
+				"rimraf": "^2.6.2",
+				"run-async": "^2.0.0",
+				"shelljs": "^0.8.0",
+				"text-table": "^0.2.0",
+				"through2": "^2.0.0",
+				"yeoman-environment": "^2.0.5"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15548,7 +15550,7 @@
 					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -15557,9 +15559,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -15577,7 +15579,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -15620,7 +15622,7 @@
 					"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -15656,7 +15658,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
 			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"chalk": "2.3.1",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -51,7 +51,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -60,9 +60,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -77,7 +77,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -91,7 +91,7 @@
 				"@babel/code-frame": "7.0.0-beta.31",
 				"@babel/types": "7.0.0-beta.31",
 				"babylon": "7.0.0-beta.31",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.5"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -100,9 +100,9 @@
 					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
+						"chalk": "2.3.0",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				},
 				"ansi-styles": {
@@ -111,7 +111,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"babylon": {
@@ -126,9 +126,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
 					}
 				},
 				"supports-color": {
@@ -137,7 +137,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -152,10 +152,10 @@
 				"@babel/helper-function-name": "7.0.0-beta.31",
 				"@babel/types": "7.0.0-beta.31",
 				"babylon": "7.0.0-beta.31",
-				"debug": "^3.0.1",
-				"globals": "^10.0.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
+				"debug": "3.1.0",
+				"globals": "10.4.0",
+				"invariant": "2.2.2",
+				"lodash": "4.17.5"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -164,9 +164,9 @@
 					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
+						"chalk": "2.3.0",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				},
 				"ansi-styles": {
@@ -175,7 +175,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"babylon": {
@@ -190,9 +190,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
 					}
 				},
 				"debug": {
@@ -216,7 +216,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -227,9 +227,9 @@
 			"integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
-				"to-fast-properties": "^2.0.0"
+				"esutils": "2.0.2",
+				"lodash": "4.17.5",
+				"to-fast-properties": "2.0.0"
 			}
 		},
 		"@romainberger/css-diff": {
@@ -238,8 +238,8 @@
 			"integrity": "sha1-ztOHU11PQqQqwf4TwJ3pf1rhNEw=",
 			"dev": true,
 			"requires": {
-				"lodash.merge": "^4.4.0",
-				"postcss": "^5.0.21"
+				"lodash.merge": "4.6.1",
+				"postcss": "5.2.18"
 			}
 		},
 		"@sindresorhus/is": {
@@ -259,7 +259,7 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-1.0.6.tgz",
 			"integrity": "sha512-IyL7KzYGzMEg+FFyTrQzD/CUfABYCXOvmnm29vBZBA3JMER1ep3/+NFDe6CpWVEEMCw94oj2gUOSQ4YKVgDjUQ==",
 			"requires": {
-				"@wordpress/dom-ready": "^1.0.3"
+				"@wordpress/dom-ready": "1.0.4"
 			}
 		},
 		"@wordpress/autop": {
@@ -273,8 +273,8 @@
 			"integrity": "sha512-YNcXr33fUUHg9HncNhUNkG2jnCAtnvC5hN0ZdDdTVe7r7aR4l+gCTCZXvM/0SHqikrNhRNjSrE5ZM/3u2zsOyw==",
 			"dev": true,
 			"requires": {
-				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.5"
+				"gettext-parser": "1.3.1",
+				"lodash": "4.17.5"
 			},
 			"dependencies": {
 				"gettext-parser": {
@@ -283,8 +283,8 @@
 					"integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
 					"dev": true,
 					"requires": {
-						"encoding": "^0.1.12",
-						"safe-buffer": "^5.1.1"
+						"encoding": "0.1.12",
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"lodash": {
@@ -301,11 +301,11 @@
 			"integrity": "sha512-DJ4P3gwj8gUQy94GeaVdHTh2JVKQ8eNFwCQi4GDhCcq78KDAJjRO497ZwoJWJR0MVq5a3XfsrJ6fVf7S8APfUw==",
 			"dev": true,
 			"requires": {
-				"@wordpress/browserslist-config": "^2.1.3",
-				"babel-plugin-transform-object-rest-spread": "^6.23.0",
-				"babel-plugin-transform-react-jsx": "^6.24.1",
-				"babel-plugin-transform-runtime": "^6.23.0",
-				"babel-preset-env": "^1.6.1"
+				"@wordpress/browserslist-config": "2.1.3",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-runtime": "6.23.0",
+				"babel-preset-env": "1.6.1"
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -320,7 +320,7 @@
 			"integrity": "sha512-7GDENg5juXusGye4JqKAjfAr1EcKNNmJ6GUnnUrdOkXgjnT5CoAw2ADJxvtALtl4vx6o/nqzJxp9YQ/bZi85Dg==",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"@wordpress/dom-ready": {
@@ -338,10 +338,10 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-1.1.0.tgz",
 			"integrity": "sha512-zzpyhSaVOv5iLIwkJ4nrPt7FO+50xHlGDSJljfGdS+ypvFAnEHpCkkJ84F3NhHaYIIZqMEn5lC4k1edIaIqAbA==",
 			"requires": {
-				"gettext-parser": "^1.3.1",
-				"jed": "^1.1.1",
-				"lodash": "^4.17.5",
-				"memize": "^1.0.5"
+				"gettext-parser": "1.3.1",
+				"jed": "1.1.1",
+				"lodash": "4.17.5",
+				"memize": "1.0.5"
 			},
 			"dependencies": {
 				"lodash": {
@@ -362,8 +362,8 @@
 			"integrity": "sha512-PwhDL2H4EI6adnGyQo0v4p8zRokjNu4DJ3EDZpH9dmNK0/G9hKuuIAwGN2e9RGyAiqipddCkt5y4qzH1mx8PJw==",
 			"dev": true,
 			"requires": {
-				"jest-matcher-utils": "^22.4.0",
-				"lodash": "^4.17.4"
+				"jest-matcher-utils": "22.4.0",
+				"lodash": "4.17.5"
 			}
 		},
 		"@wordpress/jest-preset-default": {
@@ -372,12 +372,12 @@
 			"integrity": "sha512-1+uREUyhMWBanX4qceevrFEuaFm/gRKIKiDb36Wc5X02ODEaUaQ6qjIvrD6fariYtvxQpjC8TBjKapsvSaqHHw==",
 			"dev": true,
 			"requires": {
-				"@wordpress/jest-console": "^1.0.5",
-				"babel-jest": "^22.1.0",
-				"enzyme": "^3.3.0",
-				"enzyme-adapter-react-16": "^1.1.1",
-				"jest-enzyme": "^4.0.2",
-				"pegjs": "^0.10.0"
+				"@wordpress/jest-console": "1.0.5",
+				"babel-jest": "22.4.0",
+				"enzyme": "3.3.0",
+				"enzyme-adapter-react-16": "1.1.1",
+				"jest-enzyme": "4.2.0",
+				"pegjs": "0.10.0"
 			}
 		},
 		"@wordpress/scripts": {
@@ -386,11 +386,11 @@
 			"integrity": "sha512-gbtpV6i4SKi7Pya8qeB6N9FGyWAMBtyAsRnFg6Lv6Ejh0Pk9R2Aa71GjX4ZAMzq1LFuVNdhciIybdxDPSsP8sQ==",
 			"dev": true,
 			"requires": {
-				"@wordpress/babel-preset-default": "^1.1.1",
-				"@wordpress/jest-preset-default": "^1.0.3",
-				"cross-spawn": "^5.1.0",
-				"jest": "^22.4.0",
-				"read-pkg-up": "^3.0.0"
+				"@wordpress/babel-preset-default": "1.2.0",
+				"@wordpress/jest-preset-default": "1.0.3",
+				"cross-spawn": "5.1.0",
+				"jest": "22.4.0",
+				"read-pkg-up": "3.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -399,7 +399,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -408,10 +408,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"parse-json": {
@@ -420,8 +420,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.1",
+						"json-parse-better-errors": "1.0.1"
 					}
 				},
 				"path-type": {
@@ -430,7 +430,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				},
 				"pify": {
@@ -445,9 +445,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -456,8 +456,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
 					}
 				}
 			}
@@ -468,11 +468,11 @@
 			"integrity": "sha512-KT+C4vCh6kYux5fAcyM9Nqj0pVKxYptJde3AcggvZ1rJ71+LNJI63EQFmUhJU0reaNduzQ+YFub9tcQrc7ckmA=="
 		},
 		"@wordpress/wordcount": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-1.0.0.tgz",
-			"integrity": "sha512-N7JyhF+wdFDgDJbxZdscQ0vivdimvk/CjmNdonoSx4QHqgYfZOSSsFgpYg/rzeRBRFfT+e3RSu7LTdOZ/t54LA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-1.0.2.tgz",
+			"integrity": "sha512-UZGVjKvyTWJuTCEhbgZj0Ilmv/Ufj+dsit0nxawPz5+1m54fbqy8/hpfCH9RiS9JmMWfE3TB6rB4U/Bd0NmFZg==",
 			"requires": {
-				"lodash": "^4.17.4"
+				"lodash": "4.17.5"
 			}
 		},
 		"abab": {
@@ -498,7 +498,7 @@
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0"
+				"acorn": "5.4.1"
 			}
 		},
 		"acorn-globals": {
@@ -507,7 +507,7 @@
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0"
+				"acorn": "5.4.1"
 			}
 		},
 		"acorn-jsx": {
@@ -516,7 +516,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "^3.0.4"
+				"acorn": "3.3.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -533,7 +533,7 @@
 			"integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
 			"dev": true,
 			"requires": {
-				"es6-promisify": "^5.0.0"
+				"es6-promisify": "5.0.0"
 			}
 		},
 		"ajv": {
@@ -542,10 +542,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"co": "4.6.0",
+				"fast-deep-equal": "1.0.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
@@ -560,9 +560,9 @@
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"alphanum-sort": {
@@ -606,8 +606,8 @@
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
 			}
 		},
 		"append-transform": {
@@ -616,7 +616,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "^1.0.0"
+				"default-require-extensions": "1.0.0"
 			}
 		},
 		"aproba": {
@@ -631,8 +631,8 @@
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"dev": true,
 			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"delegates": "1.0.0",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"argparse": {
@@ -641,7 +641,7 @@
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			},
 			"dependencies": {
 				"sprintf-js": {
@@ -665,7 +665,7 @@
 			"dev": true,
 			"requires": {
 				"ast-types-flow": "0.0.7",
-				"commander": "^2.11.0"
+				"commander": "2.14.1"
 			}
 		},
 		"arr-diff": {
@@ -674,7 +674,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.0.1"
+				"arr-flatten": "1.1.0"
 			}
 		},
 		"arr-flatten": {
@@ -713,8 +713,8 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
 			}
 		},
 		"array-union": {
@@ -723,7 +723,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -761,9 +761,9 @@
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"bn.js": "4.11.8",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
 			}
 		},
 		"assert": {
@@ -811,7 +811,7 @@
 			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.14.0"
+				"lodash": "4.17.5"
 			}
 		},
 		"async-each": {
@@ -850,12 +850,12 @@
 			"integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^3.2.0",
-				"caniuse-lite": "^1.0.30000817",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^6.0.20",
-				"postcss-value-parser": "^3.2.3"
+				"browserslist": "3.2.4",
+				"caniuse-lite": "1.0.30000821",
+				"normalize-range": "0.1.2",
+				"num2fraction": "1.2.2",
+				"postcss": "6.0.21",
+				"postcss-value-parser": "3.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -864,7 +864,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"browserslist": {
@@ -873,8 +873,8 @@
 					"integrity": "sha512-Dwe62y/fNAcMfknzGJnkh7feISrrN0SmRvMFozb+Y2+qg7rfTIH5MS8yHzaIXcEWl8fPeIcdhZNQi1Lux+7dlg==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30000821",
-						"electron-to-chromium": "^1.3.41"
+						"caniuse-lite": "1.0.30000821",
+						"electron-to-chromium": "1.3.41"
 					}
 				},
 				"caniuse-lite": {
@@ -889,9 +889,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
 					}
 				},
 				"electron-to-chromium": {
@@ -912,9 +912,9 @@
 					"integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.3.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.3.0"
+						"chalk": "2.3.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.3.0"
 					}
 				},
 				"source-map": {
@@ -929,7 +929,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -966,9 +966,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			}
 		},
 		"babel-core": {
@@ -977,25 +977,25 @@
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.0",
-				"debug": "^2.6.8",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.7",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.6"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			}
 		},
 		"babel-eslint": {
@@ -1016,9 +1016,9 @@
 					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
+						"chalk": "2.3.0",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				},
 				"ansi-styles": {
@@ -1027,7 +1027,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"babylon": {
@@ -1042,9 +1042,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
 					}
 				},
 				"supports-color": {
@@ -1053,7 +1053,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -1064,14 +1064,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.5",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -1088,9 +1088,9 @@
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1099,9 +1099,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -1110,9 +1110,9 @@
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"esutils": "^2.0.2"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"esutils": "2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -1121,10 +1121,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-define-map": {
@@ -1133,10 +1133,10 @@
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.5"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -1145,9 +1145,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-explode-class": {
@@ -1156,10 +1156,10 @@
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
 			"dev": true,
 			"requires": {
-				"babel-helper-bindify-decorators": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-bindify-decorators": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -1168,11 +1168,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -1181,8 +1181,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -1191,8 +1191,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -1201,8 +1201,8 @@
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-regex": {
@@ -1211,9 +1211,9 @@
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.5"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -1222,11 +1222,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -1235,12 +1235,12 @@
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helpers": {
@@ -1249,8 +1249,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-jest": {
@@ -1259,8 +1259,8 @@
 			"integrity": "sha512-A/safCd5jSf1D98XoHCN3YYuGurtUPntuPh8b7UxsLNfEp/QC8UwdL+VEGSLN5Fk3+tS/Jdbf5NK/T2it8RGYw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.5",
-				"babel-preset-jest": "^22.2.0"
+				"babel-plugin-istanbul": "4.1.5",
+				"babel-preset-jest": "22.2.0"
 			}
 		},
 		"babel-loader": {
@@ -1269,9 +1269,9 @@
 			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^1.0.0",
-				"loader-utils": "^1.0.2",
-				"mkdirp": "^0.5.1"
+				"find-cache-dir": "1.0.0",
+				"loader-utils": "1.1.0",
+				"mkdirp": "0.5.1"
 			}
 		},
 		"babel-messages": {
@@ -1280,7 +1280,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -1289,7 +1289,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -1298,9 +1298,9 @@
 			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.7.5",
-				"test-exclude": "^4.1.1"
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.9.2",
+				"test-exclude": "4.2.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -1309,7 +1309,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				}
 			}
@@ -1398,9 +1398,9 @@
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-generators": "^6.5.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-generators": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-async-to-generator": {
@@ -1409,9 +1409,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-class-constructor-call": {
@@ -1420,9 +1420,9 @@
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-syntax-class-constructor-call": "6.18.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -1431,10 +1431,10 @@
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-decorators": {
@@ -1443,11 +1443,11 @@
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-class": "^6.24.1",
-				"babel-plugin-syntax-decorators": "^6.13.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-class": "6.24.1",
+				"babel-plugin-syntax-decorators": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1456,7 +1456,7 @@
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1465,7 +1465,7 @@
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1474,11 +1474,11 @@
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.5"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1487,15 +1487,15 @@
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-define-map": "6.26.0",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1504,8 +1504,8 @@
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1514,7 +1514,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -1523,8 +1523,8 @@
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1533,7 +1533,7 @@
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1542,9 +1542,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1553,7 +1553,7 @@
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -1562,9 +1562,9 @@
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1573,10 +1573,10 @@
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -1585,9 +1585,9 @@
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -1596,9 +1596,9 @@
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1607,8 +1607,8 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1617,12 +1617,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1631,8 +1631,8 @@
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1641,7 +1641,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1650,9 +1650,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1661,7 +1661,7 @@
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -1670,7 +1670,7 @@
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1679,9 +1679,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1690,9 +1690,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-export-extensions": {
@@ -1701,8 +1701,8 @@
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-export-extensions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-export-extensions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1711,8 +1711,8 @@
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1721,8 +1721,8 @@
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -1731,9 +1731,9 @@
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-react-jsx": "^6.24.1",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-react-jsx": "6.26.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1742,7 +1742,7 @@
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "^0.10.0"
+				"regenerator-transform": "0.10.1"
 			}
 		},
 		"babel-plugin-transform-runtime": {
@@ -1751,7 +1751,7 @@
 			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -1760,8 +1760,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-preset-env": {
@@ -1770,36 +1770,36 @@
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-to-generator": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-				"babel-plugin-transform-es2015-classes": "^6.23.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-				"babel-plugin-transform-es2015-for-of": "^6.23.0",
-				"babel-plugin-transform-es2015-function-name": "^6.22.0",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-				"babel-plugin-transform-es2015-object-super": "^6.22.0",
-				"babel-plugin-transform-es2015-parameters": "^6.23.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
-				"babel-plugin-transform-regenerator": "^6.22.0",
-				"browserslist": "^2.1.2",
-				"invariant": "^2.2.2",
-				"semver": "^5.3.0"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0",
+				"browserslist": "2.11.3",
+				"invariant": "2.2.2",
+				"semver": "5.3.0"
 			}
 		},
 		"babel-preset-es2015": {
@@ -1808,30 +1808,30 @@
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-				"babel-plugin-transform-es2015-classes": "^6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-				"babel-plugin-transform-es2015-for-of": "^6.22.0",
-				"babel-plugin-transform-es2015-function-name": "^6.24.1",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-				"babel-plugin-transform-es2015-object-super": "^6.24.1",
-				"babel-plugin-transform-es2015-parameters": "^6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-				"babel-plugin-transform-regenerator": "^6.24.1"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0"
 			}
 		},
 		"babel-preset-jest": {
@@ -1840,8 +1840,8 @@
 			"integrity": "sha512-p61cPMGYlSgfNScn1yQuVnLguWE4bjhB/br4KQDMbYZG+v6ryE5Ch7TKukjA6mRuIQj1zhyou7Sbpqrh4/N6Pg==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^22.2.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"babel-plugin-jest-hoist": "22.2.0",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
 			}
 		},
 		"babel-preset-stage-1": {
@@ -1850,9 +1850,9 @@
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-class-constructor-call": "^6.24.1",
-				"babel-plugin-transform-export-extensions": "^6.22.0",
-				"babel-preset-stage-2": "^6.24.1"
+				"babel-plugin-transform-class-constructor-call": "6.24.1",
+				"babel-plugin-transform-export-extensions": "6.22.0",
+				"babel-preset-stage-2": "6.24.1"
 			}
 		},
 		"babel-preset-stage-2": {
@@ -1861,10 +1861,10 @@
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "^6.18.0",
-				"babel-plugin-transform-class-properties": "^6.24.1",
-				"babel-plugin-transform-decorators": "^6.24.1",
-				"babel-preset-stage-3": "^6.24.1"
+				"babel-plugin-syntax-dynamic-import": "6.18.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-decorators": "6.24.1",
+				"babel-preset-stage-3": "6.24.1"
 			}
 		},
 		"babel-preset-stage-3": {
@@ -1873,11 +1873,11 @@
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-generator-functions": "^6.24.1",
-				"babel-plugin-transform-async-to-generator": "^6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
-				"babel-plugin-transform-object-rest-spread": "^6.22.0"
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-generator-functions": "6.24.1",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-object-rest-spread": "6.26.0"
 			}
 		},
 		"babel-register": {
@@ -1886,13 +1886,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.3",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.5",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1907,7 +1907,7 @@
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"dev": true,
 					"requires": {
-						"source-map": "^0.5.6"
+						"source-map": "0.5.7"
 					}
 				}
 			}
@@ -1918,8 +1918,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1936,11 +1936,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.5"
 			}
 		},
 		"babel-traverse": {
@@ -1949,15 +1949,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.2",
+				"lodash": "4.17.5"
 			}
 		},
 		"babel-types": {
@@ -1966,10 +1966,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.5",
+				"to-fast-properties": "1.0.3"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -1997,13 +1997,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2012,7 +2012,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"isobject": {
@@ -2036,7 +2036,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"big.js": {
@@ -2063,7 +2063,7 @@
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.0"
+				"inherits": "2.0.3"
 			}
 		},
 		"bluebird": {
@@ -2089,7 +2089,7 @@
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"dev": true,
 			"requires": {
-				"hoek": "4.x.x"
+				"hoek": "4.2.0"
 			}
 		},
 		"brace-expansion": {
@@ -2097,7 +2097,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -2107,9 +2107,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
 			}
 		},
 		"brorand": {
@@ -2147,12 +2147,12 @@
 			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.3",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"browserify-cipher": {
@@ -2161,9 +2161,9 @@
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
+				"browserify-aes": "1.1.1",
+				"browserify-des": "1.0.0",
+				"evp_bytestokey": "1.0.3"
 			}
 		},
 		"browserify-des": {
@@ -2172,9 +2172,9 @@
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1"
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.3"
 			}
 		},
 		"browserify-rsa": {
@@ -2183,8 +2183,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "4.11.8",
+				"randombytes": "2.0.6"
 			}
 		},
 		"browserify-sign": {
@@ -2193,13 +2193,13 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.1",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.2",
-				"elliptic": "^6.0.0",
-				"inherits": "^2.0.1",
-				"parse-asn1": "^5.0.0"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"elliptic": "6.4.0",
+				"inherits": "2.0.3",
+				"parse-asn1": "5.1.0"
 			}
 		},
 		"browserify-zlib": {
@@ -2208,7 +2208,7 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"dev": true,
 			"requires": {
-				"pako": "~1.0.5"
+				"pako": "1.0.6"
 			}
 		},
 		"browserslist": {
@@ -2217,8 +2217,8 @@
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000792",
-				"electron-to-chromium": "^1.3.30"
+				"caniuse-lite": "1.0.30000828",
+				"electron-to-chromium": "1.3.33"
 			}
 		},
 		"bser": {
@@ -2227,7 +2227,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"buffer": {
@@ -2236,9 +2236,9 @@
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"base64-js": "1.2.3",
+				"ieee754": "1.1.11",
+				"isarray": "1.0.0"
 			}
 		},
 		"buffer-xor": {
@@ -2265,19 +2265,19 @@
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.5.1",
-				"chownr": "^1.0.1",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.1.11",
-				"lru-cache": "^4.1.1",
-				"mississippi": "^2.0.0",
-				"mkdirp": "^0.5.1",
-				"move-concurrently": "^1.0.1",
-				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.2",
-				"ssri": "^5.2.4",
-				"unique-filename": "^1.1.0",
-				"y18n": "^4.0.0"
+				"bluebird": "3.5.1",
+				"chownr": "1.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.2",
+				"mississippi": "2.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.3.0",
+				"unique-filename": "1.1.0",
+				"y18n": "4.0.0"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -2286,8 +2286,8 @@
 					"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 					"dev": true,
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
 					}
 				},
 				"y18n": {
@@ -2304,15 +2304,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -2350,9 +2350,9 @@
 					"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
 					"dev": true,
 					"requires": {
-						"prepend-http": "^2.0.0",
-						"query-string": "^5.0.1",
-						"sort-keys": "^2.0.0"
+						"prepend-http": "2.0.0",
+						"query-string": "5.1.1",
+						"sort-keys": "2.0.0"
 					}
 				},
 				"prepend-http": {
@@ -2367,9 +2367,9 @@
 					"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 					"dev": true,
 					"requires": {
-						"decode-uri-component": "^0.2.0",
-						"object-assign": "^4.1.0",
-						"strict-uri-encode": "^1.0.0"
+						"decode-uri-component": "0.2.0",
+						"object-assign": "4.1.1",
+						"strict-uri-encode": "1.1.0"
 					}
 				},
 				"sort-keys": {
@@ -2378,7 +2378,7 @@
 					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 					"dev": true,
 					"requires": {
-						"is-plain-obj": "^1.0.0"
+						"is-plain-obj": "1.1.0"
 					}
 				}
 			}
@@ -2389,7 +2389,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "0.2.0"
 			},
 			"dependencies": {
 				"callsites": {
@@ -2417,8 +2417,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -2435,10 +2435,10 @@
 			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
 			"dev": true,
 			"requires": {
-				"browserslist": "^1.3.6",
-				"caniuse-db": "^1.0.30000529",
-				"lodash.memoize": "^4.1.2",
-				"lodash.uniq": "^4.5.0"
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000804",
+				"lodash.memoize": "4.1.2",
+				"lodash.uniq": "4.5.0"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -2447,8 +2447,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
+						"caniuse-db": "1.0.30000804",
+						"electron-to-chromium": "1.3.33"
 					}
 				}
 			}
@@ -2478,8 +2478,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
 			}
 		},
 		"chalk": {
@@ -2488,11 +2488,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
 			}
 		},
 		"chardet": {
@@ -2507,13 +2507,13 @@
 			"integrity": "sha512-52fHDe/0pbidY3InI33Beyb/oarySfLANlXxLGBl9lLVrLIW88XWIwu4jGJrQ1imuWzX5ukNGWXUyCgmgVUD8A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.3.0",
-				"map-values": "^1.0.1",
-				"minimist": "^1.2.0",
-				"object-filter": "^1.0.2",
-				"object.assign": "^4.0.4",
-				"run-parallel": "^1.1.4",
-				"semver": "^5.0.3"
+				"chalk": "2.3.0",
+				"map-values": "1.0.1",
+				"minimist": "1.2.0",
+				"object-filter": "1.0.2",
+				"object.assign": "4.1.0",
+				"run-parallel": "1.1.6",
+				"semver": "5.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -2522,7 +2522,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -2531,9 +2531,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
 					}
 				},
 				"minimist": {
@@ -2548,7 +2548,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -2559,12 +2559,12 @@
 			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
 			"dev": true,
 			"requires": {
-				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.0",
-				"entities": "~1.1.1",
-				"htmlparser2": "^3.9.1",
-				"lodash": "^4.15.0",
-				"parse5": "^3.0.1"
+				"css-select": "1.2.0",
+				"dom-serializer": "0.1.0",
+				"entities": "1.1.1",
+				"htmlparser2": "3.9.2",
+				"lodash": "4.17.5",
+				"parse5": "3.0.3"
 			}
 		},
 		"chokidar": {
@@ -2573,18 +2573,18 @@
 			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.1.2",
-				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"normalize-path": "^2.1.1",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.0"
+				"anymatch": "2.0.0",
+				"async-each": "1.0.1",
+				"braces": "2.3.1",
+				"fsevents": "1.1.3",
+				"glob-parent": "3.1.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "4.0.0",
+				"normalize-path": "2.1.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0",
+				"upath": "1.0.4"
 			},
 			"dependencies": {
 				"anymatch": {
@@ -2593,8 +2593,8 @@
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 					"dev": true,
 					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
+						"micromatch": "3.1.10",
+						"normalize-path": "2.1.1"
 					}
 				},
 				"arr-diff": {
@@ -2615,18 +2615,18 @@
 					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"kind-of": "^6.0.2",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"kind-of": "6.0.2",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2635,7 +2635,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -2644,7 +2644,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2655,13 +2655,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2670,7 +2670,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -2679,7 +2679,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-descriptor": {
@@ -2688,9 +2688,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -2707,14 +2707,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2723,7 +2723,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -2732,7 +2732,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2743,10 +2743,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2755,7 +2755,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2766,8 +2766,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -2776,7 +2776,7 @@
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"dev": true,
 							"requires": {
-								"is-extglob": "^2.1.0"
+								"is-extglob": "2.1.1"
 							}
 						}
 					}
@@ -2787,7 +2787,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2796,7 +2796,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2807,7 +2807,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2816,7 +2816,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2833,7 +2833,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.1"
+						"is-extglob": "2.1.1"
 					}
 				},
 				"is-number": {
@@ -2842,7 +2842,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2851,7 +2851,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2874,19 +2874,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.1",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				}
 			}
@@ -2915,8 +2915,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"circular-json": {
@@ -2937,7 +2937,7 @@
 			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3"
+				"chalk": "1.1.3"
 			}
 		},
 		"class-utils": {
@@ -2946,10 +2946,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2958,7 +2958,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2967,7 +2967,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2976,7 +2976,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2987,7 +2987,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2996,7 +2996,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -3007,9 +3007,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					}
 				},
 				"isobject": {
@@ -3037,7 +3037,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -3070,7 +3070,7 @@
 			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
-				"string-width": "^1.0.1"
+				"string-width": "1.0.2"
 			},
 			"dependencies": {
 				"string-width": {
@@ -3079,9 +3079,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -3097,9 +3097,9 @@
 			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
 			"integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
 			"requires": {
-				"good-listener": "^1.2.2",
-				"select": "^1.1.2",
-				"tiny-emitter": "^2.0.0"
+				"good-listener": "1.2.2",
+				"select": "1.1.2",
+				"tiny-emitter": "2.0.2"
 			}
 		},
 		"cliui": {
@@ -3108,9 +3108,9 @@
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wrap-ansi": "2.1.0"
 			},
 			"dependencies": {
 				"string-width": {
@@ -3119,9 +3119,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -3144,10 +3144,10 @@
 			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
 			"dev": true,
 			"requires": {
-				"for-own": "^1.0.0",
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.0",
-				"shallow-clone": "^1.0.0"
+				"for-own": "1.0.0",
+				"is-plain-object": "2.0.4",
+				"kind-of": "6.0.2",
+				"shallow-clone": "1.0.0"
 			},
 			"dependencies": {
 				"for-own": {
@@ -3156,7 +3156,7 @@
 					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
 					"dev": true,
 					"requires": {
-						"for-in": "^1.0.1"
+						"for-in": "1.0.2"
 					}
 				},
 				"kind-of": {
@@ -3173,7 +3173,7 @@
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"dev": true,
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "1.0.0"
 			}
 		},
 		"clone-stats": {
@@ -3188,9 +3188,9 @@
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
+				"inherits": "2.0.3",
+				"process-nextick-args": "2.0.0",
+				"readable-stream": "2.3.5"
 			},
 			"dependencies": {
 				"process-nextick-args": {
@@ -3205,13 +3205,13 @@
 					"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.0.3",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
 					}
 				}
 			}
@@ -3228,7 +3228,7 @@
 			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
 			"dev": true,
 			"requires": {
-				"q": "^1.1.2"
+				"q": "1.5.1"
 			}
 		},
 		"code-point-at": {
@@ -3253,8 +3253,8 @@
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
 					}
 				},
 				"assert-plus": {
@@ -3275,7 +3275,7 @@
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"cryptiles": {
@@ -3284,7 +3284,7 @@
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
 					"requires": {
-						"boom": "2.x.x"
+						"boom": "2.10.1"
 					}
 				},
 				"form-data": {
@@ -3293,9 +3293,9 @@
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
 					"dev": true,
 					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.17"
 					}
 				},
 				"har-schema": {
@@ -3310,8 +3310,8 @@
 					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
 					"dev": true,
 					"requires": {
-						"ajv": "^4.9.1",
-						"har-schema": "^1.0.5"
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
 					}
 				},
 				"hawk": {
@@ -3320,10 +3320,10 @@
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
 					"requires": {
-						"boom": "2.x.x",
-						"cryptiles": "2.x.x",
-						"hoek": "2.x.x",
-						"sntp": "1.x.x"
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
 					}
 				},
 				"hoek": {
@@ -3338,9 +3338,9 @@
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"dev": true,
 					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.1",
+						"sshpk": "1.13.1"
 					}
 				},
 				"performance-now": {
@@ -3361,28 +3361,28 @@
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
 					"dev": true,
 					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.17",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.1.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.3",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.1.0"
 					}
 				},
 				"sntp": {
@@ -3391,7 +3391,7 @@
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				}
 			}
@@ -3402,8 +3402,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color": {
@@ -3412,9 +3412,9 @@
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
 			"dev": true,
 			"requires": {
-				"clone": "^1.0.2",
-				"color-convert": "^1.3.0",
-				"color-string": "^0.3.0"
+				"clone": "1.0.3",
+				"color-convert": "1.9.1",
+				"color-string": "0.3.0"
 			}
 		},
 		"color-convert": {
@@ -3423,7 +3423,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -3438,7 +3438,7 @@
 			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.0.0"
+				"color-name": "1.1.3"
 			}
 		},
 		"colormin": {
@@ -3447,9 +3447,9 @@
 			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
 			"dev": true,
 			"requires": {
-				"color": "^0.11.0",
+				"color": "0.11.4",
 				"css-color-names": "0.0.4",
-				"has": "^1.0.1"
+				"has": "1.0.1"
 			}
 		},
 		"colors": {
@@ -3464,7 +3464,7 @@
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
@@ -3477,7 +3477,7 @@
 			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
 			"integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
 			"requires": {
-				"readable-stream": "^2.0.4"
+				"readable-stream": "2.3.3"
 			}
 		},
 		"commondir": {
@@ -3508,9 +3508,9 @@
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
 			}
 		},
 		"concurrently": {
@@ -3521,12 +3521,12 @@
 			"requires": {
 				"chalk": "0.5.1",
 				"commander": "2.6.0",
-				"date-fns": "^1.23.0",
-				"lodash": "^4.5.1",
+				"date-fns": "1.29.0",
+				"lodash": "4.17.5",
 				"rx": "2.3.24",
-				"spawn-command": "^0.0.2-1",
-				"supports-color": "^3.2.3",
-				"tree-kill": "^1.1.0"
+				"spawn-command": "0.0.2-1",
+				"supports-color": "3.2.3",
+				"tree-kill": "1.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3547,11 +3547,11 @@
 					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^1.1.0",
-						"escape-string-regexp": "^1.0.0",
-						"has-ansi": "^0.1.0",
-						"strip-ansi": "^0.3.0",
-						"supports-color": "^0.2.0"
+						"ansi-styles": "1.1.0",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "0.1.0",
+						"strip-ansi": "0.3.0",
+						"supports-color": "0.2.0"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -3574,7 +3574,7 @@
 					"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^0.2.0"
+						"ansi-regex": "0.2.1"
 					}
 				},
 				"has-flag": {
@@ -3589,7 +3589,7 @@
 					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^0.2.1"
+						"ansi-regex": "0.2.1"
 					}
 				},
 				"supports-color": {
@@ -3598,7 +3598,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -3608,8 +3608,8 @@
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
 			"integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
 			"requires": {
-				"ini": "^1.3.4",
-				"proto-list": "~1.2.1"
+				"ini": "1.3.5",
+				"proto-list": "1.2.4"
 			}
 		},
 		"console-browserify": {
@@ -3618,7 +3618,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "^0.1.4"
+				"date-now": "0.1.4"
 			}
 		},
 		"console-control-strings": {
@@ -3651,12 +3651,12 @@
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1",
-				"fs-write-stream-atomic": "^1.0.8",
-				"iferr": "^0.1.5",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.4",
-				"run-queue": "^1.0.0"
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
 			}
 		},
 		"copy-descriptor": {
@@ -3682,13 +3682,13 @@
 			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
 			"dev": true,
 			"requires": {
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.4.3",
-				"minimist": "^1.2.0",
-				"object-assign": "^4.1.0",
-				"os-homedir": "^1.0.1",
-				"parse-json": "^2.2.0",
-				"require-from-string": "^1.1.0"
+				"is-directory": "0.3.1",
+				"js-yaml": "3.10.0",
+				"minimist": "1.2.0",
+				"object-assign": "4.1.1",
+				"os-homedir": "1.0.2",
+				"parse-json": "2.2.0",
+				"require-from-string": "1.2.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -3705,8 +3705,8 @@
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.0"
 			}
 		},
 		"create-hash": {
@@ -3715,10 +3715,10 @@
 			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"sha.js": "^2.4.0"
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"sha.js": "2.4.11"
 			}
 		},
 		"create-hmac": {
@@ -3727,12 +3727,12 @@
 			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.11"
 			}
 		},
 		"cross-env": {
@@ -3741,8 +3741,8 @@
 			"integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.1.0",
-				"is-windows": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"is-windows": "1.0.1"
 			}
 		},
 		"cross-spawn": {
@@ -3750,9 +3750,9 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -3760,8 +3760,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
 					}
 				}
 			}
@@ -3772,7 +3772,7 @@
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"dev": true,
 			"requires": {
-				"boom": "5.x.x"
+				"boom": "5.2.0"
 			},
 			"dependencies": {
 				"boom": {
@@ -3781,7 +3781,7 @@
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"dev": true,
 					"requires": {
-						"hoek": "4.x.x"
+						"hoek": "4.2.0"
 					}
 				}
 			}
@@ -3792,17 +3792,17 @@
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0",
-				"randomfill": "^1.0.3"
+				"browserify-cipher": "1.0.0",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.0",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"diffie-hellman": "5.0.2",
+				"inherits": "2.0.3",
+				"pbkdf2": "3.0.14",
+				"public-encrypt": "4.0.0",
+				"randombytes": "2.0.6",
+				"randomfill": "1.0.4"
 			}
 		},
 		"css-color-names": {
@@ -3817,10 +3817,10 @@
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"dev": true,
 			"requires": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
+				"boolbase": "1.0.0",
+				"css-what": "2.1.0",
 				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
+				"nth-check": "1.0.1"
 			}
 		},
 		"css-what": {
@@ -3835,38 +3835,38 @@
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
 			"dev": true,
 			"requires": {
-				"autoprefixer": "^6.3.1",
-				"decamelize": "^1.1.2",
-				"defined": "^1.0.0",
-				"has": "^1.0.1",
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.14",
-				"postcss-calc": "^5.2.0",
-				"postcss-colormin": "^2.1.8",
-				"postcss-convert-values": "^2.3.4",
-				"postcss-discard-comments": "^2.0.4",
-				"postcss-discard-duplicates": "^2.0.1",
-				"postcss-discard-empty": "^2.0.1",
-				"postcss-discard-overridden": "^0.1.1",
-				"postcss-discard-unused": "^2.2.1",
-				"postcss-filter-plugins": "^2.0.0",
-				"postcss-merge-idents": "^2.1.5",
-				"postcss-merge-longhand": "^2.0.1",
-				"postcss-merge-rules": "^2.0.3",
-				"postcss-minify-font-values": "^1.0.2",
-				"postcss-minify-gradients": "^1.0.1",
-				"postcss-minify-params": "^1.0.4",
-				"postcss-minify-selectors": "^2.0.4",
-				"postcss-normalize-charset": "^1.1.0",
-				"postcss-normalize-url": "^3.0.7",
-				"postcss-ordered-values": "^2.1.0",
-				"postcss-reduce-idents": "^2.2.2",
-				"postcss-reduce-initial": "^1.0.0",
-				"postcss-reduce-transforms": "^1.0.3",
-				"postcss-svgo": "^2.1.1",
-				"postcss-unique-selectors": "^2.0.2",
-				"postcss-value-parser": "^3.2.3",
-				"postcss-zindex": "^2.0.1"
+				"autoprefixer": "6.7.7",
+				"decamelize": "1.2.0",
+				"defined": "1.0.0",
+				"has": "1.0.1",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-calc": "5.3.1",
+				"postcss-colormin": "2.2.2",
+				"postcss-convert-values": "2.6.1",
+				"postcss-discard-comments": "2.0.4",
+				"postcss-discard-duplicates": "2.1.0",
+				"postcss-discard-empty": "2.1.0",
+				"postcss-discard-overridden": "0.1.1",
+				"postcss-discard-unused": "2.2.3",
+				"postcss-filter-plugins": "2.0.2",
+				"postcss-merge-idents": "2.1.7",
+				"postcss-merge-longhand": "2.0.2",
+				"postcss-merge-rules": "2.1.2",
+				"postcss-minify-font-values": "1.0.5",
+				"postcss-minify-gradients": "1.0.5",
+				"postcss-minify-params": "1.2.2",
+				"postcss-minify-selectors": "2.1.1",
+				"postcss-normalize-charset": "1.1.1",
+				"postcss-normalize-url": "3.0.8",
+				"postcss-ordered-values": "2.2.3",
+				"postcss-reduce-idents": "2.4.0",
+				"postcss-reduce-initial": "1.0.1",
+				"postcss-reduce-transforms": "1.0.4",
+				"postcss-svgo": "2.1.6",
+				"postcss-unique-selectors": "2.0.2",
+				"postcss-value-parser": "3.3.0",
+				"postcss-zindex": "2.2.0"
 			},
 			"dependencies": {
 				"autoprefixer": {
@@ -3875,12 +3875,12 @@
 					"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
 					"dev": true,
 					"requires": {
-						"browserslist": "^1.7.6",
-						"caniuse-db": "^1.0.30000634",
-						"normalize-range": "^0.1.2",
-						"num2fraction": "^1.2.2",
-						"postcss": "^5.2.16",
-						"postcss-value-parser": "^3.2.3"
+						"browserslist": "1.7.7",
+						"caniuse-db": "1.0.30000804",
+						"normalize-range": "0.1.2",
+						"num2fraction": "1.2.2",
+						"postcss": "5.2.18",
+						"postcss-value-parser": "3.3.0"
 					}
 				},
 				"browserslist": {
@@ -3889,8 +3889,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
+						"caniuse-db": "1.0.30000804",
+						"electron-to-chromium": "1.3.33"
 					}
 				}
 			}
@@ -3901,8 +3901,8 @@
 			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
 			"dev": true,
 			"requires": {
-				"clap": "^1.0.9",
-				"source-map": "^0.5.3"
+				"clap": "1.2.3",
+				"source-map": "0.5.7"
 			}
 		},
 		"cssom": {
@@ -3917,7 +3917,7 @@
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "0.3.2"
 			}
 		},
 		"currently-unhandled": {
@@ -3926,7 +3926,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "^1.0.1"
+				"array-find-index": "1.0.2"
 			}
 		},
 		"cyclist": {
@@ -3953,7 +3953,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"date-fns": {
@@ -4000,7 +4000,7 @@
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 			"dev": true,
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "1.0.0"
 			}
 		},
 		"deep-equal-ident": {
@@ -4009,7 +4009,7 @@
 			"integrity": "sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=",
 			"dev": true,
 			"requires": {
-				"lodash.isequal": "^3.0"
+				"lodash.isequal": "3.0.4"
 			}
 		},
 		"deep-extend": {
@@ -4036,7 +4036,7 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "^2.0.0"
+				"strip-bom": "2.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -4045,7 +4045,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -4056,8 +4056,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
 			}
 		},
 		"define-property": {
@@ -4066,8 +4066,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4090,13 +4090,13 @@
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"dev": true,
 			"requires": {
-				"globby": "^5.0.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"rimraf": "^2.2.8"
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2"
 			}
 		},
 		"delayed-stream": {
@@ -4122,8 +4122,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
 			}
 		},
 		"detect-conflict": {
@@ -4138,7 +4138,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"detect-newline": {
@@ -4159,9 +4159,9 @@
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.1",
+				"randombytes": "2.0.6"
 			}
 		},
 		"discontinuous-range": {
@@ -4186,8 +4186,8 @@
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "~1.1.1",
-				"entities": "~1.1.1"
+				"domelementtype": "1.1.3",
+				"entities": "1.1.1"
 			},
 			"dependencies": {
 				"domelementtype": {
@@ -4216,7 +4216,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"domhandler": {
@@ -4225,7 +4225,7 @@
 			"integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1"
+				"domelementtype": "1.3.0"
 			}
 		},
 		"domutils": {
@@ -4234,8 +4234,8 @@
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
 			"dev": true,
 			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
+				"dom-serializer": "0.1.0",
+				"domelementtype": "1.3.0"
 			}
 		},
 		"duplexer3": {
@@ -4250,10 +4250,10 @@
 			"integrity": "sha1-S7RsF5bqvr7sTKmi5muAjLej2LQ=",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0",
-				"stream-shift": "^1.0.0"
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"ecc-jsbn": {
@@ -4263,7 +4263,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0"
+				"jsbn": "0.1.1"
 			}
 		},
 		"editions": {
@@ -4277,11 +4277,11 @@
 			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
 			"integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
 			"requires": {
-				"bluebird": "^3.0.5",
-				"commander": "^2.9.0",
-				"lru-cache": "^3.2.0",
-				"semver": "^5.1.0",
-				"sigmund": "^1.0.1"
+				"bluebird": "3.5.1",
+				"commander": "2.14.1",
+				"lru-cache": "3.2.0",
+				"semver": "5.3.0",
+				"sigmund": "1.0.1"
 			}
 		},
 		"ejs": {
@@ -4313,13 +4313,13 @@
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.3",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"emoji-regex": {
@@ -4339,7 +4339,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "~0.4.13"
+				"iconv-lite": "0.4.19"
 			}
 		},
 		"end-of-stream": {
@@ -4348,7 +4348,7 @@
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
-				"once": "^1.4.0"
+				"once": "1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -4357,9 +4357,9 @@
 			"integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
-				"tapable": "^1.0.0"
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"tapable": "1.0.0"
 			}
 		},
 		"entities": {
@@ -4374,22 +4374,22 @@
 			"integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
 			"dev": true,
 			"requires": {
-				"cheerio": "^1.0.0-rc.2",
-				"function.prototype.name": "^1.0.3",
-				"has": "^1.0.1",
-				"is-boolean-object": "^1.0.0",
-				"is-callable": "^1.1.3",
-				"is-number-object": "^1.0.3",
-				"is-string": "^1.0.4",
-				"is-subset": "^0.1.1",
-				"lodash": "^4.17.4",
-				"object-inspect": "^1.5.0",
-				"object-is": "^1.0.1",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.0.4",
-				"object.values": "^1.0.4",
-				"raf": "^3.4.0",
-				"rst-selector-parser": "^2.2.3"
+				"cheerio": "1.0.0-rc.2",
+				"function.prototype.name": "1.1.0",
+				"has": "1.0.1",
+				"is-boolean-object": "1.0.0",
+				"is-callable": "1.1.3",
+				"is-number-object": "1.0.3",
+				"is-string": "1.0.4",
+				"is-subset": "0.1.1",
+				"lodash": "4.17.5",
+				"object-inspect": "1.5.0",
+				"object-is": "1.0.1",
+				"object.assign": "4.1.0",
+				"object.entries": "1.0.4",
+				"object.values": "1.0.4",
+				"raf": "3.4.0",
+				"rst-selector-parser": "2.2.3"
 			}
 		},
 		"enzyme-adapter-react-16": {
@@ -4398,13 +4398,13 @@
 			"integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
 			"dev": true,
 			"requires": {
-				"enzyme-adapter-utils": "^1.3.0",
-				"lodash": "^4.17.4",
-				"object.assign": "^4.0.4",
-				"object.values": "^1.0.4",
-				"prop-types": "^15.6.0",
-				"react-reconciler": "^0.7.0",
-				"react-test-renderer": "^16.0.0-0"
+				"enzyme-adapter-utils": "1.3.0",
+				"lodash": "4.17.5",
+				"object.assign": "4.1.0",
+				"object.values": "1.0.4",
+				"prop-types": "15.6.0",
+				"react-reconciler": "0.7.0",
+				"react-test-renderer": "16.2.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -4413,9 +4413,9 @@
 					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 					"dev": true,
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				},
 				"react-test-renderer": {
@@ -4424,9 +4424,9 @@
 					"integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
 					"dev": true,
 					"requires": {
-						"fbjs": "^0.8.16",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.0"
+						"fbjs": "0.8.16",
+						"object-assign": "4.1.1",
+						"prop-types": "15.6.0"
 					}
 				}
 			}
@@ -4437,9 +4437,9 @@
 			"integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.4",
-				"object.assign": "^4.0.4",
-				"prop-types": "^15.6.0"
+				"lodash": "4.17.5",
+				"object.assign": "4.1.0",
+				"prop-types": "15.6.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -4448,9 +4448,9 @@
 					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 					"dev": true,
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
@@ -4461,8 +4461,8 @@
 			"integrity": "sha512-5Gf/mAVYx6KPAUuxuDhAGt/gu9ndPd6duFcVnH2rbEad2clgTpHZL4Df49FHFukrjEEubX9rhfeAKx0/sbfVkQ==",
 			"dev": true,
 			"requires": {
-				"circular-json-es6": "^2.0.1",
-				"deep-equal-ident": "^1.1.1"
+				"circular-json-es6": "2.0.2",
+				"deep-equal-ident": "1.1.1"
 			}
 		},
 		"enzyme-to-json": {
@@ -4471,7 +4471,7 @@
 			"integrity": "sha512-PrgRyZAgEwOrh5/8BtBWrwGcv1mC7yNohytIciAX6SUqDaXg1BlU8CepYQ9BgnDP1i1jTB65qJJITMMCph+T6A==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.4"
+				"lodash": "4.17.5"
 			}
 		},
 		"equivalent-key-map": {
@@ -4485,7 +4485,7 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"dev": true,
 			"requires": {
-				"prr": "~1.0.1"
+				"prr": "1.0.1"
 			}
 		},
 		"error": {
@@ -4494,8 +4494,8 @@
 			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
 			"dev": true,
 			"requires": {
-				"string-template": "~0.2.1",
-				"xtend": "~4.0.0"
+				"string-template": "0.2.1",
+				"xtend": "4.0.1"
 			}
 		},
 		"error-ex": {
@@ -4504,7 +4504,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -4513,11 +4513,11 @@
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -4526,9 +4526,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
 			}
 		},
 		"es6-promise": {
@@ -4543,7 +4543,7 @@
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"dev": true,
 			"requires": {
-				"es6-promise": "^4.0.3"
+				"es6-promise": "4.2.4"
 			}
 		},
 		"escape-string-regexp": {
@@ -4557,11 +4557,11 @@
 			"integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.5.6"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"esprima": {
@@ -4578,43 +4578,43 @@
 			"integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
-				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
-				"debug": "^3.1.0",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.2",
-				"esquery": "^1.0.0",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
-				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.0.1",
-				"ignore": "^3.3.3",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
-				"progress": "^2.0.0",
-				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
-				"table": "^4.0.1",
-				"text-table": "~0.2.0"
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.3.0",
+				"concat-stream": "1.6.0",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.3",
+				"esquery": "1.0.0",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.3.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.10.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.3.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.2",
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4629,7 +4629,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -4638,9 +4638,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
 					}
 				},
 				"debug": {
@@ -4658,7 +4658,7 @@
 					"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2"
+						"esutils": "2.0.2"
 					}
 				},
 				"globals": {
@@ -4679,7 +4679,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -4688,7 +4688,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -4715,8 +4715,8 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.5.0.tgz",
 			"integrity": "sha512-qoNpVicVWGjGBXAJsqRoqVuAnajgX7PWtSa2Men36XKRiXe3RS/QmRv215PXZwo4OHskYOsUoJUeiPiWtS9ULA==",
 			"requires": {
-				"comment-parser": "^0.4.2",
-				"lodash": "^4.17.4"
+				"comment-parser": "0.4.2",
+				"lodash": "4.17.5"
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
@@ -4725,13 +4725,13 @@
 			"integrity": "sha1-ZZJ3p1iwNsMFp+ShMFfDAc075z8=",
 			"dev": true,
 			"requires": {
-				"aria-query": "^0.7.0",
-				"array-includes": "^3.0.3",
+				"aria-query": "0.7.1",
+				"array-includes": "3.0.3",
 				"ast-types-flow": "0.0.7",
-				"axobject-query": "^0.1.0",
-				"damerau-levenshtein": "^1.0.0",
-				"emoji-regex": "^6.1.0",
-				"jsx-ast-utils": "^1.4.0"
+				"axobject-query": "0.1.0",
+				"damerau-levenshtein": "1.0.4",
+				"emoji-regex": "6.5.1",
+				"jsx-ast-utils": "1.4.1"
 			}
 		},
 		"eslint-plugin-node": {
@@ -4739,10 +4739,10 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
 			"requires": {
-				"ignore": "^3.3.6",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.3.3",
-				"semver": "^5.4.1"
+				"ignore": "3.3.7",
+				"minimatch": "3.0.4",
+				"resolve": "1.5.0",
+				"semver": "5.5.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -4758,10 +4758,10 @@
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
 			"dev": true,
 			"requires": {
-				"doctrine": "^2.0.2",
-				"has": "^1.0.1",
-				"jsx-ast-utils": "^2.0.1",
-				"prop-types": "^15.6.0"
+				"doctrine": "2.1.0",
+				"has": "1.0.1",
+				"jsx-ast-utils": "2.0.1",
+				"prop-types": "15.6.1"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -4770,7 +4770,7 @@
 					"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2"
+						"esutils": "2.0.2"
 					}
 				},
 				"jsx-ast-utils": {
@@ -4779,7 +4779,7 @@
 					"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
 					"dev": true,
 					"requires": {
-						"array-includes": "^3.0.3"
+						"array-includes": "3.0.3"
 					}
 				},
 				"prop-types": {
@@ -4788,22 +4788,21 @@
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"dev": true,
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
 		},
 		"eslint-plugin-wordpress": {
 			"version": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
-			"from": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
 			"requires": {
-				"eslint-plugin-i18n": "~1.2.0",
-				"eslint-plugin-jsdoc": "~3.5.0",
-				"eslint-plugin-node": "~6.0.1",
-				"eslint-plugin-wpcalypso": "~4.0.1",
-				"merge": "~1.2.0"
+				"eslint-plugin-i18n": "1.2.0",
+				"eslint-plugin-jsdoc": "3.5.0",
+				"eslint-plugin-node": "6.0.1",
+				"eslint-plugin-wpcalypso": "4.0.1",
+				"merge": "1.2.0"
 			}
 		},
 		"eslint-plugin-wpcalypso": {
@@ -4811,7 +4810,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-wpcalypso/-/eslint-plugin-wpcalypso-4.0.1.tgz",
 			"integrity": "sha512-fU5NSc0XGdel/tlEIUoESOdqphBWQN2FfSgXXNHpXKX7ftTcqXacqgzXU8OVziyhXz6s2RUzK0+JSJaNxhZ+Mw==",
 			"requires": {
-				"requireindex": "^1.1.0"
+				"requireindex": "1.2.0"
 			}
 		},
 		"eslint-scope": {
@@ -4820,8 +4819,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -4836,8 +4835,8 @@
 			"integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.4.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "5.4.1",
+				"acorn-jsx": "3.0.1"
 			}
 		},
 		"esprima": {
@@ -4852,7 +4851,7 @@
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"esrecurse": {
@@ -4861,8 +4860,8 @@
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0",
-				"object-assign": "^4.0.1"
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"estraverse": {
@@ -4889,8 +4888,8 @@
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"dev": true,
 			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
+				"md5.js": "1.3.4",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"exec-sh": {
@@ -4899,7 +4898,7 @@
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"dev": true,
 			"requires": {
-				"merge": "^1.1.3"
+				"merge": "1.2.0"
 			}
 		},
 		"execa": {
@@ -4907,13 +4906,13 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"exit": {
@@ -4934,7 +4933,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
+				"is-posix-bracket": "0.1.1"
 			}
 		},
 		"expand-range": {
@@ -4943,7 +4942,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.3"
 			}
 		},
 		"expand-tilde": {
@@ -4952,7 +4951,7 @@
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
-				"homedir-polyfill": "^1.0.1"
+				"homedir-polyfill": "1.0.1"
 			}
 		},
 		"expect": {
@@ -4961,12 +4960,12 @@
 			"integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"jest-diff": "^22.4.0",
-				"jest-get-type": "^22.1.0",
-				"jest-matcher-utils": "^22.4.0",
-				"jest-message-util": "^22.4.0",
-				"jest-regex-util": "^22.1.0"
+				"ansi-styles": "3.2.0",
+				"jest-diff": "22.4.0",
+				"jest-get-type": "22.1.0",
+				"jest-matcher-utils": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-regex-util": "22.1.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4975,7 +4974,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				}
 			}
@@ -4992,8 +4991,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5002,7 +5001,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -5013,9 +5012,9 @@
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
 			},
 			"dependencies": {
 				"tmp": {
@@ -5024,7 +5023,7 @@
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "~1.0.2"
+						"os-tmpdir": "1.0.2"
 					}
 				}
 			}
@@ -5035,7 +5034,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"extract-text-webpack-plugin": {
@@ -5044,10 +5043,10 @@
 			"integrity": "sha512-Hypkn9jUTnFr0DpekNam53X47tXn3ucY08BQumv7kdGgeVUBLq3DJHJTi6HNxv4jl9W+Skxjz9+RnK0sJyqqjA==",
 			"dev": true,
 			"requires": {
-				"async": "^2.4.1",
-				"loader-utils": "^1.1.0",
-				"schema-utils": "^0.4.5",
-				"webpack-sources": "^1.1.0"
+				"async": "2.6.0",
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.4.5",
+				"webpack-sources": "1.1.0"
 			}
 		},
 		"extract-zip": {
@@ -5103,7 +5102,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.0.0"
 			}
 		},
 		"fbjs": {
@@ -5111,13 +5110,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.9"
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
 			},
 			"dependencies": {
 				"core-js": {
@@ -5133,7 +5132,7 @@
 			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
 			"dev": true,
 			"requires": {
-				"pend": "~1.2.0"
+				"pend": "1.2.0"
 			}
 		},
 		"figures": {
@@ -5142,7 +5141,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -5151,8 +5150,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"filename-regex": {
@@ -5167,8 +5166,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
 			}
 		},
 		"fill-range": {
@@ -5177,11 +5176,11 @@
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"dev": true,
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^1.1.3",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"find-cache-dir": {
@@ -5190,9 +5189,9 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"commondir": "1.0.1",
+				"make-dir": "1.2.0",
+				"pkg-dir": "2.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -5201,7 +5200,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -5210,7 +5209,7 @@
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.1.0"
+						"find-up": "2.1.0"
 					}
 				}
 			}
@@ -5221,8 +5220,8 @@
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 			"dev": true,
 			"requires": {
-				"path-exists": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"path-exists": "2.1.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"findup": {
@@ -5231,8 +5230,8 @@
 			"integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
 			"dev": true,
 			"requires": {
-				"colors": "~0.6.0-1",
-				"commander": "~2.1.0"
+				"colors": "0.6.2",
+				"commander": "2.1.0"
 			},
 			"dependencies": {
 				"colors": {
@@ -5255,7 +5254,7 @@
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.2"
+				"readable-stream": "2.3.3"
 			}
 		},
 		"flat-cache": {
@@ -5264,10 +5263,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"write": "^0.2.1"
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
 			}
 		},
 		"flatten": {
@@ -5288,8 +5287,8 @@
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"for-in": {
@@ -5304,7 +5303,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"foreach": {
@@ -5325,9 +5324,9 @@
 			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.5",
-				"mime-types": "^2.1.12"
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.5",
+				"mime-types": "2.1.17"
 			}
 		},
 		"fragment-cache": {
@@ -5336,7 +5335,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"from2": {
@@ -5345,8 +5344,8 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -5355,10 +5354,10 @@
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"iferr": "^0.1.5",
-				"imurmurhash": "^0.1.4",
-				"readable-stream": "1 || 2"
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"fs.realpath": {
@@ -5374,8 +5373,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.3.0",
-				"node-pre-gyp": "^0.6.39"
+				"nan": "2.8.0",
+				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -5392,8 +5391,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
 					}
 				},
 				"ansi-regex": {
@@ -5468,7 +5467,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"tweetnacl": "^0.14.3"
+						"tweetnacl": "0.14.5"
 					}
 				},
 				"block-stream": {
@@ -5477,7 +5476,7 @@
 					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 					"dev": true,
 					"requires": {
-						"inherits": "~2.0.0"
+						"inherits": "2.0.3"
 					}
 				},
 				"boom": {
@@ -5486,7 +5485,7 @@
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"brace-expansion": {
@@ -5495,7 +5494,7 @@
 					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
 					"dev": true,
 					"requires": {
-						"balanced-match": "^0.4.1",
+						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -5531,7 +5530,7 @@
 					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 					"dev": true,
 					"requires": {
-						"delayed-stream": "~1.0.0"
+						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
@@ -5558,7 +5557,7 @@
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
 					"requires": {
-						"boom": "2.x.x"
+						"boom": "2.10.1"
 					}
 				},
 				"dashdash": {
@@ -5568,7 +5567,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -5624,7 +5623,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0"
+						"jsbn": "0.1.1"
 					}
 				},
 				"extend": {
@@ -5654,9 +5653,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
 					}
 				},
 				"fs.realpath": {
@@ -5671,10 +5670,10 @@
 					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
 					}
 				},
 				"fstream-ignore": {
@@ -5684,9 +5683,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fstream": "^1.0.0",
-						"inherits": "2",
-						"minimatch": "^3.0.0"
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
 					}
 				},
 				"gauge": {
@@ -5713,7 +5712,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -5759,8 +5758,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ajv": "^4.9.1",
-						"har-schema": "^1.0.5"
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
 					}
 				},
 				"has-unicode": {
@@ -5776,10 +5775,10 @@
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
 					"requires": {
-						"boom": "2.x.x",
-						"cryptiles": "2.x.x",
-						"hoek": "2.x.x",
-						"sntp": "1.x.x"
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
 					}
 				},
 				"hoek": {
@@ -5795,9 +5794,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
 					}
 				},
 				"inflight": {
@@ -5859,7 +5858,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0"
+						"jsbn": "0.1.1"
 					}
 				},
 				"jsbn": {
@@ -5883,7 +5882,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsonify": "~0.0.0"
+						"jsonify": "0.0.0"
 					}
 				},
 				"json-stringify-safe": {
@@ -5934,7 +5933,7 @@
 					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
 					"dev": true,
 					"requires": {
-						"mime-db": "~1.27.0"
+						"mime-db": "1.27.0"
 					}
 				},
 				"minimatch": {
@@ -5975,17 +5974,17 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
+						"detect-libc": "1.0.2",
 						"hawk": "3.1.3",
-						"mkdirp": "^0.5.1",
-						"nopt": "^4.0.1",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
 						"request": "2.81.0",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^2.2.1",
-						"tar-pack": "^3.4.0"
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
 					}
 				},
 				"nopt": {
@@ -6006,10 +6005,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -6062,8 +6061,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -6106,10 +6105,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "~0.4.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -6127,13 +6126,13 @@
 					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
 					"dev": true,
 					"requires": {
-						"buffer-shims": "~1.0.0",
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"string_decoder": "~1.0.0",
-						"util-deprecate": "~1.0.1"
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"request": {
@@ -6143,28 +6142,28 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
 					}
 				},
 				"rimraf": {
@@ -6173,7 +6172,7 @@
 					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -6209,7 +6208,7 @@
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"sshpk": {
@@ -6219,15 +6218,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jodid25519": "^1.0.0",
-						"jsbn": "~0.1.0",
-						"tweetnacl": "~0.14.0"
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -6256,7 +6255,7 @@
 					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
@@ -6288,9 +6287,9 @@
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 					"dev": true,
 					"requires": {
-						"block-stream": "*",
-						"fstream": "^1.0.2",
-						"inherits": "2"
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
 					}
 				},
 				"tar-pack": {
@@ -6300,14 +6299,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.2.0",
-						"fstream": "^1.0.10",
-						"fstream-ignore": "^1.0.5",
-						"once": "^1.3.3",
-						"readable-stream": "^2.1.4",
-						"rimraf": "^2.5.1",
-						"tar": "^2.2.1",
-						"uid-number": "^0.0.6"
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
 					}
 				},
 				"tough-cookie": {
@@ -6317,7 +6316,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"punycode": "^1.4.1"
+						"punycode": "1.4.1"
 					}
 				},
 				"tunnel-agent": {
@@ -6327,7 +6326,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"tweetnacl": {
@@ -6391,10 +6390,10 @@
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
+				"graceful-fs": "4.1.11",
+				"inherits": "2.0.3",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2"
 			}
 		},
 		"function-bind": {
@@ -6409,9 +6408,9 @@
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"is-callable": "^1.1.3"
+				"define-properties": "1.1.2",
+				"function-bind": "1.1.1",
+				"is-callable": "1.1.3"
 			}
 		},
 		"functional-red-black-tree": {
@@ -6426,14 +6425,14 @@
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
+				"aproba": "1.2.0",
+				"console-control-strings": "1.1.0",
+				"has-unicode": "2.0.1",
+				"object-assign": "4.1.1",
+				"signal-exit": "3.0.2",
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wide-align": "1.1.2"
 			},
 			"dependencies": {
 				"string-width": {
@@ -6442,9 +6441,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -6455,7 +6454,7 @@
 			"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
 			"dev": true,
 			"requires": {
-				"globule": "^1.0.0"
+				"globule": "1.2.0"
 			}
 		},
 		"generate-function": {
@@ -6470,7 +6469,7 @@
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
 			"dev": true,
 			"requires": {
-				"is-property": "^1.0.0"
+				"is-property": "1.0.2"
 			}
 		},
 		"get-caller-file": {
@@ -6501,7 +6500,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"gettext-parser": {
@@ -6509,8 +6508,8 @@
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
 			"integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
 			"requires": {
-				"encoding": "^0.1.12",
-				"safe-buffer": "^5.1.1"
+				"encoding": "0.1.12",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"gh-got": {
@@ -6519,8 +6518,8 @@
 			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
 			"dev": true,
 			"requires": {
-				"got": "^7.0.0",
-				"is-plain-obj": "^1.1.0"
+				"got": "7.1.0",
+				"is-plain-obj": "1.1.0"
 			},
 			"dependencies": {
 				"got": {
@@ -6529,20 +6528,20 @@
 					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
 					"dev": true,
 					"requires": {
-						"decompress-response": "^3.2.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"is-plain-obj": "^1.1.0",
-						"is-retry-allowed": "^1.0.0",
-						"is-stream": "^1.0.0",
-						"isurl": "^1.0.0-alpha5",
-						"lowercase-keys": "^1.0.0",
-						"p-cancelable": "^0.3.0",
-						"p-timeout": "^1.1.1",
-						"safe-buffer": "^5.0.1",
-						"timed-out": "^4.0.0",
-						"url-parse-lax": "^1.0.0",
-						"url-to-options": "^1.0.1"
+						"decompress-response": "3.3.0",
+						"duplexer3": "0.1.4",
+						"get-stream": "3.0.0",
+						"is-plain-obj": "1.1.0",
+						"is-retry-allowed": "1.1.0",
+						"is-stream": "1.1.0",
+						"isurl": "1.0.0",
+						"lowercase-keys": "1.0.1",
+						"p-cancelable": "0.3.0",
+						"p-timeout": "1.2.1",
+						"safe-buffer": "5.1.1",
+						"timed-out": "4.0.1",
+						"url-parse-lax": "1.0.0",
+						"url-to-options": "1.0.1"
 					}
 				},
 				"p-cancelable": {
@@ -6557,7 +6556,7 @@
 					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
 					"dev": true,
 					"requires": {
-						"p-finally": "^1.0.0"
+						"p-finally": "1.0.0"
 					}
 				},
 				"url-parse-lax": {
@@ -6566,7 +6565,7 @@
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"dev": true,
 					"requires": {
-						"prepend-http": "^1.0.1"
+						"prepend-http": "1.0.4"
 					}
 				}
 			}
@@ -6577,7 +6576,7 @@
 			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
 			"dev": true,
 			"requires": {
-				"gh-got": "^6.0.0"
+				"gh-got": "6.0.0"
 			}
 		},
 		"glob": {
@@ -6586,12 +6585,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-all": {
@@ -6600,8 +6599,8 @@
 			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5",
-				"yargs": "~1.2.6"
+				"glob": "7.1.2",
+				"yargs": "1.2.6"
 			},
 			"dependencies": {
 				"minimist": {
@@ -6616,7 +6615,7 @@
 					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
 					"dev": true,
 					"requires": {
-						"minimist": "^0.1.0"
+						"minimist": "0.1.0"
 					}
 				}
 			}
@@ -6627,8 +6626,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-parent": {
@@ -6637,7 +6636,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "2.0.1"
 			}
 		},
 		"global-modules": {
@@ -6646,9 +6645,9 @@
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
 			"dev": true,
 			"requires": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
+				"global-prefix": "1.0.2",
+				"is-windows": "1.0.1",
+				"resolve-dir": "1.0.1"
 			}
 		},
 		"global-prefix": {
@@ -6657,11 +6656,11 @@
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
-				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
+				"expand-tilde": "2.0.2",
+				"homedir-polyfill": "1.0.1",
+				"ini": "1.3.5",
+				"is-windows": "1.0.1",
+				"which": "1.3.0"
 			}
 		},
 		"globals": {
@@ -6676,12 +6675,12 @@
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 			"dev": true,
 			"requires": {
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"globule": {
@@ -6690,9 +6689,9 @@
 			"integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
 			"dev": true,
 			"requires": {
-				"glob": "~7.1.1",
-				"lodash": "~4.17.4",
-				"minimatch": "~3.0.2"
+				"glob": "7.1.2",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4"
 			}
 		},
 		"good-listener": {
@@ -6700,7 +6699,7 @@
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
 			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
 			"requires": {
-				"delegate": "^3.1.2"
+				"delegate": "3.2.0"
 			}
 		},
 		"got": {
@@ -6709,23 +6708,23 @@
 			"integrity": "sha1-a6JudfimzExrPrH+fOT+x6ushTM=",
 			"dev": true,
 			"requires": {
-				"@sindresorhus/is": "^0.7.0",
-				"cacheable-request": "^2.1.1",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"into-stream": "^3.1.0",
-				"is-retry-allowed": "^1.1.0",
-				"isurl": "^1.0.0-alpha5",
-				"lowercase-keys": "^1.0.0",
-				"mimic-response": "^1.0.0",
-				"p-cancelable": "^0.4.0",
-				"p-timeout": "^2.0.1",
-				"pify": "^3.0.0",
-				"safe-buffer": "^5.1.1",
-				"timed-out": "^4.0.1",
-				"url-parse-lax": "^3.0.0",
-				"url-to-options": "^1.0.1"
+				"@sindresorhus/is": "0.7.0",
+				"cacheable-request": "2.1.4",
+				"decompress-response": "3.3.0",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"into-stream": "3.1.0",
+				"is-retry-allowed": "1.1.0",
+				"isurl": "1.0.0",
+				"lowercase-keys": "1.0.1",
+				"mimic-response": "1.0.0",
+				"p-cancelable": "0.4.0",
+				"p-timeout": "2.0.1",
+				"pify": "3.0.0",
+				"safe-buffer": "5.1.1",
+				"timed-out": "4.0.1",
+				"url-parse-lax": "3.0.0",
+				"url-to-options": "1.0.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -6748,7 +6747,7 @@
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.2"
+				"lodash": "4.17.5"
 			}
 		},
 		"growly": {
@@ -6763,10 +6762,10 @@
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"dev": true,
 			"requires": {
-				"async": "^1.4.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.4.4",
-				"uglify-js": "^2.6"
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
 			},
 			"dependencies": {
 				"async": {
@@ -6781,7 +6780,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -6798,8 +6797,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.1.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -6808,7 +6807,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.0.2"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -6817,7 +6816,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-color": {
@@ -6850,7 +6849,7 @@
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
 			"dev": true,
 			"requires": {
-				"has-symbol-support-x": "^1.4.1"
+				"has-symbol-support-x": "1.4.2"
 			}
 		},
 		"has-unicode": {
@@ -6865,9 +6864,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -6884,8 +6883,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6894,7 +6893,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6903,7 +6902,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -6914,7 +6913,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -6925,7 +6924,7 @@
 			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1"
+				"inherits": "2.0.3"
 			}
 		},
 		"hash.js": {
@@ -6934,8 +6933,8 @@
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.0"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
 			}
 		},
 		"hawk": {
@@ -6944,10 +6943,10 @@
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"dev": true,
 			"requires": {
-				"boom": "4.x.x",
-				"cryptiles": "3.x.x",
-				"hoek": "4.x.x",
-				"sntp": "2.x.x"
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.0",
+				"sntp": "2.1.0"
 			}
 		},
 		"hmac-drbg": {
@@ -6956,9 +6955,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
+				"hash.js": "1.1.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"hoek": {
@@ -6978,8 +6977,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"homedir-polyfill": {
@@ -6988,7 +6987,7 @@
 			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
 			"dev": true,
 			"requires": {
-				"parse-passwd": "^1.0.0"
+				"parse-passwd": "1.0.0"
 			}
 		},
 		"hosted-git-info": {
@@ -7014,7 +7013,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "1.0.3"
 			}
 		},
 		"htmlparser2": {
@@ -7023,12 +7022,12 @@
 			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "^1.3.0",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.2"
+				"domelementtype": "1.3.0",
+				"domhandler": "2.4.1",
+				"domutils": "1.5.1",
+				"entities": "1.1.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"http-cache-semantics": {
@@ -7043,9 +7042,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
 			}
 		},
 		"https-browserify": {
@@ -7060,8 +7059,8 @@
 			"integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.1.0",
-				"debug": "^3.1.0"
+				"agent-base": "4.2.0",
+				"debug": "3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -7103,8 +7102,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -7113,7 +7112,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -7122,7 +7121,7 @@
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.1.0"
+						"find-up": "2.1.0"
 					}
 				}
 			}
@@ -7145,7 +7144,7 @@
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"indexes-of": {
@@ -7166,8 +7165,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -7186,20 +7185,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.0.0",
+				"chalk": "2.3.0",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.5",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7214,7 +7213,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -7223,9 +7222,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
 					}
 				},
 				"cli-cursor": {
@@ -7234,7 +7233,7 @@
 					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^2.0.0"
+						"restore-cursor": "2.0.0"
 					}
 				},
 				"figures": {
@@ -7243,7 +7242,7 @@
 					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5"
+						"escape-string-regexp": "1.0.5"
 					}
 				},
 				"onetime": {
@@ -7252,7 +7251,7 @@
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
+						"mimic-fn": "1.2.0"
 					}
 				},
 				"restore-cursor": {
@@ -7261,8 +7260,8 @@
 					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 					"dev": true,
 					"requires": {
-						"onetime": "^2.0.0",
-						"signal-exit": "^3.0.2"
+						"onetime": "2.0.1",
+						"signal-exit": "3.0.2"
 					}
 				},
 				"strip-ansi": {
@@ -7271,7 +7270,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -7280,7 +7279,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -7297,8 +7296,8 @@
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
 			"dev": true,
 			"requires": {
-				"from2": "^2.1.1",
-				"p-is-promise": "^1.1.0"
+				"from2": "2.3.0",
+				"p-is-promise": "1.1.0"
 			}
 		},
 		"invariant": {
@@ -7307,7 +7306,7 @@
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.3.1"
 			}
 		},
 		"invert-kv": {
@@ -7327,7 +7326,7 @@
 			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.0"
+				"kind-of": "6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7350,7 +7349,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "1.11.0"
 			}
 		},
 		"is-boolean-object": {
@@ -7371,7 +7370,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-callable": {
@@ -7386,7 +7385,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.0.0"
+				"ci-info": "1.1.2"
 			}
 		},
 		"is-data-descriptor": {
@@ -7395,7 +7394,7 @@
 			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.0"
+				"kind-of": "6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7418,9 +7417,9 @@
 			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "^1.0.0",
-				"is-data-descriptor": "^1.0.0",
-				"kind-of": "^6.0.2"
+				"is-accessor-descriptor": "1.0.0",
+				"is-data-descriptor": "1.0.0",
+				"kind-of": "6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7449,7 +7448,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -7470,7 +7469,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -7478,7 +7477,7 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-generator-fn": {
@@ -7493,7 +7492,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"is-my-json-valid": {
@@ -7502,10 +7501,10 @@
 			"integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
 			"dev": true,
 			"requires": {
-				"generate-function": "^2.0.0",
-				"generate-object-property": "^1.1.0",
-				"jsonpointer": "^4.0.0",
-				"xtend": "^4.0.0"
+				"generate-function": "2.0.0",
+				"generate-object-property": "1.2.0",
+				"jsonpointer": "4.0.1",
+				"xtend": "4.0.1"
 			}
 		},
 		"is-number": {
@@ -7514,7 +7513,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-number-object": {
@@ -7535,7 +7534,7 @@
 			"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "^0.2.2"
+				"symbol-observable": "0.2.4"
 			},
 			"dependencies": {
 				"symbol-observable": {
@@ -7552,7 +7551,7 @@
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0"
+				"is-number": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -7575,7 +7574,7 @@
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "1.0.1"
 			}
 		},
 		"is-path-inside": {
@@ -7584,7 +7583,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -7599,7 +7598,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -7640,7 +7639,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.1"
 			}
 		},
 		"is-resolvable": {
@@ -7661,7 +7660,7 @@
 			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
 			"dev": true,
 			"requires": {
-				"scoped-regex": "^1.0.0"
+				"scoped-regex": "1.0.0"
 			}
 		},
 		"is-stream": {
@@ -7687,7 +7686,7 @@
 			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
 			"dev": true,
 			"requires": {
-				"html-comment-regex": "^1.1.0"
+				"html-comment-regex": "1.1.1"
 			}
 		},
 		"is-symbol": {
@@ -7738,8 +7737,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
 			}
 		},
 		"isstream": {
@@ -7754,17 +7753,17 @@
 			"integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.4",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.1.2",
-				"istanbul-lib-hook": "^1.1.0",
-				"istanbul-lib-instrument": "^1.9.2",
-				"istanbul-lib-report": "^1.1.3",
-				"istanbul-lib-source-maps": "^1.2.3",
-				"istanbul-reports": "^1.1.4",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
+				"async": "2.6.0",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.1.2",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.9.2",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.1.4",
+				"js-yaml": "3.10.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -7779,7 +7778,7 @@
 			"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
 			"dev": true,
 			"requires": {
-				"append-transform": "^0.4.0"
+				"append-transform": "0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -7788,13 +7787,13 @@
 			"integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.1.2",
-				"semver": "^5.3.0"
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.1.2",
+				"semver": "5.3.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -7803,10 +7802,10 @@
 			"integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^1.1.2",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "1.1.2",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -7832,11 +7831,11 @@
 			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.1.2",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.1.2",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"debug": {
@@ -7856,7 +7855,7 @@
 			"integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.0.3"
+				"handlebars": "4.0.11"
 			}
 		},
 		"istextorbinary": {
@@ -7865,9 +7864,9 @@
 			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
 			"dev": true,
 			"requires": {
-				"binaryextensions": "2",
-				"editions": "^1.3.3",
-				"textextensions": "2"
+				"binaryextensions": "2.1.1",
+				"editions": "1.3.4",
+				"textextensions": "2.2.0"
 			}
 		},
 		"isurl": {
@@ -7876,8 +7875,8 @@
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
 			"dev": true,
 			"requires": {
-				"has-to-string-tag-x": "^1.2.0",
-				"is-object": "^1.0.1"
+				"has-to-string-tag-x": "1.4.1",
+				"is-object": "1.0.1"
 			}
 		},
 		"jed": {
@@ -7891,8 +7890,8 @@
 			"integrity": "sha512-eze1JLbBDkrbZMnE6xIlBxHkqPAmuHbz4GQbED8qRVtnpea3o6Tt/Dc3SBs3qnlTo7svema8Ho5bqLfdHyabyQ==",
 			"dev": true,
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^22.4.0"
+				"import-local": "1.0.0",
+				"jest-cli": "22.4.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7907,7 +7906,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -7916,9 +7915,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"cliui": {
@@ -7927,9 +7926,9 @@
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"find-up": {
@@ -7938,7 +7937,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"has-flag": {
@@ -7953,40 +7952,40 @@
 					"integrity": "sha512-0JlBb/PvHGQZR2I9GZwsycHgWHhriBmvBWPaaPYUT186oiIIDY4ezDxFOFt2Ts0yNTRg3iY9mTyHsfWbT5VRWA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.1.14",
-						"istanbul-lib-coverage": "^1.1.1",
-						"istanbul-lib-instrument": "^1.8.0",
-						"istanbul-lib-source-maps": "^1.2.1",
-						"jest-changed-files": "^22.2.0",
-						"jest-config": "^22.4.0",
-						"jest-environment-jsdom": "^22.4.0",
-						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^22.4.0",
-						"jest-message-util": "^22.4.0",
-						"jest-regex-util": "^22.1.0",
-						"jest-resolve-dependencies": "^22.1.0",
-						"jest-runner": "^22.4.0",
-						"jest-runtime": "^22.4.0",
-						"jest-snapshot": "^22.4.0",
-						"jest-util": "^22.4.0",
-						"jest-validate": "^22.4.0",
-						"jest-worker": "^22.2.2",
-						"micromatch": "^2.3.11",
-						"node-notifier": "^5.2.1",
-						"realpath-native": "^1.0.0",
-						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
-						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
-						"which": "^1.2.12",
-						"yargs": "^10.0.3"
+						"ansi-escapes": "3.0.0",
+						"chalk": "2.3.1",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.2.2",
+						"istanbul-lib-coverage": "1.1.2",
+						"istanbul-lib-instrument": "1.9.2",
+						"istanbul-lib-source-maps": "1.2.3",
+						"jest-changed-files": "22.2.0",
+						"jest-config": "22.4.0",
+						"jest-environment-jsdom": "22.4.0",
+						"jest-get-type": "22.1.0",
+						"jest-haste-map": "22.4.0",
+						"jest-message-util": "22.4.0",
+						"jest-regex-util": "22.1.0",
+						"jest-resolve-dependencies": "22.1.0",
+						"jest-runner": "22.4.0",
+						"jest-runtime": "22.4.0",
+						"jest-snapshot": "22.4.0",
+						"jest-util": "22.4.0",
+						"jest-validate": "22.4.0",
+						"jest-worker": "22.2.2",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.2.1",
+						"realpath-native": "1.0.0",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.0",
+						"yargs": "10.1.2"
 					}
 				},
 				"strip-ansi": {
@@ -7995,7 +7994,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -8004,7 +8003,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				},
 				"yargs": {
@@ -8013,18 +8012,18 @@
 					"integrity": "sha1-RU0HTCsWpRpD4vt4B+T53mnMtcU=",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.1.0"
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -8033,7 +8032,7 @@
 					"integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -8044,7 +8043,7 @@
 			"integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
 			"dev": true,
 			"requires": {
-				"throat": "^4.0.0"
+				"throat": "4.1.0"
 			}
 		},
 		"jest-config": {
@@ -8053,17 +8052,17 @@
 			"integrity": "sha512-hZs8qHjCybOpqni0Kwt40eAavYN/3KnJJwYxSJsBRedJ98IgGSiI18SjybCSccKayA7eHgw1A+dLkHcfI4LItQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^22.4.0",
-				"jest-environment-node": "^22.4.0",
-				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^22.4.0",
-				"jest-regex-util": "^22.1.0",
-				"jest-resolve": "^22.4.0",
-				"jest-util": "^22.4.0",
-				"jest-validate": "^22.4.0",
-				"pretty-format": "^22.4.0"
+				"chalk": "2.3.1",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "22.4.0",
+				"jest-environment-node": "22.4.0",
+				"jest-get-type": "22.1.0",
+				"jest-jasmine2": "22.4.0",
+				"jest-regex-util": "22.1.0",
+				"jest-resolve": "22.4.0",
+				"jest-util": "22.4.0",
+				"jest-validate": "22.4.0",
+				"pretty-format": "22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8072,7 +8071,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8081,9 +8080,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8098,7 +8097,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8109,10 +8108,10 @@
 			"integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^22.4.0"
+				"chalk": "2.3.1",
+				"diff": "3.4.0",
+				"jest-get-type": "22.1.0",
+				"pretty-format": "22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8121,7 +8120,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8130,9 +8129,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8147,7 +8146,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8158,7 +8157,7 @@
 			"integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "2.1.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -8167,9 +8166,9 @@
 			"integrity": "sha512-SAUCte4KFLaD2YhYwHFVEI2GkR4BHqHJsnbFgmQMGgHnZ2CfjSZE8Bnb+jlarbxIG4GXl31+2e9rjBpzbY9gKQ==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^22.2.0",
-				"jest-util": "^22.4.0",
-				"jsdom": "^11.5.1"
+				"jest-mock": "22.2.0",
+				"jest-util": "22.4.0",
+				"jsdom": "11.6.2"
 			}
 		},
 		"jest-environment-node": {
@@ -8178,8 +8177,8 @@
 			"integrity": "sha512-ihSKa2MU5jkAhmRJ17FU4nisbbfW6spvl6Jtwmm5W9kmTVa2sa9UoHWbOWAb7HXuLi3PGGjzTfEt5o3uIzisnQ==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^22.2.0",
-				"jest-util": "^22.4.0"
+				"jest-mock": "22.2.0",
+				"jest-util": "22.4.0"
 			}
 		},
 		"jest-enzyme": {
@@ -8188,8 +8187,8 @@
 			"integrity": "sha512-nna99NnU6sDbWqVX0153c81RUuxI/spTgw4Xobh049NcKihu0OAtAawbuSzZUnlCqdZOoXlKMudfjUPm0sCTsg==",
 			"dev": true,
 			"requires": {
-				"enzyme-matchers": "^4.2.0",
-				"enzyme-to-json": "^3.3.0"
+				"enzyme-matchers": "4.2.0",
+				"enzyme-to-json": "3.3.1"
 			}
 		},
 		"jest-get-type": {
@@ -8204,13 +8203,13 @@
 			"integrity": "sha512-znYomZ+GaRcuFLQz7hmwQOfLkHY2Y2Aoyd29ZcXLrwBEWts5U/c7lFsqo54XUJUlMhrM5M2IOaAUWjZ1CRqAOQ==",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-docblock": "^22.4.0",
-				"jest-serializer": "^22.4.0",
-				"jest-worker": "^22.2.2",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "22.4.0",
+				"jest-serializer": "22.4.0",
+				"jest-worker": "22.2.2",
+				"micromatch": "2.3.11",
+				"sane": "2.4.1"
 			}
 		},
 		"jest-jasmine2": {
@@ -8219,17 +8218,17 @@
 			"integrity": "sha512-oL7bNLfEL9jPVjmiwqQuwrAJ/5ddmKHSpns0kCpAmv1uQ47Q5aC9zBTXZbDWP5GVbVHj2hbYtNbkwTiXJr0e8w==",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0",
-				"chalk": "^2.0.1",
-				"co": "^4.6.0",
-				"expect": "^22.4.0",
-				"graceful-fs": "^4.1.11",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^22.4.0",
-				"jest-matcher-utils": "^22.4.0",
-				"jest-message-util": "^22.4.0",
-				"jest-snapshot": "^22.4.0",
-				"source-map-support": "^0.5.0"
+				"callsites": "2.0.0",
+				"chalk": "2.3.1",
+				"co": "4.6.0",
+				"expect": "22.4.0",
+				"graceful-fs": "4.1.11",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "22.4.0",
+				"jest-matcher-utils": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-snapshot": "22.4.0",
+				"source-map-support": "0.5.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8238,7 +8237,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8247,9 +8246,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8264,7 +8263,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8275,7 +8274,7 @@
 			"integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^22.4.0"
+				"pretty-format": "22.4.0"
 			}
 		},
 		"jest-matcher-utils": {
@@ -8284,9 +8283,9 @@
 			"integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^22.4.0"
+				"chalk": "2.3.1",
+				"jest-get-type": "22.1.0",
+				"pretty-format": "22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8295,7 +8294,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8304,9 +8303,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8321,7 +8320,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8332,11 +8331,11 @@
 			"integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
-				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
-				"stack-utils": "^1.0.1"
+				"@babel/code-frame": "7.0.0-beta.40",
+				"chalk": "2.3.1",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8345,7 +8344,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8354,9 +8353,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8371,7 +8370,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8394,8 +8393,8 @@
 			"integrity": "sha512-Vs/5VeJEHLpB0ubpYuU9QpBjcCUZRHoHnoV58ZC+N3EXyMJr/MgoqUNpo4OHGQERWlUpvl4YLAAO5uxSMF2VIg==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "^1.11.2",
-				"chalk": "^2.0.1"
+				"browser-resolve": "1.11.2",
+				"chalk": "2.3.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8404,7 +8403,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8413,9 +8412,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8430,7 +8429,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8441,7 +8440,7 @@
 			"integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^22.1.0"
+				"jest-regex-util": "22.1.0"
 			}
 		},
 		"jest-runner": {
@@ -8450,17 +8449,17 @@
 			"integrity": "sha512-x5QJQrSQs/oaZq2UxtKJxCjGq3fNF7guKRLxAIS39QIaRSAynS4agniMyvHMnLaYsBh6yzUea2SDeNHayQh+TQ==",
 			"dev": true,
 			"requires": {
-				"exit": "^0.1.2",
-				"jest-config": "^22.4.0",
-				"jest-docblock": "^22.4.0",
-				"jest-haste-map": "^22.4.0",
-				"jest-jasmine2": "^22.4.0",
-				"jest-leak-detector": "^22.4.0",
-				"jest-message-util": "^22.4.0",
-				"jest-runtime": "^22.4.0",
-				"jest-util": "^22.4.0",
-				"jest-worker": "^22.2.2",
-				"throat": "^4.0.0"
+				"exit": "0.1.2",
+				"jest-config": "22.4.0",
+				"jest-docblock": "22.4.0",
+				"jest-haste-map": "22.4.0",
+				"jest-jasmine2": "22.4.0",
+				"jest-leak-detector": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-runtime": "22.4.0",
+				"jest-util": "22.4.0",
+				"jest-worker": "22.2.2",
+				"throat": "4.1.0"
 			}
 		},
 		"jest-runtime": {
@@ -8469,26 +8468,26 @@
 			"integrity": "sha512-aixL2DIXoFQ2ubnurzK4kbNXLl3+m0m7wIBb5VWaJdl1/3nV1UCSjZ9/dJZzpWGGfXsoGw2RZd8sS0nS5s+tdw==",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^22.4.0",
-				"babel-plugin-istanbul": "^4.1.5",
-				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^22.4.0",
-				"jest-haste-map": "^22.4.0",
-				"jest-regex-util": "^22.1.0",
-				"jest-resolve": "^22.4.0",
-				"jest-util": "^22.4.0",
-				"jest-validate": "^22.4.0",
-				"json-stable-stringify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
+				"babel-core": "6.26.0",
+				"babel-jest": "22.4.0",
+				"babel-plugin-istanbul": "4.1.5",
+				"chalk": "2.3.1",
+				"convert-source-map": "1.5.1",
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "22.4.0",
+				"jest-haste-map": "22.4.0",
+				"jest-regex-util": "22.1.0",
+				"jest-resolve": "22.4.0",
+				"jest-util": "22.4.0",
+				"jest-validate": "22.4.0",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.0",
+				"slash": "1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^10.0.3"
+				"write-file-atomic": "2.3.0",
+				"yargs": "10.1.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8503,7 +8502,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8512,9 +8511,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"cliui": {
@@ -8523,9 +8522,9 @@
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"find-up": {
@@ -8534,7 +8533,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"has-flag": {
@@ -8549,7 +8548,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -8558,7 +8557,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				},
 				"yargs": {
@@ -8567,18 +8566,18 @@
 					"integrity": "sha1-RU0HTCsWpRpD4vt4B+T53mnMtcU=",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.1.0"
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -8587,7 +8586,7 @@
 					"integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -8604,12 +8603,12 @@
 			"integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-diff": "^22.4.0",
-				"jest-matcher-utils": "^22.4.0",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^22.4.0"
+				"chalk": "2.3.1",
+				"jest-diff": "22.4.0",
+				"jest-matcher-utils": "22.4.0",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8618,7 +8617,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8627,9 +8626,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8644,7 +8643,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8655,12 +8654,12 @@
 			"integrity": "sha512-652EArz3XScAGAUMhbny7FrFGlmJkp+56CO+9RTrKPtGfbtVDF2WB2D8G+6D6zorDmDW5hNtKNIGNdGfG2kj1g==",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^22.4.0",
-				"mkdirp": "^0.5.1"
+				"callsites": "2.0.0",
+				"chalk": "2.3.1",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "22.4.0",
+				"mkdirp": "0.5.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8669,7 +8668,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8678,9 +8677,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8695,7 +8694,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8706,11 +8705,11 @@
 			"integrity": "sha512-l5JwbIAso8jGp/5/Dy86BCVjOra/Rb81wyXcFTGa4VxbtIh4AEOp2WixgprHLwp+YlUrHugZwaGyuagjB+iB+A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-config": "^22.4.0",
-				"jest-get-type": "^22.1.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^22.4.0"
+				"chalk": "2.3.1",
+				"jest-config": "22.4.0",
+				"jest-get-type": "22.1.0",
+				"leven": "2.1.0",
+				"pretty-format": "22.4.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8719,7 +8718,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8728,9 +8727,9 @@
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.2.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
 					}
 				},
 				"has-flag": {
@@ -8745,7 +8744,7 @@
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8756,7 +8755,7 @@
 			"integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1"
+				"merge-stream": "1.0.1"
 			}
 		},
 		"jquery": {
@@ -8775,10 +8774,10 @@
 			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.14.tgz",
 			"integrity": "sha1-07j3Mi0CuSd9WL0jgmTDJ+WARM0=",
 			"requires": {
-				"config-chain": "~1.1.5",
-				"editorconfig": "^0.13.2",
-				"mkdirp": "~0.5.0",
-				"nopt": "~3.0.1"
+				"config-chain": "1.1.11",
+				"editorconfig": "0.13.3",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6"
 			}
 		},
 		"js-tokens": {
@@ -8792,8 +8791,8 @@
 			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.9",
+				"esprima": "4.0.0"
 			}
 		},
 		"jsbn": {
@@ -8809,21 +8808,21 @@
 			"integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.8.0",
-				"babel-preset-es2015": "^6.9.0",
-				"babel-preset-stage-1": "^6.5.0",
-				"babel-register": "^6.9.0",
-				"babylon": "^7.0.0-beta.30",
-				"colors": "^1.1.2",
-				"flow-parser": "^0.*",
-				"lodash": "^4.13.1",
-				"micromatch": "^2.3.7",
-				"neo-async": "^2.5.0",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-preset-es2015": "6.24.1",
+				"babel-preset-stage-1": "6.24.1",
+				"babel-register": "6.26.0",
+				"babylon": "7.0.0-beta.42",
+				"colors": "1.2.1",
+				"flow-parser": "0.69.0",
+				"lodash": "4.17.5",
+				"micromatch": "2.3.11",
+				"neo-async": "2.5.0",
 				"node-dir": "0.1.8",
-				"nomnom": "^1.8.1",
-				"recast": "^0.14.1",
-				"temp": "^0.8.1",
-				"write-file-atomic": "^1.2.0"
+				"nomnom": "1.8.1",
+				"recast": "0.14.7",
+				"temp": "0.8.3",
+				"write-file-atomic": "1.3.4"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8844,9 +8843,9 @@
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
+						"ansi-styles": "1.0.0",
+						"has-color": "0.1.7",
+						"strip-ansi": "0.1.1"
 					}
 				},
 				"colors": {
@@ -8861,8 +8860,8 @@
 					"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
 					"dev": true,
 					"requires": {
-						"chalk": "~0.4.0",
-						"underscore": "~1.6.0"
+						"chalk": "0.4.0",
+						"underscore": "1.6.0"
 					}
 				},
 				"strip-ansi": {
@@ -8883,9 +8882,9 @@
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
 					}
 				}
 			}
@@ -8896,32 +8895,32 @@
 			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.4",
-				"acorn": "^5.3.0",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"browser-process-hrtime": "^0.1.2",
-				"content-type-parser": "^1.0.2",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": ">= 0.2.37 < 0.3.0",
-				"domexception": "^1.0.0",
-				"escodegen": "^1.9.0",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.2.0",
-				"nwmatcher": "^1.4.3",
+				"abab": "1.0.4",
+				"acorn": "5.4.1",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"browser-process-hrtime": "0.1.2",
+				"content-type-parser": "1.0.2",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.0",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.2.0",
+				"nwmatcher": "1.4.3",
 				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.83.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.3",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-url": "^6.4.0",
-				"ws": "^4.0.0",
-				"xml-name-validator": "^3.0.0"
+				"pn": "1.1.0",
+				"request": "2.83.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.3",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-url": "6.4.0",
+				"ws": "4.0.0",
+				"xml-name-validator": "3.0.0"
 			},
 			"dependencies": {
 				"parse5": {
@@ -8968,7 +8967,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "~0.0.0"
+				"jsonify": "0.0.0"
 			}
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -9034,7 +9033,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "^1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"lazy-cache": {
@@ -9049,7 +9048,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"left-pad": {
@@ -9070,8 +9069,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"line-height": {
@@ -9079,7 +9078,7 @@
 			"resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
 			"integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
 			"requires": {
-				"computed-style": "~0.1.3"
+				"computed-style": "0.1.4"
 			}
 		},
 		"listr": {
@@ -9088,23 +9087,23 @@
 			"integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"figures": "^1.7.0",
-				"indent-string": "^2.1.0",
-				"is-observable": "^0.2.0",
-				"is-promise": "^2.1.0",
-				"is-stream": "^1.1.0",
-				"listr-silent-renderer": "^1.1.1",
-				"listr-update-renderer": "^0.4.0",
-				"listr-verbose-renderer": "^0.4.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^1.0.2",
-				"ora": "^0.2.3",
-				"p-map": "^1.1.1",
-				"rxjs": "^5.4.2",
-				"stream-to-observable": "^0.2.0",
-				"strip-ansi": "^3.0.1"
+				"chalk": "1.1.3",
+				"cli-truncate": "0.2.1",
+				"figures": "1.7.0",
+				"indent-string": "2.1.0",
+				"is-observable": "0.2.0",
+				"is-promise": "2.1.0",
+				"is-stream": "1.1.0",
+				"listr-silent-renderer": "1.1.1",
+				"listr-update-renderer": "0.4.0",
+				"listr-verbose-renderer": "0.4.1",
+				"log-symbols": "1.0.2",
+				"log-update": "1.0.2",
+				"ora": "0.2.3",
+				"p-map": "1.2.0",
+				"rxjs": "5.5.8",
+				"stream-to-observable": "0.2.0",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"figures": {
@@ -9113,8 +9112,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
 					}
 				},
 				"log-symbols": {
@@ -9123,7 +9122,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.0.0"
+						"chalk": "1.1.3"
 					}
 				}
 			}
@@ -9140,14 +9139,14 @@
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^1.0.2",
-				"strip-ansi": "^3.0.1"
+				"chalk": "1.1.3",
+				"cli-truncate": "0.2.1",
+				"elegant-spinner": "1.0.1",
+				"figures": "1.7.0",
+				"indent-string": "3.2.0",
+				"log-symbols": "1.0.2",
+				"log-update": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"figures": {
@@ -9156,8 +9155,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
 					}
 				},
 				"indent-string": {
@@ -9172,7 +9171,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.0.0"
+						"chalk": "1.1.3"
 					}
 				}
 			}
@@ -9183,10 +9182,10 @@
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-cursor": "^1.0.2",
-				"date-fns": "^1.27.2",
-				"figures": "^1.7.0"
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"date-fns": "1.29.0",
+				"figures": "1.7.0"
 			},
 			"dependencies": {
 				"cli-cursor": {
@@ -9195,7 +9194,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^1.0.1"
+						"restore-cursor": "1.0.1"
 					}
 				},
 				"figures": {
@@ -9204,8 +9203,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
 					}
 				},
 				"onetime": {
@@ -9220,8 +9219,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
 					}
 				}
 			}
@@ -9238,9 +9237,9 @@
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"dev": true,
 			"requires": {
-				"big.js": "^3.1.3",
-				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
 			}
 		},
 		"locate-path": {
@@ -9248,8 +9247,8 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			},
 			"dependencies": {
 				"path-exists": {
@@ -9275,9 +9274,9 @@
 			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
 			"dev": true,
 			"requires": {
-				"lodash.isarray": "^3.0.0",
-				"lodash.istypedarray": "^3.0.0",
-				"lodash.keys": "^3.0.0"
+				"lodash.isarray": "3.0.4",
+				"lodash.istypedarray": "3.0.6",
+				"lodash.keys": "3.1.2"
 			}
 		},
 		"lodash._bindcallback": {
@@ -9328,8 +9327,8 @@
 			"integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
 			"dev": true,
 			"requires": {
-				"lodash._baseisequal": "^3.0.0",
-				"lodash._bindcallback": "^3.0.0"
+				"lodash._baseisequal": "3.0.7",
+				"lodash._bindcallback": "3.0.1"
 			}
 		},
 		"lodash.istypedarray": {
@@ -9344,9 +9343,9 @@
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"dev": true,
 			"requires": {
-				"lodash._getnative": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
 			}
 		},
 		"lodash.memoize": {
@@ -9391,7 +9390,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "2.3.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -9400,7 +9399,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -9409,9 +9408,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
 					}
 				},
 				"has-flag": {
@@ -9426,7 +9425,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -9437,8 +9436,8 @@
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^1.0.0",
-				"cli-cursor": "^1.0.2"
+				"ansi-escapes": "1.4.0",
+				"cli-cursor": "1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -9453,7 +9452,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^1.0.1"
+						"restore-cursor": "1.0.1"
 					}
 				},
 				"onetime": {
@@ -9468,8 +9467,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
 					}
 				}
 			}
@@ -9485,7 +9484,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"loud-rejection": {
@@ -9494,8 +9493,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"lowercase-keys": {
@@ -9509,7 +9508,7 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
 			"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
 			"requires": {
-				"pseudomap": "^1.0.1"
+				"pseudomap": "1.0.2"
 			}
 		},
 		"macaddress": {
@@ -9524,7 +9523,7 @@
 			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -9541,7 +9540,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -9568,7 +9567,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"material-colors": {
@@ -9588,8 +9587,8 @@
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"dev": true,
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
 			},
 			"dependencies": {
 				"hash-base": {
@@ -9598,8 +9597,8 @@
 					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 					"dev": true,
 					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
+						"inherits": "2.0.3",
+						"safe-buffer": "5.1.1"
 					}
 				}
 			}
@@ -9609,7 +9608,7 @@
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"mem-fs": {
@@ -9618,9 +9617,9 @@
 			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
 			"dev": true,
 			"requires": {
-				"through2": "^2.0.0",
-				"vinyl": "^1.1.0",
-				"vinyl-file": "^2.0.0"
+				"through2": "2.0.3",
+				"vinyl": "1.2.0",
+				"vinyl-file": "2.0.0"
 			}
 		},
 		"mem-fs-editor": {
@@ -9629,16 +9628,16 @@
 			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"deep-extend": "^0.4.0",
-				"ejs": "^2.3.1",
-				"glob": "^7.0.3",
-				"globby": "^6.1.0",
-				"mkdirp": "^0.5.0",
-				"multimatch": "^2.0.0",
-				"rimraf": "^2.2.8",
-				"through2": "^2.0.0",
-				"vinyl": "^2.0.1"
+				"commondir": "1.0.1",
+				"deep-extend": "0.4.2",
+				"ejs": "2.5.8",
+				"glob": "7.1.2",
+				"globby": "6.1.0",
+				"mkdirp": "0.5.1",
+				"multimatch": "2.1.0",
+				"rimraf": "2.6.2",
+				"through2": "2.0.3",
+				"vinyl": "2.1.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -9659,11 +9658,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"array-union": "1.0.2",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"replace-ext": {
@@ -9699,8 +9698,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
+				"errno": "0.1.7",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"meow": {
@@ -9709,16 +9708,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
 			},
 			"dependencies": {
 				"load-json-file": {
@@ -9727,11 +9726,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"minimist": {
@@ -9746,9 +9745,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"read-pkg": {
@@ -9757,9 +9756,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -9768,8 +9767,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					}
 				},
 				"strip-bom": {
@@ -9778,7 +9777,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -9794,7 +9793,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.3"
 			}
 		},
 		"micromatch": {
@@ -9803,19 +9802,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
 			}
 		},
 		"miller-rabin": {
@@ -9824,8 +9823,8 @@
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
 			}
 		},
 		"mime": {
@@ -9846,7 +9845,7 @@
 			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.30.0"
+				"mime-db": "1.30.0"
 			}
 		},
 		"mimic-fn": {
@@ -9877,7 +9876,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.8"
 			}
 		},
 		"minimist": {
@@ -9891,16 +9890,16 @@
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "^1.5.0",
-				"duplexify": "^3.4.2",
-				"end-of-stream": "^1.1.0",
-				"flush-write-stream": "^1.0.0",
-				"from2": "^2.1.0",
-				"parallel-transform": "^1.1.0",
-				"pump": "^2.0.1",
-				"pumpify": "^1.3.3",
-				"stream-each": "^1.1.0",
-				"through2": "^2.0.0"
+				"concat-stream": "1.6.0",
+				"duplexify": "3.5.4",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.0.3",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "2.0.1",
+				"pumpify": "1.4.0",
+				"stream-each": "1.2.2",
+				"through2": "2.0.3"
 			}
 		},
 		"mixin-deep": {
@@ -9909,8 +9908,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -9919,7 +9918,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -9930,8 +9929,8 @@
 			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
+				"for-in": "0.1.8",
+				"is-extendable": "0.1.1"
 			},
 			"dependencies": {
 				"for-in": {
@@ -9960,7 +9959,7 @@
 			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
 			"integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
 			"requires": {
-				"moment": ">= 2.9.0"
+				"moment": "2.21.0"
 			}
 		},
 		"mousetrap": {
@@ -9974,12 +9973,12 @@
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1",
-				"copy-concurrently": "^1.0.0",
-				"fs-write-stream-atomic": "^1.0.8",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.4",
-				"run-queue": "^1.0.3"
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
 			}
 		},
 		"ms": {
@@ -9994,10 +9993,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "^1.0.0",
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"minimatch": "^3.0.0"
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
 			}
 		},
 		"mute-stream": {
@@ -10018,18 +10017,18 @@
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -10070,10 +10069,10 @@
 			"integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
 			"dev": true,
 			"requires": {
-				"nomnom": "~1.6.2",
-				"railroad-diagrams": "^1.0.0",
+				"nomnom": "1.6.2",
+				"railroad-diagrams": "1.0.0",
 				"randexp": "0.4.6",
-				"semver": "^5.4.1"
+				"semver": "5.5.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -10107,8 +10106,8 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
 			}
 		},
 		"node-gyp": {
@@ -10117,19 +10116,19 @@
 			"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
 			"dev": true,
 			"requires": {
-				"fstream": "^1.0.0",
-				"glob": "^7.0.3",
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"mkdirp": "^0.5.0",
-				"nopt": "2 || 3",
-				"npmlog": "0 || 1 || 2 || 3 || 4",
-				"osenv": "0",
-				"request": "2",
-				"rimraf": "2",
-				"semver": "~5.3.0",
-				"tar": "^2.0.0",
-				"which": "1"
+				"fstream": "1.0.11",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"npmlog": "4.1.2",
+				"osenv": "0.1.4",
+				"request": "2.83.0",
+				"rimraf": "2.6.2",
+				"semver": "5.3.0",
+				"tar": "2.2.1",
+				"which": "1.3.0"
 			}
 		},
 		"node-int64": {
@@ -10144,28 +10143,28 @@
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"dev": true,
 			"requires": {
-				"assert": "^1.1.1",
-				"browserify-zlib": "^0.2.0",
-				"buffer": "^4.3.0",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"crypto-browserify": "^3.11.0",
-				"domain-browser": "^1.1.1",
-				"events": "^1.0.0",
-				"https-browserify": "^1.0.0",
-				"os-browserify": "^0.3.0",
+				"assert": "1.4.1",
+				"browserify-zlib": "0.2.0",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.12.0",
+				"domain-browser": "1.2.0",
+				"events": "1.1.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "^0.11.10",
-				"punycode": "^1.2.4",
-				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.3.3",
-				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.7.2",
-				"string_decoder": "^1.0.0",
-				"timers-browserify": "^2.0.4",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.3",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.8.1",
+				"string_decoder": "1.0.3",
+				"timers-browserify": "2.0.6",
 				"tty-browserify": "0.0.0",
-				"url": "^0.11.0",
-				"util": "^0.10.3",
+				"url": "0.11.0",
+				"util": "0.10.3",
 				"vm-browserify": "0.0.4"
 			}
 		},
@@ -10175,10 +10174,10 @@
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"dev": true,
 			"requires": {
-				"growly": "^1.3.0",
-				"semver": "^5.4.1",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -10195,25 +10194,25 @@
 			"integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
 			"dev": true,
 			"requires": {
-				"async-foreach": "^0.1.3",
-				"chalk": "^1.1.1",
-				"cross-spawn": "^3.0.0",
-				"gaze": "^1.0.0",
-				"get-stdin": "^4.0.1",
-				"glob": "^7.0.3",
-				"in-publish": "^2.0.0",
-				"lodash.assign": "^4.2.0",
-				"lodash.clonedeep": "^4.3.2",
-				"lodash.mergewith": "^4.6.0",
-				"meow": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"nan": "^2.3.2",
-				"node-gyp": "^3.3.1",
-				"npmlog": "^4.0.0",
-				"request": "~2.79.0",
-				"sass-graph": "^2.2.4",
-				"stdout-stream": "^1.4.0",
-				"true-case-path": "^1.0.2"
+				"async-foreach": "0.1.3",
+				"chalk": "1.1.3",
+				"cross-spawn": "3.0.1",
+				"gaze": "1.1.2",
+				"get-stdin": "4.0.1",
+				"glob": "7.1.2",
+				"in-publish": "2.0.0",
+				"lodash.assign": "4.2.0",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.mergewith": "4.6.1",
+				"meow": "3.7.0",
+				"mkdirp": "0.5.1",
+				"nan": "2.8.0",
+				"node-gyp": "3.6.2",
+				"npmlog": "4.1.2",
+				"request": "2.79.0",
+				"sass-graph": "2.2.4",
+				"stdout-stream": "1.4.0",
+				"true-case-path": "1.0.2"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -10234,7 +10233,7 @@
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"caseless": {
@@ -10249,8 +10248,8 @@
 					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.1",
+						"which": "1.3.0"
 					}
 				},
 				"cryptiles": {
@@ -10259,7 +10258,7 @@
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
 					"requires": {
-						"boom": "2.x.x"
+						"boom": "2.10.1"
 					}
 				},
 				"form-data": {
@@ -10268,9 +10267,9 @@
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
 					"dev": true,
 					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.17"
 					}
 				},
 				"har-validator": {
@@ -10279,10 +10278,10 @@
 					"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.1.1",
-						"commander": "^2.9.0",
-						"is-my-json-valid": "^2.12.4",
-						"pinkie-promise": "^2.0.0"
+						"chalk": "1.1.3",
+						"commander": "2.14.1",
+						"is-my-json-valid": "2.17.1",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"hawk": {
@@ -10291,10 +10290,10 @@
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
 					"requires": {
-						"boom": "2.x.x",
-						"cryptiles": "2.x.x",
-						"hoek": "2.x.x",
-						"sntp": "1.x.x"
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
 					}
 				},
 				"hoek": {
@@ -10309,9 +10308,9 @@
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"dev": true,
 					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.1",
+						"sshpk": "1.13.1"
 					}
 				},
 				"lru-cache": {
@@ -10320,8 +10319,8 @@
 					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 					"dev": true,
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
 					}
 				},
 				"qs": {
@@ -10336,26 +10335,26 @@
 					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
 					"dev": true,
 					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.11.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~2.0.6",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"qs": "~6.3.0",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "~0.4.1",
-						"uuid": "^3.0.0"
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.11.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "2.0.6",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.17",
+						"oauth-sign": "0.8.2",
+						"qs": "6.3.2",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.3",
+						"tunnel-agent": "0.4.3",
+						"uuid": "3.1.0"
 					}
 				},
 				"sntp": {
@@ -10364,7 +10363,7 @@
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"tunnel-agent": {
@@ -10381,8 +10380,8 @@
 			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
 			"dev": true,
 			"requires": {
-				"colors": "0.5.x",
-				"underscore": "~1.4.4"
+				"colors": "0.5.1",
+				"underscore": "1.4.4"
 			}
 		},
 		"nopt": {
@@ -10390,7 +10389,7 @@
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 			"requires": {
-				"abbrev": "1"
+				"abbrev": "1.1.1"
 			}
 		},
 		"normalize-package-data": {
@@ -10399,10 +10398,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.3.0",
+				"validate-npm-package-license": "3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -10411,7 +10410,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"normalize-range": {
@@ -10426,10 +10425,10 @@
 			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
 			"dev": true,
 			"requires": {
-				"object-assign": "^4.0.1",
-				"prepend-http": "^1.0.0",
-				"query-string": "^4.1.0",
-				"sort-keys": "^1.0.0"
+				"object-assign": "4.1.1",
+				"prepend-http": "1.0.4",
+				"query-string": "4.3.4",
+				"sort-keys": "1.1.2"
 			}
 		},
 		"npm-run-path": {
@@ -10437,7 +10436,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"npmlog": {
@@ -10446,10 +10445,10 @@
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
 			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
+				"are-we-there-yet": "1.1.4",
+				"console-control-strings": "1.1.0",
+				"gauge": "2.7.4",
+				"set-blocking": "2.0.0"
 			}
 		},
 		"nth-check": {
@@ -10458,7 +10457,7 @@
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
 			"dev": true,
 			"requires": {
-				"boolbase": "~1.0.0"
+				"boolbase": "1.0.0"
 			}
 		},
 		"num2fraction": {
@@ -10495,9 +10494,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -10506,7 +10505,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -10515,7 +10514,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -10524,7 +10523,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-descriptor": {
@@ -10533,9 +10532,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -10578,7 +10577,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -10595,10 +10594,10 @@
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"define-properties": "1.1.2",
+				"function-bind": "1.1.1",
+				"has-symbols": "1.0.0",
+				"object-keys": "1.0.11"
 			}
 		},
 		"object.entries": {
@@ -10607,10 +10606,10 @@
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.6.1",
-				"function-bind": "^1.1.0",
-				"has": "^1.0.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.1"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -10619,8 +10618,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
 			}
 		},
 		"object.omit": {
@@ -10629,8 +10628,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			}
 		},
 		"object.pick": {
@@ -10639,7 +10638,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -10656,10 +10655,10 @@
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.6.1",
-				"function-bind": "^1.1.0",
-				"has": "^1.0.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.1"
 			}
 		},
 		"once": {
@@ -10668,7 +10667,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -10677,7 +10676,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"optimist": {
@@ -10686,8 +10685,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
 			}
 		},
 		"optionator": {
@@ -10696,12 +10695,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -10718,10 +10717,10 @@
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.1",
-				"cli-cursor": "^1.0.2",
-				"cli-spinners": "^0.1.2",
-				"object-assign": "^4.0.1"
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"cli-spinners": "0.1.2",
+				"object-assign": "4.1.1"
 			},
 			"dependencies": {
 				"cli-cursor": {
@@ -10730,7 +10729,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^1.0.1"
+						"restore-cursor": "1.0.1"
 					}
 				},
 				"onetime": {
@@ -10745,8 +10744,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
 					}
 				}
 			}
@@ -10768,9 +10767,9 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -10785,8 +10784,8 @@
 			"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"p-cancelable": {
@@ -10801,7 +10800,7 @@
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
 			"dev": true,
 			"requires": {
-				"p-reduce": "^1.0.0"
+				"p-reduce": "1.0.0"
 			}
 		},
 		"p-finally": {
@@ -10826,7 +10825,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -10834,7 +10833,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.2.0"
 			}
 		},
 		"p-map": {
@@ -10855,7 +10854,7 @@
 			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
 			"dev": true,
 			"requires": {
-				"p-finally": "^1.0.0"
+				"p-finally": "1.0.0"
 			}
 		},
 		"p-try": {
@@ -10875,9 +10874,9 @@
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 			"dev": true,
 			"requires": {
-				"cyclist": "~0.2.2",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.1.5"
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"parse-asn1": {
@@ -10886,11 +10885,11 @@
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"dev": true,
 			"requires": {
-				"asn1.js": "^4.0.0",
-				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3"
+				"asn1.js": "4.10.1",
+				"browserify-aes": "1.1.1",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.3",
+				"pbkdf2": "3.0.14"
 			}
 		},
 		"parse-glob": {
@@ -10899,10 +10898,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"parse-json": {
@@ -10911,7 +10910,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.1"
 			}
 		},
 		"parse-passwd": {
@@ -10926,7 +10925,7 @@
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*"
+				"@types/node": "9.4.6"
 			}
 		},
 		"pascalcase": {
@@ -10953,7 +10952,7 @@
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 			"dev": true,
 			"requires": {
-				"pinkie-promise": "^2.0.0"
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"path-is-absolute": {
@@ -10984,11 +10983,11 @@
 			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
 			"dev": true,
 			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.11"
 			}
 		},
 		"pegjs": {
@@ -11003,7 +11002,7 @@
 			"integrity": "sha512-ViH8WwUkc/N8H59zuarORrgCi7uxn+gDIq+Ydriw1GFJi/oUg2xvhsgDDujO6dAxRsxXMgqWESx6TKYIqHorqA==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^0.2.5"
+				"loader-utils": "0.2.17"
 			},
 			"dependencies": {
 				"loader-utils": {
@@ -11012,10 +11011,10 @@
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"dev": true,
 					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
@@ -11056,7 +11055,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pluralize": {
@@ -11088,10 +11087,10 @@
 			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"js-base64": "^2.1.9",
-				"source-map": "^0.5.6",
-				"supports-color": "^3.2.3"
+				"chalk": "1.1.3",
+				"js-base64": "2.4.3",
+				"source-map": "0.5.7",
+				"supports-color": "3.2.3"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -11106,7 +11105,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -11117,9 +11116,9 @@
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.2",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-css-calc": "^1.2.6"
+				"postcss": "5.2.18",
+				"postcss-message-helpers": "2.0.0",
+				"reduce-css-calc": "1.3.0"
 			}
 		},
 		"postcss-colormin": {
@@ -11128,9 +11127,9 @@
 			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
 			"dev": true,
 			"requires": {
-				"colormin": "^1.0.5",
-				"postcss": "^5.0.13",
-				"postcss-value-parser": "^3.2.3"
+				"colormin": "1.1.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-convert-values": {
@@ -11139,8 +11138,8 @@
 			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.11",
-				"postcss-value-parser": "^3.1.2"
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-discard-comments": {
@@ -11149,7 +11148,7 @@
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.14"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-discard-duplicates": {
@@ -11158,7 +11157,7 @@
 			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-discard-empty": {
@@ -11167,7 +11166,7 @@
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.14"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-discard-overridden": {
@@ -11176,7 +11175,7 @@
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.16"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-discard-unused": {
@@ -11185,8 +11184,8 @@
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.14",
-				"uniqs": "^2.0.0"
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-filter-plugins": {
@@ -11195,8 +11194,8 @@
 			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4",
-				"uniqid": "^4.0.0"
+				"postcss": "5.2.18",
+				"uniqid": "4.1.1"
 			}
 		},
 		"postcss-load-config": {
@@ -11205,10 +11204,10 @@
 			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "^2.1.0",
-				"object-assign": "^4.1.0",
-				"postcss-load-options": "^1.2.0",
-				"postcss-load-plugins": "^2.3.0"
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1",
+				"postcss-load-options": "1.2.0",
+				"postcss-load-plugins": "2.3.0"
 			}
 		},
 		"postcss-load-options": {
@@ -11217,8 +11216,8 @@
 			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "^2.1.0",
-				"object-assign": "^4.1.0"
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1"
 			}
 		},
 		"postcss-load-plugins": {
@@ -11227,8 +11226,8 @@
 			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "^2.1.1",
-				"object-assign": "^4.1.0"
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1"
 			}
 		},
 		"postcss-loader": {
@@ -11237,10 +11236,10 @@
 			"integrity": "sha512-RuBcNE8rjCkIB0IsbmkGFRmQJTeQJfCI88E0VTarPNTvaNSv9OFv1DvTwgtAN/qlzyiELsmmmtX/tEzKp/cdug==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"postcss": "^6.0.0",
-				"postcss-load-config": "^1.2.0",
-				"schema-utils": "^0.4.0"
+				"loader-utils": "1.1.0",
+				"postcss": "6.0.21",
+				"postcss-load-config": "1.2.0",
+				"schema-utils": "0.4.5"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -11249,7 +11248,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -11258,9 +11257,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
 					}
 				},
 				"has-flag": {
@@ -11275,9 +11274,9 @@
 					"integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.3.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.3.0"
+						"chalk": "2.3.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.3.0"
 					}
 				},
 				"source-map": {
@@ -11292,7 +11291,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -11303,9 +11302,9 @@
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.10",
-				"postcss-value-parser": "^3.1.1"
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-merge-longhand": {
@@ -11314,7 +11313,7 @@
 			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-merge-rules": {
@@ -11323,11 +11322,11 @@
 			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
 			"dev": true,
 			"requires": {
-				"browserslist": "^1.5.2",
-				"caniuse-api": "^1.5.2",
-				"postcss": "^5.0.4",
-				"postcss-selector-parser": "^2.2.2",
-				"vendors": "^1.0.0"
+				"browserslist": "1.7.7",
+				"caniuse-api": "1.6.1",
+				"postcss": "5.2.18",
+				"postcss-selector-parser": "2.2.3",
+				"vendors": "1.0.1"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -11336,8 +11335,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
+						"caniuse-db": "1.0.30000804",
+						"electron-to-chromium": "1.3.33"
 					}
 				}
 			}
@@ -11354,9 +11353,9 @@
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
 			"dev": true,
 			"requires": {
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-minify-gradients": {
@@ -11365,8 +11364,8 @@
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.12",
-				"postcss-value-parser": "^3.3.0"
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-minify-params": {
@@ -11375,10 +11374,10 @@
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.1",
-				"postcss": "^5.0.2",
-				"postcss-value-parser": "^3.0.2",
-				"uniqs": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-minify-selectors": {
@@ -11387,10 +11386,10 @@
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.2",
-				"has": "^1.0.1",
-				"postcss": "^5.0.14",
-				"postcss-selector-parser": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-selector-parser": "2.2.3"
 			}
 		},
 		"postcss-normalize-charset": {
@@ -11399,7 +11398,7 @@
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.5"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-normalize-url": {
@@ -11408,10 +11407,10 @@
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
 			"dev": true,
 			"requires": {
-				"is-absolute-url": "^2.0.0",
-				"normalize-url": "^1.4.0",
-				"postcss": "^5.0.14",
-				"postcss-value-parser": "^3.2.3"
+				"is-absolute-url": "2.1.0",
+				"normalize-url": "1.9.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-ordered-values": {
@@ -11420,8 +11419,8 @@
 			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.1"
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-reduce-idents": {
@@ -11430,8 +11429,8 @@
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-reduce-initial": {
@@ -11440,7 +11439,7 @@
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-reduce-transforms": {
@@ -11449,9 +11448,9 @@
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.8",
-				"postcss-value-parser": "^3.0.1"
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-selector-parser": {
@@ -11460,9 +11459,9 @@
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
 			"dev": true,
 			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
+				"flatten": "1.0.2",
+				"indexes-of": "1.0.1",
+				"uniq": "1.0.1"
 			}
 		},
 		"postcss-svgo": {
@@ -11471,10 +11470,10 @@
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
 			"dev": true,
 			"requires": {
-				"is-svg": "^2.0.0",
-				"postcss": "^5.0.14",
-				"postcss-value-parser": "^3.2.3",
-				"svgo": "^0.7.0"
+				"is-svg": "2.1.0",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0",
+				"svgo": "0.7.2"
 			}
 		},
 		"postcss-unique-selectors": {
@@ -11483,9 +11482,9 @@
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.1",
-				"postcss": "^5.0.4",
-				"uniqs": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-value-parser": {
@@ -11500,9 +11499,9 @@
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.4",
-				"uniqs": "^2.0.0"
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
 			}
 		},
 		"prelude-ls": {
@@ -11541,8 +11540,8 @@
 			"integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11557,7 +11556,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				}
 			}
@@ -11590,7 +11589,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "~2.0.3"
+				"asap": "2.0.6"
 			}
 		},
 		"promise-inflight": {
@@ -11604,8 +11603,8 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
 			"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
 			"requires": {
-				"fbjs": "^0.8.9",
-				"loose-envify": "^1.3.1"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1"
 			}
 		},
 		"proto-list": {
@@ -11636,11 +11635,11 @@
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"parse-asn1": "5.1.0",
+				"randombytes": "2.0.6"
 			}
 		},
 		"pump": {
@@ -11649,8 +11648,8 @@
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
 			}
 		},
 		"pumpify": {
@@ -11659,9 +11658,9 @@
 			"integrity": "sha1-gLfF334kFT0D8OesigWl0Gi9B/s=",
 			"dev": true,
 			"requires": {
-				"duplexify": "^3.5.3",
-				"inherits": "^2.0.3",
-				"pump": "^2.0.0"
+				"duplexify": "3.5.4",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
 			}
 		},
 		"punycode": {
@@ -11676,14 +11675,14 @@
 			"integrity": "sha512-4sY/6mB7+kNPGAzPGKq65tH0VG3ohUEkXHuOReB9K/tw3m1TqifYmxnMR/uDeci/UPwyk5K1gWYh8rw0U0Zscw==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"extract-zip": "^1.6.5",
-				"https-proxy-agent": "^2.1.0",
-				"mime": "^1.3.4",
-				"progress": "^2.0.0",
-				"proxy-from-env": "^1.0.0",
-				"rimraf": "^2.6.1",
-				"ws": "^3.0.0"
+				"debug": "2.6.9",
+				"extract-zip": "1.6.6",
+				"https-proxy-agent": "2.2.0",
+				"mime": "1.6.0",
+				"progress": "2.0.0",
+				"proxy-from-env": "1.0.0",
+				"rimraf": "2.6.2",
+				"ws": "3.3.3"
 			},
 			"dependencies": {
 				"ws": {
@@ -11692,9 +11691,9 @@
 					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
 					"dev": true,
 					"requires": {
-						"async-limiter": "~1.0.0",
-						"safe-buffer": "~5.1.0",
-						"ultron": "~1.1.0"
+						"async-limiter": "1.0.0",
+						"safe-buffer": "5.1.1",
+						"ultron": "1.1.1"
 					}
 				}
 			}
@@ -11717,8 +11716,8 @@
 			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
 			"dev": true,
 			"requires": {
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
+				"object-assign": "4.1.1",
+				"strict-uri-encode": "1.1.0"
 			}
 		},
 		"querystring": {
@@ -11744,7 +11743,7 @@
 			"integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
 			"dev": true,
 			"requires": {
-				"performance-now": "^2.1.0"
+				"performance-now": "2.1.0"
 			}
 		},
 		"railroad-diagrams": {
@@ -11760,7 +11759,7 @@
 			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"randomatic": {
@@ -11769,8 +11768,8 @@
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -11779,7 +11778,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11788,7 +11787,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -11799,7 +11798,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -11810,7 +11809,7 @@
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.0"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"randomfill": {
@@ -11819,8 +11818,8 @@
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"dev": true,
 			"requires": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"raw-loader": {
@@ -11839,10 +11838,10 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-16.3.0.tgz",
 			"integrity": "sha512-Qh35tNbwY8SLFELkN3PCLO16EARV+lgcmNkQnoZXfzAF1ASRpeucZYUwBlBzsRAzTb7KyfBaLQ4/K/DLC6MYeA==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11850,9 +11849,9 @@
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
@@ -11862,9 +11861,9 @@
 			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.2.tgz",
 			"integrity": "sha1-K2hApp9xOHGavOpaQp7PcwF2jAc=",
 			"requires": {
-				"autosize": "^4.0.0",
-				"line-height": "^0.3.1",
-				"prop-types": "^15.5.6"
+				"autosize": "4.0.1",
+				"line-height": "0.3.1",
+				"prop-types": "15.5.10"
 			}
 		},
 		"react-click-outside": {
@@ -11872,7 +11871,7 @@
 			"resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.3.1.tgz",
 			"integrity": "sha1-MYc3698IGko7zUaCVmNnTL6YNus=",
 			"requires": {
-				"hoist-non-react-statics": "^1.2.0"
+				"hoist-non-react-statics": "1.2.0"
 			}
 		},
 		"react-color": {
@@ -11880,11 +11879,11 @@
 			"resolved": "https://registry.npmjs.org/react-color/-/react-color-2.13.4.tgz",
 			"integrity": "sha512-rNJTTxMPTImI1NpFaKLggDIvHgKOYRXj0krVh8c+Mo1YNsrLko8O94yiFqqdnSQgtIPteiAcGEJgBo9V5+uqaw==",
 			"requires": {
-				"lodash": "^4.0.1",
-				"material-colors": "^1.2.1",
-				"prop-types": "^15.5.4",
-				"reactcss": "^1.2.0",
-				"tinycolor2": "^1.1.2"
+				"lodash": "4.17.5",
+				"material-colors": "1.2.5",
+				"prop-types": "15.5.10",
+				"reactcss": "1.2.3",
+				"tinycolor2": "1.4.1"
 			}
 		},
 		"react-datepicker": {
@@ -11892,10 +11891,10 @@
 			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-1.4.1.tgz",
 			"integrity": "sha512-O/ExTWLS81pyWJWLFg1BRQEr9S/BDd6iMEkGctxQmVrRw2srW8DNdnQm5UgFNu8LoSZGMDvI55OghYZvDpWJhw==",
 			"requires": {
-				"classnames": "^2.2.5",
-				"prop-types": "^15.6.0",
-				"react-onclickoutside": "^6.7.1",
-				"react-popper": "^0.9.1"
+				"classnames": "2.2.5",
+				"prop-types": "15.6.1",
+				"react-onclickoutside": "6.7.1",
+				"react-popper": "0.9.5"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11903,9 +11902,9 @@
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
@@ -11915,10 +11914,10 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.0.tgz",
 			"integrity": "sha512-xT/FxawAurL6AV8YtAP7LkdDJFFX2vvv17AqFLQRF81ZtWLXkV/0dcAaiFIy0lmoQEFT931TU9aaH+5dBUxTcw==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11926,9 +11925,9 @@
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
@@ -11949,8 +11948,8 @@
 			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.9.5.tgz",
 			"integrity": "sha1-AqJO8+7DOvnlToNYq3DrDjMe3QU=",
 			"requires": {
-				"popper.js": "^1.14.1",
-				"prop-types": "^15.6.1"
+				"popper.js": "1.14.3",
+				"prop-types": "15.6.1"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11958,9 +11957,9 @@
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
@@ -11971,10 +11970,10 @@
 			"integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -11983,9 +11982,9 @@
 					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 					"dev": true,
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
@@ -11996,10 +11995,10 @@
 			"integrity": "sha512-7FAfgIT8Kvew36b2VFXnhMxjKkwAnicD1dyopq7Ot19WAhfJkyhYNwPzM1AnCfYccvEhO0x4FbqJETyMGQwgIg==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.16",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0",
-				"react-is": "^16.3.0"
+				"fbjs": "0.8.16",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1",
+				"react-is": "16.3.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -12008,9 +12007,9 @@
 					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 					"dev": true,
 					"requires": {
-						"fbjs": "^0.8.16",
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
+						"fbjs": "0.8.16",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1"
 					}
 				}
 			}
@@ -12020,7 +12019,7 @@
 			"resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
 			"integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
 			"requires": {
-				"lodash": "^4.0.1"
+				"lodash": "4.17.5"
 			}
 		},
 		"read-chunk": {
@@ -12029,8 +12028,8 @@
 			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0",
-				"safe-buffer": "^5.1.1"
+				"pify": "3.0.0",
+				"safe-buffer": "5.1.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -12046,13 +12045,13 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~1.0.6",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.0.3",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "1.0.7",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"readdirp": {
@@ -12061,10 +12060,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.3",
+				"set-immediate-shim": "1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -12073,7 +12072,7 @@
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "^1.0.0"
+				"util.promisify": "1.0.0"
 			}
 		},
 		"recast": {
@@ -12083,9 +12082,9 @@
 			"dev": true,
 			"requires": {
 				"ast-types": "0.11.3",
-				"esprima": "~4.0.0",
-				"private": "~0.1.5",
-				"source-map": "~0.6.1"
+				"esprima": "4.0.0",
+				"private": "0.1.8",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12102,7 +12101,7 @@
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dev": true,
 			"requires": {
-				"resolve": "^1.1.6"
+				"resolve": "1.5.0"
 			}
 		},
 		"redent": {
@@ -12111,8 +12110,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
 			}
 		},
 		"reduce-css-calc": {
@@ -12121,9 +12120,9 @@
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
+				"balanced-match": "0.4.2",
+				"math-expression-evaluator": "1.2.17",
+				"reduce-function-call": "1.0.2"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -12140,7 +12139,7 @@
 			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^0.4.2"
+				"balanced-match": "0.4.2"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -12156,10 +12155,10 @@
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
-				"lodash": "^4.2.1",
-				"lodash-es": "^4.2.1",
-				"loose-envify": "^1.1.0",
-				"symbol-observable": "^1.0.3"
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.5",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.2.0"
 			}
 		},
 		"redux-multi": {
@@ -12195,9 +12194,9 @@
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
-				"private": "^0.1.6"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"private": "0.1.8"
 			}
 		},
 		"regex-cache": {
@@ -12206,7 +12205,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regex-not": {
@@ -12215,8 +12214,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -12225,9 +12224,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"regjsgen": {
@@ -12242,7 +12241,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			}
 		},
 		"rememo": {
@@ -12250,7 +12249,7 @@
 			"resolved": "https://registry.npmjs.org/rememo/-/rememo-2.4.0.tgz",
 			"integrity": "sha512-4rqlLATPcha9lfdvylUWqSbceiTlYiBJvEJAyUiT/68cYPlNG1zXf7ABeve7s4YPrT6o3Q6zfN6n38ecAL71lw==",
 			"requires": {
-				"shallow-equal": "^1.0.0"
+				"shallow-equal": "1.0.0"
 			}
 		},
 		"remove-trailing-separator": {
@@ -12277,7 +12276,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"replace-ext": {
@@ -12292,28 +12291,28 @@
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"hawk": "~6.0.2",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"stringstream": "~0.0.5",
-				"tough-cookie": "~2.3.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.5",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.1",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.17",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.1.0"
 			}
 		},
 		"request-promise-core": {
@@ -12322,7 +12321,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "4.17.5"
 			}
 		},
 		"request-promise-native": {
@@ -12332,8 +12331,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.3"
 			}
 		},
 		"require-directory": {
@@ -12358,8 +12357,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -12380,7 +12379,7 @@
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -12389,7 +12388,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			}
 		},
 		"resolve-dir": {
@@ -12398,8 +12397,8 @@
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
+				"expand-tilde": "2.0.2",
+				"global-modules": "1.0.0"
 			}
 		},
 		"resolve-from": {
@@ -12420,7 +12419,7 @@
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "^1.0.0"
+				"lowercase-keys": "1.0.1"
 			}
 		},
 		"restore-cursor": {
@@ -12429,8 +12428,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -12446,7 +12445,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "^0.1.1"
+				"align-text": "0.1.4"
 			}
 		},
 		"rimraf": {
@@ -12455,7 +12454,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"ripemd160": {
@@ -12464,8 +12463,8 @@
 			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
 			"dev": true,
 			"requires": {
-				"hash-base": "^2.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "2.0.2",
+				"inherits": "2.0.3"
 			}
 		},
 		"rst-selector-parser": {
@@ -12474,8 +12473,8 @@
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
 			"dev": true,
 			"requires": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
+				"lodash.flattendeep": "4.4.0",
+				"nearley": "2.11.1"
 			}
 		},
 		"rtlcss": {
@@ -12484,11 +12483,11 @@
 			"integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.3.0",
-				"findup": "^0.1.5",
-				"mkdirp": "^0.5.1",
-				"postcss": "^6.0.14",
-				"strip-json-comments": "^2.0.0"
+				"chalk": "2.3.0",
+				"findup": "0.1.5",
+				"mkdirp": "0.5.1",
+				"postcss": "6.0.17",
+				"strip-json-comments": "2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -12497,7 +12496,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -12506,9 +12505,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
 					}
 				},
 				"postcss": {
@@ -12517,9 +12516,9 @@
 					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.3.0",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.1.0"
+						"chalk": "2.3.0",
+						"source-map": "0.6.1",
+						"supports-color": "5.1.0"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -12528,7 +12527,7 @@
 							"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
 							"dev": true,
 							"requires": {
-								"has-flag": "^2.0.0"
+								"has-flag": "2.0.0"
 							}
 						}
 					}
@@ -12545,7 +12544,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -12556,7 +12555,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"run-parallel": {
@@ -12571,7 +12570,7 @@
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1"
+				"aproba": "1.2.0"
 			}
 		},
 		"rx": {
@@ -12592,7 +12591,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "*"
+				"rx-lite": "4.0.8"
 			}
 		},
 		"rxjs": {
@@ -12623,7 +12622,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"sane": {
@@ -12632,14 +12631,14 @@
 			"integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^1.3.0",
-				"exec-sh": "^0.2.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.1.1",
-				"minimatch": "^3.0.2",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
+				"anymatch": "1.3.2",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.1.3",
+				"minimatch": "3.0.4",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -12656,10 +12655,10 @@
 			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"lodash": "^4.0.0",
-				"scss-tokenizer": "^0.2.3",
-				"yargs": "^7.0.0"
+				"glob": "7.1.2",
+				"lodash": "4.17.5",
+				"scss-tokenizer": "0.2.3",
+				"yargs": "7.1.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -12674,11 +12673,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"os-locale": {
@@ -12687,7 +12686,7 @@
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"dev": true,
 					"requires": {
-						"lcid": "^1.0.0"
+						"lcid": "1.0.0"
 					}
 				},
 				"path-type": {
@@ -12696,9 +12695,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"read-pkg": {
@@ -12707,9 +12706,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -12718,8 +12717,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					}
 				},
 				"string-width": {
@@ -12728,9 +12727,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"strip-bom": {
@@ -12739,7 +12738,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				},
 				"which-module": {
@@ -12754,19 +12753,19 @@
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^5.0.0"
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "5.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -12775,7 +12774,7 @@
 					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0"
+						"camelcase": "3.0.0"
 					}
 				}
 			}
@@ -12786,11 +12785,11 @@
 			"integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
 			"dev": true,
 			"requires": {
-				"clone-deep": "^2.0.1",
-				"loader-utils": "^1.0.1",
-				"lodash.tail": "^4.1.1",
-				"neo-async": "^2.5.0",
-				"pify": "^3.0.0"
+				"clone-deep": "2.0.2",
+				"loader-utils": "1.1.0",
+				"lodash.tail": "4.1.1",
+				"neo-async": "2.5.0",
+				"pify": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -12813,8 +12812,8 @@
 			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0"
+				"ajv": "6.4.0",
+				"ajv-keywords": "3.1.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -12823,10 +12822,10 @@
 					"integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0",
-						"uri-js": "^3.0.2"
+						"fast-deep-equal": "1.0.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1",
+						"uri-js": "3.0.2"
 					}
 				},
 				"ajv-keywords": {
@@ -12849,8 +12848,8 @@
 			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
 			"dev": true,
 			"requires": {
-				"js-base64": "^2.1.8",
-				"source-map": "^0.4.2"
+				"js-base64": "2.4.3",
+				"source-map": "0.4.4"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12859,7 +12858,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -12897,10 +12896,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -12909,7 +12908,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -12925,8 +12924,8 @@
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"shallow-clone": {
@@ -12935,9 +12934,9 @@
 			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
 			"dev": true,
 			"requires": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^5.0.0",
-				"mixin-object": "^2.0.1"
+				"is-extendable": "0.1.1",
+				"kind-of": "5.1.0",
+				"mixin-object": "2.0.1"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -12958,7 +12957,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -12972,9 +12971,9 @@
 			"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"interpret": "^1.0.0",
-				"rechoir": "^0.6.2"
+				"glob": "7.1.2",
+				"interpret": "1.1.0",
+				"rechoir": "0.6.2"
 			}
 		},
 		"shellwords": {
@@ -12988,7 +12987,7 @@
 			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
 			"integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
 			"requires": {
-				"yargs": "^10.0.3"
+				"yargs": "10.1.2"
 			}
 		},
 		"sigmund": {
@@ -13030,14 +13029,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.1",
+				"use": "3.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -13046,7 +13045,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -13055,7 +13054,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -13064,7 +13063,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13073,7 +13072,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -13084,7 +13083,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13093,7 +13092,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -13104,9 +13103,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					}
 				},
 				"kind-of": {
@@ -13123,9 +13122,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -13134,7 +13133,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"isobject": {
@@ -13151,7 +13150,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			}
 		},
 		"sntp": {
@@ -13160,7 +13159,7 @@
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"dev": true,
 			"requires": {
-				"hoek": "4.x.x"
+				"hoek": "4.2.0"
 			}
 		},
 		"sort-keys": {
@@ -13169,7 +13168,7 @@
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "^1.0.0"
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"source-list-map": {
@@ -13190,11 +13189,11 @@
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.0.0",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.0",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -13203,7 +13202,7 @@
 			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
 			"dev": true,
 			"requires": {
-				"source-map": "^0.6.0"
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -13232,7 +13231,7 @@
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"dev": true,
 			"requires": {
-				"spdx-license-ids": "^1.0.2"
+				"spdx-license-ids": "1.2.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -13253,7 +13252,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -13268,14 +13267,14 @@
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"ssri": {
@@ -13284,7 +13283,7 @@
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.1"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"stack-utils": {
@@ -13299,8 +13298,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -13309,7 +13308,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -13318,7 +13317,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13327,7 +13326,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -13338,7 +13337,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13347,7 +13346,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -13358,9 +13357,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					}
 				},
 				"kind-of": {
@@ -13377,7 +13376,7 @@
 			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.3"
 			}
 		},
 		"stealthy-require": {
@@ -13392,8 +13391,8 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.1",
-				"readable-stream": "^2.0.2"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"stream-each": {
@@ -13402,8 +13401,8 @@
 			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.1.0",
-				"stream-shift": "^1.0.0"
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"stream-http": {
@@ -13412,11 +13411,11 @@
 			"integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.3.3",
-				"to-arraybuffer": "^1.0.0",
-				"xtend": "^4.0.0"
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.1"
 			}
 		},
 		"stream-shift": {
@@ -13431,7 +13430,7 @@
 			"integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
 			"dev": true,
 			"requires": {
-				"any-observable": "^0.2.0"
+				"any-observable": "0.2.0"
 			}
 		},
 		"strict-uri-encode": {
@@ -13446,8 +13445,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -13462,7 +13461,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -13478,8 +13477,8 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -13497,7 +13496,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -13507,7 +13506,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringstream": {
@@ -13521,7 +13520,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-bom": {
@@ -13536,8 +13535,8 @@
 			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
 			"dev": true,
 			"requires": {
-				"first-chunk-stream": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"first-chunk-stream": "2.0.0",
+				"strip-bom": "2.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -13546,7 +13545,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -13562,7 +13561,7 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "^4.0.1"
+				"get-stdin": "4.0.1"
 			}
 		},
 		"strip-json-comments": {
@@ -13577,8 +13576,8 @@
 			"integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"schema-utils": "^0.4.5"
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.4.5"
 			}
 		},
 		"supports-color": {
@@ -13593,13 +13592,13 @@
 			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
 			"dev": true,
 			"requires": {
-				"coa": "~1.0.1",
-				"colors": "~1.1.2",
-				"csso": "~2.3.1",
-				"js-yaml": "~3.7.0",
-				"mkdirp": "~0.5.1",
-				"sax": "~1.2.1",
-				"whet.extend": "~0.9.9"
+				"coa": "1.0.4",
+				"colors": "1.1.2",
+				"csso": "2.3.2",
+				"js-yaml": "3.7.0",
+				"mkdirp": "0.5.1",
+				"sax": "1.2.4",
+				"whet.extend": "0.9.9"
 			},
 			"dependencies": {
 				"colors": {
@@ -13620,8 +13619,8 @@
 					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
 					"dev": true,
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^2.6.0"
+						"argparse": "1.0.9",
+						"esprima": "2.7.3"
 					}
 				}
 			}
@@ -13643,12 +13642,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-keywords": "^2.1.0",
-				"chalk": "^2.1.0",
-				"lodash": "^4.17.4",
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.3.0",
+				"lodash": "4.17.5",
 				"slice-ansi": "1.0.0",
-				"string-width": "^2.1.1"
+				"string-width": "2.1.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -13657,7 +13656,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -13666,9 +13665,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -13683,7 +13682,7 @@
 					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0"
+						"is-fullwidth-code-point": "2.0.0"
 					}
 				},
 				"supports-color": {
@@ -13692,7 +13691,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -13709,9 +13708,9 @@
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"dev": true,
 			"requires": {
-				"block-stream": "*",
-				"fstream": "^1.0.2",
-				"inherits": "2"
+				"block-stream": "0.0.9",
+				"fstream": "1.0.11",
+				"inherits": "2.0.3"
 			}
 		},
 		"temp": {
@@ -13720,8 +13719,8 @@
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "^1.0.0",
-				"rimraf": "~2.2.6"
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
 			},
 			"dependencies": {
 				"rimraf": {
@@ -13738,11 +13737,11 @@
 			"integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"object-assign": "^4.1.0",
-				"read-pkg-up": "^1.0.1",
-				"require-main-filename": "^1.0.1"
+				"arrify": "1.0.1",
+				"micromatch": "2.3.11",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
 			},
 			"dependencies": {
 				"load-json-file": {
@@ -13751,11 +13750,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"path-type": {
@@ -13764,9 +13763,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"read-pkg": {
@@ -13775,9 +13774,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -13786,8 +13785,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					}
 				},
 				"strip-bom": {
@@ -13796,7 +13795,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -13831,8 +13830,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.1.5",
-				"xtend": "~4.0.1"
+				"readable-stream": "2.3.3",
+				"xtend": "4.0.1"
 			}
 		},
 		"timed-out": {
@@ -13847,7 +13846,7 @@
 			"integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
 			"dev": true,
 			"requires": {
-				"setimmediate": "^1.0.4"
+				"setimmediate": "1.0.5"
 			}
 		},
 		"tiny-emitter": {
@@ -13890,7 +13889,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"to-regex": {
@@ -13899,10 +13898,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -13911,8 +13910,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -13921,7 +13920,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				}
 			}
@@ -13932,7 +13931,7 @@
 			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
 			"dev": true,
 			"requires": {
-				"punycode": "^1.4.1"
+				"punycode": "1.4.1"
 			}
 		},
 		"tr46": {
@@ -13941,7 +13940,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.0"
 			},
 			"dependencies": {
 				"punycode": {
@@ -13976,7 +13975,7 @@
 			"integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
 			"dev": true,
 			"requires": {
-				"glob": "^6.0.4"
+				"glob": "6.0.4"
 			},
 			"dependencies": {
 				"glob": {
@@ -13985,11 +13984,11 @@
 					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
 					"dev": true,
 					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				}
 			}
@@ -14006,7 +14005,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"tweetnacl": {
@@ -14022,7 +14021,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"typedarray": {
@@ -14043,9 +14042,9 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"source-map": "~0.5.1",
-				"uglify-to-browserify": "~1.0.0",
-				"yargs": "~3.10.0"
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -14062,8 +14061,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
 						"wordwrap": "0.0.2"
 					}
 				},
@@ -14081,9 +14080,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -14102,14 +14101,14 @@
 			"integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
 			"dev": true,
 			"requires": {
-				"cacache": "^10.0.4",
-				"find-cache-dir": "^1.0.0",
-				"schema-utils": "^0.4.5",
-				"serialize-javascript": "^1.4.0",
-				"source-map": "^0.6.1",
-				"uglify-es": "^3.3.4",
-				"webpack-sources": "^1.1.0",
-				"worker-farm": "^1.5.2"
+				"cacache": "10.0.4",
+				"find-cache-dir": "1.0.0",
+				"schema-utils": "0.4.5",
+				"serialize-javascript": "1.4.0",
+				"source-map": "0.6.1",
+				"uglify-es": "3.3.9",
+				"webpack-sources": "1.1.0",
+				"worker-farm": "1.6.0"
 			},
 			"dependencies": {
 				"commander": {
@@ -14130,8 +14129,8 @@
 					"integrity": "sha1-DBxPBwC+2NvBJM2zBNJZLKID5nc=",
 					"dev": true,
 					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
+						"commander": "2.13.0",
+						"source-map": "0.6.1"
 					}
 				}
 			}
@@ -14154,10 +14153,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -14166,7 +14165,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -14175,10 +14174,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -14195,7 +14194,7 @@
 			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
 			"dev": true,
 			"requires": {
-				"macaddress": "^0.2.8"
+				"macaddress": "0.2.8"
 			}
 		},
 		"uniqs": {
@@ -14210,7 +14209,7 @@
 			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 			"dev": true,
 			"requires": {
-				"unique-slug": "^2.0.0"
+				"unique-slug": "2.0.0"
 			}
 		},
 		"unique-slug": {
@@ -14219,7 +14218,7 @@
 			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 			"dev": true,
 			"requires": {
-				"imurmurhash": "^0.1.4"
+				"imurmurhash": "0.1.4"
 			}
 		},
 		"unset-value": {
@@ -14228,8 +14227,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -14238,9 +14237,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -14286,7 +14285,7 @@
 			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.0"
 			},
 			"dependencies": {
 				"punycode": {
@@ -14327,7 +14326,7 @@
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "^2.0.0"
+				"prepend-http": "2.0.0"
 			},
 			"dependencies": {
 				"prepend-http": {
@@ -14356,7 +14355,7 @@
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.2"
+				"kind-of": "6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -14395,8 +14394,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
 			}
 		},
 		"uuid": {
@@ -14416,8 +14415,8 @@
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "~1.0.0",
-				"spdx-expression-parse": "~1.0.0"
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
 			}
 		},
 		"vendors": {
@@ -14432,9 +14431,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"vinyl": {
@@ -14443,8 +14442,8 @@
 			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 			"dev": true,
 			"requires": {
-				"clone": "^1.0.0",
-				"clone-stats": "^0.0.1",
+				"clone": "1.0.3",
+				"clone-stats": "0.0.1",
 				"replace-ext": "0.0.1"
 			}
 		},
@@ -14454,12 +14453,12 @@
 			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.3.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0",
-				"strip-bom-stream": "^2.0.0",
-				"vinyl": "^1.1.0"
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "2.0.0",
+				"vinyl": "1.2.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -14468,7 +14467,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -14488,7 +14487,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "0.1.2"
 			}
 		},
 		"walker": {
@@ -14497,7 +14496,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"watch": {
@@ -14506,8 +14505,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "^0.2.0",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -14524,9 +14523,9 @@
 			"integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0"
+				"chokidar": "2.0.3",
+				"graceful-fs": "4.1.11",
+				"neo-async": "2.5.0"
 			}
 		},
 		"webidl-conversions": {
@@ -14541,25 +14540,25 @@
 			"integrity": "sha512-iLUJcsEAjaPKWbB32ADr29Pg9fPUVfFEMPK4VXyZGftzhSEFg2BLjHLoBYZ14wdTEA8xqG/hjpuX8qOmabRYvw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0",
-				"acorn-dynamic-import": "^3.0.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"chrome-trace-event": "^0.1.1",
-				"enhanced-resolve": "^4.0.0",
-				"eslint-scope": "^3.7.1",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"micromatch": "^3.1.8",
-				"mkdirp": "~0.5.0",
-				"neo-async": "^2.5.0",
-				"node-libs-browser": "^2.0.0",
-				"schema-utils": "^0.4.2",
-				"tapable": "^1.0.0",
-				"uglifyjs-webpack-plugin": "^1.2.4",
-				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.0.1"
+				"acorn": "5.4.1",
+				"acorn-dynamic-import": "3.0.0",
+				"ajv": "6.4.0",
+				"ajv-keywords": "3.1.0",
+				"chrome-trace-event": "0.1.2",
+				"enhanced-resolve": "4.0.0",
+				"eslint-scope": "3.7.1",
+				"loader-runner": "2.3.0",
+				"loader-utils": "1.1.0",
+				"memory-fs": "0.4.1",
+				"micromatch": "3.1.10",
+				"mkdirp": "0.5.1",
+				"neo-async": "2.5.0",
+				"node-libs-browser": "2.1.0",
+				"schema-utils": "0.4.5",
+				"tapable": "1.0.0",
+				"uglifyjs-webpack-plugin": "1.2.4",
+				"watchpack": "1.5.0",
+				"webpack-sources": "1.1.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -14568,10 +14567,10 @@
 					"integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0",
-						"uri-js": "^3.0.2"
+						"fast-deep-equal": "1.0.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1",
+						"uri-js": "3.0.2"
 					}
 				},
 				"ajv-keywords": {
@@ -14598,18 +14597,18 @@
 					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"kind-of": "^6.0.2",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"kind-of": "6.0.2",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -14618,7 +14617,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -14627,7 +14626,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -14638,13 +14637,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -14653,7 +14652,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -14662,7 +14661,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-descriptor": {
@@ -14671,9 +14670,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -14690,14 +14689,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -14706,7 +14705,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -14715,7 +14714,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -14726,10 +14725,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -14738,7 +14737,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -14749,7 +14748,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -14758,7 +14757,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -14769,7 +14768,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -14778,7 +14777,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -14789,7 +14788,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -14798,7 +14797,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -14821,19 +14820,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.1",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				}
 			}
@@ -14844,7 +14843,7 @@
 			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
 			"dev": true,
 			"requires": {
-				"jscodeshift": "^0.4.0"
+				"jscodeshift": "0.4.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -14871,9 +14870,9 @@
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
+						"ansi-styles": "1.0.0",
+						"has-color": "0.1.7",
+						"strip-ansi": "0.1.1"
 					}
 				},
 				"colors": {
@@ -14888,21 +14887,21 @@
 					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
 					"dev": true,
 					"requires": {
-						"async": "^1.5.0",
-						"babel-plugin-transform-flow-strip-types": "^6.8.0",
-						"babel-preset-es2015": "^6.9.0",
-						"babel-preset-stage-1": "^6.5.0",
-						"babel-register": "^6.9.0",
-						"babylon": "^6.17.3",
-						"colors": "^1.1.2",
-						"flow-parser": "^0.*",
-						"lodash": "^4.13.1",
-						"micromatch": "^2.3.7",
+						"async": "1.5.2",
+						"babel-plugin-transform-flow-strip-types": "6.22.0",
+						"babel-preset-es2015": "6.24.1",
+						"babel-preset-stage-1": "6.24.1",
+						"babel-register": "6.26.0",
+						"babylon": "6.18.0",
+						"colors": "1.2.1",
+						"flow-parser": "0.69.0",
+						"lodash": "4.17.5",
+						"micromatch": "2.3.11",
 						"node-dir": "0.1.8",
-						"nomnom": "^1.8.1",
-						"recast": "^0.12.5",
-						"temp": "^0.8.1",
-						"write-file-atomic": "^1.2.0"
+						"nomnom": "1.8.1",
+						"recast": "0.12.9",
+						"temp": "0.8.3",
+						"write-file-atomic": "1.3.4"
 					}
 				},
 				"nomnom": {
@@ -14911,8 +14910,8 @@
 					"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
 					"dev": true,
 					"requires": {
-						"chalk": "~0.4.0",
-						"underscore": "~1.6.0"
+						"chalk": "0.4.0",
+						"underscore": "1.6.0"
 					}
 				},
 				"recast": {
@@ -14922,10 +14921,10 @@
 					"dev": true,
 					"requires": {
 						"ast-types": "0.10.1",
-						"core-js": "^2.4.1",
-						"esprima": "~4.0.0",
-						"private": "~0.1.5",
-						"source-map": "~0.6.1"
+						"core-js": "2.5.3",
+						"esprima": "4.0.0",
+						"private": "0.1.8",
+						"source-map": "0.6.1"
 					}
 				},
 				"source-map": {
@@ -14952,9 +14951,9 @@
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
 					}
 				}
 			}
@@ -14965,31 +14964,31 @@
 			"integrity": "sha512-0lnOi3yla8FsZVuMsbfnNRB/8DlfuDugKdekC+4ykydZG0+UOidMi5J5LLWN4c0VJ8PqC19yMXXkYyCq78OuqA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.3.2",
-				"cross-spawn": "^6.0.5",
-				"diff": "^3.5.0",
-				"enhanced-resolve": "^4.0.0",
-				"glob-all": "^3.1.0",
-				"global-modules": "^1.0.0",
-				"got": "^8.2.0",
-				"inquirer": "^5.1.0",
-				"interpret": "^1.0.4",
-				"jscodeshift": "^0.5.0",
-				"listr": "^0.13.0",
-				"loader-utils": "^1.1.0",
-				"lodash": "^4.17.5",
-				"log-symbols": "^2.2.0",
-				"mkdirp": "^0.5.1",
-				"p-each-series": "^1.0.0",
-				"p-lazy": "^1.0.0",
-				"prettier": "^1.5.3",
-				"resolve-cwd": "^2.0.0",
-				"supports-color": "^5.3.0",
-				"v8-compile-cache": "^1.1.2",
-				"webpack-addons": "^1.1.5",
-				"yargs": "^11.0.0",
-				"yeoman-environment": "^2.0.0",
-				"yeoman-generator": "^2.0.3"
+				"chalk": "2.3.2",
+				"cross-spawn": "6.0.5",
+				"diff": "3.5.0",
+				"enhanced-resolve": "4.0.0",
+				"glob-all": "3.1.0",
+				"global-modules": "1.0.0",
+				"got": "8.3.0",
+				"inquirer": "5.2.0",
+				"interpret": "1.1.0",
+				"jscodeshift": "0.5.0",
+				"listr": "0.13.0",
+				"loader-utils": "1.1.0",
+				"lodash": "4.17.5",
+				"log-symbols": "2.2.0",
+				"mkdirp": "0.5.1",
+				"p-each-series": "1.0.0",
+				"p-lazy": "1.0.0",
+				"prettier": "1.11.1",
+				"resolve-cwd": "2.0.0",
+				"supports-color": "5.3.0",
+				"v8-compile-cache": "1.1.2",
+				"webpack-addons": "1.1.5",
+				"yargs": "11.0.0",
+				"yeoman-environment": "2.0.5",
+				"yeoman-generator": "2.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -15004,7 +15003,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -15013,9 +15012,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
 					}
 				},
 				"cliui": {
@@ -15024,9 +15023,9 @@
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"cross-spawn": {
@@ -15035,11 +15034,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.4",
+						"path-key": "2.0.1",
+						"semver": "5.5.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
 					}
 				},
 				"diff": {
@@ -15054,7 +15053,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"has-flag": {
@@ -15069,19 +15068,19 @@
 					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.1.0",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
+						"ansi-escapes": "3.0.0",
+						"chalk": "2.3.2",
+						"cli-cursor": "2.1.0",
+						"cli-width": "2.2.0",
+						"external-editor": "2.1.0",
+						"figures": "2.0.0",
+						"lodash": "4.17.5",
 						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rxjs": "^5.5.2",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
+						"run-async": "2.3.0",
+						"rxjs": "5.5.8",
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"through": "2.3.8"
 					}
 				},
 				"lodash": {
@@ -15102,7 +15101,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -15111,7 +15110,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				},
 				"yargs": {
@@ -15120,18 +15119,18 @@
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
 					}
 				},
 				"yargs-parser": {
@@ -15140,22 +15139,21 @@
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
 		},
 		"webpack-rtl-plugin": {
 			"version": "github:yoavf/webpack-rtl-plugin#fc5a2f20dd99fde8f86f297844aefde601780fa3",
-			"from": "github:yoavf/webpack-rtl-plugin#develop",
 			"dev": true,
 			"requires": {
-				"@romainberger/css-diff": "^1.0.3",
-				"async": "^2.0.0-rc.6",
-				"cssnano": "^3.7.1",
-				"postcss": "^5.0.21",
-				"rtlcss": "^2.0.4",
-				"webpack-sources": "^0.1.2"
+				"@romainberger/css-diff": "1.0.3",
+				"async": "2.6.0",
+				"cssnano": "3.10.0",
+				"postcss": "5.2.18",
+				"rtlcss": "2.2.1",
+				"webpack-sources": "0.1.5"
 			},
 			"dependencies": {
 				"source-list-map": {
@@ -15182,8 +15180,8 @@
 			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
+				"source-list-map": "2.0.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -15214,9 +15212,9 @@
 			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.0",
-				"webidl-conversions": "^4.0.1"
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"whet.extend": {
@@ -15230,7 +15228,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -15244,7 +15242,7 @@
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.2"
+				"string-width": "1.0.2"
 			},
 			"dependencies": {
 				"string-width": {
@@ -15253,9 +15251,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -15279,7 +15277,7 @@
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
 			"dev": true,
 			"requires": {
-				"errno": "~0.1.7"
+				"errno": "0.1.7"
 			}
 		},
 		"wrap-ansi": {
@@ -15287,8 +15285,8 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"string-width": {
@@ -15296,9 +15294,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -15315,7 +15313,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -15324,9 +15322,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ws": {
@@ -15335,9 +15333,9 @@
 			"integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "~1.0.0",
-				"safe-buffer": "~5.1.0",
-				"ultron": "~1.1.0"
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1",
+				"ultron": "1.1.1"
 			}
 		},
 		"xml-name-validator": {
@@ -15367,18 +15365,18 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
 			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^8.1.0"
+				"cliui": "4.1.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "8.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -15391,9 +15389,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"find-up": {
@@ -15401,7 +15399,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -15409,7 +15407,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -15419,7 +15417,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
 			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			}
 		},
 		"yauzl": {
@@ -15428,7 +15426,7 @@
 			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
 			"dev": true,
 			"requires": {
-				"fd-slicer": "~1.0.1"
+				"fd-slicer": "1.0.1"
 			}
 		},
 		"yeoman-environment": {
@@ -15437,19 +15435,19 @@
 			"integrity": "sha512-6/W7/B54OPHJXob0n0+pmkwFsirC8cokuQkPSmT/D0lCcSxkKtg/BA6ZnjUBIwjuGqmw3DTrT4en++htaUju5g==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.1.0",
-				"debug": "^3.1.0",
-				"diff": "^3.3.1",
-				"escape-string-regexp": "^1.0.2",
-				"globby": "^6.1.0",
-				"grouped-queue": "^0.3.3",
-				"inquirer": "^3.3.0",
-				"is-scoped": "^1.0.0",
-				"lodash": "^4.17.4",
-				"log-symbols": "^2.1.0",
-				"mem-fs": "^1.1.0",
-				"text-table": "^0.2.0",
-				"untildify": "^3.0.2"
+				"chalk": "2.3.2",
+				"debug": "3.1.0",
+				"diff": "3.4.0",
+				"escape-string-regexp": "1.0.5",
+				"globby": "6.1.0",
+				"grouped-queue": "0.3.3",
+				"inquirer": "3.3.0",
+				"is-scoped": "1.0.0",
+				"lodash": "4.17.5",
+				"log-symbols": "2.2.0",
+				"mem-fs": "1.1.3",
+				"text-table": "0.2.0",
+				"untildify": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15458,7 +15456,7 @@
 					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -15467,9 +15465,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
 					}
 				},
 				"debug": {
@@ -15506,7 +15504,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -15517,31 +15515,31 @@
 			"integrity": "sha512-mODmrZ26a94djmGZZuIiomSGlN4wULdou29ZwcySupb2e9FdvoCl7Ps2FqHFjEHio3kOl/iBeaNqrnx3C3NwWg==",
 			"dev": true,
 			"requires": {
-				"async": "^2.6.0",
-				"chalk": "^2.3.0",
-				"cli-table": "^0.3.1",
-				"cross-spawn": "^5.1.0",
-				"dargs": "^5.1.0",
-				"dateformat": "^3.0.2",
-				"debug": "^3.1.0",
-				"detect-conflict": "^1.0.0",
-				"error": "^7.0.2",
-				"find-up": "^2.1.0",
-				"github-username": "^4.0.0",
-				"istextorbinary": "^2.1.0",
-				"lodash": "^4.17.4",
-				"make-dir": "^1.1.0",
-				"mem-fs-editor": "^3.0.2",
-				"minimist": "^1.2.0",
-				"pretty-bytes": "^4.0.2",
-				"read-chunk": "^2.1.0",
-				"read-pkg-up": "^3.0.0",
-				"rimraf": "^2.6.2",
-				"run-async": "^2.0.0",
-				"shelljs": "^0.8.0",
-				"text-table": "^0.2.0",
-				"through2": "^2.0.0",
-				"yeoman-environment": "^2.0.5"
+				"async": "2.6.0",
+				"chalk": "2.3.2",
+				"cli-table": "0.3.1",
+				"cross-spawn": "5.1.0",
+				"dargs": "5.1.0",
+				"dateformat": "3.0.3",
+				"debug": "3.1.0",
+				"detect-conflict": "1.0.1",
+				"error": "7.0.2",
+				"find-up": "2.1.0",
+				"github-username": "4.1.0",
+				"istextorbinary": "2.2.1",
+				"lodash": "4.17.5",
+				"make-dir": "1.2.0",
+				"mem-fs-editor": "3.0.2",
+				"minimist": "1.2.0",
+				"pretty-bytes": "4.0.2",
+				"read-chunk": "2.1.0",
+				"read-pkg-up": "3.0.0",
+				"rimraf": "2.6.2",
+				"run-async": "2.3.0",
+				"shelljs": "0.8.1",
+				"text-table": "0.2.0",
+				"through2": "2.0.3",
+				"yeoman-environment": "2.0.5"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15550,7 +15548,7 @@
 					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -15559,9 +15557,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
 					}
 				},
 				"debug": {
@@ -15579,7 +15577,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"has-flag": {
@@ -15622,7 +15620,7 @@
 					"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				},
 				"pify": {
@@ -15658,7 +15656,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@wordpress/i18n": "1.1.0",
 		"@wordpress/is-shallow-equal": "1.0.1",
 		"@wordpress/url": "1.1.0",
-		"@wordpress/wordcount": "1.0.0",
+		"@wordpress/wordcount": "1.0.2",
 		"classnames": "2.2.5",
 		"clipboard": "1.7.1",
 		"dom-react": "2.2.1",


### PR DESCRIPTION
Prevent crash on empty wordcount (fix #6617)
See: https://github.com/WordPress/packages/issues/122

## Description
Bump the `wordcount` package to fix #6617.

## How has this been tested?
Tested locally and the crash is gone.
The package itself now has tests to make sure this bug won't happen again.

## Screenshots
![2018-05-08 19 41 51](https://user-images.githubusercontent.com/90871/39776262-2dc56fae-52f8-11e8-8b9e-e28e3ba20ad8.gif)


## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
