### PR TITLE
Remove memoise withColors; Simplify API.

### DIFF
--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, compose, Fragment } from '@wordpress/element';
 import {
 	Dashicon,
 	IconButton,
@@ -141,11 +141,7 @@ class ButtonEdit extends Component {
 	}
 }
 
-export default withColors( ( getColor, setColor, { attributes } ) => {
-	return {
-		backgroundColor: getColor( attributes.backgroundColor, attributes.customBackgroundColor, 'background-color' ),
-		setBackgroundColor: setColor( 'backgroundColor', 'customBackgroundColor' ),
-		textColor: getColor( attributes.textColor, attributes.customTextColor, 'color' ),
-		setTextColor: setColor( 'textColor', 'customTextColor' ),
-	};
-} )( ButtonEdit );
+export default compose( [
+	withColors( 'backgroundColor', 'customBackgroundColor', 'background-color' ),
+	withColors( 'textColor', 'customTextColor', 'color' ),
+] )( ButtonEdit );

--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, compose, Fragment } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import {
 	Dashicon,
 	IconButton,
@@ -141,6 +141,4 @@ class ButtonEdit extends Component {
 	}
 }
 
-export default compose( [
-	withColors( 'backgroundColor', { textColor: 'color' } ),
-] )( ButtonEdit );
+export default withColors( 'backgroundColor', { textColor: 'color' } )( ButtonEdit );

--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -142,6 +142,5 @@ class ButtonEdit extends Component {
 }
 
 export default compose( [
-	withColors( 'backgroundColor', 'customBackgroundColor', 'background-color' ),
-	withColors( 'textColor', 'customTextColor', 'color' ),
+	withColors( 'backgroundColor', { textColor: 'color' } ),
 ] )( ButtonEdit );

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -454,17 +454,11 @@ export const settings = {
 		}
 	},
 
