### PR TITLE
Add back $blue-medium-500

### DIFF
--- a/edit-post/assets/stylesheets/_colors.scss
+++ b/edit-post/assets/stylesheets/_colors.scss
@@ -34,6 +34,7 @@ $blue-medium-900: #006589;
 $blue-medium-800: #00739C;
 $blue-medium-700: #007FAC;
 $blue-medium-600: #008DBE;
+$blue-medium-500: #00a0d2;
 $blue-medium-400: #33B3DB;
 $blue-medium-300: #66C6E4;
 $blue-medium-200: #BFE7F3;


### PR DESCRIPTION
This variable was removed as part of some PostCSS admin scheme improvements.

However the color is necessary outside of the color schemes, and should exist on its own.
