### PR TITLE
Edit Post: Wrap PluginPostStatusInfo with PanelRow rather than Slot

### DIFF
--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -121,12 +121,22 @@ const { __ } = wp.i18n;
 const { PluginPostStatusInfo } = wp.editPost;
 
 const MyPluginPostStatusInfo = () => (
-	<PluginPostStatusInfo>
+	<PluginPostStatusInfo
+		className="my-plugin-post-status-info"
+	>
 		{ __( 'My post status info' ) }
 	</PluginPostStatusInfo>
 );
 ```
 
+#### Props
+
+##### className
+
+An optional class name added to the row.
+
+- Type: `String`
+- Required: No
 
 ### `PluginPrePublishPanel`
 

--- a/edit-post/components/sidebar/plugin-post-status-info/index.js
+++ b/edit-post/components/sidebar/plugin-post-status-info/index.js
@@ -7,12 +7,16 @@
  */
 import { createSlotFill, PanelRow } from '@wordpress/components';
 
-export const { Fill: PluginPostStatusInfo, Slot } = createSlotFill( 'PluginPostStatusInfo' );
+export const { Fill, Slot } = createSlotFill( 'PluginPostStatusInfo' );
 
-PluginPostStatusInfo.Slot = () => (
-	<PanelRow>
-		<Slot />
-	</PanelRow>
+const PluginPostStatusInfo = ( { children, className } ) => (
+	<Fill>
+		<PanelRow className={ className }>
+			{ children }
+		</PanelRow>
+	</Fill>
 );
+
+PluginPostStatusInfo.Slot = Slot;
 
 export default PluginPostStatusInfo;

--- a/edit-post/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluginPostStatusInfo renders fill properly 1`] = `
+<div>
+  <PanelRow
+    className="my-plugin-post-status-info"
+    key="1---0/.0"
+  >
+    <div
+      className="components-panel__row my-plugin-post-status-info"
+    >
+      My plugin post status info
+    </div>
+  </PanelRow>
+</div>
+`;

--- a/edit-post/components/sidebar/plugin-post-status-info/test/index.js
+++ b/edit-post/components/sidebar/plugin-post-status-info/test/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PluginPostStatusInfo from '../';
+
+describe( 'PluginPostStatusInfo', () => {
+	test( 'renders fill properly', () => {
+		const wrapper = mount(
+			<SlotFillProvider>
+				<PluginPostStatusInfo
+					className="my-plugin-post-status-info"
+				>
+					My plugin post status info
+				</PluginPostStatusInfo>
+				<PluginPostStatusInfo.Slot />
+			</SlotFillProvider>
+		);
+
+		expect( wrapper.find( 'Slot' ).children() ).toMatchSnapshot();
+	} );
+} );

--- a/edit-post/components/sidebar/post-status/index.js
+++ b/edit-post/components/sidebar/post-status/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { compose } from '@wordpress/element';
+import { compose, Fragment } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
@@ -27,14 +27,20 @@ const PANEL_NAME = 'post-status';
 function PostStatus( { isOpened, onTogglePanel } ) {
 	return (
 		<PanelBody className="edit-post-post-status" title={ __( 'Status & Visibility' ) } opened={ isOpened } onToggle={ onTogglePanel }>
-			<PostVisibility />
-			<PostSchedule />
-			<PostFormat />
-			<PostSticky />
-			<PostPendingStatus />
-			<PostAuthor />
-			<PluginPostStatusInfo.Slot />
-			<PostTrash />
+			<PluginPostStatusInfo.Slot>
+				{ ( fills ) => (
+					<Fragment>
+						<PostVisibility />
+						<PostSchedule />
+						<PostFormat />
+						<PostSticky />
+						<PostPendingStatus />
+						<PostAuthor />
+						{ fills }
+						<PostTrash />
+					</Fragment>
+				) }
+			</PluginPostStatusInfo.Slot>
 		</PanelBody>
 	);
 }


### PR DESCRIPTION
## Description
Closes #6839 raised by @ryanboswell.
Improves the implementation from #6300 where `PanelRow` was wrongly applied to the `Slot` where it should be done for `Fill`.

### Before

```html
<div class="components-panel__row">
    <div>
        <button type="button" class="components-button button-link ">Here is a Button</button>
    </div>
</div>
```

### After

```html
<div>
    <div class="components-panel__row my-custom-class-name">
        <button type="button" class="components-button button-link ">Here is a Button</button>
    </div>
</div>
```


## How has this been tested?
Manually with the following JS code pasted into JS console:

I tested with the following code:
```js
var el = wp.element.createElement;
var __ = wp.i18n.__;
var registerPlugin = wp.plugins.registerPlugin;
var PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;

function MyPlugin() {
	return (
		el(
			PluginPostStatusInfo,
			{ className: 'my-custom-class-name' },
			__( 'My post status info' )
		)
	);
};

registerPlugin( 'my-plugin', {
	render: MyPlugin,
} );
```

Also with unit tests: `npm test`.

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
