### PR TITLE
Fix/inbetweenserter regression

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -19,7 +19,7 @@ $z-layers: (
 	'.editor-block-contextual-toolbar': 21,
 	'.editor-block-switcher__menu': 5,
 	'.components-popover__close': 5,
-	'.editor-block-list__insertion-point': 82, // @todo, test that this new elevation doesn't cause issues, used to be 5, shoud now be above side UI
+	'.editor-block-list__insertion-point': 5,
 	'.editor-format-toolbar__link-modal': 81, // should appear above block controls
 	'.editor-format-toolbar__link-container': 81, // link suggestions should also
 	'.core-blocks-gallery-item__inline-menu': 20,

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -40,6 +40,7 @@ class BlockInsertionPoint extends Component {
 		const { layout, rootUID, index, ...props } = this.props;
 		props.insertDefaultBlock( { layout }, rootUID, index );
 		props.startTyping();
+		this.onBlurInserter();
 	}
 
 	render() {

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -24,7 +24,11 @@ class BlockInsertionPoint extends Component {
 		this.onClick = this.onClick.bind( this );
 	}
 
-	onFocusInserter() {
+	onFocusInserter( event ) {
+		// We stop propagation of the focus event to avoid selecting the current block
+		// While we're trying to insert a new block
+		event.stopPropagation();
+
 		this.setState( {
 			isInserterFocused: true,
 		} );

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -11,29 +11,6 @@ describe( 'adding blocks', () => {
 	} );
 
 	/**
-	 * Given a Puppeteer ElementHandle, clicks around the center-right point.
-	 *
-	 * TEMPORARY: This is a mild hack to work around a bug in the application
-	 * which prevents clicking at center of the inserter, due to conflicting
-	 * overlap of focused block contextual toolbar.
-	 *
-	 * @see Puppeteer.ElementHandle#click
-	 *
-	 * @link https://github.com/WordPress/gutenberg/pull/5658#issuecomment-376943568
-	 *
-	 * @param {Puppeteer.ElementHandle} elementHandle Element handle.
-	 *
-	 * @return {Promise} Promise resolving when element clicked.
-	 */
-	async function clickAtRightish( elementHandle ) {
-		await elementHandle._scrollIntoViewIfNeeded();
-		const box = await elementHandle._assertBoundingBox();
-		const x = box.x + ( box.width * 0.75 );
-		const y = box.y + ( box.height / 2 );
-		return page.mouse.click( x, y );
-	}
-
-	/**
 	 * Given a Puppeteer ElementHandle, clicks below its bounding box.
 	 *
 	 * @param {Puppeteer.ElementHandle} elementHandle Element handle.
@@ -79,11 +56,14 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Code block' );
 
+		// Unselect blocks to avoid conflicts with the inbetween inserter
+		await page.click( '.editor-post-title__input' );
+
 		// Using the between inserter
-		await page.mouse.move( 200, 300 );
-		await page.mouse.move( 250, 350 );
-		const inserter = await page.$( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
-		await clickAtRightish( inserter );
+		const insertionPoint = await page.$( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
+		const rect = await insertionPoint.boundingBox();
+		await page.mouse.move( rect.x + ( rect.width / 2 ), rect.y + ( rect.height / 2 ) );
+		await page.click( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
 		await page.keyboard.type( 'Second paragraph' );
 
 		// Switch to Text Mode to check HTML Output


### PR DESCRIPTION
This fixes two regressions as part of the newly introduced inbetweenserter PR. 

1. The z-index was off. That's been fixed.
2. The inbetweenserter would linger if you clicked to insert, then clicked away from the empty paragraph. 

Thanks Riad for help!