### PR TITLE
Make sidebar toggle button open block sidebar if a block is selected

### DIFF
--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -70,10 +70,16 @@ export default compose(
 		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
+		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
 	} ) ),
-	withDispatch( ( dispatch ) => ( {
-		openGeneralSidebar: () => dispatch( 'core/edit-post' ).openGeneralSidebar( 'edit-post/document' ),
-		closeGeneralSidebar: dispatch( 'core/edit-post' ).closeGeneralSidebar,
-		togglePublishSidebar: dispatch( 'core/edit-post' ).togglePublishSidebar,
-	} ) ),
+	withDispatch( ( dispatch, { hasBlockSelection } ) => {
+		const { openGeneralSidebar, closeGeneralSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );
+		const sidebarToOpen = hasBlockSelection ? 'edit-post/block' : 'edit-post/document';
+		return {
+			openGeneralSidebar: () => openGeneralSidebar( sidebarToOpen ),
+			closeGeneralSidebar: closeGeneralSidebar,
+			togglePublishSidebar: togglePublishSidebar,
+			hasBlockSelection: undefined,
+		};
+	} ),
 )( Header );


### PR DESCRIPTION
When opening sidebar using sidebar toggle button we always opened document sidebar. This stopped the behavior of keeping block sidebar opened while a block is selected.

## How has this been tested?
Create a block close, select it close sidebar, and open the sidebar verify the sidebar that opens is the block sidebar (in master it was the document).
Unselect the block, close the sidebar and open it again, verify that the sidebar that opens, in this case, is the document sidebar.

## Screenshots
Before:
![may-10-2018 18-02-30](https://user-images.githubusercontent.com/11271197/39882661-53a92d52-547c-11e8-8c9c-11847e74517f.gif)

After:
![may-10-2018 17-56-29](https://user-images.githubusercontent.com/11271197/39882645-431a9d68-547c-11e8-8c81-2e8b01a6a050.gif)



