### PR TITLE
Classic: Fix absent editor styles

### DIFF
--- a/core-blocks/freeform/edit.js
+++ b/core-blocks/freeform/edit.js
@@ -173,7 +173,7 @@ export default class FreeformEdit extends Component {
 			<div
 				key="editor"
 				id={ `editor-${ id }` }
-				className="wp-block-freeform blocks-rich-text__tinymce"
+				className="wp-block-freeform core-blocks-rich-text__tinymce"
 			/>,
 		];
 		/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/core-blocks/freeform/editor.scss
+++ b/core-blocks/freeform/editor.scss
@@ -1,4 +1,4 @@
-.wp-block-freeform.editor-rich-text__tinymce {
+.wp-block-freeform.core-blocks-rich-text__tinymce {
 	overflow: hidden;
 	margin: -4px;
 	padding: 4px;

--- a/core-blocks/freeform/test/__snapshots__/index.js.snap
+++ b/core-blocks/freeform/test/__snapshots__/index.js.snap
@@ -8,7 +8,7 @@ Array [
     id="toolbar-undefined"
   />,
   <div
-    class="wp-block-freeform blocks-rich-text__tinymce"
+    class="wp-block-freeform core-blocks-rich-text__tinymce"
     id="editor-undefined"
   />,
 ]


### PR DESCRIPTION
## Description

I guess `core-blocks/freeform/editor.scss` was [caught in the net](https://github.com/WordPress/gutenberg/pull/6521/files#diff-edc7fbeeb6831f57a1d0f03d51032531) of #6521 by mistake. This PR undoes that change.

Before | After
-|-
<img width="661" alt="classic-fix-before" src="https://user-images.githubusercontent.com/150562/39930190-f1e68964-5531-11e8-9a9d-a69cc48005dd.png"> | <img width="658" alt="classic-fix-after" src="https://user-images.githubusercontent.com/150562/39930195-f7607ed6-5531-11e8-832a-8dbd222fd2fe.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
