### PR TITLE
Remove drag handle from breadcrumb

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -842,10 +842,6 @@
 		background: $blue-medium-focus;
 		color: $white;
 	
-		// Drag indicator
-		cursor: move; /* Fallback for IE/Edge < 14 */
-		cursor: grab;
-	
 		// Animate in
 		.editor-block-list__block:hover & {
 			@include fade_in( .1s );


### PR DESCRIPTION
Per feedback in https://github.com/WordPress/gutenberg/pull/6773#issuecomment-393861691, it seems the drag handle for the breadcrumb was premature. Although it works on the edge, it's not consistent and was a bad idea.

This simply removes the grab handle. I will open a separate ticket for making that work.
