### PR TITLE
Permit unbounded per_page=-1 requests for Pages and Shared Blocks

### DIFF
--- a/editor/components/page-attributes/parent.js
+++ b/editor/components/page-attributes/parent.js
@@ -63,7 +63,7 @@ const applyWithAPIDataItems = withAPIData( ( props, { type } ) => {
 	const isHierarchical = get( props, [ 'postType', 'hierarchical' ], false );
 	const queryString = stringify( {
 		context: 'edit',
-		per_page: 100,
+		per_page: -1,
 		exclude: postId,
 		parent_exclude: postId,
 		_fields: [ 'id', 'parent', 'title' ],

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -398,7 +398,7 @@ export default {
 		if ( id ) {
 			result = wp.apiRequest( { path: `/wp/v2/${ basePath }/${ id }` } );
 		} else {
-			result = wp.apiRequest( { path: `/wp/v2/${ basePath }` } );
+			result = wp.apiRequest( { path: `/wp/v2/${ basePath }?per_page=-1` } );
 		}
 
 		result.then(

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -430,7 +430,7 @@ function gutenberg_handle_early_callback_checks( $response, $handler, $request )
 		'/wp/v2/pages',
 		'/wp/v2/users',
 	);
-	if ( in_array( $request->get_route(), $routes ) ) {
+	if ( in_array( $request->get_route(), $routes, true ) ) {
 		$can_view_authors    = false;
 		$can_unbounded_query = false;
 		$types               = get_post_types( array( 'show_in_rest' => true ), 'objects' );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -309,6 +309,8 @@ function gutenberg_register_post_prepare_functions( $post_type ) {
 	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_permalink_template_to_posts', 10, 3 );
 	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_block_format_to_post_content', 10, 3 );
 	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_target_schema_to_links', 10, 3 );
+	add_filter( "rest_{$post_type}_collection_params", 'gutenberg_filter_post_collection_parameters', 10, 2 );
+	add_filter( "rest_{$post_type}_query", 'gutenberg_filter_post_query_arguments', 10, 2 );
 	return $post_type;
 }
 add_filter( 'registered_post_type', 'gutenberg_register_post_prepare_functions' );
@@ -423,7 +425,12 @@ add_filter( 'rest_index', 'gutenberg_ensure_wp_json_has_theme_supports' );
  * @param WP_REST_Request  $request  Request used to generate the response.
  */
 function gutenberg_handle_early_callback_checks( $response, $handler, $request ) {
-	if ( '/wp/v2/users' === $request->get_route() ) {
+	$routes = array(
+		'/wp/v2/blocks',
+		'/wp/v2/pages',
+		'/wp/v2/users',
+	);
+	if ( in_array( $request->get_route(), $routes ) ) {
 		$can_view_authors    = false;
 		$can_unbounded_query = false;
 		$types               = get_post_types( array( 'show_in_rest' => true ), 'objects' );
@@ -440,7 +447,8 @@ function gutenberg_handle_early_callback_checks( $response, $handler, $request )
 				return new WP_Error( 'rest_forbidden_per_page', __( 'Sorry, you are not allowed make unbounded queries.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 		}
-		if ( ! empty( $request['who'] ) && 'authors' === $request['who'] ) {
+		if ( '/wp/v2/users' === $request->get_route()
+			&& ! empty( $request['who'] ) && 'authors' === $request['who'] ) {
 			if ( ! $can_view_authors ) {
 				return new WP_Error( 'rest_forbidden_who', __( 'Sorry, you are not allowed to query users by this parameter.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
 			}
@@ -449,6 +457,48 @@ function gutenberg_handle_early_callback_checks( $response, $handler, $request )
 	return $response;
 }
 add_filter( 'rest_request_before_callbacks', 'gutenberg_handle_early_callback_checks', 10, 3 );
+
+/**
+ * Include additional query parameters on the posts query endpoint.
+ *
+ * @see https://core.trac.wordpress.org/ticket/43998
+ *
+ * @param array  $query_params JSON Schema-formatted collection parameters.
+ * @param string $post_type    Post type being accessed.
+ * @return array
+ */
+function gutenberg_filter_post_collection_parameters( $query_params, $post_type ) {
+	$post_types = array( 'page', 'wp_block' );
+	if ( in_array( $post_type->name, $post_types, true )
+		&& isset( $query_params['per_page'] ) ) {
+		// Change from '1' to '-1', which means unlimited.
+		$query_params['per_page']['minimum'] = -1;
+		// Default sanitize callback is 'absint', which won't work in our case.
+		$query_params['per_page']['sanitize_callback'] = 'rest_sanitize_request_arg';
+	}
+	return $query_params;
+}
+
+/**
+ * Filter post collection query parameters to include specific behavior.
+ *
+ * @see https://core.trac.wordpress.org/ticket/43998
+ *
+ * @param array           $prepared_args Array of arguments for WP_Query.
+ * @param WP_REST_Request $request       The current request.
+ * @return array
+ */
+function gutenberg_filter_post_query_arguments( $prepared_args, $request ) {
+	$post_types = array( 'page', 'wp_block' );
+	if ( in_array( $prepared_args['post_type'], $post_types, true ) ) {
+		// Avoid triggering 'rest_post_invalid_page_number' error
+		// which will need to be addressed in https://core.trac.wordpress.org/ticket/43998
+		if ( -1 === $prepared_args['posts_per_page'] ) {
+			$prepared_args['posts_per_page'] = 100000;
+		}
+	}
+	return $prepared_args;
+}
 
 /**
  * Include additional query parameters on the user query endpoint.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -492,7 +492,7 @@ function gutenberg_filter_post_query_arguments( $prepared_args, $request ) {
 	$post_types = array( 'page', 'wp_block' );
 	if ( in_array( $prepared_args['post_type'], $post_types, true ) ) {
 		// Avoid triggering 'rest_post_invalid_page_number' error
-		// which will need to be addressed in https://core.trac.wordpress.org/ticket/43998
+		// which will need to be addressed in https://core.trac.wordpress.org/ticket/43998.
 		if ( -1 === $prepared_args['posts_per_page'] ) {
 			$prepared_args['posts_per_page'] = 100000;
 		}

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -216,4 +216,24 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$data = $response->get_data();
 		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
 	}
+
+	public function test_get_pages_unbounded_per_page() {
+		wp_set_current_user( $this->author );
+		$this->factory->post->create( array( 'post_type' => 'page' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$request->set_param( 'per_page', '-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_pages_unbounded_per_page_unauthorized() {
+		wp_set_current_user( $this->subscriber );
+		$this->factory->post->create( array( 'post_type' => 'page' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$request->set_param( 'per_page', '-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 403, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
+	}
 }


### PR DESCRIPTION
## Description

Permits requests of `per_page=-1` to `/wp/v2/pages` and `/wp/v2/blocks` in order to fetch all available items; updates corresponding Gutenberg components to fetch all items.

Fixes #6487
Fixes #4632
Related #6627
See https://github.com/WordPress/gutenberg/issues/6180#issuecomment-384511059

## How has this been tested?

I generated 200 pages with:

```
wp post generate --post_type=page --post_status=publish --count=200
```

When I access the Page editor, I can see all items in the dropdown:

<img width="338" alt="image" src="https://user-images.githubusercontent.com/36432/39814724-54f30efe-534a-11e8-8bb2-df9d92addd14.png">

Similarly, I created more than 10 shared blocks and can see all of them in the inserter UI:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/36432/39814746-6637d0f0-534a-11e8-80d1-dee3561dc902.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
