### PR TITLE
Shared Blocks: Fix editing paragraph blocks

### DIFF
--- a/editor/hooks/default-autocompleters.js
+++ b/editor/hooks/default-autocompleters.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { clone } from 'lodash';
+import { clone, once } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,6 +17,8 @@ import { blockAutocompleter, userAutocompleter } from '../components';
 
 const defaultAutocompleters = [ userAutocompleter ];
 
+const fetchSharedBlocks = once( () => dispatch( 'core/editor' ).fetchSharedBlocks() );
+
 function setDefaultCompleters( completers, blockName ) {
 	if ( ! completers ) {
 		// Provide copies so filters may directly modify them.
@@ -31,7 +33,7 @@ function setDefaultCompleters( completers, blockName ) {
 			 * once we have a way for completers to Promise options while
 			 * store-based data dependencies are being resolved.
 			 */
-			dispatch( 'core/editor' ).fetchSharedBlocks();
+			fetchSharedBlocks();
 		}
 	}
 	return completers;


### PR DESCRIPTION
closes #7075

Right now editing shared blocks is broken because when we render the Autocomplete component (used in paragraph blocks), we're triggering a "fetch shared blocks" request. This requests is causing the uid of the block attached to the shared block to be regenerated which means the block will rerender (considered as a different block) and the loop continues.

The root cause of the issue is not fixed in this PR, this is a hacky fix will small implications than can land in 3.0 but as a follow-up I'm planning to fix the root issue which is the fact that we have a cycle dependency in our shared blocks state.

 `sharedBlock.id => block.uid` relation
and 
 `block.uid` => `sharedBlock.id`

This cycle is forcing us to regenerate the block attached to the shared block when we fetch them.

