### PR TITLE
Testing: Add global guard against ZWSP in E2E content retrieval

### DIFF
--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -19,6 +19,13 @@ const {
  */
 const MOD_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
 
+/**
+ * Regular expression matching zero-width space characters.
+ *
+ * @type {RegExp}
+ */
+const REGEXP_ZWSP = /[\u200B\u200C\u200D\uFEFF]/;
+
 function getUrl( WPPath, query = '' ) {
 	const url = new URL( WP_BASE_URL );
 
@@ -78,6 +85,12 @@ export async function getHTMLFromCodeEditor() {
 	await switchToEditor( 'Code' );
 	const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
 	await switchToEditor( 'Visual' );
+
+	// Globally guard against zero-width characters.
+	if ( REGEXP_ZWSP.test( textEditorContent ) ) {
+		throw new Error( 'Unexpected zero-width space character in editor content.' );
+	}
+
 	return textEditorContent;
 }
 


### PR DESCRIPTION
Extracted from #6467

This pull request seeks to add a globally-considered failing case for zero-width space characters present in end-to-end test content. An instance of this was discovered in #6467 (https://github.com/WordPress/gutenberg/pull/6467#issuecomment-387917709), and while the issue itself is resolved there, the test is not specific to the writing flow behaviors and should be considered broadly.

__Testing instructions:__

Verify end-to-end tests pass:

```
npm run test-e2e
```