### PR TITLE
Move Heading block alignment settings from sidebar to block toolbar

### DIFF
--- a/core-blocks/heading/edit.js
+++ b/core-blocks/heading/edit.js
@@ -25,15 +25,23 @@ export default function HeadingEdit( {
 
 	return (
 		<Fragment>
-			<BlockControls
-				controls={ '234'.split( '' ).map( ( level ) => ( {
-					icon: 'heading',
-					title: sprintf( __( 'Heading %s' ), level ),
-					isActive: 'H' + level === nodeName,
-					onClick: () => setAttributes( { nodeName: 'H' + level } ),
-					subscript: level,
-				} ) ) }
-			/>
+			<BlockControls>
+				<Toolbar
+					controls={ '234'.split( '' ).map( ( level ) => ( {
+						icon: 'heading',
+						title: sprintf( __( 'Heading %s' ), level ),
+						isActive: 'H' + level === nodeName,
+						onClick: () => setAttributes( { nodeName: 'H' + level } ),
+						subscript: level,
+					} ) ) }
+				/>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Heading Settings' ) }>
 					<p>{ __( 'Level' ) }</p>
@@ -45,13 +53,6 @@ export default function HeadingEdit( {
 							onClick: () => setAttributes( { nodeName: 'H' + level } ),
 							subscript: level,
 						} ) ) }
-					/>
-					<p>{ __( 'Text Alignment' ) }</p>
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
## Description
This PR addresses #6673 which requests the alignment settings of the "Heading" block to be moved from the sidebar to the block toolbar.

## How has this been tested?
This PR has been tested by adding a "Heading" block in Gutenberg editor and locating the alignment settings of the block in the block toolbar instead of the sidebar. This was tested in WP 4.9.5, Gutenberg 2.8.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![gutenberg_6673-min](https://user-images.githubusercontent.com/20284937/39854901-938c419c-544b-11e8-8b25-1d1835ee11e4.gif)

## Types of changes
This PR removes the `AlignmentToolbar` element from `InspectorControls` and nests it inside `BlockControls`. The heading level controls was wrapped with `Toolbar` for the nesting to work.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
