### PR TITLE
[Try] Add ability to extend content of other sidebars.

### DIFF
--- a/edit-post/components/sidebar/block-sidebar/index.js
+++ b/edit-post/components/sidebar/block-sidebar/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import './style.scss';
 import SettingsHeader from '../settings-header';
+import SidebarExtender from '../sidebar-extender';
 import Sidebar from '../';
 
 const SIDEBAR_NAME = 'edit-post/block';
@@ -24,6 +25,7 @@ const BlockSidebar = () => (
 			<PanelBody className="edit-post-block-sidebar__panel">
 				<BlockInspector />
 			</PanelBody>
+			<SidebarExtender.Slot />
 		</Panel>
 	</Sidebar>
 );

--- a/edit-post/components/sidebar/document-sidebar/index.js
+++ b/edit-post/components/sidebar/document-sidebar/index.js
@@ -15,6 +15,7 @@ import DiscussionPanel from '../discussion-panel';
 import LastRevision from '../last-revision';
 import PageAttributes from '../page-attributes';
 import MetaBoxes from '../../meta-boxes';
+import SidebarExtender from '../sidebar-extender';
 import SettingsHeader from '../settings-header';
 import Sidebar from '../';
 
@@ -34,6 +35,7 @@ const DocumentSidebar = () => (
 			<PostExcerpt />
 			<DiscussionPanel />
 			<PageAttributes />
+			<SidebarExtender.Slot />
 			<MetaBoxes location="side" usePanel />
 		</Panel>
 	</Sidebar>

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -13,6 +13,7 @@ import { withPluginContext } from '@wordpress/plugins';
 import PinnedPlugins from '../../header/pinned-plugins';
 import Sidebar from '../';
 import SidebarHeader from '../sidebar-header';
+import SidebarExtender from '../sidebar-extender';
 
 /**
  * Renders the plugin sidebar component.
@@ -67,6 +68,7 @@ function PluginSidebar( props ) {
 				</SidebarHeader>
 				<Panel>
 					{ children }
+					<SidebarExtender.Slot />
 				</Panel>
 			</Sidebar>
 		</Fragment>

--- a/edit-post/components/sidebar/sidebar-extender/index.js
+++ b/edit-post/components/sidebar/sidebar-extender/index.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill, Slot } = createSlotFill( 'SidebarExtender' );
+
+const SidebarExtender = Fill;
+SidebarExtender.Slot = Slot;
+
+export default SidebarExtender;

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -85,3 +85,4 @@ export { default as PluginPostStatusInfo } from './components/sidebar/plugin-pos
 export { default as PluginPrePublishPanel } from './components/sidebar/plugin-pre-publish-panel';
 export { default as PluginSidebar } from './components/sidebar/plugin-sidebar';
 export { default as PluginSidebarMoreMenuItem } from './components/header/plugin-sidebar-more-menu-item';
+export { default as SidebarExtender } from './components/sidebar/sidebar-extender';


### PR DESCRIPTION
If merged this PR will:
Add a pair of slot and fill SidebarExtender components.
Adds the slot of SidebarExtender to all general sidebars (block, document, and plugins ).

Although SidebarExtender adds the content to all sidebars, plugins can easily use withSelect + ifCondition to select exactly when they want to show something or just show something in a specific sidebar. We can also in the future create more HighLevel versions that rely on this low-level interface.

This idea appeared when reviewing https://github.com/WordPress/gutenberg/pull/6798. The original idea was to also apply the sidebar extender in pre and post-publish sidebars so PluginPrePublishPanel could just use a combination of withSelect+ ifCondition+SidebarExtender, but the querying pre and post-publish state is not possible as it uses a local sate so I end up not pursuing this idea.


## How has this been tested?
Add the following block of code in the console:
```
var el = wp.element.createElement;
var SidebarExtender = wp.editPost.SidebarExtender;
var sidebarContent = el( wp.components.PanelBody, {}, el( 'h3', {}, 'Hello world!' ) ); 
var mySidebarExtender = el( SidebarExtender, {}, sidebarContent );
wp.plugins.registerPlugin( 'test', { render: function(){ return mySidebarExtender } } );
```

Verify it adds 'Hello world!' to all sidebars including the plugins ones e.g Dropit.

Add the following block of code:

```
var el = wp.element.createElement;
var SidebarExtender = wp.editPost.SidebarExtender;
var sidebarContent = el( wp.components.PanelBody, {}, el( 'h3', {}, 'Hello world!' ) );
var MyConditionalSidebarExtender = wp.element.compose( [
    wp.data.withSelect( ( select ) => ( {
        isDocumentSidebar: 'edit-post/document' === select( 'core/edit-post' ).getActiveGeneralSidebarName()
    } ) ), 
    wp.components.ifCondition( ( props ) => props.isDocumentSidebar )
] )( SidebarExtender ); 
var mySidebarExtender = el( MyConditionalSidebarExtender, {}, sidebarContent );
wp.plugins.registerPlugin( 'test', { render: function(){ return mySidebarExtender } } );
````

Verify it writes 'Hello world! just in the document sidebar.

