### PR TITLE
Enhancement: Add link control to verse block toolbar

### DIFF
--- a/core-blocks/verse/index.js
+++ b/core-blocks/verse/index.js
@@ -82,7 +82,6 @@ export const settings = {
 					style={ { textAlign: textAlign } }
 					placeholder={ __( 'Write…' ) }
 					wrapperClassName={ className }
-					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
 				/>
 			</Fragment>
 		);


### PR DESCRIPTION
## Description
This PR addresses #6696 which requested the link control in the "Verse" block toolbar as we can see in the other blocks.

## How has this been tested?
This PR has been tested by adding a "Verse" block in Gutenberg editor and locating the link control of the block in the block toolbar. It was also made sure that the link was correctly saved and rendered in the front-end. This was tested in WP 4.9.5, Gutenberg 2.8.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![gutenberg-6696](https://user-images.githubusercontent.com/20284937/39920321-89729ea2-5538-11e8-8eb1-c38345d31e7e.gif)

## Types of changes
This PR just removes the `formattingControls` attribute from the `RichText` element which specified the block to just have the `bold`, `italic` and `strikethrough` controls.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
