### PR TITLE
Fix getInserterItems cache.

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1538,6 +1538,7 @@ export const getInserterItems = createSelector(
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
 		state.sharedBlocks.data,
+		getBlockTypes(),
 	],
 );
 


### PR DESCRIPTION
The selector depended on the result of getBlockTypes() but it was not being taken into account on the creatSelector dependents.

cc: @aduth 