### PR TITLE
Try a different inbetweenserter approach

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -19,7 +19,7 @@ $z-layers: (
 	'.editor-block-contextual-toolbar': 21,
 	'.editor-block-switcher__menu': 5,
 	'.components-popover__close': 5,
-	'.editor-block-list__insertion-point': 5,
+	'.editor-block-list__insertion-point': 82, // @todo, test that this new elevation doesn't cause issues, used to be 5, shoud now be above side UI
 	'.editor-format-toolbar__link-modal': 81, // should appear above block controls
 	'.editor-format-toolbar__link-container': 81, // link suggestions should also
 	'.core-blocks-gallery-item__inline-menu': 20,

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -128,8 +128,3 @@
 		}
 	}
 }
-
-.edit-post-visual-editor .editor-block-list__layout > .editor-block-list__insertion-point {
-	max-width: $content-width;
-	position: relative;
-}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -407,11 +407,12 @@ export class BlockListBlock extends Component {
 			isSelected,
 			isMultiSelected,
 			isFirstMultiSelected,
-			isLastInSelection,
 			isTypingWithinBlock,
 			isMultiSelecting,
 			hoverArea,
 			isLargeViewport,
+			isEmptyDefaultBlock,
+			isPreviousBlockADefaultEmptyBlock,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -423,7 +424,6 @@ export class BlockListBlock extends Component {
 
 		// If the block is selected and we're typing the block should not appear.
 		// Empty paragraph blocks should always show up as unselected.
-		const isEmptyDefaultBlock = isUnmodifiedDefaultBlock( block );
 		const isSelectedNotTyping = isSelected && ! isTypingWithinBlock;
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showEmptyBlockSideInserter && isSelectedNotTyping;
@@ -438,11 +438,8 @@ export class BlockListBlock extends Component {
 		// Insertion point can only be made visible when the side inserter is
 		// not present, and either the block is at the extent of a selection or
 		// is the first block in the top-level list rendering.
-		const shouldShowInsertionPoint = (
-			( ! isMultiSelected && ! isFirst ) ||
-			( isMultiSelected && isLastInSelection ) ||
-			( isFirst && ! rootUID && ! isEmptyDefaultBlock )
-		);
+		const shouldShowInsertionPoint = ( isMultiSelected && isFirst ) || ! isMultiSelected;
+		const canShowInBetweenInserter = ! isEmptyDefaultBlock && ! isPreviousBlockADefaultEmptyBlock;
 
 		// Generate the wrapper class names handling the different states of the block.
 		const wrapperClassName = classnames( 'editor-block-list__block', {
@@ -513,6 +510,7 @@ export class BlockListBlock extends Component {
 						uid={ uid }
 						rootUID={ rootUID }
 						layout={ layout }
+						canShowInserter={ canShowInBetweenInserter }
 					/>
 				) }
 				<BlockDropZone
@@ -621,20 +619,19 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		getBlockMode,
 		isSelectionEnabled,
 		getSelectedBlocksInitialCaretPosition,
-		getBlockSelectionEnd,
 		getEditorSettings,
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( uid );
 	const { templateLock, hasFixedToolbar } = getEditorSettings();
+	const block = getBlock( uid );
+	const previousBlockUid = getPreviousBlockUid( uid );
+	const previousBlock = getBlock( previousBlockUid );
 
 	return {
-		previousBlockUid: getPreviousBlockUid( uid ),
 		nextBlockUid: getNextBlockUid( uid ),
-		block: getBlock( uid ),
 		isMultiSelected: isBlockMultiSelected( uid ),
 		isFirstMultiSelected: isFirstMultiSelectedBlock( uid ),
 		isMultiSelecting: isMultiSelecting(),
-		isLastInSelection: getBlockSelectionEnd() === uid,
 		// We only care about this prop when the block is selected
 		// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
 		isTypingWithinBlock: isSelected && isTyping(),
@@ -643,8 +640,12 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		mode: getBlockMode( uid ),
 		isSelectionEnabled: isSelectionEnabled(),
 		initialPosition: getSelectedBlocksInitialCaretPosition(),
-		isSelected,
+		isEmptyDefaultBlock: block && isUnmodifiedDefaultBlock( block ),
+		isPreviousBlockADefaultEmptyBlock: previousBlock && isUnmodifiedDefaultBlock( previousBlock ),
 		isLocked: !! templateLock,
+		previousBlockUid,
+		block,
+		isSelected,
 		hasFixedToolbar,
 	};
 } );

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -4,13 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
-import { ifCondition } from '@wordpress/components';
+import { ifCondition, IconButton } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import IconButton from '../../../components/icon-button';
 
 class BlockInsertionPoint extends Component {
 	constructor() {
@@ -31,7 +26,7 @@ class BlockInsertionPoint extends Component {
 			<div className="editor-block-list__insertion-point">
 				{ showInsertionPoint && <div className="editor-block-list__insertion-point-indicator" /> }
 				{ showInserter && (
-					<div className="editor-block-list__insertion-point">
+					<div className="editor-block-list__insertion-point-inserter">
 						<IconButton
 							icon="insert"
 							className="editor-block-list__insertion-point-button"
@@ -45,7 +40,7 @@ class BlockInsertionPoint extends Component {
 	}
 }
 export default compose(
-	withSelect( ( select, { uid, rootUID } ) => {
+	withSelect( ( select, { uid, rootUID, canShowInserter } ) => {
 		const {
 			getBlockIndex,
 			getBlockInsertionPoint,
@@ -67,7 +62,7 @@ export default compose(
 
 		return {
 			templateLock: getEditorSettings().templateLock,
-			showInserter: ! isTyping(),
+			showInserter: ! isTyping() && canShowInserter,
 			index: insertIndex,
 			showInsertionPoint,
 		};

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -7,6 +7,11 @@ import { Component, compose } from '@wordpress/element';
 import { ifCondition } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import IconButton from '../../../components/icon-button';
+
 class BlockInsertionPoint extends Component {
 	constructor() {
 		super( ...arguments );
@@ -26,11 +31,14 @@ class BlockInsertionPoint extends Component {
 			<div className="editor-block-list__insertion-point">
 				{ showInsertionPoint && <div className="editor-block-list__insertion-point-indicator" /> }
 				{ showInserter && (
-					<button
-						className="editor-block-list__insertion-point-inserter"
-						onClick={ this.onClick }
-						aria-label={ __( 'Insert block' ) }
-					/>
+					<div className="editor-block-list__insertion-point">
+						<IconButton
+							icon="insert"
+							className="editor-block-list__insertion-point-button"
+							onClick={ this.onClick }
+							aria-label={ __( 'Insert block' ) }
+						/>
+					</div>
 				) }
 			</div>
 		);

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -10,7 +15,25 @@ import { withSelect, withDispatch } from '@wordpress/data';
 class BlockInsertionPoint extends Component {
 	constructor() {
 		super( ...arguments );
+		this.state = {
+			isInserterFocused: false,
+		};
+
+		this.onBlurInserter = this.onBlurInserter.bind( this );
+		this.onFocusInserter = this.onFocusInserter.bind( this );
 		this.onClick = this.onClick.bind( this );
+	}
+
+	onFocusInserter() {
+		this.setState( {
+			isInserterFocused: true,
+		} );
+	}
+
+	onBlurInserter() {
+		this.setState( {
+			isInserterFocused: false,
+		} );
 	}
 
 	onClick() {
@@ -20,18 +43,21 @@ class BlockInsertionPoint extends Component {
 	}
 
 	render() {
+		const { isInserterFocused } = this.state;
 		const { showInsertionPoint, showInserter } = this.props;
 
 		return (
 			<div className="editor-block-list__insertion-point">
 				{ showInsertionPoint && <div className="editor-block-list__insertion-point-indicator" /> }
 				{ showInserter && (
-					<div className="editor-block-list__insertion-point-inserter">
+					<div className={ classnames( 'editor-block-list__insertion-point-inserter', { 'is-visible': isInserterFocused } ) }>
 						<IconButton
 							icon="insert"
 							className="editor-block-list__insertion-point-button"
 							onClick={ this.onClick }
 							label={ __( 'Insert block' ) }
+							onFocus={ this.onFocusInserter }
+							onBlur={ this.onBlurInserter }
 						/>
 					</div>
 				) }

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -31,7 +31,7 @@ class BlockInsertionPoint extends Component {
 							icon="insert"
 							className="editor-block-list__insertion-point-button"
 							onClick={ this.onClick }
-							aria-label={ __( 'Insert block' ) }
+							label={ __( 'Insert block' ) }
 						/>
 					</div>
 				) }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -557,73 +557,45 @@
 	cursor: grab;
 }
 
-.editor-block-list__insertion-point {
-	position: relative;
+// In-between-serter
+.editor-block-list__block > .editor-block-list__insertion-point {
+	display: flex;
+	max-width: $content-width;
+	position: absolute;
 	z-index: z-index( '.editor-block-list__insertion-point' );
-}
-
-.editor-block-list__insertion-point-indicator {
-	position: absolute;
-	top: $block-padding - 1px; // Half the empty space between two blocks, minus the 2px height
-	height: 2px;
-	left: 0;
-	right: 0;
-	background: theme( primary );
-}
-
-.editor-block-list__insertion-point-inserter {
-	position: absolute;
-	background: none;
-	border: none;
-	display: block;
-	top: 0;
+	top: -$block-padding - 2px; // Matches the 1px paddings we use to prevent collapsing margins
+	bottom: auto;
+	left: -1px; // overlap 1px border
+	right: -1px;
 	height: $block-padding * 2; // Matches the whole empty space between two blocks
-	width: 100%;
-	cursor: pointer;
-	padding: 0;	// Unstyle inherited padding from core button
+	justify-content: center;
 
+	// Show a clickable plus
+	.editor-block-list__insertion-point-button {
+		margin-top: -4px;
+		border-radius: 50%;
+		color: $dark-gray-100;
+		background: $white;
+	}
+	
+	// Show a line indicator when hovering, but this is unclickable
 	&:before {
 		position: absolute;
 		top: $block-padding - 1px; // Half the empty space between two blocks, minus the 2px height
 		height: 2px;
-		left: $block-padding;
-		right: $block-padding;
+		left: 0;
+		right: 0;
 		background: $dark-gray-100;
 		content: '';
-		opacity: 0;
-		transition: opacity 0.1s linear 0.1s;
 	}
 
-	&:hover:before {
+	// Hide both the line and button until hovered
+	opacity: 0;
+	transition: opacity 0.1s linear 0.1s;
+
+	&:hover {
 		opacity: 1;
-		transition: opacity 0.2s linear 0.5s;
 	}
-
-	&:focus {
-		outline: none;
-	}
-
-	// Show focus style when tabbing
-	&:focus:before {
-		opacity: 1;
-		transition: opacity 0.2s linear;
-		outline: 1px solid $dark-gray-300;
-		outline-offset: 2px;
-	}
-
-	// Don't show focus style when clicking
-	&:focus:active:before {
-		outline: none;
-	}
-}
-
-.editor-block-list__block > .editor-block-list__insertion-point {
-	position: absolute;
-	top: -$block-padding;
-	height: $block-padding * 2; // Matches the whole empty space between two blocks
-	bottom: auto;
-	left: 0;
-	right: 0;
 }
 
 .editor-block-list__block .editor-block-list__block-html-textarea {

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -611,7 +611,7 @@
 	opacity: 0;
 	transition: opacity 0.1s linear 0.1s;
 
-	&:hover {
+	&:hover, &.is-visible {
 		opacity: 1;
 	}
 }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -550,23 +550,34 @@
 /**
  * In-Canvas Inserter
  */
-
 .editor-block-list .editor-inserter {
 	margin: $item-spacing;
 	cursor: move;/* Fallback for IE/Edge < 14 */
 	cursor: grab;
 }
 
-// In-between-serter
-.editor-block-list__block > .editor-block-list__insertion-point {
-	display: flex;
-	max-width: $content-width;
-	position: absolute;
+// Insertion point (includes inbetween inserter and insertion indicator)
+.editor-block-list__insertion-point {
+	position: relative;
 	z-index: z-index( '.editor-block-list__insertion-point' );
-	top: -$block-padding - 2px; // Matches the 1px paddings we use to prevent collapsing margins
+}
+
+.editor-block-list__insertion-point-indicator {
+	position: absolute;
+	top: calc( 50% - 1px);
+	height: 2px;
+	left: 0;
+	right: 0;
+	background: theme( primary );
+}
+
+.editor-block-list__insertion-point-inserter {
+	display: flex;
+	position: absolute;
+	top: 0;
 	bottom: auto;
-	left: -1px; // overlap 1px border
-	right: -1px;
+	left: 0;
+	right: 0;
 	height: $block-padding * 2; // Matches the whole empty space between two blocks
 	justify-content: center;
 
@@ -576,12 +587,19 @@
 		border-radius: 50%;
 		color: $dark-gray-100;
 		background: $white;
-	}
+		height: $block-padding * 2 + 8px;
+		width: $block-padding * 2 + 8px;
 	
+		&:not(:disabled):not([aria-disabled="true"]):hover {
+			box-shadow: none;
+		}
+	
+	}
+
 	// Show a line indicator when hovering, but this is unclickable
 	&:before {
 		position: absolute;
-		top: $block-padding - 1px; // Half the empty space between two blocks, minus the 2px height
+		top: calc( 50% - 1px);
 		height: 2px;
 		left: 0;
 		right: 0;
@@ -596,6 +614,15 @@
 	&:hover {
 		opacity: 1;
 	}
+}
+
+.editor-block-list__block > .editor-block-list__insertion-point {
+	position: absolute;
+	top: -$block-padding - $block-spacing / 2;
+	height: $block-padding * 2; // Matches the whole empty space between two blocks
+	bottom: auto;
+	left: -1px;
+	right: -1px;
 }
 
 .editor-block-list__block .editor-block-list__block-html-textarea {

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -81,7 +81,7 @@ describe( 'adding blocks', () => {
 		// Using the between inserter
 		await page.mouse.move( 200, 300 );
 		await page.mouse.move( 250, 350 );
-		const inserter = await page.$( '[data-type="core/quote"] .editor-block-list__insertion-point-inserter' );
+		const inserter = await page.$( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
 		await clickAtRightish( inserter );
 		await page.keyboard.type( 'Second paragraph' );
 


### PR DESCRIPTION
This is an attempt to redesign the inbetweenserter to be less frustrating. Currently in master it's too easy to invoke it whe
n you don't mean to.

This branch changes that approach. You can still hover between two lines to reveal a line indicator. But you can't click this line. Instead, a new plus button sits at the center of this line, and you have to click that to insert between.

![inbetweenserter](https://user-images.githubusercontent.com/1204802/40228910-e30cb164-5a92-11e8-8c5b-62419f889bd3.gif)

Please give this a spin. Depending on feedback, it needs visual love, and other tweaks. Right now it's definitely a try branch, and needs your thoughts. For example, when you click to insert a provisional placeholder block, you're still hovering in an area where the inserter line will appear, but it should immediately fade out instead. We might also want to look at some of that sizing magic that @aduth used for the old inbetweenserter. 
