### PR TITLE
Allow inserting a link with no text selected

### DIFF
--- a/editor/components/rich-text/format-toolbar/index.js
+++ b/editor/components/rich-text/format-toolbar/index.js
@@ -120,7 +120,7 @@ class FormatToolbar extends Component {
 
 	setLinkTarget( opensInNewWindow ) {
 		this.setState( { opensInNewWindow } );
-		if ( this.props.formats.link ) {
+		if ( this.props.formats.link && ! this.props.formats.link.isAdding ) {
 			this.props.onChange( { link: {
 				value: this.props.formats.link.value,
 				target: opensInNewWindow ? '_blank' : null,

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -809,20 +809,20 @@ export class RichText extends Component {
 						return;
 					}
 
-					const { value: href, ...params } = formatValue;
+					const { value: href, target } = formatValue;
 
 					if ( ! this.isFormatActive( 'link' ) && this.editor.selection.isCollapsed() ) {
 						// When no link or text is selected, insert a link with the URL as its text
 						const anchorHTML = this.editor.dom.createHTML(
 							'a',
-							{ href, ...params },
+							{ href, target },
 							this.editor.dom.encode( href )
 						);
 						this.editor.insertContent( anchorHTML );
 					} else {
 						// Use built-in TinyMCE command turn the selection into a link. This takes
 						// care of deleting any existing links within the selection
-						this.editor.execCommand( 'mceInsertLink', false, { href, ...params } );
+						this.editor.execCommand( 'mceInsertLink', false, { href, target } );
 					}
 				} else {
 					this.editor.execCommand( 'Unlink' );


### PR DESCRIPTION
## Description
Closes #5960 and fixes #6900. When creating a link with no text selected, the link should be inserted with its text set to the URL.

## How has this been tested?
1. Place cursor within a text block and insert a link
2. Select some text and insert a link
3. Select some text and insert a link that opens in a new window
4. Select some text that contains an existing link and insert a link

## Screenshots <!-- if applicable -->
![links](https://user-images.githubusercontent.com/612155/40346336-ccff0426-5ddf-11e8-96c2-4a704f83eabf.gif)
