### PR TITLE
Introduce `wp:action-publish`; update corresponding UI to reference

### DIFF
--- a/editor/components/post-pending-status/check.js
+++ b/editor/components/post-pending-status/check.js
@@ -6,14 +6,11 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
-export function PostPendingStatusCheck( { isPublished, children, user } ) {
-	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-
-	if ( isPublished || ! userCanPublishPosts ) {
+export function PostPendingStatusCheck( { hasPublishAction, isPublished, children } ) {
+	if ( isPublished || ! hasPublishAction ) {
 		return null;
 	}
 
@@ -22,17 +19,11 @@ export function PostPendingStatusCheck( { isPublished, children, user } ) {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { isCurrentPostPublished, getCurrentPostType } = select( 'core/editor' );
+		const { isCurrentPostPublished, getCurrentPostType, getCurrentPost } = select( 'core/editor' );
 		return {
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			isPublished: isCurrentPostPublished(),
 			postType: getCurrentPostType(),
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} )
 )( PostPendingStatusCheck );

--- a/editor/components/post-pending-status/test/check.js
+++ b/editor/components/post-pending-status/test/check.js
@@ -9,21 +9,9 @@ import { shallow } from 'enzyme';
 import { PostPendingStatusCheck } from '../check';
 
 describe( 'PostPendingStatusCheck', () => {
-	const user = {
-		data: {
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
 	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
-		let wrapper = shallow( <PostPendingStatusCheck user={ {} }>status</PostPendingStatusCheck> );
-		expect( wrapper.type() ).toBe( null );
-		wrapper = shallow(
-			<PostPendingStatusCheck user={
-				{ data: { post_type_capabilities: { publish_posts: false } } }
-			}>
+		const wrapper = shallow(
+			<PostPendingStatusCheck hasPublishAction={ false }>
 				status
 			</PostPendingStatusCheck>
 		);
@@ -31,7 +19,7 @@ describe( 'PostPendingStatusCheck', () => {
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow( <PostPendingStatusCheck user={ user }>status</PostPendingStatusCheck> );
+		const wrapper = shallow( <PostPendingStatusCheck hasPublishAction={ true }>status</PostPendingStatusCheck> );
 		expect( wrapper.type() ).not.toBe( null );
 	} );
 } );

--- a/editor/components/post-schedule/check.js
+++ b/editor/components/post-schedule/check.js
@@ -6,14 +6,11 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
-export function PostScheduleCheck( { user, children } ) {
-	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-
-	if ( ! userCanPublishPosts ) {
+export function PostScheduleCheck( { hasPublishAction, children } ) {
+	if ( ! hasPublishAction ) {
 		return null;
 	}
 
@@ -22,15 +19,10 @@ export function PostScheduleCheck( { user, children } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
+		const { getCurrentPost, getCurrentPostType } = select( 'core/editor' );
 		return {
-			postType: select( 'core/editor' ).getCurrentPostType(),
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			postType: getCurrentPostType(),
 		};
 	} ),
 ] )( PostScheduleCheck );

--- a/editor/components/post-schedule/test/check.js
+++ b/editor/components/post-schedule/test/check.js
@@ -9,25 +9,13 @@ import { shallow } from 'enzyme';
 import { PostScheduleCheck } from '../check';
 
 describe( 'PostScheduleCheck', () => {
-	const user = {
-		data: {
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
 	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
-		let wrapper = shallow( <PostScheduleCheck user={ {} } >yes</PostScheduleCheck> );
-		expect( wrapper.type() ).toBe( null );
-		wrapper = shallow( <PostScheduleCheck user={
-			{ data: { post_type_capabilities: { publish_posts: false } } }
-		}>yes</PostScheduleCheck> );
+		const wrapper = shallow( <PostScheduleCheck hasPublishAction={ false } >yes</PostScheduleCheck> );
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow( <PostScheduleCheck user={ user }>yes</PostScheduleCheck> );
+		const wrapper = shallow( <PostScheduleCheck hasPublishAction={ true }>yes</PostScheduleCheck> );
 		expect( wrapper.type() ).not.toBe( null );
 	} );
 } );

--- a/editor/components/post-visibility/check.js
+++ b/editor/components/post-visibility/check.js
@@ -6,27 +6,20 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
-export function PostVisibilityCheck( { user, render } ) {
-	const canEdit = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-
+export function PostVisibilityCheck( { hasPublishAction, render } ) {
+	const canEdit = hasPublishAction;
 	return render( { canEdit } );
 }
 
 export default compose( [
 	withSelect( ( select ) => {
+		const { getCurrentPost, getCurrentPostType } = select( 'core/editor' );
 		return {
-			postType: select( 'core/editor' ).getCurrentPostType(),
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			postType: getCurrentPostType(),
 		};
 	} ),
 ] )( PostVisibilityCheck );

--- a/editor/components/post-visibility/test/check.js
+++ b/editor/components/post-visibility/test/check.js
@@ -9,28 +9,15 @@ import { shallow } from 'enzyme';
 import { PostVisibilityCheck } from '../check';
 
 describe( 'PostVisibilityCheck', () => {
-	const user = {
-		data: {
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
 	const render = ( { canEdit } ) => ( canEdit ? 'yes' : 'no' );
 
 	it( 'should not render the edit link if the user doesn\'t have the right capability', () => {
-		let wrapper = shallow( <PostVisibilityCheck user={ {} } render={ render } /> );
-		expect( wrapper.text() ).toBe( 'no' );
-
-		wrapper = shallow( <PostVisibilityCheck postType="post" render={ render } user={
-			{ data: { post_type_capabilities: { publish_posts: false } } }
-		} /> );
+		const wrapper = shallow( <PostVisibilityCheck hasPublishAction={ false } render={ render } /> );
 		expect( wrapper.text() ).toBe( 'no' );
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow( <PostVisibilityCheck user={ user } render={ render } /> );
+		const wrapper = shallow( <PostVisibilityCheck hasPublishAction={ true } render={ render } /> );
 		expect( wrapper.text() ).toBe( 'yes' );
 	} );
 } );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -292,6 +292,24 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 			);
 		}
 	}
+	if ( 'edit' === $request['context'] ) {
+		if ( current_user_can( $post_type->cap->publish_posts ) ) {
+			$new_links['https://api.w.org/action-publish'] = array(
+				array(
+					'title'        => __( 'The current user can publish this post.', 'gutenberg' ),
+					'href'         => $orig_links['self'][0]['href'],
+					'targetSchema' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'status' => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+			);
+		}
+	}
 	// Only Posts can be sticky.
 	if ( 'post' === $post->post_type && 'edit' === $request['context'] ) {
 		if ( current_user_can( $post_type->cap->edit_others_posts )

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -274,12 +274,13 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 	$new_links  = array();
 	$orig_links = $response->get_links();
 	$post_type  = get_post_type_object( $post->post_type );
+	$orig_href  = ! empty( $orig_links['self'][0]['href'] ) ? $orig_links['self'][0]['href'] : null;
 	if ( 'edit' === $request['context'] && post_type_supports( $post_type->name, 'author' ) ) {
 		if ( current_user_can( $post_type->cap->edit_others_posts ) ) {
 			$new_links['https://api.w.org/action-assign-author'] = array(
 				array(
 					'title'        => __( 'The current user can change the author on this post.', 'gutenberg' ),
-					'href'         => $orig_links['self'][0]['href'],
+					'href'         => $orig_href,
 					'targetSchema' => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -297,7 +298,7 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 			$new_links['https://api.w.org/action-publish'] = array(
 				array(
 					'title'        => __( 'The current user can publish this post.', 'gutenberg' ),
-					'href'         => $orig_links['self'][0]['href'],
+					'href'         => $orig_href,
 					'targetSchema' => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -318,7 +319,7 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 			$new_links['https://api.w.org/action-sticky'] = array(
 				array(
 					'title'        => __( 'The current user can sticky this post.', 'gutenberg' ),
-					'href'         => $orig_links['self'][0]['href'],
+					'href'         => $orig_href,
 					'targetSchema' => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -303,6 +303,7 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
 						'properties' => array(
 							'status' => array(
 								'type' => 'string',
+								'enum' => array( 'publish', 'future' ),
 							),
 						),
 					),

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -21,6 +21,9 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$this->editor        = $this->factory->user->create( array(
 			'role' => 'editor',
 		) );
+		$this->contributor   = $this->factory->user->create( array(
+			'role' => 'contributor',
+		) );
 		$this->subscriber    = $this->factory->user->create(
 			array(
 				'role'         => 'subscriber',
@@ -149,6 +152,37 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$this->assertTrue( isset( $links[ $check_key ] ) );
 		// editors can assign author but not included for context != edit.
 		wp_set_current_user( $this->editor );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'view' );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertFalse( isset( $links[ $check_key ] ) );
+	}
+
+	/**
+	 * Only returns wp:action-publish when current user can publish.
+	 */
+	function test_link_publish_only_appears_for_author() {
+		$post_id   = $this->factory->post->create( array(
+			'post_author' => $this->author,
+		) );
+		$check_key = 'https://api.w.org/action-publish';
+		// contributors cannot sticky.
+		wp_set_current_user( $this->contributor );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertFalse( isset( $links[ $check_key ] ) );
+		// authors can publish.
+		wp_set_current_user( $this->author );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+		$links    = $response->get_links();
+		$this->assertTrue( isset( $links[ $check_key ] ) );
+		// authors can publish but not included for context != edit.
+		wp_set_current_user( $this->author );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
 		$request->set_param( 'context', 'view' );
 		$response = rest_do_request( $request );


### PR DESCRIPTION
## Description

Introduces a `wp:action-publish` `targetSchema` attribute and updates `post-pending-status`, `post-schedule`, and `post-visibility` to reference it.

See #6361
Previously #6529 #6630

## How has this been tested?

Sign in as an Author to see the corresponding UI as editable:

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/36432/39846598-753b863e-53b1-11e8-8a74-c82abb62494b.png">

As a Contributor, this UI is no longer accessible:

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/36432/39846628-93a70922-53b1-11e8-9db1-52a1585dd43e.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
