### PR TITLE
Use new "theme" style mechanism to restore Quote styles on the front.

### DIFF
--- a/core-blocks/quote/editor.scss
+++ b/core-blocks/quote/editor.scss
@@ -3,10 +3,6 @@
 
 	cite {
 		display: block;
+		font-size: $default-font-size;
 	}
-}
-
-.wp-block-quote:not(.is-large) {
-	border-left: 4px solid $black;
-	padding-left: 1em;
 }

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -22,6 +22,7 @@ import {
  */
 import './style.scss';
 import './editor.scss';
+import './theme.scss';
 
 const toRichTextValue = ( value ) => value.map( ( ( subValue ) => subValue.children ) );
 const fromRichTextValue = ( value ) => value.map( ( subValue ) => ( {

--- a/core-blocks/quote/style.scss
+++ b/core-blocks/quote/style.scss
@@ -1,10 +1,8 @@
 .wp-block-quote {
 	cite,
 	footer {
-		color: $dark-gray-300;
 		margin-top: 1em;
 		position: relative;
-		font-size: $default-font-size;
 		font-style: normal;
 	}
 

--- a/core-blocks/quote/theme.scss
+++ b/core-blocks/quote/theme.scss
@@ -1,0 +1,18 @@
+.wp-block-quote {
+	margin: 20px 0;
+
+	cite,
+	footer {
+		color: $dark-gray-300;
+		font-size: $default-font-size;
+	}
+
+	p {
+		margin-bottom: 16px;
+	}
+}
+
+.wp-block-quote:not(.is-large) {
+	border-left: 4px solid $black;
+	padding-left: 1em;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/548849/40795685-1ae73abc-6503-11e8-8268-4a1c7847001e.png)

See #6947. Previously: #3262.