### PR TITLE
Add a filter('editor.FeaturedImage') for the FeaturedImage component

### DIFF
--- a/edit-post/components/sidebar/featured-image/index.js
+++ b/edit-post/components/sidebar/featured-image/index.js
@@ -7,7 +7,7 @@ import { get, partial } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, withFilters } from '@wordpress/components';
 import { PostFeaturedImage, PostFeaturedImageCheck } from '@wordpress/editor';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -57,4 +57,5 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 export default compose(
 	applyWithSelect,
 	applyWithDispatch,
+	withFilters( 'editor.FeaturedImage' ),
 )( FeaturedImage );

--- a/edit-post/components/sidebar/featured-image/index.js
+++ b/edit-post/components/sidebar/featured-image/index.js
@@ -7,7 +7,7 @@ import { get, partial } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, withFilters } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { PostFeaturedImage, PostFeaturedImageCheck } from '@wordpress/editor';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -57,5 +57,4 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 export default compose(
 	applyWithSelect,
 	applyWithDispatch,
-	withFilters( 'editor.FeaturedImage' ),
 )( FeaturedImage );

--- a/editor/components/post-featured-image/README.md
+++ b/editor/components/post-featured-image/README.md
@@ -1,0 +1,47 @@
+PostFeaturedImage
+===========
+
+PostFeaturedImage is a React component used to render the Post Featured Image selection tool.
+It includes a filter `editor.PostFeaturedImage` that enables developers to replace or extend it.
+
+## Examples
+Replace the contents of the panel:
+
+```js
+wp.hooks.addFilter( 
+	'editor.PostFeaturedImage', 
+	'myplugin/myhook', 
+	function() { 
+		return function() { 
+			return wp.element.createElement( 
+				'div', 
+				{}, 
+				'The replacement contents or components.' 
+			); 
+		} 
+	} 
+);
+```
+
+Prepend/Append to the panel contents:
+```js
+wp.hooks.addFilter( 
+	'editor.PostFeaturedImage', 
+	'myplugin/myhook', 
+	function( original ) { 
+		return function() { 
+			return (
+				wp.element.createElement( 
+					'div', 
+					{ key: 'outer' + Math.random() }, 
+					[
+						'Prepend above',
+						_.extend( original( {} ), { key: 'my-key' } ),
+						'Append below' 
+					]
+				)
+			);
+		} 
+	} 
+);
+```

--- a/editor/components/post-featured-image/README.md
+++ b/editor/components/post-featured-image/README.md
@@ -1,47 +1,59 @@
 PostFeaturedImage
 ===========
 
-PostFeaturedImage is a React component used to render the Post Featured Image selection tool.
+`PostFeaturedImage` is a React component used to render the Post Featured Image selection tool.
+
+## Setup
+
 It includes a `wp.hooks` filter `editor.PostFeaturedImage` that enables developers to replace or extend it.
 
-## Examples
+_Examples:_
+
 Replace the contents of the panel:
 
 ```js
+function replacePostFeaturedImage() { 
+	return function() { 
+		return wp.element.createElement( 
+			'div', 
+			{}, 
+			'The replacement contents or components.' 
+		); 
+	} 
+} 
+
 wp.hooks.addFilter( 
 	'editor.PostFeaturedImage', 
-	'myplugin/myhook', 
-	function() { 
-		return function() { 
-			return wp.element.createElement( 
-				'div', 
-				{}, 
-				'The replacement contents or components.' 
-			); 
-		} 
-	} 
+	'my-plugin/replace-post-featured-image', 
+	replacePostFeaturedImage
 );
 ```
 
-Prepend/Append to the panel contents:
+Prepend and append to the panel contents:
+
 ```js
+var el = wp.element.createElement;
+
+function wrapPostFeaturedImage( OriginalComponent ) { 
+	return function( props ) {
+		return (
+			el(
+				wp.element.Fragment,
+				{}, 
+				'Prepend above',
+				el(
+					OriginalComponent,
+					props
+				),
+				'Append below'
+			)
+		);
+	} 
+} 
+	
 wp.hooks.addFilter( 
 	'editor.PostFeaturedImage', 
-	'myplugin/myhook', 
-	function( original ) { 
-		return function() { 
-			return (
-				wp.element.createElement( 
-					'div', 
-					{ key: 'outer' + Math.random() }, 
-					[
-						'Prepend above',
-						_.extend( original( {} ), { key: 'my-key' } ),
-						'Append below' 
-					]
-				)
-			);
-		} 
-	} 
+	'my-plugin/wrap-post-featured-image', 
+	wrapPostFeaturedImage
 );
 ```

--- a/editor/components/post-featured-image/README.md
+++ b/editor/components/post-featured-image/README.md
@@ -2,7 +2,7 @@ PostFeaturedImage
 ===========
 
 PostFeaturedImage is a React component used to render the Post Featured Image selection tool.
-It includes a filter `editor.PostFeaturedImage` that enables developers to replace or extend it.
+It includes a `wp.hooks` filter `editor.PostFeaturedImage` that enables developers to replace or extend it.
 
 ## Examples
 Replace the contents of the panel:

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Spinner, ResponsiveWrapper } from '@wordpress/components';
+import { Button, Spinner, ResponsiveWrapper, withFilters } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -114,4 +114,5 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 export default compose(
 	applyWithSelect,
 	applyWithDispatch,
+	withFilters( 'editor.PostFeaturedImage' ),
 )( PostFeaturedImage );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "3.1.1",
+	"version": "3.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
## Description

Enables developers to change what is displayed for the post's featured image panel, or append to it.

Fixes https://github.com/WordPress/gutenberg/issues/6533.

Similar to the current core `admin_post_thumbnail_html` filter, this enables filtering of the featured image component.

## How has this been tested?
Using the console, I tested replacing and appending to the panel.

#### Replacing the panel
```js
// Replace the panel.
wp.hooks.addFilter( 
	'editor.PostFeaturedImage', 
	'myhook', 
	function() { 
		return function() { 
			return wp.element.createElement( 
				'div', 
				{}, 
				'This is a test' 
			); 
		} 
	} 
);
```

#### Appending to the panel
```js
wp.hooks.addFilter( 
	'editor.PostFeaturedImage', 
	'myhook', 
	function( original ) { 
		return function() { 
			return (
				wp.element.createElement( 
					'div', 
					{ key: 'outer' + Math.random() }, 
					[
						_.extend( original( {} ), { key: 'below' + Math.random() } ),
						'Add something below...' 
					]
				)
			);
		} 
	} 
);
```

## Screenshots <!-- if applicable -->
![replace](https://cl.ly/0u3n1a101736/download/Image%202018-07-03%20at%208.44.23%20AM.png)

![append](https://cl.ly/2S0N330L1b2C/Image%202018-07-03%20at%208.44.10%20AM.png)

## Types of changes
Filters the FeaturedImage component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
