### PR TITLE
Allow context injection in core-block tests

### DIFF
--- a/core-blocks/test/helpers/index.js
+++ b/core-blocks/test/helpers/index.js
@@ -1,5 +1,5 @@
 /**
- * External dependencie
+ * External dependencies
  */
 import { render } from 'enzyme';
 import { noop } from 'lodash';
@@ -12,17 +12,19 @@ import {
 	getBlockType,
 	registerBlockType,
 } from '@wordpress/blocks';
-// Requiredd to register the editor's store
+// Required to register the editor's store
 import '@wordpress/editor';
 
 // Hack to avoid the wrapping HoCs.
 import { BlockEdit } from '../../../editor/components/block-edit';
 
-export const blockEditRender = ( name, settings ) => {
+export const blockEditRender = ( name, settings, context, contextTypes ) => {
 	if ( ! getBlockType( name ) ) {
 		registerBlockType( name, settings );
 	}
 	const block = createBlock( name );
+
+	BlockEdit.contextTypes = contextTypes;
 
 	return render(
 		<BlockEdit
@@ -32,6 +34,7 @@ export const blockEditRender = ( name, settings ) => {
 			setAttributes={ noop }
 			user={ {} }
 			createInnerBlockList={ noop }
-		/>
+		/>,
+		{ context }
 	);
 };


### PR DESCRIPTION
## Description
This adds the ability to inject context when testing `core-block` components.

This will allow components using a context-dependent HOC (like `withAPIData`) to be snapshot tested using the same `blockEditRender()` test helper.

## Example of intended usage
For a quick test, you can check out [this commit](https://github.com/WordPress/gutenberg/pull/6805/commits/677b35cac299e93ec9409ab5f73b66a9a03bcacf) and try the following as a test case in `core-blocks/file/test/index.js`

```
test( 'block edit matches snapshot', () => {
	const contextTypes = {
		getAPISchema: noop,
		getAPIPostTypeRestBaseMapping: noop,
		getAPITaxonomyRestBaseMapping: noop,
	};

	const context = Object.assign( {}, contextTypes );
	context.getAPISchema = () => {
		return { routes: null };
	};

	const wrapper = blockEditRender( name, settings, context, contextTypes );

	expect( wrapper ).toMatchSnapshot();
} );
```
