### PR TITLE
Polish menus and focus styles

### DIFF
--- a/components/menu-item/style.scss
+++ b/components/menu-item/style.scss
@@ -20,11 +20,11 @@
 		padding-left: 0;
 	}
 
-	&:hover {
+	&:hover:not(:disabled):not([aria-disabled="true"]) {
 		@include menu-style__neutral;
 	}
 
-	&:focus {
+	&:focus:not(:disabled):not([aria-disabled="true"]) {
 		@include menu-style__focus;
 	}
 }

--- a/components/menu-item/style.scss
+++ b/components/menu-item/style.scss
@@ -30,6 +30,7 @@
 }
 
 .components-menu-item__shortcut {
-	float: right;
 	opacity: .5;
+	margin-right: 0;
+	margin-left: auto;
 }

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -76,7 +76,7 @@
 	color: $dark-gray-900;
 	@include menu-style__neutral;
 
-	&:focus {
+	&:focus:not(:disabled):not([aria-disabled="true"]) {
 		@include menu-style__focus;
 	}
 

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -80,7 +80,7 @@
 
 	.components-popover:not(.is-mobile) & {
 		position: absolute;
-		min-width: 240px;
+		min-width: 260px;
 		height: auto;
 	}
 

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -80,9 +80,8 @@
 		cursor: pointer;
 		@include menu-style__neutral;
 
-		&:hover,
-		&:focus,
-		&:not(:disabled):hover {
+		&:hover:not(:disabled):not([aria-disabled="true"]),
+		&:focus:not(:disabled):not([aria-disabled="true"]) {
 			@include menu-style__focus;
 		}
 

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -49,4 +49,13 @@
 		margin-right: 8px;
 		height: 20px;
 	}
+
+	&:hover:not(:disabled):not([aria-disabled="true"]) {
+		@include menu-style__neutral;
+	}
+
+	&:focus:not(:disabled):not([aria-disabled="true"]) {
+		@include menu-style__focus;
+	}
+
 }

--- a/editor/components/post-last-revision/style.scss
+++ b/editor/components/post-last-revision/style.scss
@@ -8,7 +8,7 @@
 }
 
 // Needs specificity
-.components-icon-button:not(:disabled).editor-post-last-revision__title {
+.components-icon-button:not(:disabled):not([aria-disabled="true"]).editor-post-last-revision__title {
 
 	&:hover,
 	&:active {

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -74,10 +74,10 @@ export const displayShortcut = mapValues( modifiers, ( modifier ) => {
 	return ( character, _isMac = isMacOS ) => {
 		const isMac = _isMac();
 		const replacementKeyMap = {
-			[ ALT ]: isMac ? '⌥option' : 'Alt',
-			[ CTRL ]: isMac ? '⌃control' : 'Ctrl',
+			[ ALT ]: isMac ? 'Option' : 'Alt',
+			[ CTRL ]: isMac ? 'Ctrl' : 'Ctrl',
 			[ COMMAND ]: '⌘',
-			[ SHIFT ]: isMac ? '⇧shift' : 'Shift',
+			[ SHIFT ]: isMac ? 'Shift' : 'Shift',
 		};
 		const shortcut = [
 			...modifier( _isMac ).map( ( key ) => get( replacementKeyMap, key, key ) ),

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -75,9 +75,9 @@ export const displayShortcut = mapValues( modifiers, ( modifier ) => {
 		const isMac = _isMac();
 		const replacementKeyMap = {
 			[ ALT ]: isMac ? 'Option' : 'Alt',
-			[ CTRL ]: isMac ? 'Ctrl' : 'Ctrl',
+			[ CTRL ]: 'Ctrl',
 			[ COMMAND ]: '⌘',
-			[ SHIFT ]: isMac ? 'Shift' : 'Shift',
+			[ SHIFT ]: 'Shift',
 		};
 		const shortcut = [
 			...modifier( _isMac ).map( ( key ) => get( replacementKeyMap, key, key ) ),

--- a/utils/test/keycodes.js
+++ b/utils/test/keycodes.js
@@ -31,7 +31,7 @@ describe( 'displayShortcut', () => {
 
 		it( 'should output shift+command symbols on MacOS', () => {
 			const shortcut = displayShortcut.primaryShift( 'm', isMacOSTrue );
-			expect( shortcut ).toEqual( '⇧shift+⌘M' );
+			expect( shortcut ).toEqual( 'Shift+⌘M' );
 		} );
 	} );
 
@@ -43,7 +43,7 @@ describe( 'displayShortcut', () => {
 
 		it( 'should output shift+option+command symbols on MacOS', () => {
 			const shortcut = displayShortcut.secondary( 'm', isMacOSTrue );
-			expect( shortcut ).toEqual( '⇧shift+⌥option+⌘M' );
+			expect( shortcut ).toEqual( 'Shift+Option+⌘M' );
 		} );
 	} );
 
@@ -55,7 +55,7 @@ describe( 'displayShortcut', () => {
 
 		it( 'should output control+option symbols on MacOS', () => {
 			const shortcut = displayShortcut.access( 'm', isMacOSTrue );
-			expect( shortcut ).toEqual( '⌃control+⌥option+M' );
+			expect( shortcut ).toEqual( 'Ctrl+Option+M' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This fixes a regression in menu focus styles that was introduced as part of some focus fixes to the movers way back.

It also fixes #6734, as it changes how the shortcuts are spelled out.

<img width="310" alt="screen shot 2018-05-18 at 09 37 06" src="https://user-images.githubusercontent.com/1204802/40222379-9536d4e6-5a7f-11e8-8bd2-21db854303e8.png">

<img width="346" alt="screen shot 2018-05-18 at 09 37 12" src="https://user-images.githubusercontent.com/1204802/40222381-966fbe9a-5a7f-11e8-9ea2-2bdd19fe02f5.png">
