### PR TITLE
Build tooling: Add linting for package.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.47",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz",
-			"integrity": "sha512-W7IeG4MoVf4oUvWfHUx9VG9if3E0xSUDf1urrnNYtC2ow1dz2ptvQ6YsJfyVXDuPTFXz66jkHhzMW7a5Eld7TA==",
+			"version": "7.0.0-beta.49",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
+			"integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.47"
+				"@babel/highlight": "7.0.0-beta.49"
 			}
 		},
 		"@babel/helper-function-name": {
@@ -35,9 +35,9 @@
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.47",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
-			"integrity": "sha512-d505K3Hth1eg0b2swfEF7oFMw3J9M8ceFg0s6dhCSxOOF+07WDvJ0HKT/YbK/Jk9wn8Wyr6HIRAUPKJ9Wfv8Rg==",
+			"version": "7.0.0-beta.49",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
+			"integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
@@ -560,17 +560,26 @@
 				"pegjs": "^0.10.0"
 			}
 		},
+		"@wordpress/npm-package-json-lint-config": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-1.0.0.tgz",
+			"integrity": "sha512-6urMrDWGh56VpPVdrsJjOh4Xb3oe/xOj9Ah5nC0UG8zZyrlBNbUbniSwp6dzhRVQ/tSYtQBjEafxq96O3OY47w==",
+			"dev": true
+		},
 		"@wordpress/scripts": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-1.1.6.tgz",
-			"integrity": "sha512-DW0Idf7RQOQvgIjCaNfHTdLtRG1TGYxTjJz3BZO4mch7/M+yY22AU5MytJv/3/l2UCU1S3YSNSNrjUj/zPMvUA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-1.2.0.tgz",
+			"integrity": "sha512-3o2y5n4XmygXDVHi2hqmQUL589t3q0+H/t+LEqHVVvKt4R9MH/z32uTS9PjFsuxKfwfoOHwVYq+vqI5cO6B1OQ==",
 			"dev": true,
 			"requires": {
 				"@wordpress/babel-preset-default": "^1.3.0",
 				"@wordpress/jest-preset-default": "^1.0.6",
+				"@wordpress/npm-package-json-lint-config": "^1.0.0",
 				"cross-spawn": "^5.1.0",
 				"jest": "^22.4.0",
-				"read-pkg-up": "^3.0.0"
+				"npm-package-json-lint": "^3.0.1",
+				"read-pkg-up": "^3.0.0",
+				"resolve-bin": "^0.4.0"
 			},
 			"dependencies": {
 				"read-pkg-up": {
@@ -832,6 +841,12 @@
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+			"dev": true
+		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -851,6 +866,18 @@
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.7.0"
 			}
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+			"dev": true
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+			"dev": true
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -3916,9 +3943,9 @@
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "0.2.37",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
+			"integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -4937,6 +4964,32 @@
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
 		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			},
+			"dependencies": {
+				"split": {
+					"version": "0.3.3",
+					"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+					"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+					"dev": true,
+					"requires": {
+						"through": "2"
+					}
+				}
+			}
+		},
 		"events": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -5409,6 +5462,12 @@
 				"pkg-dir": "^2.0.0"
 			}
 		},
+		"find-parent-dir": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+			"dev": true
+		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -5530,6 +5589,12 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -7022,6 +7087,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"irregular-plurals": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
+			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
+			"dev": true
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
@@ -8619,9 +8690,9 @@
 			}
 		},
 		"jsdom": {
-			"version": "11.10.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
-			"integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
+			"integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
 			"dev": true,
 			"requires": {
 				"abab": "^1.0.4",
@@ -8629,13 +8700,13 @@
 				"acorn-globals": "^4.1.0",
 				"array-equal": "^1.0.0",
 				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": ">= 0.2.37 < 0.3.0",
+				"cssstyle": ">= 0.3.1 < 0.4.0",
 				"data-urls": "^1.0.0",
 				"domexception": "^1.0.0",
 				"escodegen": "^1.9.0",
 				"html-encoding-sniffer": "^1.0.2",
 				"left-pad": "^1.2.0",
-				"nwmatcher": "^1.4.3",
+				"nwsapi": "^2.0.0",
 				"parse5": "4.0.0",
 				"pn": "^1.1.0",
 				"request": "^2.83.0",
@@ -8647,7 +8718,7 @@
 				"webidl-conversions": "^4.0.2",
 				"whatwg-encoding": "^1.0.3",
 				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.0",
+				"whatwg-url": "^6.4.1",
 				"ws": "^4.0.0",
 				"xml-name-validator": "^3.0.0"
 			},
@@ -9393,6 +9464,12 @@
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
 			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"map-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
@@ -9536,6 +9613,12 @@
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+			"dev": true
 		},
 		"meow": {
 			"version": "4.0.1",
@@ -10200,6 +10283,129 @@
 				}
 			}
 		},
