### PR TITLE
Properly associate the spacer height input label.

### DIFF
--- a/core-blocks/spacer/editor.scss
+++ b/core-blocks/spacer/editor.scss
@@ -1,14 +1,14 @@
 .editor-block-list__block[data-type="core/spacer"].is-selected .editor-block-list__block-edit {
 	background: $light-gray-200;
 
-	.wp-block-spacer__resize-handler-top,
-	.wp-block-spacer__resize-handler-bottom {
+	.block-spacer__resize-handler-top,
+	.block-spacer__resize-handler-bottom {
 		display: block;
 	}
 }
 
-.wp-block-spacer__resize-handler-top,
-.wp-block-spacer__resize-handler-bottom {
+.block-spacer__resize-handler-top,
+.block-spacer__resize-handler-bottom {
 	display: none;
 	border-radius: 50%;
 	border: 2px solid white;

--- a/core-blocks/spacer/index.js
+++ b/core-blocks/spacer/index.js
@@ -47,8 +47,8 @@ export const settings = {
 						} }
 						minHeight="20"
 						handleClasses={ {
-							top: 'block-spacer__resize-handler-top',
-							bottom: 'block-spacer__resize-handler-bottom',
+							top: 'core-blocks-spacer__resize-handler-top',
+							bottom: 'core-blocks-spacer__resize-handler-bottom',
 						} }
 						enable={ {
 							top: true,

--- a/core-blocks/spacer/index.js
+++ b/core-blocks/spacer/index.js
@@ -9,7 +9,7 @@ import ResizableBox from 're-resizable';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/editor';
-import { BaseControl, PanelBody } from '@wordpress/components';
+import { BaseControl, PanelBody, withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -34,61 +34,64 @@ export const settings = {
 		},
 	},
 
-	edit( { attributes, setAttributes, toggleSelection } ) {
-		const { height } = attributes;
+	edit: withInstanceId(
+		( { attributes, setAttributes, toggleSelection, instanceId } ) => {
+			const { height } = attributes;
+			const id = `block-spacer-height-input-${ instanceId }`;
 
-		return (
-			<Fragment>
-				<ResizableBox
-					size={ {
-						height,
-					} }
-					minHeight="20"
-					handleClasses={ {
-						top: 'wp-block-spacer__resize-handler-top',
-						bottom: 'wp-block-spacer__resize-handler-bottom',
-					} }
-					enable={ {
-						top: true,
-						right: false,
-						bottom: true,
-						left: false,
-						topRight: false,
-						bottomRight: false,
-						bottomLeft: false,
-						topLeft: false,
-					} }
-					onResizeStop={ ( event, direction, elt, delta ) => {
-						setAttributes( {
-							height: parseInt( height + delta.height, 10 ),
-						} );
-						toggleSelection( true );
-					} }
-					onResizeStart={ () => {
-						toggleSelection( false );
-					} }
-				/>
-				<InspectorControls>
-					<PanelBody title={ __( 'Spacer Settings' ) }>
-						<BaseControl label={ __( 'Height in pixels' ) }>
-							<input
-								type="number"
-								onChange={ ( event ) => {
-									setAttributes( {
-										height: parseInt( event.target.value, 10 ),
-									} );
-								} }
-								aria-label={ __( 'Height for the spacer element in pixels.' ) }
-								value={ height }
-								min="20"
-								step="10"
-							/>
-						</BaseControl>
-					</PanelBody>
-				</InspectorControls>
-			</Fragment>
-		);
-	},
+			return (
+				<Fragment>
+					<ResizableBox
+						size={ {
+							height,
+						} }
+						minHeight="20"
+						handleClasses={ {
+							top: 'block-spacer__resize-handler-top',
+							bottom: 'block-spacer__resize-handler-bottom',
+						} }
+						enable={ {
+							top: true,
+							right: false,
+							bottom: true,
+							left: false,
+							topRight: false,
+							bottomRight: false,
+							bottomLeft: false,
+							topLeft: false,
+						} }
+						onResizeStop={ ( event, direction, elt, delta ) => {
+							setAttributes( {
+								height: parseInt( height + delta.height, 10 ),
+							} );
+							toggleSelection( true );
+						} }
+						onResizeStart={ () => {
+							toggleSelection( false );
+						} }
+					/>
+					<InspectorControls>
+						<PanelBody title={ __( 'Spacer Settings' ) }>
+							<BaseControl label={ __( 'Height in pixels' ) } id={ id }>
+								<input
+									type="number"
+									id={ id }
+									onChange={ ( event ) => {
+										setAttributes( {
+											height: parseInt( event.target.value, 10 ),
+										} );
+									} }
+									value={ height }
+									min="20"
+									step="10"
+								/>
+							</BaseControl>
+						</PanelBody>
+					</InspectorControls>
+				</Fragment>
+			);
+		}
+	),
 
 	save( { attributes } ) {
 		return <div style={ { height: attributes.height } } aria-hidden />;


### PR DESCRIPTION
## Description

Properly associates the existing `<label>` element to the spacer height input field.

<img width="311" alt="screen shot 2018-05-23 at 18 34 38" src="https://user-images.githubusercontent.com/1682452/40438719-0b792f04-5eb9-11e8-90d0-943417dfeeba.png">

I'd like to remind, once again, that any UI control must be properly labeled. In order fo preference:
- with a visible `<label>` element associated with for/id attributes
- with a visually hidden `<label>`
- with aria-label or aria-labelledby

A visible, properly associated label is preferable because:
- it works with any device/assistive technology
- when clicked, it focuses the associated control
- it's visible, so it's available to all users including, for example, speech recognition software users who need to know the name of a control to activate it

Currently, the `<label>` element is just a stray label. Not associated with anything. This way, it's just text in the page and doesn't have any purpose. Additionally, the input field has an `aria-label` attribute that basically repeats the visible label and doesn't add any relevant information:
- label: `Height in pixels`
- aria-label: `Height for the spacer element in pixels.`

This PR:
- uses for/id attributes to associate the visible label
- removes the aria-label
- fixes the class names used in `edit` removing the `wp-` prefix

Worth noting the `aria-hidden` attribute rendered in the front-end is pointless because an empty `<div>` is not exposed in any way to assistive technologies. Ideally, it should be removed but it doesn't harm anything.

Fixes #6918 