### PR TITLE
Fix issues with new inserter

### DIFF
--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -217,6 +217,23 @@ $float-margin: calc( 50% - #{ $content-width-padding / 2 } );
 	outline: 1px dotted $dark-gray-500;
 }
 
+// Blocks in the Inserter
+@mixin block-style__disabled {
+	opacity: 0.6;
+	cursor: default;
+}
+
+@mixin block-style__hover {
+	box-shadow: inset 0 0 0 1px rgba( $dark-gray-900, .2 ), 0 1px 3px rgba( $dark-gray-900, .4 );
+}
+
+@mixin block-style__focus-active() {
+	box-shadow: inset 0 0 0 1px $dark-gray-300;
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+}
 
 /**
  * Applies editor left position to the selector passed as argument

--- a/editor/components/inserter/item-list.js
+++ b/editor/components/inserter/item-list.js
@@ -94,7 +94,7 @@ class ItemList extends Component {
 						>
 							<span className="editor-inserter__item-icon">
 								<BlockIcon icon={ item.icon } />
-								{ item.hasChildBlocks ? <span className="editor-inserter__item-icon-stack"></span> : '' }
+								{ item.hasChildBlocks && <span className="editor-inserter__item-icon-stack" /> }
 							</span>
 
 							<span className="editor-inserter__item-title">

--- a/editor/components/inserter/item-list.js
+++ b/editor/components/inserter/item-list.js
@@ -94,6 +94,7 @@ class ItemList extends Component {
 						>
 							<span className="editor-inserter__item-icon">
 								<BlockIcon icon={ item.icon } />
+								{ item.hasChildBlocks ? <span className="editor-inserter__item-icon-stack"></span> : '' }
 							</span>
 
 							<span className="editor-inserter__item-title">

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -62,11 +62,12 @@ $block-inserter-search-height: 38px;
 
 .components-popover input[type="search"].editor-inserter__search {
 	display: block;
-	margin: -1px;
+	margin: 0;
 	padding: 11px 16px;
 	position: relative;
 	z-index: 1;
-	border: 1px solid $light-gray-500;
+	border: none;
+	border-bottom: 1px solid $light-gray-500;
 
 	// fonts smaller than 16px causes mobile safari to zoom
 	font-size: $mobile-text-min-font-size;
@@ -82,6 +83,11 @@ $block-inserter-search-height: 38px;
 	@include break-medium {
 		height: $block-inserter-content-height + $block-inserter-tabs-height;
 		box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
+	}
+
+	// Don't show the top border on the first panel, let the Search border be the border.
+	.components-panel__body:first-child {
+		border-top: none;
 	}
 }
 

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -106,38 +106,41 @@ $block-inserter-search-height: 38px;
 	align-items: stretch;
 	justify-content: center;
 	cursor: pointer;
-	border: none;
 	background: transparent;
-	overflow: hidden;
 	word-break: break-word;
 	border-radius: 4px;
 	border: 1px solid transparent;
 	transition: all 0.05s ease-in-out;
 
 	&:disabled {
-		@include button-style__disabled;
+		@include button-style__disabled();
 	}
 
 	&:not(:disabled) {
 		&:hover {
-			border-color: $light-gray-700;
-
 			.editor-inserter__item-icon {
 				color: $dark-gray-900;
-				border-radius: 4px 4px 0 0;
+				@include button-style__hover();
+			}
+			.editor-inserter__item-title {
+				color: $dark-gray-900;
+			}
+		}
+		&:active,
+		&.is-active,
+		&:focus {
+			position: relative;
+
+			// Show the focus style in the icon inside instead.
+			outline: none;
+
+			.editor-inserter__item-icon {
+				@include button-style__focus-active();
 			}
 
 			.editor-inserter__item-title {
-				color: $dark-gray-800;
+				color: $dark-gray-900;
 			}
-		}
-
-		&:focus,
-		&:active,
-		&.is-active {
-			@include button-style__focus-active;
-			position: relative;
-			outline: 1px solid $dark-gray-500;
 		}
 	}
 }

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -178,19 +178,19 @@ $block-inserter-search-height: 38px;
 		top: -2px;
 		left: -2px;
 
-		// Show a "stacked card" below an item that has children.
-		&:after {
-			content: "";
-			display: block;
-			background: rgba( $dark-gray-900, .3 );
-			width: 100%;
-			height: 100%;
-			position: absolute;
-			z-index: -1; // Show below the card as a shadow
-			bottom: -4px;
-			right: -4px;
-			border-radius: 4px;
-		}
+	}
+
+	// Show a "stacked card" below an item that has children.
+	.editor-inserter__item-icon-stack {
+		display: block;
+		background: rgba( $dark-gray-900, .3 );
+		width: 100%;
+		height: 100%;
+		position: absolute;
+		z-index: -1; // Show below the card as a shadow
+		bottom: -4px;
+		right: -4px;
+		border-radius: 4px;
 	}
 }
 

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -173,7 +173,6 @@ $block-inserter-search-height: 38px;
 
 .editor-inserter__item-has-children {
 	.editor-inserter__item-icon {
-		//box-shadow: 4px 4px rgba( $dark-gray-900, 0.3 ); // redo this
 		margin-right: 3px;
 		position: relative;
 		top: -2px;

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -79,6 +79,8 @@ $block-inserter-search-height: 38px;
 .editor-inserter__results {
 	flex-grow: 1;
 	overflow: auto;
+	position: relative;
+	z-index: 1; // Necessary for the stacked card below parent blocks to show up.
 
 	@include break-medium {
 		height: $block-inserter-content-height + $block-inserter-tabs-height;
@@ -113,15 +115,15 @@ $block-inserter-search-height: 38px;
 	transition: all 0.05s ease-in-out;
 
 	&:disabled {
-		@include button-style__disabled();
+		@include block-style__disabled();
 	}
 
 	&:not(:disabled) {
 		&:hover {
 			.editor-inserter__item-icon {
-				color: $dark-gray-900;
-				@include button-style__hover();
+				@include block-style__hover();
 			}
+
 			.editor-inserter__item-title {
 				color: $dark-gray-900;
 			}
@@ -135,7 +137,7 @@ $block-inserter-search-height: 38px;
 			outline: none;
 
 			.editor-inserter__item-icon {
-				@include button-style__focus-active();
+				@include block-style__focus-active();
 			}
 
 			.editor-inserter__item-title {
@@ -171,11 +173,25 @@ $block-inserter-search-height: 38px;
 
 .editor-inserter__item-has-children {
 	.editor-inserter__item-icon {
-	    box-shadow: 4px 4px rgba( $dark-gray-900, 0.3 );
+		//box-shadow: 4px 4px rgba( $dark-gray-900, 0.3 ); // redo this
 		margin-right: 3px;
 		position: relative;
 		top: -2px;
 		left: -2px;
+
+		// Show a "stacked card" below an item that has children.
+		&:after {
+			content: "";
+			display: block;
+			background: rgba( $dark-gray-900, .3 );
+			width: 100%;
+			height: 100%;
+			position: absolute;
+			z-index: -1; // Show below the card as a shadow
+			bottom: -4px;
+			right: -4px;
+			border-radius: 4px;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes #7059.

It fixes an issue with IE11 where there was a horizontal scrollbar:

<img width="609" alt="screen shot 2018-06-01 at 10 11 35" src="https://user-images.githubusercontent.com/1204802/40830180-ffc8f850-6585-11e8-9ce4-6302ac02c312.png">

It changes and improves focus and hover styles to both look better overall, use mixins, and work in stacked contexts:

![inserter](https://user-images.githubusercontent.com/1204802/40832605-fcfdb4fc-658b-11e8-82d4-86b5b543c243.gif)
