### PR TITLE
Move editorMediaUpload to the editor module

### DIFF
--- a/blocks/index.js
+++ b/blocks/index.js
@@ -8,5 +8,3 @@
 // Blocks are inferred from the HTML source of a post through a parsing mechanism
 // and then stored as objects in state, from which it is then rendered for editing.
 export * from './api';
-
-export { default as editorMediaUpload } from './editor-media-upload';

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -10,11 +10,11 @@ import {
 	Toolbar,
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
-import { editorMediaUpload } from '@wordpress/blocks';
 import {
 	MediaUpload,
 	RichText,
 	BlockControls,
+	editorMediaUpload,
 } from '@wordpress/editor';
 
 /**

--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -18,13 +18,13 @@ import {
 	ToggleControl,
 	Toolbar,
 } from '@wordpress/components';
-import { editorMediaUpload } from '@wordpress/blocks';
 import {
 	BlockControls,
 	BlockAlignmentToolbar,
 	MediaUpload,
 	ImagePlaceholder,
 	InspectorControls,
+	editorMediaUpload,
 } from '@wordpress/editor';
 
 /**

--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -7,11 +7,8 @@ import { filter, every } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	createBlock,
-	editorMediaUpload,
-} from '@wordpress/blocks';
-import { RichText } from '@wordpress/editor';
+import { createBlock } from '@wordpress/blocks';
+import { RichText, editorMediaUpload } from '@wordpress/editor';
 
 /**
  * Internal dependencies

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -28,7 +28,6 @@ import {
 	Toolbar,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
-import { editorMediaUpload } from '@wordpress/blocks';
 import {
 	RichText,
 	BlockControls,
@@ -37,6 +36,7 @@ import {
 	MediaUpload,
 	BlockAlignmentToolbar,
 	UrlInputButton,
+	editorMediaUpload,
 } from '@wordpress/editor';
 
 /**

--- a/core-blocks/video/index.js
+++ b/core-blocks/video/index.js
@@ -14,12 +14,12 @@ import {
 	Toolbar,
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
-import { editorMediaUpload } from '@wordpress/blocks';
 import {
 	BlockAlignmentToolbar,
 	BlockControls,
 	MediaUpload,
 	RichText,
+	editorMediaUpload,
 } from '@wordpress/editor';
 
 /**

--- a/editor/components/image-placeholder/index.js
+++ b/editor/components/image-placeholder/index.js
@@ -8,11 +8,12 @@ import { map } from 'lodash';
  */
 import { DropZone, FormFileUpload, Placeholder, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { editorMediaUpload, rawHandler } from '@wordpress/blocks';
+import { rawHandler } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
+import { editorMediaUpload } from '../../utils';
 import MediaUpload from '../media-upload';
 
 /**

--- a/editor/deprecated.js
+++ b/editor/deprecated.js
@@ -35,6 +35,7 @@ import {
 	getColorName,
 	withColors,
 } from './components';
+import { editorMediaUpload } from './utils';
 
 const componentsToDepreacate = {
 	Autocomplete,
@@ -63,6 +64,7 @@ const functionsToDeprecate = {
 	getColorClass,
 	getColorName,
 	withColors,
+	editorMediaUpload,
 };
 
 forEach( componentsToDepreacate, ( WrappedComponent, key ) => {

--- a/editor/index.js
+++ b/editor/index.js
@@ -3,3 +3,4 @@ import './store';
 import './hooks';
 
 export * from './components';
+export * from './utils';

--- a/editor/utils/editor-media-upload/index.js
+++ b/editor/utils/editor-media-upload/index.js
@@ -13,11 +13,7 @@ import { mediaUpload } from '@wordpress/utils';
  * @param {string}   allowedType  The type of media that can be uploaded.
  */
 export default function editorMediaUpload( filesList, onFileChange, allowedType ) {
-	let postId = null;
-	// Editor isn't guaranteed in block context.
-	if ( select( 'core/editor' ) ) {
-		postId = select( 'core/editor' ).getCurrentPostId();
-	}
+	const postId = select( 'core/editor' ).getCurrentPostId();
 	mediaUpload( filesList, onFileChange, allowedType, {
 		post: postId,
 	} );

--- a/editor/utils/index.js
+++ b/editor/utils/index.js
@@ -1,0 +1,1 @@
+export { default as editorMediaUpload } from './editor-media-upload';


### PR DESCRIPTION
Related #6275 

This PR moves the editorMediaUpload helper to the editor module because it has a dependency towards the editor store. This allows us to remove the check for the store existence.

**Testing instructions**

 - Check that uploading images directly from the image block works as expected.