### PR TITLE
Fix issue with rich text toolbar being gone in captions

### DIFF
--- a/core-blocks/gallery/editor.scss
+++ b/core-blocks/gallery/editor.scss
@@ -2,7 +2,7 @@
 	margin: 0px;
 }
 .gutenberg .wp-block-gallery:not( .components-placeholder ) {
-	// allow gallery items to go edge to edge
+	// Allow gallery items to go edge to edge.
 	margin-left: -8px;
 	margin-right: -8px;
 }
@@ -35,13 +35,13 @@
 		left: 4px;
 		margin-top: -4px;
 
-		// if this inline toolbar has negative margin, it's hidden by the overflow that we need for scrolling long captions
+		// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
 		.editor-rich-text__inline-toolbar {
 			top: 0;
 		}
 
-		// make extra space for the inline toolbar
-		figcaption {
+		// Make extra space for the inline toolbar.
+		.editor-rich-text__tinymce {
 			padding-top: 48px;
 		}
 	}

--- a/core-blocks/gallery/editor.scss
+++ b/core-blocks/gallery/editor.scss
@@ -34,6 +34,16 @@
 		width: calc( 100% - 8px );
 		left: 4px;
 		margin-top: -4px;
+
+		// if this inline toolbar has negative margin, it's hidden by the overflow that we need for scrolling long captions
+		.editor-rich-text__inline-toolbar {
+			top: 0;
+		}
+
+		// make extra space for the inline toolbar
+		figcaption {
+			padding-top: 48px;
+		}
 	}
 
 	.components-form-file-upload,


### PR DESCRIPTION
Fixes #7049.

This changes how the caption field works in gallery items, so that the rich text toolbar is present. It was pushed upwards, and therefore hidden by an overflow rule. But that overflow rule was there to ensure that if you write an essay as a caption, the caption scrolls.

<img width="310" alt="screen shot 2018-05-31 at 13 19 35" src="https://user-images.githubusercontent.com/1204802/40779734-536c0e44-64d6-11e8-8ac5-f17f355e5119.png">

<img width="257" alt="screen shot 2018-05-31 at 13 19 40" src="https://user-images.githubusercontent.com/1204802/40779737-54f94f2e-64d6-11e8-8bcf-3ae88981332d.png">

<img width="249" alt="screen shot 2018-05-31 at 13 19 44" src="https://user-images.githubusercontent.com/1204802/40779739-565983b6-64d6-11e8-8c6f-2dd62354b676.png">
