### PR TITLE
Attempt to fix some intermittent E2E test failures

### DIFF
--- a/test/e2e/specs/managing-links.test.js
+++ b/test/e2e/specs/managing-links.test.js
@@ -42,7 +42,7 @@ describe( 'Managing links', () => {
 	} );
 
 	it( 'Pressing Left and Esc in Link Dialog in "Docked Toolbar" mode', async () => {
-		setFixedToolbar( false );
+		await setFixedToolbar( false );
 
 		await page.click( '.editor-default-block-appender' );
 		await page.keyboard.type( 'Text' );

--- a/test/e2e/specs/multi-block-selection.test.js
+++ b/test/e2e/specs/multi-block-selection.test.js
@@ -32,19 +32,19 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.type( 'Quote Block' );
 
 		const blocks = [ firstBlockSelector, secondBlockSelector, thirdBlockSelector ];
-		const expectMultiSelected = ( selectors, areMultiSelected ) => {
-			selectors.forEach( async ( selector ) => {
+		const expectMultiSelected = async ( selectors, areMultiSelected ) => {
+			for ( const selector of selectors ) {
 				const className = await page.$eval( selector, ( element ) => element.className );
 				if ( areMultiSelected ) {
 					expect( className ).toEqual( expect.stringContaining( multiSelectedCssClass ) );
 				} else {
 					expect( className ).not.toEqual( expect.stringContaining( multiSelectedCssClass ) );
 				}
-			} );
+			}
 		};
 
 		// Default: No selection
-		expectMultiSelected( blocks, false );
+		await expectMultiSelected( blocks, false );
 
 		// Multiselect via Shift + click
 		await page.mouse.move( 200, 300 );
@@ -54,25 +54,25 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.up( 'Shift' );
 
 		// Verify selection
-		expectMultiSelected( blocks, true );
+		await expectMultiSelected( blocks, true );
 
 		// Unselect
 		await page.click( secondBlockSelector );
 
 		// No selection
-		expectMultiSelected( blocks, false );
+		await expectMultiSelected( blocks, false );
 
 		// Multiselect via keyboard
 		await page.click( 'body' );
 		await pressWithModifier( 'Mod', 'a' );
 
 		// Verify selection
-		expectMultiSelected( blocks, true );
+		await expectMultiSelected( blocks, true );
 
 		// Unselect
 		await page.keyboard.press( 'Escape' );
 
 		// No selection
-		expectMultiSelected( blocks, false );
+		await expectMultiSelected( blocks, false );
 	} );
 } );


### PR DESCRIPTION
The `multi-block-selection` and `managing-links` E2E tests seem to fail intermittently in Travis CI but always pass locally for me.

My guess is that it's because we're sometimes calling asynchronous functions without waiting (using `await`) for the result. 

It's difficult to verify that this PR fixes the issue. An 'All checks have passed' is good—but we might have just gotten lucky 🤷‍♂️ 