### PR TITLE
Packages: Update all WordPress packages to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -240,9 +240,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.1.tgz",
-			"integrity": "sha512-n7wxy8r2tjVcrzZoKJlyZmi1C1VhXGHAGhDEO1iqp7fbsTSsDF3dVA50KFsPg77EXqzNJqbzcna8Mi4m7a1lyw==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
+			"integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -472,9 +472,9 @@
 			"integrity": "sha512-nqm/gP+ipeUMvEngh4Sp4k5umph8SPqfc5aCd9Ge03mz4JSWAIE4z36pPQwId0a1B3hGqri5Wo40O1hQ851ZnA=="
 		},
 		"@wordpress/babel-plugin-makepot": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-1.0.0.tgz",
-			"integrity": "sha512-YNcXr33fUUHg9HncNhUNkG2jnCAtnvC5hN0ZdDdTVe7r7aR4l+gCTCZXvM/0SHqikrNhRNjSrE5ZM/3u2zsOyw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-1.0.1.tgz",
+			"integrity": "sha512-n0ifXqE4jbEWxz+tCj3IM2nPH9sgelQx2ApKTPJNrOOMJq29s6RRXcUYzN8g68rNakXAGuFLlIRmPzIGrA1wWA==",
 			"dev": true,
 			"requires": {
 				"gettext-parser": "^1.3.1",
@@ -482,12 +482,13 @@
 			}
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-1.2.0.tgz",
-			"integrity": "sha512-DJ4P3gwj8gUQy94GeaVdHTh2JVKQ8eNFwCQi4GDhCcq78KDAJjRO497ZwoJWJR0MVq5a3XfsrJ6fVf7S8APfUw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-1.3.0.tgz",
+			"integrity": "sha512-xAw0qp9MJjPPNw0OS8cT3SCcPLVul3rJVwz+/KuJAJXuO/R3omGDX864FVuFDKFHZF+1jydXRW0GPih4MZ+6Lw==",
 			"dev": true,
 			"requires": {
-				"@wordpress/browserslist-config": "^2.1.3",
+				"@wordpress/browserslist-config": "^2.1.4",
+				"babel-plugin-transform-async-generator-functions": "^6.24.1",
 				"babel-plugin-transform-object-rest-spread": "^6.23.0",
 				"babel-plugin-transform-react-jsx": "^6.24.1",
 				"babel-plugin-transform-runtime": "^6.23.0",
@@ -495,15 +496,15 @@
 			}
 		},
 		"@wordpress/browserslist-config": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.1.3.tgz",
-			"integrity": "sha512-I8xUK/oqxI0LYoTar2U/vvQS78pWnEXWqClyhzmQ53NfWWaGydYgNdH3X2+oCGZjNUtdEkXuhjnyAwSZ12h0HQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.1.4.tgz",
+			"integrity": "sha512-J8vd88IFsjYwYZSIVATDjWa0pH997zvQ6quor30UdwhqdZ4ZWxIh4AEADqZA3I4EwskWVmg9n9DF7jVUDZPxwg==",
 			"dev": true
 		},
 		"@wordpress/custom-templated-path-webpack-plugin": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/custom-templated-path-webpack-plugin/-/custom-templated-path-webpack-plugin-1.0.0.tgz",
-			"integrity": "sha512-7GDENg5juXusGye4JqKAjfAr1EcKNNmJ6GUnnUrdOkXgjnT5CoAw2ADJxvtALtl4vx6o/nqzJxp9YQ/bZi85Dg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/custom-templated-path-webpack-plugin/-/custom-templated-path-webpack-plugin-1.0.2.tgz",
+			"integrity": "sha512-bm8lZo6YUMkrjcqxjPm0H3hz2nIKwLLXzz8RaOppo8FomkcaPSqmRl2N6Urwf9h9pKGh25K+5jyefKvhOMMw1A==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -536,9 +537,9 @@
 			"integrity": "sha512-xDw008Z8oILY/a0zwysEH9oknO6FCfMRVQYFqud5BiUGugxB78kE47KcOVqLkC5cm9wbvbYgly5w7DMwFLv5uw=="
 		},
 		"@wordpress/jest-console": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-1.0.6.tgz",
