### PR TITLE
Enhancement: Add text alignment options to preformatted block toolbar

### DIFF
--- a/core-blocks/preformatted/index.js
+++ b/core-blocks/preformatted/index.js
@@ -2,8 +2,13 @@
  * WordPress
  */
 import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
 import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
-import { RichText } from '@wordpress/editor';
+import {
+	RichText,
+	BlockControls,
+	AlignmentToolbar,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -26,6 +31,9 @@ export const settings = {
 			type: 'array',
 			source: 'children',
 			selector: 'pre',
+		},
+		align: {
+			type: 'string',
 		},
 	},
 
@@ -64,26 +72,37 @@ export const settings = {
 	},
 
 	edit( { attributes, setAttributes, className } ) {
-		const { content } = attributes;
+		const { align, content } = attributes;
 
 		return (
-			<RichText
-				tagName="pre"
-				value={ content }
-				onChange={ ( nextContent ) => {
-					setAttributes( {
-						content: nextContent,
-					} );
-				} }
-				placeholder={ __( 'Write preformatted text…' ) }
-				wrapperClassName={ className }
-			/>
+			<Fragment>
+				<BlockControls>
+					<AlignmentToolbar
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
+					/>
+				</BlockControls>
+				<RichText
+					tagName="pre"
+					value={ content }
+					onChange={ ( nextContent ) => {
+						setAttributes( {
+							content: nextContent,
+						} );
+					} }
+					style={ { textAlign: align } }
+					placeholder={ __( 'Write preformatted text…' ) }
+					wrapperClassName={ className }
+				/>
+			</Fragment>
 		);
 	},
 
 	save( { attributes } ) {
-		const { content } = attributes;
+		const { align, content } = attributes;
 
-		return <RichText.Content tagName="pre" value={ content } />;
+		return <RichText.Content tagName="pre" style={ { textAlign: align } } value={ content } />;
 	},
 };


### PR DESCRIPTION
## Description
This PR addresses #6698 which requested a text alignment option (left/centre/right) in the "Preformatted" block as we can see in the heading/paragraph/subhead and other blocks.

## How has this been tested?
This PR has been tested by adding a "Preformatted" block in Gutenberg editor and locating the alignment settings of the block in the block toolbar. It was also made sure that the alignment settings were correctly saved and rendered in the front-end. This was tested in WP 4.9.5, Gutenberg 2.8.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![gutenberg-6698-min](https://user-images.githubusercontent.com/20284937/39910726-66c7d188-551a-11e8-85e2-75d5935fede9.gif)


## Types of changes
This PR imports the dependencies required for the preformatted block toolbar and text alignment options ( i.e. `Fragment`, `BlockControls` and `AlignmentToolbar` ), adds the `align` attributes in the `edit` and `save` functions and lastly outputs the block toolbar.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
