### PR TITLE
Ensure contributors can create tags and manage categories

### DIFF
--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -81,7 +81,7 @@ export function receiveEntityRecords( kind, name, records ) {
 export function receiveTaxonomies( taxonomies ) {
 	return {
 		type: 'RECEIVE_TAXONOMIES',
-		taxonomies: taxonomies,
+		taxonomies,
 	};
 }
 

--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -72,6 +72,20 @@ export function receiveEntityRecords( kind, name, records ) {
 }
 
 /**
+ * Returns an action object used in signalling that taxonomies have been received.
+ *
+ * @param {Array} taxonomies Taxonomies received.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveTaxonomies( taxonomies ) {
+	return {
+		type: 'RECEIVE_TAXONOMIES',
+		taxonomies: taxonomies,
+	};
+}
+
+/**
  * Returns an action object used in signalling that the index has been received.
  *
  * @param {Object} index Index received.

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -74,6 +74,23 @@ export function users( state = { byId: {}, queries: {} }, action ) {
 }
 
 /**
+ * Reducer managing taxonomies.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function taxonomies( state = [], action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_TAXONOMIES':
+			return action.taxonomies;
+	}
+
+	return state;
+}
+
+/**
  * Reducer managing theme supports data.
  *
  * @param {Object} state  Current state.
@@ -146,6 +163,7 @@ export const entities = combineReducers( Object.entries( entitiesByKind ).reduce
 export default combineReducers( {
 	terms,
 	users,
+	taxonomies,
 	themeSupports,
 	entities,
 } );

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -11,6 +11,7 @@ import {
 	receiveTerms,
 	receiveUserQuery,
 	receiveEntityRecords,
+	receiveTaxonomies,
 	receiveThemeSupportsFromIndex,
 } from './actions';
 import { getEntity } from './entities';
@@ -45,6 +46,15 @@ export async function* getEntityRecord( state, kind, name, key ) {
 	const entity = getEntity( kind, name );
 	const record = await apiRequest( { path: `${ entity.baseUrl }/${ key }?context=edit` } );
 	yield receiveEntityRecords( kind, name, record );
+}
+
+/**
+ * Requests taxonomies from the REST API, yielding action objects on request
+ * progress.
+ */
+export async function* getTaxonomies() {
+	const taxonomies = await apiRequest( { path: '/wp/v2/taxonomies?context=edit' } );
+	yield receiveTaxonomies( taxonomies );
 }
 
 /**

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -91,6 +91,17 @@ export function getEntityRecord( state, kind, name, key ) {
 }
 
 /**
+ * Returns all the available taxonomies.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Array} Taxonomies list.
+ */
+export function getTaxonomies( state ) {
+	return state.taxonomies;
+}
+
+/**
  * Return theme suports data in the index.
  *
  * @param {Object} state Data state.

--- a/editor/components/post-taxonomies/check.js
+++ b/editor/components/post-taxonomies/check.js
@@ -6,12 +6,11 @@ import { some, includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
 export function PostTaxonomiesCheck( { postType, taxonomies, children } ) {
-	const hasTaxonomies = some( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
+	const hasTaxonomies = some( taxonomies, ( taxonomy ) => includes( taxonomy.types, postType ) );
 	if ( ! hasTaxonomies ) {
 		return null;
 	}
@@ -23,10 +22,8 @@ export default compose( [
 	withSelect( ( select ) => {
 		return {
 			postType: select( 'core/editor' ).getCurrentPostType(),
+			taxonomies: select( 'core' ).getTaxonomies(),
 		};
 	} ),
-	withAPIData( () => ( {
-		taxonomies: '/wp/v2/taxonomies?context=edit',
-	} ) ),
 ] )( PostTaxonomiesCheck );
 

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -158,6 +158,11 @@ class FlatTermSelector extends Component {
 
 	render() {
 		const { slug, taxonomy, hasAssignAction } = this.props;
+
+		if ( ! hasAssignAction ) {
+			return null;
+		}
+
 		const { loading, availableTerms, selectedTerms } = this.state;
 		const termNames = availableTerms.map( ( term ) => term.name );
 		const newTermPlaceholderLabel = get(
@@ -173,10 +178,6 @@ class FlatTermSelector extends Component {
 		const termAddedLabel = sprintf( _x( '%s added', 'term' ), singularName );
 		const termRemovedLabel = sprintf( _x( '%s removed', 'term' ), singularName );
 		const removeTermLabel = sprintf( _x( 'Remove %s', 'term' ), singularName );
-
-		if ( ! hasAssignAction ) {
-			return null;
-		}
 
 		return (
 			<FormTokenField

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -207,7 +207,10 @@ export default compose(
 		};
 	} ),
 	withSelect( ( select, ownProps ) => {
+		const { getCurrentPost } = select( 'core/editor' );
 		return {
+			hasCreateAction: get( getCurrentPost(), [ '_links', 'wp:action-create-' + ownProps.restBase ], false ),
+			hasAssignAction: get( getCurrentPost(), [ '_links', 'wp:action-assign-' + ownProps.restBase ], false ),
 			terms: select( 'core/editor' ).getEditedPostAttribute( ownProps.restBase ),
 		};
 	} ),

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -157,7 +157,7 @@ class FlatTermSelector extends Component {
 	}
 
 	render() {
-		const { slug, taxonomy } = this.props;
+		const { slug, taxonomy, hasAssignAction } = this.props;
 		const { loading, availableTerms, selectedTerms } = this.state;
 		const termNames = availableTerms.map( ( term ) => term.name );
 		const newTermPlaceholderLabel = get(
@@ -173,6 +173,10 @@ class FlatTermSelector extends Component {
 		const termAddedLabel = sprintf( _x( '%s added', 'term' ), singularName );
 		const termRemovedLabel = sprintf( _x( '%s removed', 'term' ), singularName );
 		const removeTermLabel = sprintf( _x( 'Remove %s', 'term' ), singularName );
+
+		if ( ! hasAssignAction ) {
+			return null;
+		}
 
 		return (
 			<FormTokenField

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -306,7 +306,10 @@ export default compose( [
 		};
 	} ),
 	withSelect( ( select, ownProps ) => {
+		const { getCurrentPost } = select( 'core/editor' );
 		return {
+			hasCreateAction: get( getCurrentPost(), [ '_links', 'wp:action-create-' + ownProps.restBase ], false ),
+			hasAssignAction: get( getCurrentPost(), [ '_links', 'wp:action-assign-' + ownProps.restBase ], false ),
 			terms: select( 'core/editor' ).getEditedPostAttribute( ownProps.restBase ),
 		};
 	} ),

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -216,7 +216,7 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	render() {
-		const { slug, taxonomy, instanceId } = this.props;
+		const { slug, taxonomy, instanceId, hasCreateAction, hasAssignAction } = this.props;
 		const { availableTermsTree, availableTerms, formName, formParent, loading, showForm } = this.state;
 		const labelWithFallback = ( labelProperty, fallbackIsCategory, fallbackIsNotCategory ) => get(
 			taxonomy,
@@ -242,10 +242,14 @@ class HierarchicalTermSelector extends Component {
 		const newTermSubmitLabel = newTermButtonLabel;
 		const inputId = `editor-post-taxonomies__hierarchical-terms-input-${ instanceId }`;
 
+		if ( ! hasAssignAction ) {
+			return null;
+		}
+
 		/* eslint-disable jsx-a11y/no-onchange */
 		return [
 			...this.renderTerms( availableTermsTree ),
-			! loading && (
+			! loading && hasCreateAction && (
 				<button
 					key="term-add-button"
 					onClick={ this.onToggleForm }

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -217,6 +217,11 @@ class HierarchicalTermSelector extends Component {
 
 	render() {
 		const { slug, taxonomy, instanceId, hasCreateAction, hasAssignAction } = this.props;
+
+		if ( ! hasAssignAction ) {
+			return null;
+		}
+
 		const { availableTermsTree, availableTerms, formName, formParent, loading, showForm } = this.state;
 		const labelWithFallback = ( labelProperty, fallbackIsCategory, fallbackIsNotCategory ) => get(
 			taxonomy,
@@ -241,10 +246,6 @@ class HierarchicalTermSelector extends Component {
 		const noParentOption = `— ${ parentSelectLabel } —`;
 		const newTermSubmitLabel = newTermButtonLabel;
 		const inputId = `editor-post-taxonomies__hierarchical-terms-input-${ instanceId }`;
-
-		if ( ! hasAssignAction ) {
-			return null;
-		}
 
 		/* eslint-disable jsx-a11y/no-onchange */
 		return [

--- a/editor/components/post-taxonomies/index.js
+++ b/editor/components/post-taxonomies/index.js
@@ -6,7 +6,6 @@ import { filter, identity, includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
 import { compose, Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
@@ -18,7 +17,7 @@ import HierarchicalTermSelector from './hierarchical-term-selector';
 import FlatTermSelector from './flat-term-selector';
 
 export function PostTaxonomies( { postType, taxonomies, taxonomyWrapper = identity } ) {
-	const availableTaxonomies = filter( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
+	const availableTaxonomies = filter( taxonomies, ( taxonomy ) => includes( taxonomy.types, postType ) );
 	const visibleTaxonomies = filter( availableTaxonomies, ( taxonomy ) => taxonomy.visibility.show_ui );
 	return visibleTaxonomies.map( ( taxonomy ) => {
 		const TaxonomyComponent = taxonomy.hierarchical ? HierarchicalTermSelector : FlatTermSelector;
@@ -42,10 +41,8 @@ export default compose( [
 	withSelect( ( select ) => {
 		return {
 			postType: select( 'core/editor' ).getCurrentPostType(),
+			taxonomies: select( 'core' ).getTaxonomies(),
 		};
 	} ),
-	withAPIData( () => ( {
-		taxonomies: '/wp/v2/taxonomies?context=edit',
-	} ) ),
 ] )( PostTaxonomies );
 

--- a/editor/components/post-taxonomies/index.js
+++ b/editor/components/post-taxonomies/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { filter, get, identity, includes } from 'lodash';
+import { filter, identity, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,23 +16,18 @@ import './style.scss';
 import HierarchicalTermSelector from './hierarchical-term-selector';
 import FlatTermSelector from './flat-term-selector';
 
-export function PostTaxonomies( { post, postType, taxonomies, taxonomyWrapper = identity } ) {
+export function PostTaxonomies( { postType, taxonomies, taxonomyWrapper = identity } ) {
 	const availableTaxonomies = filter( taxonomies, ( taxonomy ) => includes( taxonomy.types, postType ) );
 	const visibleTaxonomies = filter( availableTaxonomies, ( taxonomy ) => taxonomy.visibility.show_ui );
 	return visibleTaxonomies.map( ( taxonomy ) => {
 		const TaxonomyComponent = taxonomy.hierarchical ? HierarchicalTermSelector : FlatTermSelector;
-		const restBase = taxonomy.rest_base;
-		const hasCreateAction = get( post, [ '_links', 'wp:action-create-' + restBase ], false );
-		const hasAssignAction = get( post, [ '_links', 'wp:action-assign-' + restBase ], false );
 		return (
 			<Fragment key={ `taxonomy-${ taxonomy.slug }` }>
 				{
 					taxonomyWrapper(
 						<TaxonomyComponent
-							restBase={ restBase }
+							restBase={ taxonomy.rest_base }
 							slug={ taxonomy.slug }
-							hasCreateAction={ hasCreateAction }
-							hasAssignAction={ hasAssignAction }
 						/>,
 						taxonomy
 					)
@@ -45,7 +40,6 @@ export function PostTaxonomies( { post, postType, taxonomies, taxonomyWrapper = 
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			post: select( 'core/editor' ).getCurrentPost(),
 			postType: select( 'core/editor' ).getCurrentPostType(),
 			taxonomies: select( 'core' ).getTaxonomies(),
 		};

--- a/editor/components/post-taxonomies/test/index.js
+++ b/editor/components/post-taxonomies/test/index.js
@@ -52,7 +52,7 @@ describe( 'PostTaxonomies', () => {
 
 		const wrapperTwo = shallow(
 			<PostTaxonomies postType="book"
-				taxonomies={[
+				taxonomies={ [
 					genresTaxonomy,
 					{
 						...categoriesTaxonomy,

--- a/editor/components/post-taxonomies/test/index.js
+++ b/editor/components/post-taxonomies/test/index.js
@@ -44,9 +44,7 @@ describe( 'PostTaxonomies', () => {
 
 		const wrapperOne = shallow(
 			<PostTaxonomies postType="book"
-				taxonomies={ {
-					data: [ genresTaxonomy, categoriesTaxonomy ],
-				} }
+				taxonomies={ [ genresTaxonomy, categoriesTaxonomy ] }
 			/>
 		);
 
@@ -54,15 +52,13 @@ describe( 'PostTaxonomies', () => {
 
 		const wrapperTwo = shallow(
 			<PostTaxonomies postType="book"
-				taxonomies={ {
-					data: [
-						genresTaxonomy,
-						{
-							...categoriesTaxonomy,
-							types: [ 'post', 'page', 'book' ],
-						},
-					],
-				} }
+				taxonomies={[
+					genresTaxonomy,
+					{
+						...categoriesTaxonomy,
+						types: [ 'post', 'page', 'book' ],
+					},
+				] }
 			/>
 		);
 
@@ -83,9 +79,7 @@ describe( 'PostTaxonomies', () => {
 
 		const wrapperOne = shallow(
 			<PostTaxonomies postType="book"
-				taxonomies={ {
-					data: [ genresTaxonomy ],
-				} }
+				taxonomies={ [ genresTaxonomy ] }
 			/>
 		);
 
@@ -93,14 +87,12 @@ describe( 'PostTaxonomies', () => {
 
 		const wrapperTwo = shallow(
 			<PostTaxonomies postType="book"
-				taxonomies={ {
-					data: [
-						{
-							...genresTaxonomy,
-							visibility: { show_ui: false },
-						},
-					],
-				} }
+				taxonomies={ [
+					{
+						...genresTaxonomy,
+						visibility: { show_ui: false },
+					},
+				] }
 			/>
 		);
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -729,16 +729,12 @@ function gutenberg_filter_request_after_callbacks( $response, $handler, $request
 		if ( 'rest_cannot_create' === $response->get_error_code()
 			&& is_array( $handler['permission_callback'] )
 			&& is_a( $handler['permission_callback'][0], 'WP_REST_Terms_Controller' ) ) {
-			// 'taxonomy' is a protected attribute, and PHP 5.2 doesn't support
-			// ReflectionProperty->setAccessible(), so we need to get really dirty.
-			$controller_object = var_export( $handler['permission_callback'][0], true );
-			preg_match( "#'taxonomy' =\> '([^']+)'#", $controller_object, $matches );
-			if ( ! empty( $matches[1] ) ) {
-				$taxonomy_obj = get_taxonomy( $matches[1] );
-				if ( ! is_taxonomy_hierarchical( $taxonomy_obj->name )
-					&& current_user_can( $taxonomy_obj->cap->assign_terms ) ) {
-					$should_rerun_response = true;
-				}
+			$schema = $handler['permission_callback'][0]->get_item_schema();
+			$taxonomy = 'tag' === $schema['title'] ? 'post_tag' : $schema['title'];
+			$taxonomy_obj = get_taxonomy( $taxonomy );
+			if ( ! is_taxonomy_hierarchical( $taxonomy_obj->name )
+				&& current_user_can( $taxonomy_obj->cap->assign_terms ) ) {
+				$should_rerun_response = true;
 			}
 		}
 	}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -729,8 +729,8 @@ function gutenberg_filter_request_after_callbacks( $response, $handler, $request
 		if ( 'rest_cannot_create' === $response->get_error_code()
 			&& is_array( $handler['permission_callback'] )
 			&& is_a( $handler['permission_callback'][0], 'WP_REST_Terms_Controller' ) ) {
-			$schema = $handler['permission_callback'][0]->get_item_schema();
-			$taxonomy = 'tag' === $schema['title'] ? 'post_tag' : $schema['title'];
+			$schema       = $handler['permission_callback'][0]->get_item_schema();
+			$taxonomy     = 'tag' === $schema['title'] ? 'post_tag' : $schema['title'];
 			$taxonomy_obj = get_taxonomy( $taxonomy );
 			if ( ! is_taxonomy_hierarchical( $taxonomy_obj->name )
 				&& current_user_can( $taxonomy_obj->cap->assign_terms ) ) {

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -682,15 +682,16 @@ function gutenberg_filter_request_after_callbacks( $response, $handler, $request
 		if ( 'rest_cannot_create' === $response->get_error_code()
 			&& is_array( $handler['permission_callback'] )
 			&& is_a( $handler['permission_callback'][0], 'WP_REST_Terms_Controller' ) ) {
-			// 'taxonomy' is a protected attribute, so we need Reflection to access.
-			$reflection_obj  = new ReflectionClass( $handler['permission_callback'][0] );
-			$reflection_prop = $reflection_obj->getProperty( 'taxonomy' );
-			$reflection_prop->setAccessible( true );
-			$taxonomy     = $reflection_prop->getValue( $handler['permission_callback'][0] );
-			$taxonomy_obj = get_taxonomy( $taxonomy );
-			if ( ! is_taxonomy_hierarchical( $taxonomy_obj->name )
-				&& current_user_can( $taxonomy_obj->cap->assign_terms ) ) {
-				$should_rerun_response = true;
+			// 'taxonomy' is a protected attribute, and PHP 5.2 doesn't support
+			// ReflectionProperty->setAccessible(), so we need to get really dirty.
+			$controller_object = var_export( $handler['permission_callback'][0], true );
+			preg_match( "#'taxonomy' =\> '([^']+)'#", $controller_object, $matches );
+			if ( ! empty( $matches[1] ) ) {
+				$taxonomy_obj = get_taxonomy( $matches[1] );
+				if ( ! is_taxonomy_hierarchical( $taxonomy_obj->name )
+					&& current_user_can( $taxonomy_obj->cap->assign_terms ) ) {
+					$should_rerun_response = true;
+				}
 			}
 		}
 	}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -637,3 +637,114 @@ function gutenberg_filter_user_query_arguments( $prepared_args, $request ) {
 	return $prepared_args;
 }
 add_filter( 'rest_user_query', 'gutenberg_filter_user_query_arguments', 10, 2 );
+
+/**
+ * Overload taxonomy and term permission handling to address our new necessary behavior.
+ *
+ * This is temporary code that will be removed once the Trac ticket lands in a release.
+ *
+ * @see https://core.trac.wordpress.org/ticket/44096
+ *
+ * @param WP_HTTP_Response $response Result to send to the client. Usually a WP_REST_Response.
+ * @param WP_REST_Server   $handler  ResponseHandler instance (usually WP_REST_Server).
+ * @param WP_REST_Request  $request  Request used to generate the response.
+ * @return $response
+ */
+function gutenberg_filter_request_after_callbacks( $response, $handler, $request ) {
+	$should_rerun_response = false;
+	if ( is_wp_error( $response ) ) {
+		// Handle GET /wp/v2/taxonomies?context=edit when user can assign_terms
+		// but not manage_terms.
+		if ( '/wp/v2/taxonomies' === $request->get_route()
+			&& is_array( $handler['permission_callback'] )
+			&& is_a( $handler['permission_callback'][0], 'WP_REST_Taxonomies_Controller' )
+			&& 'edit' === $request['context']
+			&& 'rest_cannot_view' === $response->get_error_code() ) {
+			if ( ! empty( $request['type'] ) ) {
+				$taxonomies = get_object_taxonomies( $request['type'], 'objects' );
+			} else {
+				$taxonomies = get_taxonomies( '', 'objects' );
+			}
+			foreach ( $taxonomies as $taxonomy ) {
+				if ( ! empty( $taxonomy->show_in_rest )
+					&& current_user_can( $taxonomy->cap->assign_terms ) ) {
+					$GLOBALS['Gutenberg_Temporary_Taxonomies_Controller'] = $handler['permission_callback'][0];
+
+					$handler['callback']   = 'gutenberg_taxonomies_controller_get_items';
+					$should_rerun_response = true;
+					break;
+				}
+			}
+		}
+		// Handle POST /wp/v2/tags (and non-hiearchical taxonomies) when user
+		// can assign_terms but not manage terms. Users should be able to create
+		// terms.
+		if ( 'rest_cannot_create' === $response->get_error_code()
+			&& is_array( $handler['permission_callback'] )
+			&& is_a( $handler['permission_callback'][0], 'WP_REST_Terms_Controller' ) ) {
+			// 'taxonomy' is a protected attribute, so we need Reflection to access.
+			$reflection_obj  = new ReflectionClass( $handler['permission_callback'][0] );
+			$reflection_prop = $reflection_obj->getProperty( 'taxonomy' );
+			$reflection_prop->setAccessible( true );
+			$taxonomy     = $reflection_prop->getValue( $handler['permission_callback'][0] );
+			$taxonomy_obj = get_taxonomy( $taxonomy );
+			if ( ! is_taxonomy_hierarchical( $taxonomy_obj->name )
+				&& current_user_can( $taxonomy_obj->cap->assign_terms ) ) {
+				$should_rerun_response = true;
+			}
+		}
+	}
+	// Re-run the response generation if we've decided we need to.
+	if ( $should_rerun_response ) {
+		$callback = $handler['callback'];
+		// Filter defined in class-wp-rest-server.php.
+		$dispatch_result = apply_filters( 'rest_dispatch_request', null, $request, $request->get_route(), $handler );
+
+		// Allow plugins to halt the request via this filter.
+		if ( null !== $dispatch_result ) {
+			$response = $dispatch_result;
+		} else {
+			$response = call_user_func( $callback, $request );
+		}
+	}
+	return $response;
+}
+add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_request_after_callbacks', 10, 3 );
+
+/**
+ * Overloaded version of WP_REST_Taxonomies_Controller::get_items()
+ *
+ * This is temporary code that will be removed once the Trac ticket lands in a release.
+ *
+ * @see https://core.trac.wordpress.org/ticket/44096
+ *
+ * @param WP_REST_Request $request Full details about the request.
+ * @return WP_REST_Response Response object on success, or WP_Error object on failure.
+ */
+function gutenberg_taxonomies_controller_get_items( $request ) {
+	$controller = $GLOBALS['Gutenberg_Temporary_Taxonomies_Controller'];
+	// Retrieve the controller of registered collection query parameters.
+	$registered = $controller->get_collection_params();
+
+	if ( isset( $registered['type'] ) && ! empty( $request['type'] ) ) {
+		$taxonomies = get_object_taxonomies( $request['type'], 'objects' );
+	} else {
+		$taxonomies = get_taxonomies( '', 'objects' );
+	}
+	$data = array();
+	foreach ( $taxonomies as $tax_type => $value ) {
+		if ( empty( $value->show_in_rest ) || ( 'edit' === $request['context'] && ! current_user_can( $value->cap->assign_terms ) ) ) {
+			continue;
+		}
+		$tax               = $controller->prepare_item_for_response( $value, $request );
+		$tax               = $controller->prepare_response_for_collection( $tax );
+		$data[ $tax_type ] = $tax;
+	}
+
+	if ( empty( $data ) ) {
+		// Response should still be returned as a JSON object when it is empty.
+		$data = (object) $data;
+	}
+
+	return rest_ensure_response( $data );
+}

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -8,7 +8,7 @@
 /**
  * Tests for WP_Block_Type_Registry
  */
-class Gutenberg_REST_API_Test extends WP_UnitTestCase {
+class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 	function setUp() {
 		parent::setUp();
 
@@ -246,6 +246,85 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 0, $response->get_data() );
+	}
+
+	public function test_get_taxonomies_context_edit() {
+		wp_set_current_user( $this->contributor );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data       = $response->get_data();
+		$taxonomies = array();
+		foreach ( get_taxonomies( '', 'objects' ) as $taxonomy ) {
+			if ( ! empty( $taxonomy->show_in_rest ) ) {
+				$taxonomies[] = $taxonomy;
+			}
+		}
+		$this->assertEquals( count( $taxonomies ), count( $data ) );
+		$this->assertEquals( 'Categories', $data['category']['name'] );
+		$this->assertEquals( 'category', $data['category']['slug'] );
+		$this->assertEquals( true, $data['category']['hierarchical'] );
+		$this->assertEquals( 'Tags', $data['post_tag']['name'] );
+		$this->assertEquals( 'post_tag', $data['post_tag']['slug'] );
+		$this->assertEquals( false, $data['post_tag']['hierarchical'] );
+		$this->assertEquals( 'tags', $data['post_tag']['rest_base'] );
+	}
+
+	public function test_get_taxonomies_invalid_permission_for_context() {
+		wp_set_current_user( $this->subscriber );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 403 );
+	}
+
+	public function test_create_category_incorrect_permissions_author() {
+		wp_set_current_user( $this->author );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories' );
+		$request->set_param( 'name', 'Incorrect permissions' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_create', $response, 403 );
+	}
+
+	public function test_create_category_editor() {
+		wp_set_current_user( $this->editor );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories' );
+		$request->set_param( 'name', 'My Awesome Term' );
+		$request->set_param( 'description', 'This term is so awesome.' );
+		$request->set_param( 'slug', 'so-awesome' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+		$headers = $response->get_headers();
+		$data    = $response->get_data();
+		$this->assertContains( '/wp/v2/categories/' . $data['id'], $headers['Location'] );
+		$this->assertEquals( 'My Awesome Term', $data['name'] );
+		$this->assertEquals( 'This term is so awesome.', $data['description'] );
+		$this->assertEquals( 'so-awesome', $data['slug'] );
+	}
+
+	public function test_create_tag_incorrect_permissions_subscriber() {
+		wp_set_current_user( $this->subscriber );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/tags' );
+		$request->set_param( 'name', 'Incorrect permissions' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_create', $response, 403 );
+	}
+
+	public function test_create_tag_contributor() {
+		wp_set_current_user( $this->contributor );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/tags' );
+		$request->set_param( 'name', 'My Awesome Term' );
+		$request->set_param( 'description', 'This term is so awesome.' );
+		$request->set_param( 'slug', 'so-awesome' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+		$headers = $response->get_headers();
+		$data    = $response->get_data();
+		$this->assertContains( '/wp/v2/tags/' . $data['id'], $headers['Location'] );
+		$this->assertEquals( 'My Awesome Term', $data['name'] );
+		$this->assertEquals( 'This term is so awesome.', $data['description'] );
+		$this->assertEquals( 'so-awesome', $data['slug'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Ensures contributors and authors can create tags and manage categories. More specifically, this pull request:

* Incorporates REST API capability changes [identified in this Trac ticket](https://core.trac.wordpress.org/ticket/44096). Doing so required a series of amazing hacks.
* Migrates taxonomy data to `core-data`.
* Uses `wp:action-*` targetSchema to expose whether or not the current user can create or assign terms for each taxonomy.

See #6361
Fixes #5879

## How has this been tested?

When signed in as a contributor, you should be able to create tags and assign categories:

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/36432/40089492-db206a4c-5860-11e8-9853-55fc1f159ebc.png">

When signed in as an editor, you should be able to also create new categories:

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/36432/40089527-01c86456-5861-11e8-985a-94f8e8e267fa.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
