### PR TITLE
Inserter: Move "Saved" blocks to the bottom and show icon

### DIFF
--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -37,9 +37,9 @@ class PanelBody extends Component {
 	}
 
 	render() {
-		const { title, children, opened, className } = this.props;
+		const { title, children, opened, className, icon } = this.props;
 		const isOpened = opened === undefined ? this.state.opened : opened;
-		const icon = `arrow-${ isOpened ? 'up' : 'down' }`;
+		const arrow = `arrow-${ isOpened ? 'up' : 'down' }`;
 		const classes = classnames( 'components-panel__body', className, { 'is-opened': isOpened } );
 
 		return (
@@ -51,7 +51,8 @@ class PanelBody extends Component {
 							onClick={ this.toggle }
 							aria-expanded={ isOpened }
 						>
-							<Dashicon icon={ icon } />
+							<Dashicon icon={ arrow } className="components-panel__arrow" />
+							{ icon && <Dashicon icon={ icon } className="components-panel__icon" /> }
 							{ title }
 						</Button>
 					</h2>

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -80,7 +80,7 @@
 		@include menu-style__focus;
 	}
 
-	.dashicon {
+	.components-panel__arrow {
 		position: absolute;
 		right: $item-spacing;
 		top: 50%;
@@ -96,6 +96,13 @@
 		margin-top: -10px;
 	}
 	/* rtl:end:ignore */
+}
+
+.components-panel__icon {
+	color: $dark-gray-400;
+	margin-right: 5px;
+	position: relative;
+	top: -2px;
 }
 
 .components-panel__body-toggle-icon {

--- a/edit-post/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
@@ -26,11 +26,12 @@ exports[`PluginPostPublishPanel renders fill properly 1`] = `
             type="button"
           >
             <Dashicon
+              className="components-panel__arrow"
               icon="arrow-up"
             >
               <svg
                 aria-hidden={true}
-                className="dashicon dashicons-arrow-up"
+                className="dashicon dashicons-arrow-up components-panel__arrow"
                 focusable="false"
                 height={20}
                 role="img"

--- a/edit-post/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
@@ -26,11 +26,12 @@ exports[`PluginPrePublishPanel renders fill properly 1`] = `
             type="button"
           >
             <Dashicon
+              className="components-panel__arrow"
               icon="arrow-up"
             >
               <svg
                 aria-hidden={true}
-                className="dashicon dashicons-arrow-up"
+                className="dashicon dashicons-arrow-up components-panel__arrow"
                 focusable="false"
                 height={20}
                 role="img"

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -185,17 +185,6 @@ export class InserterMenu extends Component {
 							<ItemList items={ suggestedItems } onSelect={ onSelect } onHover={ this.onHover } />
 						</PanelBody>
 					}
-
-					{ !! sharedItems.length && (
-						<PanelBody
-							title={ __( 'Shared' ) }
-							opened={ isPanelOpen( 'shared' ) }
-							onToggle={ this.onTogglePanel( 'shared' ) }
-						>
-							<ItemList items={ sharedItems } onSelect={ onSelect } onHover={ this.onHover } />
-						</PanelBody>
-					) }
-
 					{ map( getCategories(), ( category ) => {
 						const categoryItems = itemsPerCategory[ category.slug ];
 						if ( ! categoryItems || ! categoryItems.length ) {
@@ -212,7 +201,16 @@ export class InserterMenu extends Component {
 							</PanelBody>
 						);
 					} ) }
-
+					{ !! sharedItems.length && (
+						<PanelBody
+							title={ __( 'Shared' ) }
+							opened={ isPanelOpen( 'shared' ) }
+							onToggle={ this.onTogglePanel( 'shared' ) }
+							icon="controls-repeat"
+						>
+							<ItemList items={ sharedItems } onSelect={ onSelect } onHover={ this.onHover } />
+						</PanelBody>
+					) }
 					{ isEmpty( suggestedItems ) && isEmpty( sharedItems ) && isEmpty( itemsPerCategory ) && (
 						<p className="editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
 					) }


### PR DESCRIPTION
This PR moves the "saved" blocks panel to the bottom of the list and adds an icon representative of these special blocks — it's also shown on the block itself when you insert it.

![image](https://user-images.githubusercontent.com/548849/40729534-deb7897e-642c-11e8-8967-579e170da72f.png)
