### PR TITLE
Avoid change in RichText when possible

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -410,9 +410,25 @@ export class RichText extends Component {
 		this.props.onChange( this.savedContent );
 	}
 
-	onCreateUndoLevel() {
-		// Always ensure the content is up-to-date.
-		this.onChange();
+	onCreateUndoLevel( event ) {
+		// TinyMCE fires a `change` event when the first letter in an instance
+		// is typed. This should not create a history record in Gutenberg.
+		// https://github.com/tinymce/tinymce/blob/4.7.11/src/core/main/ts/api/UndoManager.ts#L116-L125
+		// In other cases TinyMCE won't fire a `change` with at least a previous
+		// record present, so this is a reliable check.
+		// https://github.com/tinymce/tinymce/blob/4.7.11/src/core/main/ts/api/UndoManager.ts#L272-L275
+		if ( event && event.lastLevel === null ) {
+			return;
+		}
+
+		// Always ensure the content is up-to-date. This is needed because e.g.
+		// making something bold will trigger a TinyMCE change event but no
+		// input event. Avoid dispatching an action if the original event is
+		// blur because the content will already be up-to-date.
+		if ( ! event || ! event.originalEvent || event.originalEvent.type !== 'blur' ) {
+			this.onChange();
+		}
+
 		this.context.onCreateUndoLevel();
 	}
 
@@ -774,11 +790,15 @@ export class RichText extends Component {
 	removeFormat( format ) {
 		this.editor.focus();
 		this.editor.formatter.remove( format );
+		// Formatter does not trigger a change event like `execCommand` does.
+		this.onCreateUndoLevel();
 	}
 
 	applyFormat( format, args, node ) {
 		this.editor.focus();
 		this.editor.formatter.apply( format, args, node );
+		// Formatter does not trigger a change event like `execCommand` does.
+		this.onCreateUndoLevel();
 	}
 
 	changeFormats( formats ) {


### PR DESCRIPTION
## Description
This is #6455 (which has been reverted in #6455) plus a fix to ensure formatting changes are synced, and a history level is added. We are using the formatter directly which doesn't trigger an `execCommand` event as it does with core TinyMCE buttons. Those buttons make use of the `mceToggleFormat` command. This can be fix by calling `onCreateUndoLevel` directly in the formatting functions we have.

The reason this works in master and stopped working with #6455 is that the editor is blurred and focussed whenever formatting is applied (except for the first time).

## How has this been tested?
See #6455. Also ensure a history record is created (and the update button enabled) when you make something bold as the first change you make. This last issue is broken in master too.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->