### PR TITLE
Improve performance; Stop unnecessary rerenders caused by withColors

### DIFF
--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -157,11 +157,11 @@ class ButtonEdit extends Component {
 	}
 }
 
-export default withColors( ( getColor, setColor, { attributes, setAttributes } ) => {
+export default withColors( ( getColor, setColor, { attributes } ) => {
 	return {
 		backgroundColor: getColor( attributes.backgroundColor, attributes.customBackgroundColor, 'background-color' ),
-		setBackgroundColor: setColor( 'backgroundColor', 'customBackgroundColor', setAttributes ),
+		setBackgroundColor: setColor( 'backgroundColor', 'customBackgroundColor' ),
 		textColor: getColor( attributes.textColor, attributes.customTextColor, 'color' ),
-		setTextColor: setColor( 'textColor', 'customTextColor', setAttributes ),
+		setTextColor: setColor( 'textColor', 'customTextColor' ),
 	};
 } )( ButtonEdit );

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -449,12 +449,12 @@ export const settings = {
 	},
 
 	edit: compose(
-		withColors( ( getColor, setColor, { attributes, setAttributes } ) => {
+		withColors( ( getColor, setColor, { attributes } ) => {
 			return {
 				backgroundColor: getColor( attributes.backgroundColor, attributes.customBackgroundColor, 'background-color' ),
-				setBackgroundColor: setColor( 'backgroundColor', 'customBackgroundColor', setAttributes ),
+				setBackgroundColor: setColor( 'backgroundColor', 'customBackgroundColor' ),
 				textColor: getColor( attributes.textColor, attributes.customTextColor, 'color' ),
-				setTextColor: setColor( 'textColor', 'customTextColor', setAttributes ),
+				setTextColor: setColor( 'textColor', 'customTextColor' ),
 			};
 		} ),
 		FallbackStyles,

--- a/editor/components/colors/with-colors.js
+++ b/editor/components/colors/with-colors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, memoize } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +13,40 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { getColorValue, getColorClass, setColorValue } from './utils';
+
+const memoizedGetColor = memoize(
+	( colors ) =>
+		memoize(
+			( colorName, customColorValue, colorContext ) => {
+				return {
+					name: colorName,
+					class: getColorClass( colorContext, colorName ),
+					value: getColorValue( colors, colorName, customColorValue ),
+				};
+			},
+			( colorName, customColorValue, colorContext ) =>
+				`${ colorName }-${ customColorValue }-${ colorContext }`
+		)
+);
+/**
+ * Even though, we don't expect setAttributes to change memoizing it is essential.
+ * If setAttributes is not memoized, each time memoizedSetColor is called:
+ * a new function reference is returned (even if setAttributes has not changed).
+ * This would make our memoized chain useless.
+ */
+const memoizedSetColor = memoize(
+	( setAttributes ) =>
+		memoize(
+			( colors ) =>
+				memoize(
+					( colorNameAttribute, customColorAttribute ) => {
+						return setColorValue( colors, colorNameAttribute, customColorAttribute, setAttributes );
+					},
+					( colorNameAttribute, customColorAttribute ) =>
+						`${ colorNameAttribute }-${ customColorAttribute }`
+				)
+		)
+);
 
 /**
  * Higher-order component, which handles color logic for class generation
@@ -28,17 +62,7 @@ export default ( mapGetSetColorToProps ) => createHigherOrderComponent(
 		( select, props ) => {
 			const settings = select( 'core/editor' ).getEditorSettings();
 			const colors = get( settings, [ 'colors' ], [] );
-			const getColor = ( colorName, customColorValue, colorContext ) => {
-				return {
-					name: colorName,
-					class: getColorClass( colorContext, colorName ),
-					value: getColorValue( colors, colorName, customColorValue ),
-				};
-			};
-			const setColor = ( colorNameAttribute, customColorAttribute, setAttributes ) => {
-				return setColorValue( colors, colorNameAttribute, customColorAttribute, setAttributes );
-			};
-			return mapGetSetColorToProps( getColor, setColor, props );
+			return mapGetSetColorToProps( memoizedGetColor( colors ), memoizedSetColor( props.setAttributes )( colors ), props );
 		} ),
 	'withColors'
 );


### PR DESCRIPTION
The getColor and setColor functions returned a new object or a new function every time, although the code looked correct it made unnecessary rerenders happen.

We now return memoized functions this ensures that if the parameters are not changed we will return references for the same object or function so the props the HOC returns are not changed and no rerender happen.

## How has this been tested?
Verify setting colors in paragraph and button continues to work the same way as before.
Toggle the Highlights updates feature and verify, and verify the number of rerenders decreased.

## Screenshots <!-- if applicable -->
Before:
![may-10-2018 14-51-48](https://user-images.githubusercontent.com/11271197/39873396-aeca5ac2-5462-11e8-806d-62d87cba0aa1.gif)
After:
![may-10-2018 14-49-49](https://user-images.githubusercontent.com/11271197/39873408-be67de28-5462-11e8-9cd2-3fbe68109808.gif)


