### PR TITLE
[WIP] Core blocks: Refactor heading styles to use dropdown

### DIFF
--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -38,12 +38,15 @@ div.components-toolbar {
 	display: inline-flex;
 	align-items: flex-end;
 	margin: 0;
-	padding: 3px;
 	outline: none;
 	cursor: pointer;
 	position: relative;
-	width: $icon-button-size;
 	height: $icon-button-size;
+	padding: 3px 1px;
+
+	@include break-small() {
+		padding: 3px;
+	}
 
 	// unset icon button styles
 	&:active,

--- a/core-blocks/heading/edit.js
+++ b/core-blocks/heading/edit.js
@@ -1,17 +1,16 @@
 /**
  * WordPress dependencies
  */
-
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { PanelBody, Toolbar } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
-import { RichText, BlockControls, InspectorControls, AlignmentToolbar } from '@wordpress/editor';
+import { RichText, BlockControls, AlignmentToolbar } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
+import HeadingStylesToolbar from './styles-toolbar';
 
 export default function HeadingEdit( {
 	attributes,
@@ -26,37 +25,19 @@ export default function HeadingEdit( {
 	return (
 		<Fragment>
 			<BlockControls>
-				<Toolbar
-					controls={ '234'.split( '' ).map( ( level ) => ( {
-						icon: 'heading',
-						title: sprintf( __( 'Heading %s' ), level ),
-						isActive: 'H' + level === nodeName,
-						onClick: () => setAttributes( { nodeName: 'H' + level } ),
-						subscript: level,
-					} ) ) }
+				<HeadingStylesToolbar
+					value={ nodeName }
+					onChange={ ( nextNodeName ) => {
+						setAttributes( { nodeName: nextNodeName } );
+					} }
+				/>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
 				/>
 			</BlockControls>
-			<InspectorControls>
-				<PanelBody title={ __( 'Heading Settings' ) }>
-					<p>{ __( 'Level' ) }</p>
-					<Toolbar
-						controls={ '123456'.split( '' ).map( ( level ) => ( {
-							icon: 'heading',
-							title: sprintf( __( 'Heading %s' ), level ),
-							isActive: 'H' + level === nodeName,
-							onClick: () => setAttributes( { nodeName: 'H' + level } ),
-							subscript: level,
-						} ) ) }
-					/>
-					<p>{ __( 'Text Alignment' ) }</p>
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-					/>
-				</PanelBody>
-			</InspectorControls>
 			<RichText
 				wrapperClassName="wp-block-heading"
 				tagName={ nodeName.toLowerCase() }

--- a/core-blocks/heading/editor.scss
+++ b/core-blocks/heading/editor.scss
@@ -33,3 +33,19 @@
 		font-size: 0.8em;
 	}
 }
+
+.core-blocks-heading__icon {
+	height: 20px;
+	position: relative;
+	width: 20px;
+
+	&:after {
+		content: attr( data-subscript );
+		font-family: $default-font;
+		font-size: $default-font-size;
+		font-weight: 600;
+		position: absolute;
+		bottom: 0;
+		left: 16px;
+	}
+}

--- a/core-blocks/heading/editor.scss
+++ b/core-blocks/heading/editor.scss
@@ -36,10 +36,11 @@
 
 .core-blocks-heading__icon {
 	height: 20px;
-	position: relative;
 	width: 20px;
+	display: inline-flex;
+	position: relative;
 
-	&:after {
+	/*&:after {
 		content: attr( data-subscript );
 		font-family: $default-font;
 		font-size: $default-font-size;
@@ -47,5 +48,30 @@
 		position: absolute;
 		bottom: 0;
 		left: 16px;
+	}*/
+
+	// subscript for numbered icon buttons, like headings
+	/*&[data-subscript] svg {
+		padding: 4px 8px 4px 0;
+	}*/
+
+	&[data-subscript]:after {
+		content: attr( data-subscript );
+		font-family: $default-font;
+		font-size: $default-font-size;
+		font-weight: 600;
+		position: absolute;
+		right: -5px;
+		bottom: 0;
+	}
+}
+
+.core-blocks-heading__styles-toolbar {
+	.components-icon-button {
+		padding: 8px 4px;
+
+		@include break-small() {
+			padding: 8px;
+		}
 	}
 }

--- a/core-blocks/heading/styles-toolbar.js
+++ b/core-blocks/heading/styles-toolbar.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu } from '@wordpress/components';
+import { keycodes } from '@wordpress/utils';
+
+const HeadingIcon = ( { subscript } ) => (
+	<span className="core-blocks-heading__icon" data-subscript={ subscript }>
+		<Dashicon icon="heading" />
+	</span>
+);
+
+const HeadingStylesToolbar = ( { value, onChange } ) => (
+	<Dropdown
+		className="core-blocks-heading__styles-toolbar"
+		contentClassName="core-blocks-heading__styles-toolbar-popover"
+		renderToggle={ ( { onToggle, isOpen } ) => {
+			const openOnArrowDown = ( event ) => {
+				if ( ! isOpen && event.keyCode === keycodes.DOWN ) {
+					event.preventDefault();
+					event.stopPropagation();
+					onToggle();
+				}
+			};
+			const label = __( 'Change heading style' );
+
+			return (
+				<Toolbar>
+					<IconButton
+						icon={ <HeadingIcon subscript={ value.substring( 1 ) } /> }
+						onClick={ onToggle }
+						aria-haspopup="true"
+						aria-expanded={ isOpen }
+						label={ label }
+						tooltip={ label }
+						onKeyDown={ openOnArrowDown }
+					>
+						<Dashicon icon="arrow-down" />
+					</IconButton>
+				</Toolbar>
+			);
+		} }
+		renderContent={ ( { onClose } ) => (
+			<div>
+				<span
+					className="core-blocks-heading__styles-toolbar-menu-title"
+				>
+					{ __( 'Transform into:' ) }
+				</span>
+				<NavigableMenu
+					role="menu"
+					aria-label={ __( 'Heading styles' ) }
+				>
+					{ '123456'.split( '' ).map( ( level ) => (
+						<IconButton
+							key={ `heading${ level }` }
+							icon={ <HeadingIcon subscript={ level } /> }
+							subscript={ level }
+							className={ classnames(
+								'core-blocks-heading__styles-toolbar-menu-item', {
+									'is-active': value === 'H' + level,
+								}
+							) }
+							onClick={ () => {
+								onChange( 'H' + level );
+								onClose();
+							} }
+							role="menuitem"
+						>
+							{ sprintf( __( 'Heading %s' ), level ) }
+						</IconButton>
+					) ) }
+				</NavigableMenu>
+			</div>
+		) }
+	/>
+);
+
+export default HeadingStylesToolbar;

--- a/core-blocks/heading/styles-toolbar.js
+++ b/core-blocks/heading/styles-toolbar.js
@@ -51,7 +51,7 @@ const HeadingStylesToolbar = ( { value, onChange } ) => (
 				<span
 					className="core-blocks-heading__styles-toolbar-menu-title"
 				>
-					{ __( 'Transform into:' ) }
+					{ __( 'Heading style:' ) }
 				</span>
 				<NavigableMenu
 					role="menu"

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -9,8 +9,12 @@
 .editor-block-switcher__toggle {
 	width: auto;
 	margin: 0;
-	padding: 8px;
 	border-radius: 0;
+	padding: 8px 4px;
+
+	@include break-small() {
+		padding: 8px;
+	}
 
 	&:focus:before {
 		top: -3px;


### PR DESCRIPTION
## Description
Related issue: #783.

This PR tries to fix a regression introduced in #6675. On mobile devices, some controls are hard to access because there are too many of the rendered in the toolbar.

The proposed solution was described by @SuperGeniusZeb in https://github.com/WordPress/gutenberg/pull/5635#issuecomment-388158382

> The Heading block now has text alignment controls in its block toolbar thanks to #6675. Of course, now the block toolbar is the longest of any block, and likely not very mobile friendly.
> 
> I think the heading level/size switcher should be a single button with a dropdown, but should not be merged with the block converter/switcher dropdown.
> 
> Here is a (kind of sloppy) mockup I made:
> ![image](https://user-images.githubusercontent.com/19592990/39889154-a4cf18b0-545c-11e8-8de7-8bedfbbcfbcd.png)
> 
> (Yeah, that is not an h3 heading in the mockup... I forgot to change the number.)
> 
> I think the block converter/switcher should probably use a different icon, both to differentiate it from the heading level/size switcher, and to make its function a bit more clear. Personally, I have always thought it was a little odd that the block converter/switcher used the icon of the current block. I think it should look more like this instead:
> ![image](https://user-images.githubusercontent.com/19592990/39889448-872f4478-545d-11e8-90cb-1a2e547bcff7.png)
> 
> Maybe you could combine the two icon styles by replacing one of the squares in the previous mockup with the icon of the current block. That could also work.


## How has this been tested?
Manually.

## Screenshots <!-- if applicable -->

It still needs more ❤️ .

![screen shot 2018-05-16 at 16 17 38](https://user-images.githubusercontent.com/699132/40122738-c656a03a-5924-11e8-91d5-4fedda0a2c65.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
