### PR TITLE
Add formatting options to the Table block inspector sidebar

### DIFF
--- a/core-blocks/table/editor.scss
+++ b/core-blocks/table/editor.scss
@@ -7,7 +7,7 @@
 	td,
 	th {
 		padding: 0.5em;
-		border: 1px solid currentColor;
+		border: 1px solid #444;
 	}
 
 	td[data-mce-selected="1"],

--- a/core-blocks/table/index.js
+++ b/core-blocks/table/index.js
@@ -10,13 +10,13 @@ import classnames from 'classnames';
 import { Fragment } from '@wordpress/element';
 import { getPhrasingContentSchema } from '@wordpress/blocks';
 import {
-	BlockControls,
 	BlockAlignmentToolbar,
 	RichText,
 	InspectorControls,
 } from '@wordpress/editor';
 
 import {
+	BaseControl,
 	PanelBody,
 	ToggleControl,
 } from '@wordpress/components';
@@ -119,12 +119,6 @@ export const settings = {
 
 		return (
 			<Fragment>
-				<BlockControls>
-					<BlockAlignmentToolbar
-						value={ attributes.align }
-						onChange={ updateAlignment }
-					/>
-				</BlockControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Table Settings' ) } className="blocks-table-settings">
 						<ToggleControl
@@ -132,6 +126,16 @@ export const settings = {
 							checked={ !! hasFixedLayout }
 							onChange={ toggleFixedLayout }
 						/>
+						<BaseControl
+							label={ __( 'Alignment' ) }
+							id="inspector-block-alignment"
+							className="components-block-alignment"
+						>
+							<BlockAlignmentToolbar
+								value={ attributes.align }
+								onChange={ updateAlignment }
+							/>
+						</BaseControl>
 					</PanelBody>
 				</InspectorControls>
 				<TableBlock

--- a/core-blocks/table/style.scss
+++ b/core-blocks/table/style.scss
@@ -13,7 +13,7 @@
 	td,
 	th {
 		padding: 0.5em;
-		border: 1px solid currentColor;
+		border: 1px solid #444;
 	}
 
 	// Fixed layout toggle

--- a/core-blocks/table/style.scss
+++ b/core-blocks/table/style.scss
@@ -21,3 +21,6 @@
 		table-layout: fixed;
 	}
 }
+.edit-post-sidebar .components-block-alignment .components-toolbar {
+	margin-bottom: 0;
+}

--- a/core-blocks/table/table-block.js
+++ b/core-blocks/table/table-block.js
@@ -1,18 +1,27 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { find, parseInt, isEmpty } from 'lodash';
+import tinycolor from 'tinycolor2';
 
 /**
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
-import { Toolbar, DropdownMenu } from '@wordpress/components';
+import {
+	Toolbar,
+	DropdownMenu,
+	FontSizePicker,
+	PanelBody,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
+	ContrastChecker,
+	InspectorControls,
+	PanelColor,
 } from '@wordpress/editor';
 
 /**
@@ -81,17 +90,45 @@ const TABLE_CONTROLS = [
 	},
 ];
 
+const FONT_SIZES = [
+	{
+		name: 'small',
+		shortName: 'S',
+		size: 14,
+	},
+	{
+		name: 'regular',
+		shortName: 'M',
+		size: 16,
+	},
+	{
+		name: 'large',
+		shortName: 'L',
+		size: 36,
+	},
+	{
+		name: 'larger',
+		shortName: 'XL',
+		size: 48,
+	},
+];
+
 export default class TableBlock extends Component {
 	constructor() {
-		super();
+		super( ...arguments );
 		this.handleSetup = this.handleSetup.bind( this );
-		this.alignText = this.alignText.bind( this );
+		this.getFontSize = this.getFontSize.bind( this );
+		this.setFontSize = this.setFontSize.bind( this );
+		this.setBorderColor = this.setBorderColor.bind( this );
+		this.updateTableCellStyle = this.updateTableCellStyle.bind( this );
 		this.state = {
 			editor: null,
 		};
 	}
 
-	handleSetup( editor, isSelected ) {
+	handleSetup( editor ) {
+		const { isSelected } = this.props;
+
 		// select the end of the first table cell
 		editor.on( 'init', () => {
 			if ( isSelected ) {
@@ -99,47 +136,129 @@ export default class TableBlock extends Component {
 			}
 		} );
 
-		// Update the alignment toolbar to match the CSS `text-align`
-		// property of the current table cell.
+		// Update the alignment toolbar, font size, text and background color
+		// value for the current table cell.
 		editor.on( 'nodechange', ( { selectionChange, parents } ) => {
 			if ( document.activeElement !== editor.getBody() ) {
 				return;
 			}
+
 			if ( selectionChange ) {
 				const selectedCell = find( parents, ( node ) => node.tagName === 'TD' || node.tagName === 'TH' );
-				const textAlign = selectedCell ? selectedCell.style.textAlign : null;
-				this.setState( { textAlign } );
+				const {
+					textAlign,
+					borderColor,
+					fontSize,
+					color,
+					backgroundColor,
+				} = selectedCell ? selectedCell.style : {};
+
+				this.setFontSize( parseInt( fontSize ) );
+				this.setState( {
+					textAlign,
+					color: color ? tinycolor( color ).toHexString() : null,
+					backgroundColor: backgroundColor ? tinycolor( backgroundColor ).toHexString() : null,
+					borderColor: borderColor ? tinycolor( borderColor ).toHexString() : null,
+				} );
 			}
 		} );
 
 		this.setState( { editor } );
 	}
 
+	// Get the correct font size value using the font size data stored
+	// in state.
+	getFontSize() {
+		const { customFontSize, fontSize } = this.state;
+
+		if ( fontSize ) {
+			const fontSizeObj = find( FONT_SIZES, { name: fontSize } );
+			if ( fontSizeObj ) {
+				return fontSizeObj.size;
+			}
+		}
+
+		if ( customFontSize ) {
+			return customFontSize;
+		}
+	}
+
 	/**
-	 * Sets the CSS `text-align` property of the current table cell.
+	 * Save the correct font size value in state. If the font size is a
+	 * defined in the `FONT_SIZES` constant, save the name of the font
+	 * size instead.
 	 *
-	 * @param {string} nextAlign The next `text-align` value to set.
+	 * @param {number} fontSizeValue The numeric font size value.
 	 */
-	alignText( nextAlign ) {
+	setFontSize( fontSizeValue ) {
+		const thresholdFontSize = find( FONT_SIZES, { size: fontSizeValue } );
+
+		if ( thresholdFontSize ) {
+			this.setState( {
+				fontSize: thresholdFontSize.name,
+				customFontSize: undefined,
+			} );
+			return;
+		}
+
+		this.setState( {
+			fontSize: undefined,
+			customFontSize: fontSizeValue,
+		} );
+	}
+
+	/**
+	 * Sets the specified CSS property of the current table cell.
+	 *
+	 * @param {string} 					property					The CSS property name (camelcased).
+	 * @param {(string|number)}	value 						The value to set.
+	 * @param {boolean}					updateStateValue 	Whether to update the property value stored in state.
+	 */
+	updateTableCellStyle( property, value, updateStateValue = true ) {
 		const { editor } = this.state;
 		const { onChange } = this.props;
 		const currentNode = editor.selection.getNode();
 		const tableCell = editor.dom.getParent( currentNode, ( parentNode ) => parentNode.tagName === 'TD' || parentNode.tagName === 'TH' );
 
 		if ( tableCell ) {
-			// If `nextAlign` is undefined, set the `textAlign` value to an empty
-			// string in order to update both the CSS `text-align` property on the
-			// current table cell and the current state value.
-			const textAlign = nextAlign ? nextAlign : '';
-			editor.dom.setStyle( tableCell, 'text-align', textAlign );
+			// If `propertyValue` is undefined, set `propertyValue` to an empty
+			// string in order to update both the CSS property on the current
+			// table cell and the current state value.
+			const propertyValue = value ? value : '';
+			editor.dom.setStyle( tableCell, property, propertyValue );
 			const content = domToFormat( editor.getBody().childNodes || [], 'element', editor );
 			onChange( content );
-			this.setState( { textAlign } );
+
+			if ( updateStateValue ) {
+				this.setState( { [ property ]: propertyValue } );
+			}
+		}
+	}
+
+	/**
+	 * Set the border color for each table cell.
+	 *
+	 * @param {string} nextBorderColor The next border color value to set.
+	 */
+	setBorderColor( nextBorderColor ) {
+		const { onChange } = this.props;
+		const { editor } = this.state;
+		const cells = editor.dom.select( 'td,th' );
+
+		if ( ! isEmpty( cells ) ) {
+			const borderColor = nextBorderColor ? nextBorderColor : '';
+			editor.dom.setStyle( cells, 'border-color', borderColor );
+			const content = domToFormat( editor.getBody().childNodes || [], 'element', editor );
+			onChange( content );
+
+			this.setState( { borderColor: nextBorderColor } );
 		}
 	}
 
 	render() {
-		const { content, onChange, className, isSelected } = this.props;
+		const { content, onChange, className } = this.props;
+		const { textAlign, color, backgroundColor, borderColor, editor } = this.state;
+		const fontSize = this.getFontSize();
 
 		return (
 			<Fragment>
@@ -151,7 +270,8 @@ export default class TableBlock extends Component {
 						plugins: ( settings.plugins || [] ).concat( 'table' ),
 						table_tab_navigation: false,
 					} ) }
-					onSetup={ ( editor ) => this.handleSetup( editor, isSelected ) }
+					style={ borderColor ? { borderColor } : null }
+					onSetup={ ( currentEditor ) => this.handleSetup( currentEditor ) }
 					onChange={ onChange }
 					value={ content }
 				/>
@@ -163,15 +283,50 @@ export default class TableBlock extends Component {
 							controls={
 								TABLE_CONTROLS.map( ( control ) => ( {
 									...control,
-									onClick: () => control.onClick( this.state.editor ),
+									onClick: () => control.onClick( editor ),
 								} ) ) }
 						/>
 					</Toolbar>
 					<AlignmentToolbar
-						value={ this.state.textAlign }
-						onChange={ this.alignText }
+						value={ textAlign }
+						onChange={ ( nextAlign ) => this.updateTableCellStyle( 'textAlign', nextAlign ) }
 					/>
 				</BlockControls>
+				<InspectorControls>
+					<PanelColor
+						colorValue={ borderColor }
+						initialOpen={ false }
+						title={ __( 'Border Color' ) }
+						onChange={ this.setBorderColor }
+					/>
+					<PanelBody title={ __( 'Text Size' ) } className="blocks-font-size">
+						<FontSizePicker
+							fontSizes={ FONT_SIZES }
+							value={ fontSize }
+							onChange={ ( nextFontSize ) => {
+								this.updateTableCellStyle( 'fontSize', nextFontSize, false );
+								this.setFontSize( nextFontSize );
+							} }
+						/>
+					</PanelBody>
+					<PanelColor
+						colorValue={ color }
+						initialOpen={ false }
+						title={ __( 'Text Color' ) }
+						onChange={ ( nextTextColor ) => this.updateTableCellStyle( 'color', nextTextColor ) }
+					/>
+					<ContrastChecker
+						textColor={ color }
+						backgroundColor={ backgroundColor }
+						isLargeText={ fontSize >= 18 }
+					/>
+					<PanelColor
+						colorValue={ backgroundColor }
+						initialOpen={ false }
+						title={ __( 'Background Color' ) }
+						onChange={ ( nextBackgroundColor ) => this.updateTableCellStyle( 'backgroundColor', nextBackgroundColor ) }
+					/>
+				</InspectorControls>
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
## Description
Related #6923.

This PR addresses my issue #7008 which requests that formatting options be added to the **Table** block inspector sidebar. The following formats were added:
1. Table border color
2. Table cell text size
3. Table cell text color
4. Table cell background color

## How has this been tested?
This solution was tested using the following steps:
1. Create a new page, add a Table block, then add text to each of the four initial table cells.
2. Select any cell and apply a border color (applies to all cells).
3. Select each cell and apply a text and background color, and text size.
4. Ensure that each adjustment creates an undo level for the TinyMCE instance by checking changes that occur when pressing the Undo and Redo action buttons.
5. Ensure all changes save correctly when saving then previewing the page.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots
<img width="500" alt="sidebar" src="https://user-images.githubusercontent.com/39569148/40751903-2f9cc800-643b-11e8-8544-551cde91fc11.gif">

## Types of changes
1. **New dependencies**
   - `isEmpty` and `parseInt` from lodash
   - `tinycolor` from tinycolor2
   - `FontSizePicker` and `PanelBody` from @wordpress/components
   - `ContrastChecker`, `InspectorControls` and `PanelColor` from @wordpress/editor
2. **Stylesheet changes** - Changed default border color to dark grey since the previous style inherited the color from the `color` property.
3. New Table block methods to help set styles and state

This was tested in:

- WordPress 4.9.6
- Gutenberg 2.9.2
- Apache/PHP 7.1.16
- MySQL 5.7.22

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
