### PR TITLE
Blocks: Update all tests which depend on editor

### DIFF
--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -30,8 +30,8 @@ describe( 'block factory', () => {
 	};
 
 	beforeAll( () => {
-		// Load all hooks that modify blocks
-		require( 'editor/hooks' );
+		// Load blocks store
+		require( 'blocks/store' );
 	} );
 
 	afterEach( () => {
@@ -77,41 +77,6 @@ describe( 'block factory', () => {
 			expect( block.innerBlocks ).toHaveLength( 1 );
 			expect( block.innerBlocks[ 0 ].name ).toBe( 'core/test-block' );
 			expect( typeof block.uid ).toBe( 'string' );
-		} );
-
-		it( 'should keep the className if the block supports it', () => {
-			registerBlockType( 'core/test-block', {
-				attributes: {},
-				save: noop,
-				category: 'common',
-				title: 'test block',
-			} );
-			const block = createBlock( 'core/test-block', {
-				className: 'chicken',
-			} );
-
-			expect( block.attributes ).toEqual( {
-				className: 'chicken',
-			} );
-			expect( block.isValid ).toBe( true );
-		} );
-
-		it( 'should not keep the className if the block supports it', () => {
-			registerBlockType( 'core/test-block', {
-				attributes: {},
-				save: noop,
-				category: 'common',
-				title: 'test block',
-				supports: {
-					customClassName: false,
-				},
-			} );
-			const block = createBlock( 'core/test-block', {
-				className: 'chicken',
-			} );
-
-			expect( block.attributes ).toEqual( {} );
-			expect( block.isValid ).toBe( true );
 		} );
 	} );
 

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -42,8 +42,8 @@ describe( 'block parser', () => {
 	};
 
 	beforeAll( () => {
-		// Load all hooks that modify blocks
-		require( 'editor/hooks' );
+		// Initialize the block store.
+		require( '../../store' );
 	} );
 
 	afterEach( () => {
@@ -235,7 +235,7 @@ describe( 'block parser', () => {
 						},
 					],
 				},
-				'<span class="wp-block-test-block">Bananas</span>',
+				'<span>Bananas</span>',
 				{},
 			);
 			expect( attributesAndInnerBlocks.attributes ).toEqual( { fruit: 'Bananas' } );
@@ -260,7 +260,7 @@ describe( 'block parser', () => {
 						},
 					],
 				},
-				'<span class="wp-block-test-block">Bananas</span>',
+				'<span>Bananas</span>',
 				{},
 				[ {
 					name: 'core/test-block',
@@ -301,7 +301,7 @@ describe( 'block parser', () => {
 						},
 					],
 				},
-				'<span class="wp-block-test-block">Bananas</span>',
+				'<span>Bananas</span>',
 				{},
 			);
 
@@ -396,7 +396,7 @@ describe( 'block parser', () => {
 
 			const block = createBlockWithFallback( {
 				blockName: 'core/test-block',
-				innerHTML: '<span class="wp-block-test-block">Bananas</span>',
+				innerHTML: '<span>Bananas</span>',
 				attrs: { fruit: 'Bananas' },
 			} );
 			expect( block.name ).toEqual( 'core/test-block' );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -29,10 +29,7 @@ describe( 'blocks', () => {
 	const defaultBlockSettings = { save: noop, category: 'common', title: 'block title' };
 
 	beforeAll( () => {
-		// Load all hooks that modify blocks
-		require( 'editor/hooks' );
-
-		// Initialize the block store
+		// Initialize the block store.
 		require( '../../store' );
 	} );
 
@@ -91,14 +88,6 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				attributes: {
-					className: {
-						type: 'string',
-					},
-					layout: {
-						type: 'string',
-					},
-				},
 			} );
 		} );
 
@@ -183,12 +172,6 @@ describe( 'blocks', () => {
 					ok: {
 						type: 'boolean',
 					},
-					className: {
-						type: 'string',
-					},
-					layout: {
-						type: 'string',
-					},
 				},
 			} );
 		} );
@@ -204,14 +187,6 @@ describe( 'blocks', () => {
 				category: 'common',
 				title: 'block title',
 				icon: 'block-default',
-				attributes: {
-					className: {
-						type: 'string',
-					},
-					layout: {
-						type: 'string',
-					},
-				},
 			} );
 		} );
 
