### PR TITLE
Color Palette support setup with single array argument (backwards compatible)

### DIFF
--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -8,7 +8,7 @@ To opt-in for one of these features, call `add_theme_support` in the `functions.
 
 ```php
 function mytheme_setup_theme_supported_features() {
-	add_theme_support( 'editor-color-palette',
+	add_theme_support( 'editor-color-palette', array(
 		array(
 			'name' => 'strong magenta',
 			'color' => '#a156b4',
@@ -24,8 +24,8 @@ function mytheme_setup_theme_supported_features() {
 		array(
 			'name' => 'very dark gray',
 			'color' => '#444',
-		)
-	);
+		),
+	) );
 }
 
 add_action( 'after_setup_theme', 'mytheme_setup_theme_supported_features' );
@@ -46,7 +46,7 @@ add_theme_support( 'align-wide' );
 Different blocks have the possibility of customizing colors. Gutenberg provides a default palette, but a theme can overwrite it and provide its own:
 
 ```php
-add_theme_support( 'editor-color-palette',
+add_theme_support( 'editor-color-palette', array(
 	array(
 		'name' => 'strong magenta',
 		'color' => '#a156b4',
@@ -62,8 +62,8 @@ add_theme_support( 'editor-color-palette',
 	array(
 		'name' => 'very dark gray',
 		'color' => '#444',
-	)
-);
+	),
+) );
 ```
 
 The colors will be shown in order on the palette, and there's no limit to how many can be specified.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1025,7 +1025,18 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
 	$align_wide              = get_theme_support( 'align-wide' );
-	$color_palette           = get_theme_support( 'editor-color-palette' );
+	$color_palette           = current( (array) get_theme_support( 'editor-color-palette' ) );
+
+	// Backcompat for Color Palette set as multiple parameters.
+	if ( is_string( $color_palette ) || isset( $color_palette['color'] ) ) {
+		$color_palette = get_theme_support( 'editor-color-palette' );
+		wp_add_inline_script(
+			'wp-edit-post',
+			'console.warn( "' .
+				__( 'Setting colors using multiple parameters is deprecated. Please pass a single parameter with an array of colors. See https://wordpress.org/gutenberg/handbook/extensibility/theme-support/ for details.', 'gutenberg' ) .
+			'");'
+		);
+	}
 
 	// Backcompat for Color Palette set through `gutenberg` array.
 	if ( empty( $color_palette ) && ! empty( $gutenberg_theme_support[0]['colors'] ) ) {


### PR DESCRIPTION
## Description

Allowing `editor-color-palette` theme support setup with a single array of colors parameter/argument. This way only one argument is passed to `add_theme_support( 'editor-color-palette', $arg )` instead of multiple arguments for each color.

This code is backwards compatible with current implementation (colors are passed as multiple parameters/arguments).

Fising issue #6425