+		"npm-package-json-lint": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.0.1.tgz",
+			"integrity": "sha1-cMUePLOzaGeFlhJAHy9fTK1b2QQ=",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.4.0",
+				"chalk": "^2.4.1",
+				"glob": "^7.1.2",
+				"is-path-inside": "^2.0.0",
+				"is-plain-obj": "^1.1.0",
+				"is-resolvable": "^1.1.0",
+				"log-symbols": "^2.2.0",
+				"meow": "^5.0.0",
+				"plur": "^3.0.1",
+				"semver": "^5.5.0",
+				"strip-json-comments": "^2.0.1",
+				"validator": "^10.1.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+					"integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0",
+						"uri-js": "^4.2.1"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
+				},
+				"is-path-inside": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.0.0.tgz",
+					"integrity": "sha512-OmUXvSq+P7aI/aRbl1dzwdlyLn8vW7Nr2/11S7y/dcLLgnQ89hgYJp7tfc+A5SRid3rNCLpruOp2CAV68/iOcA==",
+					"dev": true,
+					"requires": {
+						"path-is-inside": "^1.0.2"
+					}
+				},
+				"meow": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+					"dev": true,
+					"requires": {
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0",
+						"yargs-parser": "^10.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
+					"integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.4",
+				"memorystream": "^0.3.1",
+				"minimatch": "^3.0.4",
+				"ps-tree": "^1.1.0",
+				"read-pkg": "^3.0.0",
+				"shell-quote": "^1.6.1",
+				"string.prototype.padend": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				}
+			}
+		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -10239,10 +10445,10 @@
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
-		"nwmatcher": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+		"nwsapi": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.1.tgz",
+			"integrity": "sha512-xOJJb7kAAGy6UOklbaIPA0iu/27VMHfAbMUgYJlXz4qRXytIkPGM2vwfbxa+tbaqcqHNsP6RN4eDZlePelWKpQ==",
 			"dev": true
 		},
 		"oauth-sign": {
@@ -10764,6 +10970,15 @@
 				"pify": "^3.0.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"pbkdf2": {
 			"version": "3.0.16",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
@@ -10849,6 +11064,15 @@
 			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
+			}
+		},
+		"plur": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-3.0.1.tgz",
+			"integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
+			"dev": true,
+			"requires": {
+				"irregular-plurals": "^2.0.0"
 			}
 		},
 		"pluralize": {
@@ -12933,6 +13157,15 @@
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
 			"dev": true
 		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "~3.3.0"
+			}
+		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -13799,6 +14032,15 @@
 				"path-parse": "^1.0.5"
 			}
 		},
+		"resolve-bin": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.0.tgz",
+			"integrity": "sha1-RxMiSYkRAa+xmZH+k3ywpfBy5dk=",
+			"dev": true,
+			"requires": {
+				"find-parent-dir": "~0.3.0"
+			}
+		},
 		"resolve-cwd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
@@ -14277,6 +14519,18 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"dev": true,
+			"requires": {
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
+			}
+		},
 		"shelljs": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
@@ -14712,6 +14966,15 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
 		"stream-each": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
@@ -14811,6 +15074,17 @@
 						"ansi-regex": "^3.0.0"
 					}
 				}
