### PR TITLE
Blocks: Replace js-beautify with element beautification

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { isEmpty, reduce, isObject, castArray, startsWith } from 'lodash';
-import { html as beautifyHtml } from 'js-beautify';
 
 /**
  * WordPress dependencies
@@ -117,7 +116,8 @@ export function getSaveElement( blockType, attributes, innerBlocks = [] ) {
  * @return {string} Save content.
  */
 export function getSaveContent( blockType, attributes, innerBlocks ) {
-	return renderToString( getSaveElement( blockType, attributes, innerBlocks ) );
+	const element = getSaveElement( blockType, attributes, innerBlocks );
+	return renderToString( element, { beautify: true } );
 }
 
 /**
@@ -173,22 +173,6 @@ export function serializeAttributes( attrs ) {
 }
 
 /**
- * Returns HTML markup processed by a markup beautifier configured for use in
- * block serialization.
- *
- * @param {string} content Original HTML.
- *
- * @return {string} Beautiful HTML.
- */
-export function getBeautifulContent( content ) {
-	return beautifyHtml( content, {
-		indent_inner_html: true,
-		indent_with_tabs: true,
-		wrap_line_length: 0,
-	} );
-}
-
-/**
  * Given a block object, returns the Block's Inner HTML markup.
  *
  * @param {Object} block Block Object.
@@ -211,7 +195,7 @@ export function getBlockContent( block ) {
 		} catch ( error ) {}
 	}
 
-	return getUnknownTypeHandlerName() === block.name || ! saveContent ? saveContent : getBeautifulContent( saveContent );
+	return saveContent;
 }
 
 /**

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -8,7 +8,6 @@ import { createElement, Component } from '@wordpress/element';
  */
 import serialize, {
 	getCommentAttributes,
-	getBeautifulContent,
 	getSaveContent,
 	serializeAttributes,
 	getCommentDelimitedContent,
@@ -33,14 +32,6 @@ describe( 'block serializer', () => {
 		setUnknownTypeHandlerName( undefined );
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
-		} );
-	} );
-
-	describe( 'getBeautifulContent()', () => {
-		it( 'returns beautiful content', () => {
-			const content = getBeautifulContent( '<div><div>Beautiful</div></div>' );
-
-			expect( content ).toBe( '<div>\n\t<div>Beautiful</div>\n</div>' );
 		} );
 	} );
 
