### PR TITLE
Build Tooling: Avoid using spread for objects to work with all node 8x versions

### DIFF
--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -20,26 +20,32 @@ const plugins = map( babelDefaultConfig.plugins, ( plugin ) => {
 } );
 
 const babelConfigs = {
-	main: {
-		...babelDefaultConfig,
-		babelrc: false,
-		plugins,
-		presets: map( babelDefaultConfig.presets, ( preset ) => {
-			if ( isArray( preset ) && preset[ 0 ] === babelPresetEnv ) {
-				return [ babelPresetEnv, Object.assign(
-					{},
-					preset[ 1 ],
-					{ modules: 'commonjs' }
-				) ];
-			}
-			return preset;
-		} ),
-	},
-	module: {
-		...babelDefaultConfig,
-		babelrc: false,
-		plugins,
-	},
+	main: Object.assign(
+		{},
+		babelDefaultConfig,
+		{
+			babelrc: false,
+			plugins,
+			presets: map( babelDefaultConfig.presets, ( preset ) => {
+				if ( isArray( preset ) && preset[ 0 ] === babelPresetEnv ) {
+					return [ babelPresetEnv, Object.assign(
+						{},
+						preset[ 1 ],
+						{ modules: 'commonjs' }
+					) ];
+				}
+				return preset;
+			} ),
+		}
+	),
+	module: Object.assign(
+		{},
+		babelDefaultConfig,
+		{
+			babelrc: false,
+			plugins,
+		}
+	),
 };
 
 function getBabelConfig( environment ) {


### PR DESCRIPTION
## Description

Fixes issue raised by @jasmussen:

> Could this PR have broken `npm install` for me? I'm getting this error:
> 
> <img width="913" alt="screen shot 2018-05-31 at 09 51 15" src="https://user-images.githubusercontent.com/1204802/40769422-3c97366c-64b8-11e8-97df-49d95a4023d7.png">
> 

## How has this been tested?
`npm install`
`npm run dev`
`npm run build`

All of them should work on Node 8.2.x.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
