### PR TITLE
Inserter: Expand matching categories when searching

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -159,8 +159,9 @@ export class InserterMenu extends Component {
 
 	render() {
 		const { instanceId, onSelect, rootUID } = this.props;
-		const { childItems, hoveredItem, suggestedItems, sharedItems, itemsPerCategory, openPanels } = this.state;
+		const { childItems, filterValue, hoveredItem, suggestedItems, sharedItems, itemsPerCategory, openPanels } = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
+		const isSearching = !! filterValue;
 
 		// Disable reason: The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of
@@ -207,7 +208,7 @@ export class InserterMenu extends Component {
 							<PanelBody
 								key={ category.slug }
 								title={ category.title }
-								opened={ isPanelOpen( category.slug ) }
+								opened={ isSearching || isPanelOpen( category.slug ) }
 								onToggle={ this.onTogglePanel( category.slug ) }
 							>
 								<ItemList items={ categoryItems } onSelect={ onSelect } onHover={ this.onHover } />

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -281,18 +281,22 @@ describe( 'InserterMenu', () => {
 		);
 		wrapper.find( '.editor-inserter__search' ).simulate( 'change', { target: { value: 'text' } } );
 
-		// Two tabs
-		const tabs = wrapper.find( '.editor-inserter__results .components-panel__body' );
-		expect( tabs ).toHaveLength( 2 );
+		// Two panels
+		const panels = wrapper.find( '.editor-inserter__results .components-panel__body' );
+		expect( panels ).toHaveLength( 2 );
 
-		// The tab one is active
-		const activeCategory = wrapper.find( '.components-panel__body.is-opened > .components-panel__body-title' );
-		expect( activeCategory.text() ).toBe( 'Common Blocks' );
+		// Matching panels expand
+		const matchingCategories = wrapper.find( '.components-panel__body.is-opened > .components-panel__body-title' );
+		expect( matchingCategories ).toHaveLength( 2 );
+		expect( matchingCategories.at( 0 ).text() ).toBe( 'Common Blocks' );
+		expect( matchingCategories.at( 1 ).text() ).toBe( 'Embeds' );
 
+		// Find blocks across panels
 		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
-		expect( visibleBlocks ).toHaveLength( 2 );
+		expect( visibleBlocks ).toHaveLength( 3 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );
+		expect( visibleBlocks.at( 2 ).text() ).toBe( 'A Text Embed' );
 
 		const noResultsMessage = wrapper.find( '.editor-inserter__no-results' );
 		expect( noResultsMessage ).toBeEmpty();
@@ -310,18 +314,22 @@ describe( 'InserterMenu', () => {
 		);
 		wrapper.find( '.editor-inserter__search' ).simulate( 'change', { target: { value: ' text' } } );
 
-		// Two tabs
-		const tabs = wrapper.find( '.editor-inserter__results .components-panel__body' );
-		expect( tabs ).toHaveLength( 2 );
+		// Two panels
+		const panels = wrapper.find( '.editor-inserter__results .components-panel__body' );
+		expect( panels ).toHaveLength( 2 );
 
-		// The tab one is active
-		const activeCategory = wrapper.find( '.components-panel__body.is-opened > .components-panel__body-title' );
-		expect( activeCategory.text() ).toBe( 'Common Blocks' );
+		// Matching panels expand
+		const matchingCategories = wrapper.find( '.components-panel__body.is-opened > .components-panel__body-title' );
+		expect( matchingCategories ).toHaveLength( 2 );
+		expect( matchingCategories.at( 0 ).text() ).toBe( 'Common Blocks' );
+		expect( matchingCategories.at( 1 ).text() ).toBe( 'Embeds' );
 
+		// Find blocks across panels
 		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
-		expect( visibleBlocks ).toHaveLength( 2 );
+		expect( visibleBlocks ).toHaveLength( 3 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );
+		expect( visibleBlocks.at( 2 ).text() ).toBe( 'A Text Embed' );
 	} );
 } );
 


### PR DESCRIPTION
## Description
Fixes #7046 by expanding accordions containing blocks matching a search term.

## How has this been tested?

Per the parent issue:

1. Click the main Add Block button to invoke the Inserter
1. Search, for example, for "embed"
1. Expect to see results akin to:

<img width="300" src="https://user-images.githubusercontent.com/1682452/40775517-92219112-64c8-11e8-94a6-43c85ff268da.png">

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
