### PR TITLE
Fix state variable name in core-data

### DIFF
--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -119,7 +119,7 @@ function entity( entityConfig ) {
 			case 'RECEIVE_ENTITY_RECORDS':
 				return {
 					byKey: {
-						...state.key,
+						...state.byKey,
 						...keyBy( action.records, key ),
 					},
 				};


### PR DESCRIPTION
## Description
There was a typo in entities reducer of core-data store.

## How has this been tested?
Checking the `state.byKey` after changing the type of the post more than once

## Types of changes
Renaming a state property (from `state.key` to `state.byKey`). 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
