### PR TITLE
Build: Skip test files when generating build folders for packages

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -121,8 +121,10 @@ function buildFileFor( file, silent, environment ) {
  */
 function buildPackage( packagePath ) {
 	const srcDir = path.resolve( packagePath, SRC_DIR );
-	const files = glob.sync( srcDir + '/**/*.js', { nodir: true } )
-		.filter( ( file ) => ! /\.test\.js/.test( file ) );
+	const files = glob.sync( `${ srcDir }/**/*.js`, {
+		ignore: `${ srcDir }/**/test/**/*.js`,
+		nodir: true,
+	} );
 
 	process.stdout.write( `${ path.basename( packagePath ) }\n` );
 


### PR DESCRIPTION
## Description
I noticed that the number of the unit tests has increased unexpectedly. It turned out we run the same tests from `packages` folder 3 times because they are included in the build folders. This PR fixes the issue.

#### Before

> Test Suites: 1 skipped, 188 passed, 188 of 189 total
> Tests:       3 skipped, 1807 passed, 1810 total
> Snapshots:   59 passed, 59 total

#### After

> Test Suites: 1 skipped, 176 passed, 176 of 177 total
> Tests:       3 skipped, 1585 passed, 1588 total
> Snapshots:   59 passed, 59 total

## How has this been tested?
`npm test` to check if the number of tests has changed.
`npm build` to make sure all files are properly transpiled and copied.

## Screenshots

#### Before

<img width="250" alt="screen shot 2018-05-28 at 08 13 03" src="https://user-images.githubusercontent.com/699132/40599767-11a70f06-624f-11e8-8b79-2fcd3317fd21.png">


#### After

<img width="237" alt="screen shot 2018-05-28 at 08 26 30" src="https://user-images.githubusercontent.com/699132/40600208-dbad827a-6250-11e8-8d86-1e4a3672f149.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
