### PR TITLE
Add 'gutenberg_can_edit_post' filter

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -257,24 +257,32 @@ function gutenberg_collect_meta_box_data() {
  */
 function gutenberg_can_edit_post( $post ) {
 	$post = get_post( $post );
+	$can_edit = true;
 
 	if ( ! $post ) {
-		return false;
+		$can_edit = false;
 	}
 
 	if ( 'trash' === $post->post_status ) {
-		return false;
+		$can_edit = false;
 	}
 
 	if ( ! gutenberg_can_edit_post_type( $post->post_type ) ) {
-		return false;
+		$can_edit = false;
 	}
 
 	if( ! current_user_can( 'edit_post', $post->ID ) ) {
-		return false;
+		$can_edit = false;
 	}
 
-	return apply_filters( 'gutenberg_can_edit_post', true, $post );
+	/**
+	 * Filter to allow plugins to enable/disable Gutenberg for particular posts.
+	 *
+	 *
+	 * @param bool   $can_edit  Whether the post can be edited or not.
+	 * @param string $post The post being checked.
+	 */
+	return apply_filters( 'gutenberg_can_edit_post', $can_edit, $post );
 }
 
 /**

--- a/lib/register.php
+++ b/lib/register.php
@@ -270,7 +270,11 @@ function gutenberg_can_edit_post( $post ) {
 		return false;
 	}
 
-	return current_user_can( 'edit_post', $post->ID );
+	if( ! current_user_can( 'edit_post', $post->ID ) ) {
+		return false;
+	}
+
+	return apply_filters( 'gutenberg_can_edit_post', true, $post );
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
There was no way to disable / enable Gutenberg on a per-post basis. This can be very helpful to highly-customized sites which are running third-party or custom-made post editors. This filter can also be useful for plugins which affect / alter the publishing process.

## Types of changes
Introduce 'gutenberg_can_edit_post' filter, a filter very comparable to the 'gutenberg_can_edit_post_type' filter.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
