### PR TITLE
Shared Blocks: Preview should be rendered outside the scrollable container

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -249,11 +249,11 @@ export class InserterMenu extends Component {
 					{ isEmpty( suggestedItems ) && isEmpty( sharedItems ) && isEmpty( itemsPerCategory ) && (
 						<p className="editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
 					) }
-
-					{ hoveredItem && isSharedBlock( hoveredItem ) &&
-						<BlockPreview name={ hoveredItem.name } attributes={ hoveredItem.initialAttributes } />
-					}
 				</div>
+
+				{ hoveredItem && isSharedBlock( hoveredItem ) &&
+					<BlockPreview name={ hoveredItem.name } attributes={ hoveredItem.initialAttributes } />
+				}
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-autofocus */


### PR DESCRIPTION
Fix the shared blocks preview.

**Testing instructions**

 - Save a shared block
 - Open the inserter and hover this block
 - The preview should show up on the right of the inserter.