### PR TITLE
Grammatical fix

### DIFF
--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -14,7 +14,7 @@ export const name = 'core/freeform';
 export const settings = {
 	title: __( 'Classic' ),
 
-	description: __( 'It\'s the classic WordPress editor and its block! Drop the editor right in.' ),
+	description: __( 'It\'s the classic WordPress editor and it's a block! Drop the editor right in.' ),
 
 	icon: 'editor-kitchensink',
 

--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -14,7 +14,7 @@ export const name = 'core/freeform';
 export const settings = {
 	title: __( 'Classic' ),
 
-	description: __( 'It\'s the classic WordPress editor and it's a block! Drop the editor right in.' ),
+	description: __( 'It\'s the classic WordPress editor and it\'s a block! Drop the editor right in.' ),
 
 	icon: 'editor-kitchensink',
 

--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -14,7 +14,7 @@ export const name = 'core/freeform';
 export const settings = {
 	title: __( 'Classic' ),
 
-	description: __( 'It\'s the classic WordPress editor and it\'s block! Drop the editor right in.' ),
+	description: __( 'It\'s the classic WordPress editor and its block! Drop the editor right in.' ),
 
 	icon: 'editor-kitchensink',
 


### PR DESCRIPTION
Remove errant apostrophe in block description

## Description
Removed a grammatically incorrect apostrophe from the Classic Block block description.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
