### PR TITLE
Block API: Introduce block definitions and implementations

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get, set, isFunction, some } from 'lodash';
+import { get, set, isFunction, some, omit, mapValues, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -168,7 +168,19 @@ export function registerBlockType( name, settings ) {
 		set( settings, [ 'supports', 'multiple' ], ! settings.useOnce );
 	}
 
-	dispatch( 'core/blocks' ).addBlockTypes( settings );
+	const blockTypeDefinition = omit( settings, [ 'transforms', 'edit', 'save', 'icon', 'getEditWrapperProps' ] );
+	blockTypeDefinition.attributes = mapValues(
+		settings.attributes,
+		( attribute ) => pick( attribute, [ 'type', 'default' ] )
+	);
+	const blockTypeImplementation = pick( settings, [ 'name', 'transforms', 'edit', 'save', 'icon', 'getEditWrapperProps' ] );
+	blockTypeImplementation.attributes = mapValues(
+		settings.attributes,
+		( attribute ) => omit( attribute, [ 'type', 'default' ] )
+	);
+
+	dispatch( 'core/blocks' ).addBlockTypes( blockTypeDefinition );
+	dispatch( 'core/blocks' ).implementBlockTypes( blockTypeImplementation );
 
 	return settings;
 }

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -168,12 +168,13 @@ export function registerBlockType( name, settings ) {
 		set( settings, [ 'supports', 'multiple' ], ! settings.useOnce );
 	}
 
-	const blockTypeDefinition = omit( settings, [ 'transforms', 'edit', 'save', 'icon', 'getEditWrapperProps' ] );
+	const implementationOnlyAttributes = [ 'transforms', 'edit', 'save', 'icon', 'getEditWrapperProps' ];
+	const blockTypeDefinition = omit( settings, implementationOnlyAttributes );
 	blockTypeDefinition.attributes = mapValues(
 		settings.attributes,
 		( attribute ) => pick( attribute, [ 'type', 'default' ] )
 	);
-	const blockTypeImplementation = pick( settings, [ 'name', 'transforms', 'edit', 'save', 'icon', 'getEditWrapperProps' ] );
+	const blockTypeImplementation = pick( settings, [ 'name' ].concat( implementationOnlyAttributes ) );
 	blockTypeImplementation.attributes = mapValues(
 		settings.attributes,
 		( attribute ) => omit( attribute, [ 'type', 'default' ] )

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -214,6 +214,7 @@ describe( 'blocks', () => {
 							fill="red" stroke="blue" strokeWidth="10" />
 					</svg> ),
 				},
+				attributes: {},
 			} );
 		} );
 
@@ -233,6 +234,7 @@ describe( 'blocks', () => {
 				icon: {
 					src: 'foo',
 				},
+				attributes: {},
 			} );
 		} );
 
@@ -258,6 +260,7 @@ describe( 'blocks', () => {
 				icon: {
 					src: MyTestIcon,
 				},
+				attributes: {},
 			} );
 		} );
 
@@ -289,6 +292,7 @@ describe( 'blocks', () => {
 							fill="red" stroke="blue" strokeWidth="10" />
 					</svg> ),
 				},
+				attributes: {},
 			} );
 		} );
 
@@ -305,6 +309,7 @@ describe( 'blocks', () => {
 				icon: {
 					src: 'block-default',
 				},
+				attributes: {},
 			} );
 		} );
 
@@ -345,6 +350,7 @@ describe( 'blocks', () => {
 					icon: {
 						src: 'block-default',
 					},
+					attributes: {},
 				},
 			] );
 			const oldBlock = unregisterBlockType( 'core/test-block' );
@@ -357,6 +363,7 @@ describe( 'blocks', () => {
 				icon: {
 					src: 'block-default',
 				},
+				attributes: {},
 			} );
 			expect( getBlockTypes() ).toEqual( [] );
 		} );
@@ -401,6 +408,7 @@ describe( 'blocks', () => {
 				icon: {
 					src: 'block-default',
 				},
+				attributes: {},
 			} );
 		} );
 
@@ -416,6 +424,7 @@ describe( 'blocks', () => {
 				icon: {
 					src: 'block-default',
 				},
+				attributes: {},
 			} );
 		} );
 	} );
@@ -438,6 +447,7 @@ describe( 'blocks', () => {
 					icon: {
 						src: 'block-default',
 					},
+					attributes: {},
 				},
 				{
 					name: 'core/test-block-with-settings',
@@ -448,6 +458,7 @@ describe( 'blocks', () => {
 					icon: {
 						src: 'block-default',
 					},
+					attributes: {},
 				},
 			] );
 		} );

