### PR TITLE
fix: Remove "Wrap text" from Button settings (fix #6563)

### DIFF
--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -11,8 +11,6 @@ import { Component, Fragment } from '@wordpress/element';
 import {
 	Dashicon,
 	IconButton,
-	PanelBody,
-	ToggleControl,
 	withFallbackStyles,
 } from '@wordpress/components';
 import {
@@ -49,16 +47,10 @@ class ButtonEdit extends Component {
 		this.nodeRef = null;
 		this.bindRef = this.bindRef.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
-		this.toggleClear = this.toggleClear.bind( this );
 	}
 
 	updateAlignment( nextAlign ) {
 		this.props.setAttributes( { align: nextAlign } );
-	}
-
-	toggleClear() {
-		const { attributes, setAttributes } = this.props;
-		setAttributes( { clear: ! attributes.clear } );
 	}
 
 	bindRef( node ) {
@@ -85,7 +77,6 @@ class ButtonEdit extends Component {
 			url,
 			title,
 			align,
-			clear,
 		} = attributes;
 
 		return (
@@ -115,29 +106,22 @@ class ButtonEdit extends Component {
 						keepPlaceholderOnFocus
 					/>
 					<InspectorControls>
-						<PanelBody>
-							<ToggleControl
-								label={ __( 'Wrap text' ) }
-								checked={ !! clear }
-								onChange={ this.toggleClear }
-							/>
-							<PanelColor
-								colorValue={ backgroundColor.value }
-								title={ __( 'Background Color' ) }
-								onChange={ setBackgroundColor }
-							/>
-							<PanelColor
-								colorValue={ textColor.value }
-								title={ __( 'Text Color' ) }
-								onChange={ setTextColor }
-							/>
-							{ this.nodeRef && <ContrastCheckerWithFallbackStyles
-								node={ this.nodeRef }
-								textColor={ textColor.value }
-								backgroundColor={ backgroundColor.value }
-								isLargeText={ true }
-							/> }
-						</PanelBody>
+						<PanelColor
+							colorValue={ backgroundColor.value }
+							title={ __( 'Background Color' ) }
+							onChange={ setBackgroundColor }
+						/>
+						<PanelColor
+							colorValue={ textColor.value }
+							title={ __( 'Text Color' ) }
+							onChange={ setTextColor }
+						/>
+						{ this.nodeRef && <ContrastCheckerWithFallbackStyles
+							node={ this.nodeRef }
+							textColor={ textColor.value }
+							backgroundColor={ backgroundColor.value }
+							isLargeText={ true }
+						/> }
 					</InspectorControls>
 				</span>
 				{ isSelected && (

--- a/core-blocks/button/index.js
+++ b/core-blocks/button/index.js
@@ -77,15 +77,11 @@ export const settings = {
 	attributes: blockAttributes,
 
 	getEditWrapperProps( attributes ) {
-		const { align, clear } = attributes;
+		const { align } = attributes;
 		const props = { 'data-resized': true };
 
 		if ( 'left' === align || 'right' === align || 'center' === align ) {
 			props[ 'data-align' ] = align;
-		}
-
-		if ( clear ) {
-			props[ 'data-clear' ] = 'true';
 		}
 
 		return props;


### PR DESCRIPTION
## Description
Remove the unused "Wrap text" setting for the Button block and accompanying code. fix #6563

## How has this been tested?
Used the Button settings and published a page; button still worked fine.

## Screenshots

### Before
<img width="280" alt="screenshot 2018-06-04 15 56 00" src="https://user-images.githubusercontent.com/90871/40902682-c9b96524-680f-11e8-88ab-03f06b064654.png">

### After
<img width="282" alt="screenshot 2018-06-04 15 48 07" src="https://user-images.githubusercontent.com/90871/40902656-b246cf30-680f-11e8-87d0-4f5165607233.png">

## Types of changes
Removed an unused setting.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->