### PR TITLE
Simplify the Inserter accessibility

### DIFF
--- a/editor/components/inserter/item-list.js
+++ b/editor/components/inserter/item-list.js
@@ -19,40 +19,47 @@ class ItemList extends Component {
 		const { items, onSelect, onHover } = this.props;
 
 		return (
-			<div className="editor-inserter__item-list">
+			/*
+			 * Disable reason: The `list` ARIA role is redundant but
+			 * Safari+VoiceOver won't announce the list otherwise.
+			 */
+			/* eslint-disable jsx-a11y/no-redundant-roles */
+			<ul role="list" className="editor-inserter__list">
 				{ items.map( ( item ) => {
 					return (
-						<button
-							key={ item.id }
-							className={
-								classnames(
-									'editor-inserter__item',
-									getBlockMenuDefaultClassName( item.id ),
-									{
-										'editor-inserter__item-has-children': item.hasChildBlocks,
-									}
-								)
-							}
-							onClick={ () => onSelect( item ) }
-							disabled={ item.isDisabled }
-							onMouseEnter={ () => onHover( item ) }
-							onMouseLeave={ () => onHover( null ) }
-							onFocus={ () => onHover( item ) }
-							onBlur={ () => onHover( null ) }
-							aria-label={ item.title } // Fix for IE11 and JAWS 2018.
-						>
-							<span className="editor-inserter__item-icon">
-								<BlockIcon icon={ item.icon } />
-								{ item.hasChildBlocks && <span className="editor-inserter__item-icon-stack" /> }
-							</span>
+						<li className="editor-inserter__list-item" key={ item.id }>
+							<button
+								className={
+									classnames(
+										'editor-inserter__item',
+										getBlockMenuDefaultClassName( item.id ),
+										{
+											'editor-inserter__item-has-children': item.hasChildBlocks,
+										}
+									)
+								}
+								onClick={ () => onSelect( item ) }
+								disabled={ item.isDisabled }
+								onMouseEnter={ () => onHover( item ) }
+								onMouseLeave={ () => onHover( null ) }
+								onFocus={ () => onHover( item ) }
+								onBlur={ () => onHover( null ) }
+								aria-label={ item.title } // Fix for IE11 and JAWS 2018.
+							>
+								<span className="editor-inserter__item-icon">
+									<BlockIcon icon={ item.icon } />
+									{ item.hasChildBlocks && <span className="editor-inserter__item-icon-stack" /> }
+								</span>
 
-							<span className="editor-inserter__item-title">
-								{ item.title }
-							</span>
-						</button>
+								<span className="editor-inserter__item-title">
+									{ item.title }
+								</span>
+							</button>
+						</li>
 					);
 				} ) }
-			</div>
+			</ul>
+			/* eslint-enable jsx-a11y/no-redundant-roles */
 		);
 	}
 }

--- a/editor/components/inserter/item-list.js
+++ b/editor/components/inserter/item-list.js
@@ -1,14 +1,12 @@
 /**
  * External dependencies
  */
-import { isEqual } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { NavigableMenu } from '@wordpress/components';
 import { getBlockMenuDefaultClassName } from '@wordpress/blocks';
 
 /**
@@ -16,63 +14,15 @@ import { getBlockMenuDefaultClassName } from '@wordpress/blocks';
  */
 import BlockIcon from '../block-icon';
 
-function deriveActiveItems( items ) {
-	return items.filter( ( item ) => ! item.isDisabled );
-}
-
 class ItemList extends Component {
-	constructor() {
-		super( ...arguments );
-		this.onNavigate = this.onNavigate.bind( this );
-		this.activeItems = deriveActiveItems( this.props.items );
-		this.state = {
-			current: this.activeItems.length > 0 ? this.activeItems[ 0 ] : null,
-		};
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( ! isEqual( this.props.items, prevProps.items ) ) {
-			this.activeItems = deriveActiveItems( this.props.items );
-
-			// Try and preserve any still valid selected state.
-			const currentIsStillActive = this.state.current && this.activeItems.some( ( item ) =>
-				item.id === this.state.current.id
-			);
-
-			if ( ! currentIsStillActive ) {
-				this.setState( {
-					current: this.activeItems.length > 0 ? this.activeItems[ 0 ] : null,
-				} );
-			}
-		}
-	}
-
-	onNavigate( index ) {
-		const { activeItems } = this;
-		const dest = activeItems[ index ];
-		if ( dest ) {
-			this.setState( {
-				current: dest,
-			} );
-		}
-	}
-
 	render() {
 		const { items, onSelect, onHover } = this.props;
-		const { current } = this.state;
 
 		return (
-			<NavigableMenu
-				className="editor-inserter__item-list"
-				orientation="both"
-				cycle={ false }
-				onNavigate={ this.onNavigate }
-			>
+			<div className="editor-inserter__item-list">
 				{ items.map( ( item ) => {
-					const isCurrent = current && current.id === item.id;
 					return (
 						<button
-							role="menuitem"
 							key={ item.id }
 							className={
 								classnames(
@@ -84,7 +34,6 @@ class ItemList extends Component {
 								)
 							}
 							onClick={ () => onSelect( item ) }
-							tabIndex={ isCurrent || item.isDisabled ? null : '-1' }
 							disabled={ item.isDisabled }
 							onMouseEnter={ () => onHover( item ) }
 							onMouseLeave={ () => onHover( null ) }
@@ -103,7 +52,7 @@ class ItemList extends Component {
 						</button>
 					);
 				} ) }
-			</NavigableMenu>
+			</div>
 		);
 	}
 }

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -93,8 +93,14 @@ $block-inserter-search-height: 38px;
 	}
 }
 
-.editor-inserter__item-list {
+.editor-inserter__list {
+	list-style: none;
 	margin: 0 -8px;
+	padding: 0;
+}
+
+.editor-inserter__list-item {
+	display: inline;
 }
 
 .editor-inserter__item {


### PR DESCRIPTION
## Description

This PR aims to simplify the Inserter accessibility. The Inserter is now based on collapsible accordions and many a11y things were implemented with the previous version in mind. Please refer to the related issue #7052 for more details

- removes the ARIA roles
- removes arrows navigation
- removes the active item tracking
- uses a list for the items list

Using a list adds an useful information for users: assistive technologies will announce the total number of items in a list and some screen readers will also announce the position of each item. See screenshot below:

![screen shot 2018-05-31 at 15 24 30](https://user-images.githubusercontent.com/1682452/40788465-6f2d2f4a-64f0-11e8-9e34-a29ea6e386ac.png)

Worth noting Safari has a bug (or "feature"?) and doesn't expose styled lists as lists. It needs an explicitly set ARIA role `list` which would trigger a jsx-a11y validation error (while the W3C validator throws just a warning). It's a known Safari bug you can test on this pen: https://codepen.io/afercia/full/WxmJWx/

Check the Safari dev tools > "node" tab, and see the styled `ul` has "no matching ARIA roles". Now that Chrome has a nice accessibility tab, you can double check on Chrome and see it correctly exposes the styled list as list. So, it seems Safari-specific.

![screen shot 2018-05-31 at 16 00 52](https://user-images.githubusercontent.com/1682452/40788698-ed801a2e-64f0-11e8-81e4-bbb2820c566a.png)

## How has this been tested?
- `npm test`
- rebased to latest changes from #7003 / #6998 and tested 

Fixes #7052 