### PR TITLE
Fix RichText autocomplete error

### DIFF
--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -65,6 +65,10 @@ export default class TinyMCE extends Component {
 		// while cleaning for destroy, since removal is handled by React. It
 		// does so by substituting the container to be removed.
 		this.editor.container = document.createDocumentFragment();
+		// This hack prevents TinyMCE from executing the `save` method. It is
+		// not needed for Gutenberg and will result in errors because it
+		// triggers a `nodechange` event.
+		this.editor.bodyElement = null;
 		this.editor.destroy();
 		delete this.editor;
 	}


### PR DESCRIPTION
## Description
Fixes #6640.

## How has this been tested?
Type `/image` and press enter. Ensure there is no error.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->