### PR TITLE
Fix: Caption inline toolbar overlapping media controls in video/audio blocks

### DIFF
--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -18,11 +18,38 @@ import './editor.scss';
 export default class AudioEdit extends Component {
 	constructor() {
 		super( ...arguments );
+		this.onFocusCaption = this.onFocusCaption.bind( this );
+		this.onAudioClick = this.onAudioClick.bind( this );
 		// edit component has its own src in the state so it can be edited
 		// without setting the actual value outside of the edit UI
 		this.state = {
 			editing: ! this.props.attributes.src,
+			captionFocused: false,
 		};
+	}
+
+	componentWillReceiveProps( { isSelected } ) {
+		if ( ! isSelected && this.props.isSelected && this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: false,
+			} );
+		}
+	}
+
+	onFocusCaption() {
+		if ( ! this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: true,
+			} );
+		}
+	}
+
+	onAudioClick() {
+		if ( this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: false,
+			} );
+		}
 	}
 
 	render() {
@@ -80,13 +107,15 @@ export default class AudioEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<figure className={ className }>
-					<audio controls="controls" src={ src } />
+					<audio controls="controls" src={ src } onClick={ this.onAudioClick } />
 					{ ( ( caption && caption.length ) || !! isSelected ) && (
 						<RichText
 							tagName="figcaption"
 							placeholder={ __( 'Write caption…' ) }
 							value={ caption }
+							onFocus={ this.onFocusCaption }
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
+							isSelected={ this.state.captionFocused }
 							inlineToolbar
 						/>
 					) }

--- a/core-blocks/audio/editor.scss
+++ b/core-blocks/audio/editor.scss
@@ -1,3 +1,8 @@
 .wp-block-audio audio {
 	width: 100%;
 }
+
+.wp-block-audio .editor-rich-text__inline-toolbar {
+	position: relative;
+	top: 0;
+}

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -18,11 +18,38 @@ import './editor.scss';
 export default class VideoEdit extends Component {
 	constructor() {
 		super( ...arguments );
+		this.onFocusCaption = this.onFocusCaption.bind( this );
+		this.onVideoClick = this.onVideoClick.bind( this );
 		// edit component has its own src in the state so it can be edited
 		// without setting the actual value outside of the edit UI
 		this.state = {
 			editing: ! this.props.attributes.src,
+			captionFocused: false,
 		};
+	}
+
+	componentWillReceiveProps( { isSelected } ) {
+		if ( ! isSelected && this.props.isSelected && this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: false,
+			} );
+		}
+	}
+
+	onFocusCaption() {
+		if ( ! this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: true,
+			} );
+		}
+	}
+
+	onVideoClick() {
+		if ( this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: false,
+			} );
+		}
 	}
 
 	render() {
@@ -80,13 +107,15 @@ export default class VideoEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<figure className={ className }>
-					<video controls src={ src } />
+					<video controls src={ src } onClick={ this.onVideoClick } />
 					{ ( ( caption && caption.length ) || !! isSelected ) && (
 						<RichText
 							tagName="figcaption"
 							placeholder={ __( 'Write caption…' ) }
 							value={ caption }
+							onFocus={ this.onFocusCaption }
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
+							isSelected={ this.state.captionFocused }
 							inlineToolbar
 						/>
 					) }

--- a/core-blocks/video/editor.scss
+++ b/core-blocks/video/editor.scss
@@ -1,3 +1,8 @@
 .editor-block-list__block[data-align="center"] {
 	text-align: center;
 }
+
+.wp-block-video .editor-rich-text__inline-toolbar {
+	position: relative;
+	top: 0;
+}


### PR DESCRIPTION
## Description
This PR addresses #6825 which reports the unusable media controls in video/audio blocks due to the caption inline toolbar.

## How has this been tested?
This PR has been tested by making sure:
- [x] The caption inline toolbar doesn't overlap media controls in audio/video blocks.
- [x] The media controls are completely usable.

This was tested in WP 4.9.6, Gutenberg 2.9.1, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![gutenberg-6825](https://user-images.githubusercontent.com/20284937/40281186-d4ebc3e2-5c7f-11e8-81fd-abc9855c601a.gif)

## Types of changes
My first approach was to kind-of follow the image block and check if the video/audio player has focus and if so, remove focus from the caption rich text element with the intention of getting rid of the caption inline toolbar which is causing the player controls to not work when opened.

That didn't seem to work as expected, as it seems, clicking on the media controls isn't considered as actually focusing on the player. So I ended up adding some CSS to relatively `position` the caption inline toolbar and remove the `top` property value so it doesn't overlap the media controls.

## Note
I'm really open to feedbacks and suggestions here regarding how we could achieve this in a nicer way. Thank you!

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