-			"integrity": "sha512-Ha7aSE9vpp8Z/zHPTHzd2gdYgZgM1pcng4BknG0PGAukqjvtAX6iNtzd62H203fcdxEVBe5+XQ4lsFwXMFSdbA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-1.0.7.tgz",
+			"integrity": "sha512-cYV7jhhn9KW+kpGSYZxqu8YhOitEouHujt/XDYmfCK0gYr7SMWVYu4XSN9UHxz9GFQck/7mgVQlNC1Xvf/zWlw==",
 			"dev": true,
 			"requires": {
 				"jest-matcher-utils": "^22.4.0",
@@ -546,12 +547,12 @@
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-1.0.3.tgz",
-			"integrity": "sha512-1+uREUyhMWBanX4qceevrFEuaFm/gRKIKiDb36Wc5X02ODEaUaQ6qjIvrD6fariYtvxQpjC8TBjKapsvSaqHHw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-1.0.6.tgz",
+			"integrity": "sha512-vM60YzKgGex7jhyRlkQSUoTkR4nVmicU0yTSs5mnYcScLhi94qHQqUp5qzWrntgqIBe1YaMzCrxmoTC+QqccgQ==",
 			"dev": true,
 			"requires": {
-				"@wordpress/jest-console": "^1.0.5",
+				"@wordpress/jest-console": "^1.0.7",
 				"babel-jest": "^22.1.0",
 				"enzyme": "^3.3.0",
 				"enzyme-adapter-react-16": "^1.1.1",
@@ -560,13 +561,13 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-1.1.0.tgz",
-			"integrity": "sha512-gbtpV6i4SKi7Pya8qeB6N9FGyWAMBtyAsRnFg6Lv6Ejh0Pk9R2Aa71GjX4ZAMzq1LFuVNdhciIybdxDPSsP8sQ==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-1.1.6.tgz",
+			"integrity": "sha512-DW0Idf7RQOQvgIjCaNfHTdLtRG1TGYxTjJz3BZO4mch7/M+yY22AU5MytJv/3/l2UCU1S3YSNSNrjUj/zPMvUA==",
 			"dev": true,
 			"requires": {
-				"@wordpress/babel-preset-default": "^1.1.1",
-				"@wordpress/jest-preset-default": "^1.0.3",
+				"@wordpress/babel-preset-default": "^1.3.0",
+				"@wordpress/jest-preset-default": "^1.0.6",
 				"cross-spawn": "^5.1.0",
 				"jest": "^22.4.0",
 				"read-pkg-up": "^3.0.0"
@@ -1326,13 +1327,13 @@
 			}
 		},
 		"babel-jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
-			"integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+			"integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
 			"dev": true,
 			"requires": {
 				"babel-plugin-istanbul": "^4.1.5",
-				"babel-preset-jest": "^22.4.3"
+				"babel-preset-jest": "^22.4.4"
 			}
 		},
 		"babel-loader": {
@@ -1377,9 +1378,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
-			"integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+			"integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
 			"dev": true
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -1897,12 +1898,12 @@
 			}
 		},
 		"babel-preset-jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
-			"integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+			"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^22.4.3",
+				"babel-plugin-jest-hoist": "^22.4.4",
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
@@ -7440,12 +7441,12 @@
 			},
 			"dependencies": {
 				"async": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.14.0"
+						"lodash": "^4.17.10"
 					}
 				},
 				"debug": {
@@ -7469,6 +7470,12 @@
 						"rimraf": "^2.6.1",
 						"source-map": "^0.5.3"
 					}
+				},
+				"lodash": {
+					"version": "4.17.10",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
@@ -7603,13 +7610,13 @@
 			"integrity": "sha1-elSbvZ/+FYWwzQoZHiAwVb7ldLQ="
 		},
 		"jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
-			"integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
+			"integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
 			"dev": true,
 			"requires": {
 				"import-local": "^1.0.0",
-				"jest-cli": "^22.4.3"
+				"jest-cli": "^22.4.4"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7695,9 +7702,9 @@
 					}
 				},
 				"jest-cli": {
-					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
-					"integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+					"version": "22.4.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+					"integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
@@ -7711,20 +7718,20 @@
 						"istanbul-lib-coverage": "^1.1.1",
 						"istanbul-lib-instrument": "^1.8.0",
 						"istanbul-lib-source-maps": "^1.2.1",
-						"jest-changed-files": "^22.4.3",
-						"jest-config": "^22.4.3",
-						"jest-environment-jsdom": "^22.4.3",
-						"jest-get-type": "^22.4.3",
-						"jest-haste-map": "^22.4.3",
-						"jest-message-util": "^22.4.3",
-						"jest-regex-util": "^22.4.3",
-						"jest-resolve-dependencies": "^22.4.3",
-						"jest-runner": "^22.4.3",
-						"jest-runtime": "^22.4.3",
-						"jest-snapshot": "^22.4.3",
-						"jest-util": "^22.4.3",
-						"jest-validate": "^22.4.3",
-						"jest-worker": "^22.4.3",
+						"jest-changed-files": "^22.2.0",
+						"jest-config": "^22.4.4",
+						"jest-environment-jsdom": "^22.4.1",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^22.4.2",
+						"jest-message-util": "^22.4.0",
+						"jest-regex-util": "^22.1.0",
+						"jest-resolve-dependencies": "^22.1.0",
+						"jest-runner": "^22.4.4",
+						"jest-runtime": "^22.4.4",
+						"jest-snapshot": "^22.4.0",
+						"jest-util": "^22.4.1",
+						"jest-validate": "^22.4.4",
+						"jest-worker": "^22.2.2",
 						"micromatch": "^2.3.11",
 						"node-notifier": "^5.2.1",
 						"realpath-native": "^1.0.0",
@@ -7807,22 +7814,22 @@
 			}
 		},
 		"jest-config": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