+			}
+		},
+		"string.prototype.padend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -15646,6 +15920,12 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
+		},
+		"validator": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-10.2.0.tgz",
+			"integrity": "sha512-gz/uknWtNfZTj1BLUzYHDxOoiQ7A4wZ6xPuuE6RpxswR4cNyT4I5kN9jmU0AQr7IBEap9vfYChI2TpssTN6Itg==",
+			"dev": true
 		},
 		"vendors": {
 			"version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -841,12 +841,6 @@
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
-		"array-filter": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-			"dev": true
-		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -866,18 +860,6 @@
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.7.0"
 			}
-		},
-		"array-map": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-			"dev": true
-		},
-		"array-reduce": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-			"dev": true
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -4964,32 +4946,6 @@
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
 		},
-		"event-stream": {
-			"version": "3.3.4",
-			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-			"dev": true,
-			"requires": {
-				"duplexer": "~0.1.1",
-				"from": "~0",
-				"map-stream": "~0.1.0",
-				"pause-stream": "0.0.11",
-				"split": "0.3",
-				"stream-combiner": "~0.0.4",
-				"through": "~2.3.1"
-			},
-			"dependencies": {
-				"split": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-					"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-					"dev": true,
-					"requires": {
-						"through": "2"
-					}
-				}
-			}
-		},
 		"events": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -5589,12 +5545,6 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
-		},
-		"from": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-			"dev": true
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -9464,12 +9414,6 @@
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
 			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 		},
-		"map-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-			"dev": true
-		},
 		"map-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
@@ -9613,12 +9557,6 @@
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
 			}
-		},
-		"memorystream": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
-			"dev": true
 		},
 		"meow": {
 			"version": "4.0.1",
@@ -10374,38 +10312,6 @@
 				}
 			}
 		},
-		"npm-run-all": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
-			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.4",
-				"memorystream": "^0.3.1",
-				"minimatch": "^3.0.4",
-				"ps-tree": "^1.1.0",
-				"read-pkg": "^3.0.0",
-				"shell-quote": "^1.6.1",
-				"string.prototype.padend": "^3.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				}
-			}
-		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -10968,15 +10874,6 @@
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"requires": {
 				"pify": "^3.0.0"
-			}
-		},
-		"pause-stream": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"dev": true,
-			"requires": {
-				"through": "~2.3"
 			}
 		},
 		"pbkdf2": {
@@ -13157,15 +13054,6 @@
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
 			"dev": true
 		},
-		"ps-tree": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-			"dev": true,
-			"requires": {
-				"event-stream": "~3.3.0"
-			}
-		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -14519,18 +14407,6 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
-		"shell-quote": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-			"dev": true,
-			"requires": {
-				"array-filter": "~0.0.0",
-				"array-map": "~0.0.0",
-				"array-reduce": "~0.0.0",
-				"jsonify": "~0.0.0"
-			}
-		},
 		"shelljs": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
@@ -14966,15 +14842,6 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
-		"stream-combiner": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-			"dev": true,
-			"requires": {
-				"duplexer": "~0.1.1"
-			}
-		},
 		"stream-each": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
@@ -15074,17 +14941,6 @@
 						"ansi-regex": "^3.0.0"
 					}
 				}
-			}
-		},
-		"string.prototype.padend": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.4.3",
-				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
 		"eslint-plugin-react": "7.7.0",
 		"extract-text-webpack-plugin": "4.0.0-beta.0",
 		"node-sass": "git://github.com/sass/node-sass.git#v4.7.0",
-		"npm-run-all": "4.1.3",
 		"pegjs": "0.10.0",
 		"pegjs-loader": "0.5.4",
 		"phpegjs": "1.0.0-beta7",
