### PR TITLE
Change '2017' to 'new' in docs introduction

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,6 +1,6 @@
 # Introduction
 
-"Gutenberg" is the codename for the 2017 WordPress editor focus. The goal of this focus is to create a new post and page editing experience that makes it easy for anyone to create rich post layouts. This was the kickoff goal:
+"Gutenberg" is the codename for the new WordPress editor focus. The goal of this focus is to create a new post and page editing experience that makes it easy for anyone to create rich post layouts. This was the kickoff goal:
 
 > The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.
 


### PR DESCRIPTION
In the intro doc for Gutenberg, it mentions that it's the "2017 WordPress editor focus", but we're clearly almost halfway through 2018 :laughing: so I figure that changing it to "new WordPress editor focus" will make more sense to users reading through the docs :+1: 