### PR TITLE
Add error notices mechanism directly to media placeholder

### DIFF
--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -211,8 +211,9 @@ class GalleryEdit extends Component {
 						onSelect={ this.onSelectImages }
 						accept="image/*"
 						type="image"
+						disableMaxUploadErrorMessages
 						multiple
-						notices={ noticeUI }
+						additionalNotices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }
 					/>
 				</Fragment>

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -26,7 +26,6 @@ import {
 	TextControl,
 	TextareaControl,
 	Toolbar,
-	withNotices,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import {
@@ -178,7 +177,7 @@ class ImageEdit extends Component {
 	}
 
 	render() {
-		const { attributes, setAttributes, isLargeViewport, isSelected, className, maxWidth, noticeOperations, noticeUI, toggleSelection } = this.props;
+		const { attributes, setAttributes, isLargeViewport, isSelected, className, maxWidth, toggleSelection } = this.props;
 		const { url, alt, caption, align, id, href, width, height } = attributes;
 
 		const controls = (
@@ -221,8 +220,6 @@ class ImageEdit extends Component {
 						} }
 						className={ className }
 						onSelect={ this.onSelectImage }
-						notices={ noticeUI }
-						onError={ noticeOperations.createErrorNotice }
 						accept="image/*"
 						type="image"
 					/>
@@ -318,7 +315,6 @@ class ImageEdit extends Component {
 		return (
 			<Fragment>
 				{ controls }
-				{ noticeUI }
 				<figure className={ classes }>
 					<ImageSize src={ url } dirtynessTrigger={ align }>
 						{ ( sizes ) => {
@@ -419,5 +415,4 @@ export default compose( [
 		};
 	} ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
-	withNotices,
 ] )( ImageEdit );


### PR DESCRIPTION
This change makes upload error notices available in all blocks.

I noticed while adding the error messages to other blocks(besides gallery and image) that the best way to not duplicate code and make block creation easier would be to have the messages being directly handled in media placeholder as most blocks only allow uploading via media library (that already as this errors via core functionality) and via media placeholders that now have this messages too.

Making error notices available directly in media placeholder makes all blocks even the ones created by the community take advantage of our upload error notices system.
Blocks can opt-out of this behavior and manage the notices themselves like the gallery is doing.
Gallery manages the upload error notices, because in the media placeholder for a gallery we may select many files, some may have been uploaded correctly and in some, we may have errors. When some file is uploaded correctly we stop displaying the placeholder, so if a file upload went wrong we would not display the notice. Given that the notices for the gallery are managed at the block level that problem does not happen.


## How has this been tested?
Upload files with sizes bigger than the maximum file size allowed in all blocks with media placeholders (gallery, image, audio, video, cover-image) and verify the message is correctly displayed.
Upload files with sizes lower than the maximum file size allowed in all blocks with media placeholders (gallery, image, audio, video, cover-image) and verify the upload went ok and not error message is shown.
On the gallery block upload, an allowed and an unallowed file, verify the uploaded file is showed correctly and an error message is shown above it regarding the error on the unallowed file.
