### PR TITLE
Components: Tab Panel: add initialTabIndex prop

### DIFF
--- a/components/tab-panel/README.md
+++ b/components/tab-panel/README.md
@@ -91,6 +91,14 @@ The class to add to the active tab
 - Required: No
 - Default: `is-active`
 
+### initialTabName
+
+Optionally provide a tab name for a tab to be selected upon mounting of component. If this prop is not set, the first tab will be selected by default.
+
+- Type: `String`
+- Required: No
+- Default: none
+
 ### children
 
 A function which renders the tabviews given the selected tab. The function is passed a `tabName` as an argument.

--- a/components/tab-panel/index.js
+++ b/components/tab-panel/index.js
@@ -29,12 +29,13 @@ const TabButton = ( { tabId, onClick, children, selected, ...rest } ) => (
 class TabPanel extends Component {
 	constructor() {
 		super( ...arguments );
+		const { tabs, initialTabName } = this.props;
 
 		this.handleClick = this.handleClick.bind( this );
 		this.onNavigate = this.onNavigate.bind( this );
 
 		this.state = {
-			selected: this.props.tabs.length > 0 ? this.props.tabs[ 0 ].name : null,
+			selected: initialTabName || ( tabs.length > 0 ? tabs[ 0 ].name : null ),
 		};
 	}
 

--- a/components/tab-panel/test/index.js
+++ b/components/tab-panel/test/index.js
@@ -88,4 +88,37 @@ describe( 'TabPanel', () => {
 			expect( getActiveView().text() ).toBe( 'alpha' );
 		} );
 	} );
+
+	it( 'should render with a tab initially selected by prop initialTabIndex', () => {
+		const wrapper = mount(
+			<TabPanel
+				className="test-panel"
+				activeClass="active-tab"
+				initialTabName="beta"
+				tabs={
+					[
+						{
+							name: 'alpha',
+							title: 'Alpha',
+							className: 'alpha',
+						},
+						{
+							name: 'beta',
+							title: 'Beta',
+							className: 'beta',
+						},
+					]
+				}
+			>
+				{
+					( tabName ) => {
+						return <p tabIndex="0" className={ tabName + '-view' }>{ tabName }</p>;
+					}
+				}
+			</TabPanel>
+		);
+
+		const getActiveTab = () => wrapper.find( 'button.active-tab' );
+		expect( getActiveTab().text() ).toBe( 'Beta' );
+	} );
 } );


### PR DESCRIPTION
## Description
This PR adds a prop `initialTabIndex` to the `<TabPanel />` component for the purpose of designating a tab that is initially selected when the component mounts. The current behaviour is to default to the first tab

## Use Case
I have a `<TabPanel />` component that is hidden behind an expandable button. When the button is clicked and the view expands, I'd like the tab and subsequent selection to reflect the state of the app. Sometimes, that will be the second tab, "Custom" as seen below

<img width="439" alt="screen shot 2018-05-22 at 4 46 40 pm" src="https://user-images.githubusercontent.com/1922453/40342615-c802cbe2-5ddf-11e8-9c0c-294d547aaabf.png">

## How has this been tested?
* Applied the prop to `<TabPanel />` instance
* Created unit tests as part of this PR
* The newly created prop `initialTabIndex` defaults to zero, so backwards compatibility is intact

## Types of changes
New feature to  `<TabPanel />`, adding a prop `initialTabIndex` to designate a tab that is initially selected when the component mounts

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
