### PR TITLE
Improve getSupportedBlocks selector

### DIFF
--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -35,8 +35,8 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     type="text"
     value="Write your story"
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(IfCondition(WithDispatch(InserterWithShortcuts))) />
+  <WithSelect(IfCondition(WithDispatch(Inserter)))
     position="top right"
   />
 </div>
@@ -59,8 +59,8 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     type="text"
     value="Write your story"
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(IfCondition(WithDispatch(InserterWithShortcuts))) />
+  <WithSelect(IfCondition(WithDispatch(Inserter)))
     position="top right"
   />
 </div>
@@ -83,8 +83,8 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     type="text"
     value=""
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(IfCondition(WithDispatch(InserterWithShortcuts))) />
+  <WithSelect(IfCondition(WithDispatch(Inserter)))
     position="top right"
   />
 </div>

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -8,7 +8,7 @@ import { filter, isEmpty } from 'lodash';
  */
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
-import { IconButton } from '@wordpress/components';
+import { IconButton, ifCondition } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 
@@ -18,11 +18,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import BlockIcon from '../block-icon';
 import './style.scss';
 
-function InserterWithShortcuts( { items, isLocked, onInsert } ) {
-	if ( isLocked ) {
-		return null;
-	}
-
+function InserterWithShortcuts( { items, onInsert } ) {
 	const itemsWithoutDefaultBlock = filter( items, ( item ) =>
 		item.name !== getDefaultBlockName() || ! isEmpty( item.initialAttributes )
 	).slice( 0, 3 );
@@ -46,14 +42,13 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 
 export default compose(
 	withSelect( ( select, { rootUID } ) => {
-		const { getEditorSettings, getFrecentInserterItems, getSupportedBlocks } = select( 'core/editor' );
-		const { templateLock, allowedBlockTypes } = getEditorSettings();
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
+		const { getFrecentInserterItems, getSupportedBlocks } = select( 'core/editor' );
+		const supportedBlocks = getSupportedBlocks( rootUID );
 		return {
 			items: getFrecentInserterItems( supportedBlocks, 4 ),
-			isLocked: !! templateLock,
 		};
 	} ),
+	ifCondition( ( { items } ) => items.length > 0 ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const { uid, rootUID, layout } = ownProps;
 

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton } from '@wordpress/components';
+import { Dropdown, IconButton, ifCondition } from '@wordpress/components';
 import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -45,13 +40,7 @@ class Inserter extends Component {
 			title,
 			children,
 			onInsertBlock,
-			hasSupportedBlocks,
-			isLocked,
 		} = this.props;
-
-		if ( ! hasSupportedBlocks || isLocked ) {
-			return null;
-		}
 
 		return (
 			<Dropdown
@@ -93,20 +82,18 @@ export default compose( [
 			getBlockInsertionPoint,
 			getSelectedBlock,
 			getSupportedBlocks,
-			getEditorSettings,
 		} = select( 'core/editor' );
-		const { allowedBlockTypes, templateLock } = getEditorSettings();
 		const insertionPoint = getBlockInsertionPoint();
 		const { rootUID } = insertionPoint;
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
+		const supportedBlocks = getSupportedBlocks( rootUID );
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			insertionPoint,
 			selectedBlock: getSelectedBlock(),
-			hasSupportedBlocks: true === supportedBlocks || ! isEmpty( supportedBlocks ),
-			isLocked: !! templateLock,
+			hasSupportedBlocks: supportedBlocks === true || supportedBlocks.length > 0,
 		};
 	} ),
+	ifCondition( ( { hasSupportedBlocks } ) => hasSupportedBlocks ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		showInsertionPoint: dispatch( 'core/editor' ).showInsertionPoint,
 		hideInsertionPoint: dispatch( 'core/editor' ).hideInsertionPoint,

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -342,11 +342,9 @@ export default compose(
 			getInserterItems,
 			getFrecentInserterItems,
 			getSupportedBlocks,
-			getEditorSettings,
 		} = select( 'core/editor' );
-		const { allowedBlockTypes } = getEditorSettings();
 		const { rootUID } = getBlockInsertionPoint();
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
+		const supportedBlocks = getSupportedBlocks( rootUID );
 		return {
 			items: getInserterItems( supportedBlocks ),
 			frecentItems: getFrecentInserterItems( supportedBlocks ),

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1595,33 +1595,42 @@ export function getBlockListSettings( state, uid ) {
 }
 
 /**
- * Determines the blocks that can be nested inside a given block. Or globally if a block is not specified.
+ * Determines the blocks that can be nested/inserted inside a given block. Or globally if a block is not specified.
  *
  * @param {Object}           state                     Global application state.
  * @param {?string}          uid                       Block UID.
- * @param {string[]|boolean} globallyEnabledBlockTypes Globally enabled block types, or true/false to enable/disable all types.
  *
- * @return {string[]|boolean} Blocks that can be nested inside the block with the specified uid, or true/false to enable/disable all types.
+ * @return {string[]|boolean} Blocks that can be nested/inserted inside the block with the specified uid, or true/false to enable/disable all types.
  */
-export function getSupportedBlocks( state, uid, globallyEnabledBlockTypes ) {
-	if ( ! globallyEnabledBlockTypes ) {
-		return false;
-	}
+export const getSupportedBlocks = createSelector(
+	( state, uid ) => {
+		const globallyEnabledBlockTypes = getEditorSettings( state ).allowedBlockTypes;
+		if ( ! globallyEnabledBlockTypes || !! getTemplateLock( state ) ) {
+			return false;
+		}
 
-	const supportedNestedBlocks = get( getBlockListSettings( state, uid ), [ 'supportedBlocks' ] );
-	if ( supportedNestedBlocks === true || supportedNestedBlocks === undefined ) {
-		return globallyEnabledBlockTypes;
-	}
+		const supportedNestedBlocks = get( getBlockListSettings( state, uid ), [ 'supportedBlocks' ] );
+		if ( supportedNestedBlocks === true || supportedNestedBlocks === undefined ) {
+			return globallyEnabledBlockTypes;
+		}
 
-	if ( ! supportedNestedBlocks ) {
-		return false;
-	}
+		if ( ! supportedNestedBlocks ) {
+			return false;
+		}
 
-	if ( globallyEnabledBlockTypes === true ) {
-		return supportedNestedBlocks;
+		if ( globallyEnabledBlockTypes === true ) {
+			return supportedNestedBlocks;
+		}
+		return intersection( globallyEnabledBlockTypes, supportedNestedBlocks );
+	},
+	( state, uid ) => {
+		return [
+			getBlockListSettings( state, uid ),
+			getEditorSettings( state ).allowedBlockTypes,
+			getTemplateLock( state ),
+		];
 	}
-	return intersection( globallyEnabledBlockTypes, supportedNestedBlocks );
-}
+);
 
 /*
  * Returns the editor settings.

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -3319,9 +3319,27 @@ describe( 'selectors', () => {
 						supportedBlocks: [ 'core/block1' ],
 					},
 				},
+				settings: {
+					allowedBlockTypes: false,
+				},
 			};
 
-			expect( getSupportedBlocks( state, 'block1', false ) ).toBe( false );
+			expect( getSupportedBlocks( state, 'block1' ) ).toBe( false );
+		} );
+		it( 'should return false if a template lock exists', () => {
+			const state = {
+				blockListSettings: {
+					block1: {
+						supportedBlocks: true,
+					},
+				},
+				settings: {
+					allowedBlockTypes: true,
+					templateLock: 'all',
+				},
+			};
+
+			expect( getSupportedBlocks( state, 'block1' ) ).toBe( false );
 		} );
 
 		it( 'should return the supportedBlocks of root block if all blocks are supported globally', () => {
@@ -3331,45 +3349,60 @@ describe( 'selectors', () => {
 						supportedBlocks: [ 'core/block1' ],
 					},
 				},
+				settings: {
+					allowedBlockTypes: true,
+				},
 			};
 
-			expect( getSupportedBlocks( state, 'block1', true ) ).toEqual( [ 'core/block1' ] );
+			expect( getSupportedBlocks( state, 'block1' ) ).toEqual( [ 'core/block1' ] );
 		} );
 
 		it( 'should return the globally supported blocks if all blocks are enable inside the root block', () => {
+			const supportedNestedBlocks = [ 'core/block1' ];
 			const state = {
 				blockListSettings: {
 					block1: {
 						supportedBlocks: true,
 					},
 				},
+				settings: {
+					allowedBlockTypes: supportedNestedBlocks,
+				},
 			};
 
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
+			expect( getSupportedBlocks( state, 'block1' ) ).toEqual( supportedNestedBlocks );
 		} );
 
 		it( 'should return the globally supported blocks if the root block does not sets the supported blocks', () => {
+			const supportedNestedBlocks = [ 'core/block1' ];
 			const state = {
 				blockListSettings: {
 					block1: {
 						chicken: 'ribs',
 					},
 				},
+				settings: {
+					allowedBlockTypes: supportedNestedBlocks,
+				},
 			};
 
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
+			expect( getSupportedBlocks( state, 'block1' ) ).toEqual( supportedNestedBlocks );
 		} );
 
 		it( 'should return the globally supported blocks if there are no settings for the root block', () => {
+			const supportedNestedBlocks = [ 'core/block1' ];
 			const state = {
 				blockListSettings: {
 					block1: {
 						supportedBlocks: true,
 					},
 				},
+				settings: {
+					allowedBlockTypes: supportedNestedBlocks,
+				},
 			};
 
-			expect( getSupportedBlocks( state, 'block2', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
+			expect( getSupportedBlocks( state, 'block2' ) ).toEqual( supportedNestedBlocks );
 		} );
 
 		it( 'should return false if all blocks are disabled inside the root block ', () => {
@@ -3379,9 +3412,10 @@ describe( 'selectors', () => {
 						supportedBlocks: false,
 					},
 				},
+				settings: {},
 			};
 
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toBe( false );
+			expect( getSupportedBlocks( state, 'block1' ) ).toBe( false );
 		} );
 
 		it( 'should return the intersection of globally supported blocks with the supported blocks of the root block if both sets are defined', () => {
@@ -3391,9 +3425,12 @@ describe( 'selectors', () => {
 						supportedBlocks: [ 'core/block1', 'core/block2', 'core/block3' ],
 					},
 				},
+				settings: {
+					allowedBlockTypes: [ 'core/block2', 'core/block4', 'core/block5' ],
+				},
 			};
 
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block2', 'core/block4', 'core/block5' ] ) ).toEqual(
+			expect( getSupportedBlocks( state, 'block1' ) ).toEqual(
 				[ 'core/block2' ]
 			);
 		} );


### PR DESCRIPTION
Remove globallyEnabledBlockTypes parameter from getSupportedBlocks selector;
Add cache to getSupportedBlocks;
Make getSupportedBlocks take into consideration templateLock.

These changes make the usage of getSupportedBlocks easier. With a single call to getSupportedBlocks we can know which blocks can be inserted. All the logic is now inside the selector.
 This simplification is now possible because we moved the editor settings to the editor store.

## How has this been tested?
No noticeable changes are expected.
Try to use the allowed block types filter:
```
add_filter( 'allowed_block_types', function( $allowed_block_types, $post ) {
	if ( $post->post_type === 'post' ) {
		return [ 'core/button' ];
	}
	return $allowed_block_types;
}, 10, 2 );
```
And verify things still work as expected.
Change the columns block to:
```
					<InnerBlocks
						layouts={ getColumnLayouts( columns ) }
						allowedBlocks={ [ 'core/button', 'core/paragraph' ] }
					/>
```

Verify the inserter still works as expected.

