### PR TITLE
Fix excerpt textarea fixed height overflow bug

### DIFF
--- a/editor/components/post-excerpt/style.scss
+++ b/editor/components/post-excerpt/style.scss
@@ -1,9 +1,4 @@
-.editor-post-excerpt > .components-base-control {
-	margin-bottom: 0;
-}
-
 .editor-post-excerpt__textarea {
 	width: 100%;
-	height: 80px;
 	margin-bottom: 10px;
 }


### PR DESCRIPTION
## Description
Removed excerpt textarea default value of 80px and margin-bottom 0 override.

## How has this been tested?
QA with BrowserStack major desktop and mobile browsers.

## Screenshots 
![excerpt-height-fixed](https://user-images.githubusercontent.com/5367401/40322077-8d692e64-5d07-11e8-8b01-9a88593d71e2.gif)

## Types of changes
Fix #6873 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
