### PR TITLE
Add Omar and Tim as contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -97,3 +97,5 @@ This list is manually curated to include valuable contributions by volunteers th
 | @c-shultz |
 | @nfmohit-wpmudev |
 | @noisysocks | @noisysocks |
+| @omarreiss | @omarreiss |
+| @hedgefield | @hedgefield |


### PR DESCRIPTION
## Description

* @hedgefield has contributed mockups and has co-run the Yoast user tests.
* @omarreiss has contributed to ideation and has co-run the Yoast user tests.

They both currently don't have code contributions and I don't expect them to, so adding them both to this list.