### PR TITLE
Framework: Drop features slated for 2.9 removal

### DIFF
--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -1,14 +1,8 @@
 /**
- * External dependencies
- */
-import { get, isString, some } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { registerCoreBlocks } from '@wordpress/core-blocks';
 import { render, unmountComponentAtNode } from '@wordpress/element';
-import { deprecated } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -69,26 +63,13 @@ export function initializeEditor( id, post, settings ) {
 		);
 	}
 
-	let migratedSettings;
-	const colors = get( settings, [ 'colors' ] );
-	if ( some( colors, isString ) ) {
-		migratedSettings = {
-			...settings,
-			colors: colors.map( ( color ) => isString( color ) ? { color } : color ),
-		};
-		deprecated( 'Setting theme colors without names', {
-			version: '2.9',
-			alternative: 'add_theme_support( \'colors\', array( \'name\' => \'my-color\', \'color\': \'#ff0\' );' }
-		);
-	}
-
 	const target = document.getElementById( id );
 	const reboot = reinitializeEditor.bind( null, target, settings );
 
 	registerCoreBlocks();
 
 	render(
-		<Editor settings={ migratedSettings || settings } onError={ reboot } post={ post } />,
+		<Editor settings={ settings } onError={ reboot } post={ post } />,
 		target
 	);
 

--- a/editor/components/color-palette/with-color-context.js
+++ b/editor/components/color-palette/with-color-context.js
@@ -7,22 +7,15 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { deprecated } from '@wordpress/utils';
 import { createHigherOrderComponent } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
 export default createHigherOrderComponent(
 	withSelect(
-		( select, ownProps ) => {
-			if ( ownProps.colors || ownProps.disableCustomColors ) {
-				deprecated( 'Passing props "colors" or "disableCustomColors" to @editor/PanelColor or @editor/ColorPalette', {
-					version: '2.9',
-					alternative: 'remove the props and rely on the editor settings or use @wordpress/PanelColor and @wordpress/ColorPalette',
-				} );
-			}
+		( select ) => {
 			const settings = select( 'core/editor' ).getEditorSettings();
-			const colors = ownProps.colors || settings.colors;
-			const disableCustomColors = ownProps.disableCustomColors || settings.disableCustomColors;
+			const colors = settings.colors;
+			const disableCustomColors = settings.disableCustomColors;
 			return {
 				colors,
 				disableCustomColors,


### PR DESCRIPTION
This pull request seeks to remove deprecations slated for removal in the upcoming 2.9.0 release.

Specifically, this includes:

- Custom colors: Setting theme colors without names
- Custom colors: Passing props "colors" or "disableCustomColors" to @editor/PanelColor or @editor/ColorPalette

See: https://wordpress.org/gutenberg/handbook/reference/deprecated/#2-9-0

__Testing instructions:__

Verify that there are no regressions in impacted behavior, and importantly that no references to deprecated behaviors exist in core code.