### PR TITLE
Add table cell text alignment options to table block toolbar

### DIFF
--- a/core-blocks/table/index.js
+++ b/core-blocks/table/index.js
@@ -10,13 +10,13 @@ import classnames from 'classnames';
 import { Fragment } from '@wordpress/element';
 import { getPhrasingContentSchema } from '@wordpress/blocks';
 import {
-	BlockControls,
 	BlockAlignmentToolbar,
 	RichText,
 	InspectorControls,
 } from '@wordpress/editor';
 
 import {
+	BaseControl,
 	PanelBody,
 	ToggleControl,
 } from '@wordpress/components';
@@ -119,12 +119,6 @@ export const settings = {
 
 		return (
 			<Fragment>
-				<BlockControls>
-					<BlockAlignmentToolbar
-						value={ attributes.align }
-						onChange={ updateAlignment }
-					/>
-				</BlockControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Table Settings' ) } className="blocks-table-settings">
 						<ToggleControl
@@ -132,6 +126,16 @@ export const settings = {
 							checked={ !! hasFixedLayout }
 							onChange={ toggleFixedLayout }
 						/>
+						<BaseControl
+							label={ __( 'Alignment' ) }
+							id="inspector-block-alignment"
+							className="components-block-alignment"
+						>
+							<BlockAlignmentToolbar
+								value={ attributes.align }
+								onChange={ updateAlignment }
+							/>
+						</BaseControl>
 					</PanelBody>
 				</InspectorControls>
 				<TableBlock

--- a/core-blocks/table/style.scss
+++ b/core-blocks/table/style.scss
@@ -21,3 +21,6 @@
 		table-layout: fixed;
 	}
 }
+.edit-post-sidebar .components-block-alignment .components-toolbar {
+	margin-bottom: 0;
+}


### PR DESCRIPTION
## Description
This PR addresses [#6699](https://github.com/WordPress/gutenberg/issues/6699) which requested that the left, center and right text alignment control be added to the table block toolbar.

## How has this been tested?
This solution was tested using the following steps:

1. Create a new page and add a **Table** block.
2. Add text to each of the four initial table cells.
3. Locate the new text alignment controls in the toolbar and adjust the alignment of text in all four cells.
4. Ensure that selecting the same text alignment control, twice or more times in a row, toggles both the highlight of that specific control in the toolbar and the value of the table cell's CSS `text-align` property.
5. Ensure that each adjustment of text alignment creates an **undo level** for the TinyMCE instance by checking changes that occur when pressing the **Undo** and **Redo** action buttons.
6. Ensure that all text alignment changes save correctly by previewing the page.

## Screenshot
![ezgif-4-4ea90c5714](https://user-images.githubusercontent.com/39569148/40590310-a87ce8b8-61ca-11e8-9977-dc1baaecce5a.gif)

## Types of changes
**Added dependencies:**
In order to have functioning text alignment controls for the **Table** block, the following dependencies were added:
- **External**: Lodash's `find` function
- **WordPress**: `AlignmentToolbar`
- **Internal**: `domToFormat` function from the `rich-text` editor component group.

**Added TinyMCE event handler:**
A `nodechange` TinyMCE event handler was added within the `handleSetup` method of the `table-block` component in order to update the alignment toolbar to match the CSS `text-align` property of the table cell that is being focused.

**Added new method to the Table block:**
The `textAlign` method was added to the `table-block` component to serve as the `onChange` callback function for the `AlignmentToolbar` component. This allows us to update the focused table cell's text alignment when the user clicks on either the left, center or right text alignment control. 

This was tested in:

- WordPress 4.9.6
- Gutenberg 2.9.2
- Apache/PHP 7.1.16
- MySQL 5.7.22

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
