### PR TITLE
Make classic toolbar sticky

### DIFF
--- a/core-blocks/freeform/editor.scss
+++ b/core-blocks/freeform/editor.scss
@@ -142,6 +142,9 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 	width: auto;
 	margin: -$block-padding;
 	margin-bottom: $block-padding;
+	position: sticky;
+	z-index: z-index( '.freeform-toolbar' );
+	top: 0;
 }
 
 .freeform-toolbar:empty {


### PR DESCRIPTION
The classic block's toolbar does not stick when you scroll. This PR fixes that.

![sticky classic](https://user-images.githubusercontent.com/1204802/40611624-5888cf9a-6277-11e8-919f-de47bdbb640e.gif)
