### PR TITLE
Adding an image block after an image aligned to the side produces unexpected behavior

### DIFF
--- a/core-blocks/image/editor.scss
+++ b/core-blocks/image/editor.scss
@@ -16,6 +16,10 @@
 	}
 }
 
+figure.wp-block-image {
+	display: table;
+}
+
 .wp-block-image__resize-handler-top-right,
 .wp-block-image__resize-handler-bottom-right,
 .wp-block-image__resize-handler-top-left,


### PR DESCRIPTION
Relevant Issue:
https://github.com/WordPress/gutenberg/issues/6634

## How has this been tested?
Browser: Google Chrome 67, Google Chrome 66 and Opera 53

## Video
Before: https://www.youtube.com/watch?v=bta1vBdC0cc
After: 

## Types of changes
Bug fix, only affecting a stylesheet file.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Hello World! This is my first time contributing. Please, if you see any issues, point those out and I will update accordingly.