### PR TITLE
Docs: Fix rich-text markdown source

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -32,7 +32,7 @@
 	{
 		"title": "RichText API",
 		"slug": "rich-text-api",
-		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/blocks\/rich-text\/README.md",
+		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/editor\/components\/rich-text\/README.md",
 		"parent": "block-api"
 	},
 	{


### PR DESCRIPTION
fixes source for the rich-text doc from `blocks` to `editor/components`