### PR TITLE
Utils: Deprecate isExtraSmall utility function

### DIFF
--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -15,8 +15,8 @@ import {
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
-import { getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
+import { Component, compose, Fragment } from '@wordpress/element';
+import { getBlobByURL, revokeBlobURL } from '@wordpress/utils';
 import {
 	Button,
 	ButtonGroup,
@@ -38,6 +38,7 @@ import {
 	UrlInputButton,
 	editorMediaUpload,
 } from '@wordpress/editor';
+import { withViewportMatch } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -167,7 +168,7 @@ class ImageEdit extends Component {
 	}
 
 	render() {
-		const { attributes, setAttributes, isSelected, className, maxWidth, toggleSelection } = this.props;
+		const { attributes, setAttributes, isLargeViewport, isSelected, className, maxWidth, toggleSelection } = this.props;
 		const { url, alt, caption, align, id, href, width, height } = attributes;
 
 		const controls = (
@@ -218,7 +219,7 @@ class ImageEdit extends Component {
 			'is-focused': isSelected,
 		} );
 
-		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && ( ! viewPort.isExtraSmall() );
+		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && isLargeViewport;
 
 		const getInspectorControls = ( imageWidth, imageHeight ) => (
 			<InspectorControls>
@@ -387,14 +388,17 @@ class ImageEdit extends Component {
 	}
 }
 
-export default withSelect( ( select, props ) => {
-	const { getMedia } = select( 'core' );
-	const { getEditorSettings } = select( 'core/editor' );
-	const { id } = props.attributes;
-	const { maxWidth } = getEditorSettings();
+export default compose( [
+	withSelect( ( select, props ) => {
+		const { getMedia } = select( 'core' );
+		const { getEditorSettings } = select( 'core/editor' );
+		const { id } = props.attributes;
+		const { maxWidth } = getEditorSettings();
 
-	return {
-		image: id ? getMedia( id ) : null,
-		maxWidth,
-	};
-} )( ImageEdit );
+		return {
+			image: id ? getMedia( id ) : null,
+			maxWidth,
+		};
+	} ),
+	withViewportMatch( { isLargeViewport: 'medium' } ),
+] )( ImageEdit );

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -6,6 +6,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.blocks.withEditorSettings` is removed. Please use the data module to access the editor settings `wp.data.select( "core/editor" ).getEditorSettings()`.
  - All DOM utils in `wp.utils.*` are removed. Please use `wp.dom.*` instead.
  - `isPrivate: true` has been removed from the Block API. Please use `supports.inserter: false` instead.
+ - `wp.utils.isExtraSmall` function removed. Please use `wp.viewport.*` instead.
 
 ## 3.0.0
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -226,7 +226,18 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-core-blocks',
 		gutenberg_url( 'build/core-blocks/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-blocks', 'wp-editor', 'wp-i18n', 'editor', 'wp-core-data', 'lodash' ),
+		array(
+			'editor',
+			'lodash',
+			'wp-blocks',
+			'wp-components',
+			'wp-core-data',
+			'wp-element',
+			'wp-editor',
+			'wp-i18n',
+			'wp-utils',
+			'wp-viewport',
+		),
 		filemtime( gutenberg_dir_path() . 'build/core-blocks/index.js' ),
 		true
 	);

--- a/utils/deprecated.js
+++ b/utils/deprecated.js
@@ -40,3 +40,13 @@ export const remove = wrapFunction( 'remove' );
 export const replace = wrapFunction( 'replace' );
 export const replaceTag = wrapFunction( 'replaceTag' );
 export const unwrap = wrapFunction( 'unwrap' );
+
+export function isExtraSmall() {
+	deprecated( 'wp.utils.isExtraSmall', {
+		version: '3.1',
+		alternative: 'wp.viewport.*',
+		plugin: 'Gutenberg',
+	} );
+
+	return window && window.innerWidth < 782;
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import * as keycodes from './keycodes';
-import * as viewPort from './viewport';
 import { decodeEntities } from './entities';
 
 export { decodeEntities };
 export { keycodes };
-export { viewPort };
 
 export * from './blob-cache';
 export * from './deprecation';
@@ -15,4 +13,4 @@ export * from './mediaupload';
 export * from './terms';
 
 // Deprecations
-export * from './dom-deprecated';
+export * from './deprecated';

--- a/utils/viewport.js
+++ b/utils/viewport.js
@@ -1,3 +1,0 @@
-export function isExtraSmall() {
-	return window && window.innerWidth < 782;
-}


### PR DESCRIPTION
## Description
Code refactoring which removes `isExtraSmall` utility functions and uses `withViewportMatch` HOC instead.

## How has this been tested?
Manually. Make sure it is still possible to resize an image when block's alignment set to `wide` or `full` when screed width is larger than `782px`.

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
