### PR TITLE
Fix issue with normal buttons with icons

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -72,8 +72,8 @@
 			0 1px 1px color( theme( button ) shade( 30% ) ),
 			-1px 0 1px color( theme( button ) shade( 30% ) );
 
-			&:hover,
-			&:focus:not(:disabled):not([aria-disabled="true"]) {
+		&:hover,
+		&:focus:not(:disabled):not([aria-disabled="true"]) {
 			background: color( theme( button ) shade( 5% ) );
 			border-color: color( theme( button ) shade( 50% ) );
 			box-shadow: inset 0 -1px 0 color( theme( button ) shade( 50% ) );

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -26,8 +26,7 @@
 		box-shadow: inset 0 -1px 0 #cccccc;
 		vertical-align: top;
 
-		&:hover,
-		&.components-icon-button:not(:disabled):not([aria-disabled="true"]):hover {
+		&:hover {
 			background: #fafafa;
 			border-color: #999;
 			box-shadow: inset 0 -1px 0 #999;

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -26,7 +26,8 @@
 		box-shadow: inset 0 -1px 0 #cccccc;
 		vertical-align: top;
 
-		&:hover {
+		&:hover,
+		&.components-icon-button:not(:disabled):not([aria-disabled="true"]):hover {
 			background: #fafafa;
 			border-color: #999;
 			box-shadow: inset 0 -1px 0 #999;
@@ -71,8 +72,8 @@
 			0 1px 1px color( theme( button ) shade( 30% ) ),
 			-1px 0 1px color( theme( button ) shade( 30% ) );
 
-		&:hover,
-		&:focus:not(:disabled):not([aria-disabled="true"]) {
+			&:hover,
+			&:focus:not(:disabled):not([aria-disabled="true"]) {
 			background: color( theme( button ) shade( 5% ) );
 			border-color: color( theme( button ) shade( 50% ) );
 			box-shadow: inset 0 -1px 0 color( theme( button ) shade( 50% ) );

--- a/components/form-file-upload/style.scss
+++ b/components/form-file-upload/style.scss
@@ -1,9 +1,5 @@
 .components-form-file-upload {
 	.components-button.is-large {
-		padding: 6px 12px 2px 3px;
-
-		@include break-medium() {
-			padding: 0 12px 2px 3px;
-		}
+		padding-left: 6px;
 	}
 }

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -21,7 +21,7 @@
 		outline: none;
 	}
 
-	&:not( :disabled ):not( [aria-disabled="true"] ):hover {
+	&:not( :disabled ):not( [aria-disabled="true"] ):not( .is-default ):hover {
 		@include button-style__hover;
 	}
 


### PR DESCRIPTION
Reported in https://github.com/WordPress/gutenberg/pull/5350#issuecomment-393621436, this PR fixes an issue where the icon was misaligned when using it with a standard Button look.

This scopes and adds some CSS to fix and align things. If this isn't the right approach, another approach would be to use the Button component here instead of the IconButton component (which has that no-background look). But then we would have to allow passing an icon to the Button component.

<img width="294" alt="screen shot 2018-06-01 at 09 46 57" src="https://user-images.githubusercontent.com/1204802/40828485-0ba229d0-6581-11e8-9aed-3bd38f5dd3ee.png">
