### PR TITLE
Center background-position on block-cover-image

### DIFF
--- a/core-blocks/cover-image/style.scss
+++ b/core-blocks/cover-image/style.scss
@@ -1,6 +1,7 @@
 .wp-block-cover-image {
 	position: relative;
 	background-size: cover;
+	background-position: center center;
 	min-height: 430px;
 	width: 100%;
 	margin: 0 0 1.5em 0;


### PR DESCRIPTION
## Description
Added a CSS line to properly center the bg on block cover image. Fix  #6066.

## How has this been tested?
Comparing centering changes to the ones @weavertheme posted on the respective issue.

## Screenshots

Without background-position: center center;
![no-center](https://user-images.githubusercontent.com/5367401/40079563-b00991b4-585e-11e8-92ba-69106398fd16.png)

With background-position: center center;
![center](https://user-images.githubusercontent.com/5367401/40079564-b02cf050-585e-11e8-9a87-8071a30b751d.png)

## Types of changes
Add `background-position: center center;` at /core-blocks/cover-image/style.scss:4

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