@@ -311,11 +302,11 @@ describe( 'block serializer', () => {
 			const block =	{
 				name: 'core/chicken',
 				attributes: {
-					content: 'chicken',
+					content: 'chicken\nribs',
 				},
 				isValid: true,
 			};
-			expect( getBlockContent( block ) ).toBe( 'chicken' );
+			expect( getBlockContent( block ) ).toBe( 'chicken\nribs' );
 		} );
 	} );
 } );

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -292,7 +292,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 
 			return (
 				<figure className={ embedClassName }>
-					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+					{ `\n\t${ url }` /* URL needs to be on its own line. */ }
 					{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 				</figure>
 			);

--- a/core-blocks/test/fixtures/core__audio.serialized.html
+++ b/core-blocks/test/fixtures/core__audio.serialized.html
@@ -1,3 +1,5 @@
 <!-- wp:audio {"align":"right"} -->
-<figure class="wp-block-audio alignright"><audio controls src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3"></audio></figure>
+<figure class="wp-block-audio alignright">
+	<audio controls src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3"></audio>
+</figure>
 <!-- /wp:audio -->

--- a/core-blocks/test/fixtures/core__columns.serialized.html
+++ b/core-blocks/test/fixtures/core__columns.serialized.html
@@ -1,19 +1,17 @@
 <!-- wp:columns {"columns":3} -->
-<div class="wp-block-columns has-3-columns">
-	<!-- wp:paragraph {"layout":"column-1"} -->
-	<p class="layout-column-1">Column One, Paragraph One</p>
-	<!-- /wp:paragraph -->
+<div class="wp-block-columns has-3-columns"><!-- wp:paragraph {"layout":"column-1"} -->
+<p class="layout-column-1">Column One, Paragraph One</p>
+<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph {"layout":"column-1"} -->
-	<p class="layout-column-1">Column One, Paragraph Two</p>
-	<!-- /wp:paragraph -->
+<!-- wp:paragraph {"layout":"column-1"} -->
+<p class="layout-column-1">Column One, Paragraph Two</p>
+<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph {"layout":"column-2"} -->
-	<p class="layout-column-2">Column Two, Paragraph One</p>
-	<!-- /wp:paragraph -->
+<!-- wp:paragraph {"layout":"column-2"} -->
+<p class="layout-column-2">Column Two, Paragraph One</p>
+<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph {"layout":"column-3"} -->
-	<p class="layout-column-3">Column Three, Paragraph One</p>
-	<!-- /wp:paragraph -->
-</div>
+<!-- wp:paragraph {"layout":"column-3"} -->
+<p class="layout-column-3">Column Three, Paragraph One</p>
+<!-- /wp:paragraph --></div>
 <!-- /wp:columns -->

--- a/core-blocks/test/fixtures/core__preformatted.serialized.html
+++ b/core-blocks/test/fixtures/core__preformatted.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:preformatted -->
-<pre class="wp-block-preformatted">Some <em>preformatted</em> text...<br/>And more!</pre>
+<pre class="wp-block-preformatted">Some <em>preformatted</em> text...<br />And more!</pre>
 <!-- /wp:preformatted -->

--- a/core-blocks/test/fixtures/core__pullquote.serialized.html
+++ b/core-blocks/test/fixtures/core__pullquote.serialized.html
@@ -1,4 +1,5 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-	<p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote>
+	<p>Testing pullquote block...</p><cite>...with a caption</cite>
+</blockquote>
 <!-- /wp:pullquote -->

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,5 +1,6 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
 	<p>Paragraph <strong>one</strong></p>
-	<p>Paragraph two</p><cite>by whomever</cite></blockquote>
+	<p>Paragraph two</p><cite>by whomever</cite>
+</blockquote>
 <!-- /wp:pullquote -->

--- a/core-blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/core-blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,4 +1,5 @@
 <!-- wp:quote -->
 <blockquote class="wp-block-quote">
-	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+	<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite>
+</blockquote>
 <!-- /wp:quote -->

--- a/core-blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/core-blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,4 +1,5 @@
 <!-- wp:quote {"style":2} -->
 <blockquote class="wp-block-quote is-large">
-	<p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+	<p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite>
+</blockquote>
 <!-- /wp:quote -->

--- a/core-blocks/test/fixtures/core__text__converts-to-paragraph.serialized.html
+++ b/core-blocks/test/fixtures/core__text__converts-to-paragraph.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:paragraph -->
-<p>This is an old-style text block. Changed to <code>paragraph</code> in #2135.</p>
+<p>This is an old-style text block.  Changed to <code>paragraph</code> in #2135.</p>
 <!-- /wp:paragraph -->

--- a/core-blocks/test/fixtures/core__verse.serialized.html
+++ b/core-blocks/test/fixtures/core__verse.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:verse -->
-<pre class="wp-block-verse">A <em>verse</em>…<br/>And more!</pre>
+<pre class="wp-block-verse">A <em>verse</em>…<br />And more!</pre>
 <!-- /wp:verse -->

--- a/core-blocks/test/fixtures/core__video.serialized.html
+++ b/core-blocks/test/fixtures/core__video.serialized.html
@@ -1,3 +1,5 @@
 <!-- wp:video -->
-<figure class="wp-block-video"><video controls src="https://awesome-fake.video/file.mp4"></video></figure>
+<figure class="wp-block-video">
+	<video controls src="https://awesome-fake.video/file.mp4"></video>
+</figure>
 <!-- /wp:video -->

--- a/editor/components/inner-blocks/test/__snapshots__/index.js.snap
+++ b/editor/components/inner-blocks/test/__snapshots__/index.js.snap
@@ -2,11 +2,9 @@
 
 exports[`InnerBlocks should force serialize for invalid block with inner blocks 1`] = `
 "<!-- wp:test-block -->
-<p>Invalid
-	<!-- wp:test-block -->
-	<p></p>
-	<!-- /wp:test-block -->
-</p>
+<p>Invalid<!-- wp:test-block -->
+<p></p>
+<!-- /wp:test-block --></p>
 <!-- /wp:test-block -->"
 `;
 

--- a/editor/components/inner-blocks/test/index.js
+++ b/editor/components/inner-blocks/test/index.js
@@ -9,6 +9,7 @@ import {
 	getSaveElement,
 	registerBlockType,
 	serialize,
+	parse,
 	unregisterBlockType,
 } from '@wordpress/blocks';
 import { renderToString } from '@wordpress/element';
@@ -106,6 +107,10 @@ describe( 'InnerBlocks', () => {
 		block.isValid = false;
 		block.originalContent = 'Original';
 
-		expect( serialize( block ) ).toMatchSnapshot();
+		const serialized = serialize( block );
+		expect( serialized ).toMatchSnapshot();
+		// Ensure beautification doesn't impact (trailing, leading whitespace)
+		// re-parsed content:
+		expect( parse( serialized )[ 0 ].attributes.content ).toEqual( block.attributes.content );
 	} );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -616,7 +616,8 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"acorn": {
 			"version": "5.5.3",
@@ -2145,7 +2146,8 @@
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -3040,7 +3042,8 @@
 		"commander": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+			"dev": true
 		},
 		"comment-parser": {
 			"version": "0.4.2",
@@ -3186,15 +3189,6 @@
 						"has-flag": "^1.0.0"
 					}
 				}
