### PR TITLE
Data Module: Add the getEntityRecords support

### DIFF
--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -55,20 +55,6 @@ export function receiveEntityRecords( kind, name, records ) {
 }
 
 /**
- * Returns an action object used in signalling that taxonomies have been received.
- *
- * @param {Array} taxonomies Taxonomies received.
- *
- * @return {Object} Action object.
- */
-export function receiveTaxonomies( taxonomies ) {
-	return {
-		type: 'RECEIVE_TAXONOMIES',
-		taxonomies,
-	};
-}
-
-/**
  * Returns an action object used in signalling that the index has been received.
  *
  * @param {Object} index Index received.

--- a/core-data/entities.js
+++ b/core-data/entities.js
@@ -5,7 +5,8 @@ import { find, upperFirst, camelCase } from 'lodash';
 
 const entities = [
 	{ name: 'postType', kind: 'root', key: 'slug', baseUrl: '/wp/v2/types' },
-	{ name: 'media', kind: 'root', baseUrl: '/wp/v2/media' },
+	{ name: 'media', plural: 'mediaItems', kind: 'root', baseUrl: '/wp/v2/media' },
+	{ name: 'taxonomy', kind: 'root', key: 'slug', baseUrl: '/wp/v2/taxonomies', plural: 'taxonomies' },
 ];
 
 /**
@@ -23,15 +24,19 @@ export function getEntity( kind, name ) {
 /**
  * Returns the entity's getter method name given its kind and name.
  *
- * @param {string} kind  Entity kind.
- * @param {string} name  Entity name.
+ * @param {string}  kind      Entity kind.
+ * @param {string}  name      Entity name.
+ * @param {string}  prefix    Function prefix.
+ * @param {boolean} usePlural Whether to use the plural form or not.
  *
  * @return {string} Method name
  */
-export const getMethodName = ( kind, name ) => {
+export const getMethodName = ( kind, name, prefix = 'get', usePlural = false ) => {
+	const entity = getEntity( kind, name );
 	const kindPrefix = kind === 'root' ? '' : upperFirst( camelCase( kind ) );
-	const nameSuffix = upperFirst( camelCase( name ) );
-	return `get${ kindPrefix }${ nameSuffix }`;
+	const nameSuffix = upperFirst( camelCase( name ) ) + ( usePlural ? 's' : '' );
+	const suffix = usePlural && entity.plural ? upperFirst( camelCase( entity.plural ) ) : nameSuffix;
+	return `${ prefix }${ kindPrefix }${ suffix }`;
 };
 
 export default entities;

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -21,8 +21,8 @@ export const REDUCER_KEY = 'core';
 
 const createEntityRecordGetter = ( source ) => entities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
-	const methodName = getMethodName( kind, name );
-	result[ methodName ] = ( state, key ) => source.getEntityRecord( state, kind, name, key );
+	result[ getMethodName( kind, name ) ] = ( state, key ) => source.getEntityRecord( state, kind, name, key );
+	result[ getMethodName( kind, name, 'get', true ) ] = ( state ) => source.getEntityRecords( state, kind, name );
 	return result;
 }, {} );
 

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -45,6 +45,13 @@ export async function* getEntityRecord( state, kind, name, key ) {
 	yield receiveEntityRecords( kind, name, record );
 }
 
