### PR TITLE
Adds support for returning a list of blocks from a raw transform

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flatMap, filter, compact } from 'lodash';
+import { flatMap, filter, compact, flatten } from 'lodash';
 // Also polyfills Element#matches.
 import 'element-closest';
 
@@ -168,7 +168,7 @@ export default function rawHandler( { HTML = '', plainText = '', mode = 'AUTO', 
 
 		doc.body.innerHTML = piece;
 
-		return Array.from( doc.body.children ).map( ( node ) => {
+		return flatten( Array.from( doc.body.children ).map( ( node ) => {
 			const rawTransformation = findTransform( rawTransformations, ( { isMatch } ) => isMatch( node ) );
 
 			if ( ! rawTransformation ) {
@@ -194,6 +194,6 @@ export default function rawHandler( { HTML = '', plainText = '', mode = 'AUTO', 
 					node.outerHTML
 				)
 			);
-		} );
+		} ) );
 	} ) );
 }


### PR DESCRIPTION
## Description

transforms with a `raw` type only supported a single node to a single block,
but we may need to convert raw content into a list of blocks.

If a raw transform returned a list of blocks, it would cause a crash in the
factory, because we expect each element to be a block, not a list of blocks,
so this change flattens the list returned from `rawHandler`.

## How has this been tested?

Modify an existing block with a raw transform to return its block in an array,
check that the transform still works.

## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
