### PR TITLE
State: Avoid URL redirect for published post autosave

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -174,6 +174,11 @@ export default {
 		const { previousPost, post, isAutosave } = action;
 		const { dispatch } = store;
 
+		// Autosaves are neither shown a notice nor redirected.
+		if ( isAutosave ) {
+			return;
+		}
+
 		const publishStatus = [ 'publish', 'private', 'future' ];
 		const isPublished = includes( publishStatus, previousPost.status );
 		const willPublish = includes( publishStatus, post.status );
@@ -181,8 +186,8 @@ export default {
 		let noticeMessage;
 		let shouldShowLink = true;
 
-		if ( isAutosave || ( ! isPublished && ! willPublish ) ) {
-			// If autosaving or saving a non-published post, don't show notice.
+		if ( ! isPublished && ! willPublish ) {
+			// If saving a non-published post, don't show notice.
 			noticeMessage = null;
 		} else if ( isPublished && ! willPublish ) {
 			// If undoing publish status, show specific notice

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -359,6 +359,19 @@ describe( 'effects', () => {
 				type: 'CREATE_NOTICE',
 			} ) );
 		} );
+
+		it( 'should do nothing if the updated post was autosaved', () => {
+			const dispatch = jest.fn();
+			const store = { dispatch };
+
+			const previousPost = getPublishedPost();
+			const post = { ...getPublishedPost(), id: defaultPost.id + 1 };
+
+			handler( { post, previousPost, isAutosave: true }, store );
+
+			expect( dispatch ).toHaveBeenCalledTimes( 0 );
+			expect( replaceStateSpy ).toHaveBeenCalledTimes( 0 );
+		} );
 	} );
 
 	describe( '.REQUEST_POST_UPDATE_FAILURE', () => {


### PR DESCRIPTION
Fixes #7066 

This pull request seeks to resolve an issue where the editor URL is replaced with an autosave ID when autosaves occur for published posts. Since autosave posts are not directly editable, this results in an error message if the user proceeds to reload the page.

__Implementation notes:__

As part of some consolidation refactoring in #6257, I made assumptions about an autosave success result receiving a post object, which is only partly correct. In fact, the autosave endpoints return a subset of post properties. Notably, this does not include some properties like `status`, which is considered in both the effects handlers for post save [success](https://github.com/WordPress/gutenberg/blob/802f890fd95b6b668461ce45fd3d01495fe3e9c5/editor/store/effects.js#L173-L222) and [failure](https://github.com/WordPress/gutenberg/blob/802f890fd95b6b668461ce45fd3d01495fe3e9c5/editor/store/effects.js#L223-L240), and would be `undefined` in the case of an autosave. Since these handlers seem to handle this gracefully, I did not address that as part of the changes here, but it seems fragile to allow this assumption to continue.

This change was intended to be the minimal fix to allow a 3.0 release to proceed, but I'd like to proceed with future refactorings of this behavior in subsequent pull requests, both:

- Moving the URL updating logic out of `editor` to `edit-post`
   - Related: https://github.com/WordPress/gutenberg/pull/6999#issuecomment-393647140
- Updating the post URL in response to `RESET_POST`, which won't trigger on autosave, only full saves.

__Testing instructions:__

Repeat steps to reproduce from #7066, verifying that no error screen is presented, and that the browser URL does not change after an autosave occurs for a published post.

Ensure unit tests pass:

```
npm run test-unit ./editor/store/test/effects.js
```