@@ -250,14 +225,6 @@ describe( 'blocks', () => {
 					category: 'common',
 					title: 'block title',
 					icon: 'block-default',
-					attributes: {
-						className: {
-							type: 'string',
-						},
-						layout: {
-							type: 'string',
-						},
-					},
 				},
 			] );
 			const oldBlock = unregisterBlockType( 'core/test-block' );
@@ -268,14 +235,6 @@ describe( 'blocks', () => {
 				category: 'common',
 				title: 'block title',
 				icon: 'block-default',
-				attributes: {
-					className: {
-						type: 'string',
-					},
-					layout: {
-						type: 'string',
-					},
-				},
 			} );
 			expect( getBlockTypes() ).toEqual( [] );
 		} );
@@ -318,14 +277,6 @@ describe( 'blocks', () => {
 				category: 'common',
 				title: 'block title',
 				icon: 'block-default',
-				attributes: {
-					className: {
-						type: 'string',
-					},
-					layout: {
-						type: 'string',
-					},
-				},
 			} );
 		} );
 
@@ -339,14 +290,6 @@ describe( 'blocks', () => {
 				category: 'common',
 				title: 'block title',
 				icon: 'block-default',
-				attributes: {
-					className: {
-						type: 'string',
-					},
-					layout: {
-						type: 'string',
-					},
-				},
 			} );
 		} );
 	} );
@@ -367,14 +310,6 @@ describe( 'blocks', () => {
 					category: 'common',
 					title: 'block title',
 					icon: 'block-default',
-					attributes: {
-						className: {
-							type: 'string',
-						},
-						layout: {
-							type: 'string',
-						},
-					},
 				},
 				{
 					name: 'core/test-block-with-settings',
@@ -383,14 +318,6 @@ describe( 'blocks', () => {
 					category: 'common',
 					title: 'block title',
 					icon: 'block-default',
-					attributes: {
-						className: {
-							type: 'string',
-						},
-						layout: {
-							type: 'string',
-						},
-					},
 				},
 			] );
 		} );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -16,7 +16,6 @@ import serialize, {
 	getBlockContent,
 } from '../serializer';
 import {
-	getBlockType,
 	getBlockTypes,
 	registerBlockType,
 	unregisterBlockType,
@@ -24,13 +23,10 @@ import {
 } from '../registration';
 import { createBlock } from '../';
 
-// Todo: move the test to the inner-blocks folder
-import InnerBlocks from '../../../editor/components/inner-blocks';
-
 describe( 'block serializer', () => {
 	beforeAll( () => {
-		// Load all hooks that modify blocks
-		require( 'editor/hooks' );
+		// Initialize the block store.
+		require( '../../store' );
 	} );
 
 	afterEach( () => {
@@ -59,50 +55,6 @@ describe( 'block serializer', () => {
 					{ fruit: 'Bananas' }
 				);
 
-				expect( saved ).toBe( '<div class="wp-block-fruit">Bananas</div>' );
-			} );
-
-			it( 'should use the namespace in the classname for non-core blocks', () => {
-				const saved = getSaveContent(
-					{
-						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
-						name: 'myplugin/fruit',
-					},
-					{ fruit: 'Bananas' }
-				);
-
-				expect( saved ).toBe( '<div class="wp-block-myplugin-fruit">Bananas</div>' );
-			} );
-
-			it( 'should include additional classes in block attributes', () => {
-				const saved = getSaveContent(
-					{
-						save: ( { attributes } ) => createElement( 'div', {
-							className: 'fruit',
-						}, attributes.fruit ),
-						name: 'myplugin/fruit',
-					},
-					{
-						fruit: 'Bananas',
-						className: 'fresh',
-					}
-				);
-
-				expect( saved ).toBe( '<div class="wp-block-myplugin-fruit fruit fresh">Bananas</div>' );
-			} );
-
-			it( 'should not add a className if falsy', () => {
-				const saved = getSaveContent(
-					{
-						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
-						name: 'myplugin/fruit',
-						supports: {
-							className: false,
-						},
-					},
-					{ fruit: 'Bananas' }
-				);
-
 				expect( saved ).toBe( '<div>Bananas</div>' );
 			} );
 		} );
@@ -121,46 +73,7 @@ describe( 'block serializer', () => {
 					{ fruit: 'Bananas' }
 				);
 
-				expect( saved ).toBe( '<div class="wp-block-fruit">Bananas</div>' );
-			} );
-
-			it( 'should return element as string, with inner blocks', () => {
-				registerBlockType( 'core/fruit', {
-					category: 'common',
-
-					title: 'fruit',
-
-					attributes: {
-						fruit: {
-							type: 'string',
-						},
-					},
-
-					supports: {
-						className: false,
-					},
-
-					save( { attributes } ) {
-						return (
-							<div>
-								{ attributes.fruit }
-								<InnerBlocks.Content />
-							</div>
-						);
-					},
-				} );
-
-				const saved = getSaveContent(
-					getBlockType( 'core/fruit' ),
-					{ fruit: 'Bananas' },
-					[ createBlock( 'core/fruit', { fruit: 'Apples' } ) ],
-				);
-
-				expect( saved ).toBe(
-					'<div>Bananas<!-- wp:fruit {"fruit":"Apples"} -->\n' +
-					'<div>Apples</div>\n' +
-					'<!-- /wp:fruit --></div>'
-				);
+				expect( saved ).toBe( '<div>Bananas</div>' );
 			} );
 		} );
 	} );
