### PR TITLE
Improve performance of global inserter: don't rerender on every attribute change.

### DIFF
--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -97,28 +97,37 @@ export default compose( [
 		} = select( 'core/editor' );
 		const { allowedBlockTypes, templateLock } = getEditorSettings();
 		const insertionPoint = getBlockInsertionPoint();
-		const { rootUID } = insertionPoint;
-		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
+		const {
+			rootUID: insertionPointRootUID,
+			index: insertionPointIndex,
+			layout: insertionPointLayout,
+		} = insertionPoint;
+		const supportedBlocks = getSupportedBlocks( insertionPointRootUID, allowedBlockTypes );
+		const selectedBlock = getSelectedBlock();
+		const selectedBlockUid = selectedBlock && selectedBlock.uid;
+		const blockIsUnmodifiedDefaultBlock = selectedBlock && isUnmodifiedDefaultBlock( selectedBlock );
 		return {
 			title: getEditedPostAttribute( 'title' ),
-			insertionPoint,
-			selectedBlock: getSelectedBlock(),
 			hasSupportedBlocks: true === supportedBlocks || ! isEmpty( supportedBlocks ),
 			isLocked: !! templateLock,
+			selectedBlockUid,
+			blockIsUnmodifiedDefaultBlock,
+			insertionPointRootUID,
+			insertionPointIndex,
+			insertionPointLayout,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		showInsertionPoint: dispatch( 'core/editor' ).showInsertionPoint,
 		hideInsertionPoint: dispatch( 'core/editor' ).hideInsertionPoint,
 		onInsertBlock: ( item ) => {
-			const { insertionPoint, selectedBlock } = ownProps;
-			const { index, rootUID, layout } = insertionPoint;
+			const { selectedBlockUid, blockIsUnmodifiedDefaultBlock, insertionPointIndex, insertionPointLayout, insertionPointRootUID } = ownProps;
 			const { name, initialAttributes } = item;
-			const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
-			if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
-				return dispatch( 'core/editor' ).replaceBlocks( selectedBlock.uid, insertedBlock );
+			const insertedBlock = createBlock( name, { ...initialAttributes, layout: insertionPointLayout } );
+			if ( blockIsUnmodifiedDefaultBlock ) {
+				return dispatch( 'core/editor' ).replaceBlocks( selectedBlockUid, insertedBlock );
 			}
-			return dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootUID );
+			return dispatch( 'core/editor' ).insertBlock( insertedBlock, insertionPointIndex, insertionPointRootUID );
 		},
 	} ) ),
 ] )( Inserter );


### PR DESCRIPTION
Inserter withSelect passed many props that contain objects that change on every block attribute change e.g.: getBlocks. These props are used only on withDispatch. We changed the withSelect not to pass complete objects but just pass the properties that in fact, withDispatch uses.


## How has this been tested?
Verify the global inserter still works as expected.
Use the highlight updates browser feature to check it does not rerender on every attribute change e.g: key press in a paragraph.

## Screenshots <!-- if applicable -->
Before:
![may-17-2018 10-58-49](https://user-images.githubusercontent.com/11271197/40171502-5504aa7c-59c3-11e8-8cfa-6570135758d7.gif)
After:
![may-17-2018 10-56-45](https://user-images.githubusercontent.com/11271197/40171513-5d878ca0-59c3-11e8-9b0f-544771f1a425.gif)


