### PR TITLE
Scope the rule that adds a white bg on the html element

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -37,8 +37,9 @@
 	}
 }
 
-// in order to use mix-blend-mode, this element needs to have an explicitly set background-color
-html {
+// In order to use mix-blend-mode, this element needs to have an explicitly set background-color
+// We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations
+html.wp-toolbar {
 	background: $white;
 }
 


### PR DESCRIPTION
Since merging in the PR that makes the editing canvas friendly to themes, we've added a CSS rule to the `html` element that simply adds a background color. This is due to a bug in Chrome that makes mix-blend-mode only work when a background is actually applied. See https://css-tricks.com/almanac/properties/m/mix-blend-mode/

However this HTML element rule was unscoped, and in case you run Gutenberg in other implementations that don't include the wp-admin, this can cause you to run into this following obscure and exotic CSS situation: https://css-tricks.com/just-one-of-those-weird-things-about-css-background-on-body/

Ideally we had a different CSS class on the HTML element than `wp-toolbar`, however it doesn't seem WordPress has a plugin API to let you add that. Instead of jumping into CSS wizardry, I simply latched on to the existing class, which appears to be wp-admin only.

Any thoughts? Any different approaches you'd recommend?

Mix-blend-mode _could_ be revisited, I could potentially use a background-filter instead. But it's a good way to ensure contrast to the multi selection color.
