### PR TITLE
Add `i18n` rules from `eslint-plugin-wordpress`

### DIFF
--- a/eslint/config.js
+++ b/eslint/config.js
@@ -3,6 +3,7 @@ module.exports = {
 	extends: [
 		'wordpress',
 		'plugin:wordpress/esnext',
+		'plugin:wordpress/i18n',
 		'plugin:react/recommended',
 		'plugin:jsx-a11y/recommended',
 	],


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Adds ESLint `i18n` rules from `eslint-plugin-wordpress`

This PR stems from a Slack conversation between @danielbachhuber and @aduth [here](https://wordpress.slack.com/archives/C02QB2JS7/p1525972170000329)

The `eslint-plugin-wordpress` ESlint config includes the `i18n` [rules from](https://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress/blob/master/lib/configs/rules/i18n.js) `eslint-plugin-wpcalypso` 

In particular, the rule cited in the chat was the `wpcalypso/i18n-ellipsis` rule which is [configured currently](https://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress/blob/master/lib/configs/rules/i18n.js#L16-L17) to `warn`, this can be easily changed to `error`

Any of the other rules included in `plugin:wordpress/i18n` may require tweaks, this `plugin:wordpress/i18n` has had very little real-world WordPress testing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I've not tested this locally, let's see what Travis CI has to say about it.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Build Tool Update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
