### PR TITLE
Add unit test for core-blocks/more/edit.js components

### DIFF
--- a/core-blocks/more/test/__snapshots__/edit.js.snap
+++ b/core-blocks/more/test/__snapshots__/edit.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
+<React.Fragment>
+  <IfBlockEditSelected(InspectorControlsFill)>
+    <PanelBody>
+      <_class
+        checked={false}
+        label="Hide the teaser before the \\"More\\" tag"
+        onChange={[Function]}
+      />
+    </PanelBody>
+  </IfBlockEditSelected(InspectorControlsFill)>
+  <div
+    className="wp-block-more"
+  >
+    <input
+      onChange={[Function]}
+      size={1}
+      type="text"
+      value=""
+    />
+  </div>
+</React.Fragment>
+`;
+
+exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
+<React.Fragment>
+  <IfBlockEditSelected(InspectorControlsFill)>
+    <PanelBody>
+      <_class
+        checked={true}
+        label="Hide the teaser before the \\"More\\" tag"
+        onChange={[Function]}
+      />
+    </PanelBody>
+  </IfBlockEditSelected(InspectorControlsFill)>
+  <div
+    className="wp-block-more"
+  >
+    <input
+      onChange={[Function]}
+      size={1}
+      type="text"
+      value=""
+    />
+  </div>
+</React.Fragment>
+`;

--- a/core-blocks/more/test/edit.js
+++ b/core-blocks/more/test/edit.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+/**
+ * Internal dependencies
+ */
+import MoreEdit from '../edit';
+
+const attributes = {
+	customText: '',
+	noTeaser: false,
+};
+
+describe( 'core/more/edit', () => {
+	beforeEach( () => {
+		attributes.noTeaser = false;
+	} );
+	test( 'should match snapshot when noTeaser is false', () => {
+		const wrapper = shallow( <MoreEdit attributes={ attributes } /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+	test( 'should match snapshot when noTeaser is true', () => {
+		attributes.noTeaser = true;
+		const wrapper = shallow( <MoreEdit attributes={ attributes } /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description
Related to progress on the issue -> Unit Testing Components #641

Added some unit test scripts for [MoreEdit](https://github.com/WordPress/gutenberg/blob/master/core-blocks/more/edit.js) component.

## How has this been tested?

Run unit test command.

```
 PASS  core-blocks/more/test/edit.js
  core/more/edit
    ✓ should match snapshot when noTeaser is false (23ms)
    ✓ should match snapshot when noTeaser is true (2ms)
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
