### PR TITLE
Fix: make sidebar closed on mobile when page loads even if it was opened before the reload

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -127,25 +127,28 @@ const effects = {
 			} )
 		);
 
-		// Collapse sidebar when viewport shrinks.
-		subscribe( onChangeListener(
-			() => select( 'core/viewport' ).isViewportMatch( '< medium' ),
-			( () => {
-				// contains the sidebar we close when going to viewport sizes lower than medium.
-				// This allows to reopen it when going again to viewport sizes greater than medium.
-				let sidebarToReOpenOnExpand = null;
-				return ( isSmall ) => {
-					if ( isSmall ) {
-						sidebarToReOpenOnExpand = getActiveGeneralSidebarName( store.getState() );
-						if ( sidebarToReOpenOnExpand ) {
-							store.dispatch( closeGeneralSidebar() );
-						}
-					} else if ( sidebarToReOpenOnExpand && ! getActiveGeneralSidebarName( store.getState() ) ) {
-						store.dispatch( openGeneralSidebar( sidebarToReOpenOnExpand ) );
+		const isMobileViewPort = () => select( 'core/viewport' ).isViewportMatch( '< medium' );
+		const adjustSidebar = ( () => {
+			// contains the sidebar we close when going to viewport sizes lower than medium.
+			// This allows to reopen it when going again to viewport sizes greater than medium.
+			let sidebarToReOpenOnExpand = null;
+			return ( isSmall ) => {
+				if ( isSmall ) {
+					sidebarToReOpenOnExpand = getActiveGeneralSidebarName( store.getState() );
+					if ( sidebarToReOpenOnExpand ) {
+						store.dispatch( closeGeneralSidebar() );
 					}
-				};
-			} )()
-		) );
+				} else if ( sidebarToReOpenOnExpand && ! getActiveGeneralSidebarName( store.getState() ) ) {
+					store.dispatch( openGeneralSidebar( sidebarToReOpenOnExpand ) );
+				}
+			};
+		} )();
+
+		adjustSidebar( isMobileViewPort() );
+
+		// Collapse sidebar when viewport shrinks.
+		// Reopen sidebar it if viewport expands and it was closed because of a previous shrink.
+		subscribe( onChangeListener( isMobileViewPort, adjustSidebar ) );
 	},
 
 };


### PR DESCRIPTION
On the desktop, we should persist the sidebar that was opened before. On mobile that should not apply and by default sidebars should be closed.
We regressed on this behavior because before the onChangeListener was invoking logic to close sidebar on mobile at the start, but during other unrelated change, the invocation stopped happening.

This PR adds a flag to onChangeListener that allows usages to explicitly set they want the listner invoked at the start.

## How has this been tested?
Open Gutenberg on mobile, verify all sidebars are closed.
Open a sidebar, reload the page and see the sidebar got closed during the reload.

End to end test added in https://github.com/WordPress/gutenberg/pull/6877.
