### PR TITLE
chore: Add npm update to build script

### DIFF
--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -73,6 +73,9 @@ fi
 echo -e $(status_message "Installing and updating NPM packages..." )
 npm install
 
+# Make sure npm is up-to-date
+npm install npm -g
+
 # There was a bug in NPM that caused changes in package-lock.json. Handle that.
 if [ "$TRAVIS" != "true" ] && ! git diff --exit-code package-lock.json >/dev/null; then
 	if ask "$(warning_message "Your package-lock.json changed, which may mean there's an issue with your NPM cache. Would you like to try and automatically clean it up?" )" N 10; then


### PR DESCRIPTION
Since #6629, npm 6 in the minimum version, so install it at setup time. Really this installs the latest version because I didn't want to deal with adding yet another 6 somewhere. If that's too dangerous we can change this to be explicitly 6–let me know.

This threw me because I created a PR and ran the app with `npm` 5 and received no error messages. It wasn't until my noisy PR came in that @gziolo pointed out I was running an out-of-date `npm`.

## Description
Globally install `npm` during set up.

## How has this been tested?
Ran the script on a new machine; it worked.

## Types of changes
Add `npm install npm -g` to start up.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->