-	edit: compose(
-		withColors( ( getColor, setColor, { attributes } ) => {
-			return {
-				backgroundColor: getColor( attributes.backgroundColor, attributes.customBackgroundColor, 'background-color' ),
-				setBackgroundColor: setColor( 'backgroundColor', 'customBackgroundColor' ),
-				textColor: getColor( attributes.textColor, attributes.customTextColor, 'color' ),
-				setTextColor: setColor( 'textColor', 'customTextColor' ),
-			};
-		} ),
+	edit: compose( [
+		withColors( 'backgroundColor', 'customBackgroundColor', 'background-color' ),
+		withColors( 'textColor', 'customTextColor', 'color' ),
 		FallbackStyles,
-	)( ParagraphBlock ),
+	] )( ParagraphBlock ),
 
 	save( { attributes } ) {
 		const {

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -455,8 +455,7 @@ export const settings = {
 	},
 
 	edit: compose( [
-		withColors( 'backgroundColor', 'customBackgroundColor', 'background-color' ),
-		withColors( 'textColor', 'customTextColor', 'color' ),
+		withColors( 'backgroundColor', { textColor: 'color' } ),
 		FallbackStyles,
 	] )( ParagraphBlock ),
 

--- a/editor/components/colors/with-colors-deprecated.js
+++ b/editor/components/colors/with-colors-deprecated.js
@@ -40,7 +40,7 @@ export default ( mapGetSetColorToProps ) => createHigherOrderComponent(
 				constructor() {
 					super( ...arguments );
 					/**
-					* Even though, we don't expect setAttributes or colors to change memoizing it is essential.
+					* Even though we don't expect setAttributes or colors to change memoizing it is essential.
 					* If setAttributes or colors are not memoized, each time memoizedGetColor/memoizedSetColor are called:
 					* a new function reference is returned (even if arguments have not changed).
 					* This would make our memoized chain useless.

--- a/editor/components/colors/with-colors-deprecated.js
+++ b/editor/components/colors/with-colors-deprecated.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import memoize from 'memize';
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent, Component, compose } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getColorValue, getColorClass, setColorValue } from './utils';
+
+const DEFAULT_COLORS = [];
+
+/**
+ * Higher-order component, which handles color logic for class generation
+ * color value, retrieval and color attribute setting.
+ *
+ * @param {Function} mapGetSetColorToProps Function that receives getColor, setColor, and props,
+ *                                         and returns additional props to pass to the component.
+ *
+ * @return {Function} Higher-order component.
+ */
+export default ( mapGetSetColorToProps ) => createHigherOrderComponent(
+	compose( [
+		withSelect(
+			( select ) => {
+				const settings = select( 'core/editor' ).getEditorSettings();
+				return {
+					colors: get( settings, [ 'colors' ], DEFAULT_COLORS ),
+				};
+			} ),
+		( WrappedComponent ) => {
+			return class extends Component {
+				constructor() {
+					super( ...arguments );
+					/**
+					* Even though, we don't expect setAttributes or colors to change memoizing it is essential.
+					* If setAttributes or colors are not memoized, each time memoizedGetColor/memoizedSetColor are called:
+					* a new function reference is returned (even if arguments have not changed).
+					* This would make our memoized chain useless.
+					*/
+					this.memoizedGetColor = memoize( this.memoizedGetColor, { maxSize: 1 } );
+					this.memoizedSetColor = memoize( this.memoizedSetColor, { maxSize: 1 } );
+				}
+
+				memoizedGetColor( colors ) {
+					return memoize(
+						( colorName, customColorValue, colorContext ) => {
+							return {
+								name: colorName,
+								class: getColorClass( colorContext, colorName ),
+								value: getColorValue( colors, colorName, customColorValue ),
+							};
+						}
+					);
+				}
+
+				memoizedSetColor( setAttributes, colors ) {
+					return memoize(
+						( colorNameAttribute, customColorAttribute ) => {
+							return setColorValue( colors, colorNameAttribute, customColorAttribute, setAttributes );
+						}
+					);
+				}
+
+				render() {
+					return (
+						<WrappedComponent
+							{ ...{
+								...this.props,
+								colors: undefined,
+								...mapGetSetColorToProps(
+									this.memoizedGetColor( this.props.colors ),
+									this.memoizedSetColor( this.props.setAttributes, this.props.colors ),
+									this.props
+								),
+							} }
+						/>
+					);
+				}
+			};
+		},
+	] ),
+	'withColors'
+);

--- a/editor/components/colors/with-colors.js
+++ b/editor/components/colors/with-colors.js
@@ -14,7 +14,7 @@ import { deprecated } from '@wordpress/utils';
  * Internal dependencies
  */
 import { getColorValue, getColorClass } from './utils';
-import { default as withColorsDeprecated } from './with-colors-deprecated';
+import withColorsDeprecated from './with-colors-deprecated';
 
 const DEFAULT_COLORS = [];
 
@@ -36,15 +36,15 @@ const DEFAULT_COLORS = [];
 export default ( ...args ) => {
 	if ( isFunction( args[ 0 ] ) ) {
 		deprecated( 'Using withColors( mapGetSetColorToProps ) ', {
-			version: '3.2',
+			version: '3.3',
 			alternative: 'withColors( colorAttributeName, { secondColorAttributeName: \'color-context\' }, ... )',
 		} );
 		return withColorsDeprecated( args[ 0 ] );
 	}
 
-	const colorMap = reduce( args, ( colorObj, arg ) => {
+	const colorMap = reduce( args, ( colorObject, arg ) => {
 		return {
-			...colorObj,
+			...colorObject,
 			...( isString( arg ) ? { [ arg ]: kebabCase( arg ) } : arg ),
 		};
 	}, {} );
@@ -68,25 +68,26 @@ export default ( ...args ) => {
 					}
 
 					createSetters() {
-						return reduce( colorMap, ( settersAcc, colorContext, colorAttributeName ) => {
-							const ufColorAttrName = upperFirst( colorAttributeName );
-							const customColorAttributeName = `custom${ ufColorAttrName }`;
-							settersAcc[ `set${ ufColorAttrName }` ] = this.createSetColor( colorAttributeName, customColorAttributeName );
-							return settersAcc;
+						return reduce( colorMap, ( settersAccumulator, colorContext, colorAttributeName ) => {
+							const upperFirstColorAttributeName = upperFirst( colorAttributeName );
+							const customColorAttributeName = `custom${ upperFirstColorAttributeName }`;
+							settersAccumulator[ `set${ upperFirstColorAttributeName }` ] =
+								this.createSetColor( colorAttributeName, customColorAttributeName );
+							return settersAccumulator;
 						}, {} );
 					}
 
 					createSetColor( colorAttributeName, customColorAttributeName ) {
 						return ( colorValue ) => {
-							const colorObj = find( this.props.colors, { color: colorValue } );
+							const colorObject = find( this.props.colors, { color: colorValue } );
 							this.props.setAttributes( {
-								[ colorAttributeName ]: colorObj && colorObj.name ? colorObj.name : undefined,
-								[ customColorAttributeName ]: colorObj && colorObj.name ? undefined : colorValue,
+								[ colorAttributeName ]: colorObject && colorObject.name ? colorObject.name : undefined,
+								[ customColorAttributeName ]: colorObject && colorObject.name ? undefined : colorValue,
 							} );
 						};
 					}
 
-					static getDerivedStateFromProps( { attributes, colors }, prevState ) {
+					static getDerivedStateFromProps( { attributes, colors }, previousState ) {
 						return reduce( colorMap, ( newState, colorContext, colorAttributeName ) => {
 							const colorName = attributes[ colorAttributeName ];
 							const colorValue = getColorValue(
@@ -94,15 +95,15 @@ export default ( ...args ) => {
 								colorName,
 								attributes[ `custom${ upperFirst( colorAttributeName ) }` ]
 							);
-							const prevColorObject = prevState[ colorAttributeName ];
-							const prevColorValue = get( prevColorObject, [ 'value' ] );
+							const previousColorObject = previousState[ colorAttributeName ];
+							const previousColorValue = get( previousColorObject, [ 'value' ] );
 							/**
-							* && prevColorObject checks that a previous color object was already computed.
-							* At the start prevColorValue and colorValue are both equal to undefined
-							* bus as prevColorObject does not exist we should compute the object.
+							* The "and previousColorObject" condition checks that a previous color object was already computed.
+							* At the start previousColorObject and colorValue are both equal to undefined
+							* bus as previousColorObject does not exist we should compute the object.
 							*/
-							if ( prevColorValue === colorValue && prevColorObject ) {
-								newState[ colorAttributeName ] = prevColorObject;
+							if ( previousColorValue === colorValue && previousColorObject ) {
+								newState[ colorAttributeName ] = previousColorObject;
 							} else {
 								newState[ colorAttributeName ] = {
 									name: colorName,


### PR DESCRIPTION
This PR simplify the withColors HOC so we can avoid the usage of memoize while still having a correct implementation without unnecessary rerenders.
It is based on a solution proposed by @aduth in https://github.com/WordPress/gutenberg/pull/6686#issuecomment-388377662. Unfortunately passing a single parameter as suggested e.g.:`withColors( 'color' ),` was not possible for all cases so this API uses three parameters. I think we may add a single parameter version in the future. It may handle this case `withColors( 'backgroundColor', 'customBackgroundColor', 'background-color' ),` as everything can be derived from backgroundColor but not this case `withColors( 'textColor', 'customTextColor', 'color' ),. So having the three parameters version is a must.

## How has this been tested?
No noticeable changes are expected. Verify setting colors (and custom colors) in paragraph and button still work as expected. Use the Highlight updates browser feature and check no unexpected rerenders are happening (when compared to master).

Revert changes in paragraph and button and test things still work as before, (we are backcompatible)
