### PR TITLE
Close the post publish panel only when the post becomes dirty

### DIFF
--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -45,7 +45,7 @@ class PostPublishPanel extends Component {
 	componentDidUpdate( prevProps ) {
 		// Automatically collapse the publish sidebar when a post
 		// is published and the user makes an edit.
-		if ( prevProps.isPublished && this.props.isDirty ) {
+		if ( prevProps.isPublished && ! this.props.isSaving && this.props.isDirty ) {
 			this.props.onClose();
 		}
 	}

--- a/test/e2e/specs/publishing.test.js
+++ b/test/e2e/specs/publishing.test.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage, wait } from '../support/utils';
+
+describe( 'Publishing', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+	} );
+
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'Should publish a post and close the panel once we start editing again', async () => {
+		await page.type( '.editor-post-title__input', 'E2E Test Post' );
+
+		// Opens the publish panel
+		await page.click( '.editor-post-publish-panel__toggle' );
+
+		// Wait for a second ( wait for the animation )
+		await wait( 1000 );
+
+		// Publish the post
+		await page.click( '.editor-post-publish-button' );
+
+		// A success notice should show up
+		page.waitForSelector( '.notice-success' );
+
+		// The post publish panel is visible
+		expect( await page.$( '.editor-post-publish-panel' ) ).not.toBeNull();
+
+		// Start editing again
+		await page.type( '.editor-post-title__input', ' (Updated)' );
+
+		// The post publish panel is not visible anymore
+		expect( await page.$( '.editor-post-publish-panel' ) ).toBeNull();
+	} );
+} );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -99,3 +99,14 @@ export async function pressWithModifier( modifier, key ) {
 	await page.keyboard.press( key );
 	return page.keyboard.up( modifier );
 }
+
+/**
+ * Promise setTimeout Wrapper.
+ *
+ * @param {number} timeout Timeout in milliseconds
+ *
+ * @return {Promise} Promise resolving after the given timeout
+ */
+export async function wait( timeout ) {
+	return new Promise( ( resolve ) => setTimeout( resolve, timeout ) );
+}


### PR DESCRIPTION
This PR fixes a regression introduced here https://github.com/WordPress/gutenberg/pull/6209#discussion_r189227083 where we consider post being saved as dirty, so we need to ensure we're not saving the post before closing the post publish panel.

**Testing instructions**

 - Publish a post
 - The post publish panel should show up
 - Start editing something
 - The post publish panel should hide.