### PR TITLE
Fix missing comma from example

### DIFF
--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -52,7 +52,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 		var content = props.attributes.content;
 
 		return el( RichText.Content, {
-			tagName: 'p'
+			tagName: 'p',
 			className: props.className,
 			value: content
 		} );


### PR DESCRIPTION


## Description
Fix missing comma at line 55 (after tagName: 'p'), so that the example to be usable.

## How has this been tested?
Followed the example and fixed the JS error

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
