### PR TITLE
Use the large image size when inserting from the media library.

### DIFF
--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -118,7 +118,8 @@ class ImageEdit extends Component {
 			return;
 		}
 		this.props.setAttributes( {
-			...pick( media, [ 'alt', 'id', 'caption', 'url' ] ),
+			...pick( media, [ 'alt', 'id', 'caption' ] ),
+			url: media.sizes && media.sizes.large ? media.sizes.large.url || media.sizes.large.source_url : media.url,
 			width: undefined,
 			height: undefined,
 		} );

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -61,6 +61,10 @@ export function mediaUpload( {
 				if ( caption ) {
 					mediaObject.caption = [ caption ];
 				}
+				const sizes = get( savedMedia, [ 'media_details', 'sizes' ] );
+				if ( sizes ) {
+					mediaObject.sizes = sizes;
+				}
 				setAndUpdateFiles( idx, mediaObject );
 			},
 			() => {


### PR DESCRIPTION
## Description
For performance, avoid using the full size image by default when inserting an image. Note that the media object from the media library will include a `url` property for each image size, while media objects build returned by the REST API via the mediaUploader component will have a `source_url` property instead, so this needs to cover both cases.

See #6177.

## How has this been tested?
Tested by adding and selecting an image via both the media uploader and the wp.media modal and checking to see that the large size was selected rather than the full size.

## Types of changes

- This is an enhancement to improve performance of the default image selection in Gutenberg for image blocks.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
