### PR TITLE
replace docs code example

### DIFF
--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -13,7 +13,7 @@ One challenge of maintaining the representation of a block as a JavaScript objec
 ```js
 var el = wp.element.createElement,
 	registerBlockType = wp.blocks.registerBlockType,
-	RichText = wp.editor.RichText;
+	RichText = wp.blocks.RichText;
 
 registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 	title: 'Hello World (Step 3)',
@@ -60,8 +60,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 ```
 {% ESNext %}
 ```js
-const { registerBlockType } = wp.blocks;
-const { RichText } = wp.editor;
+const { registerBlockType, RichText } = wp.blocks;
 
 registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 	title: 'Hello World (Step 3)',


### PR DESCRIPTION
The PR is patch for the issue
 -> `const { RichText } = wp.editor;` does not works #6745

## Description
Fix docs example code.

## How has this been tested?
1. copy and paste the example code
2. build the code by webpack
3. check your gutenberg editor


## Types of changes
Bug fix (non-breaking change which fixes an issue) for gutenberg handbook.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
