### PR TITLE
Add day/time of weekly meeting to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Gutenberg is a big change, and there will be ways to ensure that existing functi
 
 ## Get involved
 
-We’re calling this editor project "Gutenberg" because it's a big undertaking. We are working on it every day in GitHub, and we'd love your help building it. You’re also welcome to give feedback, the easiest is to join us in <a href="https://make.wordpress.org/chat/">our Slack channel</a>, `#core-editor`.
+We’re calling this editor project "Gutenberg" because it's a big undertaking. We are working on it every day in GitHub, and we'd love your help building it. You’re also welcome to give feedback, the easiest is to join us in <a href="https://make.wordpress.org/chat/">our Slack channel</a>, `#core-editor`. A weekly meeting is held in the Slack channel on Wednesdays at 13:00 UTC.
 
 ## Contributors
 


### PR DESCRIPTION
## Description
Added the day and time (Wednesday at 13:00 UTC) of the weekly meeting to the README. As far as I can tell the only place this is listed is in the sidebar of make/core, which is a bit hard to find if you don't know it's there.

(I also considered adding a timeanddate.com link for converting the time zone, but the links they generate require including a specific date so it would have to be updated weekly. Not ideal.)

## How has this been tested?
n/a

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
