### PR TITLE
Run `npm audit fix`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9365,12 +9365,6 @@
 				"pseudomap": "^1.0.1"
 			}
 		},
-		"macaddress": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-			"dev": true
-		},
 		"make-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -11486,13 +11480,12 @@
 			}
 		},
 		"postcss-filter-plugins": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
+			"integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4",
-				"uniqid": "^4.0.0"
+				"postcss": "^5.0.4"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15445,15 +15438,6 @@
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
 			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
 			"dev": true
-		},
-		"uniqid": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-			"dev": true,
-			"requires": {
-				"macaddress": "^0.2.8"
-			}
 		},
 		"uniqs": {
 			"version": "2.0.0",


### PR DESCRIPTION
## Description

`npm` 6.1.0 introduces the `npm audit fix` command, which automatically fixes the issues that cause `npm audit` to throw errors.

This PR is the result of running `npm audit fix` against `master`.