### PR TITLE
Fix: Text colour on focused primary buttons

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -22,6 +22,10 @@
 		@include button-style__focus-active;
 	}
 
+	&.button-primary:not( :disabled ):not( [aria-disabled="true"] ):focus {
+		color: $white;
+	}
+
 	&.is-busy,
 	&.is-busy[disabled] {
 		animation: components-button__busy-animation 2500ms infinite linear;


### PR DESCRIPTION
## Description
This PR addresses #6668 and fixes the wrong colour on not just the focused "Publish" button but also all other buttons with the `.button-primary` class on focus.

## How has this been tested?
This PR has been tested by making sure the text colour of the "Publish" button is white on focus. This was tested in WP 4.9.5, Gutenberg 2.8.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![gutenberg-6668](https://user-images.githubusercontent.com/20284937/39936055-15152dc4-556d-11e8-8a8a-2339eb128653.png)

## Types of changes
This PR adds a new style which enforces the buttons having the `.button-primary` class to have the white colour. I'm open to recommendations if a new mixin should be introduced for these buttons or if this can be done in a more optimal way.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
