### PR TITLE
Add InnerBlocks locking

### DIFF
--- a/editor/components/block-drop-zone/index.js
+++ b/editor/components/block-drop-zone/index.js
@@ -137,11 +137,10 @@ export default compose(
 			},
 		};
 	} ),
-	withSelect( ( select ) => {
-		const { templateLock } = select( 'core/editor' ).getEditorSettings();
-
+	withSelect( ( select, { rootUID } ) => {
+		const { getTemplateLock } = select( 'core/editor' );
 		return {
-			isLocked: !! templateLock,
+			isLocked: !! getTemplateLock( rootUID ),
 		};
 	} )
 )( BlockDropZone );

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -596,13 +596,16 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		getSelectedBlocksInitialCaretPosition,
 		getEditorSettings,
 		hasSelectedInnerBlock,
+		getTemplateLock,
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( uid );
 	const isParentOfSelectedBlock = hasSelectedInnerBlock( uid );
-	const { templateLock, hasFixedToolbar } = getEditorSettings();
+	const { hasFixedToolbar } = getEditorSettings();
 	const block = getBlock( uid );
 	const previousBlockUid = getPreviousBlockUid( uid );
 	const previousBlock = getBlock( previousBlockUid );
+	const templateLock = getTemplateLock( rootUID );
+
 	return {
 		nextBlockUid: getNextBlockUid( uid ),
 		isPartOfMultiSelection: isBlockMultiSelected( uid ) || isAncestorMultiSelected( uid ),

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -83,7 +83,7 @@ export default compose(
 			getBlock,
 			isBlockInsertionPointVisible,
 			isTyping,
-			getEditorSettings,
+			getTemplateLock,
 		} = select( 'core/editor' );
 		const blockIndex = uid ? getBlockIndex( uid, rootUID ) : -1;
 		const insertIndex = blockIndex;
@@ -97,13 +97,13 @@ export default compose(
 		);
 
 		return {
-			templateLock: getEditorSettings().templateLock,
+			isLocked: !! getTemplateLock( insertionPoint.rootUID ),
 			showInserter: ! isTyping() && canShowInserter,
 			index: insertIndex,
 			showInsertionPoint,
 		};
 	} ),
