### PR TITLE
Address Andrew feedback

### DIFF
--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -194,8 +194,9 @@ export const settings = {
 	save( { attributes } ) {
 		const { url, alt, caption, align, href, width, height, id } = attributes;
 
-		const classes = classnames( align ? `align${ align }` : null, {
-			'is-resized': !! width || !! height,
+		const classes = classnames( {
+			[ `align${ align }` ]: align,
+			'is-resized': width || height,
 		} );
 
 		const image = (

--- a/core-blocks/table/editor.scss
+++ b/core-blocks/table/editor.scss
@@ -15,16 +15,3 @@
 		background-color: $light-gray-300;
 	}
 }
-
-// Style the resize handles
-.ephox-snooker-resizer-rows {
-	cursor: row-resize;
-}
-
-.ephox-snooker-resizer-cols {
-	cursor: col-resize;
-}
-
-.ephox-snooker-resizer-bar-dragging {
-	background: $blue-medium-500;
-}

--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -1,3 +1,12 @@
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
 @mixin animate_fade {
 	animation: animate_fade 0.1s ease-out;
 	animation-fill-mode: forwards;

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -200,11 +200,15 @@ body.gutenberg-editor-page {
 	}
 }
 
-@keyframes fade-in {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
+// Style the TinyMCE table resize handles
+.ephox-snooker-resizer-rows {
+	cursor: row-resize;
+}
+
+.ephox-snooker-resizer-cols {
+	cursor: col-resize;
+}
+
+.ephox-snooker-resizer-bar-dragging {
+	background: $blue-medium-500;
 }


### PR DESCRIPTION
This PR addresses feedback in https://github.com/WordPress/gutenberg/pull/6314#pullrequestreview-122596136 and https://github.com/WordPress/gutenberg/pull/6496#pullrequestreview-122594397.

Specifically, it:

- refines the image classes saved
- moves the TinyMCE table handle styles to the main stylesheet, since they are global
- cleans up an animation that was astray seemingly

Thank you Andrew, appreciate it!