### PR TITLE
Add support for Child Blocks

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -264,6 +264,19 @@ A once-only block can be inserted into each post, one time only. For example, th
 useOnce: true,
 ```
 
+#### parent (optional)
+
+* **Type:** `Array`
+
+Blocks can be inserted into other blocks as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
+
+Setting `parent` lets a block require that it is only available when nested within the specified blocks.
+
+```js
+// Only allow this block when it is nested in a Columns block
+parent: [ 'core/columns' ],
+```
+
 #### supports (optional)
 
 * **Type:** `Object`

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -13,6 +13,9 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - All DOM utils in `wp.utils.*` are removed. Please use `wp.dom.*` instead.
  - `isPrivate: true` has been removed from the Block API. Please use `supports.inserter: false` instead.
  - `wp.utils.isExtraSmall` function removed. Please use `wp.viewport.isExtraSmall` instead.
+- `getInserterItems`: The `allowedBlockTypes` argument was removed and the `parentUID` argument was added.
+- `getFrecentInserterItems` selector removed. Please use `getInserterItems` instead.
+- `getSupportedBlocks` selector removed. Please use `canInsertBlockType` instead.
 
 ## 3.0.0
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -5,6 +5,9 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.data.withRehydratation` has been renamed to `wp.data.withRehydration`.
  - The `wp.editor.ImagePlaceholder` component is removed. Please use `wp.editor.MediaPlaceholder` instead.
  - `wp.utils.deprecated` function removed. Please use `wp.deprecated` instead.
+- `getInserterItems`: the `allowedBlockTypes` argument was removed and the `parentUID` argument was added.
+- `getFrecentInserterItems` selector removed. Please use `getInserterItems` instead.
+- `getSupportedBlocks` selector removed. Please use `canInsertBlockType` instead.
 
 ## 3.1.0
 
@@ -13,9 +16,6 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - All DOM utils in `wp.utils.*` are removed. Please use `wp.dom.*` instead.
  - `isPrivate: true` has been removed from the Block API. Please use `supports.inserter: false` instead.
  - `wp.utils.isExtraSmall` function removed. Please use `wp.viewport.isExtraSmall` instead.
-- `getInserterItems`: The `allowedBlockTypes` argument was removed and the `parentUID` argument was added.
-- `getFrecentInserterItems` selector removed. Please use `getInserterItems` instead.
-- `getSupportedBlocks` selector removed. Please use `canInsertBlockType` instead.
 
 ## 3.0.0
 

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -46,11 +46,10 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 
 export default compose(
 	withSelect( ( select, { rootUID } ) => {
-		const { getEditorSettings, getFrecentInserterItems, getSupportedBlocks } = select( 'core/editor' );
-		const { templateLock, allowedBlockTypes } = getEditorSettings();
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
+		const { getEditorSettings, getInserterItems } = select( 'core/editor' );
+		const { templateLock } = getEditorSettings();
 		return {
-			items: getFrecentInserterItems( supportedBlocks, 4 ),
+			items: getInserterItems( rootUID ),
 			isLocked: !! templateLock,
 		};
 	} ),

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -41,15 +36,15 @@ class Inserter extends Component {
 
 	render() {
 		const {
+			items,
 			position,
 			title,
 			children,
 			onInsertBlock,
-			hasSupportedBlocks,
 			isLocked,
 		} = this.props;
 
-		if ( ! hasSupportedBlocks || isLocked ) {
+		if ( items.length === 0 || isLocked ) {
 			return null;
 		}
 
@@ -80,7 +75,7 @@ class Inserter extends Component {
 						onClose();
 					};
 
-					return <InserterMenu onSelect={ onSelect } />;
+					return <InserterMenu items={ items } onSelect={ onSelect } />;
 				} }
 			/>
 		);
@@ -93,18 +88,17 @@ export default compose( [
 			getEditedPostAttribute,
 			getBlockInsertionPoint,
 			getSelectedBlock,
-			getSupportedBlocks,
 			getEditorSettings,
+			getInserterItems,
 		} = select( 'core/editor' );
-		const { allowedBlockTypes, templateLock } = getEditorSettings();
+		const { templateLock } = getEditorSettings();
 		const insertionPoint = getBlockInsertionPoint();
 		const { rootUID } = insertionPoint;
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			insertionPoint,
 			selectedBlock: getSelectedBlock(),
-			hasSupportedBlocks: true === supportedBlocks || ! isEmpty( supportedBlocks ),
+			items: getInserterItems( rootUID ),
 			isLocked: !! templateLock,
 		};
 	} ),

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -41,10 +41,9 @@ class Inserter extends Component {
 			title,
 			children,
 			onInsertBlock,
-			isLocked,
 		} = this.props;
 
