### PR TITLE
Fix regression in Spacer block

### DIFF
--- a/core-blocks/spacer/editor.scss
+++ b/core-blocks/spacer/editor.scss
@@ -1,14 +1,14 @@
 .editor-block-list__block[data-type="core/spacer"].is-selected .editor-block-list__block-edit {
 	background: $light-gray-200;
 
-	.block-spacer__resize-handler-top,
-	.block-spacer__resize-handler-bottom {
+	.core-blocks-spacer__resize-handler-top,
+	.core-blocks-spacer__resize-handler-bottom {
 		display: block;
 	}
 }
 
-.block-spacer__resize-handler-top,
-.block-spacer__resize-handler-bottom {
+.core-blocks-spacer__resize-handler-top,
+.core-blocks-spacer__resize-handler-bottom {
 	display: none;
 	border-radius: 50%;
 	border: 2px solid white;

--- a/core-blocks/spacer/index.js
+++ b/core-blocks/spacer/index.js
@@ -47,8 +47,8 @@ export const settings = {
 						} }
 						minHeight="20"
 						handleClasses={ {
-							top: 'core-blocks-spacer__resize-handler-top',
-							bottom: 'core-blocks-spacer__resize-handler-bottom',
+							top: 'block-spacer__resize-handler-top',
+							bottom: 'block-spacer__resize-handler-bottom',
 						} }
 						enable={ {
 							top: true,

--- a/core-blocks/spacer/index.js
+++ b/core-blocks/spacer/index.js
@@ -47,8 +47,8 @@ export const settings = {
 						} }
 						minHeight="20"
 						handleClasses={ {
-							top: 'block-spacer__resize-handler-top',
-							bottom: 'block-spacer__resize-handler-bottom',
+							top: 'core-blocks-spacer__resize-handler-top',
+							bottom: 'core-blocks-spacer__resize-handler-bottom',
 						} }
 						enable={ {
 							top: true,


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/WordPress/gutenberg/commit/59f2ad86bc66ebf5f4008b2dfcfbd782966ee253, which made the resizing dots disappear from the spacer block. You could still resize, there just weren't any visual handles. This fixes that.

There was a typo in the rename of the drag handle and associated CSS class.

![screen shot 2018-05-30 at 19 13 13](https://user-images.githubusercontent.com/1204802/40736228-bcdf150e-643d-11e8-868a-88f9f91a3970.png)
