### PR TITLE
Explicitly set background-color for sidebar headings

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -6,6 +6,7 @@
 	border: 0;
 	cursor: pointer;
 	-webkit-appearance: none;
+	background: none;
 
 	&.is-button {
 		padding: 0 10px 1px;


### PR DESCRIPTION
## Description
Background color was not defined for `.components-panel__body-toggle.components-button` so the element was loading with the default grey bg color from FF UA styles.

## How has this been tested?
QA on macOS FF 59 and 32 and Android FF 51 

## Screenshots 
![imagem](https://user-images.githubusercontent.com/5367401/40382897-dfe84ea8-5dd5-11e8-83e2-d384de8f1a08.png)

## Types of changes
Style fix for sidebar accordion headings. Fix #6898.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
