### PR TITLE
Improve title "block" so it works with and without editor styles

### DIFF
--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -131,7 +131,7 @@ To change the main column width of the editor, add the following CSS to `style-e
 
 ```css
 /* Main column width */
-body.gutenberg-editor-page .editor-post-title,
+body.gutenberg-editor-page .editor-post-title__block,
 body.gutenberg-editor-page .editor-default-block-appender,
 body.gutenberg-editor-page .editor-block-list__block {
 	max-width: 720px;

--- a/edit-post/components/text-editor/style.scss
+++ b/edit-post/components/text-editor/style.scss
@@ -27,8 +27,29 @@
 	}
 
 	// Always show outlines in code editor
-	.editor-post-title div {
-		border: 1px solid $light-gray-500;
+	.editor-post-title__block {
+		textarea {
+			border: 1px solid $light-gray-500;
+			margin-bottom: 4px;
+		}
+
+		textarea:hover,
+		&.is-selected textarea {
+			box-shadow: 0 0 0 1px $light-gray-500;
+		}
+	}
+
+	.editor-post-permalink {
+		left: 0;
+		right: 0;
+		margin-top: -6px;
+	}
+
+	@include break-small() {
+		.editor-post-title,
+		.editor-post-title__block {
+			padding: 0;
+		}
 	}
 
 	.editor-post-text-editor {

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -67,15 +67,28 @@
 }
 
 // The base width of the title should match that of blocks even if it isn't a block
-.edit-post-visual-editor .editor-post-title {
+.editor-post-title {
+	@include break-small() {
+		padding-left: $block-side-ui-padding;
+		padding-right: $block-side-ui-padding;
+	}
+}
+.edit-post-visual-editor .editor-post-title__block {
 	margin-left: auto;
 	margin-right: auto;
 	max-width: $content-width;
 
+	// stack borders
+	> div {
+		margin-left: -1px;
+		margin-right: -1px;
+	}
+
+	// include space for side UI on desktops
 	@include break-small() {
 		> div {
-			margin-left: -$block-side-ui-padding;
-			margin-right: -$block-side-ui-padding;
+			margin-left: -$block-side-ui-padding - 1px;
+			margin-right: -$block-side-ui-padding - 1px;
 		}
 	}
 }

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -90,33 +90,35 @@ class PostTitle extends Component {
 	render() {
 		const { title, placeholder, instanceId, isPostTypeViewable } = this.props;
 		const { isSelected } = this.state;
-		const className = classnames( 'editor-post-title', { 'is-selected': isSelected } );
+		const className = classnames( 'editor-post-title__block', { 'is-selected': isSelected } );
 		const decodedPlaceholder = decodeEntities( placeholder );
 
 		return (
 			<PostTypeSupportCheck supportKeys="title">
-				<div className={ className }>
-					<KeyboardShortcuts
-						shortcuts={ {
-							'mod+z': this.redirectHistory,
-							'mod+shift+z': this.redirectHistory,
-						} }
-					>
-						<label htmlFor={ `post-title-${ instanceId }` } className="screen-reader-text">
-							{ decodedPlaceholder || __( 'Add title' ) }
-						</label>
-						<Textarea
-							id={ `post-title-${ instanceId }` }
-							className="editor-post-title__input"
-							value={ title }
-							onChange={ this.onChange }
-							placeholder={ decodedPlaceholder || __( 'Add title' ) }
-							onFocus={ this.onSelect }
-							onKeyDown={ this.onKeyDown }
-							onKeyPress={ this.onUnselect }
-						/>
-					</KeyboardShortcuts>
-					{ isSelected && isPostTypeViewable && <PostPermalink /> }
+				<div className="editor-post-title">
+					<div className={ className }>
+						<KeyboardShortcuts
+							shortcuts={ {
+								'mod+z': this.redirectHistory,
+								'mod+shift+z': this.redirectHistory,
+							} }
+						>
+							<label htmlFor={ `post-title-${ instanceId }` } className="screen-reader-text">
+								{ decodedPlaceholder || __( 'Add title' ) }
+							</label>
+							<Textarea
+								id={ `post-title-${ instanceId }` }
+								className="editor-post-title__input"
+								value={ title }
+								onChange={ this.onChange }
+								placeholder={ decodedPlaceholder || __( 'Add title' ) }
+								onFocus={ this.onSelect }
+								onKeyDown={ this.onKeyDown }
+								onKeyPress={ this.onUnselect }
+							/>
+						</KeyboardShortcuts>
+						{ isSelected && isPostTypeViewable && <PostPermalink /> }
+					</div>
 				</div>
 			</PostTypeSupportCheck>
 		);

--- a/editor/components/post-title/style.scss
+++ b/editor/components/post-title/style.scss
@@ -37,7 +37,7 @@
 	font-size: $default-font-size;
 	color: $dark-gray-900;
 	position: absolute;
-	top: -$block-toolbar-height + 1px + 1px; // move upwards the toolbar height, but subtract borders
+	top: -$block-toolbar-height + 1px + 1px; // Shift this element upward the same height as the block toolbar, minus the border size
 	left: 0;
 	right: 0;
 

--- a/editor/components/post-title/style.scss
+++ b/editor/components/post-title/style.scss
@@ -1,4 +1,4 @@
-.editor-post-title {
+.editor-post-title__block {
 	position: relative;
 	padding: 5px 0;
 	
@@ -35,8 +35,9 @@
 
 .editor-post-title .editor-post-permalink {
 	font-size: $default-font-size;
+	color: $dark-gray-900;
 	position: absolute;
-	top: -35px;
+	top: -$block-toolbar-height + 1px + 1px; // move upwards the toolbar height, but subtract borders
 	left: 0;
 	right: 0;
 


### PR DESCRIPTION
The title block is tricky. Because it's not a block. It also relies on a `textarea` as opposed to a div with `contenteditable`. Because of this, the unique rules that apply to textareas make it hard to style with negative margins and such.

It's very complicated, but the short of it is, in order to _look and behave_ like a block, the CSS styles are somewhat complex. I recently introduced a regression as a result of trying to make it more theme style friendly. But the fix to that regression caused a regression in turn to the theme styles.

This PR tries to fix all that. The title now looks and behaves like a block, on all breakpoints, _and_ it's easily stylable by theme editor styles. For example, with the following CSS rules, you can have an editor that fills the entire canvas:

```
body.gutenberg-editor-page {

	.editor-post-title__block,
	.editor-default-block-appender,
	.editor-block-list__block,
	.editor-block-list__block[data-align="wide"],
	.editor-block-list__block[data-align="full"] {
		max-width: none;
	}

}
```

Or you can even apply a specific pixel or percent value.

Previously you had to make special rules JUST for the title block, so as to match the other elements.

One less cool thing about this PR, and suggestions are welcome, is that it introduces a new div, and renames a CSS class (to follow bem rules of hierarchy). I wish there was a different way.

Thoughts?

Screenshots:

<img width="1565" alt="screen shot 2018-05-23 at 10 34 39" src="https://user-images.githubusercontent.com/1204802/40415175-a014a7e0-5e7a-11e8-9b0d-7718cfc8ca3d.png">

<img width="382" alt="screen shot 2018-05-23 at 11 08 08" src="https://user-images.githubusercontent.com/1204802/40415200-abe56d70-5e7a-11e8-8fc6-28f49b9e9e12.png">
