### PR TITLE
Fix intermittent adding-blocks E2E test failure

### DIFF
--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -50,6 +50,7 @@ describe( 'adding blocks', () => {
 
 		// Using the regular inserter
 		await page.click( '.edit-post-header [aria-label="Add block"]' );
+		await page.waitForSelector( '.editor-inserter__menu' );
 		await page.keyboard.type( 'code' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );


### PR DESCRIPTION
See #6956.

The problem is that the `adding-blocks` E2E test intermittently fails with this error message:

<img width="961" alt="image" src="https://user-images.githubusercontent.com/36432/40548864-c4fc4966-5fea-11e8-8017-de2646ef3965.png">

The good news is that I was able to consistently reproduce this on my dev machine by running the test many times in a row:

```bash
#!/bin/bash
for i in {1..25}
do
	$(npm bin)/jest --config test/e2e/jest.config.json adding-blocks
done
```

I usually witness a failure after about the 6th or 7th try.

The bad news is that all of my attempts to figure out what was going on caused the error to no longer occur. I tried various approaches, including `PUPPETEER_HEADLESS=false`, `page.screenshot()`, and dumping out HTML using `page.evaluate()`. 

![image](https://user-images.githubusercontent.com/612155/40636947-60b44af4-6345-11e8-9aa7-9cad2eee864e.png)

A clue was that inserting a `console.log()` after line 52 would cause the error to go away. My theory is that, sometimes, React is too slow to render the inserter menu and that this causes unexpected results. I'm not sure why a list block is inserted, though.

My fix is to add a `waitForSelector` so that Puppeteer waits for the menu to render before continuing on with the test. With this patch applied, I have yet to witness the error.

🤷‍♂️ 