### PR TITLE
Fix undo on paragraph split

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isFinite, find, omit } from 'lodash';
+import { isFinite, find, last, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -84,7 +84,7 @@ class ParagraphBlock extends Component {
 		this.setFontSize = this.setFontSize.bind( this );
 	}
 
-	onReplace( blocks ) {
+	onReplace( blocks, blockToSelect ) {
 		const { attributes, onReplace } = this.props;
 		onReplace( blocks.map( ( block, index ) => (
 			index === 0 && block.name === name ?
@@ -93,9 +93,10 @@ class ParagraphBlock extends Component {
 						...attributes,
 						...block.attributes,
 					},
+					uid: this.props.id,
 				} :
 				block
-		) ) );
+		) ), blockToSelect );
 	}
 
 	toggleDropCap() {
@@ -236,14 +237,12 @@ class ParagraphBlock extends Component {
 								if ( after ) {
 									blocks.push( createBlock( name, { content: after } ) );
 								}
+								const replaceArrayStart = before ?
+									[ createBlock( name, { ...attributes, content: before } ) ] :
+									[];
 
-								insertBlocksAfter( blocks );
-
-								if ( before ) {
-									setAttributes( { content: before } );
-								} else {
-									onReplace( [] );
-								}
+								const newBlocks = replaceArrayStart.concat( blocks );
+								this.onReplace( newBlocks, newBlocks.length > 1 ? last( newBlocks ).uid : undefined );
 							} :
 							undefined
 						}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -684,12 +684,15 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		onMerge( ...args ) {
 			mergeBlocks( ...args );
 		},
-		onReplace( blocks ) {
+		onReplace( blocks, blockToSelect ) {
 			const { layout } = ownProps;
 			blocks = castArray( blocks ).map( ( block ) => (
-				cloneBlock( block, { layout } )
+				{ ...block, layout }
 			) );
 			replaceBlocks( [ ownProps.uid ], blocks );
+			if ( blockToSelect ) {
+				selectBlock( blockToSelect );
+			}
 		},
 		onMetaChange( meta ) {
 			editPost( { meta } );


### PR DESCRIPTION
## Description
Splitting was not a single operation but two operations insert blocks + setAttributes. That made undo behave in a strange way.
In this PR we make onSplit a single operation using onReplace (props to @iseulde for this idea).
onReplace by default selects the first block. That was not what we wanted in this use case so a new prop was added that allows choosing the bock we want to select.
To accomplish this onReplace was changed to not clone the blocks because cloning changes the UID.
I think we should remove clone from onReplace anyway even if we find an alternative approach to the PR. When a user asks for some blocks to be replaced I think the expectation is that the new blocks the user set are the used ones and the UID's saved in the state are the same that the user passed. In PR https://github.com/WordPress/gutenberg/pull/6325 I felt the same need and I applied the same change to onReplace.

We did not added more test cases yet if we find this approach something we want to pursue I will add them.

## How has this been tested?
Add a paragraph write some text, press enter in the middle, see the paragraphs were divided. Press undo see that undo works as expected and the paragraphs are joined again.
Try to do some testing to verify removing clone fro onReplace does not cause unexpected behaviors.

## Screenshots <!-- if applicable -->
Before:
![before](https://user-images.githubusercontent.com/11271197/40565606-2372ebba-6065-11e8-8e88-6c86d60ecba2.gif)
After:
![after](https://user-images.githubusercontent.com/11271197/40565619-2a32a1ac-6065-11e8-8a01-044ac87d95fb.gif)


