### PR TITLE
Enhancement: Add text alignment options to verse block toolbar

### DIFF
--- a/core-blocks/verse/index.js
+++ b/core-blocks/verse/index.js
@@ -34,7 +34,7 @@ export const settings = {
 			source: 'children',
 			selector: 'pre',
 		},
-		align: {
+		textAlign: {
 			type: 'string',
 		},
 	},
@@ -59,15 +59,15 @@ export const settings = {
 	},
 
 	edit( { attributes, setAttributes, className } ) {
-		const { align, content } = attributes;
+		const { textAlign, content } = attributes;
 
 		return (
 			<Fragment>
 				<BlockControls>
 					<AlignmentToolbar
-						value={ align }
+						value={ textAlign }
 						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
+							setAttributes( { textAlign: nextAlign } );
 						} }
 					/>
 				</BlockControls>
@@ -79,7 +79,7 @@ export const settings = {
 							content: nextContent,
 						} );
 					} }
-					style={ { textAlign: align } }
+					style={ { textAlign: textAlign } }
 					placeholder={ __( 'Write…' ) }
 					wrapperClassName={ className }
 					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
@@ -89,13 +89,13 @@ export const settings = {
 	},
 
 	save( { attributes, className } ) {
-		const { align, content } = attributes;
+		const { textAlign, content } = attributes;
 
 		return (
 			<RichText.Content
 				tagName="pre"
 				className={ className }
-				style={ { textAlign: align } }
+				style={ { textAlign: textAlign } }
 				value={ content }
 			/>
 		);

--- a/core-blocks/verse/index.js
+++ b/core-blocks/verse/index.js
@@ -2,8 +2,13 @@
  * WordPress
  */
 import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import { RichText } from '@wordpress/editor';
+import {
+	RichText,
+	BlockControls,
+	AlignmentToolbar,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -29,6 +34,9 @@ export const settings = {
 			source: 'children',
 			selector: 'pre',
 		},
+		align: {
+			type: 'string',
+		},
 	},
 
 	transforms: {
@@ -51,30 +59,44 @@ export const settings = {
 	},
 
 	edit( { attributes, setAttributes, className } ) {
-		const { content } = attributes;
+		const { align, content } = attributes;
 
 		return (
-			<RichText
-				tagName="pre"
-				value={ content }
-				onChange={ ( nextContent ) => {
-					setAttributes( {
-						content: nextContent,
-					} );
-				} }
-				placeholder={ __( 'Write…' ) }
-				wrapperClassName={ className }
-				formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
-			/>
+			<Fragment>
+				<BlockControls>
+					<AlignmentToolbar
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
+					/>
+				</BlockControls>
+				<RichText
+					tagName="pre"
+					value={ content }
+					onChange={ ( nextContent ) => {
+						setAttributes( {
+							content: nextContent,
+						} );
+					} }
+					style={ { textAlign: align } }
+					placeholder={ __( 'Write…' ) }
+					wrapperClassName={ className }
+					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+				/>
+			</Fragment>
 		);
 	},
 
 	save( { attributes, className } ) {
+		const { align, content } = attributes;
+
 		return (
 			<RichText.Content
 				tagName="pre"
 				className={ className }
-				value={ attributes.content }
+				style={ { textAlign: align } }
+				value={ content }
 			/>
 		);
 	},


### PR DESCRIPTION
## Description
This PR addresses #6695 which requested a text alignment option (left/centre/right) in the verse block as we can see in the heading/paragraph/subhead and other blocks.

## How has this been tested?
This PR has been tested by adding a "Verse" block in Gutenberg editor and locating the alignment settings of the block in the block toolbar. It was also made sure that the alignment settings were correctly saved and rendered in the front-end. This was tested in WP 4.9.5, Gutenberg 2.8.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![gutenberg-6695-min](https://user-images.githubusercontent.com/20284937/39909770-07fbe9e0-5516-11e8-8a6b-85a4b9921d3b.gif)


## Types of changes
This PR imports the dependencies required for the verse block toolbar and text alignment options ( i.e. `Fragment`, `BlockControls` and `AlignmentToolbar` ), adds the `align` attributes in the `edit` and `save` functions and lastly outputs the block toolbar.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
