### PR TITLE
Fix getWPAdminUrl function to actually return the /wp-admin/ URL

### DIFF
--- a/editor/components/post-last-revision/index.js
+++ b/editor/components/post-last-revision/index.js
@@ -4,13 +4,13 @@
 import { sprintf, _n } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { getWPAdminURL } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import PostLastRevisionCheck from './check';
-import { getWPAdminURL } from '../../utils/url';
 
 function LastRevision( { lastRevisionId, revisionsCount } ) {
 	return (

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -10,13 +10,13 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { Component, compose } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ClipboardButton, Button } from '@wordpress/components';
+import { getWPAdminURL } from '@wordpress/utils';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
 import PostPermalinkEditor from './editor.js';
-import { getWPAdminURL } from '../../utils/url';
 
 class PostPermalink extends Component {
 	constructor() {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -24,7 +24,7 @@ import { speak } from '@wordpress/a11y';
 /**
  * Internal dependencies
  */
-import { getWPAdminURL } from '../utils/url';
+import { getWPAdminURL } from '@wordpress/utils';
 import {
 	setupEditorState,
 	resetAutosave,

--- a/editor/utils/url.js
+++ b/editor/utils/url.js
@@ -1,7 +1,14 @@
 /**
+ * External Dependencies
+ */
+
+ import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
+import { select } from '@wordpress/data';
 
 /**
  * Returns the URL of a WPAdmin Page.
@@ -14,7 +21,8 @@ import { addQueryArgs } from '@wordpress/url';
  * @return {string} WPAdmin URL.
  */
 export function getWPAdminURL( page, query ) {
-	const url = ( window._wpAdminURL ) ? window._wpAdminURL + page : page;
+	const settings = select( 'core/editor' ).getEditorSettings();
+	const url = get( settings, 'wpAdminURL', '' ) + page;
 	return addQueryArgs( url, query );
 }
 

--- a/editor/utils/url.js
+++ b/editor/utils/url.js
@@ -1,29 +1,3 @@
-/**
- * External Dependencies
- */
-import { get } from 'lodash';
-
-/**
- * WordPress dependencies
- */
-import { addQueryArgs } from '@wordpress/url';
-import { select } from '@wordpress/data';
-
-/**
- * Returns the URL of a WPAdmin Page.
- *
- * TODO: This should be moved to a module less specific to the editor.
- *
- * @param {string} page  Page to navigate to.
- * @param {Object} query Query Args.
- *
- * @return {string} WPAdmin URL.
- */
-export function getWPAdminURL( page, query ) {
-	const settings = select( 'core/editor' ).getEditorSettings();
-	const url = get( settings, [ 'wpAdminURL' ], '' ) + page;
-	return addQueryArgs( url, query );
-}
 
 /**
  * Returns a URL for display.

--- a/editor/utils/url.js
+++ b/editor/utils/url.js
@@ -14,7 +14,8 @@ import { addQueryArgs } from '@wordpress/url';
  * @return {string} WPAdmin URL.
  */
 export function getWPAdminURL( page, query ) {
-	return addQueryArgs( page, query );
+	const url = ( window._wpAdminURL ) ? window._wpAdminURL + page : page;
+	return addQueryArgs( url, query );
 }
 
 /**

--- a/editor/utils/url.js
+++ b/editor/utils/url.js
@@ -1,8 +1,7 @@
 /**
  * External Dependencies
  */
-
- import { get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,7 +21,7 @@ import { select } from '@wordpress/data';
  */
 export function getWPAdminURL( page, query ) {
 	const settings = select( 'core/editor' ).getEditorSettings();
-	const url = get( settings, 'wpAdminURL', '' ) + page;
+	const url = get( settings, [ 'wpAdminURL' ], '' ) + page;
 	return addQueryArgs( url, query );
 }
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1152,6 +1152,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	$script  = '( function() {';
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
+	$script .= sprintf( 'window._wpAdminURL = %s;', wp_json_encode( admin_url() ) );
 	$script .= <<<JS
 		window._wpLoadGutenbergEditor = new Promise( function( resolve ) {
 			wp.api.init().then( function() {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1131,6 +1131,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
 		'isRTL'               => is_rtl(),
 		'autosaveInterval'    => 10,
+		'wpAdminURL'          => admin_url(),
 	);
 
 	$post_autosave = get_autosave_newer_than_post_save( $post );
@@ -1152,7 +1153,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	$script  = '( function() {';
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
-	$script .= sprintf( 'window._wpAdminURL = %s;', wp_json_encode( admin_url() ) );
 	$script .= <<<JS
 		window._wpLoadGutenbergEditor = new Promise( function( resolve ) {
 			wp.api.init().then( function() {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -166,6 +166,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_add_inline_script( 'wp-utils', 'var originalUtils = window.wp && window.wp.utils ? window.wp.utils : {};', 'before' );
 	wp_add_inline_script( 'wp-utils', 'for ( var key in originalUtils ) wp.utils[ key ] = originalUtils[ key ];' );
+	wp_add_inline_script( 'wp-utils', sprintf( 'wp.utils.setWPAdminURL( %s );', wp_json_encode( admin_url() ) ), 'after' );
 	wp_register_script(
 		'wp-date',
 		gutenberg_url( 'build/date/index.js' ),
@@ -1131,7 +1132,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
 		'isRTL'               => is_rtl(),
 		'autosaveInterval'    => 10,
-		'wpAdminURL'          => admin_url(),
 	);
 
 	$post_autosave = get_autosave_newer_than_post_save( $post );

--- a/utils/index.js
+++ b/utils/index.js
@@ -10,5 +10,7 @@ export { keycodes };
 export * from './mediaupload';
 export * from './terms';
 
+export { setWPAdminURL, getWPAdminURL } from './urls';
+
 // Deprecations
 export * from './deprecated';

--- a/utils/urls.js
+++ b/utils/urls.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+var wpAdminURL = "";
+/**
+ * Returns the URL of a WPAdmin Page.
+ *
+ * @param {string} page  Page to navigate to.
+ * @param {Object} query Query Args.
+ *
+ * @return {string} WPAdmin URL.
+ */
+export function getWPAdminURL( page, query ) {
+	const url = wpAdminURL + page;
+	return addQueryArgs( url, query );
+}
+
+export function setWPAdminURL( url ) {
+	wpAdminURL = url;
+}

--- a/utils/urls.js
+++ b/utils/urls.js
@@ -3,7 +3,8 @@
  */
 import { addQueryArgs } from '@wordpress/url';
 
-var wpAdminURL = "";
+let wpAdminURL = '';
+
 /**
  * Returns the URL of a WPAdmin Page.
  *


### PR DESCRIPTION
## Description

This adds a getter and setter function to `wp.utils` for the wpAdminURL.

When loading Gutenberg, it will call `setWPAdminURL( %s )` where %s is the results of `admin_url()`

This can then be used when needed with a similar call using `wp.utils.getWPAdminURL( path )`

Fixes #7095 

## How has this been tested?

The getWPAdminURL is used during "Move to Trash", and confirmed the proper admin url is returned during the trash sequence.

You can also check it is set properly by calling `wp.utils.getWPAdminURL( 'foo.php' )` in the console after a page is loading and it should return a full `/wp-admin/foo.php` however it is configured for the WP install.

