### PR TITLE
Rename isPrivate → supports.inserter

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -3,13 +3,14 @@
 /**
  * External dependencies
  */
-import { get, isFunction, some } from 'lodash';
+import { get, set, isFunction, some } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
+import { deprecated } from '@wordpress/utils';
 
 /**
  * Defined behavior of a block type.
@@ -135,6 +136,14 @@ export function registerBlockType( name, settings ) {
 	}
 	if ( ! settings.icon ) {
 		settings.icon = 'block-default';
+	}
+	if ( 'isPrivate' in settings ) {
+		deprecated( 'isPrivate', {
+			version: '3.1',
+			alternative: 'supports.inserter',
+			plugin: 'Gutenberg',
+		} );
+		set( settings, [ 'supports', 'inserter' ], ! settings.isPrivate );
 	}
 
 	dispatch( 'core/blocks' ).addBlockTypes( settings );

--- a/core-blocks/block/index.js
+++ b/core-blocks/block/index.js
@@ -13,7 +13,6 @@ export const name = 'core/block';
 export const settings = {
 	title: __( 'Shared Block' ),
 	category: 'shared',
-	isPrivate: true,
 
 	attributes: {
 		ref: {
@@ -24,6 +23,7 @@ export const settings = {
 	supports: {
 		customClassName: false,
 		html: false,
+		inserter: false,
 	},
 
 	edit,

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -298,6 +298,13 @@ className: false,
 html: false,
 ```
 
+- `inserter` (default `true`): By default, all blocks will appear in the Gutenberg inserter. To hide a block so that it can only be inserted programatically, set `inserter` to `false`.
+
+```js
+// Hide this block from the inserter.
+inserter: false,
+```
+
 ## Edit and Save
 
 The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](../docs/block-api/block-edit-save.md).

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -5,7 +5,8 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - All components in `wp.blocks.*` are removed. Please use `wp.editor.*` instead.
  - `wp.blocks.withEditorSettings` is removed. Please use the data module to access the editor settings `wp.data.select( "core/editor" ).getEditorSettings()`.
  - All DOM utils in `wp.utils.*` are removed. Please use `wp.dom.*` instead.
- 
+ - `isPrivate: true` has been removed from the Block API. Please use `supports.inserter: false` instead.
+
 ## 3.0.0
 
 - `wp.blocks.registerCoreBlocks` function removed. Please use `wp.coreBlocks.registerCoreBlocks` instead.

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -22,7 +22,7 @@ import createSelector from 'rememo';
 /**
  * WordPress dependencies
  */
-import { serialize, getBlockType, getBlockTypes } from '@wordpress/blocks';
+import { serialize, getBlockType, getBlockTypes, hasBlockSupport } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { moment } from '@wordpress/date';
@@ -1235,7 +1235,7 @@ function buildInserterItemFromBlockType( state, allowedBlockTypes, blockType ) {
 		return null;
 	}
 
-	if ( blockType.isPrivate ) {
+	if ( ! hasBlockSupport( blockType, 'inserter', true ) ) {
 		return null;
 	}
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -7,7 +7,12 @@ import { filter, property, union } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType, unregisterBlockType, getBlockTypes } from '@wordpress/blocks';
+import {
+	getBlockTypes,
+	hasBlockSupport,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
 import { moment } from '@wordpress/date';
 import { registerCoreBlocks } from '@wordpress/core-blocks';
 
@@ -2627,7 +2632,9 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const blockTypes = getBlockTypes().filter( ( blockType ) => ! blockType.isPrivate );
+			const blockTypes = getBlockTypes().filter( ( blockType ) =>
+				hasBlockSupport( blockType, 'inserter', true )
+			);
 			expect( getInserterItems( state, true ) ).toHaveLength( blockTypes.length );
 		} );
 


### PR DESCRIPTION
## Description
Removes the `inPrivate` property in lieu of a `supports` flag. This came up in https://github.com/WordPress/gutenberg/pull/6346#discussion_r186694811. Also adds documentation so as to fix #4486.

## How has this been tested?
1. Open the inserter
2. Check that _Shared Block_ doesn't appear anywhere