-		if ( items.length === 0 || isLocked ) {
+		if ( items.length === 0 ) {
 			return null;
 		}
 
@@ -88,10 +87,8 @@ export default compose( [
 			getEditedPostAttribute,
 			getBlockInsertionPoint,
 			getSelectedBlock,
-			getEditorSettings,
 			getInserterItems,
 		} = select( 'core/editor' );
-		const { templateLock } = getEditorSettings();
 		const insertionPoint = getBlockInsertionPoint();
 		const { rootUID } = insertionPoint;
 		return {
@@ -99,7 +96,6 @@ export default compose( [
 			insertionPoint,
 			selectedBlock: getSelectedBlock(),
 			items: getInserterItems( rootUID ),
-			isLocked: !! templateLock,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -24,7 +24,7 @@ import {
 	PanelBody,
 } from '@wordpress/components';
 import { getCategories, isSharedBlock } from '@wordpress/blocks';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -32,6 +32,8 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import './style.scss';
 import BlockPreview from '../block-preview';
 import ItemList from './item-list';
+
+const MAX_SUGGESTED_ITEMS = 9;
 
 /**
  * Filters an item list given a search term.
@@ -56,9 +58,10 @@ export class InserterMenu extends Component {
 		this.state = {
 			filterValue: '',
 			hoveredItem: null,
+			suggestedItems: [],
 			sharedItems: [],
 			itemsPerCategory: {},
-			openPanels: [ 'frecent' ],
+			openPanels: [ 'suggested' ],
 		};
 		this.onChangeSearchInput = this.onChangeSearchInput.bind( this );
 		this.onHover = this.onHover.bind( this );
@@ -107,7 +110,15 @@ export class InserterMenu extends Component {
 	filter( filterValue = '' ) {
 		const { items } = this.props;
 		const filteredItems = searchItems( items, filterValue );
+
+		let suggestedItems = [];
+		if ( ! filterValue ) {
+			const maxSuggestedItems = this.props.maxSuggestedItems || MAX_SUGGESTED_ITEMS;
+			suggestedItems = filter( items, ( item ) => item.utility > 0 ).slice( 0, maxSuggestedItems );
+		}
+
 		const sharedItems = filter( filteredItems, { category: 'shared' } );
+
 		const getCategoryIndex = ( item ) => {
 			return findIndex( getCategories(), ( category ) => category.slug === item.category );
 		};
@@ -116,10 +127,11 @@ export class InserterMenu extends Component {
 			( itemList ) => sortBy( itemList, getCategoryIndex ),
 			( itemList ) => groupBy( itemList, 'category' )
 		)( filteredItems );
+
 		let openPanels = this.state.openPanels;
 		if ( filterValue !== this.state.filterValue ) {
 			if ( ! filterValue ) {
-				openPanels = [ 'frecent' ];
+				openPanels = [ 'suggested' ];
 			} else if ( sharedItems.length ) {
 				openPanels = [ 'shared' ];
 			} else if ( filteredItems.length ) {
@@ -131,6 +143,7 @@ export class InserterMenu extends Component {
 		this.setState( {
 			hoveredItem: null,
 			filterValue,
+			suggestedItems,
 			sharedItems,
 			itemsPerCategory,
 			openPanels,
@@ -138,9 +151,8 @@ export class InserterMenu extends Component {
 	}
 
 	render() {
-		const { instanceId, frecentItems, onSelect } = this.props;
-		const { hoveredItem, filterValue, sharedItems, itemsPerCategory, openPanels } = this.state;
-		const isSearching = !! filterValue;
+		const { instanceId, onSelect } = this.props;
+		const { hoveredItem, suggestedItems, sharedItems, itemsPerCategory, openPanels } = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
 
 		// Disable reason: The inserter menu is a modal display, not one which
@@ -163,13 +175,13 @@ export class InserterMenu extends Component {
 				/>
 
 				<div className="editor-inserter__results">
-					{ ! isSearching &&
+					{ !! suggestedItems.length &&
 						<PanelBody
 							title={ __( 'Most Used' ) }
-							opened={ isPanelOpen( 'frecent' ) }
-							onToggle={ this.onTogglePanel( 'frecent' ) }
+							opened={ isPanelOpen( 'suggested' ) }
+							onToggle={ this.onTogglePanel( 'suggested' ) }
 						>
-							<ItemList items={ frecentItems } onSelect={ onSelect } onHover={ this.onHover } />
+							<ItemList items={ suggestedItems } onSelect={ onSelect } onHover={ this.onHover } />
 						</PanelBody>
 					}
 
@@ -211,22 +223,6 @@ export class InserterMenu extends Component {
 }
 
 export default compose(
-	withSelect( ( select ) => {
-		const {
-			getBlockInsertionPoint,
-			getInserterItems,
-			getFrecentInserterItems,
-			getSupportedBlocks,
-			getEditorSettings,
-		} = select( 'core/editor' );
-		const { allowedBlockTypes } = getEditorSettings();
-		const { rootUID } = getBlockInsertionPoint();
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
-		return {
-			items: getInserterItems( supportedBlocks ),
-			frecentItems: getFrecentInserterItems( supportedBlocks ),
-		};
-	} ),
 	withDispatch( ( dispatch ) => ( {
 		fetchSharedBlocks: dispatch( 'core/editor' ).fetchSharedBlocks,
 	} ) ),

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -16,6 +16,7 @@ const textItem = {
 	title: 'Text',
 	category: 'common',
 	isDisabled: false,
+	utility: 1,
 };
 
 const advancedTextItem = {
@@ -25,6 +26,7 @@ const advancedTextItem = {
 	title: 'Advanced Text',
 	category: 'common',
 	isDisabled: false,
+	utility: 1,
 };
 
 const someOtherItem = {
@@ -34,6 +36,7 @@ const someOtherItem = {
 	title: 'Some Other Block',
 	category: 'common',
 	isDisabled: false,
+	utility: 1,
 };
 
 const moreItem = {
@@ -43,6 +46,7 @@ const moreItem = {
 	title: 'More',
 	category: 'layout',
 	isDisabled: true,
+	utility: 0,
 };
 
 const youtubeItem = {
@@ -53,6 +57,7 @@ const youtubeItem = {
 	category: 'embed',
 	keywords: [ 'google' ],
 	isDisabled: false,
+	utility: 0,
 };
 
 const textEmbedItem = {
@@ -62,6 +67,7 @@ const textEmbedItem = {
 	title: 'A Text Embed',
 	category: 'embed',
 	isDisabled: false,
+	utility: 0,
 };
 
 const sharedItem = {
@@ -71,6 +77,7 @@ const sharedItem = {
 	title: 'My shared block',
 	category: 'shared',
 	isDisabled: false,
+	utility: 0,
 };
 
 const items = [
@@ -93,19 +100,14 @@ describe( 'InserterMenu', () => {
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				items={ [] }
-				frecentItems={ [] }
+				items={ items }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
-				blockTypes
 			/>
 		);
 
 		const activeCategory = wrapper.find( '.components-panel__body.is-opened > .components-panel__body-title' );
 		expect( activeCategory.text() ).toBe( 'Most Used' );
-
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
-		expect( visibleBlocks ).toHaveLength( 0 );
 	} );
 
 	it( 'should show nothing if there are no items', () => {
@@ -114,7 +116,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ [] }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -124,13 +125,12 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 0 );
 	} );
 
-	it( 'should show frecently used items in the suggested tab', () => {
+	it( 'should show only high utility items in the suggested tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [ advancedTextItem, textItem, someOtherItem ] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -138,9 +138,25 @@ describe( 'InserterMenu', () => {
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
 		expect( visibleBlocks ).toHaveLength( 3 );
-		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Advanced Text' );
-		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Text' );
+		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
+		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );
 		expect( visibleBlocks.at( 2 ).text() ).toBe( 'Some Other Block' );
+	} );
+
+	it( 'should limit the number of items shown in the suggested tab', () => {
+		const wrapper = mount(
+			<InserterMenu
+				position={ 'top center' }
+				instanceId={ 1 }
+				items={ items }
+				debouncedSpeak={ noop }
+				fetchSharedBlocks={ noop }
+				maxSuggestedItems={ 2 }
+			/>
+		);
+
+		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		expect( visibleBlocks ).toHaveLength( 2 );
 	} );
 
 	it( 'should show items from the embed category in the embed tab', () => {
@@ -149,7 +165,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -176,7 +191,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -202,7 +216,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -230,11 +243,14 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ items }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
 		);
+
+		const layoutTab = wrapper.find( '.components-panel__body button.components-panel__body-toggle' )
+			.filterWhere( ( node ) => node.text() === 'Layout Elements' );
+		layoutTab.simulate( 'click' );
 
 		const disabledBlocks = wrapper.find( '.editor-inserter__item[disabled=true]' );
 		expect( disabledBlocks ).toHaveLength( 1 );
@@ -247,7 +263,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>
@@ -274,7 +289,6 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				items={ items }
-				frecentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchSharedBlocks={ noop }
 			/>

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -36,6 +36,9 @@ export const INSERTER_UTILITY_HIGH = 3;
 export const INSERTER_UTILITY_MEDIUM = 2;
 export const INSERTER_UTILITY_LOW = 1;
 export const INSERTER_UTILITY_NONE = 0;
+const SECONDS_PER_HOUR = 3600;
+const SECONDS_PER_DAY = 24 * 3600;
+const SECONDS_PER_WEEK = 7 * 24 * 3600;
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -1356,11 +1359,11 @@ export const getInserterItems = createSelector(
 
 			const duration = Date.now() - time;
 			switch ( true ) {
-				case duration < 3600:
+				case duration < SECONDS_PER_HOUR:
 					return count * 4;
-				case duration < ( 24 * 3600 ):
+				case duration < SECONDS_PER_DAY:
 					return count * 2;
-				case duration < ( 7 * 24 * 3600 ):
+				case duration < SECONDS_PER_WEEK:
 					return count / 2;
 				default:
 					return count / 4;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -32,6 +32,10 @@ import { deprecated } from '@wordpress/utils';
 const MAX_RECENT_BLOCKS = 9;
 export const POST_UPDATE_TRANSACTION_ID = 'post-update';
 const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
+export const INSERTER_UTILITY_HIGH = 3;
+export const INSERTER_UTILITY_MEDIUM = 2;
+export const INSERTER_UTILITY_LOW = 1;
+export const INSERTER_UTILITY_NONE = 0;
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -1336,13 +1340,13 @@ export const getInserterItems = createSelector(
 
 		const calculateUtility = ( category, count, isContextual ) => {
 			if ( isContextual ) {
-				return 3;
+				return INSERTER_UTILITY_HIGH;
 			} else if ( count > 0 ) {
-				return 2;
+				return INSERTER_UTILITY_MEDIUM;
 			} else if ( category === 'common' ) {
-				return 1;
+				return INSERTER_UTILITY_LOW;
 			}
-			return 0;
+			return INSERTER_UTILITY_NONE;
 		};
 
 		const calculateFrecency = ( time, count ) => {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1274,12 +1274,12 @@ export const canInsertBlockType = createSelector(
  * @param {Object} state Global application state.
  * @param {string} id    A string which identifies the insert, e.g. 'core/block/12'
  *
- * @return {{ time: ?number, count: number }} An object containing `time` which is when the last
+ * @return {?{ time: number, count: number }} An object containing `time` which is when the last
  *                                            insert occured as a UNIX epoch, and `count` which is
  *                                            the number of inserts that have occurred.
  */
 function getInsertUsage( state, id ) {
-	return state.preferences.insertUsage[ id ] || { time: undefined, count: 0 };
+	return state.preferences.insertUsage[ id ] || null;
 }
 
 /**
@@ -1384,7 +1384,7 @@ export const getInserterItems = createSelector(
 			}
 
 			const isContextual = isArray( blockType.parent );
-			const { time, count } = getInsertUsage( state, id );
+			const { time, count = 0 } = getInsertUsage( state, id ) || {};
 
 			return {
 				id,
@@ -1428,7 +1428,7 @@ export const getInserterItems = createSelector(
 			const referencedBlock = getBlock( state, sharedBlock.uid );
 			const referencedBlockType = getBlockType( referencedBlock.name );
 
-			const { time, count } = getInsertUsage( state, id );
+			const { time, count = 0 } = getInsertUsage( state, id ) || {};
 			const utility = calculateUtility( 'shared', count, false );
 			const frecency = calculateFrecency( time, count );
 

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -2,20 +2,19 @@
  * External dependencies
  */
 import {
-	map,
+	castArray,
+	find,
 	first,
 	get,
 	has,
-	intersection,
+	includes,
+	isArray,
+	isBoolean,
 	last,
+	map,
+	orderBy,
 	reduce,
 	size,
-	compact,
-	find,
-	unionWith,
-	includes,
-	values,
-	castArray,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -25,6 +24,7 @@ import createSelector from 'rememo';
 import { serialize, getBlockType, getBlockTypes, hasBlockSupport } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { moment } from '@wordpress/date';
+import { deprecated } from '@wordpress/utils';
 
 /***
  * Module constants
@@ -1196,8 +1196,116 @@ export function getNotices( state ) {
 }
 
 /**
- * An item that appears in the inserter. Inserting this item will create a new
- * block. Inserter items encapsulate both regular blocks and shared blocks.
+ * Determines if the given block type is allowed to be inserted, and, if
+ * parentUID is provided, whether it is allowed to be nested within the given
+ * parent.
+ *
+ * @param {Object} state      Global application state.
+ * @param {string} blockName  The name of the given block type, e.g. 'core/paragraph'.
+ * @param {?string} parentUID The parent that the given block is to be nested within, or null.
+ *
+ * @return {boolean} Whether or not the given block type is allowed to be inserted.
+ */
+export const canInsertBlockType = createSelector(
+	( state, blockName, parentUID = null ) => {
+		const checkAllowList = ( list, item, defaultResult = null ) => {
+			if ( isBoolean( list ) ) {
+				return list;
+			}
+			if ( isArray( list ) ) {
+				return includes( list, item );
+			}
+			return defaultResult;
+		};
+
+		const blockType = getBlockType( blockName );
+		if ( ! blockType ) {
+			return false;
+		}
+
+		const { allowedBlockTypes, templateLock } = getEditorSettings( state );
+
+		const isBlockAllowedInEditor = checkAllowList( allowedBlockTypes, blockName, true );
+		if ( ! isBlockAllowedInEditor ) {
+			return false;
+		}
+
+		const isEditorLocked = !! templateLock;
+		if ( isEditorLocked ) {
+			return false;
+		}
+
+		const parentBlockListSettings = getBlockListSettings( state, parentUID );
+		const parentAllowedBlocks = get( parentBlockListSettings, [ 'supportedBlocks' ] );
+		const hasParentAllowedBlock = checkAllowList( parentAllowedBlocks, blockName );
+
+		const blockAllowedParentBlocks = blockType.parent;
+		const parentName = getBlockName( state, parentUID );
+		const hasBlockAllowedParent = checkAllowList( blockAllowedParentBlocks, parentName );
+
+		let isBlockAllowedInParent;
+		if ( hasParentAllowedBlock !== null && hasBlockAllowedParent !== null ) {
+			isBlockAllowedInParent = hasParentAllowedBlock || hasBlockAllowedParent;
+		} else if ( hasParentAllowedBlock !== null ) {
+			isBlockAllowedInParent = hasParentAllowedBlock;
+		} else if ( hasBlockAllowedParent !== null ) {
+			isBlockAllowedInParent = hasBlockAllowedParent;
+		} else {
+			isBlockAllowedInParent = true;
+		}
+
+		if ( ! isBlockAllowedInParent ) {
+			return false;
+		}
+
+		return true;
+	},
+	( state, blockName, parentUID ) => [
+		state.blockListSettings[ parentUID ],
+		state.editor.present.blocksByUID[ parentUID ],
+		state.settings.allowedBlockTypes,
+		state.settings.templateLock,
+	],
+);
+
+/**
+ * Returns information about how recently and frequently a block has been inserted.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} id    A string which identifies the insert, e.g. 'core/block/12'
+ *
+ * @return {{ time: ?number, count: number }} An object containing `time` which is when the last
+ *                                            insert occured as a UNIX epoch, and `count` which is
+ *                                            the number of inserts that have occurred.
+ */
+function getInsertUsage( state, id ) {
+	return state.preferences.insertUsage[ id ] || { time: undefined, count: 0 };
+}
+
+/**
+ * Determines the items that appear in the the inserter. Includes both static
+ * items (e.g. a regular block type) and dynamic items (e.g. a shared block).
+ *
+ * Each item object contains what's necessary to display a button in the
+ * inserter and handle its selection.
+ *
+ * The 'utility' property indicates how useful we think an item will be to the
+ * user. There are 4 levels of utility:
+ *
+ * 1. Blocks that are contextually useful (utility = 3)
+ * 2. Blocks that have been previously inserted (utility = 2)
+ * 3. Blocks that are in the common category (utility = 1)
+ * 4. All other blocks (utility = 0)
+ *
+ * The 'frecency' property is a herustic (https://en.wikipedia.org/wiki/Frecency)
+ * that combines block usage frequenty and recency.
+ *
+ * Items are returned ordered descendingly by their 'utility' and 'frecency'.
+ *
+ * @param {Object} state     Global application state.
+ * @param {?string} parentUID The block we are inserting into, if any.
+ *
+ * @return {Editor.InserterItem[]} Items that appear in inserter.
  *
  * @typedef {Object} Editor.InserterItem
  * @property {string}   id                Unique identifier for the item.
@@ -1207,141 +1315,161 @@ export function getNotices( state ) {
  * @property {string}   icon              Dashicon for the item, as it appears in the inserter.
  * @property {string}   category          Block category that the item is associated with.
  * @property {string[]} keywords          Keywords that can be searched to find this item.
- * @property {boolean}  isDisabled        Whether or not the user should be prevented from inserting this item.
+ * @property {boolean}  isDisabled        Whether or not the user should be prevented from inserting
+ *                                        this item.
+ * @property {number}   utility           How useful we think this item is, between 0 and 3.
+ * @property {number}   frecency          Hueristic that combines recency and frecency.
  */
-
-/**
- * Given a regular block type, constructs an item that appears in the inserter.
- *
- * @param {Object}           state             Global application state.
- * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
- * @param {Object}           blockType         Block type, likely from getBlockType().
- *
- * @return {Editor.InserterItem} Item that appears in inserter.
- */
-function buildInserterItemFromBlockType( state, allowedBlockTypes, blockType ) {
-	if ( ! allowedBlockTypes || ! blockType ) {
-		return null;
-	}
-
-	const blockTypeIsDisabled = Array.isArray( allowedBlockTypes ) && ! includes( allowedBlockTypes, blockType.name );
-	if ( blockTypeIsDisabled ) {
-		return null;
-	}
-
-	if ( ! hasBlockSupport( blockType, 'inserter', true ) ) {
-		return null;
-	}
-
-	return {
-		id: blockType.name,
-		name: blockType.name,
-		initialAttributes: {},
-		title: blockType.title,
-		icon: blockType.icon,
-		category: blockType.category,
-		keywords: blockType.keywords,
-		isDisabled: !! blockType.useOnce && getBlocks( state ).some( ( block ) => block.name === blockType.name ),
-	};
-}
-
-/**
- * Given a shared block, constructs an item that appears in the inserter.
- *
- * @param {Object}           state             Global application state.
- * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
- * @param {Object}           sharedBlock       Shared block, likely from getSharedBlock().
- *
- * @return {Editor.InserterItem} Item that appears in inserter.
- */
-function buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock ) {
-	if ( ! allowedBlockTypes || ! sharedBlock ) {
-		return null;
-	}
-
-	const blockTypeIsDisabled = Array.isArray( allowedBlockTypes ) && ! includes( allowedBlockTypes, 'core/block' );
-	if ( blockTypeIsDisabled ) {
-		return null;
-	}
-
-	const referencedBlock = getBlock( state, sharedBlock.uid );
-	if ( ! referencedBlock ) {
-		return null;
-	}
-
-	const referencedBlockType = getBlockType( referencedBlock.name );
-	if ( ! referencedBlockType ) {
-		return null;
-	}
-
-	return {
-		id: `core/block/${ sharedBlock.id }`,
-		name: 'core/block',
-		initialAttributes: { ref: sharedBlock.id },
-		title: sharedBlock.title,
-		icon: referencedBlockType.icon,
-		category: 'shared',
-		keywords: [],
-		isDisabled: false,
-	};
-}
-
-/**
- * Determines the items that appear in the the inserter. Includes both static
- * items (e.g. a regular block type) and dynamic items (e.g. a shared block).
- *
- * @param {Object}           state             Global application state.
- * @param {string[]|boolean} allowedBlockTypes Allowed block types, or true/false to enable/disable all types.
- *
- * @return {Editor.InserterItem[]} Items that appear in inserter.
- */
-export function getInserterItems( state, allowedBlockTypes ) {
-	if ( ! allowedBlockTypes ) {
-		return [];
-	}
-
-	const staticItems = getBlockTypes().map( ( blockType ) =>
-		buildInserterItemFromBlockType( state, allowedBlockTypes, blockType )
-	);
-
-	const dynamicItems = getSharedBlocks( state ).map( ( sharedBlock ) =>
-		buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock )
-	);
-
-	const items = [ ...staticItems, ...dynamicItems ];
-	return compact( items );
-}
-
-function fillWithCommonBlocks( inserts ) {
-	// Filter out any inserts that are associated with a block type that isn't registered
-	const items = inserts.filter( ( insert ) => getBlockType( insert.name ) );
-
-	// Common blocks that we'll use to pad out our list
-	const commonInserts = getBlockTypes()
-		.filter( ( blockType ) => blockType.category === 'common' )
-		.map( ( blockType ) => ( { name: blockType.name } ) );
-
-	const areInsertsEqual = ( a, b ) => a.name === b.name && a.ref === b.ref;
-	return unionWith( items, commonInserts, areInsertsEqual );
-}
-
-function getItemsFromInserts( state, inserts, allowedBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
-	if ( ! allowedBlockTypes ) {
-		return [];
-	}
-
-	const items = fillWithCommonBlocks( inserts ).map( ( insert ) => {
-		if ( insert.ref ) {
-			const sharedBlock = getSharedBlock( state, insert.ref );
-			return buildInserterItemFromSharedBlock( state, allowedBlockTypes, sharedBlock );
+export const getInserterItems = createSelector(
+	( state, parentUID = null ) => {
+		/**
+		 * The second argument used to be {boolean|array} allowedBlockTypes but it is no
+		 * longer necessary.
+		 */
+		if ( isBoolean( parentUID ) || isArray( parentUID ) ) {
+			deprecated( 'allowedBlockTypes', {
+				version: '3.1',
+				plugin: 'Gutenberg',
+			} );
+			parentUID = null;
 		}
 
-		const blockType = getBlockType( insert.name );
-		return buildInserterItemFromBlockType( state, allowedBlockTypes, blockType );
-	} );
+		const calculateUtility = ( category, count, isContextual ) => {
+			if ( isContextual ) {
+				return 3;
+			} else if ( count > 0 ) {
+				return 2;
+			} else if ( category === 'common' ) {
+				return 1;
+			}
+			return 0;
+		};
 
-	return compact( items ).slice( 0, maximum );
-}
+		const calculateFrecency = ( time, count ) => {
+			if ( ! time ) {
+				return count;
+			}
+
+			const duration = Date.now() - time;
+			switch ( true ) {
+				case duration < 3600:
+					return count * 4;
+				case duration < ( 24 * 3600 ):
+					return count * 2;
+				case duration < ( 7 * 24 * 3600 ):
+					return count / 2;
+				default:
+					return count / 4;
+			}
+		};
+
+		const shouldIncludeBlockType = ( blockType ) => {
+			if ( ! hasBlockSupport( blockType, 'inserter', true ) ) {
+				return false;
+			}
+
+			if ( ! canInsertBlockType( state, blockType.name, parentUID ) ) {
+				return false;
+			}
+
+			return true;
+		};
+
+		const buildBlockTypeInserterItem = ( blockType ) => {
+			const id = blockType.name;
+
+			let isDisabled = false;
+			if ( blockType.useOnce ) {
+				isDisabled = getBlocks( state ).some( ( block ) => block.name === blockType.name );
+			}
+
+			const isContextual = isArray( blockType.parent );
+			const { time, count } = getInsertUsage( state, id );
+
+			return {
+				id,
+				name: blockType.name,
+				initialAttributes: {},
+				title: blockType.title,
+				icon: blockType.icon,
+				category: blockType.category,
+				keywords: blockType.keywords,
+				isDisabled,
+				utility: calculateUtility( blockType.category, count, isContextual ),
+				frecency: calculateFrecency( time, count ),
+			};
+		};
+
+		const shouldIncludeSharedBlock = ( sharedBlock ) => {
+			if ( ! canInsertBlockType( state, 'core/block', parentUID ) ) {
+				return false;
+			}
+
+			const referencedBlock = getBlock( state, sharedBlock.uid );
+			if ( ! referencedBlock ) {
+				return false;
+			}
+
+			const referencedBlockType = getBlockType( referencedBlock.name );
+			if ( ! referencedBlockType ) {
+				return false;
+			}
+
+			if ( ! canInsertBlockType( state, referencedBlockType.name, parentUID ) ) {
+				return false;
+			}
+
+			return true;
+		};
+
+		const buildSharedBlockInserterItem = ( sharedBlock ) => {
+			const id = `core/block/${ sharedBlock.id }`;
+
+			const referencedBlock = getBlock( state, sharedBlock.uid );
+			const referencedBlockType = getBlockType( referencedBlock.name );
+
+			const { time, count } = getInsertUsage( state, id );
+			const utility = calculateUtility( 'shared', count, false );
+			const frecency = calculateFrecency( time, count );
+
+			return {
+				id,
+				name: 'core/block',
+				initialAttributes: { ref: sharedBlock.id },
+				title: sharedBlock.title,
+				icon: referencedBlockType.icon,
+				category: 'shared',
+				keywords: [],
+				isDisabled: false,
+				utility,
+				frecency,
+			};
+		};
+
+		const blockTypeInserterItems = getBlockTypes()
+			.filter( shouldIncludeBlockType )
+			.map( buildBlockTypeInserterItem );
+
+		const sharedBlockInserterItems = getSharedBlocks( state )
+			.filter( shouldIncludeSharedBlock )
+			.map( buildSharedBlockInserterItem );
+
+		return orderBy(
+			[ ...blockTypeInserterItems, ...sharedBlockInserterItems ],
+			[ 'utility', 'frecency' ],
+			[ 'desc', 'desc' ]
+		);
+	},
+	( state, editorAllowedBlockTypes, parentUID ) => [
+		state.blockListSettings[ parentUID ],
+		state.editor.present.blockOrder,
+		state.editor.present.blocksByUID,
+		state.preferences.insertUsage,
+		state.settings.allowedBlockTypes,
+		state.settings.templateLock,
+		state.sharedBlocks.data,
+	],
+);
 
 /**
  * Returns a list of items which the user is likely to want to insert. These
@@ -1357,28 +1485,16 @@ function getItemsFromInserts( state, inserts, allowedBlockTypes, maximum = MAX_R
  * @return {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
  */
 export function getFrecentInserterItems( state, allowedBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
-	const calculateFrecency = ( time, count ) => {
-		if ( ! time ) {
-			return count;
-		}
+	deprecated( 'getFrecentInserterItems', {
+		version: '3.1',
+		alternative: 'getInserterItems',
+		plugin: 'Gutenberg',
+	} );
 
-		const duration = Date.now() - time;
-		switch ( true ) {
-			case duration < 3600:
-				return count * 4;
-			case duration < ( 24 * 3600 ):
-				return count * 2;
-			case duration < ( 7 * 24 * 3600 ):
-				return count / 2;
-			default:
-				return count / 4;
-		}
-	};
-
-	const sortedInserts = values( state.preferences.insertUsage )
-		.sort( ( a, b ) => calculateFrecency( b.time, b.count ) - calculateFrecency( a.time, a.count ) )
-		.map( ( { insert } ) => insert );
-	return getItemsFromInserts( state, sortedInserts, allowedBlockTypes, maximum );
+	const items = getInserterItems( state, allowedBlockTypes );
+	const usefulItems = items.filter( ( item ) => item.utility > 0 );
+	const sortedItems = orderBy( usefulItems, [ 'utility', 'frecency' ], [ 'desc', 'desc' ] );
+	return sortedItems.slice( 0, maximum );
 }
 
 /**
@@ -1597,24 +1713,16 @@ export function getBlockListSettings( state, uid ) {
  *
  * @return {string[]|boolean} Blocks that can be nested inside the block with the specified uid, or true/false to enable/disable all types.
  */
-export function getSupportedBlocks( state, uid, globallyEnabledBlockTypes ) {
-	if ( ! globallyEnabledBlockTypes ) {
-		return false;
-	}
+export function getSupportedBlocks( state, uid ) {
+	deprecated( 'getSupportedBlocks', {
+		version: '3.1',
+		alternative: 'canInsertBlockType',
+		plugin: 'Gutenberg',
+	} );
 
-	const supportedNestedBlocks = get( getBlockListSettings( state, uid ), [ 'supportedBlocks' ] );
-	if ( supportedNestedBlocks === true || supportedNestedBlocks === undefined ) {
-		return globallyEnabledBlockTypes;
-	}
-
-	if ( ! supportedNestedBlocks ) {
-		return false;
-	}
-
-	if ( globallyEnabledBlockTypes === true ) {
-		return supportedNestedBlocks;
-	}
-	return intersection( globallyEnabledBlockTypes, supportedNestedBlocks );
+	return getBlockTypes()
+		.filter( ( blockType ) => canInsertBlockType( state, blockType.name, uid ) )
+		.map( ( blockType ) => blockType.name );
 }
 
 /*

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1328,7 +1328,7 @@ export const getInserterItems = createSelector(
 		 */
 		if ( isBoolean( parentUID ) || isArray( parentUID ) ) {
 			deprecated( 'allowedBlockTypes', {
-				version: '3.1',
+				version: '3.2',
 				plugin: 'Gutenberg',
 			} );
 			parentUID = null;
@@ -1486,7 +1486,7 @@ export const getInserterItems = createSelector(
  */
 export function getFrecentInserterItems( state, allowedBlockTypes, maximum = MAX_RECENT_BLOCKS ) {
 	deprecated( 'getFrecentInserterItems', {
-		version: '3.1',
+		version: '3.2',
 		alternative: 'getInserterItems',
 		plugin: 'Gutenberg',
 	} );
@@ -1717,7 +1717,7 @@ export function getBlockListSettings( state, uid ) {
 // eslint-disable-next-line no-unused-vars
 export function getSupportedBlocks( state, uid, globallyEnabledBlockTypes ) {
 	deprecated( 'getSupportedBlocks', {
-		version: '3.1',
+		version: '3.2',
 		alternative: 'canInsertBlockType',
 		plugin: 'Gutenberg',
 	} );

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1318,7 +1318,7 @@ function getInsertUsage( state, id ) {
  * @property {boolean}  isDisabled        Whether or not the user should be prevented from inserting
  *                                        this item.
  * @property {number}   utility           How useful we think this item is, between 0 and 3.
- * @property {number}   frecency          Hueristic that combines recency and frecency.
+ * @property {number}   frecency          Hueristic that combines frequency and recency.
  */
 export const getInserterItems = createSelector(
 	( state, parentUID = null ) => {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1713,7 +1713,9 @@ export function getBlockListSettings( state, uid ) {
  *
  * @return {string[]|boolean} Blocks that can be nested inside the block with the specified uid, or true/false to enable/disable all types.
  */
-export function getSupportedBlocks( state, uid ) {
+// Disable reason: We have to accept `globallyEnabledBlockTypes` so as to be backwards compatible
+// eslint-disable-next-line no-unused-vars
+export function getSupportedBlocks( state, uid, globallyEnabledBlockTypes ) {
 	deprecated( 'getSupportedBlocks', {
 		version: '3.1',
 		alternative: 'canInsertBlockType',

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -89,6 +89,9 @@ const {
 	isPermalinkEditable,
 	getPermalink,
 	getPermalinkParts,
+	INSERTER_UTILITY_HIGH,
+	INSERTER_UTILITY_MEDIUM,
+	INSERTER_UTILITY_LOW,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -2918,7 +2921,7 @@ describe( 'selectors', () => {
 			expect( testBlockBItem.isDisabled ).toBe( true );
 		} );
 
-		it( 'should give common blocks a medium utility', () => {
+		it( 'should give common blocks a low utility', () => {
 			const state = {
 				editor: {
 					present: {
@@ -2939,10 +2942,10 @@ describe( 'selectors', () => {
 			};
 			const items = getInserterItems( state );
 			const testBlockBItem = items.find( ( item ) => item.id === 'core/test-block-b' );
-			expect( testBlockBItem.utility ).toBe( 1 );
+			expect( testBlockBItem.utility ).toBe( INSERTER_UTILITY_LOW );
 		} );
 
-		it( 'should give used blocks a high utility and set a frecency', () => {
+		it( 'should give used blocks a medium utility and set a frecency', () => {
 			const state = {
 				editor: {
 					present: {
@@ -2965,11 +2968,11 @@ describe( 'selectors', () => {
 			};
 			const items = getInserterItems( state );
 			const sharedBlock2Item = items.find( ( item ) => item.id === 'core/test-block-b' );
-			expect( sharedBlock2Item.utility ).toBe( 2 );
+			expect( sharedBlock2Item.utility ).toBe( INSERTER_UTILITY_MEDIUM );
 			expect( sharedBlock2Item.frecency ).toBe( 2.5 );
 		} );
 
-		it( 'should give contextual blocks the highest utility', () => {
+		it( 'should give contextual blocks a high utility', () => {
 			const state = {
 				editor: {
 					present: {
@@ -2994,7 +2997,7 @@ describe( 'selectors', () => {
 			};
 			const items = getInserterItems( state, 'block1' );
 			const testBlockCItem = items.find( ( item ) => item.id === 'core/test-block-c' );
-			expect( testBlockCItem.utility ).toBe( 3 );
+			expect( testBlockCItem.utility ).toBe( INSERTER_UTILITY_HIGH );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -1,20 +1,14 @@
 /**
  * External dependencies
  */
-import { filter, property, union } from 'lodash';
+import { filter, property } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	getBlockTypes,
-	hasBlockSupport,
-	registerBlockType,
-	unregisterBlockType,
-} from '@wordpress/blocks';
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { moment } from '@wordpress/date';
-import { registerCoreBlocks } from '@wordpress/core-blocks';
 
 /**
  * Internal dependencies
@@ -84,14 +78,13 @@ const {
 	getSharedBlocks,
 	getStateBeforeOptimisticTransaction,
 	isPublishingPost,
+	canInsertBlockType,
 	getInserterItems,
-	getFrecentInserterItems,
 	getProvisionalBlockUID,
 	isValidTemplate,
 	getTemplate,
 	getTemplateLock,
 	getBlockListSettings,
-	getSupportedBlocks,
 	POST_UPDATE_TRANSACTION_ID,
 	isPermalinkEditable,
 	getPermalink,
@@ -102,13 +95,39 @@ describe( 'selectors', () => {
 	let cachedSelectors;
 
 	beforeAll( () => {
-		registerBlockType( 'core/test-block', {
+		registerBlockType( 'core/block', {
+			save: () => null,
+			category: 'shared',
+			title: 'Shared Block Stub',
+			supports: {
+				inserter: false,
+			},
+		} );
+
+		registerBlockType( 'core/test-block-a', {
+			save: ( props ) => props.attributes.text,
+			category: 'formatting',
+			title: 'Test Block A',
+			icon: 'test',
+			keywords: [ 'testing' ],
+		} );
+
+		registerBlockType( 'core/test-block-b', {
 			save: ( props ) => props.attributes.text,
 			category: 'common',
-			title: 'test block',
+			title: 'Test Block B',
 			icon: 'test',
 			keywords: [ 'testing' ],
 			useOnce: true,
+		} );
+
+		registerBlockType( 'core/test-block-c', {
+			save: ( props ) => props.attributes.text,
+			category: 'common',
+			title: 'Test Block C',
+			icon: 'test',
+			keywords: [ 'testing' ],
+			parent: [ 'core/test-block-b' ],
 		} );
 
 		cachedSelectors = filter( selectors, property( 'clear' ) );
@@ -119,7 +138,9 @@ describe( 'selectors', () => {
 	} );
 
 	afterAll( () => {
-		unregisterBlockType( 'core/test-block' );
+		unregisterBlockType( 'core/test-block-a' );
+		unregisterBlockType( 'core/test-block-b' );
+		unregisterBlockType( 'core/test-block-c' );
 	} );
 
 	describe( 'hasEditorUndo', () => {
@@ -1463,6 +1484,8 @@ describe( 'selectors', () => {
 				},
 				innerBlocks: [],
 			} );
+
+			unregisterBlockType( 'core/meta-block' );
 		} );
 	} );
 
@@ -2616,224 +2639,335 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getInserterItems', () => {
-		it( 'should list all non-private regular block types', () => {
+	describe( 'canInsertBlockType', () => {
+		it( 'should deny blocks that are not registered', () => {
 			const state = {
 				editor: {
 					present: {
 						blocksByUID: {},
-						blockOrder: {},
-						edits: {},
 					},
 				},
-				currentPost: {},
-				sharedBlocks: {
-					data: {},
-				},
+				blockListSettings: {},
+				settings: {},
 			};
-
-			const blockTypes = getBlockTypes().filter( ( blockType ) =>
-				hasBlockSupport( blockType, 'inserter', true )
-			);
-			expect( getInserterItems( state, true ) ).toHaveLength( blockTypes.length );
+			expect( canInsertBlockType( state, 'core/invalid' ) ).toBe( false );
 		} );
 
-		it( 'should properly list a regular block type', () => {
+		it( 'should deny blocks that are not allowed by the editor', () => {
 			const state = {
 				editor: {
 					present: {
 						blocksByUID: {},
+					},
+				},
+				blockListSettings: {},
+				settings: {
+					allowedBlockTypes: [],
+				},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe( false );
+		} );
+
+		it( 'should allow blocks that are allowed by the editor', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {},
+					},
+				},
+				blockListSettings: {},
+				settings: {
+					allowedBlockTypes: [ 'core/test-block-a' ],
+				},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe( true );
+		} );
+
+		it( 'should deny blocks when the editor has a template lock', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {},
+					},
+				},
+				blockListSettings: {},
+				settings: {
+					templateLock: 'all',
+				},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe( false );
+		} );
+
+		it( 'should deny blocks that restrict parent from being inserted into the root', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {},
+					},
+				},
+				blockListSettings: {},
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-c' ) ).toBe( false );
+		} );
+
+		it( 'should deny blocks that restrict parent from being inserted into a restricted parent', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {
+							block1: { name: 'core/test-block-a' },
+						},
+					},
+				},
+				blockListSettings: {},
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-c', 'block1' ) ).toBe( false );
+		} );
+
+		it( 'should allow blocks that restrict parent to be inserted into an allowed parent', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {
+							block1: { name: 'core/test-block-b' },
+						},
+					},
+				},
+				blockListSettings: {},
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-c', 'block1' ) ).toBe( true );
+		} );
+
+		it( 'should deny restricted blocks from being inserted into a block that restricts allowedBlocks', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {
+							block1: { name: 'core/test-block-a' },
+						},
+					},
+				},
+				blockListSettings: {
+					block1: {
+						supportedBlocks: [ 'core/test-block-c' ],
+					},
+				},
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-b', 'block1' ) ).toBe( false );
+		} );
+
+		it( 'should allow allowed blocks to be inserted into a block that restricts allowedBlocks', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {
+							block1: { name: 'core/test-block-a' },
+						},
+					},
+				},
+				blockListSettings: {
+					block1: {
+						supportedBlocks: [ 'core/test-block-b' ],
+					},
+				},
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-b', 'block1' ) ).toBe( true );
+		} );
+
+		it( 'should prioritise parent over allowedBlocks', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {
+							block1: { name: 'core/test-block-b' },
+						},
+					},
+				},
+				blockListSettings: {
+					block1: {
+						supportedBlocks: [],
+					},
+				},
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/test-block-c', 'block1' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'getInserterItems', () => {
+		it( 'should properly list block type and shared block items', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {
+							block1: { name: 'core/test-block-a' },
+						},
 						blockOrder: {},
 						edits: {},
 					},
 				},
-				currentPost: {},
 				sharedBlocks: {
-					data: {},
+					data: {
+						1: { uid: 'block1', title: 'Shared Block 1' },
+					},
 				},
+				currentPost: {},
+				preferences: {
+					insertUsage: {},
+				},
+				blockListSettings: {},
+				settings: {},
 			};
-
-			expect( getInserterItems( state, [ 'core/test-block' ] ) ).toEqual( [
+			expect( getInserterItems( state ) ).toEqual( [
 				{
-					id: 'core/test-block',
-					name: 'core/test-block',
+					id: 'core/test-block-b',
+					name: 'core/test-block-b',
 					initialAttributes: {},
-					title: 'test block',
+					title: 'Test Block B',
 					icon: 'test',
 					category: 'common',
 					keywords: [ 'testing' ],
 					isDisabled: false,
+					utility: 1,
+					frecency: 0,
 				},
-			] );
-		} );
-
-		it( 'should set isDisabled when a regular block type with useOnce has been used', () => {
-			const state = {
-				editor: {
-					present: {
-						blocksByUID: {
-							1: { uid: 1, name: 'core/test-block', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 1 ],
-						},
-						edits: {},
-					},
-				},
-				currentPost: {},
-				sharedBlocks: {
-					data: {},
-				},
-			};
-
-			const items = getInserterItems( state, [ 'core/test-block' ] );
-			expect( items[ 0 ].isDisabled ).toBe( true );
-		} );
-
-		it( 'should properly list shared blocks', () => {
-			const state = {
-				editor: {
-					present: {
-						blocksByUID: {
-							carrot: { name: 'core/test-block' },
-						},
-						blockOrder: {},
-						edits: {},
-					},
-				},
-				currentPost: {},
-				sharedBlocks: {
-					data: {
-						123: { uid: 'carrot', title: 'My shared block' },
-					},
-				},
-			};
-
-			expect( getInserterItems( state, [ 'core/block' ] ) ).toEqual( [
 				{
-					id: 'core/block/123',
+					id: 'core/test-block-a',
+					name: 'core/test-block-a',
+					initialAttributes: {},
+					title: 'Test Block A',
+					icon: 'test',
+					category: 'formatting',
+					keywords: [ 'testing' ],
+					isDisabled: false,
+					utility: 0,
+					frecency: 0,
+				},
+				{
+					id: 'core/block/1',
 					name: 'core/block',
-					initialAttributes: { ref: 123 },
-					title: 'My shared block',
+					initialAttributes: { ref: 1 },
+					title: 'Shared Block 1',
 					icon: 'test',
 					category: 'shared',
 					keywords: [],
 					isDisabled: false,
+					utility: 0,
+					frecency: 0,
 				},
 			] );
 		} );
 
-		it( 'should return nothing when all block types are disabled', () => {
-			expect( getInserterItems( {}, false ) ).toEqual( [] );
-		} );
-	} );
-
-	describe( 'getFrecentInserterItems', () => {
-		beforeAll( () => {
-			registerCoreBlocks();
-		} );
-
-		it( 'should return the most frecently used blocks', () => {
+		it( 'should set isDisabled when a block with useOnce has been used', () => {
 			const state = {
-				preferences: {
-					insertUsage: {
-						'core/deleted-block': { time: 1000, count: 10, insert: { name: 'core/deleted-block' } }, // Deleted blocks should be filtered out
-						'core/block/456': { time: 1000, count: 4, insert: { name: 'core/block', ref: 456 } }, // Deleted shared blocks should be filtered out
-						'core/image': { time: 1000, count: 3, insert: { name: 'core/image' } },
-						'core/block/123': { time: 1000, count: 5, insert: { name: 'core/block', ref: 123 } },
-						'core/paragraph': { time: 1000, count: 2, insert: { name: 'core/paragraph' } },
-					},
-				},
 				editor: {
 					present: {
 						blocksByUID: {
-							carrot: { name: 'core/test-block' },
+							block1: { name: 'core/test-block-b' },
 						},
-						blockOrder: [],
+						blockOrder: {
+							'': [ 'block1' ],
+						},
 						edits: {},
 					},
 				},
 				sharedBlocks: {
-					data: {
-						123: { uid: 'carrot' },
-					},
+					data: {},
 				},
 				currentPost: {},
+				preferences: {
+					insertUsage: {},
+				},
+				blockListSettings: {},
+				settings: {},
 			};
-
-			expect( getFrecentInserterItems( state, true, 3 ) ).toMatchObject( [
-				{ name: 'core/block', initialAttributes: { ref: 123 } },
-				{ name: 'core/image', initialAttributes: {} },
-				{ name: 'core/paragraph', initialAttributes: {} },
-			] );
+			const items = getInserterItems( state );
+			const testBlockBItem = items.find( ( item ) => item.id === 'core/test-block-b' );
+			expect( testBlockBItem.isDisabled ).toBe( true );
 		} );
 
-		it( 'should weight by time', () => {
+		it( 'should give common blocks a medium utility', () => {
 			const state = {
-				preferences: {
-					insertUsage: {
-						'core/image': { time: Date.now() - 1000, count: 2, insert: { name: 'core/image' } },
-						'core/paragraph': { time: Date.now() - 4000, count: 3, insert: { name: 'core/paragraph' } },
-					},
-				},
 				editor: {
 					present: {
-						blockOrder: [],
+						blocksByUID: {},
+						blockOrder: {},
+						edits: {},
 					},
 				},
 				sharedBlocks: {
 					data: {},
 				},
+				currentPost: {},
+				preferences: {
+					insertUsage: {},
+				},
+				blockListSettings: {},
+				settings: {},
 			};
-
-			expect( getFrecentInserterItems( state, true, 2 ) ).toMatchObject( [
-				{ name: 'core/image', initialAttributes: {} },
-				{ name: 'core/paragraph', initialAttributes: {} },
-			] );
+			const items = getInserterItems( state );
+			const testBlockBItem = items.find( ( item ) => item.id === 'core/test-block-b' );
+			expect( testBlockBItem.utility ).toBe( 1 );
 		} );
 
-		it( 'should be backwards-compatible with old preferences values', () => {
+		it( 'should give used blocks a high utility and set a frecency', () => {
 			const state = {
-				preferences: {
-					insertUsage: {
-						'core/image': { time: Date.now(), count: 1, insert: { name: 'core/image' } },
-						'core/paragraph': { time: undefined, count: 5, insert: { name: 'core/paragraph' } },
-					},
-				},
 				editor: {
 					present: {
-						blockOrder: [],
+						blocksByUID: {},
+						blockOrder: {},
+						edits: {},
 					},
 				},
 				sharedBlocks: {
 					data: {},
 				},
-			};
-
-			expect( getFrecentInserterItems( state, true, 2 ) ).toMatchObject( [
-				{ name: 'core/paragraph', initialAttributes: {} },
-				{ name: 'core/image', initialAttributes: {} },
-			] );
-		} );
-
-		it( 'should pad list out with blocks from the common category', () => {
-			const state = {
+				currentPost: {},
 				preferences: {
 					insertUsage: {
-						'core/image': { time: 1000, count: 2, insert: { name: 'core/paragraph' } },
+						'core/test-block-b': { count: 10, time: 1000 },
 					},
 				},
+				blockListSettings: {},
+				settings: {},
+			};
+			const items = getInserterItems( state );
+			const sharedBlock2Item = items.find( ( item ) => item.id === 'core/test-block-b' );
+			expect( sharedBlock2Item.utility ).toBe( 2 );
+			expect( sharedBlock2Item.frecency ).toBe( 2.5 );
+		} );
+
+		it( 'should give contextual blocks the highest utility', () => {
+			const state = {
 				editor: {
 					present: {
-						blockOrder: [],
+						blocksByUID: {
+							block1: { name: 'core/test-block-b' },
+						},
+						blockOrder: {
+							'': [ 'block1' ],
+						},
+						edits: {},
 					},
 				},
+				sharedBlocks: {
+					data: {},
+				},
+				currentPost: {},
+				preferences: {
+					insertUsage: {},
+				},
+				blockListSettings: {},
+				settings: {},
 			};
-
-			// We should get back 4 items with no duplicates
-			const items = getFrecentInserterItems( state, true, 4 );
-			const blockNames = items.map( ( item ) => item.name );
-			expect( union( blockNames ) ).toHaveLength( 4 );
+			const items = getInserterItems( state, 'block1' );
+			const testBlockCItem = items.find( ( item ) => item.id === 'core/test-block-c' );
+			expect( testBlockCItem.utility ).toBe( 3 );
 		} );
 	} );
 
@@ -3315,94 +3449,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getBlockListSettings( state, 'chicken' ) ).toBe( undefined );
-		} );
-	} );
-
-	describe( 'getSupportedBlocks', () => {
-		it( 'should return false if all blocks are disabled globally', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: [ 'core/block1' ],
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', false ) ).toBe( false );
-		} );
-
-		it( 'should return the supportedBlocks of root block if all blocks are supported globally', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: [ 'core/block1' ],
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', true ) ).toEqual( [ 'core/block1' ] );
-		} );
-
-		it( 'should return the globally supported blocks if all blocks are enable inside the root block', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: true,
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
-		} );
-
-		it( 'should return the globally supported blocks if the root block does not sets the supported blocks', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						chicken: 'ribs',
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
-		} );
-
-		it( 'should return the globally supported blocks if there are no settings for the root block', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: true,
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block2', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
-		} );
-
-		it( 'should return false if all blocks are disabled inside the root block ', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: false,
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toBe( false );
-		} );
-
-		it( 'should return the intersection of globally supported blocks with the supported blocks of the root block if both sets are defined', () => {
-			const state = {
-				blockListSettings: {
-					block1: {
-						supportedBlocks: [ 'core/block1', 'core/block2', 'core/block3' ],
-					},
-				},
-			};
-
-			expect( getSupportedBlocks( state, 'block1', [ 'core/block2', 'core/block4', 'core/block5' ] ) ).toEqual(
-				[ 'core/block2' ]
-			);
 		} );
 	} );
 } );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -138,6 +138,7 @@ describe( 'selectors', () => {
 	} );
 
 	afterAll( () => {
+		unregisterBlockType( 'core/block' );
 		unregisterBlockType( 'core/test-block-a' );
 		unregisterBlockType( 'core/test-block-b' );
 		unregisterBlockType( 'core/test-block-c' );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2824,43 +2824,69 @@ describe( 'selectors', () => {
 				blockListSettings: {},
 				settings: {},
 			};
-			expect( getInserterItems( state ) ).toEqual( [
-				{
-					id: 'core/test-block-b',
-					name: 'core/test-block-b',
-					initialAttributes: {},
-					title: 'Test Block B',
-					icon: 'test',
-					category: 'common',
-					keywords: [ 'testing' ],
-					isDisabled: false,
-					utility: 1,
-					frecency: 0,
+			const items = getInserterItems( state );
+			const testBlockAItem = items.find( ( item ) => item.id === 'core/test-block-a' );
+			expect( testBlockAItem ).toEqual( {
+				id: 'core/test-block-a',
+				name: 'core/test-block-a',
+				initialAttributes: {},
+				title: 'Test Block A',
+				icon: 'test',
+				category: 'formatting',
+				keywords: [ 'testing' ],
+				isDisabled: false,
+				utility: 0,
+				frecency: 0,
+			} );
+			const sharedBlockItem = items.find( ( item ) => item.id === 'core/block/1' );
+			expect( sharedBlockItem ).toEqual( {
+				id: 'core/block/1',
+				name: 'core/block',
+				initialAttributes: { ref: 1 },
+				title: 'Shared Block 1',
+				icon: 'test',
+				category: 'shared',
+				keywords: [],
+				isDisabled: false,
+				utility: 0,
+				frecency: 0,
+			} );
+		} );
+
+		it( 'should order items by descending utility and frecency', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {
+							block1: { name: 'core/test-block-a' },
+							block2: { name: 'core/test-block-a' },
+						},
+						blockOrder: {},
+						edits: {},
+					},
 				},
-				{
-					id: 'core/test-block-a',
-					name: 'core/test-block-a',
-					initialAttributes: {},
-					title: 'Test Block A',
-					icon: 'test',
-					category: 'formatting',
-					keywords: [ 'testing' ],
-					isDisabled: false,
-					utility: 0,
-					frecency: 0,
+				sharedBlocks: {
+					data: {
+						1: { uid: 'block1', title: 'Shared Block 1' },
+						2: { uid: 'block1', title: 'Shared Block 2' },
+					},
 				},
-				{
-					id: 'core/block/1',
-					name: 'core/block',
-					initialAttributes: { ref: 1 },
-					title: 'Shared Block 1',
-					icon: 'test',
-					category: 'shared',
-					keywords: [],
-					isDisabled: false,
-					utility: 0,
-					frecency: 0,
+				currentPost: {},
+				preferences: {
+					insertUsage: {
+						'core/block/1': { count: 10, time: 1000 },
+						'core/block/2': { count: 20, time: 1000 },
+					},
 				},
+				blockListSettings: {},
+				settings: {},
+			};
+			const itemIDs = getInserterItems( state ).map( ( item ) => item.id );
+			expect( itemIDs ).toEqual( [
+				'core/block/2',
+				'core/block/1',
+				'core/test-block-b',
+				'core/test-block-a',
 			] );
 		} );
 


### PR DESCRIPTION
## Description

Closes #5540. I split this out from https://github.com/WordPress/gutenberg/pull/6346 which was mostly experimental — head there for extra context!

Adds `parent` which lets you restrict a block so that it is only available as a nested block. 

```js
registerBlockType( 'acme/buy-button', {
	title: 'Buy Button',
	icon: 'cart',
	category: 'common',

	// Only allow in products:
	parent: [ 'acme/product' ],

	...
} );
```

## How has this been tested?
I wrote a [test plugin](https://gist.github.com/noisysocks/9b9503bd6489ffa51088d35c7a2a8ba0) which uses the new API. I then made sure that _Buy Button_ blocks only appear when inserted into a _Product_ block.

A quick way to test this is to paste the contents of [`block.js`](https://gist.github.com/noisysocks/9b9503bd6489ffa51088d35c7a2a8ba0#file-block-js) into your browser console.

## Screenshots <!-- if applicable -->

![child-blocks](https://user-images.githubusercontent.com/612155/40043490-ee6a50b6-5867-11e8-824b-1fc87a1c275d.gif)

## Types of changes

Block registration API changes:

- Introduces `parent` which lets one specify which block types a block can be nested into.

Selector changes:

- Adds `canInsertBlockType` which is the source of truth for whether a block can be inserted or nested.
- Removes the `allowedBlockTypes` argument from `getInserterItems`. This can be determined from state, now.
- Items returned by `getInserterItems` will include new `utility` and `frecency` attributes. `utility` indicates how useful we think inserting the block will be. This lets us show contextually useful blocks at the top of the Suggested tab.
- Deprecates `getSupportedBlockTypes`. `getInserterItems` will remove any blocks that are not supported. Alternatively, `canInsertBlockType` can be called directly.
- Deprecates `getFrecentInserterItems`. Instead, call `getInserterItems` and filter/sort by `frecency`.

Inserter changes:

- Both `inserter` and `inserter-with-shortcuts` have been changed to use `getInserterItems` and its new functionality.