### PR TITLE
Permit unbounded per_page=-1 requests for Categories and Tags

### DIFF
--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -21,7 +21,7 @@ import { getEntity } from './entities';
  */
 export async function* getCategories() {
 	yield setRequested( 'terms', 'categories' );
-	const categories = await apiRequest( { path: '/wp/v2/categories' } );
+	const categories = await apiRequest( { path: '/wp/v2/categories?per_page=-1' } );
 	yield receiveTerms( 'categories', categories );
 }
 

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -16,7 +16,7 @@ describe( 'getCategories', () => {
 
 	beforeAll( () => {
 		apiRequest.mockImplementation( ( options ) => {
-			if ( options.path === '/wp/v2/categories' ) {
+			if ( options.path === '/wp/v2/categories?per_page=-1' ) {
 				return Promise.resolve( CATEGORIES );
 			}
 		} );

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -16,7 +16,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
  * Module constants
  */
 const DEFAULT_QUERY = {
-	per_page: 100,
+	per_page: -1,
 	orderby: 'count',
 	order: 'desc',
 	_fields: 'id,name',

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -17,7 +17,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
  * Module Constants
  */
 const DEFAULT_QUERY = {
-	per_page: 100,
+	per_page: -1,
 	orderby: 'count',
 	order: 'desc',
 	_fields: 'id,name,parent',

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -474,14 +474,7 @@ add_filter( 'rest_index', 'gutenberg_ensure_wp_json_has_theme_supports' );
  * @param WP_REST_Request  $request  Request used to generate the response.
  */
 function gutenberg_handle_early_callback_checks( $response, $handler, $request ) {
-	$routes = array(
-		'/wp/v2/blocks',
-		'/wp/v2/categories',
-		'/wp/v2/tags',
-		'/wp/v2/pages',
-		'/wp/v2/users',
-	);
-	if ( in_array( $request->get_route(), $routes, true ) ) {
+	if ( 0 === strpos( $request->get_route(), '/wp/v2/' ) ) {
 		$can_view_authors    = false;
 		$can_unbounded_query = false;
 		$types               = get_post_types( array( 'show_in_rest' => true ), 'objects' );
@@ -561,8 +554,9 @@ function gutenberg_filter_post_query_arguments( $prepared_args, $request ) {
  * @return array
  */
 function gutenberg_filter_term_collection_parameters( $query_params, $taxonomy ) {
-	$taxonomies = array( 'category', 'post_tag' );
-	if ( in_array( $taxonomy->name, $taxonomies, true )
+	if ( $taxonomy->show_in_rest
+		&& ( false === $taxonomy->rest_controller_class
+			|| 'WP_REST_Terms_Controller' === $taxonomy->rest_controller_class )
 		&& isset( $query_params['per_page'] ) ) {
 		// Change from '1' to '-1', which means unlimited.
 		$query_params['per_page']['minimum'] = -1;

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -354,6 +354,17 @@ function gutenberg_register_post_prepare_functions( $post_type ) {
 add_filter( 'registered_post_type', 'gutenberg_register_post_prepare_functions' );
 
 /**
+ * Whenever a taxonomy is registered, ensure we're hooked into its WP REST API response.
+ *
+ * @param string $taxonomy The newly registered taxonomy.
+ */
+function gutenberg_register_taxonomy_prepare_functions( $taxonomy ) {
+	add_filter( "rest_{$taxonomy}_collection_params", 'gutenberg_filter_term_collection_parameters', 10, 2 );
+	add_filter( "rest_{$taxonomy}_query", 'gutenberg_filter_term_query_arguments', 10, 2 );
+}
+add_filter( 'registered_taxonomy', 'gutenberg_register_taxonomy_prepare_functions' );
+
+/**
  * Includes the value for the 'viewable' attribute of a post type resource.
  *
  * @see https://core.trac.wordpress.org/ticket/43739
@@ -465,6 +476,8 @@ add_filter( 'rest_index', 'gutenberg_ensure_wp_json_has_theme_supports' );
 function gutenberg_handle_early_callback_checks( $response, $handler, $request ) {
 	$routes = array(
 		'/wp/v2/blocks',
+		'/wp/v2/categories',
+		'/wp/v2/tags',
 		'/wp/v2/pages',
 		'/wp/v2/users',
 	);
@@ -533,6 +546,51 @@ function gutenberg_filter_post_query_arguments( $prepared_args, $request ) {
 		// which will need to be addressed in https://core.trac.wordpress.org/ticket/43998.
 		if ( -1 === $prepared_args['posts_per_page'] ) {
 			$prepared_args['posts_per_page'] = 100000;
+		}
+	}
+	return $prepared_args;
+}
+
+/**
+ * Include additional query parameters on the terms query endpoint.
+ *
+ * @see https://core.trac.wordpress.org/ticket/43998
+ *
+ * @param array  $query_params JSON Schema-formatted collection parameters.
+ * @param object $taxonomy     Taxonomy being accessed.
+ * @return array
+ */
+function gutenberg_filter_term_collection_parameters( $query_params, $taxonomy ) {
+	$taxonomies = array( 'category', 'post_tag' );
+	if ( in_array( $taxonomy->name, $taxonomies, true )
+		&& isset( $query_params['per_page'] ) ) {
+		// Change from '1' to '-1', which means unlimited.
+		$query_params['per_page']['minimum'] = -1;
+		// Default sanitize callback is 'absint', which won't work in our case.
+		$query_params['per_page']['sanitize_callback'] = 'rest_sanitize_request_arg';
+	}
+	return $query_params;
+}
+
+/**
+ * Filter term collection query parameters to include specific behavior.
+ *
+ * @see https://core.trac.wordpress.org/ticket/43998
+ *
+ * @param array           $prepared_args Array of arguments for WP_Term_Query.
+ * @param WP_REST_Request $request       The current request.
+ * @return array
+ */
+function gutenberg_filter_term_query_arguments( $prepared_args, $request ) {
+	// Can't check the actual taxonomy here because it's not
+	// passed through in $prepared_args (or the filter generally).
+	if ( 0 === strpos( $request->get_route(), '/wp/v2/' ) ) {
+		if ( -1 === $prepared_args['number'] ) {
+			// This should be unset( $prepared_args['number'] )
+			// but WP_REST_Terms Controller needs to be updated to support
+			// unbounded queries.
+			// Will be addressed in https://core.trac.wordpress.org/ticket/43998.
+			$prepared_args['number'] = 100000;
 		}
 	}
 	return $prepared_args;

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -280,6 +280,26 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
 	}
 
+	public function test_get_categories_unbounded_per_page() {
+		wp_set_current_user( $this->author );
+		$this->factory->category->create();
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+		$request->set_param( 'per_page', '-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_categories_unbounded_per_page_unauthorized() {
+		wp_set_current_user( $this->subscriber );
+		$this->factory->category->create();
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+		$request->set_param( 'per_page', '-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 403, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
+	}
+
 	public function test_get_pages_unbounded_per_page() {
 		wp_set_current_user( $this->author );
 		$this->factory->post->create( array( 'post_type' => 'page' ) );


### PR DESCRIPTION
## Description

Permits requests of per_page=-1 to `/wp/v2/categories` and `/wp/v2/tags` in order to fetch all available items; updates corresponding Gutenberg components to fetch all items.

Fixes #5820
Fixes #4022
Related #6627 #6657
See https://github.com/WordPress/gutenberg/issues/6180#issuecomment-384511059

## How has this been tested?

I generated 200 categories with:

```
wp term generate category --count=200
```

When I access the category selection UI, I see all 200 categories:

<img width="341" alt="image" src="https://user-images.githubusercontent.com/36432/39950721-2c266a08-5538-11e8-9aba-e124aa12bfc5.png">

Similarly, when I insert a category block, I see all categories:

<img width="790" alt="image" src="https://user-images.githubusercontent.com/36432/39950730-43188ade-5538-11e8-90db-faa9877b5607.png">

It also works with a custom taxonomy:

```
add_action( 'init', function(){
	register_taxonomy( 'section', array( 'post' ), array(
		'hierarchical' => true,
		'show_in_rest' => true,
		'rest_base'    => 'sections',
	));
});
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
