### PR TITLE
Support adding opt-in visual styles for core blocks

### DIFF
--- a/core-blocks/separator/index.js
+++ b/core-blocks/separator/index.js
@@ -8,6 +8,7 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import './style.scss';
+import './theme.scss';
 
 export const name = 'core/separator';
 

--- a/core-blocks/separator/theme.scss
+++ b/core-blocks/separator/theme.scss
@@ -1,0 +1,2 @@
+// TODO: Remove this comment when adding theme styles.
+// Including an empty file for now so webpack will build an aggregate build/core-blocks/theme.css.

--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -151,3 +151,11 @@ body.gutenberg-editor-page .editor-block-list__block[data-align="full"] {
 You can use those editor widths to match those in your theme. You can use any CSS width unit, including `%` or `px`.
 
 Further reading: [Applying Styles with Stylesheets](https://wordpress.org/gutenberg/handbook/blocks/applying-styles-with-stylesheets/).
+
+## Styling blocks
+
+Core blocks come with default styles. The styles are always enqueued for the editor but, by default, are not enqueued for the front end. If you'd like to take advantage of these styles on the front end, simply add theme support for `wp-block-styles`, and the styles will be enqueued.
+
+```php
+add_theme_support( 'wp-block-styles' );
+```

--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -152,9 +152,9 @@ You can use those editor widths to match those in your theme. You can use any CS
 
 Further reading: [Applying Styles with Stylesheets](https://wordpress.org/gutenberg/handbook/blocks/applying-styles-with-stylesheets/).
 
-## Styling blocks
+## Default block styles
 
-Core blocks come with default styles. The styles are always enqueued for the editor but, by default, are not enqueued for the front end. If you'd like to take advantage of these styles on the front end, simply add theme support for `wp-block-styles`, and the styles will be enqueued.
+Core blocks include default styles. The styles are enqueued for editing but are not enqueued for viewing unless the theme opts-in to the core styles. If you'd like to use default styles in your theme, add theme support for `wp-block-styles`:
 
 ```php
 add_theme_support( 'wp-block-styles' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -426,7 +426,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_style(
 		'wp-core-blocks',
 		gutenberg_url( 'build/core-blocks/style.css' ),
-		array(),
+		current_theme_supports( 'wp-block-styles' ) ? array( 'wp-core-blocks-theme' ) : array(),
 		filemtime( gutenberg_dir_path() . 'build/core-blocks/style.css' )
 	);
 	wp_style_add_data( 'wp-core-blocks', 'rtl', 'replace' );
@@ -434,10 +434,23 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_style(
 		'wp-edit-blocks',
 		gutenberg_url( 'build/core-blocks/edit-blocks.css' ),
-		array( 'wp-components', 'wp-editor' ),
+		array(
+			'wp-components',
+			'wp-editor',
+			// Always include theme styles to avoid appearance of a broken editor.
+			'wp-core-blocks-theme',
+		),
 		filemtime( gutenberg_dir_path() . 'build/core-blocks/edit-blocks.css' )
 	);
 	wp_style_add_data( 'wp-edit-blocks', 'rtl', 'replace' );
+
+	wp_register_style(
+		'wp-core-blocks-theme',
+		gutenberg_url( 'build/core-blocks/theme.css' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/core-blocks/theme.css' )
+	);
+	wp_style_add_data( 'wp-core-blocks-theme', 'rtl', 'replace' );
 
 	wp_register_script(
 		'wp-plugins',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -437,7 +437,7 @@ function gutenberg_register_scripts_and_styles() {
 		array(
 			'wp-components',
 			'wp-editor',
-			// Always include theme styles to avoid appearance of a broken editor.
+			// Always include visual styles so the editor never appears broken.
 			'wp-core-blocks-theme',
 		),
 		filemtime( gutenberg_dir_path() . 'build/core-blocks/edit-blocks.css' )

--- a/phpunit/class-core-block-theme-test.php
+++ b/phpunit/class-core-block-theme-test.php
@@ -43,7 +43,7 @@ class Core_Block_Theme_Test extends WP_UnitTestCase {
 	}
 
 	function test_block_theme_in_editor_without_theme_support() {
-		// Confirm assumption.
+		// Confirm we are without theme support by default.
 		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
 
 		gutenberg_register_scripts_and_styles();
@@ -63,7 +63,7 @@ class Core_Block_Theme_Test extends WP_UnitTestCase {
 	}
 
 	function test_no_block_theme_on_front_end_without_theme_support() {
-		// Confirm assumption.
+		// Confirm we are without theme support by default.
 		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
 
 		gutenberg_register_scripts_and_styles();

--- a/phpunit/class-core-block-theme-test.php
+++ b/phpunit/class-core-block-theme-test.php
@@ -42,7 +42,12 @@ class Core_Block_Theme_Test extends WP_UnitTestCase {
 		parent::tearDown();
 	}
 
-	function test_block_theme_in_editor_without_theme_support() {
+	/**
+	 * Tests that visual block styles are enqueued in the editor even when there is not theme support for 'wp-block-styles'.
+	 *
+	 * Visual block styles should always be enqueued when editing to avoid the appearance of a broken editor.
+	 */
+	function test_block_styles_for_editing_without_theme_support() {
 		// Confirm we are without theme support by default.
 		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
 
@@ -53,7 +58,12 @@ class Core_Block_Theme_Test extends WP_UnitTestCase {
 		$this->assertTrue( wp_style_is( 'wp-core-blocks-theme' ) );
 	}
 
-	function test_block_theme_in_editor_with_theme_support() {
+	/**
+	 * Tests that visual block styles are enqueued when there is theme support for 'wp-block-styles'.
+	 *
+	 * Visual block styles should always be enqueued when editing to avoid the appearance of a broken editor.
+	 */
+	function test_block_styles_for_editing_with_theme_support() {
 		add_theme_support( 'wp-block-styles' );
 		gutenberg_register_scripts_and_styles();
 
@@ -62,7 +72,13 @@ class Core_Block_Theme_Test extends WP_UnitTestCase {
 		$this->assertTrue( wp_style_is( 'wp-core-blocks-theme' ) );
 	}
 
-	function test_no_block_theme_on_front_end_without_theme_support() {
+	/**
+	 * Tests that visual block styles are not enqueued for viewing when there is no theme support for 'wp-block-styles'.
+	 *
+	 * Visual block styles should not be enqueued unless a theme opts in.
+	 * This way we avoid style conflicts with existing themes.
+	 */
+	function test_no_block_styles_for_viewing_without_theme_support() {
 		// Confirm we are without theme support by default.
 		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
 
@@ -73,7 +89,12 @@ class Core_Block_Theme_Test extends WP_UnitTestCase {
 		$this->assertFalse( wp_style_is( 'wp-core-blocks-theme' ) );
 	}
 
-	function test_block_theme_on_front_end_with_theme_support() {
+	/**
+	 * Tests that visual block styles are enqueued for viewing when there is theme support for 'wp-block-styles'.
+	 *
+	 * Visual block styles should be enqueued when a theme opts in.
+	 */
+	function test_block_styles_for_viewing_with_theme_support() {
 		add_theme_support( 'wp-block-styles' );
 
 		gutenberg_register_scripts_and_styles();

--- a/phpunit/class-core-block-theme-test.php
+++ b/phpunit/class-core-block-theme-test.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Core block theme tests.
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Test inclusion of opt-in core block theme.
+ */
+class Core_Block_Theme_Test extends WP_UnitTestCase {
+	private $old_wp_styles;
+	private $old_wp_scripts;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
+		remove_action( 'wp_default_scripts', 'wp_default_scripts' );
+
+		$GLOBALS['wp_scripts']                  = new WP_Scripts();
+		$GLOBALS['wp_scripts']->default_version = get_bloginfo( 'version' );
+
+		$this->old_wp_styles = isset( $GLOBALS['wp_styles'] ) ? $GLOBALS['wp_styles'] : null;
+		remove_action( 'wp_default_styles', 'wp_default_styles' );
+
+		$GLOBALS['wp_styles']                  = new WP_Styles();
+		$GLOBALS['wp_styles']->default_version = get_bloginfo( 'version' );
+	}
+
+	function tearDown() {
+		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
+		add_action( 'wp_default_scripts', 'wp_default_scripts' );
+
+		$GLOBALS['wp_styles'] = $this->old_wp_styles;
+		add_action( 'wp_default_styles', 'wp_default_styles' );
+
+		if ( current_theme_supports( 'wp-block-styles' ) ) {
+			remove_theme_support( 'wp-block-styles' );
+		}
+
+		parent::tearDown();
+	}
+
+	function test_block_theme_in_editor_without_theme_support() {
+		// Confirm assumption.
+		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
+
+		gutenberg_register_scripts_and_styles();
+
+		$this->assertFalse( wp_style_is( 'wp-core-blocks-theme' ) );
+		wp_enqueue_style( 'wp-edit-blocks' );
+		$this->assertTrue( wp_style_is( 'wp-core-blocks-theme' ) );
+	}
+
+	function test_block_theme_in_editor_with_theme_support() {
+		add_theme_support( 'wp-block-styles' );
+		gutenberg_register_scripts_and_styles();
+
+		$this->assertFalse( wp_style_is( 'wp-core-blocks-theme' ) );
+		wp_enqueue_style( 'wp-edit-blocks' );
+		$this->assertTrue( wp_style_is( 'wp-core-blocks-theme' ) );
+	}
+
+	function test_no_block_theme_on_front_end_without_theme_support() {
+		// Confirm assumption.
+		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
+
+		gutenberg_register_scripts_and_styles();
+
+		$this->assertFalse( wp_style_is( 'wp-core-blocks-theme' ) );
+		wp_enqueue_style( 'wp-core-blocks' );
+		$this->assertFalse( wp_style_is( 'wp-core-blocks-theme' ) );
+	}
+
+	function test_block_theme_on_front_end_with_theme_support() {
+		add_theme_support( 'wp-block-styles' );
+
+		gutenberg_register_scripts_and_styles();
+
+		$this->assertFalse( wp_style_is( 'wp-core-blocks-theme' ) );
+		wp_enqueue_style( 'wp-core-blocks' );
+		$this->assertTrue( wp_style_is( 'wp-core-blocks-theme' ) );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,11 @@ const blocksCSSPlugin = new ExtractTextPlugin( {
 	filename: './build/core-blocks/style.css',
 } );
 
+// CSS loader for default visual block styles.
+const themeBlocksCSSPlugin = new ExtractTextPlugin( {
+	filename: './build/core-blocks/theme.css',
+} );
+
 // Configuration for the ExtractTextPlugin.
 const extractConfig = {
 	use: [
@@ -238,6 +243,13 @@ const config = {
 				use: editBlocksCSSPlugin.extract( extractConfig ),
 			},
 			{
+				test: /\/theme\.s?css$/,
+				include: [
+					/core-blocks/,
+				],
+				use: themeBlocksCSSPlugin.extract( extractConfig ),
+			},
+			{
 				test: /\.s?css$/,
 				exclude: [
 					/core-blocks/,
@@ -249,6 +261,7 @@ const config = {
 	plugins: [
 		blocksCSSPlugin,
 		editBlocksCSSPlugin,
+		themeBlocksCSSPlugin,
 		mainCSSExtractTextPlugin,
 		// Create RTL files with a -rtl suffix
 		new WebpackRTLPlugin( {


### PR DESCRIPTION
## Description
This PR enables separating visual block styles from those required for block function and provides a way for themes to opt into those styles. The purpose is to offer default visual styles for themes that want them without interfering with existing themes that provide their own.

Contributes to #5360.

## How has this been tested?

This has been tested manually on the front and back end by adding and removing theme support for `wp-block-styles` and observing the presence or absence of `build/core-blocks/theme.css` in the Chrome dev tools Network tab.

I am working on some simple unit tests.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This PR enables separating visual block styles from structural styles on the front end. Core blocks may include a `theme.scss` file containing visual styles, and those styles will be built into `build/core-blocks/theme.css`. By default, `theme.css` will be enqueued for the editor but not on the front end. To include it on the front end, themes may add theme support for `wp-block-styles`.

```js
add_theme_support( 'wp-block-styles' );
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

