### PR TITLE
 Normalize unicode in raw handling

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -88,6 +88,11 @@ export default function rawHandler( { HTML = '', plainText = '', mode = 'AUTO', 
 		return parseWithGrammar( HTML );
 	}
 
+	// Normalize unicode to use composed characters.
+	// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+	// See https://core.trac.wordpress.org/ticket/30130
+	HTML = HTML.normalize();
+
 	// Parse Markdown (and encoded HTML) if:
 	// * There is a plain text version.
 	// * There is no HTML version, or it has no formatting.

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -79,6 +79,15 @@ describe( 'Blocks raw handling', () => {
 		expect( filtered ).toBe( 'test<br>test' );
 	} );
 
+	it( 'should normalize decomposed characters', () => {
+		const filtered = rawHandler( {
+			HTML: 'schön',
+			mode: 'INLINE',
+		} );
+
+		expect( filtered ).toBe( 'schön' );
+	} );
+
 	describe( 'serialize', () => {
 		function readFile( filePath ) {
 			return fs.existsSync( filePath ) ? fs.readFileSync( filePath, 'utf8' ).trim() : '';


### PR DESCRIPTION
## Description
Fixes #433 and https://core.trac.wordpress.org/ticket/30130 for core.

This branch fixes an issue when copy pasting decomposed characters from an external source. The characters should be composed (normalised) so matching works properly. Decomposed characters can also appear strange in some browsers.

## How has this been tested?
See https://core.trac.wordpress.org/ticket/30130 for a PDF to test. Paste the content in Gutenberg in e.g. Safari where the appearance is strange. Also try searching one of the pasted words but in composed form, which will fail.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->