### PR TITLE
Restore The wp-blocks stylesheet for backwards compatibility concerns

### DIFF
--- a/docs/blocks/applying-styles-with-stylesheets.md
+++ b/docs/blocks/applying-styles-with-stylesheets.md
@@ -100,7 +100,7 @@ function gutenberg_boilerplate_block() {
 	wp_register_style(
 		'gutenberg-boilerplate-es5-step02',
 		plugins_url( 'step-02/style.css', __FILE__ ),
-		array( 'wp-blocks' ),
+		array(),
 		filemtime( plugin_dir_path( __FILE__ ) . 'step-02/style.css' )
 	);
 

--- a/docs/blocks/generate-blocks-with-wp-cli.md
+++ b/docs/blocks/generate-blocks-with-wp-cli.md
@@ -83,9 +83,7 @@ function movie_block_init() {
 	wp_register_style(
 		'movie-block-editor',
 		plugins_url( $editor_css, __FILE__ ),
-		array(
-			'wp-blocks',
-		),
+		array(),
 		filemtime( "$dir/$editor_css" )
 	);
 
@@ -93,9 +91,7 @@ function movie_block_init() {
 	wp_register_style(
 		'movie-block',
 		plugins_url( $style_css, __FILE__ ),
-		array(
-			'wp-blocks',
-		),
+		array(),
 		filemtime( "$dir/$style_css" )
 	);
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -360,6 +360,9 @@ function gutenberg_register_scripts_and_styles() {
 	);
 
 	// Editor Styles.
+	// This empty stylesheet is defined to ensure backwards compatibility.
+	wp_register_style( 'wp-blocks', false );
+
 	wp_register_style(
 		'wp-editor-font',
 		'https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i'


### PR DESCRIPTION
This PR restores an empty `wp-blocks` stylesheet for backwards compatibility. Several docs were suggesting adding this stylesheet as a dependency. `create-guten-blocks` also does so for each generated block.

**Question**

 - How to communicate that this is deprecated and shouldn't be depended upon?