### PR TITLE
Allow clicking the block's input fields

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -189,7 +189,7 @@
 		left: 0;
 
 		// use opacity to work in various editor styles
-		border-left: 1px solid $dark-opacity-light-500; 
+		border-left: 1px solid $dark-opacity-light-500;
 
 		.is-dark-theme & {
 			border-left-color: $light-opacity-light-500;
@@ -223,6 +223,7 @@
 			bottom: -$block-padding;
 			left: -$block-padding;
 			outline: 1px solid transparent;
+			pointer-events: none;
 		}
 
 	}
@@ -231,7 +232,7 @@
 	&.is-selected > .editor-block-list__block-edit:before {
 		// use opacity to work in various editor styles
 		outline: 1px solid $dark-opacity-light-500;
-	
+
 		.is-dark-theme & {
 			outline-color: $light-opacity-light-500;
 		}
@@ -259,7 +260,7 @@
 
 		// use opacity to work in various editor styles
 		mix-blend-mode: multiply;
-	
+
 		.is-dark-theme & {
 			mix-blend-mode: soft-light;
 		}
@@ -697,10 +698,10 @@
 	// use opacity to work in various editor styles
 	background-clip: padding-box;
 	box-sizing: padding-box;
-	border: 1px solid $dark-opacity-light-500; 
+	border: 1px solid $dark-opacity-light-500;
 
 	.is-dark-theme & {
-		border-color: $light-opacity-light-500; 
+		border-color: $light-opacity-light-500;
 	}
 
 	// this prevents floats from messing up the position


### PR DESCRIPTION
This PR disables pointer events on the block's outline "element" to allow clicking the block content avoiding any z-index issues.

closes #6836 

**Testing instructions**

 - Add a code block
 - Click outside the block and then try to click the block to write content in it
 - You should be able to focus the input and write.