@@ -125,7 +124,7 @@
 			"valid-values-author": [
 				"error",
 				[
-					"WordPress"
+					"The WordPress Contributors"
 				]
 			],
 			"valid-values-publishConfig": [
@@ -150,8 +149,8 @@
 		"fixtures:clean": "rimraf \"core-blocks/test/fixtures/*.+(json|serialized.html)\"",
 		"fixtures:server-registered": "docker-compose run -w /var/www/html/wp-content/plugins/gutenberg --rm wordpress ./bin/get-server-blocks.php > core-blocks/test/server-registered.json",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
-		"fixtures:regenerate": "npm-run-all fixtures:clean fixtures:generate",
-		"lint": "npm-run-all lint-js lint-pkg-json",
+		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
+		"lint": "npm run lint-js && npm run lint-pkg-json",
 		"lint-js": "eslint .",
 		"lint-js:fix": "eslint . --fix",
 		"lint-php": "docker-compose run --rm composer run-script lint",
@@ -162,10 +161,10 @@
 		"publish:check": "lerna updated",
 		"publish:dev": "lerna publish --npm-tag next",
 		"publish:prod": "lerna publish",
-		"test": "npm-run-all lint test-unit",
+		"test": "npm run lint && npm run test-unit",
 		"test-e2e": "wp-scripts test-unit-js --config test/e2e/jest.config.json",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
-		"test-php": "npm-run-all lint-php test-unit-php",
+		"test-php": "npm run lint-php && npm run test-unit-php",
 		"test-unit": "wp-scripts test-unit-js --config test/unit/jest.config.json",
 		"test-unit:coverage": "npm run test-unit -- --coverage",
 		"test-unit:coverage-ci": "npm run test-unit -- --coverage --maxWorkers 1 && codecov",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"@wordpress/browserslist-config": "2.1.4",
 		"@wordpress/custom-templated-path-webpack-plugin": "1.0.2",
 		"@wordpress/jest-preset-default": "1.0.6",
-		"@wordpress/scripts": "1.1.6",
+		"@wordpress/scripts": "1.2.0",
 		"autoprefixer": "8.2.0",
 		"babel-core": "6.26.0",
 		"babel-eslint": "8.0.3",
@@ -85,6 +85,7 @@
 		"eslint-plugin-react": "7.7.0",
 		"extract-text-webpack-plugin": "4.0.0-beta.0",
 		"node-sass": "git://github.com/sass/node-sass.git#v4.7.0",
+		"npm-run-all": "4.1.3",
 		"pegjs": "0.10.0",
 		"pegjs-loader": "0.5.4",
 		"phpegjs": "1.0.0-beta7",
@@ -117,36 +118,59 @@
 			}
 		}
 	},
