### PR TITLE
Fix autocompletion in IE11

### DIFF
--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -37,7 +37,7 @@ function needsInternetExplorerInputFix( editorNode ) {
 }
 
 /**
- * Applies a fix that provides `input` events for contenteditable in InternetExplorer.
+ * Applies a fix that provides `input` events for contenteditable in Internet Explorer.
  *
  * @param {Element} editorNode The root editor node.
  *
@@ -101,7 +101,7 @@ const IS_PLACEHOLDER_VISIBLE_ATTR_NAME = 'data-is-placeholder-visible';
 export default class TinyMCE extends Component {
 	constructor() {
 		super();
-		this.saveEditorNode = this.saveEditorNode.bind( this );
+		this.bindEditorNode = this.bindEditorNode.bind( this );
 	}
 
 	componentDidMount() {
@@ -182,7 +182,7 @@ export default class TinyMCE extends Component {
 		} );
 	}
 
-	saveEditorNode( editorNode ) {
+	bindEditorNode( editorNode ) {
 		this.editorNode = editorNode;
 
 		/**
@@ -191,12 +191,12 @@ export default class TinyMCE extends Component {
 		 */
 		if ( this.removeInternetExplorerInputFix ) {
 			this.removeInternetExplorerInputFix();
+			this.removeInternetExplorerInputFix = null;
 		}
 
-		this.removeInternetExplorerInputFix =
-			editorNode && needsInternetExplorerInputFix( editorNode ) ?
-				applyInternetExplorerInputFix( editorNode ) :
-				null;
+		if ( editorNode && needsInternetExplorerInputFix( editorNode ) ) {
+			this.removeInternetExplorerInputFix = applyInternetExplorerInputFix( editorNode );
+		}
 	}
 
 	render() {
@@ -215,7 +215,7 @@ export default class TinyMCE extends Component {
 			className: classnames( className, 'editor-rich-text__tinymce' ),
 			contentEditable: true,
 			[ IS_PLACEHOLDER_VISIBLE_ATTR_NAME ]: isPlaceholderVisible,
-			ref: this.saveEditorNode,
+			ref: this.bindEditorNode,
 			style,
 			suppressContentEditableWarning: true,
 			dangerouslySetInnerHTML: { __html: valueToString( defaultValue, format ) },


### PR DESCRIPTION
## Description
This is a PR to fix autocompletion in IE11.

Fixes #3409.

## Details

The cause for this breakage is that IE11 doesn't dispatch `input` events for contenteditable, only for `<input>` and `<textarea>` elements.

The proposed fix is to update our TinyMCE component to listen for IE11's comparable `textinput` event and manually creating and dispatching an `input` on the same target. In addition, because `textinput` isn't dispatched for deletions, we also dispatch `input` for Delete and Backspace `keyup` events.

## How has this been tested?
Loaded Gutenberg in IE11, Chrome, Firefox, and Safari and exercised the block and user completers.

I also used the IE11 and Chrome debuggers to verify the fix is applied for just IE and that its event listeners are removed when unmounted.

## Screenshots <!-- if applicable -->

<img width="766" alt="screen shot 2018-05-09 at 1 18 09 pm" src="https://user-images.githubusercontent.com/530877/39837852-726bd280-538c-11e8-84e4-ef93f89a9dd0.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
