### PR TITLE
Fix a typo in classic block, and scope Quote editor styles

### DIFF
--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -14,7 +14,7 @@ export const name = 'core/freeform';
 export const settings = {
 	title: __( 'Classic' ),
 
-	description: __( 'It\'s the classic WordPress editor and it\'s block! Drop the editor right in.' ),
+	description: __( 'It\'s the classic WordPress editor and it\'s a block! Drop the editor right in.' ),
 
 	icon: 'editor-kitchensink',
 

--- a/core-blocks/quote/editor.scss
+++ b/core-blocks/quote/editor.scss
@@ -1,13 +1,12 @@
-.editor-block-list__block[data-type="core/quote"] .wp-block-quote {
+.wp-block-quote {
 	margin: 0;
 
 	cite {
 		display: block;
 	}
+}
 
-	&:not(.is-large) {
-		border-left: 4px solid $black;
-		padding-left: 1em;
-	}
-	
+.wp-block-quote:not(.is-large) {
+	border-left: 4px solid $black;
+	padding-left: 1em;
 }

--- a/core-blocks/quote/editor.scss
+++ b/core-blocks/quote/editor.scss
@@ -1,12 +1,13 @@
-.wp-block-quote {
+.editor-block-list__block[data-type="core/image"] .wp-block-quote {
 	margin: 0;
 
 	cite {
 		display: block;
 	}
-}
 
-.wp-block-quote:not(.is-large) {
-	border-left: 4px solid $black;
-	padding-left: 1em;
+	&:not(.is-large) {
+		border-left: 4px solid $black;
+		padding-left: 1em;
+	}
+	
 }

--- a/core-blocks/quote/editor.scss
+++ b/core-blocks/quote/editor.scss
@@ -1,4 +1,4 @@
-.editor-block-list__block[data-type="core/image"] .wp-block-quote {
+.editor-block-list__block[data-type="core/quote"] .wp-block-quote {
 	margin: 0;
 
 	cite {


### PR DESCRIPTION
This PR does two things

1. It fixes a typo in the classic block

2. It scopes the editor quote styles to truly be editor-only.

Number 2 is important for implementations that might load Gutenberg itself on the front-end. Scoping the styles to be in-editor helps prevent CSS bleed to outside the editing canvas. 

I would like your thoughts on this, because if 2 is approved, then perhaps we should use the same pattern for all other blocks. Right now were using a mixture of `.editor-block-list__block[data-type="core/blockname"]` and `.wp-block-blockname`. If every editor style was scoped with the former, we'd truly keep it in-canvas, enhancing reusability.

Let me know if this is a good plan, and I'll expand this PR with a few commits. 

By the way this PR was done "blind", because I'm blocked on what I think is an issue with the build process currently: https://github.com/WordPress/gutenberg/pull/7027#issuecomment-393442906