### PR TITLE
Fix typo: withRehydratation → withRehydration

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -15,7 +15,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  */
 import registerDataStore from './store';
 
-export { loadAndPersist, withRehydratation } from './persist';
+export { loadAndPersist, withRehydration, withRehydratation } from './persist';
 
 /**
  * Module constants

--- a/data/persist.js
+++ b/data/persist.js
@@ -1,10 +1,15 @@
 /**
+ * WordPress dependencies
+ */
+import { deprecated } from '@wordpress/utils';
+
+/**
  * External dependencies
  */
 import { get } from 'lodash';
 
 /**
- * Adds the rehydratation behavior to redux reducers.
+ * Adds the rehydration behavior to redux reducers.
  *
  * @param {Function} reducer    The reducer to enhance.
  * @param {string}   reducerKey The reducer key to persist.
@@ -12,7 +17,7 @@ import { get } from 'lodash';
  *
  * @return {Function} Enhanced reducer.
  */
-export function withRehydratation( reducer, reducerKey, storageKey ) {
+export function withRehydration( reducer, reducerKey, storageKey ) {
 	// EnhancedReducer with auto-rehydration
 	const enhancedReducer = ( state, action ) => {
 		const nextState = reducer( state, action );
@@ -28,6 +33,25 @@ export function withRehydratation( reducer, reducerKey, storageKey ) {
 	};
 
 	return enhancedReducer;
+}
+
+/**
+ * Export withRehydratation (a misspelling of withRehydration) for backwards
+ * compatibility.
+ *
+ * @param {Function} reducer    The reducer to enhance.
+ * @param {string}   reducerKey The reducer key to persist.
+ * @param {string}   storageKey The storage key to use.
+ *
+ * @return {Function} Enhanced reducer.
+ */
+export function withRehydratation( reducer, reducerKey, storageKey ) {
+	deprecated( 'wp.data.withRehydratation', {
+		version: '3.2',
+		alternative: 'wp.data.withRehydration',
+		plugin: 'Gutenberg',
+	} );
+	return withRehydration( reducer, reducerKey, storageKey );
 }
 
 /**

--- a/data/test/persist.js
+++ b/data/test/persist.js
@@ -6,7 +6,7 @@ import { createStore } from 'redux';
 /**
  * Internal dependencies
  */
-import { loadAndPersist, withRehydratation } from '../persist';
+import { loadAndPersist, withRehydration } from '../persist';
 
 describe( 'loadAndPersist', () => {
 	it( 'should load the initial value from the local storage integrating it into reducer default value.', () => {
@@ -17,7 +17,7 @@ describe( 'loadAndPersist', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( withRehydratation( reducer, 'preferences', storageKey ) );
+		const store = createStore( withRehydration( reducer, 'preferences', storageKey ) );
 		loadAndPersist(
 			store,
 			reducer,
@@ -35,7 +35,7 @@ describe( 'loadAndPersist', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( withRehydratation( reducer, 'preferences', storageKey + 'change' ) );
+		const store = createStore( withRehydration( reducer, 'preferences', storageKey + 'change' ) );
 		loadAndPersist(
 			store,
 			reducer,
@@ -62,7 +62,7 @@ describe( 'loadAndPersist', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( withRehydratation( reducer, 'preferences', storageKey ) );
+		const store = createStore( withRehydration( reducer, 'preferences', storageKey ) );
 		loadAndPersist(
 			store,
 			reducer,
@@ -90,7 +90,7 @@ describe( 'loadAndPersist', () => {
 		// store preferences without the `counter` default
 		window.localStorage.setItem( storageKey, JSON.stringify( {} ) );
 
-		const store = createStore( withRehydratation( reducer, 'preferences', storageKey ) );
+		const store = createStore( withRehydration( reducer, 'preferences', storageKey ) );
 		loadAndPersist(
 			store,
 			reducer,
@@ -120,7 +120,7 @@ describe( 'loadAndPersist', () => {
 
 		window.localStorage.setItem( storageKey, JSON.stringify( { counter: 1 } ) );
 
-		const store = createStore( withRehydratation( reducer, 'preferences', storageKey ) );
+		const store = createStore( withRehydration( reducer, 'preferences', storageKey ) );
 
 		loadAndPersist(
 			store,

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,5 +1,9 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 3.2.0
+
+- `wp.data.withRehydratation` has been renamed to `wp.data.withRehydration`.
+
 ## 3.1.0
 
  - All components in `wp.blocks.*` are removed. Please use `wp.editor.*` instead.

--- a/edit-post/store/index.js
+++ b/edit-post/store/index.js
@@ -3,7 +3,7 @@
  */
 import {
 	registerStore,
-	withRehydratation,
+	withRehydration,
 	loadAndPersist,
 } from '@wordpress/data';
 
@@ -21,7 +21,7 @@ import * as selectors from './selectors';
 const STORAGE_KEY = `WP_EDIT_POST_PREFERENCES_${ window.userSettings.uid }`;
 
 const store = registerStore( 'core/edit-post', {
-	reducer: withRehydratation( reducer, 'preferences', STORAGE_KEY ),
+	reducer: withRehydration( reducer, 'preferences', STORAGE_KEY ),
 	actions,
 	selectors,
 } );

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -5,7 +5,7 @@ import {
 	registerReducer,
 	registerSelectors,
 	registerActions,
-	withRehydratation,
+	withRehydration,
 	loadAndPersist,
 } from '@wordpress/data';
 
@@ -24,7 +24,7 @@ const STORAGE_KEY = `GUTENBERG_PREFERENCES_${ window.userSettings.uid }`;
 const MODULE_KEY = 'core/editor';
 
 const store = applyMiddlewares(
-	registerReducer( MODULE_KEY, withRehydratation( reducer, 'preferences', STORAGE_KEY ) )
+	registerReducer( MODULE_KEY, withRehydration( reducer, 'preferences', STORAGE_KEY ) )
 );
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 


### PR DESCRIPTION
Renames `withRehydratation` to `withRehydration` in a backwards compatible way.

To test:

1. Open or close the sidebar
2. Refresh the page—the sidebar should remain opened or closed