### PR TITLE
Restore Post Formats UI by fixing editorSettings variable reference

### DIFF
--- a/editor/components/post-format/check.js
+++ b/editor/components/post-format/check.js
@@ -14,8 +14,11 @@ function PostFormatCheck( { disablePostFormats, ...props } ) {
 }
 
 export default withSelect(
-	( select ) => ( {
-		disablePostFormats: select( 'core/editor' ).getEditorSettings(),
-	} )
+	( select ) => {
+		const editorSettings = select( 'core/editor' ).getEditorSettings();
+		return {
+			disablePostFormats: editorSettings.disablePostFormats,
+		};
+	}
 )( PostFormatCheck );
 

--- a/test/e2e/specs/hello.test.js
+++ b/test/e2e/specs/hello.test.js
@@ -12,10 +12,15 @@ describe( 'hello', () => {
 
 	it( 'Should show the New Post Page in Gutenberg', async () => {
 		expect( page.url() ).toEqual( expect.stringContaining( 'post-new.php' ) );
+		// Should display the title.
 		const title = await page.$( '[placeholder="Add title"]' );
 		expect( title ).not.toBeNull();
+		// Should display the Preview button.
 		const postPreviewButton = await page.$( '.editor-post-preview.components-button' );
 		expect( postPreviewButton ).not.toBeNull();
+		// Should display the Post Formats UI.
+		const postFormatsUi = await page.$( '.editor-post-format' );
+		expect( postFormatsUi ).not.toBeNull();
 	} );
 
 	it( 'Should have no history', async () => {


### PR DESCRIPTION
Adds e2e test to prevent future regression.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/36432/40329514-9e06791a-5cfe-11e8-89c6-925f61f4ee4e.png">

Fixes #6864