### PR TITLE
Upgrade rememo dependency to 3.0.0

### DIFF
--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -157,7 +157,9 @@ export const hasMetaBoxes = createSelector(
 			return metaBox.isActive;
 		} );
 	},
-	( state ) => state.metaBoxes,
+	( state ) => [
+		state.metaBoxes,
+	],
 );
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -13534,12 +13534,9 @@
 			}
 		},
 		"rememo": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/rememo/-/rememo-2.4.0.tgz",
-			"integrity": "sha512-4rqlLATPcha9lfdvylUWqSbceiTlYiBJvEJAyUiT/68cYPlNG1zXf7ABeve7s4YPrT6o3Q6zfN6n38ecAL71lw==",
-			"requires": {
-				"shallow-equal": "^1.0.0"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+			"integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -14234,11 +14231,6 @@
 					"dev": true
 				}
 			}
-		},
-		"shallow-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.0.0.tgz",
-			"integrity": "sha1-UI0YOLPeWQq4dXsBGyXkMJAJRfc="
 		},
 		"shebang-command": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"redux-multi": "0.1.12",
 		"redux-optimist": "1.0.0",
 		"refx": "3.0.0",
-		"rememo": "2.4.0",
+		"rememo": "3.0.0",
 		"showdown": "1.8.6",
 		"simple-html-tokenizer": "0.4.1",
 		"tinycolor2": "1.4.1",


### PR DESCRIPTION
## Description
This PR upgrades our rememo dependency to the latest version.

[This is useful](https://github.com/WordPress/gutenberg/pull/6753#discussion_r188490629) because it means we will get access to [`getDependants`](https://github.com/aduth/rememo#api) which was added in  3.0.0.

The only [breaking change](https://github.com/aduth/rememo/blob/master/CHANGELOG.md#v300-2018-02-17) is that the second argument of `createSelector` now must return an array. I confirmed that this is the case throughout our codebase.

<!-- Please describe what you have changed or added -->

## How has this been tested?
1. `npm install; npm test`
2. Click through the editor and demo post and perform a quick smoke test