### PR TITLE
Fix appender height

### DIFF
--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -9,7 +9,6 @@ $empty-paragraph-height: $text-editor-font-size * 4;
 		margin: 0;
 		max-width: none; // fixes a bleed issue from the admin
 		padding: $block-padding;
-		height: $empty-paragraph-height;
 		font-size: $editor-font-size;
 		font-family: $editor-font;
 		cursor: text;
@@ -17,6 +16,11 @@ $empty-paragraph-height: $text-editor-font-size * 4;
 		font-family: $editor-font;
 		outline: 1px solid transparent;
 		transition: 0.2s outline;
+
+		// match the height of an empty paragraph
+		// to prevent margins from collapsing we add 1px padding top and bottom to both .editor-block-list__block and .editor-block-list__block-edit (coming to a total of 4px extra)
+		// @todo: revisit when we allow margins to collapse
+		height: $empty-paragraph-height + 4px;
 
 		// use opacity to work in various editor styles
 		color: $dark-opacity-300;


### PR DESCRIPTION
The default block appender did not match the height of a Paragraph block, which it should since it's supposed to emulate an empty paragraph block.

This is because we add 1px padding top and bottom to both .editor-block-list__block and .editor-block-list__block-edit (coming to a total of 4px extra), in order to prevent margins from collapsing.

We mean to revisit this in the future, when we allow margins to collapse. Then this can be revisited. But in the interim, this makes the two match.

Worth adding? Yes, because allowing margins to collapse is going to be very challenging, and we might do this not for all blocks but for some. 

![matching](https://user-images.githubusercontent.com/1204802/40226012-ea4d9022-5a8a-11e8-9dc1-0b93bf204b58.gif)
