### PR TITLE
[WIP] Core blocks: Refactor Gallery and Image blocks to avoid RichText warnings

### DIFF
--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -154,7 +154,6 @@ class GalleryEdit extends Component {
 		if ( ! nextProps.isSelected && this.props.isSelected ) {
 			this.setState( {
 				selectedImage: null,
-				captionSelected: false,
 			} );
 		}
 	}

--- a/core-blocks/gallery/gallery-image.js
+++ b/core-blocks/gallery/gallery-image.js
@@ -6,12 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress Dependencies
  */
-import { Component, compose } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { IconButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { keycodes } from '@wordpress/utils';
 import { withSelect } from '@wordpress/data';
-import { RichText, withBlockEditContext } from '@wordpress/editor';
+import { RichText } from '@wordpress/editor';
 
 /**
  * Module constants
@@ -22,17 +22,12 @@ class GalleryImage extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.onImageClick = this.onImageClick.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
 	}
 
 	bindContainer( ref ) {
 		this.container = ref;
-	}
-
-	onImageClick() {
-		this.props.setFocusedElement( null );
 	}
 
 	onKeyDown( event ) {
@@ -72,7 +67,7 @@ class GalleryImage extends Component {
 		// Disable reason: Image itself is not meant to be
 		// interactive, but should direct image selection and unfocus caption fields
 		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
-		const img = url ? <img src={ url } alt={ alt } data-id={ id } onClick={ this.onImageClick } /> : <Spinner />;
+		const img = url ? <img src={ url } alt={ alt } data-id={ id } /> : <Spinner />;
 
 		const className = classnames( {
 			'is-selected': isSelected,
@@ -115,18 +110,11 @@ class GalleryImage extends Component {
 	}
 }
 
-export default compose( [
-	withBlockEditContext( ( { setFocusedElement } ) => {
-		return {
-			setFocusedElement,
-		};
-	} ),
-	withSelect( ( select, ownProps ) => {
-		const { getMedia } = select( 'core' );
-		const { id } = ownProps;
+export default withSelect( ( select, ownProps ) => {
+	const { getMedia } = select( 'core' );
+	const { id } = ownProps;
 
-		return {
-			image: id ? getMedia( id ) : null,
-		};
-	} ),
-] )( GalleryImage );
+	return {
+		image: id ? getMedia( id ) : null,
+	};
+} )( GalleryImage );

--- a/core-blocks/gallery/gallery-image.js
+++ b/core-blocks/gallery/gallery-image.js
@@ -85,7 +85,7 @@ class GalleryImage extends Component {
 			<figure
 				className={ className }
 				tabIndex="-1"
-				onClick={ this.props.onSelect }
+				onFocus={ this.props.onSelect }
 				onKeyDown={ this.onKeyDown }
 				ref={ this.bindContainer }
 			>

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -38,6 +38,7 @@ import {
 	BlockAlignmentToolbar,
 	UrlInputButton,
 	editorMediaUpload,
+	withBlockEditContext,
 } from '@wordpress/editor';
 import { withViewportMatch } from '@wordpress/viewport';
 
@@ -57,7 +58,6 @@ class ImageEdit extends Component {
 		super( ...arguments );
 		this.updateAlt = this.updateAlt.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
-		this.onFocusCaption = this.onFocusCaption.bind( this );
 		this.onImageClick = this.onImageClick.bind( this );
 		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSetHref = this.onSetHref.bind( this );
@@ -65,10 +65,6 @@ class ImageEdit extends Component {
 		this.updateWidth = this.updateWidth.bind( this );
 		this.updateHeight = this.updateHeight.bind( this );
 		this.updateDimensions = this.updateDimensions.bind( this );
-
-		this.state = {
-			captionFocused: false,
-		};
 	}
 
 	componentDidMount() {
@@ -99,14 +95,6 @@ class ImageEdit extends Component {
 		}
 	}
 
-	componentWillReceiveProps( { isSelected } ) {
-		if ( ! isSelected && this.props.isSelected && this.state.captionFocused ) {
-			this.setState( {
-				captionFocused: false,
-			} );
-		}
-	}
-
 	onSelectImage( media ) {
 		if ( ! media ) {
 			this.props.setAttributes( {
@@ -128,20 +116,8 @@ class ImageEdit extends Component {
 		this.props.setAttributes( { href: value } );
 	}
 
-	onFocusCaption() {
-		if ( ! this.state.captionFocused ) {
-			this.setState( {
-				captionFocused: true,
-			} );
-		}
-	}
-
 	onImageClick() {
-		if ( this.state.captionFocused ) {
-			this.setState( {
-				captionFocused: false,
-			} );
-		}
+		this.props.setFocusedElement( null );
 	}
 
 	updateAlt( newAlt ) {
@@ -393,9 +369,7 @@ class ImageEdit extends Component {
 							tagName="figcaption"
 							placeholder={ __( 'Write caption…' ) }
 							value={ caption || [] }
-							onFocus={ this.onFocusCaption }
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
-							isSelected={ this.state.captionFocused }
 							inlineToolbar
 						/>
 					) : null }
@@ -407,6 +381,11 @@ class ImageEdit extends Component {
 }
 
 export default compose( [
+	withBlockEditContext( ( { setFocusedElement } ) => {
+		return {
+			setFocusedElement,
+		};
+	} ),
 	withSelect( ( select, props ) => {
 		const { getMedia } = select( 'core' );
 		const { getEditorSettings } = select( 'core/editor' );

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -38,7 +38,6 @@ import {
 	BlockAlignmentToolbar,
 	UrlInputButton,
 	editorMediaUpload,
-	withBlockEditContext,
 } from '@wordpress/editor';
 import { withViewportMatch } from '@wordpress/viewport';
 
@@ -58,7 +57,6 @@ class ImageEdit extends Component {
 		super( ...arguments );
 		this.updateAlt = this.updateAlt.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
-		this.onImageClick = this.onImageClick.bind( this );
 		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSetHref = this.onSetHref.bind( this );
 		this.updateImageURL = this.updateImageURL.bind( this );
@@ -114,10 +112,6 @@ class ImageEdit extends Component {
 
 	onSetHref( value ) {
 		this.props.setAttributes( { href: value } );
-	}
-
-	onImageClick() {
-		this.props.setFocusedElement( null );
 	}
 
 	updateAlt( newAlt ) {
@@ -308,7 +302,7 @@ class ImageEdit extends Component {
 							// Disable reason: Image itself is not meant to be
 							// interactive, but should direct focus to block
 							// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-							const img = <img src={ url } alt={ alt } onClick={ this.onImageClick } />;
+							const img = <img src={ url } alt={ alt } />;
 
 							if ( ! isResizable || ! imageWidthWithinContainer ) {
 								return (
@@ -381,11 +375,6 @@ class ImageEdit extends Component {
 }
 
 export default compose( [
-	withBlockEditContext( ( { setFocusedElement } ) => {
-		return {
-			setFocusedElement,
-		};
-	} ),
 	withSelect( ( select, props ) => {
 		const { getMedia } = select( 'core' );
 		const { getEditorSettings } = select( 'core/editor' );

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -5,6 +5,7 @@ export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit } from './block-edit';
+export { withBlockEditContext } from './block-edit/context';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
 export { default as ColorPalette } from './color-palette';

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -5,7 +5,6 @@ export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit } from './block-edit';
-export { withBlockEditContext } from './block-edit/context';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
 export { default as ColorPalette } from './color-palette';


### PR DESCRIPTION
## Description
With #6286 we have deprecated event proxying. 

@youknowriad discovered the following:
> I wonder if we should introduce an explicit onFocus prop, it seems to be something commonly used across blocks even after #5039

This PR tries to fix it.

## How has this been tested?
Make sure that Image and Gallery blocks work like before and there are no warnings on JS console related to `RichText` component.

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
