### PR TITLE
Blocks: Remove onFocus from core blocks' RichText usage

### DIFF
--- a/core-blocks/gallery/gallery-image.js
+++ b/core-blocks/gallery/gallery-image.js
@@ -134,7 +134,7 @@ class GalleryImage extends Component {
 						value={ caption }
 						isSelected={ this.state.captionSelected }
 						onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
-						onFocus={ this.onSelectCaption }
+						unstableOnFocus={ this.onSelectCaption }
 						inlineToolbar
 					/>
 				) : null }

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -395,7 +395,7 @@ class ImageEdit extends Component {
 							tagName="figcaption"
 							placeholder={ __( 'Write caption…' ) }
 							value={ caption || [] }
-							onFocus={ this.onFocusCaption }
+							unstableOnFocus={ this.onFocusCaption }
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
 							isSelected={ this.state.captionFocused }
 							inlineToolbar

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -111,6 +111,7 @@ export class RichText extends Component {
 		this.onInit = this.onInit.bind( this );
 		this.getSettings = this.getSettings.bind( this );
 		this.onSetup = this.onSetup.bind( this );
+		this.onFocus = this.onFocus.bind( this );
 		this.onChange = this.onChange.bind( this );
 		this.onNewBlock = this.onNewBlock.bind( this );
 		this.onNodeChange = this.onNodeChange.bind( this );
@@ -185,6 +186,7 @@ export class RichText extends Component {
 		editor.on( 'BeforeExecCommand', this.onPropagateUndo );
 		editor.on( 'PastePreProcess', this.onPastePreProcess, true /* Add before core handlers */ );
 		editor.on( 'paste', this.onPaste, true /* Add before core handlers */ );
+		editor.on( 'focus', this.onFocus );
 		editor.on( 'input', this.onChange );
 		// The change event in TinyMCE fires every time an undo level is added.
 		editor.on( 'change', this.onCreateUndoLevel );
@@ -396,6 +398,30 @@ export class RichText extends Component {
 			} else {
 				this.splitContent( content, { paste: true } );
 			}
+		}
+	}
+
+	/**
+	 * Handles a focus event on the contenteditable field, calling the
+	 * `unstableOnFocus` prop callback if one is defined. The callback does not
+	 * receive any arguments.
+	 *
+	 * This is marked as a private API and the `unstableOnFocus` prop is not
+	 * documented, as the current requirements where it is used are subject to
+	 * future refactoring following `isSelected` handling.
+	 *
+	 * In contrast with `setFocusedElement`, this is only triggered in response
+	 * to focus within the contenteditable field, whereas `setFocusedElement`
+	 * is triggered on focus within any `RichText` descendent element.
+	 *
+	 * @see setFocusedElement
+	 *
+	 * @private
+	 */
+	onFocus() {
+		const { unstableOnFocus } = this.props;
+		if ( unstableOnFocus ) {
+			unstableOnFocus();
 		}
 	}
 


### PR DESCRIPTION
Closes #6944

This pull request seeks to remove core blocks' use of `RichText` `onFocus`, which was deprecated in 2.8 and slated for removal in 3.0. Rather than restore functionality of the `onFocus` prop, which would have the effect of not breaking `onFocus` as-promised by compatibility messaging for existing plugin use, and given that the current plan is for `onFocus` to not remain in its current form pending refactoring as discussed / proposed in #6871, I opted instead for a separate, private (unstable) prop name `unstableOnFocus`.

__Testing instructions:__

I don't know why these blocks use this. There are no code comments for myself, the future maintainer, to reference. I guess based on the callback handler, something about captions and block being selected?

https://github.com/WordPress/gutenberg/blob/eb4fc18fa1c8cae5daf22afd51b9fe22c7f89513/core-blocks/gallery/gallery-image.js#L39-L49

**Edit:** Okay, I think the expected behavior we want to preserve, for gallery at least, is that clicking a caption directly without first selecting the image in the gallery causes the image in the gallery to be selected. Still not sure about image block.