### PR TITLE
Fix Windows-unfriendly theme.scss loader rule

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -243,7 +243,7 @@ const config = {
 				use: editBlocksCSSPlugin.extract( extractConfig ),
 			},
 			{
-				test: /\/theme\.s?css$/,
+				test: /theme\.s?css$/,
 				include: [
 					/core-blocks/,
 				],


### PR DESCRIPTION
## Description

The webpack module loader rule for theme.scss files contained a unix-style path separator that resulted in theme.scss not being matched with the ExtractTextPlugin and processed by SASS. Instead, it was being treated as a JS import, and our stub `core-blocks/separator/theme.scss` file happens to also parse as JS.  This meant there was no build error but also no `build/core-blocks/theme.css` file when building in Windows. This commit simply removes the offending separator because it is unnecessary.

Fixes #7064.


<!-- Please describe what you have changed or added -->

## How has this been tested?

I ran the build in the following environments and noted that `build/core-blocks/theme.css` and its rtl variant are created.
* Windows 10, Command Prompt
* Windows 10, Git Bash terminal
* macOS 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
