### PR TITLE
Fix paste with selection/caret at start or end

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -233,11 +233,17 @@ class ParagraphBlock extends Component {
 						} }
 						onSplit={ insertBlocksAfter ?
 							( before, after, ...blocks ) => {
-								setAttributes( { content: before } );
-								insertBlocksAfter( [
-									...blocks,
-									createBlock( 'core/paragraph', { content: after } ),
-								] );
+								if ( after ) {
+									blocks.push( createBlock( name, { content: after } ) );
+								}
+
+								insertBlocksAfter( blocks );
+
+								if ( before ) {
+									setAttributes( { content: before } );
+								} else {
+									onReplace( [] );
+								}
 							} :
 							undefined
 						}

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -396,7 +396,7 @@ export class RichText extends Component {
 			if ( shouldReplace ) {
 				this.props.onReplace( content );
 			} else {
-				this.splitContent( content );
+				this.splitContent( content, { paste: true } );
 			}
 		}
 	}
@@ -589,9 +589,10 @@ export class RichText extends Component {
 	 * before the selection. Sends the elements after the selection to the `onSplit`
 	 * handler.
 	 *
-	 * @param {Array} blocks The blocks to add after the split point.
+	 * @param {Array}  blocks  The blocks to add after the split point.
+	 * @param {Object} context The context for splitting.
 	 */
-	splitContent( blocks = [] ) {
+	splitContent( blocks = [], context = {} ) {
 		if ( ! this.props.onSplit ) {
 			return;
 		}
@@ -613,10 +614,17 @@ export class RichText extends Component {
 			const afterFragment = afterRange.extractContents();
 
 			const { format } = this.props;
-			const before = domToFormat( filterEmptyNodes( beforeFragment.childNodes ), format, this.editor );
-			const after = domToFormat( filterEmptyNodes( afterFragment.childNodes ), format, this.editor );
+			let before = domToFormat( filterEmptyNodes( beforeFragment.childNodes ), format, this.editor );
+			let after = domToFormat( filterEmptyNodes( afterFragment.childNodes ), format, this.editor );
+
+			if ( context.paste ) {
+				before = this.isEmpty( before ) ? null : before;
+				after = this.isEmpty( after ) ? null : after;
+			}
 
 			this.restoreContentAndSplit( before, after, blocks );
+		} else if ( context.paste ) {
+			this.restoreContentAndSplit( null, null, blocks );
 		} else {
 			this.restoreContentAndSplit( [], [], blocks );
 		}
@@ -831,11 +839,7 @@ export class RichText extends Component {
 	 */
 	restoreContentAndSplit( before, after, blocks = [] ) {
 		this.updateContent();
-		this.props.onSplit(
-			this.isEmpty( before ) ? null : before,
-			this.isEmpty( after ) ? null : after,
-			...blocks
-		);
+		this.props.onSplit( before, after, ...blocks );
 	}
 
 	render() {


### PR DESCRIPTION
## Description

Currently pasting pasting content on a fully selected paragraph, or with the selection or caret at the start or end, is broken. It may create extra paragraph tags before and after the inserted content. Why? Because the content is split on the selection (before and after content empty). Solution? Check if the content is empty and handle it in `onSplit`.

## How has this been tested?
See above

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
