### PR TITLE
Documentation: Fix component name - FormTokenField

### DIFF
--- a/components/form-token-field/README.md
+++ b/components/form-token-field/README.md
@@ -1,4 +1,4 @@
-Token Field
+Form Token Field
 ===========
 
 A `FormTokenField` is a field similar to the tags and categories fields in the interim editor chrome, or the "to" field in Mail on OS X. Tokens can be entered by typing them or selecting them from a list of suggested tokens.
@@ -20,15 +20,15 @@ The `value` property is handled in a manner similar to controlled form component
 
 - `value` - An array of strings or objects to display as tokens in the field. If objects are present in the array, they **must** have a property of `value`. Here is an example object that could be passed in as a value:
 
-	  ```javascript
-	  {
-	    value: '(string) The value of the token.',
-	    status: "(string) One of 'error', 'validating', or 'success'. Applies styles to token."
-	    title: '(string) If not falsey, will add a title to the token.',
-	    onMouserEnter: '(function) Function to call when onMouseEnter event triggered on token.'
-	    onMouseLeave: '(function) Function to call when onMouseLeave is triggered on token.'
-	  }
-	  ```
+```javascript
+{
+	value: '(string) The value of the token.',
+	status: "(string) One of 'error', 'validating', or 'success'. Applies styles to token."
+	title: '(string) If not falsey, will add a title to the token.',
+	onMouserEnter: '(function) Function to call when onMouseEnter event triggered on token.'
+	onMouseLeave: '(function) Function to call when onMouseLeave is triggered on token.'
+}
+```
 - `displayTransform` - Function to call to transform tokens for display.  (In
   the editor, this is needed to decode HTML entities embedded in tags -
   otherwise entities like `&` in tag names are double-encoded like `&amp;`,
@@ -58,7 +58,7 @@ The `value` property is handled in a manner similar to controlled form component
 class extends Component {
 	render() {
 		return (
-			<TokenField
+			<FormTokenField
 				value={ this.state.tokens }
 				onChange={ this.onTokensChange }
 				suggestions={ this.state.suggestions } />


### PR DESCRIPTION
## Description
Update component name from `TokenField` to `FormTokenField`

## Screenshots <!-- if applicable -->

## Types of changes
Documentation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
