### PR TITLE
Support adding a human-readable deprecation hint

### DIFF
--- a/utils/deprecation.js
+++ b/utils/deprecation.js
@@ -7,13 +7,15 @@
  * @param {?string} options.alternative Feature to use instead
  * @param {?string} options.plugin      Plugin name if it's a plugin feature
  * @param {?string} options.link        Link to documentation
+ * @param {?string} options.hint		Additional message to help transition away from the deprecated feature.
  */
-export function deprecated( feature, { version, alternative, plugin, link } = {} ) {
+export function deprecated( feature, { version, alternative, plugin, link, hint } = {} ) {
 	const pluginMessage = plugin ? ` from ${ plugin }` : '';
 	const versionMessage = version ? `${ pluginMessage } in ${ version }` : '';
 	const useInsteadMessage = alternative ? ` Please use ${ alternative } instead.` : '';
 	const linkMessage = link ? ` See: ${ link }` : '';
-	const message = `${ feature } is deprecated and will be removed${ versionMessage }.${ useInsteadMessage }${ linkMessage }`;
+	const hintMessage = hint ? ` Note: ${ hint }` : '';
+	const message = `${ feature } is deprecated and will be removed${ versionMessage }.${ useInsteadMessage }${ linkMessage }${ hintMessage }`;
 
 	// eslint-disable-next-line no-console
 	console.warn( message );

--- a/utils/deprecation.js
+++ b/utils/deprecation.js
@@ -7,7 +7,7 @@
  * @param {?string} options.alternative Feature to use instead
  * @param {?string} options.plugin      Plugin name if it's a plugin feature
  * @param {?string} options.link        Link to documentation
- * @param {?string} options.hint		Additional message to help transition away from the deprecated feature.
+ * @param {?string} options.hint        Additional message to help transition away from the deprecated feature.
  */
 export function deprecated( feature, { version, alternative, plugin, link, hint } = {} ) {
 	const pluginMessage = plugin ? ` from ${ plugin }` : '';

--- a/utils/test/deprecation.js
+++ b/utils/test/deprecation.js
@@ -52,4 +52,17 @@ describe( 'deprecated', () => {
 			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead. See: https://en.wikipedia.org/wiki/Vegetarianism'
 		);
 	} );
+
+	it( 'should show a deprecation warning with a hint', () => {
+		deprecated( 'Eating meat', {
+			version: 'the future',
+			alternative: 'vegetables',
+			plugin: 'the earth',
+			hint: 'You may find it beneficial to transition gradually.',
+		} );
+
+		expect( console ).toHaveWarnedWith(
+			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead. Note: You may find it beneficial to transition gradually.'
+		);
+	} );
 } );


### PR DESCRIPTION
## Description
There are situations where it can be useful to add a helpful hint to deprecation warnings.

For example, in #6753, we deprecate `getFrecentInserterItems` and recommend  `getInserterItems` instead, but `getInserterItems` doesn't naturally sort items by frecency. The caller has to do that. It might be good to offer a clue for those transitioning away from `getFrecentInserterItems`.

Today, the deprecation warning would be:
> getFrecentInserterItems is deprecated and will be removed from Gutenberg in 3.1. Please use getInserterItems instead.

But we can provide additional useful information with a message like:
> getFrecentInserterItems is deprecated and will be removed from Gutenberg in 3.1. Please use getInserterItems instead. Note: For an equivalent list, you may sort inserter items by their \`frecency\` property.

This PR adds support for an optional `hint` argument to our `deprecation` util to include additional information in the deprecation warning.

## How has this been tested?
Added a unit test and ran the test suite successfully.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
