### PR TITLE
Upgrade mousetrap to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9823,9 +9823,9 @@
 			}
 		},
 		"mousetrap": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.1.tgz",
-			"integrity": "sha1-KghfXHUSlMdefoH27CVFspy/Qtk="
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.2.tgz",
+			"integrity": "sha512-jDjhi7wlHwdO6q6DS7YRmSHcuI+RVxadBkLt3KHrhd3C2b+w5pKefg3oj5beTcHZyVFA9Aksf+yEE1y5jxUjVA=="
 		},
 		"move-concurrently": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"memize": "1.0.5",
 		"moment": "2.22.1",
 		"moment-timezone": "0.5.16",
-		"mousetrap": "1.6.1",
+		"mousetrap": "1.6.2",
 		"prop-types": "15.5.10",
 		"querystringify": "1.0.0",
 		"re-resizable": "4.4.8",


### PR DESCRIPTION
As part of #6508, we found that the `mousetrap` library had an Apache 2.0 license, which is not compatible with GPL2.

The `mousetrap` author has kindly agreed to add the [LLVM exception](https://spdx.org/licenses/LLVM-exception.html) to the license, making it GPL2 compatible.

This is the only change in the [mousetrap 1.6.2 release](https://github.com/ccampbell/mousetrap/releases/tag/1.6.2).