@@ -332,7 +245,6 @@ describe( 'block serializer', () => {
 					return (
 						<p>
 							{ attributes.content }
-							<InnerBlocks.Content />
 						</p>
 					);
 				},
@@ -347,7 +259,7 @@ describe( 'block serializer', () => {
 				content: 'Ribs & Chicken',
 				stuff: 'left & right -- but <not>',
 			} );
-			const expectedPostContent = '<!-- wp:test-block {"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs &amp; Chicken</p>\n<!-- /wp:test-block -->';
+			const expectedPostContent = '<!-- wp:test-block {"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p>Ribs &amp; Chicken</p>\n<!-- /wp:test-block -->';
 
 			expect( serialize( [ block ] ) ).toEqual( expectedPostContent );
 			expect( serialize( block ) ).toEqual( expectedPostContent );
@@ -363,27 +275,6 @@ describe( 'block serializer', () => {
 
 			expect( serialize( block ) ).toEqual(
 				'<!-- wp:test-block -->\nCorrect\n<!-- /wp:test-block -->'
-			);
-		} );
-
-		it( 'should force serialize for invalid block with inner blocks', () => {
-			const block = createBlock(
-				'core/test-block',
-				{ content: 'Invalid' },
-				[ createBlock( 'core/test-block' ) ]
-			);
-
-			block.isValid = false;
-			block.originalContent = 'Original';
-
-			expect( serialize( block ) ).toEqual(
-				'<!-- wp:test-block -->\n' +
-				'<p class="wp-block-test-block">Invalid\n' +
-				'\t<!-- wp:test-block -->\n' +
-				'\t<p class="wp-block-test-block"></p>\n' +
-				'\t<!-- /wp:test-block -->\n' +
-				'</p>\n' +
-				'<!-- /wp:test-block -->'
 			);
 		} );
 

--- a/editor/components/inner-blocks/test/__snapshots__/index.js.snap
+++ b/editor/components/inner-blocks/test/__snapshots__/index.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InnerBlocks should force serialize for invalid block with inner blocks 1`] = `
+"<!-- wp:test-block -->
+<p>Invalid
+	<!-- wp:test-block -->
+	<p></p>
+	<!-- /wp:test-block -->
+</p>
+<!-- /wp:test-block -->"
+`;
+
+exports[`InnerBlocks should return element as string, with inner blocks 1`] = `
+"<div>Bananas<!-- wp:fruit {\\"fruit\\":\\"Apples\\"} -->
+<div>Apples</div>
+<!-- /wp:fruit --></div>"
+`;

--- a/editor/components/inner-blocks/test/index.js
+++ b/editor/components/inner-blocks/test/index.js
@@ -1,0 +1,111 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	getBlockType,
+	getBlockTypes,
+	setUnknownTypeHandlerName,
+	getSaveElement,
+	registerBlockType,
+	serialize,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+import { renderToString } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import InnerBlocks from '../';
+
+describe( 'InnerBlocks', () => {
+	afterEach( () => {
+		setUnknownTypeHandlerName( undefined );
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'should return element as string, with inner blocks', () => {
+		registerBlockType( 'core/fruit', {
+			category: 'common',
+
+			title: 'fruit',
+
+			attributes: {
+				fruit: {
+					type: 'string',
+				},
+			},
+
+			supports: {
+				className: false,
+			},
+
+			save( { attributes } ) {
+				return (
+					<div>
+						{ attributes.fruit }
+						<InnerBlocks.Content />
+					</div>
+				);
+			},
+		} );
+
+		const saved = renderToString(
+			getSaveElement(
+				getBlockType( 'core/fruit' ),
+				{ fruit: 'Bananas' },
+				[ createBlock( 'core/fruit', { fruit: 'Apples' } ) ],
+			)
+		);
+
+		expect( saved ).toMatchSnapshot();
+	} );
+
+	it( 'should force serialize for invalid block with inner blocks', () => {
+		const blockType = {
+			attributes: {
+				throw: {
+					type: 'boolean',
+				},
+				defaulted: {
+					type: 'boolean',
+					default: false,
+				},
+				content: {
+					type: 'string',
+					source: 'text',
+				},
+				stuff: {
+					type: 'string',
+				},
+			},
+			save( { attributes } ) {
+				if ( attributes.throw ) {
+					throw new Error();
+				}
+
+				return (
+					<p>
+						{ attributes.content }
+						<InnerBlocks.Content />
+					</p>
+				);
+			},
+			category: 'common',
+			title: 'block title',
+		};
+		registerBlockType( 'core/test-block', blockType );
+		const block = createBlock(
+			'core/test-block',
+			{ content: 'Invalid' },
+			[ createBlock( 'core/test-block' ) ]
+		);
+
+		block.isValid = false;
+		block.originalContent = 'Original';
+
+		expect( serialize( block ) ).toMatchSnapshot();
+	} );
+} );

--- a/test/integration/is-valid-block.spec.js
+++ b/test/integration/is-valid-block.spec.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { isValidBlock } from '@wordpress/blocks';
+import { createElement } from '@wordpress/element';
+
+describe( 'isValidBlock', () => {
+	beforeAll( () => {
+		// Load all hooks that modify blocks
+		require( 'editor/hooks' );
+	} );
+
+	it( 'should use the namespace in the classname for non-core blocks', () => {
+		const valid = isValidBlock(
+			'<div class="wp-block-myplugin-fruit">Bananas</div>',
+			{
+				save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+				name: 'myplugin/fruit',
+			},
+			{ fruit: 'Bananas' }
+		);
+
+		expect( valid ).toBe( true );
+	} );
+
+	it( 'should include additional classes in block attributes', () => {
+		const valid = isValidBlock(
+			'<div class="wp-block-myplugin-fruit fruit fresh">Bananas</div>',
+			{
+				save: ( { attributes } ) => createElement( 'div', {
+					className: 'fruit',
+				}, attributes.fruit ),
+				name: 'myplugin/fruit',
+			},
+			{
+				fruit: 'Bananas',
+				className: 'fresh',
+			}
+		);
+
+		expect( valid ).toBe( true );
+	} );
+
+	it( 'should not add a className if falsy', () => {
+		const valid = isValidBlock(
+			'<div>Bananas</div>',
+			{
+				save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+				name: 'myplugin/fruit',
+				supports: {
+					className: false,
+				},
+			},
+			{ fruit: 'Bananas' }
+		);
+
+		expect( valid ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
## Description
Follow up for #6731. An alternative solution to #6730.

This PR removes the dependency on the `editor` module code from `blocks` tests. To accomplish that I updated all tests to work without all editor hooks applied. I moved also tests related to `InnerBlocks` component to be located next to the source code. Finally, I moved code that tests multiple hooks applied to the newly introduced `integration` folder.

## How has this been tested?
`npm test`

## Types of changes
Refactoring for tests, no production code changed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
