### PR TITLE
Exclude private blocks from the autocompleter

### DIFF
--- a/editor/components/autocompleters/block.js
+++ b/editor/components/autocompleters/block.js
@@ -1,18 +1,28 @@
 /**
  * External dependencies
  */
-import { sortBy, once } from 'lodash';
+import { filter, sortBy, once, flow } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { createBlock, getBlockTypes } from '@wordpress/blocks';
+import { createBlock, getBlockTypes, hasBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import BlockIcon from '../block-icon';
+
+function filterBlockTypes( blockTypes ) {
+	// Exclude blocks that don't support being shown in the inserter
+	return filter( blockTypes, ( blockType ) => hasBlockSupport( blockType, 'inserter', true ) );
+}
+
+function sortBlockTypes( blockTypes ) {
+	// Prioritize blocks in the common common category
+	return sortBy( blockTypes, ( { category } ) => 'common' !== category );
+}
 
 /**
  * A blocks repeater for replacing the current block with a selected block type.
@@ -24,13 +34,7 @@ export default {
 	className: 'editor-autocompleters__block',
 	triggerPrefix: '/',
 	options: once( function options() {
-		return Promise.resolve(
-			// Prioritize common category in block type options
-			sortBy(
-				getBlockTypes(),
-				( { category } ) => 'common' !== category
-			)
-		);
+		return Promise.resolve( flow( filterBlockTypes, sortBlockTypes )( getBlockTypes() ) );
 	} ),
 	getOptionKeywords( blockSettings ) {
 		const { title, keywords = [] } = blockSettings;


### PR DESCRIPTION
Prevent blocks that do not have `supports.inserter` set from displaying in the blocks autocompleter.

Fixes the bug that @gziolo noticed in https://github.com/WordPress/gutenberg/pull/6766#issuecomment-389426395:

![screen shot 2018-05-16 at 09 41 45](https://user-images.githubusercontent.com/699132/40103438-b4a70db6-58ed-11e8-9070-2fe9ef54f641.png)

**To test:**

1. Type `/` to bring up the autocompleter
2. Search for 'block'
3. _Shared Block_ should not appear