### PR TITLE
Try making the grays less dull.

### DIFF
--- a/edit-post/assets/stylesheets/_colors.scss
+++ b/edit-post/assets/stylesheets/_colors.scss
@@ -26,24 +26,24 @@ $light-gray-100: #f8f9f9;
 $white: #fff;
 
 // Dark opacities, for use with light themes
-$dark-opacity-900: rgba( $dark-gray-900, .8 );
-$dark-opacity-800: rgba( $dark-gray-900, .75 );
-$dark-opacity-700: rgba( $dark-gray-900, .7 );
-$dark-opacity-600: rgba( $dark-gray-900, .65 );
-$dark-opacity-500: rgba( $dark-gray-900, .6 );
-$dark-opacity-400: rgba( $dark-gray-900, .55 );
-$dark-opacity-300: rgba( $dark-gray-900, .5 );
-$dark-opacity-200: rgba( $dark-gray-900, .45 );
-$dark-opacity-100: rgba( $dark-gray-900, .4 );
-$dark-opacity-light-900: rgba( $dark-gray-900, .35 );
-$dark-opacity-light-800: rgba( $dark-gray-900, .3 );
-$dark-opacity-light-700: rgba( $dark-gray-900, .25 );
-$dark-opacity-light-600: rgba( $dark-gray-900, .2 );
-$dark-opacity-light-500: rgba( $dark-gray-900, .15 );
-$dark-opacity-light-400: rgba( $dark-gray-900, .1 );
-$dark-opacity-light-300: rgba( $dark-gray-900, .075 );
-$dark-opacity-light-200: rgba( $dark-gray-900, .05 );
-$dark-opacity-light-100: rgba( $dark-gray-900, .025 );
+$dark-opacity-900: rgba( #000510, .9 );
+$dark-opacity-800: rgba( #00000a, .85 );
+$dark-opacity-700: rgba( #06060b, .8 );
+$dark-opacity-600: rgba( #000913, .75 );
+$dark-opacity-500: rgba( #0a1829, .7 );
+$dark-opacity-400: rgba( #0a1829, .65 );
+$dark-opacity-300: rgba( #0e1c2e, .6 );
+$dark-opacity-200: rgba( #162435, .55 );
+$dark-opacity-100: rgba(#223443, .5 );
+$dark-opacity-light-900: rgba( #304455, .45 );
+$dark-opacity-light-800: rgba( #425863, .4 );
+$dark-opacity-light-700: rgba( #667886, .35 );
+$dark-opacity-light-600: rgba( #7b86a2, .3 );
+$dark-opacity-light-500: rgba( #9197a2, .25 );
+$dark-opacity-light-400: rgba( #95959c, .2 );
+$dark-opacity-light-300: rgba( #829493, .15 );
+$dark-opacity-light-200: rgba( #8b8b96, .1 );
+$dark-opacity-light-100: rgba( #747474, .05 );
 
 // Light opacities, for use with dark themes
 $light-opacity-900: rgba( $white, 1 );

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -171,16 +171,16 @@ body.gutenberg-editor-page {
 	textarea {
 		// use opacity to work in various editor styles
 		&::-webkit-input-placeholder {
-			color: $dark-opacity-300;
+			color: $dark-opacity-100;
 		}
 		&::-moz-placeholder {
-			color: $dark-opacity-300;
+			color: $dark-opacity-100;
 		}
 		&:-ms-input-placeholder {
-			color: $dark-opacity-300;
+			color: $dark-opacity-100;
 		}
 		&:-moz-placeholder {
-			color: $dark-opacity-300;
+			color: $dark-opacity-100;
 		}
 
 		.is-dark-theme & {


### PR DESCRIPTION
When we merged in the pull request to make the colors of the editing canvas more friendly to themed background colors, we replaced all UI colors that floated on here with a range of opacities instead.

Those opacities can be improved, because as a result, they are a bit dull compared to Hugo's glorious shades of gray.

In this PR I try to improve those shades using a highly scientific metho... who am I kidding, I did this manually and it was quite the work.

I took the solid grays on one side, copied each of them and set them to a range of opacities ranging from .9 for the darkest and .1 for the lightest. Then I adjusted the saturation and brightness to mimic the original colors as closely as possible. The reason being, as soon as opacity is introduced, the colors lose punch proportionally to the loss of opacity. We can compensate for that with darker base colors, and increased saturation.

Please test that these colors, when viewed on a white background, have sufficient contrast in all the in-canvas editing UI where they are applied.

The end goal is for the opacities, when shown on a white background, to be as close to the range of solid grays we have, as possible.

Here's the file where I, in Photoshop, manually adjusted each color to look its best at a given opacity:

![grays](https://user-images.githubusercontent.com/1204802/40483099-295eac1c-5f57-11e8-83ca-1cf644476d8f.png)

See also codepen where I experimented with the opacities: https://codepen.io/joen/pen/vjwjpx?editors=1100

Here are the new opacities on a colored background:

<img width="813" alt="screen shot 2018-05-24 at 13 28 53" src="https://user-images.githubusercontent.com/1204802/40483178-60070926-5f57-11e8-8629-ace52d367a77.png">
