### PR TITLE
Extensibility: Add publish panels support for plugins

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,3 +94,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @Cloud887 |
 | @hblackett |
 | @vishalkakadiya |
+| @c-shultz |

--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -140,6 +140,7 @@ const { PluginPrePublishPanel } = wp.editPost;
 
 const MyPluginPrePublishPanel = () => (
 	<PluginPrePublishPanel
+		className="my-plugin-pre-publish-panel"
 		title={ __( 'My panel title' ) }
 		initialOpen={ true }
 	>
@@ -149,6 +150,13 @@ const MyPluginPrePublishPanel = () => (
 ```
 
 #### Props
+
+##### className
+
+An optional class name added to the panel.
+
+- Type: `String`
+- Required: No
 
 ##### title
 
@@ -176,8 +184,9 @@ _Example:_
 const { __ } = wp.i18n;
 const { PluginPostPublishPanel } = wp.editPost;
 
-const MyPluginPrePublishPanel = () => (
+const MyPluginPostPublishPanel = () => (
 	<PluginPostPublishPanel
+		className="my-plugin-post-publish-panel"
 		title={ __( 'My panel title' ) }
 		initialOpen={ true }
 	>
@@ -187,6 +196,13 @@ const MyPluginPrePublishPanel = () => (
 ```
 
 #### Props
+
+##### className
+
+An optional class name added to the panel.
+
+- Type: `String`
+- Required: No
 
 ##### title
 

--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -109,6 +109,7 @@ The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug st
 - Required: No
 - Default: _inherits from the plugin_
 
+
 ### `PluginPostStatusInfo`
 
 Renders a row in the Status & Visibility panel of the Document sidebar.
@@ -127,3 +128,77 @@ const MyPluginPostStatusInfo = () => (
 ```
 
 
+### `PluginPrePublishPanel`
+
+Renders provided content to the pre-publish side panel in the publish flow (side panel that opens when a user first pushes "Publish" from the main editor).
+
+_Example:_
+
+```jsx
+const { __ } = wp.i18n;
+const { PluginPrePublishPanel } = wp.editPost;
+
+const MyPluginPrePublishPanel = () => (
+	<PluginPrePublishPanel
+		title={ __( 'My panel title' ) }
+		initialOpen={ true }
+	>
+	    { __( 'My panel content' ) }
+	</PluginPrePublishPanel>
+);
+```
+
+#### Props
+
+##### title
+
+Title displayed at the top of the panel.
+
+- Type: `String`
+- Required: No
+
+##### initialOpen
+
+Whether to have the panel initially opened. When no title is provided it is always opened.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
+
+### `PluginPostPublishPanel`
+
+Renders provided content to the post-publish panel in the publish flow (side panel that opens after a user publishes the post).
+
+_Example:_
+
+```jsx
+const { __ } = wp.i18n;
+const { PluginPostPublishPanel } = wp.editPost;
+
+const MyPluginPrePublishPanel = () => (
+	<PluginPostPublishPanel
+		title={ __( 'My panel title' ) }
+		initialOpen={ true }
+	>
+        { __( 'My panel content' ) }
+	</PluginPostPublishPanel>
+);
+```
+
+#### Props
+
+##### title
+
+Title displayed at the top of the panel.
+
+- Type: `String`
+- Required: No
+
+##### initialOpen
+
+Whether to have the panel initially opened. When no title is provided it is always opened. 
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -35,6 +35,8 @@ import EditorModeKeyboardShortcuts from '../keyboard-shortcuts';
 import MetaBoxes from '../meta-boxes';
 import { getMetaBoxContainer } from '../../utils/meta-boxes';
 import Sidebar from '../sidebar';
+import PluginPostPublishPanel from '../sidebar/plugin-post-publish-panel';
+import PluginPrePublishPanel from '../sidebar/plugin-pre-publish-panel';
 
 function Layout( {
 	mode,
@@ -84,6 +86,8 @@ function Layout( {
 					onClose={ closePublishSidebar }
 					forceIsDirty={ hasActiveMetaboxes }
 					forceIsSaving={ isSaving }
+					renderPrePublishExtension={ () => <PluginPrePublishPanel.Slot /> }
+					renderPostPublishExtension={ () => <PluginPostPublishPanel.Slot /> }
 				/>
 			) }
 			<DocumentSidebar />

--- a/edit-post/components/sidebar/plugin-post-publish-panel/index.js
+++ b/edit-post/components/sidebar/plugin-post-publish-panel/index.js
@@ -5,9 +5,13 @@ import { createSlotFill, PanelBody } from '@wordpress/components';
 
 const { Fill, Slot } = createSlotFill( 'PluginPostPublishPanel' );
 
-const PluginPostPublishPanel = ( { children, title, initialOpen = false } ) => (
+const PluginPostPublishPanel = ( { children, className, title, initialOpen = false } ) => (
 	<Fill>
-		<PanelBody initialOpen={ initialOpen || ! title } title={ title }>
+		<PanelBody
+			className={ className }
+			initialOpen={ initialOpen || ! title }
+			title={ title }
+		>
 			{ children }
 		</PanelBody>
 	</Fill>

--- a/edit-post/components/sidebar/plugin-post-publish-panel/index.js
+++ b/edit-post/components/sidebar/plugin-post-publish-panel/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill, PanelBody } from '@wordpress/components';
+
+const { Fill, Slot } = createSlotFill( 'PluginPostPublishPanel' );
+
+const PluginPostPublishPanel = ( { children, title, initialOpen = false } ) => (
+	<Fill>
+		<PanelBody initialOpen={ initialOpen || ! title } title={ title }>
+			{ children }
+		</PanelBody>
+	</Fill>
+);
+
+PluginPostPublishPanel.Slot = Slot;
+
+export default PluginPostPublishPanel;

--- a/edit-post/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluginPostPublishPanel renders fill properly 1`] = `
+<div>
+  <PanelBody
+    className="my-plugin-post-publish-panel"
+    initialOpen={true}
+    key="1---0/.0"
+    title="My panel title"
+  >
+    <div
+      className="components-panel__body my-plugin-post-publish-panel is-opened"
+    >
+      <h2
+        className="components-panel__body-title"
+      >
+        <Button
+          aria-expanded={true}
+          className="components-panel__body-toggle"
+          onClick={[Function]}
+        >
+          <button
+            aria-expanded={true}
+            className="components-button components-panel__body-toggle"
+            onClick={[Function]}
+            type="button"
+          >
+            <Dashicon
+              icon="arrow-up"
+            >
+              <svg
+                aria-hidden={true}
+                className="dashicon dashicons-arrow-up"
+                focusable="false"
+                height={20}
+                role="img"
+                viewBox="0 0 20 20"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 13l4.03-6L15 13H7z"
+                />
+              </svg>
+            </Dashicon>
+            My panel title
+          </button>
+        </Button>
+      </h2>
+      My panel content
+    </div>
+  </PanelBody>
+</div>
+`;

--- a/edit-post/components/sidebar/plugin-post-publish-panel/test/index.js
+++ b/edit-post/components/sidebar/plugin-post-publish-panel/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PluginPostPublishPanel from '../';
+
+describe( 'PluginPostPublishPanel', () => {
+	test( 'renders fill properly', () => {
+		const wrapper = mount(
+			<SlotFillProvider>
+				<PluginPostPublishPanel
+					className="my-plugin-post-publish-panel"
+					title="My panel title"
+					initialOpen={ true }
+				>
+					My panel content
+				</PluginPostPublishPanel>
+				<PluginPostPublishPanel.Slot />
+			</SlotFillProvider>
+		);
+
+		expect( wrapper.find( 'Slot' ).children() ).toMatchSnapshot();
+	} );
+} );

--- a/edit-post/components/sidebar/plugin-pre-publish-panel/index.js
+++ b/edit-post/components/sidebar/plugin-pre-publish-panel/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill, PanelBody } from '@wordpress/components';
+
+const { Fill, Slot } = createSlotFill( 'PluginPrePublishPanel' );
+
+const PluginPrePublishPanel = ( { children, title, initialOpen = false } ) => (
+	<Fill>
+		<PanelBody initialOpen={ initialOpen || ! title } title={ title }>
+			{ children }
+		</PanelBody>
+	</Fill>
+);
+
+PluginPrePublishPanel.Slot = Slot;
+
+export default PluginPrePublishPanel;

--- a/edit-post/components/sidebar/plugin-pre-publish-panel/index.js
+++ b/edit-post/components/sidebar/plugin-pre-publish-panel/index.js
@@ -5,9 +5,13 @@ import { createSlotFill, PanelBody } from '@wordpress/components';
 
 const { Fill, Slot } = createSlotFill( 'PluginPrePublishPanel' );
 
-const PluginPrePublishPanel = ( { children, title, initialOpen = false } ) => (
+const PluginPrePublishPanel = ( { children, className, title, initialOpen = false } ) => (
 	<Fill>
-		<PanelBody initialOpen={ initialOpen || ! title } title={ title }>
+		<PanelBody
+			className={ className }
+			initialOpen={ initialOpen || ! title }
+			title={ title }
+		>
 			{ children }
 		</PanelBody>
 	</Fill>

--- a/edit-post/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluginPrePublishPanel renders fill properly 1`] = `
+<div>
+  <PanelBody
+    className="my-plugin-pre-publish-panel"
+    initialOpen={true}
+    key="1---0/.0"
+    title="My panel title"
+  >
+    <div
+      className="components-panel__body my-plugin-pre-publish-panel is-opened"
+    >
+      <h2
+        className="components-panel__body-title"
+      >
+        <Button
+          aria-expanded={true}
+          className="components-panel__body-toggle"
+          onClick={[Function]}
+        >
+          <button
+            aria-expanded={true}
+            className="components-button components-panel__body-toggle"
+            onClick={[Function]}
+            type="button"
+          >
+            <Dashicon
+              icon="arrow-up"
+            >
+              <svg
+                aria-hidden={true}
+                className="dashicon dashicons-arrow-up"
+                focusable="false"
+                height={20}
+                role="img"
+                viewBox="0 0 20 20"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 13l4.03-6L15 13H7z"
+                />
+              </svg>
+            </Dashicon>
+            My panel title
+          </button>
+        </Button>
+      </h2>
+      My panel content
+    </div>
+  </PanelBody>
+</div>
+`;

--- a/edit-post/components/sidebar/plugin-pre-publish-panel/test/index.js
+++ b/edit-post/components/sidebar/plugin-pre-publish-panel/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PluginPrePublishPanel from '../';
+
+describe( 'PluginPrePublishPanel', () => {
+	test( 'renders fill properly', () => {
+		const wrapper = mount(
+			<SlotFillProvider>
+				<PluginPrePublishPanel
+					className="my-plugin-pre-publish-panel"
+					title="My panel title"
+					initialOpen={ true }
+				>
+					My panel content
+				</PluginPrePublishPanel>
+				<PluginPrePublishPanel.Slot />
+			</SlotFillProvider>
+		);
+
+		expect( wrapper.find( 'Slot' ).children() ).toMatchSnapshot();
+	} );
+} );

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -80,6 +80,8 @@ export function initializeEditor( id, post, settings ) {
 	};
 }
 
+export { default as PluginPostPublishPanel } from './components/sidebar/plugin-post-publish-panel';
 export { default as PluginPostStatusInfo } from './components/sidebar/plugin-post-status-info';
+export { default as PluginPrePublishPanel } from './components/sidebar/plugin-pre-publish-panel';
 export { default as PluginSidebar } from './components/sidebar/plugin-sidebar';
 export { default as PluginSidebarMoreMenuItem } from './components/header/plugin-sidebar-more-menu-item';

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -60,7 +60,7 @@ class PostPublishPanel extends Component {
 	}
 
 	render() {
-		const { isScheduled, onClose, forceIsDirty, forceIsSaving } = this.props;
+		const { isScheduled, onClose, forceIsDirty, forceIsSaving, renderPrePublishExtension, renderPostPublishExtension } = this.props;
 		const { loading, submitted } = this.state;
 		return (
 			<div className="editor-post-publish-panel">
@@ -82,9 +82,17 @@ class PostPublishPanel extends Component {
 					/>
 				</div>
 				<div className="editor-post-publish-panel__content">
-					{ ! loading && ! submitted && <PostPublishPanelPrepublish /> }
+					{ ! loading && ! submitted && (
+						<PostPublishPanelPrepublish>
+							{ renderPrePublishExtension() }
+						</PostPublishPanelPrepublish>
+					) }
 					{ loading && ! submitted && <Spinner /> }
-					{ submitted && <PostPublishPanelPostpublish /> }
+					{ submitted && (
+						<PostPublishPanelPostpublish>
+							{ renderPostPublishExtension() }
+						</PostPublishPanelPostpublish>
+					) }
 				</div>
 			</div>
 		);

--- a/editor/components/post-publish-panel/postpublish.js
+++ b/editor/components/post-publish-panel/postpublish.js
@@ -48,7 +48,7 @@ class PostPublishPanelPostpublish extends Component {
 	}
 
 	render() {
-		const { isScheduled, post, postType } = this.props;
+		const { children, isScheduled, post, postType } = this.props;
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
 
 		const postPublishNonLinkHeader = isScheduled ?
@@ -84,6 +84,7 @@ class PostPublishPanelPostpublish extends Component {
 						</ClipboardButton>
 					</div>
 				</PanelBody>
+				{ children }
 			</div>
 		);
 	}

--- a/editor/components/post-publish-panel/prepublish.js
+++ b/editor/components/post-publish-panel/prepublish.js
@@ -12,7 +12,7 @@ import PostVisibilityLabel from '../post-visibility/label';
 import PostSchedule from '../post-schedule';
 import PostScheduleLabel from '../post-schedule/label';
 
-function PostPublishPanelPrepublish() {
+function PostPublishPanelPrepublish( { children } ) {
 	return (
 		<div className="editor-post-publish-panel__prepublish">
 			<div><strong>{ __( 'Are you ready to publish?' ) }</strong></div>
@@ -29,6 +29,7 @@ function PostPublishPanelPrepublish() {
 			] }>
 				<PostSchedule />
 			</PanelBody>
+			{ children }
 		</div>
 	);
 }


### PR DESCRIPTION
## Description

Fixes #3264.

> To support the current Publicize integration strategy per Jetpack PR Automattic/jetpack#9144, I'm proposing Gutenberg provide extensibility in a couple areas:
> 
> - Provide extendable pre and publish panels (see strategy in #3264) 
>
> Added `PluginPrePublishPanel` and `PluginPostPublishPanel` to for plugins to add content to pre-publish sidebar or post-publish sidebar respectively.

Continues work started by @c-shultz in #5795. To make it easier to proceed I moved those changes to the upstream repository. Sorry, for losing commits history @c-shultz and thanks for your initial work which made this change very easy.

## How has this been tested?

Code to paste into your browser: https://gist.github.com/gziolo/fd8141f2cde7fcb1b513c09eea45d27f.

## Screenshots <!-- if applicable -->

#### Pre-publish

![screen shot 2018-05-17 at 13 39 03](https://user-images.githubusercontent.com/699132/40175235-c672ab46-59d7-11e8-942f-a2c871d9e3ce.png)

#### Post-publish

Desktop:
![screen shot 2018-05-17 at 13 37 15](https://user-images.githubusercontent.com/699132/40175233-c63c78aa-59d7-11e8-8ee3-b6f008b6a89c.png)

Mobile:
![screen shot 2018-05-17 at 13 37 41](https://user-images.githubusercontent.com/699132/40175234-c65776e6-59d7-11e8-95d7-16a12042d7cb.png)


## Types of changes
 New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
