### PR TITLE
Collapse all editor and sidebar panels and keep only one expanded

### DIFF
--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -45,9 +45,9 @@ export const preferences = combineReducers( {
 	panels( state = PREFERENCES_DEFAULTS.panels, action ) {
 		if ( action.type === 'TOGGLE_GENERAL_SIDEBAR_EDITOR_PANEL' ) {
 			return {
-                ...(mapValues(state, () => false)),
-                [ action.panel ]: ! state[ action.panel ],
-            };
+				...( mapValues( state, () => false ) ),
+				[ action.panel ]: ! state[ action.panel ],
+			};
 		}
 
 		return state;

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { get } from 'lodash';
+import mapValues from 'lodash/mapValues';
 
 /**
  * WordPress dependencies
@@ -44,9 +45,9 @@ export const preferences = combineReducers( {
 	panels( state = PREFERENCES_DEFAULTS.panels, action ) {
 		if ( action.type === 'TOGGLE_GENERAL_SIDEBAR_EDITOR_PANEL' ) {
 			return {
-				...state,
-				[ action.panel ]: ! state[ action.panel ],
-			};
+                ...(mapValues(state, () => false)),
+                [ action.panel ]: ! state[ action.panel ],
+            };
 		}
 
 		return state;

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -93,7 +93,6 @@ export function isPublishSidebarOpened( state ) {
  */
 export function isEditorSidebarPanelOpened( state, panel ) {
 	const panels = getPreference( state, 'panels' );
-    // console.log( panels, panel )
 	return panels ? !! panels[ panel ] : false;
 }
 

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -93,6 +93,7 @@ export function isPublishSidebarOpened( state ) {
  */
 export function isEditorSidebarPanelOpened( state, panel ) {
 	const panels = getPreference( state, 'panels' );
+    // console.log( panels, panel )
 	return panels ? !! panels[ panel ] : false;
 }
 

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -91,14 +91,11 @@ export class InserterMenu extends Component {
 			const isOpened = this.state.openPanels.indexOf( panel ) !== -1;
 			if ( isOpened ) {
 				this.setState( {
-					openPanels: without( this.state.openPanels, panel ),
+					openPanels: [],
 				} );
 			} else {
 				this.setState( {
-					openPanels: [
-						...this.state.openPanels,
-						panel,
-					],
+					openPanels: [panel],
 				} );
 			}
 		};

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -10,7 +10,6 @@ import {
 	sortBy,
 	findIndex,
 	find,
-	without,
 } from 'lodash';
 
 /**
@@ -95,7 +94,7 @@ export class InserterMenu extends Component {
 				} );
 			} else {
 				this.setState( {
-					openPanels: [panel],
+					openPanels: [ panel ],
 				} );
 			}
 		};


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
I thought it might be a good user experience if you collapse back the editor panels (block containers) as the user navigates through them.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Running the test unit all tests passed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
not necessary for such changes.
Note: this does not address the block sidebar panels.