### PR TITLE
Add cache to getUserQueryResults; Avoid authors rerender on every key press.

### DIFF
--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import createSelector from 'rememo';
 import { map } from 'lodash';
 
 /**
@@ -70,11 +71,14 @@ export function getAuthors( state ) {
  *
  * @return {Array} Users list.
  */
-export function getUserQueryResults( state, queryID ) {
-	const queryResults = state.users.queries[ queryID ];
+export const getUserQueryResults = createSelector(
+	( state, queryID ) => {
+		const queryResults = state.users.queries[ queryID ];
 
-	return map( queryResults, ( id ) => state.users.byId[ id ] );
-}
+		return map( queryResults, ( id ) => state.users.byId[ id ] );
+	},
+	( state, queryID ) => [ state.users.queries[ queryID ], state.users.byId ]
+);
 
 /**
  * Returns the Entity's record object by key.


### PR DESCRIPTION
The selector used a map which means that each time it was invoked even if no relevant state changes happened the selector return a new reference to an array. This caused the author selector to re-render on every state change e.g: every key press in the editor.

## How has this been tested?
Verify the author selector still works as expected.
Use the highlight updates browser feature to check it does not rerender on every attribute change e.g: key press in a paragraph.

## Screenshots <!-- if applicable -->

Before:
![may-17-2018 12-10-31](https://user-images.githubusercontent.com/11271197/40173962-704d8b84-59cb-11e8-96a4-0dd6dc2d7d8e.gif)

After:

![may-17-2018 12-06-01](https://user-images.githubusercontent.com/11271197/40173969-79ff36e6-59cb-11e8-8595-e834b48bcbdd.gif)

