### PR TITLE
Adding an image block after an image aligned to the side produces unexpected behavior

### DIFF
--- a/core-blocks/image/editor.scss
+++ b/core-blocks/image/editor.scss
@@ -87,6 +87,10 @@
 	}
 }
 
+.editor-block-list__block[data-type="core/image"] .editor-block-list__block-edit {
+	display: table;
+}
+
 .edit-post-sidebar .blocks-image__dimensions {
 	margin-bottom: 1em;
 


### PR DESCRIPTION
Relevant Issue:
https://github.com/WordPress/gutenberg/issues/6634

## How has this been tested?
Browser: Google Chrome 67, Google Chrome 66 and Opera 53

## Video
Before: https://www.youtube.com/watch?v=bta1vBdC0cc
After: 

## Types of changes
Bug fix, only affecting a stylesheet file.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Hello World! This is my first time contributing. Please, if you see any issues, point those out and I will update accordingly.