### PR TITLE
Add lint rule to check that memize() is used

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,6 +110,10 @@ module.exports = {
 				selector: 'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] Literal[value=/\\.{3}/]',
 				message: 'Use ellipsis character (…) in place of three dots',
 			},
+			{
+				selector: 'ImportDeclaration[source.value="lodash"] Identifier.imported[name="memoize"]',
+				message: 'Use memize instead of Lodash\'s memoize',
+			},
 		],
 	},
 	overrides: [


### PR DESCRIPTION
Fixes #6707. 

We should be using [memize](https://www.npmjs.com/package/memize) over lodash's built-in `memoize`. 

This adds a ESLint rule that warns us if `import { memoize } from 'lodash'` is used. It won't catch any usage that comes from `import _ from 'lodash'`, but that's a rare case.

**To test:**
1. Add `import { memoize } from 'lodash';` to the top of any JavaScript file
2. Run `npm run lint`