### PR TITLE
Tests: Add missing unit test for received entity records

### DIFF
--- a/core-data/test/reducer.js
+++ b/core-data/test/reducer.js
@@ -91,4 +91,29 @@ describe( 'entities', () => {
 			},
 		} );
 	} );
+
+	it( 'appends the received post types by slug', () => {
+		const originalState = deepFreeze( {
+			root: {
+				postType: {
+					byKey: {
+						w: { slug: 'w', title: 'water' },
+					},
+				},
+			},
+		} );
+		const state = entities( originalState, {
+			type: 'RECEIVE_ENTITY_RECORDS',
+			records: [ { slug: 'b', title: 'beach' } ],
+			kind: 'root',
+			name: 'postType',
+		} );
+
+		expect( state.root.postType ).toEqual( {
+			byKey: {
+				w: { slug: 'w', title: 'water' },
+				b: { slug: 'b', title: 'beach' },
+			},
+		} );
+	} );
 } );


### PR DESCRIPTION
## Description
Follow-up for fix introduced by @SofiaSousa  in #6759.

This PR adds a unit test which covers an issue fixed in the previous PR.

## How has this been tested?
`npm test`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
