### PR TITLE
Fix #7082 multiple hover styles

### DIFF
--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -23,10 +23,12 @@
 
 	&:not( :disabled ):not( [aria-disabled="true"] ):not( .is-default ):hover {
 		@include button-style__hover;
+		box-shadow: none;
 	}
 
 	&:not( :disabled ):not( [aria-disabled="true"] ):active {
 		@include button-style__active;
+		box-shadow: none;
 	}
 
 	&[aria-disabled=true]:focus,

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -23,12 +23,10 @@
 
 	&:not( :disabled ):not( [aria-disabled="true"] ):not( .is-default ):hover {
 		@include button-style__hover;
-		box-shadow: none;
 	}
 
 	&:not( :disabled ):not( [aria-disabled="true"] ):active {
 		@include button-style__active;
-		box-shadow: none;
 	}
 
 	&[aria-disabled=true]:focus,

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -45,7 +45,7 @@ div.components-toolbar {
 	width: $icon-button-size;
 	height: $icon-button-size;
 
-	// unset icon button styles
+	// Unset icon button styles
 	&:active,
 	&:not( [aria-disabled="true"] ):hover,
 	&:not( [aria-disabled="true"] ):focus {
@@ -55,7 +55,7 @@ div.components-toolbar {
 		border: none;
 	}
 
-	// disabled
+	// Disabled
 	&:disabled {
 		cursor: default;
 	}
@@ -66,7 +66,7 @@ div.components-toolbar {
 		border-radius: $button-style__radius-roundrect;
 	}
 
-	// subscript for numbered icon buttons, like headings
+	// Subscript for numbered icon buttons, like headings
 	&[data-subscript] svg {
 		padding: 4px 8px 4px 0;
 	}
@@ -81,13 +81,17 @@ div.components-toolbar {
 		bottom: 8px;
 	}
 
-	// hover style
+	// Assign hover style to child element, not the button itself
+	&:not( :disabled ):not([aria-disabled="true"]):hover {
+		box-shadow: none;
+	}
+
 	&:not( :disabled ).is-active > svg,
 	&:not( :disabled ):hover > svg {
 		@include formatting-button-style__hover;
 	}
 
-	// active & toggled style
+	// Active & toggled style
 	&:not(:disabled).is-active > svg {
 		@include formatting-button-style__active;
 	}
@@ -96,7 +100,7 @@ div.components-toolbar {
 		color: $white;
 	}
 
-	// focus style
+	// Focus style
 	&:not(:disabled):focus > svg {
 		@include formatting-button-style__focus;
 	}


### PR DESCRIPTION
## Description
Fix the issue (#7028) that block toolbar buttons use multiple hover styles.

## How has this been tested?
Ran `npm test`:
```
Test Suites: 1 skipped, 178 passed, 178 of 179 total
Tests:       3 skipped, 1598 passed, 1601 total
Snapshots:   59 passed, 59 total
Time:        54.724s
Ran all test suites.
```

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
