### PR TITLE
Try unifying all the media blocks placeholder under a unique component

### DIFF
--- a/core-blocks/audio/editor.scss
+++ b/core-blocks/audio/editor.scss
@@ -1,19 +1,3 @@
-.wp-block-audio .components-placeholder__input {
-	margin-top: 0.5em;
-}
-
-.wp-block-audio .components-button.is-large {
-	margin-top: 0.5em;
-}
-
 .wp-block-audio audio {
 	width: 100%;
-}
-
-.wp-block-audio .components-placeholder__fieldset {
-	max-width: 400px;
-
-	form {
-		max-width: none;
-	}
 }

--- a/core-blocks/audio/test/__snapshots__/index.js.snap
+++ b/core-blocks/audio/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`core/audio block edit matches snapshot 1`] = `
 <div
-  class="components-placeholder wp-block-audio"
+  class="components-placeholder editor-media-placeholder wp-block-audio"
 >
   <div
     class="components-placeholder__label"
@@ -26,15 +26,42 @@ exports[`core/audio block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__instructions"
   >
-    Select an audio file from your library, or upload a new one
+    Drag an audio, upload a new one or select a file from your library.
   </div>
   <div
     class="components-placeholder__fieldset"
   >
+    <div
+      class="components-drop-zone"
+    >
+      <div
+        class="components-drop-zone__content"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload components-drop-zone__content-icon"
+          focusable="false"
+          height="40"
+          role="img"
+          viewBox="0 0 20 20"
+          width="40"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        <span
+          class="components-drop-zone__content-text"
+        >
+          Drop files to upload
+        </span>
+      </div>
+    </div>
     <form>
       <input
         class="components-placeholder__input"
-        placeholder="Enter URL of audio file here…"
+        placeholder="Enter URL here…"
         type="url"
         value=""
       />
@@ -49,7 +76,7 @@ exports[`core/audio block edit matches snapshot 1`] = `
       class="components-form-file-upload"
     >
       <button
-        class="components-button components-icon-button wp-block-audio__upload-button is-button is-default is-large"
+        class="components-button components-icon-button editor-media-placeholder__upload-button is-button is-default is-large"
         type="button"
       >
         <svg

--- a/core-blocks/cover-image/index.js
+++ b/core-blocks/cover-image/index.js
@@ -15,7 +15,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	BlockAlignmentToolbar,
-	ImagePlaceholder,
+	MediaPlaceholder,
 	MediaUpload,
 	AlignmentToolbar,
 	RichText,
@@ -183,8 +183,16 @@ export const settings = {
 			return (
 				<Fragment>
 					{ controls }
-					<ImagePlaceholder
-						{ ...{ className, icon, label, onSelectImage } }
+					<MediaPlaceholder
+						icon={ icon }
+						className={ className }
+						labels={ {
+							title: label,
+							name: __( 'an image' ),
+						} }
+						onSelect={ onSelectImage }
+						accept="image/*"
+						type="image"
 					/>
 				</Fragment>
 			);

--- a/core-blocks/cover-image/test/__snapshots__/index.js.snap
+++ b/core-blocks/cover-image/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`core/cover-image block edit matches snapshot 1`] = `
 <div
-  class="components-placeholder wp-block-cover-image"
+  class="components-placeholder editor-media-placeholder wp-block-cover-image"
 >
   <div
     class="components-placeholder__label"
