### PR TITLE
Edit Post: Improve perf for PublishPanel and extenstions

### DIFF
--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -86,8 +86,8 @@ function Layout( {
 					onClose={ closePublishSidebar }
 					forceIsDirty={ hasActiveMetaboxes }
 					forceIsSaving={ isSaving }
-					renderPrePublishExtension={ () => <PluginPrePublishPanel.Slot /> }
-					renderPostPublishExtension={ () => <PluginPostPublishPanel.Slot /> }
+					PrePublishExtension={ PluginPrePublishPanel.Slot }
+					PostPublishExtension={ PluginPostPublishPanel.Slot }
 				/>
 			) }
 			<DocumentSidebar />

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -60,7 +60,7 @@ class PostPublishPanel extends Component {
 	}
 
 	render() {
-		const { isScheduled, onClose, forceIsDirty, forceIsSaving, renderPrePublishExtension, renderPostPublishExtension } = this.props;
+		const { isScheduled, onClose, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension } = this.props;
 		const { loading, submitted } = this.state;
 		return (
 			<div className="editor-post-publish-panel">
@@ -84,13 +84,13 @@ class PostPublishPanel extends Component {
 				<div className="editor-post-publish-panel__content">
 					{ ! loading && ! submitted && (
 						<PostPublishPanelPrepublish>
-							{ renderPrePublishExtension() }
+							{ PrePublishExtension && <PrePublishExtension /> }
 						</PostPublishPanelPrepublish>
 					) }
 					{ loading && ! submitted && <Spinner /> }
 					{ submitted && (
 						<PostPublishPanelPostpublish>
-							{ renderPostPublishExtension() }
+							{ PostPublishExtension && <PostPublishExtension /> }
 						</PostPublishPanelPostpublish>
 					) }
 				</div>


### PR DESCRIPTION
Addresses [the comment](https://github.com/WordPress/gutenberg/pull/6798#discussion_r190381013) from @aduth:

> This will cause render reconciliation more than necessary because it's creating a new function each render.
> 
> Why not hoist to a top-level variable? Or could `renderPrePublishExtension` be interpreted as a component, so we could pass the `PluginPrePublishPanel.Slot` reference directly instead of a function?

## How has this been tested?

Code to paste into your browser: https://gist.github.com/gziolo/fd8141f2cde7fcb1b513c09eea45d27f.

## Screenshots <!-- if applicable -->

#### Pre-publish

![screen shot 2018-05-17 at 13 39 03](https://user-images.githubusercontent.com/699132/40175235-c672ab46-59d7-11e8-942f-a2c871d9e3ce.png)

#### Post-publish

Desktop:
![screen shot 2018-05-17 at 13 37 15](https://user-images.githubusercontent.com/699132/40175233-c63c78aa-59d7-11e8-8ee3-b6f008b6a89c.png)

Mobile:
![screen shot 2018-05-17 at 13 37 41](https://user-images.githubusercontent.com/699132/40175234-c65776e6-59d7-11e8-95d7-16a12042d7cb.png)


## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->