### PR TITLE
Blocks: Add a data store to manage the block/categories registration

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -1,21 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-
-/**
- * Block categories are defined groups for organizing blocks.
- *
- * @var {Array} categories
- */
-const categories = [
-	{ slug: 'common', title: __( 'Common Blocks' ) },
-	{ slug: 'formatting', title: __( 'Formatting' ) },
-	{ slug: 'layout', title: __( 'Layout Elements' ) },
-	{ slug: 'widgets', title: __( 'Widgets' ) },
-	{ slug: 'embed', title: __( 'Embeds' ) },
-	{ slug: 'shared', title: __( 'Shared Blocks' ) },
-];
+import { select } from '@wordpress/data';
 
 /**
  * Returns all the block categories.
@@ -23,5 +9,5 @@ const categories = [
  * @return {Array} Block categories.
  */
 export function getCategories() {
-	return categories;
+	return select( 'core/blocks' ).getCategories();
 }

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -37,20 +37,6 @@ import { select, dispatch } from '@wordpress/data';
  */
 
 /**
- * Name of block handling unknown types.
- *
- * @type {?string}
- */
-let unknownTypeHandlerName;
-
-/**
- * Name of the default block.
- *
- * @type {?string}
- */
-let defaultBlockName;
-
-/**
  * Constant mapping post formats to the expected default block.
  *
  * @type {Object}
@@ -182,7 +168,7 @@ export function unregisterBlockType( name ) {
  * @param {string} name Block name.
  */
 export function setUnknownTypeHandlerName( name ) {
-	unknownTypeHandlerName = name;
+	dispatch( 'core/blocks' ).setFallbackBlockType( name );
 }
 
 /**
@@ -192,7 +178,7 @@ export function setUnknownTypeHandlerName( name ) {
  * @return {?string} Blog name.
  */
 export function getUnknownTypeHandlerName() {
-	return unknownTypeHandlerName;
+	return select( 'core/blocks' ).getFallbackBlockTypeName();
 }
 
 /**
@@ -201,7 +187,7 @@ export function getUnknownTypeHandlerName() {
  * @param {string} name Block name.
  */
 export function setDefaultBlockName( name ) {
-	defaultBlockName = name;
+	dispatch( 'core/blocks' ).setDefaultBlockType( name );
 }
 
 /**
@@ -210,7 +196,7 @@ export function setDefaultBlockName( name ) {
  * @return {?string} Block name.
  */
 export function getDefaultBlockName() {
-	return defaultBlockName;
+	return select( 'core/blocks' ).getDefaultBlockTypeName();
 }
 
 /**

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -168,7 +168,7 @@ export function unregisterBlockType( name ) {
  * @param {string} name Block name.
  */
 export function setUnknownTypeHandlerName( name ) {
-	dispatch( 'core/blocks' ).setFallbackBlockType( name );
+	dispatch( 'core/blocks' ).setFallbackBlockName( name );
 }
 
 /**
@@ -178,7 +178,7 @@ export function setUnknownTypeHandlerName( name ) {
  * @return {?string} Blog name.
  */
 export function getUnknownTypeHandlerName() {
-	return select( 'core/blocks' ).getFallbackBlockTypeName();
+	return select( 'core/blocks' ).getFallbackBlockName();
 }
 
 /**
@@ -187,7 +187,7 @@ export function getUnknownTypeHandlerName() {
  * @param {string} name Block name.
  */
 export function setDefaultBlockName( name ) {
-	dispatch( 'core/blocks' ).setDefaultBlockType( name );
+	dispatch( 'core/blocks' ).setDefaultBlockName( name );
 }
 
 /**
@@ -196,7 +196,7 @@ export function setDefaultBlockName( name ) {
  * @return {?string} Block name.
  */
 export function getDefaultBlockName() {
-	return select( 'core/blocks' ).getDefaultBlockTypeName();
+	return select( 'core/blocks' ).getDefaultBlockName();
 }
 
 /**

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -291,7 +291,7 @@ describe( 'blocks', () => {
 
 	describe( 'getUnknownTypeHandlerName()', () => {
 		it( 'defaults to undefined', () => {
-			expect( getUnknownTypeHandlerName() ).toBeUndefined();
+			expect( getUnknownTypeHandlerName() ).toBeNull();
 		} );
 	} );
 
@@ -305,7 +305,7 @@ describe( 'blocks', () => {
 
 	describe( 'getDefaultBlockName()', () => {
 		it( 'defaults to undefined', () => {
-			expect( getDefaultBlockName() ).toBeUndefined();
+			expect( getDefaultBlockName() ).toBeNull();
 		} );
 	} );
 

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -31,6 +31,9 @@ describe( 'blocks', () => {
 	beforeAll( () => {
 		// Load all hooks that modify blocks
 		require( 'editor/hooks' );
+
+		// Initialize the block store
+		require( '../../store' );
 	} );
 
 	afterEach( () => {

--- a/blocks/api/test/templates.js
+++ b/blocks/api/test/templates.js
@@ -11,6 +11,11 @@ import { getBlockTypes, unregisterBlockType, registerBlockType } from '../regist
 import { doBlocksMatchTemplate, synchronizeBlocksWithTemplate } from '../templates';
 
 describe( 'templates', () => {
+	beforeAll( () => {
+		// Initialize the block store
+		require( '../../store' );
+	} );
+
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );

--- a/blocks/api/test/utils.js
+++ b/blocks/api/test/utils.js
@@ -11,6 +11,11 @@ import { getBlockTypes, unregisterBlockType, registerBlockType, setDefaultBlockN
 import { isUnmodifiedDefaultBlock } from '../utils';
 
 describe( 'block helpers', () => {
+	beforeAll( () => {
+		// Initialize the block store
+		require( '../../store' );
+	} );
+
 	afterEach( () => {
 		setDefaultBlockName( undefined );
 		getBlockTypes().forEach( ( block ) => {

--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -29,6 +29,10 @@ describe( 'validation', () => {
 		category: 'common',
 		title: 'block title',
 	};
+	beforeAll( () => {
+		// Initialize the block store
+		require( '../../store' );
+	} );
 
 	afterEach( () => {
 		setUnknownTypeHandlerName( undefined );

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -7,4 +7,5 @@
 //
 // Blocks are inferred from the HTML source of a post through a parsing mechanism
 // and then stored as objects in state, from which it is then rendered for editing.
+import './store';
 export * from './api';

--- a/blocks/store/actions.js
+++ b/blocks/store/actions.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { castArray } from 'lodash';
+
+/**
+ * Returns an action object used in signalling that block types have been added.
+ *
+ * @param {Array|Object} blockTypes Block types received.
+ *
+ * @return {Object} Action object.
+ */
+export function addBlockTypes( blockTypes ) {
+	return {
+		type: 'ADD_BLOCK_TYPES',
+		blockTypes: castArray( blockTypes ),
+	};
+}
+
+/**
+ * Returns an action object used to remove a registered block type.
+ *
+ * @param {string|Array} names Block name.
+ *
+ * @return {Object} Action object.
+ */
+export function removeBlockTypes( names ) {
+	return {
+		type: 'REMOVE_BLOCK_TYPES',
+		names: castArray( names ),
+	};
+}

