### PR TITLE
Try optimizing the default column width

### DIFF
--- a/edit-post/assets/stylesheets/_variables.scss
+++ b/edit-post/assets/stylesheets/_variables.scss
@@ -32,8 +32,7 @@ $shadow-below-only: 0 5px 10px rgba( $dark-gray-900, .1 ), 0 2px 2px rgba( $dark
 
 // Editor Widths
 $sidebar-width: 280px;
-$text-editor-max-width: 760px;	// @todo: merge with variable below
-$content-width: 636px;	// @todo: leverage theme $content_width variable
+$content-width: 610px; // For the visual width, subtract 30px (2 * $block-padding + 2px borders). This comes to 580px, which is optimized for 70 characters.
 
 // Block UI
 $block-controls-height: 36px;

--- a/edit-post/components/text-editor/style.scss
+++ b/edit-post/components/text-editor/style.scss
@@ -16,13 +16,13 @@
 	padding-right: 20px;
 
 	@include break-large() {
-		padding-left: calc( 50% - #{ $text-editor-max-width / 2 } );
-		padding-right: calc( 50% - #{ $text-editor-max-width / 2 } );
+		padding-left: calc( 50% - #{ $content-width / 2 } );
+		padding-right: calc( 50% - #{ $content-width / 2 } );
 	}
 
 	.edit-post-post-text-editor__toolbar {
 		width: 100%;
-		max-width: $text-editor-max-width;
+		max-width: $content-width;
 		margin: 0 auto;
 	}
 


### PR DESCRIPTION
This PR does a few things.

- Primarily it changes the _default_ column width. It used to be 608, now it's 580px. 580px is about the width of 70 characters, which is widely suggested as the maximum amount of characters per column for readibility. Don't worry, you can still customize this width with an editor style, we've recently made that easier to do: https://wordpress.org/gutenberg/handbook/extensibility/theme-support/#changing-the-width-of-the-editor
- It retires a text-editor width variable, and uses the same content width variable, so the two editors are the same widths.
- It removes a few ToDo's.

I'm open to suggestions as to the width of the main column — this is a suggestion for now. But it would be nice to choose a nice and round number other than 608, and apply it to both the visual and the text editor. 

Screenshots, before:

![screen shot 2018-06-04 at 08 59 23](https://user-images.githubusercontent.com/1204802/40903948-68b0a886-67d9-11e8-9256-da544ce0e57c.png)

![screen shot 2018-06-04 at 08 59 54](https://user-images.githubusercontent.com/1204802/40903953-6a2cbc54-67d9-11e8-99d8-a2de9ff81d74.png)

Screenshots, after:

![screen shot 2018-06-04 at 09 21 04](https://user-images.githubusercontent.com/1204802/40903960-709b515e-67d9-11e8-91ec-1470737767da.png)

![screen shot 2018-06-04 at 09 21 07](https://user-images.githubusercontent.com/1204802/40903964-72ef95e6-67d9-11e8-8e04-f3983935c766.png)

