### PR TITLE
Send all fields when transmitting an autosave.

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -118,20 +118,23 @@ export default {
 
 		let request;
 		if ( isAutosave ) {
-			toSend.parent = post.id;
+			const autosaveData = {};
 
 			// Ensure autosaves contain all fields.
-			Object.assign( toSend,
-			{
-				title: post.title,
-				content: post.content,
-				excerpt: post.excerpt,
-			}, toSend );
+			Object.assign( autosaveData,
+				{
+					title: post.title,
+					content: post.content,
+					excerpt: post.excerpt,
+				},
+				toSend
+			);
+			autosaveData.parent = post.id;
 
 			request = wp.apiRequest( {
 				path: `/wp/v2/${ basePath }/${ post.id }/autosaves`,
 				method: 'POST',
-				data: toSend,
+				data: autosaveData,
 			} );
 		} else {
 			dispatch( {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -62,7 +62,7 @@ import {
 	isBlockSelected,
 	getTemplate,
 	getTemplateLock,
-	getCurrentAutosave,
+	getAutosave,
 	POST_UPDATE_TRANSACTION_ID,
 } from './selectors';
 
@@ -123,7 +123,7 @@ export default {
 			// post values as fallback if not otherwise included in edits.
 			toSend = {
 				...pick( post, [ 'title', 'content', 'excerpt' ] ),
-				...getCurrentAutosave( state ),
+				...getAutosave( state ),
 				...toSend,
 				parent: post.id,
 			};

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -120,6 +120,14 @@ export default {
 		if ( isAutosave ) {
 			toSend.parent = post.id;
 
+			// Ensure autosaves contain all fields.
+			Object.assign( toSend,
+			{
+				title: post.title,
+				content: post.content,
+				excerpt: post.excerpt,
+			}, toSend );
+
 			request = wp.apiRequest( {
 				path: `/wp/v2/${ basePath }/${ post.id }/autosaves`,
 				method: 'POST',

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -345,9 +345,23 @@ export function isEditedPostAutosaveable( state ) {
 	}
 
 	// If the title, excerpt or content has changed, the post is autosaveable.
+	const autosave = getAutosave( state );
 	return [ 'title', 'excerpt', 'content' ].some( ( field ) => (
-		state.autosave[ field ] !== getEditedPostAttribute( state, field )
+		autosave[ field ] !== getEditedPostAttribute( state, field )
 	) );
+}
+
+/**
+ * Returns the current autosave, or null if one is not set (i.e. if the post
+ * has yet to be autosaved, or has been saved or published since the last
+ * autosave).
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {?Object} Current autosave, if exists.
+ */
+export function getAutosave( state ) {
+	return state.autosave;
 }
 
 /**
@@ -358,7 +372,7 @@ export function isEditedPostAutosaveable( state ) {
  * @return {boolean} Whether there is an existing autosave.
  */
 export function hasAutosave( state ) {
-	return !! state.autosave;
+	return !! getAutosave( state );
 }
 
 /**

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -36,6 +36,8 @@ const {
 	isEditedPostPublishable,
 	isEditedPostSaveable,
 	isEditedPostAutosaveable,
+	getAutosave,
+	hasAutosave,
 	isEditedPostEmpty,
 	isEditedPostBeingScheduled,
 	getEditedPostPreviewLink,
@@ -1105,6 +1107,49 @@ describe( 'selectors', () => {
 					expect( isEditedPostAutosaveable( state ) ).toBe( true );
 				}
 			}
+		} );
+	} );
+
+	describe( 'getAutosave', () => {
+		it( 'returns null if there is no autosave', () => {
+			const state = {
+				autosave: null,
+			};
+
+			const result = getAutosave( state );
+
+			expect( result ).toBe( null );
+		} );
+
+		it( 'returns the autosave', () => {
+			const autosave = { title: '', excerpt: '', content: '' };
+			const state = { autosave };
+
+			const result = getAutosave( state );
+
+			expect( result ).toEqual( autosave );
+		} );
+	} );
+
+	describe( 'hasAutosave', () => {
+		it( 'returns false if there is no autosave', () => {
+			const state = {
+				autosave: null,
+			};
+
+			const result = hasAutosave( state );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'returns true if there is a autosave', () => {
+			const state = {
+				autosave: { title: '', excerpt: '', content: '' },
+			};
+
+			const result = hasAutosave( state );
+
+			expect( result ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
merges the post object with toSend before sending the autosave, ensuring that unedited fields are sent with their current values. 

Fixes https://github.com/WordPress/gutenberg/issues/7078

## How has this been tested?
Create a post and publish it.
Change the content of the post and wait 10 seconds for the autosave to fire.
Check the autosave REST request - note that the title is present in the request. Check the database and note the autosave title is present in the database.

## Changes
I found that altering the original object sets up an infinite save loop, to avoid this I create a new object to send to autosaves and leave toSend untouched.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
