### PR TITLE
Fix typos: Arary → Array, nox → box

### DIFF
--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -139,7 +139,7 @@ export function requestMetaBoxUpdates() {
 }
 
 /**
- * Returns an action object used signal a successfull meta nox update.
+ * Returns an action object used signal a successfull meta box update.
  *
  * @return {Object} Action object.
  */

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -150,7 +150,7 @@ export function metaBoxUpdatesSuccess() {
 }
 
 /**
- * Returns an action object used set the saved meta boxes data.
+ * Returns an action object used to set the saved meta boxes data.
  * This is used to check if the meta boxes have been touched when leaving the editor.
  *
  * @param   {Object} dataPerLocation Meta Boxes Data per location.

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -47,7 +47,7 @@ export function closePublishSidebar() {
 }
 
 /**
- * Returns an action object used in signalling that the user toggles the publish sidebar
+ * Returns an action object used in signalling that the user toggles the publish sidebar.
  *
  * @return {Object} Action object
  */

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1067,7 +1067,7 @@ export function isValidTemplate( state ) {
  * Returns the defined block template
  *
  * @param {boolean} state
- * @return {?Arary}        Block Template
+ * @return {?Array}        Block Template
  */
 export function getTemplate( state ) {
 	return state.settings.template;


### PR DESCRIPTION
Fixes some typos in `editor/store/selectors.js` and `edit-post/store/actions.js`

`Arary` -> `Array`
`nox` -> `box`

Adds "to" to docblock:

> Returns an action object used `to` set the saved meta boxes data.

Adds a missing period to docblock for consistency.