### PR TITLE
Make sure the Title uses the same max-width as blocks

### DIFF
--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -37,6 +37,7 @@
 	margin: #{ -1 * $block-spacing } auto -50px;
 }
 
+// The base width of blocks
 .edit-post-visual-editor .editor-block-list__block {
 	margin-left: auto;
 	margin-right: auto;
@@ -65,25 +66,21 @@
 	}
 }
 
-// This is a focus style shown for blocks that need an indicator even when in an isEditing state
-// like for example an image block that receives arrowkey focus.
-.edit-post-visual-editor .editor-block-list__block:not( .is-selected ) {
-	.editor-block-list__block-edit {
-		box-shadow: 0 0 0 0 $white, 0 0 0 0 $dark-gray-900;
-		transition: .1s box-shadow .05s;
-	}
-
-	&:focus .editor-block-list__block-edit {
-		box-shadow: 0 0 0 1px $white, 0 0 0 3px $dark-gray-900;
-	}
-}
-
+// The base width of the title should match that of blocks even if it isn't a block
 .edit-post-visual-editor .editor-post-title {
 	margin-left: auto;
 	margin-right: auto;
-	max-width: $content-width + ( 2 * $block-side-ui-padding );
+	max-width: $content-width;
 
-	.editor-post-permalink {
+	@include break-small() {
+		> div {
+			margin-left: -$block-side-ui-padding;
+			margin-right: -$block-side-ui-padding;
+		}
+	}
+
+
+	/*.editor-post-permalink {
 		left: $block-padding;
 		right: $block-padding;
 		color: $dark-gray-900;
@@ -96,6 +93,19 @@
 			left: $block-side-ui-padding;
 			right: $block-side-ui-padding;
 		}
+	}*/
+}
+
+// This is a focus style shown for blocks that need an indicator even when in an isEditing state
+// like for example an image block that receives arrowkey focus.
+.edit-post-visual-editor .editor-block-list__block:not( .is-selected ) {
+	.editor-block-list__block-edit {
+		box-shadow: 0 0 0 0 $white, 0 0 0 0 $dark-gray-900;
+		transition: .1s box-shadow .05s;
+	}
+
+	&:focus .editor-block-list__block-edit {
+		box-shadow: 0 0 0 1px $white, 0 0 0 3px $dark-gray-900;
 	}
 }
 

--- a/editor/components/post-title/style.scss
+++ b/editor/components/post-title/style.scss
@@ -1,6 +1,10 @@
 .editor-post-title {
 	position: relative;
 	padding: 5px 0;
+	
+	@include break-small() {
+		padding: 5px $block-side-ui-padding;
+	}
 
 	.editor-post-title__input {
 		display: block;
@@ -35,4 +39,9 @@
 	top: -35px;
 	left: 0;
 	right: 0;
+
+	@include break-small() {
+		left: $block-side-ui-padding;
+		right: $block-side-ui-padding;
+	}
 }


### PR DESCRIPTION
During the development of #6438, it was noted that the Title does not use the same `$content-width` as a block. Which means if you want to change the width of titles and blocks per [these instructions](https://wordpress.org/gutenberg/handbook/extensibility/theme-support/#changing-the-width-of-the-editor), you actually have to compensate for the title. 

This PR fixes that. The title and normal nonwide blocks now have exactly the same width.

Test that:

- The width of the title doesn't regress in mobile or desktop breakpoitns
- the widht of the title block and post permalink matches that of a normal block

<img width="765" alt="screen shot 2018-05-18 at 10 13 27" src="https://user-images.githubusercontent.com/1204802/40224207-c043bf68-5a85-11e8-9cee-17c3b03d7983.png">
