### PR TITLE
Fix a JavaScript error when focus is attempted on undefined

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -684,6 +684,9 @@ export class RichText extends Component {
 			// Otherwise, position the Link UI below the cursor or text selection
 			rect = getRectangleFromRange( this.editor.selection.getRng() );
 		}
+		if ( ! rect ) {
+			return;
+		}
 		const focusPosition = this.getFocusPosition( rect );
 
 		this.setState( { formats, focusPosition, selectedNodeId: this.state.selectedNodeId + 1 } );


### PR DESCRIPTION
## Description
In our custom blocks, we sometimes see an error in the console:
`cannot read property 'top' of undefined`

![](https://cl.ly/3v1N033z1z2G/Image%202018-05-31%20at%2011.10.18%20AM.png)

This is happening here in the `RichText` component in `getFocusPosition`: https://github.com/WordPress/gutenberg/blob/master/editor/components/rich-text/index.js#L433

which is called from `onNodeChange` here: https://github.com/WordPress/gutenberg/blob/master/editor/components/rich-text/index.js#L687

I don't quite understand why the `rect` setup fails (https://github.com/WordPress/gutenberg/blob/master/editor/components/rich-text/index.js#L680-L686) and I can look into this further, however adding a safety check and bailing early here to avoid JavaScript errors still seems useful in case rect is undefined in some other cases.

## How has this been tested?
In my local, I see the error from the screenshot above when interacting with my custom block. With the code change, the error no longer appears.


## Types of changes

Add a check in `RichText->onNodeChange` to see if `rect` was found before attempting to use it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
