### PR TITLE
Make ClipboardButton inside a block work correctly in Safari

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (Next)
+
+### Breaking Changes
+
+- `CopyHandler` will now only catch cut/copy events coming from its `props.children`, instead of from anywhere in the `document`.
+
 ## 1.0.0 (2019-03-06)
 
 ### New Features

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0 (Next)
+## 2.0.0 (Unreleased)
 
 ### Breaking Changes
 

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -1,33 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
 import { serialize } from '@wordpress/blocks';
 import { documentHasSelection } from '@wordpress/dom';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-class CopyHandler extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.onCopy = ( event ) => this.props.onCopy( event );
-		this.onCut = ( event ) => this.props.onCut( event );
-	}
-
-	componentDidMount() {
-		document.addEventListener( 'copy', this.onCopy );
-		document.addEventListener( 'cut', this.onCut );
-	}
-
-	componentWillUnmount() {
-		document.removeEventListener( 'copy', this.onCopy );
-		document.removeEventListener( 'cut', this.onCut );
-	}
-
-	render() {
-		return null;
-	}
+function CopyHandler( { children, onCopy, onCut } ) {
+	return (
+		<div onCopy={ onCopy } onCut={ onCut }>
+			{ children }
+		</div>
+	);
 }
 
 export default compose( [

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -5,7 +5,9 @@
 * Expose the `className` property to style the `PluginSidebar` component.
 
 ### Bug Fixes
- - Fix 'save' keyboard shortcut not functioning in the Code Editor.
+
+- Fix 'save' keyboard shortcut not functioning in the Code Editor.
+- Prevent `ClipboardButton` from incorrectly copying a serialized block string instead of the intended text in Safari.
 
 ## 3.1.7 (2019-01-03)
 

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -26,12 +26,13 @@ function VisualEditor() {
 	return (
 		<BlockSelectionClearer className="edit-post-visual-editor editor-styles-wrapper">
 			<VisualEditorGlobalKeyboardShortcuts />
-			<CopyHandler />
 			<MultiSelectScrollIntoView />
 			<WritingFlow>
 				<ObserveTyping>
-					<PostTitle />
-					<BlockList />
+					<CopyHandler>
+						<PostTitle />
+						<BlockList />
+					</CopyHandler>
 				</ObserveTyping>
 			</WritingFlow>
 			<_BlockSettingsMenuFirstItem>


### PR DESCRIPTION
## Description
This PR addresses some quirks in Safari that can cause a `ClipboardButton` inside a block to not work correctly.

I [encountered this problem](https://github.com/WordPress/gutenberg/pull/6805#pullrequestreview-123950246) while implementing the Copy URL functionality in the File block (#6805).

## Test directions
1. Add a `ClipboardButton` component to some block
```
import { ClipboardButton } from '@wordpress/components';

// Put this somewhere inside render()
<ClipboardButton text="foo">{ 'Copy' }</ClipboardButton>
```
2. In Safari, start a new post (`/wp-admin/post-new.php`), and add the block
3. Click on the Copy button

    Expected behavior: “foo” is copied to clipboard

    Actual behavior (before this fix): A serialized string of the block is copied to clipboard

### Other things to test
- Make sure that multiblock copy is working correctly (Select multiple blocks and ⌘C)
- Make sure that a ClipboardButton outside of a block still works correctly (like the Copy Link button that appears after publishing a post)

## Technical notes
This is a strange combination of multiple Safari quirks and how they interact with `CopyHandler`.

1. In Safari, the hidden `textarea` created by [clipboard.js](https://clipboardjs.com/) is not the `document.activeElement` at the moment when the copy event fires, causing `CopyHandler` to misinterpret the event as `documentHasSelection() === false`. This causes a serialized block string to be copied instead of the intended text.

    The workaround is to listen to copy events on ClipboardButton, and explicitly `e.target.focus()` on the textarea.

2. There is an inconsistency in event order between the following two cases, presumably because of mount order.

    - Pre-saved block instances (i.e. at least one instance of that block type was already saved in the post when the page loaded): Copy handler on **ClipboardButton fires first**, then copy handler on document
    - New blocks: Copy handler on **document fires first**, then copy handler on ClipboardButton

    While this behavior is the same across browsers, in Safari it causes a problem in the latter case because the `e.target.focus()` workaround in 1 will not work unless the copy handler on ClipboardButton fires first.

    The workaround is to attach the event listeners directly on CopyHandler in React, instead of doing `document.addEventListener()`. This ensures a consistent event order.

3. While the two workarounds above are enough to fix the copy bug, there is another quirk in Safari where multiblock copy events can only be caught at the document level. Therefore, we need to **also** keep the document-level event listeners to have multiblock copy work in Safari.

## Is this workaround worth the trouble?

I’m not entirely sure. Maybe we wouldn’t need this if we rewrote clipboard.js. But that seems like a lot of trouble, too.