-	ifCondition( ( { templateLock } ) => ! templateLock ),
+	ifCondition( ( { isLocked } ) => ! isLocked ),
 	withDispatch( ( dispatch ) => {
 		const { insertDefaultBlock, startTyping } = dispatch( 'core/editor' );
 		return {

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -107,15 +107,14 @@ export class BlockMover extends Component {
 
 export default compose(
 	withSelect( ( select, { uids, rootUID } ) => {
-		const { getBlock, getBlockIndex, getEditorSettings } = select( 'core/editor' );
+		const { getBlock, getBlockIndex, getTemplateLock } = select( 'core/editor' );
 		const firstUID = first( castArray( uids ) );
 		const block = getBlock( firstUID );
-		const { templateLock } = getEditorSettings();
 
 		return {
 			firstIndex: getBlockIndex( firstUID, rootUID ),
 			blockType: block ? getBlockType( block.name ) : null,
-			isLocked: templateLock === 'all',
+			isLocked: getTemplateLock( rootUID ) === 'all',
 		};
 	} ),
 	withDispatch( ( dispatch, { uids, rootUID } ) => {

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -37,12 +37,11 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 
 export default compose(
 	withSelect( ( select, { uids, rootUID } ) => {
-		const { getBlocksByUID, getBlockIndex, getEditorSettings } = select( 'core/editor' );
-		const { templateLock } = getEditorSettings();
+		const { getBlocksByUID, getBlockIndex, getTemplateLock } = select( 'core/editor' );
 		return {
 			blocks: getBlocksByUID( uids ),
 			index: getBlockIndex( last( castArray( uids ) ), rootUID ),
-			isLocked: !! templateLock,
+			isLocked: !! getTemplateLock( rootUID ),
 		};
 	} ),
 	withDispatch( ( dispatch, { blocks, index, rootUID } ) => ( {

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, noop } from 'lodash';
+import { castArray, flow, noop, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -38,11 +38,14 @@ export default compose(
 			dispatch( 'core/editor' ).removeBlocks( uids );
 		},
 	} ) ),
-	withSelect( ( select ) => {
-		const { templateLock } = select( 'core/editor' ).getEditorSettings();
-
+	withSelect( ( select, { uids } ) => {
+		const { getBlockRootUID, getTemplateLock } = select( 'core/editor' );
 		return {
-			isLocked: !! templateLock,
+			isLocked: some( castArray( uids ), ( uid ) => {
+				const rootUID = getBlockRootUID( uid );
+				const templateLock = getTemplateLock( rootUID );
+				return templateLock === 'all';
+			} ),
 		};
 	} ),
 )( BlockRemoveButton );

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { castArray, get, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -128,11 +128,10 @@ export class BlockSwitcher extends Component {
 
 export default compose(
 	withSelect( ( select, ownProps ) => {
-		const { getBlock, getEditorSettings } = select( 'core/editor' );
-		const { templateLock } = getEditorSettings();
+		const { getBlock, getBlockRootUID, getTemplateLock } = select( 'core/editor' );
 		return {
 			blocks: ownProps.uids.map( getBlock ),
-			isLocked: !! templateLock,
+			isLocked: some( castArray( ownProps.uids ), ( uid ) => !! getTemplateLock( getBlockRootUID( uid ) ) ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -67,18 +67,18 @@ export function DefaultBlockAppender( {
 }
 export default compose(
 	withSelect( ( select, ownProps ) => {
-		const { getBlockCount, getBlock, getEditorSettings } = select( 'core/editor' );
+		const { getBlockCount, getBlock, getEditorSettings, getTemplateLock } = select( 'core/editor' );
 		const { isTipVisible } = select( 'core/nux' );
 
 		const isEmpty = ! getBlockCount( ownProps.rootUID );
 		const lastBlock = getBlock( ownProps.lastBlockUID );
 		const isLastBlockDefault = get( lastBlock, [ 'name' ] ) === getDefaultBlockName();
-		const { templateLock, bodyPlaceholder } = getEditorSettings();
+		const { bodyPlaceholder } = getEditorSettings();
 
 		return {
 			isVisible: isEmpty || ! isLastBlockDefault,
 			showPrompt: isEmpty,
-			isLocked: !! templateLock,
+			isLocked: !! getTemplateLock( ownProps.rootUID ),
 			placeholder: bodyPlaceholder,
 			hasTip: isTipVisible( 'core/editor.inserter' ),
 		};

--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { first, last } from 'lodash';
+import { first, last, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -96,16 +96,17 @@ export default compose( [
 			getBlockOrder,
 			getMultiSelectedBlockUids,
 			hasMultiSelection,
-			getEditorSettings,
 			isEditedPostDirty,
+			getBlockRootUID,
+			getTemplateLock,
 		} = select( 'core/editor' );
-		const { templateLock } = getEditorSettings();
+		const multiSelectedBlockUids = getMultiSelectedBlockUids();
 
 		return {
 			uids: getBlockOrder(),
-			multiSelectedBlockUids: getMultiSelectedBlockUids(),
+			multiSelectedBlockUids,
 			hasMultiSelection: hasMultiSelection(),
-			isLocked: !! templateLock,
+			isLocked: some( multiSelectedBlockUids, ( uid ) => !! getTemplateLock( getBlockRootUID( uid ) ) ),
 			isDirty: isEditedPostDirty(),
 		};
 	} ),

--- a/editor/components/inner-blocks/index.js
+++ b/editor/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, get } from 'lodash';
+import { pick } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -43,15 +43,19 @@ class InnerBlocks extends Component {
 	updateNestedSettings() {
 		const {
 			blockListSettings,
-			allowedBlocks: nextAllowedBlocks,
+			allowedBlocks,
+			templateLock,
+			parentLock,
 			updateNestedSettings,
 		} = this.props;
 
-		const allowedBlocks = get( blockListSettings, [ 'allowedBlocks' ] );
-		if ( ! isShallowEqual( allowedBlocks, nextAllowedBlocks ) ) {
-			updateNestedSettings( {
-				allowedBlocks: nextAllowedBlocks,
-			} );
+		const newSettings = {
+			allowedBlocks,
+			templateLock: templateLock === undefined ? parentLock : templateLock,
+		};
+
+		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {
+			updateNestedSettings( newSettings );
 		}
 	}
 
@@ -60,6 +64,7 @@ class InnerBlocks extends Component {
 			uid,
 			layouts,
 			allowedBlocks,
+			templateLock,
 			template,
 			isSmallScreen,
 			isSelectedBlockInRoot,
@@ -73,7 +78,7 @@ class InnerBlocks extends Component {
 			<div className={ classes }>
 				<BlockList
 					rootUID={ uid }
-					{ ...{ layouts, allowedBlocks, template } }
+					{ ...{ layouts, allowedBlocks, templateLock, template } }
 				/>
 			</div>
 		);
@@ -89,13 +94,16 @@ InnerBlocks = compose( [
 			hasSelectedInnerBlock,
 			getBlock,
 			getBlockListSettings,
+			getBlockRootUID,
+			getTemplateLock,
 		} = select( 'core/editor' );
 		const { uid } = ownProps;
-
+		const parentUID = getBlockRootUID( uid );
 		return {
 			isSelectedBlockInRoot: isBlockSelected( uid ) || hasSelectedInnerBlock( uid ),
 			block: getBlock( uid ),
 			blockListSettings: getBlockListSettings( uid ),
+			parentLock: getTemplateLock( parentUID ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -50,11 +50,10 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 
 export default compose(
 	withSelect( ( select, { rootUID } ) => {
-		const { getEditorSettings, getInserterItems } = select( 'core/editor' );
-		const { templateLock } = getEditorSettings();
+		const { getInserterItems, getTemplateLock } = select( 'core/editor' );
 		return {
 			items: getInserterItems( rootUID ),
-			isLocked: !! templateLock,
+			isLocked: !! getTemplateLock( rootUID ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1192,12 +1192,22 @@ export function getTemplate( state ) {
 
 /**
  * Returns the defined block template lock
+ * in the context of a given root block or in the global context.
  *
  * @param {boolean} state
+ * @param {?string} rootUID Block UID.
+ *
  * @return {?string}        Block Template Lock
  */
-export function getTemplateLock( state ) {
-	return state.settings.templateLock;
+export function getTemplateLock( state, rootUID ) {
+	if ( ! rootUID ) {
+		return state.settings.templateLock;
+	}
+	const blockListSettings = getBlockListSettings( state, rootUID );
+	if ( ! blockListSettings ) {
+		return null;
+	}
+	return blockListSettings.templateLock;
 }
 
 /**
@@ -1358,15 +1368,15 @@ export const canInsertBlockType = createSelector(
 			return false;
 		}
 
-		const { allowedBlockTypes, templateLock } = getEditorSettings( state );
+		const { allowedBlockTypes } = getEditorSettings( state );
 
 		const isBlockAllowedInEditor = checkAllowList( allowedBlockTypes, blockName, true );
 		if ( ! isBlockAllowedInEditor ) {
 			return false;
 		}
 
-		const isEditorLocked = !! templateLock;
-		if ( isEditorLocked ) {
+		const isLocked = !! getTemplateLock( state, parentUID );
+		if ( isLocked ) {
 			return false;
 		}
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -3606,12 +3606,51 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getTemplateLock', () => {
-		it( 'should return the template object', () => {
+		it( 'should return the general template lock if no uid was set', () => {
 			const state = {
 				settings: { templateLock: 'all' },
 			};
 
 			expect( getTemplateLock( state ) ).toBe( 'all' );
+		} );
+
+		it( 'should return null if the specified uid was not found ', () => {
+			const state = {
+				settings: { templateLock: 'all' },
+				blockListSettings: {
+					chicken: {
+						templateLock: 'insert',
+					},
+				},
+			};
+
+			expect( getTemplateLock( state, 'ribs' ) ).toBe( null );
+		} );
+
+		it( 'should return null if template lock was not set on the specified block', () => {
+			const state = {
+				settings: { templateLock: 'all' },
+				blockListSettings: {
+					chicken: {
+						test: 'tes1t',
+					},
+				},
+			};
+
+			expect( getTemplateLock( state, 'ribs' ) ).toBe( null );
+		} );
+
+		it( 'should return the template lock for the specified uid', () => {
+			const state = {
+				settings: { templateLock: 'all' },
+				blockListSettings: {
+					chicken: {
+						templateLock: 'insert',
+					},
+				},
+			};
+
+			expect( getTemplateLock( state, 'chicken' ) ).toBe( 'insert' );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
The feature is required by #6993.
This PR adds the possibility to set locking in InnerBlocks in a similar way we can now do with the template locking.
Usage:

```js
edit() {
	return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
		el( InnerBlocks, {
			locking: 'insert', // all, insert, or none
			template: [
				[ 'core/paragraph', {
					placeholder: 'Enter locking insert p1 content…',
				} ],
				[ 'core/paragraph', {
					placeholder: 'Enter locking insert p2 content…',
				} ],
			],
		} )
	);
}
```


Locking can be all, insert or not set.
Right now, with template locking if we have locking active and a template with a column block we cannot insert anything into the column so it seems locking applies to children.
We followed the same logic in this PR locking applies to descends even if the descends set a less restrictive locking or no locking at all. We may change this behavior but if changing it we should also change it for the CPT templates case.

## How has this been tested?

The best way is to use the test blocks in https://gist.github.com/jorgefilipecosta/2bac096fe3be7f6ff0de7452292161cb, and verify everything works as expected. To simplest way to have the blocks is to paste all the code in the developer console.