### PR TITLE
Editor: Introduce `name` prop for RichText to handle changes automatically

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -156,7 +156,6 @@ class ParagraphBlock extends Component {
 
 		const {
 			align,
-			content,
 			dropCap,
 			placeholder,
 		} = attributes;
@@ -213,6 +212,7 @@ class ParagraphBlock extends Component {
 				<div>
 					<RichText
 						tagName="p"
+						name="content"
 						className={ classnames( 'wp-block-paragraph', className, {
 							'has-background': backgroundColor.value,
 							'has-drop-cap': dropCap,
@@ -224,12 +224,6 @@ class ParagraphBlock extends Component {
 							color: textColor.class ? undefined : textColor.value,
 							fontSize: fontSize ? fontSize + 'px' : undefined,
 							textAlign: align,
-						} }
-						value={ content }
-						onChange={ ( nextContent ) => {
-							setAttributes( {
-								content: nextContent,
-							} );
 						} }
 						onSplit={ insertBlocksAfter ?
 							( before, after, ...blocks ) => {

--- a/editor/components/block-edit/context.js
+++ b/editor/components/block-edit/context.js
@@ -10,6 +10,8 @@ import { createContext, createHigherOrderComponent } from '@wordpress/element';
 
 const { Consumer, Provider } = createContext( {
 	name: '',
+	attributes: {},
+	setAttribute: noop,
 	isSelected: false,
 	focusedElement: null,
 	setFocusedElement: noop,

--- a/editor/components/block-edit/index.js
+++ b/editor/components/block-edit/index.js
@@ -19,8 +19,10 @@ import { BlockEditContextProvider } from './context';
 export class BlockEdit extends Component {
 	constructor( props ) {
 		super( props );
+		this.setAttribute = this.setAttribute.bind( this );
 		this.setFocusedElement = this.setFocusedElement.bind( this );
 		this.state = {
+			setAttribute: this.setAttribute,
 			focusedElement: null,
 			setFocusedElement: this.setFocusedElement,
 		};
@@ -42,6 +44,12 @@ export class BlockEdit extends Component {
 		};
 	}
 
+	setAttribute( name, value ) {
+		this.props.setAttributes( {
+			[ name ]: value,
+		} );
+	}
+
 	setFocusedElement( focusedElement ) {
 		this.setState( ( prevState ) => {
 			if ( prevState.focusedElement === focusedElement ) {
@@ -51,9 +59,10 @@ export class BlockEdit extends Component {
 		} );
 	}
 
-	static getDerivedStateFromProps( { name, isSelected }, prevState ) {
+	static getDerivedStateFromProps( { name, attributes, isSelected }, prevState ) {
 		if (
 			name === prevState.name &&
+			attributes === prevState.attributes &&
 			isSelected === prevState.isSelected
 		) {
 			return null;
@@ -62,6 +71,7 @@ export class BlockEdit extends Component {
 		return {
 			...prevState,
 			name,
+			attributes,
 			isSelected,
 		};
 	}

--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -18,11 +18,15 @@ a traditional `input` field, usually when the user exits the field.
 
 ### `value: Array|String`
 
-*Required.* Depending on the format prop, this value could be an array of React DOM to make editable or an HTML string. The rendered HTML should be valid, and valid with respect to the `tagName` and `inline` property.
+*Optional.* Depending on the format prop, this value could be an array of React DOM to make editable or an HTML string. The rendered HTML should be valid, and valid with respect to the `tagName` and `inline` property. Omit this prop and use `name` instead if you prefer to have it handled by the editor.
 
 ### `onChange( value: Array|String ): Function`
 
-*Required.* Called when the value changes.
+*Optional.* Called when the value changes. Omit this prop and use `name` instead if you prefer to have it handled by the editor.
+
+### `name: String`
+
+*Optional.*  It has to match the name of one of block's attributes. It enables the default handling of `value` and `onChange` props controlled by the editor.
 
 ### `tagName: String`
 
@@ -93,11 +97,8 @@ wp.blocks.registerBlockType( /* ... */, {
 	edit: function( props ) {
 		return wp.element.createElement( wp.editor.RichText, {
 			tagName: 'h2',
-			className: props.className,
-			value: props.attributes.content,
-			onChange: function( content ) {
-				props.setAttributes( { content: content } );
-			}
+			name: 'content',
+			className: props.className
 		} );
 	},
 
@@ -124,13 +125,12 @@ registerBlockType( /* ... */, {
 		},
 	},
 
-	edit( { className, attributes, setAttributes } ) {
+	edit( { className } ) {
 		return (
 			<RichText
 				tagName="h2"
+				name="content"
 				className={ className }
-				value={ attributes.content }
-				onChange={ ( content ) => setAttributes( { content } ) }
 			/>
 		);
 	},

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -405,10 +405,14 @@ export class RichText extends Component {
 	/**
 	 * Handles any case where the content of the tinyMCE instance has changed.
 	 */
-
 	onChange() {
+		const { name, onChange, setAttribute } = this.props;
+		const setContent = setAttribute && name ?
+			setAttribute.bind( null, name ) :
+			onChange;
+
 		this.savedContent = this.getContent();
-		this.props.onChange( this.savedContent );
+		setContent( this.savedContent );
 	}
 
 	onCreateUndoLevel() {
@@ -924,18 +928,29 @@ RichText.defaultProps = {
 const RichTextContainer = compose( [
 	withInstanceId,
 	withBlockEditContext( ( context, ownProps ) => {
+		let newProps = {};
+
+		if ( ! ownProps.onChange && ownProps.name ) {
+			newProps = {
+				value: context.attributes[ ownProps.name ],
+				setAttribute: context.setAttribute,
+			};
+		}
+
 		// When explicitly set as not selected, do nothing.
 		if ( ownProps.isSelected === false ) {
-			return {};
+			return newProps;
 		}
 		// When explicitly set as selected, use the value stored in the context instead.
 		if ( ownProps.isSelected === true ) {
 			return {
+				...newProps,
 				isSelected: context.isSelected,
 			};
 		}
 		// Ensures that only one RichText component can be focused.
 		return {
+			...newProps,
 			isSelected: context.isSelected && context.focusedElement === ownProps.instanceId,
 			setFocusedElement: context.setFocusedElement,
 		};


### PR DESCRIPTION
## Description
Similar to #6419 where we introduced an automatic handling of focus for `RichText` component.

This PR proposes to make `value` and `onChange` props from `RichText` optional. When omitting those props you would have to use `name` instead. It would have to match the name of one of the block's attributes and it would enable the default handling of `value` and `onChange` props controlled by the editor.

```diff
+	edit( { className } ) {
-	edit( { className, attributes, setAttributes } ) {
		return (
			<RichText
				tagName="h2"
+				name="content"
				className={ className }
-				value={ attributes.content }
-				onChange={ ( content ) => setAttributes( { content } ) }
			/>
		);
	},
```

## TODO

When we agree on the proposed improvement, we can also do:

* [ ] Apply the same changes to `PlainText` and update all usage in core blocks.
* [ ] Update all blocks that use `RichText` in a way that Paragraph block does.
* [ ] Update all docs to promote new approach whenever applicable.

In theory, it could be sprinkled on all controls, but we would have to fix the issue with the context not being properly applied to components rendered as children of fills. This applies to `BlockControls`, `InspectorControls` and `AdvancedInspectorControls`.

## How has this been tested?
Manually.
I made sure that editing `RichText` still works as before when it's handled automatically with `name` props (Paragraph block) or with `value` and `onChange` for all other blocks.

## Types of changes
Refactoring - improvement for developers convenience.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
