### PR TITLE
Fix: Wrong color on active toolbar buttons in classic block

### DIFF
--- a/core-blocks/freeform/editor.scss
+++ b/core-blocks/freeform/editor.scss
@@ -189,3 +189,7 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 .freeform-toolbar.has-advanced-toolbar .mce-toolbar-grp .mce-toolbar {
 	display: block;
 }
+
+.freeform-toolbar .mce-toolbar .mce-btn.mce-active i {
+	color: #555d66;
+}


### PR DESCRIPTION
## Description
This PR addresses #6978 which reports the wrong color on active toolbar buttons in the classic block.

## Reason of the issue
This issue seems to have been introduced in the latest WP release (4.9.6). I'm assuming this might be due to TinyMCE's update to 4.7.11.

However, this only happens in Gutenberg editor and not the classic editor because of the way the `wp-includes/css/editor.css` file in being enqueued. 

In case of the classic editor, it is enqueued inside the `wp-content-wrap` element, i.e. after TinyMCE's skin CSS is enqueued (in `<head>`).

In case of the Gutenberg editor, the `wp-includes/css/editor.css` is enqueued in `<head>` prior to TinyMCE's skin CSS, as a result, the TinyMCE's skin CSS is holding more priority, thus causing the issue.
(Text extracted/adapted from [#6978(comment)](https://github.com/WordPress/gutenberg/issues/6978#issuecomment-393546998) ).

## How has this been tested?
This PR verifies that the active toolbar buttons have the correct colors (according to the classic editor). This was tested in WP 4.9.6, Gutenberg 2.9.2, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-6978](https://user-images.githubusercontent.com/20284937/40789360-0ec4842c-6514-11e8-80cc-99089c02ead7.png)


## Types of changes
This PR just adds CSS to freeform block's `editor.scss` file to force the correct color only in case of Gutenberg's classic block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
