### PR TITLE
Use `wp:action-publish` to determine whether to display publish UI

### DIFF
--- a/editor/components/post-publish-button/index.js
+++ b/editor/components/post-publish-button/index.js
@@ -7,7 +7,7 @@ import { noop, get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Button, withAPIData } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -25,15 +25,14 @@ export function PostPublishButton( {
 	visibility,
 	isPublishable,
 	isSaveable,
-	user,
+	hasPublishAction,
 	onSubmit = noop,
 	forceIsSaving,
 } ) {
-	const isButtonEnabled = user.data && ! isSaving && isPublishable && isSaveable;
-	const isContributor = ! get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
+	const isButtonEnabled = ! isSaving && isPublishable && isSaveable;
 
 	let publishStatus;
-	if ( isContributor ) {
+	if ( ! hasPublishAction ) {
 		publishStatus = 'pending';
 	} else if ( isBeingScheduled ) {
 		publishStatus = 'future';
@@ -74,6 +73,7 @@ export default compose( [
 			getEditedPostVisibility,
 			isEditedPostSaveable,
 			isEditedPostPublishable,
+			getCurrentPost,
 			getCurrentPostType,
 		} = select( 'core/editor' );
 		return {
@@ -82,6 +82,7 @@ export default compose( [
 			visibility: getEditedPostVisibility(),
 			isSaveable: isEditedPostSaveable(),
 			isPublishable: forceIsDirty || isEditedPostPublishable(),
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			postType: getCurrentPostType(),
 		};
 	} ),
@@ -90,13 +91,6 @@ export default compose( [
 		return {
 			onStatusChange: ( status ) => editPost( { status } ),
 			onSave: savePost,
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} ),
 ] )( PostPublishButton );

--- a/editor/components/post-publish-button/label.js
+++ b/editor/components/post-publish-button/label.js
@@ -7,7 +7,6 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
@@ -21,11 +20,8 @@ export function PublishButtonLabel( {
 	isBeingScheduled,
 	isSaving,
 	isPublishing,
-	user,
+	hasPublishAction,
 } ) {
-	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-	const isContributor = user.data && ! userCanPublishPosts;
-
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
 	} else if ( isPublished && isSaving ) {
@@ -34,7 +30,7 @@ export function PublishButtonLabel( {
 		return __( 'Scheduling…' );
 	}
 
-	if ( isContributor ) {
+	if ( ! hasPublishAction ) {
 		return __( 'Submit for Review' );
 	} else if ( isPublished ) {
 		return __( 'Update' );
@@ -52,6 +48,7 @@ export default compose( [
 			isEditedPostBeingScheduled,
 			isSavingPost,
 			isPublishingPost,
+			getCurrentPost,
 			getCurrentPostType,
 		} = select( 'core/editor' );
 		return {
@@ -59,14 +56,8 @@ export default compose( [
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isSaving: forceIsSaving || isSavingPost(),
 			isPublishing: isPublishingPost(),
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			postType: getCurrentPostType(),
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} ),
 ] )( PublishButtonLabel );

--- a/editor/components/post-publish-button/test/index.js
+++ b/editor/components/post-publish-button/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,35 +9,10 @@ import { merge } from 'lodash';
 import { PostPublishButton } from '../';
 
 describe( 'PostPublishButton', () => {
-	const user = {
-		data: {
-			id: 1,
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
-	const contributor = merge( {}, user, {
-		data: {
-			post_type_capabilities: {
-				publish_posts: false,
-			},
-		},
-	} );
-
 	describe( 'disabled', () => {
-		it( 'should be disabled if current user is unknown', () => {
-			const wrapper = shallow(
-				<PostPublishButton user={ {} } />
-			);
-
-			expect( wrapper.prop( 'disabled' ) ).toBe( true );
-		} );
-
 		it( 'should be disabled if post is currently saving', () => {
 			const wrapper = shallow(
-				<PostPublishButton user={ user } isSaving />
+				<PostPublishButton hasPublishAction={ true } isSaving />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
@@ -46,7 +20,7 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be disabled if post is not publishable', () => {
 			const wrapper = shallow(
-				<PostPublishButton user={ user } isPublishable={ false } />
+				<PostPublishButton hasPublishAction={ true } isPublishable={ false } />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
@@ -54,7 +28,7 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be disabled if post is not saveable', () => {
 			const wrapper = shallow(
-				<PostPublishButton user={ user } isSaveable={ false } />
+				<PostPublishButton hasPublishAction={ true } isSaveable={ false } />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
@@ -62,7 +36,7 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be enabled otherwise', () => {
 			const wrapper = shallow(
-				<PostPublishButton user={ user } isPublishable isSaveable />
+				<PostPublishButton hasPublishAction={ true } isPublishable isSaveable />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( false );
@@ -75,7 +49,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ contributor }
+					hasPublishAction={ false }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave } />
 			);
@@ -90,7 +64,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ user }
+					hasPublishAction={ true }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
 					isBeingScheduled />
@@ -106,7 +80,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ user }
+					hasPublishAction={ true }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
 					visibility="private" />
@@ -122,7 +96,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ user }
+					hasPublishAction={ true }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave } />
 			);
@@ -139,7 +113,7 @@ describe( 'PostPublishButton', () => {
 			const onSave = jest.fn();
 			const wrapper = shallow(
 				<PostPublishButton
-					user={ user }
+					hasPublishAction={ true }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave } />
 			);
@@ -153,7 +127,7 @@ describe( 'PostPublishButton', () => {
 
 	it( 'should have save modifier class', () => {
 		const wrapper = shallow(
-			<PostPublishButton user={ user } isSaving />
+			<PostPublishButton hasPublishAction={ true } isSaving />
 		);
 
 		expect( wrapper.hasClass( 'is-saving' ) ).toBe( true );

--- a/editor/components/post-publish-button/test/label.js
+++ b/editor/components/post-publish-button/test/label.js
@@ -1,73 +1,46 @@
 /**
- * External dependencies
- */
-import { merge } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { PublishButtonLabel } from '../label';
 
 describe( 'PublishButtonLabel', () => {
-	const user = {
-		data: {
-			id: 1,
-			post_type_capabilities: {
-				publish_posts: true,
-			},
-		},
-	};
-
-	const contributor = merge( {}, user, {
-		data: {
-			post_type_capabilities: {
-				publish_posts: false,
-			},
-		},
-	} );
-
 	it( 'should show publishing if publishing in progress', () => {
-		const label = PublishButtonLabel( { user, isPublishing: true } );
+		const label = PublishButtonLabel( { hasPublishAction: true, isPublishing: true } );
 		expect( label ).toBe( 'Publishing…' );
 	} );
 
 	it( 'should show updating if published and saving in progress', () => {
-		const label = PublishButtonLabel( { user, isPublished: true, isSaving: true } );
+		const label = PublishButtonLabel( { hasPublishAction: true, isPublished: true, isSaving: true } );
 		expect( label ).toBe( 'Updating…' );
 	} );
 
 	it( 'should show scheduling if scheduled and saving in progress', () => {
-		const label = PublishButtonLabel( { user, isBeingScheduled: true, isSaving: true } );
+		const label = PublishButtonLabel( { hasPublishAction: true, isBeingScheduled: true, isSaving: true } );
 		expect( label ).toBe( 'Scheduling…' );
 	} );
 
 	it( 'should show publish if not published and saving in progress', () => {
-		const label = PublishButtonLabel( { user, isPublished: false, isSaving: true } );
-		expect( label ).toBe( 'Publish' );
-	} );
-
-	it( 'should show publish if user unknown', () => {
-		const label = PublishButtonLabel( { user: {} } );
+		const label = PublishButtonLabel( { hasPublishAction: true, isPublished: false, isSaving: true } );
 		expect( label ).toBe( 'Publish' );
 	} );
 
 	it( 'should show submit for review for contributor', () => {
-		const label = PublishButtonLabel( { user: contributor } );
+		const label = PublishButtonLabel( { hasPublishAction: false } );
 		expect( label ).toBe( 'Submit for Review' );
 	} );
 
 	it( 'should show update for already published', () => {
-		const label = PublishButtonLabel( { user, isPublished: true } );
+		const label = PublishButtonLabel( { hasPublishAction: true, isPublished: true } );
 		expect( label ).toBe( 'Update' );
 	} );
 
 	it( 'should show schedule for scheduled', () => {
-		const label = PublishButtonLabel( { user, isBeingScheduled: true } );
+		const label = PublishButtonLabel( { hasPublishAction: true, isBeingScheduled: true } );
 		expect( label ).toBe( 'Schedule' );
 	} );
 
 	it( 'should show publish otherwise', () => {
-		const label = PublishButtonLabel( { user } );
+		const label = PublishButtonLabel( { hasPublishAction: true } );
 		expect( label ).toBe( 'Publish' );
 	} );
 } );

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { compose, Component } from '@wordpress/element';
-import { withAPIData, IconButton, Spinner } from '@wordpress/components';
+import { IconButton, Spinner } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -51,10 +51,8 @@ class PostPublishPanel extends Component {
 	}
 
 	onSubmit() {
-		const { user, onClose } = this.props;
-		const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-		const isContributor = user.data && ! userCanPublishPosts;
-		if ( isContributor ) {
+		const { onClose, hasPublishAction } = this.props;
+		if ( ! hasPublishAction ) {
 			onClose();
 			return;
 		}
@@ -96,6 +94,7 @@ class PostPublishPanel extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const {
+			getCurrentPost,
 			getCurrentPostType,
 			isCurrentPostPublished,
 			isCurrentPostScheduled,
@@ -104,17 +103,11 @@ export default compose( [
 		} = select( 'core/editor' );
 		return {
 			postType: getCurrentPostType(),
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			isPublished: isCurrentPostPublished(),
 			isScheduled: isCurrentPostScheduled(),
 			isSaving: isSavingPost(),
 			isDirty: isEditedPostDirty(),
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} ),
 ] )( PostPublishPanel );

--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * WordPress Dependencies
  */
-import { Button, withAPIData } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
@@ -17,7 +17,7 @@ import { withSelect } from '@wordpress/data';
 import PostPublishButton from '../post-publish-button';
 
 function PostPublishPanelToggle( {
-	user,
+	hasPublishAction,
 	isSaving,
 	isPublishable,
 	isSaveable,
@@ -34,9 +34,7 @@ function PostPublishPanelToggle( {
 		! isSaving && ! forceIsSaving && isPublishable && isSaveable
 	) || isPublished;
 
-	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
-	const isContributor = user.data && ! userCanPublishPosts;
-	const showToggle = ! isPublished && ! ( isScheduled && isBeingScheduled ) && ! ( isPending && isContributor );
+	const showToggle = ! isPublished && ! ( isScheduled && isBeingScheduled ) && ! ( isPending && ! hasPublishAction );
 
 	if ( ! showToggle ) {
 		return <PostPublishButton forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />;
@@ -66,9 +64,11 @@ export default compose( [
 			isCurrentPostPublished,
 			isEditedPostBeingScheduled,
 			isCurrentPostScheduled,
+			getCurrentPost,
 			getCurrentPostType,
 		} = select( 'core/editor' );
 		return {
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			isSaving: isSavingPost(),
 			isSaveable: isEditedPostSaveable(),
 			isPublishable: isEditedPostPublishable(),
@@ -77,13 +77,6 @@ export default compose( [
 			isScheduled: isCurrentPostScheduled(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			postType: getCurrentPostType(),
-		};
-	} ),
-	withAPIData( ( props ) => {
-		const { postType } = props;
-
-		return {
-			user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 		};
 	} ),
 ] )( PostPublishPanelToggle );


### PR DESCRIPTION
## Description

Updates `post-publish-button` and `post-publish-panel` to use `wp:action-publish` attribute when determining what to display.

See #6361
Previously #6529 #6630 #6670

## How has this been tested?

I published a post as an author without JavaScript errors, and submitted a post for review as a contributor without JavaScript errors.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