--- a/blocks/store/actions.js
+++ b/blocks/store/actions.js
@@ -30,3 +30,31 @@ export function removeBlockTypes( names ) {
 		names: castArray( names ),
 	};
 }
+
+/**
+ * Returns an action object used to set the default block type.
+ *
+ * @param {string} name Block name.
+ *
+ * @return {Object} Action object.
+ */
+export function setDefaultBlockType( name ) {
+	return {
+		type: 'SET_DEFAULT_BLOCK_TYPE',
+		name,
+	};
+}
+
+/**
+ * Returns an action object used to set the fallback block type.
+ *
+ * @param {string} name Block name.
+ *
+ * @return {Object} Action object.
+ */
+export function setFallbackBlockType( name ) {
+	return {
+		type: 'SET_FALLBACK_BLOCK_TYPE',
+		name,
+	};
+}

--- a/blocks/store/actions.js
+++ b/blocks/store/actions.js
@@ -32,29 +32,29 @@ export function removeBlockTypes( names ) {
 }
 
 /**
- * Returns an action object used to set the default block type.
+ * Returns an action object used to set the default block name.
  *
  * @param {string} name Block name.
  *
  * @return {Object} Action object.
  */
-export function setDefaultBlockType( name ) {
+export function setDefaultBlockName( name ) {
 	return {
-		type: 'SET_DEFAULT_BLOCK_TYPE',
+		type: 'SET_DEFAULT_BLOCK_NAME',
 		name,
 	};
 }
 
 /**
- * Returns an action object used to set the fallback block type.
+ * Returns an action object used to set the fallback block name.
  *
  * @param {string} name Block name.
  *
  * @return {Object} Action object.
  */
-export function setFallbackBlockType( name ) {
+export function setFallbackBlockName( name ) {
 	return {
-		type: 'SET_FALLBACK_BLOCK_TYPE',
+		type: 'SET_FALLBACK_BLOCK_NAME',
 		name,
 	};
 }

--- a/blocks/store/index.js
+++ b/blocks/store/index.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+
+registerStore( 'core/blocks', { reducer, selectors, actions } );

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -44,7 +44,7 @@ export function blockTypes( state = {}, action ) {
 }
 
 /**
- * Higher-order Reducer creating a reducer keeping track of give block name.
+ * Higher-order Reducer creating a reducer keeping track of given block name.
  *
  * @param {string} setActionType  Action type.
  *

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, map } from 'lodash';
+import { filter, map, keyBy, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,22 +24,20 @@ export const DEFAULT_CATEGORIES = [
 /**
  * Reducer managing the block types
  *
- * @param {Array} state  Current state.
+ * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @return {Array} Updated state.
+ * @return {Object} Updated state.
  */
-export function blockTypes( state = [], action ) {
+export function blockTypes( state = {}, action ) {
 	switch ( action.type ) {
 		case 'ADD_BLOCK_TYPES':
-			const addedNames = map( action.blockTypes, ( blockType ) => blockType.name );
-			const previousState = filter(
-				state,
-				( blockType ) => addedNames.indexOf( blockType.name ) === -1
-			);
-			return [ ...previousState, ...action.blockTypes ];
+			return {
+				...state,
+				...keyBy( action.blockTypes, 'name' ),
+			};
 		case 'REMOVE_BLOCK_TYPES':
-			return filter( state, ( blockType ) => action.names.indexOf( blockType.name ) === -1 );
+			return omit( state, action.names );
 	}
 
 	return state;

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -24,40 +24,66 @@ export const DEFAULT_CATEGORIES = [
 /**
  * Reducer managing the block types
  *
- * @param {Object} state  Current state.
+ * @param {Array} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @return {Object} Updated state.
+ * @return {Array} Updated state.
  */
-export function blockTypes( state = { types: [] }, action ) {
+export function blockTypes( state = [], action ) {
 	switch ( action.type ) {
 		case 'ADD_BLOCK_TYPES':
 			const addedNames = map( action.blockTypes, ( blockType ) => blockType.name );
 			const previousState = filter(
-				state.types,
+				state,
 				( blockType ) => addedNames.indexOf( blockType.name ) === -1
 			);
-			return {
-				...state,
-				types: [ ...previousState, ...action.blockTypes ],
-			};
+			return [ ...previousState, ...action.blockTypes ];
 		case 'REMOVE_BLOCK_TYPES':
-			return {
-				...state,
-				types: filter( state.types, ( blockType ) => action.names.indexOf( blockType.name ) === -1 ),
-				defaultBlockType: action.names.indexOf( state.defaultBlockType ) !== -1 ? undefined : state.defaultBlockType,
-				fallbackBlockType: action.names.indexOf( state.fallbackBlockType ) !== -1 ? undefined : state.fallbackBlockType,
-			};
+			return filter( state, ( blockType ) => action.names.indexOf( blockType.name ) === -1 );
+	}
+
+	return state;
+}
+
+/**
+ * Reducer keeping track of the default block type.
+ *
+ * @param {string?} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {string?} Updated state.
+ */
+export function defaultBlockType( state = null, action ) {
+	switch ( action.type ) {
+		case 'REMOVE_BLOCK_TYPES':
+			if ( action.names.indexOf( state ) !== -1 ) {
+				return null;
+			}
+			return state;
 		case 'SET_DEFAULT_BLOCK_TYPE':
-			return {
-				...state,
-				defaultBlockType: action.name,
-			};
+			return action.name || null;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer keeping track of the fallback block type.
+ *
+ * @param {string?} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {string?} Updated state.
+ */
+export function fallbackBlockType( state = null, action ) {
+	switch ( action.type ) {
+		case 'REMOVE_BLOCK_TYPES':
+			if ( action.names.indexOf( state ) !== -1 ) {
+				return null;
+			}
+			return state;
 		case 'SET_FALLBACK_BLOCK_TYPE':
-			return {
-				...state,
-				fallbackBlockType: action.name,
-			};
+			return action.name || null;
 	}
 
 	return state;
@@ -83,5 +109,7 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 
 export default combineReducers( {
 	blockTypes,
+	defaultBlockType,
+	fallbackBlockType,
 	categories,
 } );

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -29,14 +29,35 @@ export const DEFAULT_CATEGORIES = [
  *
  * @return {Object} Updated state.
  */
-export function blockTypes( state = [], action ) {
+export function blockTypes( state = { types: [] }, action ) {
 	switch ( action.type ) {
 		case 'ADD_BLOCK_TYPES':
 			const addedNames = map( action.blockTypes, ( blockType ) => blockType.name );
-			const previousState = filter( state, ( blockType ) => addedNames.indexOf( blockType.name ) === -1 );
-			return [ ...previousState, ...action.blockTypes ];
+			const previousState = filter(
+				state.types,
+				( blockType ) => addedNames.indexOf( blockType.name ) === -1
+			);
+			return {
+				...state,
+				types: [ ...previousState, ...action.blockTypes ],
+			};
 		case 'REMOVE_BLOCK_TYPES':
-			return filter( state, ( blockType ) => action.names.indexOf( blockType.name ) === -1 );
+			return {
+				...state,
+				types: filter( state.types, ( blockType ) => action.names.indexOf( blockType.name ) === -1 ),
+				defaultBlockType: action.names.indexOf( state.defaultBlockType ) !== -1 ? undefined : state.defaultBlockType,
+				fallbackBlockType: action.names.indexOf( state.fallbackBlockType ) !== -1 ? undefined : state.fallbackBlockType,
+			};
+		case 'SET_DEFAULT_BLOCK_TYPE':
+			return {
+				...state,
+				defaultBlockType: action.name,
+			};
+		case 'SET_FALLBACK_BLOCK_TYPE':
+			return {
+				...state,
+				fallbackBlockType: action.name,
+			};
 	}
 
 	return state;

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -44,48 +44,32 @@ export function blockTypes( state = {}, action ) {
 }
 
 /**
- * Reducer keeping track of the default block name.
+ * Higher-order Reducer creating a reducer keeping track of give block name.
  *
- * @param {string?} state  Current state.
- * @param {Object} action Dispatched action.
+ * @param {string} setActionType  Action type.
  *
- * @return {string?} Updated state.
+ * @return {function} Reducer.
  */
-export function defaultBlockName( state = null, action ) {
-	switch ( action.type ) {
-		case 'REMOVE_BLOCK_TYPES':
-			if ( action.names.indexOf( state ) !== -1 ) {
-				return null;
-			}
-			return state;
-		case 'SET_DEFAULT_BLOCK_NAME':
-			return action.name || null;
-	}
+export function createBlockNameSetterReducer( setActionType ) {
+	return ( state = null, action ) => {
+		switch ( action.type ) {
+			case 'REMOVE_BLOCK_TYPES':
+				if ( action.names.indexOf( state ) !== -1 ) {
+					return null;
+				}
+				return state;
 
-	return state;
+			case setActionType:
+				return action.name || null;
+		}
+
+		return state;
+	};
 }
 
-/**
- * Reducer keeping track of the fallback block name.
- *
- * @param {string?} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {string?} Updated state.
- */
-export function fallbackBlockName( state = null, action ) {
-	switch ( action.type ) {
-		case 'REMOVE_BLOCK_TYPES':
-			if ( action.names.indexOf( state ) !== -1 ) {
-				return null;
-			}
-			return state;
-		case 'SET_FALLBACK_BLOCK_NAME':
-			return action.name || null;
-	}
+export const defaultBlockName = createBlockNameSetterReducer( 'SET_DEFAULT_BLOCK_NAME' );
 
-	return state;
-}
+export const fallbackBlockName = createBlockNameSetterReducer( 'SET_FALLBACK_BLOCK_NAME' );
 
 /**
  * Reducer managing the categories

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { filter, map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Module Constants
+ */
+export const DEFAULT_CATEGORIES = [
+	{ slug: 'common', title: __( 'Common Blocks' ) },
+	{ slug: 'formatting', title: __( 'Formatting' ) },
+	{ slug: 'layout', title: __( 'Layout Elements' ) },
+	{ slug: 'widgets', title: __( 'Widgets' ) },
+	{ slug: 'embed', title: __( 'Embeds' ) },
+	{ slug: 'shared', title: __( 'Shared Blocks' ) },
+];
+
+/**
+ * Reducer managing the block types
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function blockTypes( state = [], action ) {
+	switch ( action.type ) {
+		case 'ADD_BLOCK_TYPES':
+			const addedNames = map( action.blockTypes, ( blockType ) => blockType.name );
+			const previousState = filter( state, ( blockType ) => addedNames.indexOf( blockType.name ) === -1 );
+			return [ ...previousState, ...action.blockTypes ];
+		case 'REMOVE_BLOCK_TYPES':
+			return filter( state, ( blockType ) => action.names.indexOf( blockType.name ) === -1 );
+	}
+
+	return state;
+}
+
+/**
+ * Reducer managing the categories
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function categories( state = DEFAULT_CATEGORIES, action ) {
+	if ( action.type === 'ADD_CATEGORIES' ) {
+		const addedSlugs = map( action.categories, ( category ) => category.slug );
+		const previousState = filter( state, ( category ) => addedSlugs.indexOf( category.slug ) === -1 );
+		return [ ...previousState, ...action.categories ];
+	}
+
+	return state;
+}
+
+export default combineReducers( {
+	blockTypes,
+	categories,
+} );

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -46,21 +46,21 @@ export function blockTypes( state = [], action ) {
 }
 
 /**
- * Reducer keeping track of the default block type.
+ * Reducer keeping track of the default block name.
  *
  * @param {string?} state  Current state.
  * @param {Object} action Dispatched action.
  *
  * @return {string?} Updated state.
  */
-export function defaultBlockType( state = null, action ) {
+export function defaultBlockName( state = null, action ) {
 	switch ( action.type ) {
 		case 'REMOVE_BLOCK_TYPES':
 			if ( action.names.indexOf( state ) !== -1 ) {
 				return null;
 			}
 			return state;
-		case 'SET_DEFAULT_BLOCK_TYPE':
+		case 'SET_DEFAULT_BLOCK_NAME':
 			return action.name || null;
 	}
 
@@ -68,21 +68,21 @@ export function defaultBlockType( state = null, action ) {
 }
 
 /**
- * Reducer keeping track of the fallback block type.
+ * Reducer keeping track of the fallback block name.
  *
  * @param {string?} state  Current state.
  * @param {Object} action Dispatched action.
  *
  * @return {string?} Updated state.
  */
-export function fallbackBlockType( state = null, action ) {
+export function fallbackBlockName( state = null, action ) {
 	switch ( action.type ) {
 		case 'REMOVE_BLOCK_TYPES':
 			if ( action.names.indexOf( state ) !== -1 ) {
 				return null;
 			}
 			return state;
-		case 'SET_FALLBACK_BLOCK_TYPE':
+		case 'SET_FALLBACK_BLOCK_NAME':
 			return action.name || null;
 	}
 
@@ -109,7 +109,7 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 
 export default combineReducers( {
 	blockTypes,
-	defaultBlockType,
-	fallbackBlockType,
+	defaultBlockName,
+	fallbackBlockName,
 	categories,
 } );

--- a/blocks/store/selectors.js
+++ b/blocks/store/selectors.js
@@ -11,11 +11,11 @@ import { find } from 'lodash';
  * @return {Array} Block Types.
  */
 export function getBlockTypes( state ) {
-	return state.blockTypes;
+	return state.blockTypes.types;
 }
 
 export function getBlockType( state, name ) {
-	return find( state.blockTypes, { name } );
+	return find( state.blockTypes.types, { name } );
 }
 
 /**
@@ -27,4 +27,26 @@ export function getBlockType( state, name ) {
  */
 export function getCategories( state ) {
 	return state.categories;
+}
+
+/**
+ * Returns the name of the default block type
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {string?} Default block type name.
+ */
+export function getDefaultBlockTypeName( state ) {
+	return state.blockTypes.defaultBlockType;
+}
+
+/**
+ * Returns the name of the fallback block type
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {string?} Fallback block type name.
+ */
+export function getFallbackBlockTypeName( state ) {
+	return state.blockTypes.fallbackBlockType;
 }

--- a/blocks/store/selectors.js
+++ b/blocks/store/selectors.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * Returns all the available block types.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Array} Block Types.
+ */
+export function getBlockTypes( state ) {
+	return state.blockTypes;
+}
+
+export function getBlockType( state, name ) {
+	return find( state.blockTypes, { name } );
+}
+
+/**
+ * Returns all the available categories.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Array} Categories list.
+ */
+export function getCategories( state ) {
+	return state.categories;
+}

--- a/blocks/store/selectors.js
+++ b/blocks/store/selectors.js
@@ -11,11 +11,11 @@ import { find } from 'lodash';
  * @return {Array} Block Types.
  */
 export function getBlockTypes( state ) {
-	return state.blockTypes.types;
+	return state.blockTypes;
 }
 
 export function getBlockType( state, name ) {
-	return find( state.blockTypes.types, { name } );
+	return find( state.blockTypes, { name } );
 }
 
 /**
@@ -37,7 +37,7 @@ export function getCategories( state ) {
  * @return {string?} Default block type name.
  */
 export function getDefaultBlockTypeName( state ) {
-	return state.blockTypes.defaultBlockType;
+	return state.defaultBlockType;
 }
 
 /**
@@ -48,5 +48,5 @@ export function getDefaultBlockTypeName( state ) {
  * @return {string?} Fallback block type name.
  */
 export function getFallbackBlockTypeName( state ) {
-	return state.blockTypes.fallbackBlockType;
+	return state.fallbackBlockType;
 }

--- a/blocks/store/selectors.js
+++ b/blocks/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import createSelector from 'rememo';
 
 /**
  * Returns all the available block types.
@@ -10,12 +10,21 @@ import { find } from 'lodash';
  *
  * @return {Array} Block Types.
  */
-export function getBlockTypes( state ) {
-	return state.blockTypes;
-}
+export const getBlockTypes = createSelector(
+	( state ) => Object.values( state.blockTypes ),
+	( state ) => state.blockTypes
+);
 
+/**
+ * Returns a block type by name.
+ *
+ * @param {Object} state Data state.
+ * @param {string} name Block type name.
+ *
+ * @return {Object?} Block Type.
+ */
 export function getBlockType( state, name ) {
-	return find( state.blockTypes, { name } );
+	return state.blockTypes[ name ];
 }
 
 /**

--- a/blocks/store/selectors.js
+++ b/blocks/store/selectors.js
@@ -30,23 +30,23 @@ export function getCategories( state ) {
 }
 
 /**
- * Returns the name of the default block type
+ * Returns the name of the default block name.
  *
  * @param {Object} state Data state.
  *
- * @return {string?} Default block type name.
+ * @return {string?} Default block name.
  */
-export function getDefaultBlockTypeName( state ) {
-	return state.defaultBlockType;
+export function getDefaultBlockName( state ) {
+	return state.defaultBlockName;
 }
 
 /**
- * Returns the name of the fallback block type
+ * Returns the name of the fallback block name.
  *
  * @param {Object} state Data state.
  *
- * @return {string?} Fallback block type name.
+ * @return {string?} Fallback block name.
  */
-export function getFallbackBlockTypeName( state ) {
-	return state.fallbackBlockType;
+export function getFallbackBlockName( state ) {
+	return state.fallbackBlockName;
 }

--- a/blocks/store/selectors.js
+++ b/blocks/store/selectors.js
@@ -12,7 +12,9 @@ import createSelector from 'rememo';
  */
 export const getBlockTypes = createSelector(
 	( state ) => Object.values( state.blockTypes ),
-	( state ) => state.blockTypes
+	( state ) => [
+		state.blockTypes,
+	]
 );
 
 /**

--- a/blocks/store/test/reducer.js
+++ b/blocks/store/test/reducer.js
@@ -10,39 +10,73 @@ import { blockTypes, categories, DEFAULT_CATEGORIES } from '../reducer';
 
 describe( 'blockTypes', () => {
 	it( 'should return an empty array as default state', () => {
-		expect( blockTypes( undefined, {} ) ).toEqual( [] );
+		expect( blockTypes( undefined, {} ) ).toEqual( { types: [] } );
 	} );
 
 	it( 'should add add a new block type', () => {
-		const original = deepFreeze( [
-			{ name: 'core/paragraph' },
-		] );
+		const original = deepFreeze( {
+			types: [
+				{ name: 'core/paragraph' },
+			],
+		} );
 
 		const state = blockTypes( original, {
 			type: 'ADD_BLOCK_TYPES',
 			blockTypes: [ { name: 'core/code' } ],
 		} );
 
-		expect( state ).toEqual( [
+		expect( state.types ).toEqual( [
 			{ name: 'core/paragraph' },
 			{ name: 'core/code' },
 		] );
 	} );
 
 	it( 'should remove block types', () => {
-		const original = deepFreeze( [
-			{ name: 'core/paragraph' },
-			{ name: 'core/code' },
-		] );
+		const original = deepFreeze( {
+			types: [
+				{ name: 'core/paragraph' },
+				{ name: 'core/code' },
+			],
+		} );
 
 		const state = blockTypes( original, {
 			type: 'REMOVE_BLOCK_TYPES',
 			names: [ 'core/code' ],
 		} );
 
-		expect( state ).toEqual( [
+		expect( state.types ).toEqual( [
 			{ name: 'core/paragraph' },
 		] );
+	} );
+
+	it( 'should set the default block type', () => {
+		const original = deepFreeze( {
+			types: [
+				{ name: 'core/paragraph' },
+			],
+		} );
+
+		const state = blockTypes( original, {
+			type: 'SET_DEFAULT_BLOCK_TYPE',
+			name: 'core/paragraph',
+		} );
+
+		expect( state.defaultBlockType ).toBe( 'core/paragraph' );
+	} );
+
+	it( 'should set the fallback block type', () => {
+		const original = deepFreeze( {
+			types: [
+				{ name: 'core/paragraph' },
+			],
+		} );
+
+		const state = blockTypes( original, {
+			type: 'SET_FALLBACK_BLOCK_TYPE',
+			name: 'core/paragraph',
+		} );
+
+		expect( state.fallbackBlockType ).toBe( 'core/paragraph' );
 	} );
 } );
 

--- a/blocks/store/test/reducer.js
+++ b/blocks/store/test/reducer.js
@@ -9,40 +9,40 @@ import deepFreeze from 'deep-freeze';
 import { blockTypes, categories, defaultBlockName, fallbackBlockName, DEFAULT_CATEGORIES } from '../reducer';
 
 describe( 'blockTypes', () => {
-	it( 'should return an empty array as default state', () => {
-		expect( blockTypes( undefined, {} ) ).toEqual( [] );
+	it( 'should return an empty object as default state', () => {
+		expect( blockTypes( undefined, {} ) ).toEqual( {} );
 	} );
 
 	it( 'should add add a new block type', () => {
-		const original = deepFreeze( [
-			{ name: 'core/paragraph' },
-		] );
+		const original = deepFreeze( {
+			'core/paragraph': { name: 'core/paragraph' },
+		} );
 
 		const state = blockTypes( original, {
 			type: 'ADD_BLOCK_TYPES',
 			blockTypes: [ { name: 'core/code' } ],
 		} );
 
-		expect( state ).toEqual( [
-			{ name: 'core/paragraph' },
-			{ name: 'core/code' },
-		] );
+		expect( state ).toEqual( {
+			'core/paragraph': { name: 'core/paragraph' },
+			'core/code': { name: 'core/code' },
+		} );
 	} );
 
 	it( 'should remove block types', () => {
-		const original = deepFreeze( [
-			{ name: 'core/paragraph' },
-			{ name: 'core/code' },
-		] );
+		const original = deepFreeze( {
+			'core/paragraph': { name: 'core/paragraph' },
+			'core/code': { name: 'core/code' },
+		} );
 
 		const state = blockTypes( original, {
 			type: 'REMOVE_BLOCK_TYPES',
 			names: [ 'core/code' ],
 		} );
 
-		expect( state ).toEqual( [
-			{ name: 'core/paragraph' },
-		] );
+		expect( state ).toEqual( {
+			'core/paragraph': { name: 'core/paragraph' },
+		} );
 	} );
 } );
 

--- a/blocks/store/test/reducer.js
+++ b/blocks/store/test/reducer.js
@@ -6,77 +6,91 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { blockTypes, categories, DEFAULT_CATEGORIES } from '../reducer';
+import { blockTypes, categories, defaultBlockType, fallbackBlockType, DEFAULT_CATEGORIES } from '../reducer';
 
 describe( 'blockTypes', () => {
 	it( 'should return an empty array as default state', () => {
-		expect( blockTypes( undefined, {} ) ).toEqual( { types: [] } );
+		expect( blockTypes( undefined, {} ) ).toEqual( [] );
 	} );
 
 	it( 'should add add a new block type', () => {
-		const original = deepFreeze( {
-			types: [
-				{ name: 'core/paragraph' },
-			],
-		} );
+		const original = deepFreeze( [
+			{ name: 'core/paragraph' },
+		] );
 
 		const state = blockTypes( original, {
 			type: 'ADD_BLOCK_TYPES',
 			blockTypes: [ { name: 'core/code' } ],
 		} );
 
-		expect( state.types ).toEqual( [
+		expect( state ).toEqual( [
 			{ name: 'core/paragraph' },
 			{ name: 'core/code' },
 		] );
 	} );
 
 	it( 'should remove block types', () => {
-		const original = deepFreeze( {
-			types: [
-				{ name: 'core/paragraph' },
-				{ name: 'core/code' },
-			],
-		} );
+		const original = deepFreeze( [
+			{ name: 'core/paragraph' },
+			{ name: 'core/code' },
+		] );
 
 		const state = blockTypes( original, {
 			type: 'REMOVE_BLOCK_TYPES',
 			names: [ 'core/code' ],
 		} );
 
-		expect( state.types ).toEqual( [
+		expect( state ).toEqual( [
 			{ name: 'core/paragraph' },
 		] );
 	} );
+} );
+
+describe( 'defaultBlockType', () => {
+	it( 'should return null as default state', () => {
+		expect( defaultBlockType( undefined, {} ) ).toBeNull();
+	} );
 
 	it( 'should set the default block type', () => {
-		const original = deepFreeze( {
-			types: [
-				{ name: 'core/paragraph' },
-			],
-		} );
-
-		const state = blockTypes( original, {
+		const state = defaultBlockType( null, {
 			type: 'SET_DEFAULT_BLOCK_TYPE',
 			name: 'core/paragraph',
 		} );
 
-		expect( state.defaultBlockType ).toBe( 'core/paragraph' );
+		expect( state ).toBe( 'core/paragraph' );
+	} );
+
+	it( 'should reset the fallback block type', () => {
+		const state = defaultBlockType( 'core/code', {
+			type: 'REMOVE_BLOCK_TYPES',
+			names: [ 'core/code' ],
+		} );
+
+		expect( state ).toBeNull();
+	} );
+} );
+
+describe( 'fallbackBlockType', () => {
+	it( 'should return null as default state', () => {
+		expect( fallbackBlockType( undefined, {} ) ).toBeNull();
 	} );
 
 	it( 'should set the fallback block type', () => {
-		const original = deepFreeze( {
-			types: [
-				{ name: 'core/paragraph' },
-			],
-		} );
-
-		const state = blockTypes( original, {
+		const state = fallbackBlockType( null, {
 			type: 'SET_FALLBACK_BLOCK_TYPE',
 			name: 'core/paragraph',
 		} );
 
-		expect( state.fallbackBlockType ).toBe( 'core/paragraph' );
+		expect( state ).toBe( 'core/paragraph' );
+	} );
+
+	it( 'should reset the fallback block type', () => {
+		const state = fallbackBlockType( 'core/code', {
+			type: 'REMOVE_BLOCK_TYPES',
+			names: [ 'core/code' ],
+		} );
+
+		expect( state ).toBeNull();
 	} );
 } );
 

--- a/blocks/store/test/reducer.js
+++ b/blocks/store/test/reducer.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { blockTypes, categories, defaultBlockType, fallbackBlockType, DEFAULT_CATEGORIES } from '../reducer';
+import { blockTypes, categories, defaultBlockName, fallbackBlockName, DEFAULT_CATEGORIES } from '../reducer';
 
 describe( 'blockTypes', () => {
 	it( 'should return an empty array as default state', () => {
@@ -46,22 +46,22 @@ describe( 'blockTypes', () => {
 	} );
 } );
 
-describe( 'defaultBlockType', () => {
+describe( 'defaultBlockName', () => {
 	it( 'should return null as default state', () => {
-		expect( defaultBlockType( undefined, {} ) ).toBeNull();
+		expect( defaultBlockName( undefined, {} ) ).toBeNull();
 	} );
 
-	it( 'should set the default block type', () => {
-		const state = defaultBlockType( null, {
-			type: 'SET_DEFAULT_BLOCK_TYPE',
+	it( 'should set the default block name', () => {
+		const state = defaultBlockName( null, {
+			type: 'SET_DEFAULT_BLOCK_NAME',
 			name: 'core/paragraph',
 		} );
 
 		expect( state ).toBe( 'core/paragraph' );
 	} );
 
-	it( 'should reset the fallback block type', () => {
-		const state = defaultBlockType( 'core/code', {
+	it( 'should reset the fallback block name', () => {
+		const state = defaultBlockName( 'core/code', {
 			type: 'REMOVE_BLOCK_TYPES',
 			names: [ 'core/code' ],
 		} );
@@ -70,22 +70,22 @@ describe( 'defaultBlockType', () => {
 	} );
 } );
 
-describe( 'fallbackBlockType', () => {
+describe( 'fallbackBlockName', () => {
 	it( 'should return null as default state', () => {
-		expect( fallbackBlockType( undefined, {} ) ).toBeNull();
+		expect( fallbackBlockName( undefined, {} ) ).toBeNull();
 	} );
 
-	it( 'should set the fallback block type', () => {
-		const state = fallbackBlockType( null, {
-			type: 'SET_FALLBACK_BLOCK_TYPE',
+	it( 'should set the fallback block name', () => {
+		const state = fallbackBlockName( null, {
+			type: 'SET_FALLBACK_BLOCK_NAME',
 			name: 'core/paragraph',
 		} );
 
 		expect( state ).toBe( 'core/paragraph' );
 	} );
 
-	it( 'should reset the fallback block type', () => {
-		const state = fallbackBlockType( 'core/code', {
+	it( 'should reset the fallback block name', () => {
+		const state = fallbackBlockName( 'core/code', {
 			type: 'REMOVE_BLOCK_TYPES',
 			names: [ 'core/code' ],
 		} );

--- a/blocks/store/test/reducer.js
+++ b/blocks/store/test/reducer.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { blockTypes, categories, DEFAULT_CATEGORIES } from '../reducer';
+
+describe( 'blockTypes', () => {
+	it( 'should return an empty array as default state', () => {
+		expect( blockTypes( undefined, {} ) ).toEqual( [] );
+	} );
+
+	it( 'should add add a new block type', () => {
+		const original = deepFreeze( [
+			{ name: 'core/paragraph' },
+		] );
+
+		const state = blockTypes( original, {
+			type: 'ADD_BLOCK_TYPES',
+			blockTypes: [ { name: 'core/code' } ],
+		} );
+
+		expect( state ).toEqual( [
+			{ name: 'core/paragraph' },
+			{ name: 'core/code' },
+		] );
+	} );
+
+	it( 'should remove block types', () => {
+		const original = deepFreeze( [
+			{ name: 'core/paragraph' },
+			{ name: 'core/code' },
+		] );
+
+		const state = blockTypes( original, {
+			type: 'REMOVE_BLOCK_TYPES',
+			names: [ 'core/code' ],
+		} );
+
+		expect( state ).toEqual( [
+			{ name: 'core/paragraph' },
+		] );
+	} );
+} );
+
+describe( 'categories', () => {
+	it( 'should return the default categories as default state', () => {
+		expect( categories( undefined, {} ) ).toEqual( DEFAULT_CATEGORIES );
+	} );
+
+	it( 'should add add a new category', () => {
+		const original = deepFreeze( [
+			{ slug: 'chicken', title: 'Chicken' },
+		] );
+
+		const state = categories( original, {
+			type: 'ADD_CATEGORIES',
+			categories: [ { slug: 'wings', title: 'Wings' } ],
+		} );
+
+		expect( state ).toEqual( [
+			{ slug: 'chicken', title: 'Chicken' },
+			{ slug: 'wings', title: 'Wings' },
+		] );
+	} );
+} );


### PR DESCRIPTION
This PR introduces a store to the blocks module, this allows things like:

 - using `withSelect` to retrieve blocks/categories...
 - reacting to block registration
 - pave the way to an `addCategories` action.

This has been on my mind for a long time now, but I thought it would be a good first step towards the refactoring needed to introduce the server-side block awareness (`registerBlockType` and `implementBlockType`). My idea is to update the retrieval of blockTypes etc... to rely on the selector and we could change the underlying implementation of the selector if we split block registration into "defining the existence of a block" and "implement the block in the editor".

At the moment, the external API remains the same, there's no deprecation or anything (I prefer to leave this for the server-side awareness work which would clarify the API needed). So basically, I just updated the existing APIs to call `select/dispatch` instead of relying on the local variables. So as a follow-up task, I'd like to update our current usage of the block module API and use `withSelect` instead


