### PR TITLE
Packages: Always publish main and module distributions

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -17,7 +17,8 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"main": "src/index.js",
+	"main": "build/index.js",
+	"module": "build-module/index.js",
 	"dependencies": {
 		"@wordpress/deprecated": "^1.0.0-alpha.0",
 		"@wordpress/element": "^1.0.0-alpha.0",

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -16,7 +16,8 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"main": "src/index.js",
+	"main": "build/index.js",
+	"module": "build-module/index.js",
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -17,7 +17,7 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"main": "src/index.js",
+	"main": "build/index.js",
 	"dependencies": {
 		"lodash": "4.17.5",
 		"webpack-sources": "1.1.0"

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -20,7 +20,7 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"main": "src/index.js",
+	"main": "build/index.js",
 	"dependencies": {
 		"postcss": "^6.0.16"
 	},


### PR DESCRIPTION
## Description

> Reported by @Shelob9:
> I'm getting an error when importing the data package, or requiring it. I'm using create-react-app.
> 
> `const data = require( '@wordpress/data' );` and `import { data } from '@wordpress/data';` result in Jest throwing an error like this:
> 
> 
> ```
> /caldera-grid/node_modules/@wordpress/data/src/index.js:4
>     import { combineReducers, createStore } from 'redux';
>            ^
>     
>     SyntaxError: Unexpected token {
> ```

The issue was on my side. I didn't set `main` and `module` inside `package.json` files properly. This PR fixes it.

## How has this been tested?
`npm run dev` and `npm run build` still work properly.

@youknowriad, can you confirm that `postcss-themes` still works as expected?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
