### PR TITLE
Inserter: Fix 'no results' message

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -3,13 +3,14 @@
  */
 import {
 	filter,
+	find,
+	findIndex,
+	flow,
 	groupBy,
+	isEmpty,
 	map,
 	some,
-	flow,
 	sortBy,
-	findIndex,
-	find,
 	without,
 } from 'lodash';
 
@@ -211,6 +212,10 @@ export class InserterMenu extends Component {
 							</PanelBody>
 						);
 					} ) }
+
+					{ isEmpty( suggestedItems ) && isEmpty( sharedItems ) && isEmpty( itemsPerCategory ) && (
+						<p className="editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
+					) }
 
 					{ hoveredItem && isSharedBlock( hoveredItem ) &&
 						<BlockPreview name={ hoveredItem.name } attributes={ hoveredItem.initialAttributes } />

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -161,3 +161,9 @@ input[type="search"].editor-inserter__search {
 .editor-inserter__item-title {
 	padding: 4px 2px;
 }
+
+.editor-inserter__no-results {
+	font-style: italic;
+	padding: 24px;
+	text-align: center;
+}

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -123,6 +123,9 @@ describe( 'InserterMenu', () => {
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
 		expect( visibleBlocks ).toHaveLength( 0 );
+
+		const noResultsMessage = wrapper.find( '.editor-inserter__no-results' );
+		expect( noResultsMessage ).toHaveLength( 1 );
 	} );
 
 	it( 'should show only high utility items in the suggested tab', () => {
@@ -183,6 +186,9 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 2 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'YouTube' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'A Text Embed' );
+
+		const noResultsMessage = wrapper.find( '.editor-inserter__no-results' );
+		expect( noResultsMessage ).toBeEmpty();
 	} );
 
 	it( 'should show shared items in the shared tab', () => {
@@ -208,6 +214,9 @@ describe( 'InserterMenu', () => {
 		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
 		expect( visibleBlocks ).toHaveLength( 1 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'My shared block' );
+
+		const noResultsMessage = wrapper.find( '.editor-inserter__no-results' );
+		expect( noResultsMessage ).toBeEmpty();
 	} );
 
 	it( 'should show the common category blocks', () => {
@@ -235,6 +244,9 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );
 		expect( visibleBlocks.at( 2 ).text() ).toBe( 'Some Other Block' );
+
+		const noResultsMessage = wrapper.find( '.editor-inserter__no-results' );
+		expect( noResultsMessage ).toBeEmpty();
 	} );
 
 	it( 'should disable items with `isDisabled`', () => {
@@ -281,6 +293,9 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 2 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );
+
+		const noResultsMessage = wrapper.find( '.editor-inserter__no-results' );
+		expect( noResultsMessage ).toBeEmpty();
 	} );
 
 	it( 'should trim whitespace of search terms', () => {


### PR DESCRIPTION
Fixes #6975.

<img width="374" alt="screen shot 2018-05-29 at 16 43 21" src="https://user-images.githubusercontent.com/612155/40642121-6f0d810a-635f-11e8-86eb-88f6b45d681b.png">

The inserter should display some explanatory text when the user searches for a block but there is no block found.

This was first added in https://github.com/WordPress/gutenberg/pull/4040 and then accidentally removed in https://github.com/WordPress/gutenberg/pull/6636.

**To test:**

1. Open the inserter
2. Search for that which does not exist
3. You should see a friendly error message