### PR TITLE
Update drop-cap design to better balance line length.

### DIFF
--- a/core-blocks/paragraph/style.scss
+++ b/core-blocks/paragraph/style.scss
@@ -21,10 +21,10 @@ p {
 	// typing at the end of the paragraph doesn't work.
 	&.has-drop-cap:not( :focus ):first-letter {
 		float: left;
-		font-size: 4.1em;
-		line-height: 0.7;
-		font-weight: 600;
-		margin: .07em .23em 0 0;
+		font-size: 8.4em;
+		line-height: 0.68;
+		font-weight: 100;
+		margin: .05em .1em 0 0;
 		text-transform: uppercase;
 		font-style: normal;
 	}


### PR DESCRIPTION
Our current drop-cap occupies just two lines of the paragraph, which feels unbalanced compared to the default length of the word line.

![image](https://user-images.githubusercontent.com/548849/40857404-583693ee-65db-11e8-8fb4-449e7e6ba2d9.png)