@@ -26,7 +26,7 @@ exports[`core/cover-image block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__instructions"
   >
-    Drag image here or add from media library
+    Drag an image, upload a new one or select a file from your library.
   </div>
   <div
     class="components-placeholder__fieldset"
@@ -62,7 +62,7 @@ exports[`core/cover-image block edit matches snapshot 1`] = `
       class="components-form-file-upload"
     >
       <button
-        class="components-button components-icon-button wp-block-image__upload-button is-button is-default is-large"
+        class="components-button components-icon-button editor-media-placeholder__upload-button is-button is-default is-large"
         type="button"
       >
         <svg

--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -22,7 +22,7 @@ import {
 	BlockControls,
 	BlockAlignmentToolbar,
 	MediaUpload,
-	ImagePlaceholder,
+	MediaPlaceholder,
 	InspectorControls,
 	editorMediaUpload,
 } from '@wordpress/editor';
@@ -199,11 +199,16 @@ export default class GalleryEdit extends Component {
 			return (
 				<Fragment>
 					{ controls }
-					<ImagePlaceholder
-						className={ className }
+					<MediaPlaceholder
 						icon="format-gallery"
-						label={ __( 'Gallery' ) }
-						onSelectImage={ this.onSelectImages }
+						className={ className }
+						labels={ {
+							title: __( 'Gallery' ),
+							name: __( 'images' ),
+						} }
+						onSelect={ this.onSelectImages }
+						accept="image/*"
+						type="image"
 						multiple
 					/>
 				</Fragment>

--- a/core-blocks/gallery/test/__snapshots__/index.js.snap
+++ b/core-blocks/gallery/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`core/gallery block edit matches snapshot 1`] = `
 <div
-  class="components-placeholder wp-block-gallery"
+  class="components-placeholder editor-media-placeholder wp-block-gallery"
 >
   <div
     class="components-placeholder__label"
@@ -26,7 +26,7 @@ exports[`core/gallery block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__instructions"
   >
-    Drag images here or add from media library
+    Drag images, upload a new one or select a file from your library.
   </div>
   <div
     class="components-placeholder__fieldset"
@@ -62,7 +62,7 @@ exports[`core/gallery block edit matches snapshot 1`] = `
       class="components-form-file-upload"
     >
       <button
-        class="components-button components-icon-button wp-block-image__upload-button is-button is-default is-large"
+        class="components-button components-icon-button editor-media-placeholder__upload-button is-button is-default is-large"
         type="button"
       >
         <svg

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -32,7 +32,7 @@ import {
 	RichText,
 	BlockControls,
 	InspectorControls,
-	ImagePlaceholder,
+	MediaPlaceholder,
 	MediaUpload,
 	BlockAlignmentToolbar,
 	UrlInputButton,
@@ -203,11 +203,16 @@ class ImageEdit extends Component {
 			return (
 				<Fragment>
 					{ controls }
-					<ImagePlaceholder
-						className={ className }
+					<MediaPlaceholder
 						icon="format-image"
-						label={ __( 'Image' ) }
-						onSelectImage={ this.onSelectImage }
+						labels={ {
+							title: __( 'Image' ),
+							name: __( 'an image' ),
+						} }
+						className={ className }
+						onSelect={ this.onSelectImage }
+						accept="image/*"
+						type="image"
 					/>
 				</Fragment>
 			);

--- a/core-blocks/image/editor.scss
+++ b/core-blocks/image/editor.scss
@@ -59,22 +59,6 @@
 }
 /*!rtl:end:ignore*/
 
-.wp-block-audio__upload-button.components-button,
-.wp-block-image__upload-button.components-button,
-.wp-block-video__upload-button.components-button {
-	margin-right: 5px;
-
-	.dashicon {
-		vertical-align: middle;
-		margin-bottom: 3px;
-	}
-
-
-	&:hover {
-		color: $dark-gray-800;
-	}
-}
-
 .editor-block-list__block[data-type="core/image"][data-align="center"] {
 	.wp-block-image {
 		margin-left: auto;

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -15,7 +15,7 @@ import {
  */
 import './editor.scss';
 
-export default class AudioEdit extends Component {
+export default class VideoEdit extends Component {
 	constructor() {
 		super( ...arguments );
 		// edit component has its own src in the state so it can be edited
@@ -32,7 +32,7 @@ export default class AudioEdit extends Component {
 		const switchToEditing = () => {
 			this.setState( { editing: true } );
 		};
-		const onSelectAudio = ( media ) => {
+		const onSelectVideo = ( media ) => {
 			if ( media && media.url ) {
 				// sets the block's attribute and updates the edit component from the
 				// selected media, then switches off the editing UI
@@ -51,16 +51,16 @@ export default class AudioEdit extends Component {
 		if ( editing ) {
 			return (
 				<MediaPlaceholder
-					icon="media-audio"
+					icon="media-video"
 					labels={ {
-						title: __( 'Audio' ),
-						name: __( 'an audio' ),
+						title: __( 'Video' ),
+						name: __( 'a video' ),
 					} }
 					className={ className }
-					onSelect={ onSelectAudio }
+					onSelect={ onSelectVideo }
 					onSelectUrl={ onSelectUrl }
-					accept="audio/*"
-					type="audio"
+					accept="video/*"
+					type="video"
 					value={ this.props.attributes }
 				/>
 			);
@@ -73,14 +73,14 @@ export default class AudioEdit extends Component {
 					<Toolbar>
 						<IconButton
 							className="components-icon-button components-toolbar__control"
-							label={ __( 'Edit audio' ) }
+							label={ __( 'Edit video' ) }
 							onClick={ switchToEditing }
 							icon="edit"
 						/>
 					</Toolbar>
 				</BlockControls>
 				<figure className={ className }>
-					<audio controls="controls" src={ src } />
+					<video controls src={ src } />
 					{ ( ( caption && caption.length ) || !! isSelected ) && (
 						<RichText
 							tagName="figcaption"

--- a/core-blocks/video/editor.scss
+++ b/core-blocks/video/editor.scss
@@ -1,23 +1,3 @@
-.wp-block-video .components-placeholder__input {
-	margin-top: 0.5em;
-}
-
-.wp-block-video .components-button.is-large {
-	margin-top: 0.5em;
-}
-
-.wp-block-video audio {
-	width: 100%;
-}
-
-.wp-block-video .components-placeholder__fieldset {
-	max-width: 400px;
-
-	form {
-		max-width: none;
-	}
-}
-
 .editor-block-list__block[data-align="center"] {
 	text-align: center;
 }

--- a/core-blocks/video/index.js
+++ b/core-blocks/video/index.js
@@ -6,27 +6,13 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	FormFileUpload,
-	IconButton,
-	Placeholder,
-	Toolbar,
-} from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
-import {
-	BlockAlignmentToolbar,
-	BlockControls,
-	MediaUpload,
-	RichText,
-	editorMediaUpload,
-} from '@wordpress/editor';
+import { RichText } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import './editor.scss';
+import edit from './edit';
 
 export const name = 'core/video';
 
@@ -40,9 +26,6 @@ export const settings = {
 	category: 'common',
 
 	attributes: {
-		align: {
-			type: 'string',
-		},
 		id: {
 			type: 'number',
 		},
@@ -59,142 +42,17 @@ export const settings = {
 		},
 	},
 
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( 'left' === align || 'center' === align || 'right' === align || 'wide' === align || 'full' === align ) {
-			return { 'data-align': align };
-		}
+	supports: {
+		align: true,
 	},
 
-	edit: class extends Component {
-		constructor() {
-			super( ...arguments );
-			// edit component has its own src in the state so it can be edited
-			// without setting the actual value outside of the edit UI
-			this.state = {
-				editing: ! this.props.attributes.src,
-				src: this.props.attributes.src,
-			};
-		}
-
-		render() {
-			const { align, caption, id } = this.props.attributes;
-			const { setAttributes, isSelected, className } = this.props;
-			const { editing, src } = this.state;
-			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
-			const switchToEditing = () => {
-				this.setState( { editing: true } );
-			};
-			const onSelectVideo = ( media ) => {
-				if ( media && media.url ) {
-					// sets the block's attribute and updates the edit component from the
-					// selected media, then switches off the editing UI
-					setAttributes( { src: media.url, id: media.id } );
-					this.setState( { src: media.url, editing: false } );
-				}
-			};
-			const onSelectUrl = ( event ) => {
-				event.preventDefault();
-				if ( src ) {
-					// set the block's src from the edit component's state, and switch off the editing UI
-					setAttributes( { src } );
-					this.setState( { editing: false } );
-				}
-				return false;
-			};
-			const setVideo = ( [ audio ] ) => onSelectVideo( audio );
-			const uploadFromFiles = ( event ) => editorMediaUpload( event.target.files, setVideo, 'video' );
-			const controls = (
-				<BlockControls>
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ updateAlignment }
-					/>
-					{ ! editing && (
-						<Toolbar>
-							<IconButton
-								className="components-icon-button components-toolbar__control"
-								label={ __( 'Edit video' ) }
-								onClick={ switchToEditing }
-								icon="edit"
-							/>
-						</Toolbar>
-					) }
-				</BlockControls>
-			);
-
-			if ( editing ) {
-				return (
-					<Fragment>
-						{ controls }
-						<Placeholder
-							icon="media-video"
-							label={ __( 'Video' ) }
-							instructions={ __( 'Select a video file from your library, or upload a new one' ) }
-							className={ className }>
-							<form onSubmit={ onSelectUrl }>
-								<input
-									type="url"
-									className="components-placeholder__input"
-									placeholder={ __( 'Enter URL of video file here…' ) }
-									onChange={ ( event ) => this.setState( { src: event.target.value } ) }
-									value={ src || '' } />
-								<Button
-									isLarge
-									type="submit">
-									{ __( 'Use URL' ) }
-								</Button>
-							</form>
-							<FormFileUpload
-								isLarge
-								className="wp-block-video__upload-button"
-								onChange={ uploadFromFiles }
-								accept="video/*"
-							>
-								{ __( 'Upload' ) }
-							</FormFileUpload>
-							<MediaUpload
-								onSelect={ onSelectVideo }
-								type="video"
-								id={ id }
-								render={ ( { open } ) => (
-									<Button isLarge onClick={ open } >
-										{ __( 'Media Library' ) }
-									</Button>
-								) }
-							/>
-						</Placeholder>
-					</Fragment>
-				);
-			}
-
-			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-			return (
-				<Fragment>
-					{ controls }
-					<figure className={ className }>
-						<video controls src={ src } />
-						{ ( ( caption && caption.length ) || isSelected ) && (
-							<RichText
-								tagName="figcaption"
-								placeholder={ __( 'Write caption…' ) }
-								value={ caption }
-								onChange={ ( value ) => setAttributes( { caption: value } ) }
-								inlineToolbar
-							/>
-						) }
-					</figure>
-				</Fragment>
-			);
-			/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-		}
-	},
+	edit,
 
 	save( { attributes } ) {
-		const { src, caption, align } = attributes;
+		const { src, caption } = attributes;
 		return (
 
-			<figure className={ align ? `align${ align }` : null }>
+			<figure>
 				{ src && <video controls src={ src } /> }
 				{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 			</figure>

--- a/core-blocks/video/test/__snapshots__/index.js.snap
+++ b/core-blocks/video/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`core/video block edit matches snapshot 1`] = `
 <div
-  class="components-placeholder wp-block-video"
+  class="components-placeholder editor-media-placeholder wp-block-video"
 >
   <div
     class="components-placeholder__label"
@@ -26,15 +26,42 @@ exports[`core/video block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__instructions"
   >
-    Select a video file from your library, or upload a new one
+    Drag a video, upload a new one or select a file from your library.
   </div>
   <div
     class="components-placeholder__fieldset"
   >
+    <div
+      class="components-drop-zone"
+    >
+      <div
+        class="components-drop-zone__content"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload components-drop-zone__content-icon"
+          focusable="false"
+          height="40"
+          role="img"
+          viewBox="0 0 20 20"
+          width="40"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        <span
+          class="components-drop-zone__content-text"
+        >
+          Drop files to upload
+        </span>
+      </div>
+    </div>
     <form>
       <input
         class="components-placeholder__input"
-        placeholder="Enter URL of video file here…"
+        placeholder="Enter URL here…"
         type="url"
         value=""
       />
@@ -49,7 +76,7 @@ exports[`core/video block edit matches snapshot 1`] = `
       class="components-form-file-upload"
     >
       <button
-        class="components-button components-icon-button wp-block-video__upload-button is-button is-default is-large"
+        class="components-button components-icon-button editor-media-placeholder__upload-button is-button is-default is-large"
         type="button"
       >
         <svg

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -2,7 +2,8 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 
 ## 3.2.0
 
-- `wp.data.withRehydratation` has been renamed to `wp.data.withRehydration`.
+ - `wp.data.withRehydratation` has been renamed to `wp.data.withRehydration`.
+ - The `wp.editor.ImagePlaceholder` component is removed. Please use `wp.editor.MediaPlaceholder` instead.
 
 ## 3.1.0
 

--- a/editor/components/image-placeholder/index.js
+++ b/editor/components/image-placeholder/index.js
@@ -1,69 +1,43 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { DropZone, FormFileUpload, Placeholder, Button } from '@wordpress/components';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { rawHandler } from '@wordpress/blocks';
+import { deprecated } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
-import { editorMediaUpload } from '../../utils';
-import MediaUpload from '../media-upload';
+import MediaPlaceholder from '../media-placeholder';
 
 /**
  *  ImagePlaceholder is a react component used by blocks containing user configurable images e.g: image and cover image.
- *
- * @param   {Object} props  React props passed to the component.
- *
- * @return {Object} Rendered placeholder.
  */
-export default function ImagePlaceholder( { className, icon, label, onSelectImage, multiple = false } ) {
-	const setImage = multiple ? onSelectImage : ( [ image ] ) => onSelectImage( image );
-	const onFilesDrop = ( files ) => editorMediaUpload( files, setImage, 'image' );
-	const onHTMLDrop = ( HTML ) => setImage( map(
-		rawHandler( { HTML, mode: 'BLOCKS' } )
-			.filter( ( { name } ) => name === 'core/image' ),
-		'attributes'
-	) );
-	const uploadFromFiles = ( event ) => editorMediaUpload( event.target.files, setImage, 'image' );
-	return (
-		<Placeholder
-			className={ className }
-			instructions={ multiple ?
-				__( 'Drag images here or add from media library' ) :
-				__( 'Drag image here or add from media library' ) }
-			icon={ icon }
-			label={ label } >
-			<DropZone
-				onFilesDrop={ onFilesDrop }
-				onHTMLDrop={ onHTMLDrop }
-			/>
-			<FormFileUpload
-				multiple={ multiple }
-				isLarge
-				className="wp-block-image__upload-button"
-				onChange={ uploadFromFiles }
-				accept="image/*"
-			>
-				{ __( 'Upload' ) }
-			</FormFileUpload>
-			<MediaUpload
-				gallery={ multiple }
-				multiple={ multiple }
+class ImagePlaceholder extends Component {
+	componentDidMount() {
+		deprecated( 'wp.editor.ImagePlacehoder', {
+			version: '3.2',
+			alternative: 'wp.editor.MediaPlaceholder',
+			plugin: 'Gutenberg',
+		} );
+	}
+
+	render() {
+		const { label, onSelectImage, multiple = false, ...props } = this.props;
+		return (
+			<MediaPlaceholder
+				labels={ {
+					title: label,
+					name: multiple ? __( 'images' ) : __( 'an image' ),
+				} }
 				onSelect={ onSelectImage }
+				accept="image/*"
 				type="image"
-				render={ ( { open } ) => (
-					<Button isLarge onClick={ open }>
-						{ __( 'Media Library' ) }
-					</Button>
-				) }
+				multiple={ multiple }
+				{ ...props }
 			/>
-		</Placeholder>
-	);
+		);
+	}
 }
+
+export default ImagePlaceholder;

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -19,6 +19,7 @@ export { default as PanelColor } from './panel-color';
 export { default as PlainText } from './plain-text';
 export { default as RichText } from './rich-text';
 export { default as RichTextProvider } from './rich-text/provider';
+export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
 export { default as UrlInput } from './url-input';
 export { default as UrlInputButton } from './url-input/button';

--- a/editor/components/media-placeholder/index.js
+++ b/editor/components/media-placeholder/index.js
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { get, noop } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	FormFileUpload,
+	Placeholder,
+	DropZone,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import MediaUpload from '../media-upload';
+import editorMediaUpload from '../../utils/editor-media-upload';
+
+class MediaPlaceholder extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			src: '',
+		};
+		this.onChangeSrc = this.onChangeSrc.bind( this );
+		this.onSubmitSrc = this.onSubmitSrc.bind( this );
+		this.onUpload = this.onUpload.bind( this );
+		this.onFilesUpload = this.onFilesUpload.bind( this );
+	}
+
+	componentDidMount() {
+		this.setState( { src: get( this.props.value, [ 'src' ], '' ) } );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( get( prevProps.value, [ 'src' ], '' ) !== get( this.props.value, [ 'src' ], '' ) ) {
+			this.setState( { src: get( this.props.value, [ 'src' ], '' ) } );
+		}
+	}
+
+	onChangeSrc( event ) {
+		this.setState( {
+			src: event.target.value,
+		} );
+	}
+
+	onSubmitSrc( event ) {
+		event.preventDefault();
+		if ( this.state.src ) {
+			this.props.onSelectUrl( this.state.src );
+		}
+	}
+
+	onUpload( event ) {
+		this.onFilesUpload( event.target.files );
+	}
+
+	onFilesUpload( files ) {
+		const { onSelect, type, multiple } = this.props;
+		const setMedia = multiple ? onSelect : ( [ media ] ) => onSelect( media );
+		editorMediaUpload( files, setMedia, type );
+	}
+
+	render() {
+		const {
+			type,
+			accept,
+			icon,
+			className,
+			labels,
+			onSelect,
+			value = {},
+			onSelectUrl,
+			onHTMLDrop = noop,
+			multiple = false,
+		} = this.props;
+
+		return (
+			<Placeholder
+				icon={ icon }
+				label={ labels.title }
+				instructions={ sprintf( __( 'Drag %s, upload a new one or select a file from your library.' ), labels.name ) }
+				className={ classnames( 'editor-media-placeholder', className ) }
+			>
+				<DropZone
+					onFilesDrop={ this.onFilesUpload }
+					onHTMLDrop={ onHTMLDrop }
+				/>
+				{ onSelectUrl && (
+					<form onSubmit={ this.onSubmitSrc }>
+						<input
+							type="url"
+							className="components-placeholder__input"
+							placeholder={ __( 'Enter URL here…' ) }
+							onChange={ this.onChangeSrc }
+							value={ this.state.src } />
+						<Button
+							isLarge
+							type="submit">
+							{ __( 'Use URL' ) }
+						</Button>
+					</form>
+				) }
+				<FormFileUpload
+					isLarge
+					className="editor-media-placeholder__upload-button"
+					onChange={ this.onUpload }
+					accept={ accept }
+					multiple={ multiple }
+				>
+					{ __( 'Upload' ) }
+				</FormFileUpload>
+				<MediaUpload
+					gallery={ multiple }
+					multiple={ multiple }
+					onSelect={ onSelect }
+					type={ type }
+					value={ value.id }
+					render={ ( { open } ) => (
+						<Button isLarge onClick={ open }>
+							{ __( 'Media Library' ) }
+						</Button>
+					) }
+				/>
+			</Placeholder>
+		);
+	}
+}
+
+export default MediaPlaceholder;

--- a/editor/components/media-placeholder/style.scss
+++ b/editor/components/media-placeholder/style.scss
@@ -1,0 +1,30 @@
+.editor-media-placeholder {
+	.components-placeholder__input {
+		margin-top: 0.5em;
+	}
+
+	.components-button.is-large {
+		margin-top: 0.5em;
+	}
+
+	.components-placeholder__fieldset {
+		max-width: 400px;
+
+		form {
+			max-width: none;
+		}
+	}
+}
+
+.editor-media-placeholder__upload-button.components-button {
+	margin-right: 5px;
+
+	.dashicon {
+		vertical-align: middle;
+		margin-bottom: 3px;
+	}
+
+	&:hover {
+		color: $dark-gray-800;
+	}
+}


### PR DESCRIPTION
This PR adds a `MediaPlaceholder` component used in all the media blocks to unify their UI. #5456

This brings dropzones to audio/video blocks. At the moment the `image` `cover-image` and `gallery` blocks do not show the "URL" input because if we do so we need to rething the "editing" flow of these blocks. (How to you update the URL? Should we change the edit button in the toolbar to trigger the placeholder even if the media is there (like audio/video)?). 

So this refactors to use the same component while keeping the same features/flow.

**Testing instructions**

 - Test the different flows of the media blocks (uploading, dragging, media library, editing...)