--- a/blocks/store/actions.js
+++ b/blocks/store/actions.js
@@ -18,7 +18,7 @@ export function addBlockTypes( blockTypes ) {
 }
 
 /**
- * Returns an action object used in signalling that block types have been added.
+ * Returns an action object used in signalling that block types have been implemented.
  *
  * @param {Array|Object} implementations Block types implementations.
  *

--- a/blocks/store/actions.js
+++ b/blocks/store/actions.js
@@ -18,6 +18,20 @@ export function addBlockTypes( blockTypes ) {
 }
 
 /**
+ * Returns an action object used in signalling that block types have been added.
+ *
+ * @param {Array|Object} implementations Block types implementations.
+ *
+ * @return {Object} Action object.
+ */
+export function implementBlockTypes( implementations ) {
+	return {
+		type: 'IMPLEMENT_BLOCK_TYPES',
+		implementations: castArray( implementations ),
+	};
+}
+
+/**
  * Returns an action object used to remove a registered block type.
  *
  * @param {string|Array} names Block name.

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -44,6 +44,28 @@ export function blockTypes( state = {}, action ) {
 }
 
 /**
+ * Reducer managing the block type implementations
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function implementations( state = {}, action ) {
+	switch ( action.type ) {
+		case 'IMPLEMENT_BLOCK_TYPES':
+			return {
+				...state,
+				...keyBy( action.implementations, 'name' ),
+			};
+		case 'REMOVE_BLOCK_TYPES':
+			return omit( state, action.names );
+	}
+
+	return state;
+}
+
+/**
  * Higher-order Reducer creating a reducer keeping track of given block name.
  *
  * @param {string} setActionType  Action type.
@@ -91,6 +113,7 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 
 export default combineReducers( {
 	blockTypes,
+	implementations,
 	defaultBlockName,
 	fallbackBlockName,
 	categories,

--- a/blocks/store/selectors.js
+++ b/blocks/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { filter, includes, map, mapValues, compact } from 'lodash';
+import { filter, includes, map, mapValues, compact, get } from 'lodash';
 
 /**
  * Returns all the available block types.
@@ -40,7 +40,7 @@ export const getBlockType = createSelector(
 			...blockTypeDefinition,
 			...blockTypeImplementation,
 			attributes: mapValues( blockTypeDefinition.attributes, ( attribute, key ) => {
-				const implementationAttribute = blockTypeImplementation.attributes ? blockTypeImplementation.attributes[ key ] : {};
+				const implementationAttribute = get( blockTypeImplementation.attributes, [ key ], {} );
 				return {
 					...attribute,
 					...implementationAttribute,

--- a/core-blocks/index.js
+++ b/core-blocks/index.js
@@ -6,6 +6,7 @@ import {
 	setDefaultBlockName,
 	setUnknownTypeHandlerName,
 } from '@wordpress/blocks';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -77,9 +78,13 @@ export const registerCoreBlocks = () => {
 		table,
 		textColumns,
 		verse,
-		video,
 	].forEach( ( { name, settings } ) => {
 		registerBlockType( name, settings );
+	} );
+
+	[ video ].forEach( ( { name, definition, implementation } ) => {
+		dispatch( 'core/blocks' ).addBlockTypes( { name, ...definition } );
+		dispatch( 'core/blocks' ).implementBlockTypes( { name, ...implementation } );
 	} );
 
 	setDefaultBlockName( paragraph.name );

--- a/core-blocks/video/index.js
+++ b/core-blocks/video/index.js
@@ -16,27 +16,33 @@ import edit from './edit';
 
 export const name = 'core/video';
 
-export const settings = {
+export const definition = {
 	title: __( 'Video' ),
-
 	description: __( 'Embed an video file and a simple video player.' ),
-
-	icon: 'format-video',
-
 	category: 'common',
-
 	attributes: {
 		id: {
 			type: 'number',
 		},
 		src: {
 			type: 'string',
+		},
+		caption: {
+			type: 'array',
+		},
+	},
+};
+
+export const implementation = {
+	icon: 'format-video',
+
+	attributes: {
+		src: {
 			source: 'attribute',
 			selector: 'video',
 			attribute: 'src',
 		},
 		caption: {
-			type: 'array',
 			source: 'children',
 			selector: 'figcaption',
 		},

--- a/core-blocks/video/test/index.js
+++ b/core-blocks/video/test/index.js
@@ -1,11 +1,27 @@
 /**
+ * External dependencies
+ */
+import { get, mapValues } from 'lodash';
+
+/**
  * Internal dependencies
  */
-import { name, settings } from '../';
+import { name, definition, implementation } from '../';
 import { blockEditRender } from '../../test/helpers';
 
 describe( 'core/video', () => {
 	test( 'block edit matches snapshot', () => {
+		const settings = {
+			...definition,
+			...implementation,
+			attributes: mapValues( definition.attributes, ( attribute, key ) => {
+				const implementationAttribute = get( implementation.attributes, [ key ], {} );
+				return {
+					...attribute,
+					...implementationAttribute,
+				};
+			} ),
+		};
 		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();


### PR DESCRIPTION
In order to move forward with the server-side awareness of blocks we need to split the block registration into two steps:

 1- Defining the existence of the block: Which means specifying its generic properties (name, title, category, description, attribute types)

 2- Implementing block types: which means providing `edit/save/parse` definitions to allow manipulating the block type in the web editor. Other implementation could exist in separate contexts.

This PR is an exploration to split the block settings between two calls:

 - `dispatch( 'core/blocks' ).addBlockType( { name, ...definition } )` (the generic part that can be moved server-side later on.

 - `dispatch( 'core/blocks' ).implementBlockType( { name, edit, save, transforms } )`

It leverages the selectors "abstraction" to avoid breaking changes.

**This raises several questions:**

 - What belongs to the definition and what is implementation? I'm considering the block name, title, category, description and attributes types (not the way we parse and serialize them) as the canonical definition of the block. 

 - What about the `icon`? It's considered as **implementation** for now mainly because we allow svg elements which can't be defined server-side. An option would be to transform it to svg string to allow it to be moved to the definition of the block.

 - What about the `blocks.registerBlockType` filter? The most logical thing to do is to split it to two filters: `addBlockType` (server-side)  and `implementBlockType` (client-side)

At the moment, this raises more questions than it solves, but let's discuss to find the best approach before introducing any deprecations.