### PR TITLE
Fix lost applied formats

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -410,25 +410,9 @@ export class RichText extends Component {
 		this.props.onChange( this.savedContent );
 	}
 
-	onCreateUndoLevel( event ) {
-		// TinyMCE fires a `change` event when the first letter in an instance
-		// is typed. This should not create a history record in Gutenberg.
-		// https://github.com/tinymce/tinymce/blob/4.7.11/src/core/main/ts/api/UndoManager.ts#L116-L125
-		// In other cases TinyMCE won't fire a `change` with at least a previous
-		// record present, so this is a reliable check.
-		// https://github.com/tinymce/tinymce/blob/4.7.11/src/core/main/ts/api/UndoManager.ts#L272-L275
-		if ( event && event.lastLevel === null ) {
-			return;
-		}
-
-		// Always ensure the content is up-to-date. This is needed because e.g.
-		// making something bold will trigger a TinyMCE change event but no
-		// input event. Avoid dispatching an action if the original event is
-		// blur because the content will already be up-to-date.
-		if ( ! event || ! event.originalEvent || event.originalEvent.type !== 'blur' ) {
-			this.onChange();
-		}
-
+	onCreateUndoLevel() {
+		// Always ensure the content is up-to-date.
+		this.onChange();
 		this.context.onCreateUndoLevel();
 	}
 

--- a/test/e2e/specs/__snapshots__/formatting-controls.test.js.snap
+++ b/test/e2e/specs/__snapshots__/formatting-controls.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Formatting Controls Should apply the formatting controls 1`] = `
+"<!-- wp:paragraph -->
+<p>Paragraph to be made <strong>\\"bold\\"</strong></p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/formatting-controls.test.js
+++ b/test/e2e/specs/formatting-controls.test.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage, pressWithModifier, getHTMLFromCodeEditor } from '../support/utils';
+
+describe( 'Formatting Controls', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+	} );
+
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'Should apply the formatting controls', async () => {
+		// Creatinig a paragraph block with some content
+		await page.click( '.editor-default-block-appender' );
+		await page.keyboard.type( 'Paragraph to be made "bold"' );
+
+		// Selecting some text
+		await page.keyboard.down( 'Shift' );
+		for ( let i = 1; i <= 6; i++ ) {
+			await page.keyboard.press( 'ArrowLeft' );
+		}
+		await page.keyboard.up( 'Shift' );
+
+		// Applying "bold"
+		await pressWithModifier( 'Mod', 'b' );
+
+		// Check content
+		const content = await getHTMLFromCodeEditor();
+		expect( content ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This PR reverts #6455 and add an e2e test to ensure the format changes are persisted properly.

**Testing instructions**

 - Add a paragraph block
 - Select some text and apply any format (bold, italic, link)
 - Save and refresh
 - The formats are still applied.

closes #6854 #6850 