### PR TITLE
Set the correct min-width for the ChromePicker popover

### DIFF
--- a/components/color-palette/index.js
+++ b/components/color-palette/index.js
@@ -47,7 +47,7 @@ export default function ColorPalette( { colors, disableCustomColors = false, val
 			{ ! disableCustomColors &&
 				<Dropdown
 					className="components-color-palette__item-wrapper components-color-palette__custom-color"
-					contentClassName="components-color-palette__picker "
+					contentClassName="components-color-palette__picker"
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<Tooltip text={ customColorPickerLabel }>
 							<button
@@ -65,7 +65,6 @@ export default function ColorPalette( { colors, disableCustomColors = false, val
 						<ChromePicker
 							color={ value }
 							onChangeComplete={ ( color ) => onChange( color.hex ) }
-							style={ { width: '100%' } }
 							disableAlpha
 						/>
 					) }

--- a/components/color-palette/style.scss
+++ b/components/color-palette/style.scss
@@ -144,3 +144,8 @@ $color-palette-circle-spacing: 14px;
 
 	background-clip: content-box, content-box, content-box, content-box, content-box, content-box, padding-box, padding-box, padding-box, padding-box, padding-box, padding-box;
 }
+
+.components-color-palette__picker:not(.is-mobile) .components-popover__content {
+	// ChromePicker has a hardcoded width of 225px, so we need to override the popover min-width.
+	min-width: 225px;
+}

--- a/components/color-palette/test/__snapshots__/index.js.snap
+++ b/components/color-palette/test/__snapshots__/index.js.snap
@@ -32,11 +32,6 @@ exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`]
       "r": 255,
     }
   }
-  style={
-    Object {
-      "width": "100%",
-    }
-  }
 />
 `;
 
@@ -57,7 +52,7 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
 exports[`ColorPalette Dropdown should render it correctly 1`] = `
 <Dropdown
   className="components-color-palette__item-wrapper components-color-palette__custom-color"
-  contentClassName="components-color-palette__picker "
+  contentClassName="components-color-palette__picker"
   renderContent={[Function]}
   renderToggle={[Function]}
 />
@@ -209,7 +204,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   </div>
   <Dropdown
     className="components-color-palette__item-wrapper components-color-palette__custom-color"
-    contentClassName="components-color-palette__picker "
+    contentClassName="components-color-palette__picker"
     renderContent={[Function]}
     renderToggle={[Function]}
   />


### PR DESCRIPTION
## Description

This PR addresses #6750, by overriding the `min-width` of the popover container of the ChromePicker widget.

This special case is required, as [ChromePicker hardcodes it's width](https://github.com/casesandberg/react-color/blob/master/src/components/chrome/Chrome.js#L19), with no apparent option for overriding it.

Note: #5962 suggested an alternate method for fixing this, but it appears that's how it was originally implemented, but it caused other problems, so was removed in #3120.

## Screenshots

Before

<img width="277" alt="Screenshot of colour picker element with incorrect width" src="https://user-images.githubusercontent.com/352291/40290839-474fa424-5d04-11e8-9028-bf39406edcac.png">

After

<img width="274" alt="Screenshot of colour picker element with corrected width" src="https://user-images.githubusercontent.com/352291/40290840-4aad00f8-5d04-11e8-954f-b7f00bacb2a9.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