+	"npmPackageJsonLintConfig": {
+		"extends": "@wordpress/npm-package-json-lint-config",
+		"rules": {
+			"require-publishConfig": "error",
+			"valid-values-author": [
+				"error",
+				[
+					"WordPress"
+				]
+			],
+			"valid-values-publishConfig": [
+				"error",
+				[
+					{
+						"access": "public"
+					}
+				]
+			]
+		}
+	},
 	"scripts": {
-		"prebuild": "check-node-version --package",
+		"prebuild": "npm run check-engines",
 		"build:packages": "rimraf ./packages/*/build ./packages/*/build-module && node ./bin/packages/build.js",
 		"build": "npm run build:packages && cross-env NODE_ENV=production webpack",
-		"lint": "eslint .",
-		"lint:fix": "eslint . --fix",
-		"lint-php": "docker-compose run --rm composer run-script lint",
-		"predev": "check-node-version --package",
+		"check-engines": "check-node-version --package",
+		"ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
+		"predev": "npm run check-engines",
 		"dev": "npm run build:packages && concurrently \"cross-env webpack --watch\" \"npm run dev:packages\"",
 		"dev:packages": "node ./bin/packages/watch.js",
-		"test": "npm run lint && npm run test-unit",
-		"test-php": "npm run lint-php && npm run test-unit-php",
-		"ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
 		"fixtures:clean": "rimraf \"core-blocks/test/fixtures/*.+(json|serialized.html)\"",
 		"fixtures:server-registered": "docker-compose run -w /var/www/html/wp-content/plugins/gutenberg --rm wordpress ./bin/get-server-blocks.php > core-blocks/test/server-registered.json",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
-		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
+		"fixtures:regenerate": "npm-run-all fixtures:clean fixtures:generate",
+		"lint": "npm-run-all lint-js lint-pkg-json",
+		"lint-js": "eslint .",
+		"lint-js:fix": "eslint . --fix",
+		"lint-php": "docker-compose run --rm composer run-script lint",
+		"lint-pkg-json": "wp-scripts lint-pkg-json ./packages",
 		"package-plugin": "./bin/build-plugin-zip.sh",
 		"postinstall": "lerna bootstrap --hoist && npm run build:packages",
 		"pot-to-php": "./bin/pot-to-php.js",
 		"publish:check": "lerna updated",
 		"publish:dev": "lerna publish --npm-tag next",
 		"publish:prod": "lerna publish",
+		"test": "npm-run-all lint test-unit",
+		"test-e2e": "wp-scripts test-unit-js --config test/e2e/jest.config.json",
+		"test-e2e:watch": "npm run test-e2e -- --watch",
+		"test-php": "npm-run-all lint-php test-unit-php",
 		"test-unit": "wp-scripts test-unit-js --config test/unit/jest.config.json",
-		"test-unit-php": "docker-compose run --rm wordpress_phpunit phpunit",
-		"test-unit-php-multisite": "docker-compose run -e WP_MULTISITE=1 --rm wordpress_phpunit phpunit",
 		"test-unit:coverage": "npm run test-unit -- --coverage",
 		"test-unit:coverage-ci": "npm run test-unit -- --coverage --maxWorkers 1 && codecov",
 		"test-unit:watch": "npm run test-unit -- --watch",
-		"test-e2e": "wp-scripts test-unit-js --config test/e2e/jest.config.json",
-		"test-e2e:watch": "npm run test-e2e -- --watch"
+		"test-unit-php": "docker-compose run --rm wordpress_phpunit phpunit",
+		"test-unit-php-multisite": "docker-compose run -e WP_MULTISITE=1 --rm wordpress_phpunit phpunit"
 	}
 }

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -2,7 +2,7 @@
 	"name": "@wordpress/blob",
 	"version": "1.0.0-alpha.0",
 	"description": "Blob utils for WordPress",
-	"author": "WordPress",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -2,7 +2,7 @@
 	"name": "@wordpress/data",
 	"version": "1.0.0-alpha.0",
 	"description": "Data module for WordPress",
-	"author": "WordPress",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -2,7 +2,7 @@
 	"name": "@wordpress/date",
 	"version": "1.0.0-alpha.0",
 	"description": "Date module for WordPress",
-	"author": "WordPress",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -2,7 +2,7 @@
 	"name": "@wordpress/deprecated",
 	"version": "1.0.0-alpha.0",
 	"description": "Deprecation utility for WordPress",
-	"author": "WordPress",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -2,7 +2,7 @@
 	"name": "@wordpress/dom",
 	"version": "1.0.0-alpha.0",
 	"description": "DOM utils module for WordPress",
-	"author": "WordPress",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -2,7 +2,7 @@
 	"name": "@wordpress/element",
 	"version": "1.0.0-alpha.0",
 	"description": "Element React module for WordPress",
-	"author": "WordPress",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -2,7 +2,7 @@
 	"name": "@wordpress/library-export-default-webpack-plugin",
 	"version": "1.0.0-alpha.0",
 	"description": "Webpack plugin for exporting default property for selected libraries",
-	"author": "WordPress",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -2,7 +2,7 @@
 	"name": "@wordpress/postcss-themes",
 	"version": "1.0.0-alpha.0",
 	"description": "PostCSS plugin to generate theme colors",
-	"author": "WordPress",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",


### PR DESCRIPTION
## Description
This PR updates `@wordpress/scripts` to the next minor version which exposed `lint-pkg-json` command. It exposed the same checks for `package.json` files for all packages maintained by Lerna. This brings the setup of Gutenberg and packages closer to each other before they get merged together in the near future.

I also reordered `scripts` section to make everything sorted by script name. I also pulled in `npm-run-all` package to make it easier to run groups of scripts.

## How has this been tested?
* `npm run lint-pkg-json`
* `npm run lint`

To make sure that this new linter works you can update any `package.json` file inside packages folder and change the order of properties or update `author` field, or remove `publishConfig` field.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
