### PR TITLE
Remove fsevents from optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,6 @@
 		"webpack-cli": "2.1.3",
 		"webpack-rtl-plugin": "github:yoavf/webpack-rtl-plugin#develop"
 	},
-	"optionalDependencies": {
-		"fsevents": "1.2.4"
-	},
 	"babel": {
 		"presets": [
 			"@wordpress/default"


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
In https://github.com/WordPress/gutenberg/pull/6772 `fsevents` was added as an optional dependency to the `package.json`.  I don't know why, but this broke our usage of gutenberg as a devDepdency for tests.  

See [this travis build](https://travis-ci.org/eventespresso/event-espresso-core/jobs/379498740#L671) for the example pass _before_ the pull (6772) was merged and [this travis build](https://travis-ci.org/eventespresso/event-espresso-core/jobs/379917553) for an example fail since the pull (6772) was merged.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I tested this by running our build against the forked version of GB (see [here](https://github.com/eventespresso/event-espresso-core/pull/456)) and verified via the resulting [travis build job](https://travis-ci.org/eventespresso/event-espresso-core/jobs/379982885) that removing the `fsevents` from `optionalDependencies` fixed things for us.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
