### PR TITLE
Fix regression with sticky toolbar border

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -717,11 +717,7 @@
 	// use opacity to work in various editor styles
 	background-clip: padding-box;
 	box-sizing: padding-box;
-	border: 1px solid $dark-opacity-light-500;
-
-	.is-dark-theme & {
-		border-color: $light-opacity-light-500;
-	}
+	border: 1px solid $light-gray-500;
 
 	// this prevents floats from messing up the position
 	position: absolute;
@@ -735,10 +731,6 @@
 	@include break-small() {
 		width: auto;
 	}
-}
-
-.editor-block-contextual-toolbar .editor-block-toolbar {
-	border-bottom: none;
 }
 
 .editor-block-list__breadcrumb .components-toolbar {


### PR DESCRIPTION
The merge of a more background color friendly UI introduced a regression where the bottom border of the toolbar was gone, to avoid stacking the transparent opacities:

![screen shot 2018-05-28 at 14 49 03](https://user-images.githubusercontent.com/1204802/40615438-09db330a-6287-11e8-8e4d-e13f76fbc8b8.png)

This PR reintroduces the solid color, and the bottom border. 

![screen shot 2018-05-28 at 14 52 22](https://user-images.githubusercontent.com/1204802/40615439-0cf99310-6287-11e8-995c-e8c5393ea67d.png)

It's still friendly to colored backgrounds.