### PR TITLE
Add second parameter to createSlotFill to define wrapper element for Slot

### DIFF
--- a/components/slot-fill/README.md
+++ b/components/slot-fill/README.md
@@ -1,4 +1,4 @@
-Slot Fill
+gSlot Fill
 =========
 
 Slot and Fill are a pair of components which enable developers to render elsewhere in a React element tree, a pattern often referred to as "portal" rendering. It is a pattern for component extensibility, where a single Slot may be occupied by an indeterminate number of Fills elsewhere in the application.
@@ -58,6 +58,15 @@ const Toolbar = () => (
 		<Slot />
 	</div>
 ); 
+```
+createSlotFill accepts an optional second parameter that allows customization of the element that wraps the items. It can accept an html tag or Component.
+
+```jsx
+// Wrap the items in a p tag
+const { Fill, Slot } = createSlotFill( 'Toolbar', 'p' );
+
+// Wrap the items in the <PanelRow/> component
+const { Fill, Slot } = createSlotFill( 'Toolbar', PanelRow );
 ```
 
 ## Props

--- a/components/slot-fill/README.md
+++ b/components/slot-fill/README.md
@@ -1,4 +1,4 @@
-gSlot Fill
+Slot Fill
 =========
 
 Slot and Fill are a pair of components which enable developers to render elsewhere in a React element tree, a pattern often referred to as "portal" rendering. It is a pattern for component extensibility, where a single Slot may be occupied by an indeterminate number of Fills elsewhere in the application.

--- a/components/slot-fill/index.js
+++ b/components/slot-fill/index.js
@@ -9,7 +9,7 @@ export { Slot };
 export { Fill };
 export { Provider };
 
-export function createSlotFill( name ) {
+export function createSlotFill( name, slotWrap = 'div' ) {
 	const FillComponent = ( { children, ...props } ) => (
 		<Fill name={ name } { ...props }>
 			{ children }
@@ -18,7 +18,7 @@ export function createSlotFill( name ) {
 	FillComponent.displayName = name + 'Fill';
 
 	const SlotComponent = ( { children, ...props } ) => (
-		<Slot name={ name } { ...props }>
+		<Slot name={ name } { ...props } SlotWrap={slotWrap}>
 			{ children }
 		</Slot>
 	);

--- a/components/slot-fill/index.js
+++ b/components/slot-fill/index.js
@@ -18,7 +18,7 @@ export function createSlotFill( name, slotWrap = 'div' ) {
 	FillComponent.displayName = name + 'Fill';
 
 	const SlotComponent = ( { children, ...props } ) => (
-		<Slot name={ name } { ...props } SlotWrap={slotWrap}>
+		<Slot name={ name } { ...props } SlotWrap={ slotWrap }>
 			{ children }
 		</Slot>
 	);

--- a/components/slot-fill/slot.js
+++ b/components/slot-fill/slot.js
@@ -11,7 +11,6 @@ import { Component, Children, cloneElement } from '@wordpress/element';
 class Slot extends Component {
 	constructor() {
 		super( ...arguments );
-
 		this.bindNode = this.bindNode.bind( this );
 	}
 
@@ -45,9 +44,8 @@ class Slot extends Component {
 	}
 
 	render() {
-		const { children, name, bubblesVirtually = false, fillProps = {} } = this.props;
+		const { children, name, bubblesVirtually = false, fillProps = {}, SlotWrap } = this.props;
 		const { getFills = noop } = this.context;
-
 		if ( bubblesVirtually ) {
 			return <div ref={ this.bindNode } />;
 		}
@@ -69,11 +67,10 @@ class Slot extends Component {
 				return cloneElement( child, { key: childKey } );
 			} );
 		} );
-
 		return (
-			<div ref={ this.bindNode }>
+			<SlotWrap ref={ this.bindNode }>
 				{ isFunction( children ) ? children( fills.filter( Boolean ) ) : fills }
-			</div>
+			</SlotWrap>
 		);
 	}
 }

--- a/components/slot-fill/slot.js
+++ b/components/slot-fill/slot.js
@@ -44,7 +44,7 @@ class Slot extends Component {
 	}
 
 	render() {
-		const { children, name, bubblesVirtually = false, fillProps = {}, SlotWrap } = this.props;
+		const { children, name, bubblesVirtually = false, fillProps = {}, SlotWrap = 'div' } = this.props;
 		const { getFills = noop } = this.context;
 		if ( bubblesVirtually ) {
 			return <div ref={ this.bindNode } />;

--- a/edit-post/components/sidebar/plugin-post-status-info/index.js
+++ b/edit-post/components/sidebar/plugin-post-status-info/index.js
@@ -7,12 +7,8 @@
  */
 import { createSlotFill, PanelRow } from '@wordpress/components';
 
-export const { Fill: PluginPostStatusInfo, Slot } = createSlotFill( 'PluginPostStatusInfo' );
+export const { Fill: PluginPostStatusInfo, Slot } = createSlotFill( 'PluginPostStatusInfo', PanelRow );
 
-PluginPostStatusInfo.Slot = () => (
-	<PanelRow>
-		<Slot />
-	</PanelRow>
-);
+PluginPostStatusInfo.Slot = Slot;
 
 export default PluginPostStatusInfo;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2518,9 +2518,9 @@
 			}
 		},
 		"caniuse-db": {
-			"version": "1.0.30000843",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000843.tgz",
-			"integrity": "sha1-T36FAfVX3JvNN90zrIWQXHZe/sI=",
+			"version": "1.0.30000844",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000844.tgz",
+			"integrity": "sha1-vKV5jNoraTHWgQDC1p5V+zOMu0E=",
 			"dev": true
 		},
 		"caniuse-lite": {
@@ -6168,9 +6168,9 @@
 			}
 		},
 		"gaze": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-			"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
 			"dev": true,
 			"requires": {
 				"globule": "^1.0.0"
@@ -9365,12 +9365,6 @@
 				"pseudomap": "^1.0.1"
 			}
 		},
-		"macaddress": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-			"dev": true
-		},
 		"make-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -11486,13 +11480,12 @@
 			}
 		},
 		"postcss-filter-plugins": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
+			"integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4",
-				"uniqid": "^4.0.0"
+				"postcss": "^5.0.4"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15446,15 +15439,6 @@
 			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
 			"dev": true
 		},
-		"uniqid": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-			"dev": true,
-			"requires": {
-				"macaddress": "^0.2.8"
-			}
-		},
 		"uniqs": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
@@ -16241,12 +16225,12 @@
 					"dev": true
 				},
 				"async": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.14.0"
+						"lodash": "^4.17.10"
 					}
 				},
 				"chalk": {
@@ -16274,6 +16258,12 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.10",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
 					"dev": true
 				},
 				"postcss": {


### PR DESCRIPTION
## Description
This PR adds an optional second parameter to createSlotFill that allows control over the element that wraps the `children`. This fixes #6839 and relates to #6867 and feels like a better approach than one I proposed in #6905

## How has this been tested?
I have tested via `npm run test` and using the following:
```jsx
const { registerPlugin } = wp.plugins;
const { PluginPostStatusInfo } = wp.editPost;

const PluginRender = () => {
	return (
		<PluginPostStatusInfo>
			<p>Hello!</p>
		</PluginPostStatusInfo>
	);
}
registerPlugin( 'my-plugin-slug', { render: PluginRender } )
```
I am seeing a React warning that is due to adding a ref to a stateless component which is due to using PanelRow as the wrapper component. I think we can address if this approach is deemed suitable.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