+/**
+ * Requests the entity's records from the REST API.
+ *
+ * @param {Object} state  State tree
+ * @param {string} kind   Entity kind.
+ * @param {string} name   Entity name.
+ */
 export async function* getEntityRecords( state, kind, name ) {
 	const entity = getEntity( kind, name );
 	const records = await apiRequest( { path: `${ entity.baseUrl }?context=edit` } );

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -10,7 +10,6 @@ import {
 	receiveTerms,
 	receiveUserQuery,
 	receiveEntityRecords,
-	receiveTaxonomies,
 	receiveThemeSupportsFromIndex,
 } from './actions';
 import { getEntity } from './entities';
@@ -46,13 +45,10 @@ export async function* getEntityRecord( state, kind, name, key ) {
 	yield receiveEntityRecords( kind, name, record );
 }
 
-/**
- * Requests taxonomies from the REST API, yielding action objects on request
- * progress.
- */
-export async function* getTaxonomies() {
-	const taxonomies = await apiRequest( { path: '/wp/v2/taxonomies?context=edit' } );
-	yield receiveTaxonomies( taxonomies );
+export async function* getEntityRecords( state, kind, name ) {
+	const entity = getEntity( kind, name );
+	const records = await apiRequest( { path: `${ entity.baseUrl }?context=edit` } );
+	yield receiveEntityRecords( kind, name, Object.values( records ) );
 }
 
 /**

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -118,15 +118,22 @@ export function getEntityRecord( state, kind, name, key ) {
 }
 
 /**
- * Returns all the available taxonomies.
+ * Returns the Entity's records.
  *
- * @param {Object} state Data state.
+ * @param {Object} state  State tree
+ * @param {string} kind   Entity kind.
+ * @param {string} name   Entity name.
  *
- * @return {Array} Taxonomies list.
+ * @return {Array} Records.
  */
-export function getTaxonomies( state ) {
-	return state.taxonomies;
-}
+export const getEntityRecords = createSelector(
+	( state, kind, name ) => {
+		return Object.values( state.entities[ kind ][ name ].byKey );
+	},
+	( state, kind, name ) => ( [
+		state.entities[ kind ][ name ].byKey,
+	]	)
+);
 
 /**
  * Return theme suports data in the index.

--- a/core-data/test/entities.js
+++ b/core-data/test/entities.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getMethodName } from '../entities';
+import { getMethodName, default as entities } from '../entities';
 
 describe( 'getMethodName', () => {
 	it( 'Should return the right method name for an entity with the root kind', () => {
@@ -10,8 +10,29 @@ describe( 'getMethodName', () => {
 		expect( methodName ).toEqual( 'getPostType' );
 	} );
 
+	it( 'Should use a different suffix', () => {
+		const methodName = getMethodName( 'root', 'postType', 'set' );
+
+		expect( methodName ).toEqual( 'setPostType' );
+	} );
+
+	it( 'Should use the plural form', () => {
+		const methodName = getMethodName( 'root', 'postType', 'get', true );
+
+		expect( methodName ).toEqual( 'getPostTypes' );
+	} );
+
+	it( 'Should use the given plural form', () => {
+		const methodName = getMethodName( 'root', 'taxonomy', 'get', true );
+
+		expect( methodName ).toEqual( 'getTaxonomies' );
+	} );
+
 	it( 'Should include the kind in the method name', () => {
+		const id = entities.length;
+		entities[ id ] = { name: 'book', kind: 'postType' };
 		const methodName = getMethodName( 'postType', 'book' );
+		delete entities[ id ];
 
 		expect( methodName ).toEqual( 'getPostTypeBook' );
 	} );

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -6,7 +6,7 @@ import apiRequest from '@wordpress/api-request';
 /**
  * Internal dependencies
  */
-import { getCategories, getEntityRecord } from '../resolvers';
+import { getCategories, getEntityRecord, getEntityRecords } from '../resolvers';
 import { receiveTerms, receiveEntityRecords } from '../actions';
 
 jest.mock( '@wordpress/api-request' );
@@ -44,5 +44,26 @@ describe( 'getEntityRecord', () => {
 		const fulfillment = getEntityRecord( {}, 'root', 'postType', 'post' );
 		const received = ( await fulfillment.next() ).value;
 		expect( received ).toEqual( receiveEntityRecords( 'root', 'postType', POST_TYPE ) );
+	} );
+} );
+
+describe( 'getEntityRecords', () => {
+	const POST_TYPES = {
+		post: { slug: 'post' },
+		page: { slug: 'page' },
+	};
+
+	beforeAll( () => {
+		apiRequest.mockImplementation( ( options ) => {
+			if ( options.path === '/wp/v2/types?context=edit' ) {
+				return Promise.resolve( POST_TYPES );
+			}
+		} );
+	} );
+
+	it( 'yields with requested post type', async () => {
+		const fulfillment = getEntityRecords( {}, 'root', 'postType' );
+		const received = ( await fulfillment.next() ).value;
+		expect( received ).toEqual( receiveEntityRecords( 'root', 'postType', Object.values( POST_TYPES ) ) );
 	} );
 } );

--- a/core-data/test/selectors.js
+++ b/core-data/test/selectors.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getTerms, isRequestingCategories, getEntityRecord } from '../selectors';
+import { getTerms, isRequestingCategories, getEntityRecord, getEntityRecords } from '../selectors';
 import { select } from '@wordpress/data';
 
 jest.mock( '@wordpress/data', () => ( {
@@ -94,5 +94,39 @@ describe( 'getEntityRecord', () => {
 			},
 		} );
 		expect( getEntityRecord( state, 'root', 'postType', 'post' ) ).toEqual( { slug: 'post' } );
+	} );
+} );
+
+describe( 'getEntityRecords', () => {
+	it( 'should return an empty array by default', () => {
+		const state = deepFreeze( {
+			entities: {
+				root: {
+					postType: {
+						byKey: {},
+					},
+				},
+			},
+		} );
+		expect( getEntityRecords( state, 'root', 'postType' ) ).toEqual( [] );
+	} );
+
+	it( 'should return all the records', () => {
+		const state = deepFreeze( {
+			entities: {
+				root: {
+					postType: {
+						byKey: {
+							post: { slug: 'post' },
+							page: { slug: 'page' },
+						},
+					},
+				},
+			},
+		} );
+		expect( getEntityRecords( state, 'root', 'postType' ) ).toEqual( [
+			{ slug: 'post' },
+			{ slug: 'page' },
+		] );
 	} );
 } );


### PR DESCRIPTION
closes #6780

This PR adds support to the `getEntityRecords` selectors/resolvers to the core data module to avoid duplication across the different entities.

**Testing instructions**

 - Ensures that the post taxonomies panel show up properly