### PR TITLE
Remove `%s` from Lerna publish message

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
 	"lerna": "2.11.0",
 	"commands": {
 		"publish": {
-			"message": "chore(release): publish %s"
+			"message": "chore(release): publish"
 		}
 	},
 	"packages": [


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
When using Lerna in `independent` the `%s` _global version number_ is not available as each _package_ will be released with its own version number.

See https://github.com/lerna/lerna#--message--m-msg


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Build Tooling change 
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