-			}
-		},
-		"config-chain": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-			"integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-			"requires": {
-				"ini": "^1.3.4",
-				"proto-list": "~1.2.1"
 			}
 		},
 		"console-browserify": {
@@ -4391,18 +4385,6 @@
 			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
 			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
 			"dev": true
-		},
-		"editorconfig": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
-			"integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
-			"requires": {
-				"bluebird": "^3.0.5",
-				"commander": "^2.9.0",
-				"lru-cache": "^3.2.0",
-				"semver": "^5.1.0",
-				"sigmund": "^1.0.1"
-			}
 		},
 		"ejs": {
 			"version": "2.6.1",
@@ -8418,17 +8400,6 @@
 			"integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
 			"dev": true
 		},
-		"js-beautify": {
-			"version": "1.6.14",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.14.tgz",
-			"integrity": "sha1-07j3Mi0CuSd9WL0jgmTDJ+WARM0=",
-			"requires": {
-				"config-chain": "~1.1.5",
-				"editorconfig": "^0.13.2",
-				"mkdirp": "~0.5.0",
-				"nopt": "~3.0.1"
-			}
-		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -9357,14 +9328,6 @@
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
 			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
-		"lru-cache": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-			"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
-			"requires": {
-				"pseudomap": "^1.0.1"
-			}
-		},
 		"make-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -10151,6 +10114,7 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
 			"requires": {
 				"abbrev": "1"
 			}
@@ -12916,11 +12880,6 @@
 				"loose-envify": "^1.3.1"
 			}
 		},
-		"proto-list": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
-		},
 		"proxy-from-env": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -14358,11 +14317,6 @@
 					}
 				}
 			}
-		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
 		},
 		"signal-exit": {
 			"version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
 		"hpq": "1.2.0",
 		"jquery": "3.2.1",
-		"js-beautify": "1.6.14",
 		"lerna": "2.11.0",
 		"lodash": "4.17.5",
 		"memize": "1.0.5",

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -170,6 +170,50 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( '<div class="greeting">Hello</div>' );
 	} );
 
