### PR TITLE
Add support for the `default_page_template_title` filter in page-attributes meta-box.

### DIFF
--- a/editor/components/page-attributes/template.js
+++ b/editor/components/page-attributes/template.js
@@ -31,7 +31,7 @@ export function PageTemplate( { availableTemplates, selectedTemplate, instanceId
 				onBlur={ onEventUpdate }
 				onChange={ onEventUpdate }
 			>
-				{ map( { '': __( 'Default template' ), ...availableTemplates }, ( templateName, templateSlug ) => (
+				{ map( availableTemplates, ( templateName, templateSlug ) => (
 					<option key={ templateSlug } value={ templateSlug }>{ templateName }</option>
 				) ) }
 			</select>

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1108,10 +1108,18 @@ JS;
  * @see WP_Theme::get_page_templates()
  */
 function gutenberg_get_available_page_attributes_templates( $post_id ) {
-	return array_merge(
-		array( '' => apply_filters( 'default_page_template_title', __( 'Default template' ), 'gutenberg' ), ),
-		wp_get_theme()->get_page_templates( get_post( $post_id ) )
-	);
+	// We only want to add the default template to the array if there are other
+	// templates since an array with only the default template will trigger the
+	// template select input in the meta box.
+	$templates = wp_get_theme()->get_page_templates( get_post( $post_id ) );
+	if ( is_array( $templates ) && ! empty( $templates ) ) {
+		return array_merge(
+			array( '' => apply_filters( 'default_page_template_title', __( 'Default template' ), 'gutenberg' ), ),
+			$templates
+		);
+	} else {
+		return array();
+	}
 }
 
 /**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1035,7 +1035,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	$editor_settings = array(
 		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
-		'availableTemplates'  => wp_get_theme()->get_page_templates( get_post( $post_to_edit['id'] ) ),
+		'availableTemplates'  => gutenberg_get_available_page_attributes_templates( $post_to_edit['id'] ),
 		'allowedBlockTypes'   => $allowed_block_types,
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
@@ -1092,6 +1092,26 @@ JS;
 	 * @since 0.4.0
 	 */
 	do_action( 'enqueue_block_editor_assets' );
+}
+
+/**
+ * Get available templates for a post.
+ *
+ * We wrap the WP_Theme::get_page_templates() method since we wish to support the
+ * `default_page_template_title` filter to change the name of the default template.
+ *
+ * @since TBD
+ *
+ * @param int $post_id The ID of the post being edited.
+ * @return array
+ *
+ * @see WP_Theme::get_page_templates()
+ */
+function gutenberg_get_available_page_attributes_templates( $post_id ) {
+	return array_merge(
+		array( '' => apply_filters( 'default_page_template_title', __( 'Default template' ), 'gutenberg' ), ),
+		wp_get_theme()->get_page_templates( get_post( $post_id ) )
+	);
 }
 
 /**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1033,9 +1033,17 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	 */
 	$allowed_block_types = apply_filters( 'allowed_block_types', true, $post );
 
+	$available_templates = wp_get_theme()->get_page_templates( $post_to_edit['id'] );
+	$available_templates = array_merge(
+		array(
+			'' => apply_filters( 'default_page_template_title', __( 'Default template', 'gutenberg' ), 'rest-api' ),
+		),
+		$available_templates
+	);
+
 	$editor_settings = array(
 		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
-		'availableTemplates'  => gutenberg_get_available_page_attributes_templates( $post_to_edit['id'] ),
+		'availableTemplates'  => $available_templates,
 		'allowedBlockTypes'   => $allowed_block_types,
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
@@ -1092,34 +1100,6 @@ JS;
 	 * @since 0.4.0
 	 */
 	do_action( 'enqueue_block_editor_assets' );
-}
-
-/**
- * Get available templates for a post.
- *
- * We wrap the WP_Theme::get_page_templates() method since we wish to support the
- * `default_page_template_title` filter to change the name of the default template.
- *
- * @since TBD
- *
- * @param int $post_id The ID of the post being edited.
- * @return array
- *
- * @see WP_Theme::get_page_templates()
- */
-function gutenberg_get_available_page_attributes_templates( $post_id ) {
-	// We only want to add the default template to the array if there are other
-	// templates since an array with only the default template will trigger the
-	// template select input in the meta box.
-	$templates = wp_get_theme()->get_page_templates( get_post( $post_id ) );
-	if ( is_array( $templates ) && ! empty( $templates ) ) {
-		return array_merge(
-			array( '' => apply_filters( 'default_page_template_title', __( 'Default template' ), 'gutenberg' ), ),
-			$templates
-		);
-	} else {
-		return array();
-	}
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
I have wrapped the `availableTemplates` call to `wp_get_theme()->get_page_templates(...)` in a PHP function to directly add the default template into the array so we can use the already existing `default_page_template_title` filter instead of hardcoding it in the `editor/components/page-attributes/template.js` file.

More about the reasoning can be found in #6946 

Fixes #6946

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
The change is very isolated and will only have any effect on the `page-attributes` meta box. I have run manual testing by testing the following scenarios:

* Make sure we only append the default template logic if the page have any templates (done by using the Twentysixteen theme).
* Make a child theme of Twentysixteen and add a template.
* Save / update the post to make sure the value is "saved correctly" (more precisely the lack of a value since the value for the default template is an empty string).

The environment was a clean vanilla install of WordPress 4.9.6 with Twentysixteen 1.5 run on a custom Docker installation (PHP 7.1 / Apache 2.4) with a manually run `npm install` and `npm run dev`.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Added new functionality to support already existing functionality in WordPress.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
