### PR TITLE
RichText is in wp.blocks, not in wp.editor.

### DIFF
--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -13,7 +13,7 @@ One challenge of maintaining the representation of a block as a JavaScript objec
 ```js
 var el = wp.element.createElement,
 	registerBlockType = wp.blocks.registerBlockType,
-	RichText = wp.editor.RichText;
+	RichText = wp.blocks.RichText;
 
 registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 	title: 'Hello World (Step 3)',
@@ -60,8 +60,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 ```
 {% ESNext %}
 ```js
-const { registerBlockType } = wp.blocks;
-const { RichText } = wp.editor;
+const { registerBlockType, RichText } = wp.blocks;
 
 registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 	title: 'Hello World (Step 3)',


### PR DESCRIPTION
## Description
In [Introducing Attributes and Fields](https://wordpress.org/gutenberg/handbook/blocks/introducing-attributes-and-editable-fields/) document, it is said that we can get RichText component from wp.editor.

But in reality, it is in wp.blocks. 

## How has this been tested?
I've just copied and pasted the code from the document:
* jsx code to gutenberg.jsx. 
* php code to gutenberg.php. (This is a variation from the [first block document](https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/)).

```
function gutenberg_boilerplate_block() {
    wp_register_script(
        'gdp-theme-gutenberg',
        get_template_directory_uri() . '/public/js/gutenberg.min.js',
        array( 'wp-blocks', 'wp-element' )
    );

    register_block_type( 'gutenberg-boilerplate-esnext/hello-world-step-03', array(
        'editor_script' => 'gdp-theme-gutenberg',
    ) );
}
```

## Screenshots 

There is no editor field under wp. And all the blocks are under wp.blocks. 

![no-editor](https://user-images.githubusercontent.com/8130013/40043643-13c0e3dc-5860-11e8-9187-7e76755310a4.png)

## Types of changes

It is not a change of code. So, there is no new feature or breaking change. 

But it can cause a serious confusion. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