+	it( 'does not beautify by default', () => {
+		const result = renderElement(
+			<section>
+				<p>Content</p>
+			</section>
+		);
+
+		expect( result ).toBe(
+			'<section><p>Content</p></section>'
+		);
+	} );
+
+	it( 'performs basic beautification on children of block-level elements', () => {
+		const result = renderElement(
+			<section>
+				String
+				<RawHTML>Raw</RawHTML>
+				{ '\n\tString' }
+				<h2>Hello <em>World!</em></h2>
+				<span>On previous line</span>
+				<p>This is content.</p>
+				<div>
+					<span>Nesting:</span>
+					<p>Can get out of control.</p>
+				</div><pre><code>{ 'foo\nbar\t' }</code></pre>
+			</section>,
+			{},
+			0
+		);
+
+		expect( result ).toBe(
+			'<section>StringRaw\n' +
+			'\tString\n' +
+			'\t<h2>Hello <em>World!</em></h2><span>On previous line</span>\n' +
+			'\t<p>This is content.</p>\n' +
+			'\t<div><span>Nesting:</span>\n' +
+			'\t\t<p>Can get out of control.</p>\n' +
+			'\t</div>\n' +
+			'\t<pre><code>foo\n' +
+			'bar	</code></pre>\n' +
+			'</section>'
+		);
+	} );
+
 	it( 'renders function component', () => {
 		function Greeting() {
 			return <div className="greeting">Hello</div>;
@@ -274,13 +318,13 @@ describe( 'renderNativeComponent()', () => {
 		it( 'should render self-closing elements', () => {
 			const result = renderNativeComponent( 'img', { src: 'foo.png' } );
 
-			expect( result ).toBe( '<img src="foo.png"/>' );
+			expect( result ).toBe( '<img src="foo.png" />' );
 		} );
 
 		it( 'should ignore self-closing elements children', () => {
 			const result = renderNativeComponent( 'img', { src: 'foo.png', children: [ 'Surprise!' ] } );
 
-			expect( result ).toBe( '<img src="foo.png"/>' );
+			expect( result ).toBe( '<img src="foo.png" />' );
 		} );
 	} );
 

--- a/test/integration/fixtures/apple-out.html
+++ b/test/integration/fixtures/apple-out.html
@@ -35,36 +35,36 @@
 	<tbody>
 		<tr>
 			<td>
-				One
-			</td>
+One
+</td>
 			<td>
-				Two
-			</td>
+Two
+</td>
 			<td>
-				Three
-			</td>
+Three
+</td>
 		</tr>
 		<tr>
 			<td>
-				1
-			</td>
+1
+</td>
 			<td>
-				2
-			</td>
+2
+</td>
 			<td>
-				3
-			</td>
+3
+</td>
 		</tr>
 		<tr>
 			<td>
-				I
-			</td>
+I
+</td>
 			<td>
-				II
-			</td>
+II
+</td>
 			<td>
-				III
-			</td>
+III
+</td>
 		</tr>
 	</tbody>
 </table>

--- a/test/integration/fixtures/classic-out.html
+++ b/test/integration/fixtures/classic-out.html
@@ -15,7 +15,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Fourth paragraph</p>
+<p>Fourth  paragraph</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:more -->

--- a/test/integration/fixtures/evernote-out.html
+++ b/test/integration/fixtures/evernote-out.html
@@ -1,7 +1,7 @@
 <!-- wp:paragraph -->
 <p>This is a <em>paragraph</em>.
-	<br/>This is a <a href="https://w.org">link</a>.
-	<br/></p>
+	<br />This is a <a href="https://w.org">link</a>.
+	<br /></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->

--- a/test/integration/fixtures/evernote-out.html
+++ b/test/integration/fixtures/evernote-out.html
@@ -1,7 +1,7 @@
 <!-- wp:paragraph -->
 <p>This is a <em>paragraph</em>.
-	<br />This is a <a href="https://w.org">link</a>.
-	<br /></p>
+<br />This is a <a href="https://w.org">link</a>.
+<br /></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
@@ -37,19 +37,19 @@
 	<tbody>
 		<tr>
 			<td>One
-			</td>
+</td>
 			<td>Two
-			</td>
+</td>
 			<td>Three
-			</td>
+</td>
 		</tr>
 		<tr>
 			<td>Four
-			</td>
+</td>
 			<td>Five
-			</td>
+</td>
 			<td>Six
-			</td>
+</td>
 		</tr>
 	</tbody>
 </table>

--- a/test/integration/fixtures/google-docs-out.html
+++ b/test/integration/fixtures/google-docs-out.html
@@ -1,5 +1,5 @@
 <!-- wp:paragraph -->
-<p>This is a <strong>title</strong><br/></p>
+<p>This is a <strong>title</strong><br /></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
@@ -7,7 +7,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>This is a <strong>paragraph</strong> with a <a href="https://w.org">link</a>.<br/></p>
+<p>This is a <strong>paragraph</strong> with a <a href="https://w.org">link</a>.<br /></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
@@ -57,7 +57,7 @@
 <!-- /wp:separator -->
 
 <!-- wp:paragraph -->
-<p>An image:<br/></p>
+<p>An image:<br /></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->

--- a/test/integration/fixtures/markdown-out.html
+++ b/test/integration/fixtures/markdown-out.html
@@ -7,7 +7,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Preserve<br/> line breaks please.</p>
+<p>Preserve<br /> line breaks please.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->

--- a/test/integration/fixtures/markdown-out.html
+++ b/test/integration/fixtures/markdown-out.html
@@ -7,7 +7,8 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Preserve<br /> line breaks please.</p>
+<p>Preserve<br />
+line breaks please.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->

--- a/test/integration/fixtures/ms-word-out.html
+++ b/test/integration/fixtures/ms-word-out.html
@@ -1,11 +1,11 @@
 <!-- wp:paragraph -->
-<p>This is a title
-</p>
+<p>This is a
+title</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>This is a subtitle
-</p>
+<p>This is a
+subtitle</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
@@ -45,36 +45,36 @@
 	<tbody>
 		<tr>
 			<td>
-				One
-			</td>
+  One
+  </td>
 			<td>
-				Two
-			</td>
+  Two
+  </td>
 			<td>
-				Three
-			</td>
+  Three
+  </td>
 		</tr>
 		<tr>
 			<td>
-				1
-			</td>
+  1
+  </td>
 			<td>
-				2
-			</td>
+  2
+  </td>
 			<td>
-				3
-			</td>
+  3
+  </td>
 		</tr>
 		<tr>
 			<td>
-				I
-			</td>
+  I
+  </td>
 			<td>
-				II
-			</td>
+  II
+  </td>
 			<td>
-				III
-			</td>
+  III
+  </td>
 		</tr>
 	</tbody>
 </table>

--- a/test/integration/fixtures/plain-out.html
+++ b/test/integration/fixtures/plain-out.html
@@ -1,7 +1,7 @@
 <!-- wp:paragraph -->
-<p>test<br/>test</p>
+<p>test<br />test</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>test<br/></p>
+<p>test<br /></p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
Fixes #4456

This pull request seeks to replace `js-beautify` with a beautification option built-in to `wp.element.renderToString`. This reduces the bundle size of `build/blocks/index.js` from 242kb (87kb gzipped) to 194kb (68.9kb gzipped), a savings of 48kb (18.1kb gzipped). Further, it should have a runtime performance benefit, as the save content generated for a post no longer needs to be re-parsed and re-generated by the beautifier as a post-processing step after serialization, and is instead built into the serialization itself. Furtherer, it should hold us more accountable to legitimate issues which were made non-obvious by prior beautification behavior obscuring (e.g. whitespace collapsing).

**In-Progress:** There are some issues with raw transforms resulting in failing tests. This is specifically caused by the behaviors of `children` matchers in respecting HTML whitespace (via `node.childNodes`). This is considered a blocker, but should be explored separately: Either ignoring whitespace-only nodes from `children`, or ensuring that whitespace is collapsed before passing HTML into a `children` matcher.

![Whitespace nodes](https://user-images.githubusercontent.com/1779930/39938016-8772e04e-551f-11e8-9ae3-aa9db3506a59.png)