### PR TITLE
Only load Gutenberg Polyfill in Gutenberg pages

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1093,9 +1093,25 @@ JS;
  * Remove this in Gutenberg 3.1
  */
 function polyfill_blocks_module_in_scripts() {
-	if ( is_admin() ) {
-		wp_enqueue_script( 'wp-editor' );
+	global $post;
+
+	if ( ! is_admin() ) {
+		return;
 	}
+
+	if ( get_current_screen()->base !== 'post' ) {
+		return;
+	}
+
+	if ( isset( $_GET['classic-editor'] ) ) {
+		return;
+	}
+
+	if ( ! gutenberg_can_edit_post( $post ) ) {
+		return;
+	}
+
+	wp_enqueue_script( 'wp-editor' );
 }
 
 add_action( 'enqueue_block_editor_assets', 'polyfill_blocks_module_in_scripts', 9 );

--- a/test/e2e/specs/classic-editor.test.js
+++ b/test/e2e/specs/classic-editor.test.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { visitAdmin, newDesktopBrowserPage } from '../support/utils';
+
+describe( 'classic editor', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await visitAdmin( 'post-new.php', 'classic-editor' );
+	} );
+
+	it( 'Should work properly', async () => {
+		// Click visual editor
+		await page.click( '#content-tmce' );
+		await page.click( '#content_ifr' );
+
+		// type some random text
+		await page.keyboard.type( 'Typing in classic editor' );
+
+		// Swtich to HTML mode
+		await page.click( '#content-html' );
+
+		const textEditorContent = await page.$eval( '.wp-editor-area', ( element ) => element.value );
+		expect( textEditorContent ).toEqual( 'Typing in classic editor' );
+	} );
+} );


### PR DESCRIPTION
This PR fixes #6847 by avoiding to load the Gutenberg scripts in the classic editor. 
This avoids any TinyMCE conflict.

I also added an e2e test to avoid this kind of regressions in the future.