### PR TITLE
Move rest api loads into conditional that confirms in rest mode

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -9,19 +9,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+// These files only need to be loaded if within a rest server instance
+// which this class will exist if that is the case.
+if ( class_exists( 'WP_REST_Controller' ) ) {
+    require dirname( __FILE__ ) . '/class-wp-rest-blocks-controller.php';
+    require dirname( __FILE__ ) . '/class-wp-rest-block-renderer-controller.php';
+    require dirname( __FILE__ ) . '/rest-api.php';
+}
+
 require dirname( __FILE__ ) . '/meta-box-partial-page.php';
 require dirname( __FILE__ ) . '/class-wp-block-type.php';
 require dirname( __FILE__ ) . '/class-wp-block-type-registry.php';
-require dirname( __FILE__ ) . '/class-wp-rest-blocks-controller.php';
-require dirname( __FILE__ ) . '/class-wp-rest-block-renderer-controller.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/compat.php';
-require dirname( __FILE__ ) . '/rest-api.php';
 require dirname( __FILE__ ) . '/plugin-compat.php';
 require dirname( __FILE__ ) . '/i18n.php';
 require dirname( __FILE__ ) . '/parser.php';
 require dirname( __FILE__ ) . '/register.php';
+
 
 // Register server-side code for individual blocks.
 foreach ( glob( dirname( __FILE__ ) . '/../core-blocks/*/index.php' ) as $block_logic ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -12,9 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 // These files only need to be loaded if within a rest server instance
 // which this class will exist if that is the case.
 if ( class_exists( 'WP_REST_Controller' ) ) {
-    require dirname( __FILE__ ) . '/class-wp-rest-blocks-controller.php';
-    require dirname( __FILE__ ) . '/class-wp-rest-block-renderer-controller.php';
-    require dirname( __FILE__ ) . '/rest-api.php';
+	require dirname( __FILE__ ) . '/class-wp-rest-blocks-controller.php';
+	require dirname( __FILE__ ) . '/class-wp-rest-block-renderer-controller.php';
+	require dirname( __FILE__ ) . '/rest-api.php';
 }
 
 require dirname( __FILE__ ) . '/meta-box-partial-page.php';


### PR DESCRIPTION
## Description

The rest api files should only be loaded if the site is in rest server mode.
I initially tested using
    `defined( 'REST_REQUEST') && REST_REQUEST`

however this wasn't detected and created errors, thus use of class_exists
checking for WP_REST_Controller

## How has this been tested?
- tested the api calls still work as expected with the routes registered
- confirmed in an instance that does not load as an rest api server and calls are made to an external api server the files are not loaded


## Types of changes

- Adds a conditional around loading the rest api files


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
