### PR TITLE
Fix regressions with Button component after PostCSS

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -60,10 +60,10 @@
 	}
 
 	&.is-primary {
-		background: color( theme( button ) shade( 10% ) );
-		border-color: color( theme( button ) shade( 20% ) ) color( theme( button ) shade( 30% ) ) color( theme( primary ) shade( 30% ) );
-		box-shadow: inset 0 -1px 0 color( theme( button ) shade( 30% ) );
-		color: #fff;
+		background: color( theme( button ) );
+		border-color: color( theme( button ) shade( 20% ) ) color( theme( button ) shade( 25% ) ) color( theme( primary ) shade( 25% ) );
+		box-shadow: inset 0 -1px 0 color( theme( button ) shade( 25% ) );
+		color: $white;
 		text-decoration: none;
 		text-shadow: 0 -1px 1px color( theme( button ) shade( 30% ) ),
 			1px 0 1px color( theme( button ) shade( 30% ) ),
@@ -72,7 +72,7 @@
 
 		&:hover,
 		&:focus:not(:disabled):not([aria-disabled="true"]) {
-			background: color( theme( button ) shade( 15% ) );
+			background: color( theme( button ) shade( 5% ) );
 			border-color: color( theme( button ) shade( 50% ) );
 			box-shadow: inset 0 -1px 0 color( theme( button ) shade( 50% ) );
 			color: $white;

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -104,7 +104,12 @@
 		&.is-primary.is-busy[disabled] {
 			color: $white !important;
 			background-size: 100px 100% !important;
-			background-image: repeating-linear-gradient( -45deg, theme( primary ), color( theme( primary ) shade( 50% ) ) 11px, color( theme( primary ) shade( 50% ) ) 10px, theme( primary ) 20px) !important;
+			background-image: linear-gradient(
+				-45deg,
+				theme( primary ) 28%,
+				color( theme( primary ) shade( 30% ) ) 28%,
+				color( theme( primary ) shade( 30% ) ) 72%,
+				theme( primary ) 72%) !important;
 			border-color: color( theme( primary ) shade( 50% ) ) !important;
 		}
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,17 +36,17 @@ const extractConfig = {
 				plugins: [
 					require( './packages/postcss-themes' )( {
 						defaults: {
-							primary: '#00a0d2',
-							secondary: '#0073aa',
-							toggle: '#00a0d2',
-							button: '#00a0d2',
+							primary: '#0085ba',
+							secondary: '#11a0d2',
+							toggle: '#11a0d2',
+							button: '#0085ba',
 						},
 						themes: {
 							'admin-color-light': {
-								primary: '#00a0d2',
+								primary: '#0085ba',
 								secondary: '#c75726',
-								toggle: '#00a0d2',
-								button: '#00a0d2',
+								toggle: '#11a0d2',
+								button: '#0085ba',
 							},
 							'admin-color-blue': {
 								primary: '#82b4cb',
@@ -67,10 +67,10 @@ const extractConfig = {
 								button: '#a7b656',
 							},
 							'admin-color-midnight': {
-								primary: '#e34e46',
+								primary: '#e14d43',
 								secondary: '#77a6b9',
 								toggle: '#77a6b9',
-								button: '#e34e46',
+								button: '#e14d43',
 							},
 							'admin-color-ocean': {
 								primary: '#a3b9a2',


### PR DESCRIPTION
This issue fixes a few teensy regressions that were introduced with the refactor of the button component. Notably:

- The colors of default, light, and midnight primary buttons was wrong. This was probably inherited from before, but was made clear with the new styles
- The colors of the primary buttons were too dark
- The candy-striped publishing gradient broke

Gradient before:

![gradient before](https://user-images.githubusercontent.com/1204802/40352433-1bd29fc6-5daf-11e8-8f2c-cd28b968b8bc.gif)

Gradient after:

![gradient after](https://user-images.githubusercontent.com/1204802/40352443-213e2e4e-5daf-11e8-9402-43c4feffc57f.gif)
