### PR TITLE
Add additional condition to "Available templates" logic

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1033,13 +1033,14 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	 */
 	$allowed_block_types = apply_filters( 'allowed_block_types', true, $post );
 
+	// Get all available templates for the post/page attributes meta-box.
+	// The "Default template" array element should only be added if the array is
+	// not empty so we do not trigger the template select element without any options
+	// besides the default value.
 	$available_templates = wp_get_theme()->get_page_templates( $post_to_edit['id'] );
-	$available_templates = array_merge(
-		array(
-			'' => apply_filters( 'default_page_template_title', __( 'Default template', 'gutenberg' ), 'rest-api' ),
-		),
-		$available_templates
-	);
+	$available_templates = ! empty( $available_templates ) ? array_merge( array(
+		'' => apply_filters( 'default_page_template_title', __( 'Default template', 'gutenberg' ), 'rest-api' ),
+	), $available_templates ) : $available_templates;
 
 	$editor_settings = array(
 		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
I have made a conditional check for the available template `array_merge()` so we do not get a template `<select>` in the post-attributes meta-box with only the default template as an option. 

More information about the bug introduced in #6948 can be found [here](https://github.com/WordPress/gutenberg/pull/6948#issuecomment-392040852).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
The change is very isolated and will only have any effect on the page-attributes meta box. I have run manual testing by testing the following scenarios:

* Make sure we only append the default template logic if the page have any templates (done by using the Twentysixteen theme).
* Make a child theme of Twentysixteen and add a template.
* Save / update the post to make sure the value is "saved correctly" (more precisely the lack of a value since the value for the default template is an empty string).

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
I have corrected a bug introduced in #6948 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
