### PR TITLE
Revert 6675: Move Heading block alignment settings from sidebar to bl…

### DIFF
--- a/core-blocks/heading/edit.js
+++ b/core-blocks/heading/edit.js
@@ -35,12 +35,6 @@ export default function HeadingEdit( {
 						subscript: level,
 					} ) ) }
 				/>
-				<AlignmentToolbar
-					value={ align }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
-					} }
-				/>
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Heading Settings' ) }>
@@ -53,6 +47,13 @@ export default function HeadingEdit( {
 							onClick: () => setAttributes( { nodeName: 'H' + level } ),
 							subscript: level,
 						} ) ) }
+					/>
+					<p>{ __( 'Text Alignment' ) }</p>
+					<AlignmentToolbar
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
…ock toolbar

## Description
Reverts #6675. 

We are working on a solution which doesn't regress on mobile.

## How has this been tested?
Manually.

## Screenshots <!-- if applicable -->
![screen shot 2018-05-17 at 09 48 48](https://user-images.githubusercontent.com/699132/40163721-dafc672a-59b7-11e8-9df8-ee7f3854e8dc.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
