### PR TITLE
Remove Docker compose deprecated parallel option

### DIFF
--- a/bin/install-docker.sh
+++ b/bin/install-docker.sh
@@ -24,7 +24,7 @@ docker-compose down --remove-orphans >/dev/null 2>&1
 
 # Download image updates
 echo -e $(status_message "Downloading Docker image updates...")
-docker-compose pull --parallel
+docker-compose pull
 
 # Launch the containers
 echo -e $(status_message "Starting Docker containers...")


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR addresses #6588 which addresses removing the deprecated docker compose option

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Command  `./bin/setup-local-env.sh` was tested after the changes


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Updates docker compose command according to new docker version.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