-			"integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+			"integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^22.4.3",
-				"jest-environment-node": "^22.4.3",
-				"jest-get-type": "^22.4.3",
-				"jest-jasmine2": "^22.4.3",
-				"jest-regex-util": "^22.4.3",
-				"jest-resolve": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-validate": "^22.4.3",
-				"pretty-format": "^22.4.3"
+				"jest-environment-jsdom": "^22.4.1",
+				"jest-environment-node": "^22.4.1",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^22.4.4",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.2",
+				"jest-util": "^22.4.1",
+				"jest-validate": "^22.4.4",
+				"pretty-format": "^22.4.0"
 			}
 		},
 		"jest-diff": {
@@ -7981,21 +7988,21 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
-			"integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+			"integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^22.4.3",
+				"expect": "^22.4.0",
 				"graceful-fs": "^4.1.11",
 				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-snapshot": "^22.4.3",
-				"jest-util": "^22.4.3",
+				"jest-diff": "^22.4.0",
+				"jest-matcher-utils": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-snapshot": "^22.4.0",
+				"jest-util": "^22.4.1",
 				"source-map-support": "^0.5.0"
 			}
 		},
@@ -8146,43 +8153,43 @@
 			}
 		},
 		"jest-runner": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
-			"integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+			"integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
 			"dev": true,
 			"requires": {
 				"exit": "^0.1.2",
-				"jest-config": "^22.4.3",
-				"jest-docblock": "^22.4.3",
-				"jest-haste-map": "^22.4.3",
-				"jest-jasmine2": "^22.4.3",
-				"jest-leak-detector": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-runtime": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-worker": "^22.4.3",
+				"jest-config": "^22.4.4",
+				"jest-docblock": "^22.4.0",
+				"jest-haste-map": "^22.4.2",
+				"jest-jasmine2": "^22.4.4",
+				"jest-leak-detector": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-runtime": "^22.4.4",
+				"jest-util": "^22.4.1",
+				"jest-worker": "^22.2.2",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-runtime": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
-			"integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+			"integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
-				"babel-jest": "^22.4.3",
+				"babel-jest": "^22.4.4",
 				"babel-plugin-istanbul": "^4.1.5",
 				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^22.4.3",
-				"jest-haste-map": "^22.4.3",
-				"jest-regex-util": "^22.4.3",
-				"jest-resolve": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-validate": "^22.4.3",
+				"jest-config": "^22.4.4",
+				"jest-haste-map": "^22.4.2",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.2",
+				"jest-util": "^22.4.1",
+				"jest-validate": "^22.4.4",
 				"json-stable-stringify": "^1.0.1",
 				"micromatch": "^2.3.11",
 				"realpath-native": "^1.0.0",
@@ -8379,16 +8386,16 @@
 			}
 		},
 		"jest-validate": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
-			"integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+			"integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-config": "^22.4.3",
-				"jest-get-type": "^22.4.3",
+				"jest-config": "^22.4.4",
+				"jest-get-type": "^22.1.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^22.4.3"
+				"pretty-format": "^22.4.0"
 			}
 		},
 		"jest-worker": {

--- a/package.json
+++ b/package.json
@@ -61,12 +61,12 @@
 		"uuid": "3.1.0"
 	},
 	"devDependencies": {
-		"@wordpress/babel-plugin-makepot": "1.0.0",
-		"@wordpress/babel-preset-default": "1.2.0",
-		"@wordpress/browserslist-config": "2.1.3",
-		"@wordpress/custom-templated-path-webpack-plugin": "1.0.0",
-		"@wordpress/jest-preset-default": "1.0.3",
-		"@wordpress/scripts": "1.1.0",
+		"@wordpress/babel-plugin-makepot": "1.0.1",
+		"@wordpress/babel-preset-default": "1.3.0",
+		"@wordpress/browserslist-config": "2.1.4",
+		"@wordpress/custom-templated-path-webpack-plugin": "1.0.2",
+		"@wordpress/jest-preset-default": "1.0.6",
+		"@wordpress/scripts": "1.1.6",
 		"autoprefixer": "8.2.0",
 		"babel-core": "6.26.0",
 		"babel-eslint": "8.0.3",
@@ -104,9 +104,6 @@
 		"presets": [
 			"@wordpress/default"
 		],
-		"plugins": [
-			"transform-async-generator-functions"
-		],
 		"env": {
 			"production": {
 				"plugins": [
@@ -115,8 +112,7 @@
 						{
 							"output": "languages/gutenberg.pot"
 						}
-					],
-					"transform-async-generator-functions"
+					]
 				]
 			}
 		}


### PR DESCRIPTION
## Description
Related to #6708.

This PR updates all WordPress packages to the latest version. The biggest change is related to Babel preset update which now includes the plugin for async generator functions.

## How has this been tested?

* `npm test`
* `npm run dev`
* `npm run build`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
