### PR TITLE
fix: Restore placeholders for all RichText Blocks

### DIFF
--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -112,7 +112,6 @@ class ButtonEdit extends Component {
 							backgroundColor: backgroundColor.class ? undefined : backgroundColor.value,
 							color: textColor.class ? undefined : textColor.value,
 						} }
-						keepPlaceholderOnFocus
 					/>
 					<InspectorControls>
 						<PanelBody>

--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -61,10 +61,6 @@ a traditional `input` field, usually when the user exits the field.
 
 *Optional.* Whether to show the input is selected or not in order to show the formatting controls. By default it renders the controls when the block is selected.
 
-### `keepPlaceholderOnFocus: Boolean`
-
-*Optional.* By default, the placeholder will hide as soon as the editable field receives focus. With this setting it can be be kept while the field is focussed and empty.
-
 ### `autocompleters: Array<Completer>`
 
 *Optional.* A list of autocompleters to use instead of the default.

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -829,7 +829,6 @@ export class RichText extends Component {
 			formattingControls,
 			placeholder,
 			multiline: MultilineTag,
-			keepPlaceholderOnFocus = false,
 			isSelected,
 			formatters,
 			autocompleters,
@@ -842,7 +841,7 @@ export class RichText extends Component {
 		// changes, we unmount and destroy the previous TinyMCE element, then
 		// mount and initialize a new child element in its place.
 		const key = [ 'editor', Tagname ].join();
-		const isPlaceholderVisible = placeholder && ( ! isSelected || keepPlaceholderOnFocus ) && this.isEmpty();
+		const isPlaceholderVisible = placeholder && this.isEmpty();
 		const classes = classnames( wrapperClassName, 'editor-rich-text' );
 
 		const formatToolbar = (


### PR DESCRIPTION
Fix #6470.

Restores placeholders for all RichText blocks.

## Description
Restored placeholders for all RichText blocks. These were removed in #2624. Both this issue and the removal of the placeholder on focus were okayed by @karmatosed so I'm not sure what the preferred UX is here... but I'll say I find the disappearing placeholder on focus to be inconsistent with the rest of Gutenberg and also the web in general.

## How has this been tested?
Tested in Chrome/Firefox/Edge/Safari and it worked.

## Screenshots

### Before
![2018-05-08 21 07 13](https://user-images.githubusercontent.com/90871/39780477-4a00a8bc-5304-11e8-95a8-d96dd7c91293.gif)

### After
![2018-05-08 20 56 14](https://user-images.githubusercontent.com/90871/39780478-4d1ee068-5304-11e8-9026-dd45c7810985.gif)

## Types of changes
New feature/restoration of feature (placeholders always displayed).
Removed the `keepPlaceholderOnFocus` prop from `RichText` because nothing else in Gutenberg was using it. Not sure if that counts as breaking and we need to deprecate.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
