### PR TITLE
Clean up shared block tests

### DIFF
--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -467,43 +467,48 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should take an optional id argument', () => {
-			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
-			expect( fetchSharedBlocks( id ) ).toEqual( {
+			expect( fetchSharedBlocks( 123 ) ).toEqual( {
 				type: 'FETCH_SHARED_BLOCKS',
-				id,
+				id: 123,
 			} );
 		} );
 	} );
 
 	describe( 'saveSharedBlock', () => {
-		const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
-		expect( saveSharedBlock( id ) ).toEqual( {
-			type: 'SAVE_SHARED_BLOCK',
-			id,
+		it( 'should return the SAVE_SHARED_BLOCK action', () => {
+			expect( saveSharedBlock( 123 ) ).toEqual( {
+				type: 'SAVE_SHARED_BLOCK',
+				id: 123,
+			} );
 		} );
 	} );
 
 	describe( 'deleteSharedBlock', () => {
-		const id = 123;
-		expect( deleteSharedBlock( id ) ).toEqual( {
-			type: 'DELETE_SHARED_BLOCK',
-			id,
+		it( 'should return the DELETE_SHARED_BLOCK action', () => {
+			expect( deleteSharedBlock( 123 ) ).toEqual( {
+				type: 'DELETE_SHARED_BLOCK',
+				id: 123,
+			} );
 		} );
 	} );
 
 	describe( 'convertBlockToStatic', () => {
-		const uid = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
-		expect( convertBlockToStatic( uid ) ).toEqual( {
-			type: 'CONVERT_BLOCK_TO_STATIC',
-			uid,
+		it( 'should return the CONVERT_BLOCK_TO_STATIC action', () => {
+			const uid = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			expect( convertBlockToStatic( uid ) ).toEqual( {
+				type: 'CONVERT_BLOCK_TO_STATIC',
+				uid,
+			} );
 		} );
 	} );
 
 	describe( 'convertBlockToShared', () => {
-		const uid = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
-		expect( convertBlockToShared( uid ) ).toEqual( {
-			type: 'CONVERT_BLOCK_TO_SHARED',
-			uid,
+		it( 'should return the CONVERT_BLOCK_TO_SHARED action', () => {
+			const uid = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			expect( convertBlockToShared( uid ) ).toEqual( {
+				type: 'CONVERT_BLOCK_TO_SHARED',
+				uid,
+			} );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2887,7 +2887,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const sharedBlock = getSharedBlock( state, '358b59ee-bab3-4d6f-8445-e8c6971a5605' );
+			const sharedBlock = getSharedBlock( state, 123 );
 			expect( sharedBlock ).toBeNull();
 		} );
 	} );


### PR DESCRIPTION
Minor clean-up of some shared block tests. 

- Shared blocks use integer IDs, not string UUIDs
- `expect()` assertions should happen in an `it()`, not a `describe()`
