### PR TITLE
Writing Flow: Consider horizontal handled by stopPropagation in RichText

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -25,15 +25,7 @@ import {
 	getScrollContainer,
 } from '@wordpress/dom';
 import { createBlobURL } from '@wordpress/blob';
-import {
-	BACKSPACE,
-	DELETE,
-	ENTER,
-	LEFT,
-	RIGHT,
-	TINYMCE_ZERO_WIDTH_SPACE,
-	rawShortcut,
-} from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, rawShortcut } from '@wordpress/keycodes';
 import { withInstanceId, withSafeTimeout, Slot } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { rawHandler } from '@wordpress/blocks';
@@ -59,6 +51,16 @@ import TokenUI from './tokens/ui';
 const { Node } = window;
 
 /**
+ * Zero-width space character used by TinyMCE as a caret landing point for
+ * inline boundary nodes.
+ *
+ * @see tinymce/src/core/main/ts/text/Zwsp.ts
+ *
+ * @type {string}
+ */
+const TINYMCE_ZWSP = '\uFEFF';
+
+/**
  * Returns true if the node is the inline node boundary. This is used in node
  * filtering prevent the inline boundary from being included in the split which
  * occurs while within but at the end of an inline node, since TinyMCE includes
@@ -72,7 +74,7 @@ const { Node } = window;
  */
 export function isEmptyInlineBoundary( node ) {
 	const text = node.nodeName === 'A' ? node.innerText : node.textContent;
-	return text === TINYMCE_ZERO_WIDTH_SPACE;
+	return text === TINYMCE_ZWSP;
 }
 
 /**
@@ -476,11 +478,11 @@ export class RichText extends Component {
 		// only be exempt when focusNode is not _only_ the ZWSP, which occurs
 		// when caret is placed on the right outside edge of inline boundary.
 		if ( ! isReverse && focusOffset === nodeValue.length &&
-				nodeValue.length > 1 && nodeValue[ 0 ] === TINYMCE_ZERO_WIDTH_SPACE ) {
+				nodeValue.length > 1 && nodeValue[ 0 ] === TINYMCE_ZWSP ) {
 			offset = 0;
 		}
 
-		if ( nodeValue[ offset ] === TINYMCE_ZERO_WIDTH_SPACE ) {
+		if ( nodeValue[ offset ] === TINYMCE_ZWSP ) {
 			event.stopPropagation();
 		}
 	}

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -467,16 +467,24 @@ export class RichText extends Component {
 
 		const isReverse = event.keyCode === LEFT;
 
+		// Look to previous character for ZWSP if navigating in reverse.
 		let offset = focusOffset;
 		if ( isReverse ) {
 			offset--;
 		}
 
-		// [WORKAROUND]: When in a new paragraph in a new inline boundary node,
-		// while typing the zero-width space occurs as the first child instead
-		// of at the end of the inline boundary where the caret is. This should
-		// only be exempt when focusNode is not _only_ the ZWSP, which occurs
-		// when caret is placed on the right outside edge of inline boundary.
+		// Workaround: In a new inline boundary node, the zero-width space
+		// wrongly lingers at the beginning of the node, rather than following
+		// the caret. If we are at the extent of the inline boundary, but the
+		// ZWSP exists at the beginning, consider as though it were to be
+		// handled as a transition outside the inline boundary.
+		//
+		// Since this condition could also be satisfied in the case that we're
+		// on the right edge of an inline boundary -- where the ZWSP exists as
+		// as an otherwise empty focus node -- ensure that the focus node is
+		// non-empty.
+		//
+		// See: https://github.com/tinymce/tinymce/issues/4472
 		if ( ! isReverse && focusOffset === nodeValue.length &&
 				nodeValue.length > 1 && nodeValue[ 0 ] === TINYMCE_ZWSP ) {
 			offset = 0;

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -25,7 +25,15 @@ import {
 	getScrollContainer,
 } from '@wordpress/dom';
 import { createBlobURL } from '@wordpress/blob';
-import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, rawShortcut } from '@wordpress/keycodes';
+import {
+	BACKSPACE,
+	DELETE,
+	ENTER,
+	LEFT,
+	RIGHT,
+	TINYMCE_ZERO_WIDTH_SPACE,
+	rawShortcut,
+} from '@wordpress/keycodes';
 import { withInstanceId, withSafeTimeout, Slot } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { rawHandler } from '@wordpress/blocks';
@@ -51,16 +59,6 @@ import TokenUI from './tokens/ui';
 const { Node } = window;
 
 /**
- * Zero-width space character used by TinyMCE as a caret landing point for
- * inline boundary nodes.
- *
- * @see tinymce/src/core/main/ts/text/Zwsp.ts
- *
- * @type {string}
- */
-const TINYMCE_ZWSP = '\uFEFF';
-
-/**
  * Returns true if the node is the inline node boundary. This is used in node
  * filtering prevent the inline boundary from being included in the split which
  * occurs while within but at the end of an inline node, since TinyMCE includes
@@ -74,7 +72,7 @@ const TINYMCE_ZWSP = '\uFEFF';
  */
 export function isEmptyInlineBoundary( node ) {
 	const text = node.nodeName === 'A' ? node.innerText : node.textContent;
-	return text === TINYMCE_ZWSP;
+	return text === TINYMCE_ZERO_WIDTH_SPACE;
 }
 
 /**
@@ -478,11 +476,11 @@ export class RichText extends Component {
 		// only be exempt when focusNode is not _only_ the ZWSP, which occurs
 		// when caret is placed on the right outside edge of inline boundary.
 		if ( ! isReverse && focusOffset === nodeValue.length &&
-				nodeValue.length > 1 && nodeValue[ 0 ] === TINYMCE_ZWSP ) {
+				nodeValue.length > 1 && nodeValue[ 0 ] === TINYMCE_ZERO_WIDTH_SPACE ) {
 			offset = 0;
 		}
 
-		if ( nodeValue[ offset ] === TINYMCE_ZWSP ) {
+		if ( nodeValue[ offset ] === TINYMCE_ZERO_WIDTH_SPACE ) {
 			event.stopPropagation();
 		}
 	}

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -188,6 +188,16 @@ class WritingFlow extends Component {
 	onKeyDown( event ) {
 		const { hasMultiSelection, onMultiSelect, blocks } = this.props;
 
+		// If navigation has already been handled (e.g. TinyMCE inline
+		// boundaries), abort. Ideally this uses Event#defaultPrevented. This
+		// is currently not possible because TinyMCE will misreport an event
+		// default as prevented on outside edges of inline boundaries.
+		//
+		// See: https://github.com/tinymce/tinymce/issues/4476
+		if ( event.nativeEvent._navigationHandled ) {
+			return;
+		}
+
 		const { keyCode, target } = event;
 		const isUp = keyCode === UP;
 		const isDown = keyCode === DOWN;

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -34,6 +34,16 @@ export const COMMAND = 'meta';
 export const SHIFT = 'shift';
 
 /**
+ * Zero-width space character used by TinyMCE as a caret landing point for
+ * inline boundary nodes.
+ *
+ * @see tinymce/src/core/main/ts/text/Zwsp.ts
+ *
+ * @type {string}
+ */
+export const TINYMCE_ZERO_WIDTH_SPACE = '\uFEFF';
+
+/**
  * Return true if platform is MacOS.
  *
  * @param {Object} _window   window object by default; used for DI testing.

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -34,16 +34,6 @@ export const COMMAND = 'meta';
 export const SHIFT = 'shift';
 
 /**
- * Zero-width space character used by TinyMCE as a caret landing point for
- * inline boundary nodes.
- *
- * @see tinymce/src/core/main/ts/text/Zwsp.ts
- *
- * @type {string}
- */
-export const TINYMCE_ZERO_WIDTH_SPACE = '\uFEFF';
-
-/**
  * Return true if platform is MacOS.
  *
  * @param {Object} _window   window object by default; used for DI testing.

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -21,3 +21,17 @@ exports[`adding blocks Should navigate inner blocks with arrow keys 1`] = `
 <p>Second paragraph</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`adding blocks should navigate around inline boundaries 1`] = `
+"<!-- wp:paragraph -->
+<p>FirstAfter</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Before<strong>InsideSecondInside</strong>After</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BeforeThird</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -4,6 +4,11 @@
 import { join } from 'path';
 import { URL } from 'url';
 
+/**
+ * External dependencies
+ */
+import { times } from 'lodash';
+
 const {
 	WP_BASE_URL = 'http://localhost:8888',
 	WP_USERNAME = 'admin',
@@ -25,6 +30,21 @@ const MOD_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
  * @type {RegExp}
  */
 const REGEXP_ZWSP = /[\u200B\u200C\u200D\uFEFF]/;
+
+/**
+ * Given an array of functions, each returning a promise, performs all
+ * promises in sequence (waterfall) order.
+ *
+ * @param {Function[]} sequence Array of promise creators.
+ *
+ * @return {Promise} Promise resolving once all in the sequence complete.
+ */
+async function promiseSequence( sequence ) {
+	return sequence.reduce(
+		( current, next ) => current.then( next ),
+		Promise.resolve()
+	);
+}
 
 export function getUrl( WPPath, query = '' ) {
 	const url = new URL( WP_BASE_URL );
@@ -230,6 +250,18 @@ export async function openDocumentSettingsSidebar() {
 	if ( openButton ) {
 		await page.click( openButton );
 	}
+}
+
+/**
+ * Presses the given keyboard key a number of times in sequence.
+ *
+ * @param {string} key   Key to press.
+ * @param {number} count Number of times to press.
+ *
+ * @return {Promise} Promise resolving when key presses complete.
+ */
+export async function pressTimes( key, count ) {
+	return promiseSequence( times( count, () => () => page.keyboard.press( key ) ) );
 }
 
 export async function clearLocalStorage() {


### PR DESCRIPTION
Extracted from #6467
Fixes #5095

This pull request seeks to stop propagation of horizontal arrow key down events when it's inferred that this is to be handled by TinyMCE in traversing out of an inline boundary. This avoids an issue where TinyMCE moves the caret, then the WritingFlow proceeds to consider the arrow navigation, leading to it being impossible to arrow-navigate out of an inline boundary at the end of a paragraph (since TinyMCE moves the caret out, then WritingFlow moves the caret to the next block).

__Testing instructions:__

Repeat steps to reproduce from #5095, noting that you can escape out of the italicized text by pressing ArrowRight at the end of the paragraph.