### PR TITLE
Provide cross-browser node containment checking

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -150,6 +150,13 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/dom/index.js' ),
 		true
 	);
+	wp_add_inline_script(
+		'wp-dom',
+		gutenberg_get_script_polyfill( array(
+			'document.contains' => 'node-contains',
+		) ),
+		'before'
+	);
 	wp_register_script(
 		'wp-utils',
 		gutenberg_url( 'build/utils/index.js' ),
@@ -559,6 +566,10 @@ function gutenberg_register_vendor_scripts() {
 	gutenberg_register_vendor_script(
 		'formdata',
 		'https://unpkg.com/formdata-polyfill@3.0.9/formdata.min.js'
+	);
+	gutenberg_register_vendor_script(
+		'node-contains',
+		'https://unpkg.com/polyfill-library@3.26.0-0/polyfills/Node/prototype/contains/polyfill.js'
 	);
 }
 


### PR DESCRIPTION
## Description

IE11's `Node#contains` implementation does not support checking whether text nodes are contained within an element, and `Node#contains` is used by at least the `Autocomplete` component. This PR adds a `nodeContains` function to the `@wordpress/dom` package to provide containment checking that works cross-browser.

Honestly, I'd prefer to add a polyfill so `Node#contains` just works throughout our code base, but with the breakdown of packages and dependencies, I'm not sure where and how it should be added. I see how we are including external polyfills in `lib/client-assets.php` but have not identified a good external polyfill for this.

I'm putting this out there because it is working, and we can convert it to a polyfill if desired.

This update is part of getting autocompletion working in IE11. It was originally part of #6667.

## How has this been tested?
Unit tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
