### PR TITLE
Update Notice README

### DIFF
--- a/components/notice/README.md
+++ b/components/notice/README.md
@@ -1,10 +1,30 @@
-This component is used to implement notices in editor.
+Notice
+======
 
-#### Props
+This component is used to display notices in editor.
+
+## Usage
+
+To display a plain notice, pass `Notice` a string:
+
+```jsx
+<Notice status="error">
+    An unknown error occurred.
+</Notice>
+```
+
+For more complex markup, you can pass any JSX element:
+
+```jsx
+<Notice status="error">
+    <p>An error occurred: <code>{ errorDetails }</code>.</p>
+</Notice>
+```
+
+### Props
 
 The following props are used to control the display of the component.
 
 * `status`: (string) can be `warning` (red), `success` (green), `error` (red), `info` (yellow)
-* `content`: (string) the text of the notice
 * `onRemove`: function called when dismissing the notice
 * `isDismissible`: (bool) defaults to true, whether the notice should be dismissible or not


### PR DESCRIPTION
`content` is no longer a property as the content of the notice is defined by the children of the component.

From https://wordpress.slack.com/archives/C02QB2JS7/p1525848612000302
