### PR TITLE
Testing: Fail E2E tests when uncaught page error occurs

### DIFF
--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -65,6 +65,17 @@ export async function newPost( postType ) {
 
 export async function newDesktopBrowserPage() {
 	global.page = await browser.newPage();
+
+	page.on( 'pageerror', ( error ) => {
+		// Disable reason: `jest/globals` doesn't include `fail`, but it is
+		// part of the global context supplied by the underlying Jasmine:
+		//
+		//  https://jasmine.github.io/api/3.0/global.html#fail
+
+		// eslint-disable-next-line no-undef
+		fail( error );
+	} );
+
 	await page.setViewport( { width: 1000, height: 700 } );
 }
 


### PR DESCRIPTION
This pull request seeks to enhance end-to-end tests to fail a test if any uncaught page errors occur during their execution.

__Testing instructions:__

Fortunately, there are no existing page failures in existing tests. You can introduce one by adding this to `edit-post/index.js` in your local branch:

```js
setTimeout( () => {
	throw new Error( 'Oops!' );
}, 1 );
```

Then verify that the end-to-end tests fail:

```
npm run test-e2e
```

__Related resources:__

- https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#event-error
- https://github.com/facebook/jest/issues/2713
- https://github.com/jasmine/jasmine/issues/577