### PR TITLE
Update plugin to version 3.0.

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 2.9.2
+ * Version: 3.0.0
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -86,7 +86,7 @@ add_action( 'admin_menu', 'gutenberg_menu' );
  */
 function gutenberg_wordpress_version_notice() {
 	echo '<div class="error"><p>';
-	echo __( 'Gutenberg requires WordPress 4.9 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
+	echo __( 'Gutenberg requires WordPress 4.9.6 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
 	echo '</p></div>';
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );
@@ -120,18 +120,12 @@ function gutenberg_pre_init() {
 	// Strip '-src' from the version string. Messes up version_compare().
 	$version = str_replace( '-src', '', $wp_version );
 
-	if ( version_compare( $version, '4.9', '<' ) ) {
+	if ( version_compare( $version, '4.9.6', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
 		return;
 	}
 
 	require_once dirname( __FILE__ ) . '/lib/load.php';
-
-	if ( version_compare( $version, '4.9-beta1-41829', '<' ) ) {
-		add_action( 'load-post.php', 'gutenberg_intercept_edit_post' );
-		add_action( 'load-post-new.php', 'gutenberg_intercept_post_new' );
-		return;
-	}
 
 	add_filter( 'replace_editor', 'gutenberg_init', 10, 2 );
 }
@@ -172,152 +166,6 @@ function gutenberg_init( $return, $post ) {
 	the_gutenberg_project();
 
 	return true;
-}
-
-/**
- * Emulate post.php
- */
-function gutenberg_intercept_edit_post() {
-	global $post_type, $post_type_object, $post, $post_id, $post_ID, $title, $editing,
-		$typenow, $parent_file, $submenu_file, $post_new_file;
-
-	wp_reset_vars( array( 'action' ) );
-
-	// Other actions are handled in post.php.
-	if ( 'edit' !== $GLOBALS['action'] ) {
-		return;
-	}
-
-	if ( empty( $_GET['post'] ) || ! is_numeric( $_GET['post'] ) ) {
-		return;
-	}
-
-	$post_ID = (int) $_GET['post'];
-	$post_id = $post_ID;
-
-	$post = get_post( $post_id );
-
-	// Errors and invalid requests are handled in post.php, do not intercept.
-	if ( ! $post ) {
-		return;
-	}
-
-	$post_type        = $post->post_type;
-	$post_type_object = get_post_type_object( $post_type );
-
-	if ( ! $post_type_object ) {
-		return;
-	}
-
-	if ( ! in_array( $typenow, get_post_types( array( 'show_ui' => true ) ), true ) ) {
-		return;
-	}
-
-	if ( ! current_user_can( 'edit_post', $post_id ) ) {
-		return;
-	}
-
-	if ( 'trash' === $post->post_status ) {
-		return;
-	}
-
-	if ( ! empty( $_GET['get-post-lock'] ) ) {
-		check_admin_referer( 'lock-post_' . $post_id );
-		wp_set_post_lock( $post_id );
-		wp_redirect( get_edit_post_link( $post_id, 'url' ) );
-		exit();
-	}
-
-	$editing = true;
-	$title   = $post_type_object->labels->edit_item;
-
-	if ( 'post' === $post_type ) {
-		$parent_file   = 'edit.php';
-		$submenu_file  = 'edit.php';
-		$post_new_file = 'post-new.php';
-	} elseif ( 'attachment' === $post_type ) {
-		$parent_file   = 'upload.php';
-		$submenu_file  = 'upload.php';
-		$post_new_file = 'media-new.php';
-	} else {
-		if ( isset( $post_type_object ) && $post_type_object->show_in_menu && true !== $post_type_object->show_in_menu ) {
-			$parent_file = $post_type_object->show_in_menu;
-		} else {
-			$parent_file = "edit.php?post_type=$post_type";
-		}
-
-		$submenu_file  = "edit.php?post_type=$post_type";
-		$post_new_file = "post-new.php?post_type=$post_type";
-	}
-
-	if ( gutenberg_init( false, $post ) ) {
-		include ABSPATH . 'wp-admin/admin-footer.php';
-		exit;
-	}
-}
-
-/**
- * Emulate post-new.php
- */
-function gutenberg_intercept_post_new() {
-	global $post_type, $post_type_object, $post, $post_ID, $title, $editing,
-		$parent_file, $submenu_file, $_registered_pages;
-
-	if ( ! isset( $_GET['post_type'] ) ) {
-		$post_type = 'post';
-	} elseif ( in_array( $_GET['post_type'], get_post_types( array( 'show_ui' => true ) ), true ) ) {
-		$post_type = $_GET['post_type'];
-	} else {
-		return;
-	}
-	$post_type_object = get_post_type_object( $post_type );
-
-	if ( 'post' === $post_type ) {
-		$parent_file  = 'edit.php';
-		$submenu_file = 'post-new.php';
-	} elseif ( 'attachment' === $post_type ) {
-		if ( wp_redirect( admin_url( 'media-new.php' ) ) ) {
-			exit;
-		}
-	} else {
-		$submenu_file = "post-new.php?post_type=$post_type";
-		if ( isset( $post_type_object ) && $post_type_object->show_in_menu && true !== $post_type_object->show_in_menu ) {
-			$parent_file = $post_type_object->show_in_menu;
-			// What if there isn't a post-new.php item for this post type?
-			if ( ! isset( $_registered_pages[ get_plugin_page_hookname( "post-new.php?post_type=$post_type", $post_type_object->show_in_menu ) ] ) ) {
-				if ( isset( $_registered_pages[ get_plugin_page_hookname( "edit.php?post_type=$post_type", $post_type_object->show_in_menu ) ] ) ) {
-					// Fall back to edit.php for that post type, if it exists.
-					$submenu_file = "edit.php?post_type=$post_type";
-				} else {
-					// Otherwise, give up and highlight the parent.
-					$submenu_file = $parent_file;
-				}
-			}
-		} else {
-			$parent_file = "edit.php?post_type=$post_type";
-		}
-	}
-
-	$title   = $post_type_object->labels->add_new_item;
-	$editing = true;
-
-	// Errors and invalid requests are handled in post-new.php, do not intercept.
-	if ( ! current_user_can( $post_type_object->cap->edit_posts ) || ! current_user_can( $post_type_object->cap->create_posts ) ) {
-		return;
-	}
-
-	// Schedule auto-draft cleanup.
-	if ( ! wp_next_scheduled( 'wp_scheduled_auto_draft_delete' ) ) {
-		wp_schedule_event( time(), 'daily', 'wp_scheduled_auto_draft_delete' );
-	}
-
-	$post    = get_default_post_to_edit( $post_type, true );
-	$post_ID = $post->ID;
-
-	if ( gutenberg_init( false, $post ) ) {
-		include ABSPATH . 'wp-admin/admin-footer.php';
-		exit;
-	}
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "2.9.2",
+	"version": "3.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "2.9.2",
+	"version": "3.0.0",
 	"private": true,
 	"description": "A new WordPress editor experience",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
* Redesign the inserter with collapsible panels.
* Add support for Child Blocks. These create a relationship between blocks and updates the inserter to show blocks based on context.
* Implement a new block hover and select approach to improve nested block selection and clarity.
* Allow expanding selection on consecutive Meta+A presses.
* Add shared blocks to the blocks autocompleter.
* Iterate on behaviour of the “between blocks inserter”.
* Multiple longstanding fixes to the UrlInput box by using Popover component instead of custom positioning.
* Allow themes to opt-in to the visual styles provided by core blocks.
* Allow custom colors in block icons.
* When focused on a parent with InnerBlocks set, show available child blocks clearly at the top. Blocks with children are marked visually in the root inserter.
* Add publish panels support for plugins.
* Scroll the inserter menu to the relevant position when opening a panel.
* Expand matching categories when searching the block library.
* Introduce a dedicated autosaves endpoint for handling autosave behavior. Improves general handling of revisions through REST API saves.
* Show autosave notice when autosave exists.
* Send all fields when transmitting an autosave, fixing missing titles.
* Allow clicking the block’s input fields.
* Move “Saved” blocks to the bottom and show distinct icon on the panel name.
* Improve max-upload size error message.
* Normalize unicode in raw handling.
* Allow inserting a link with no text selected.
* Center the background of the cover image block.
* Make the Classic block toolbar sticky while scrolling.
* Make Button component styles independent from Core Styles.
* Use new "theme" style mechanism to restore Quote styles on the front.
* Make various greys less dull when used with opacity.
* Set the correct min-width for the ChromePicker popover.
* Unify all the media blocks placeholders under a unique component.
* Address focus style regression in menu and improve display of keyboard shortcut.
* Refactor popover to clarify computations and address multiple cases of overflow issues.
* Avoid URL redirect for published post autosave.
* Refactor URL redirect as BrowserURL component and ensure redirect for new posts.
* Avoid superfluous changes in RichText.
* Improve performance for PublishPanel and extensions.
* Unselect blocks when opening the document settings.
* Add text alignment options to verse block toolbar.
* Make sure the Title element uses the same max-width as blocks.
* Improve title component so it works with and without editor styles.
* Properly associate the spacer height input label.
* Further visual polish to new inserter design.
* Simplify inserter accessibility.
* Fix block icon alignment in block inspector.
* Fix issue with excerpt textarea height overflow.
* Fix typo in withRehydration function call.
* Fix Post Formats UI not showing.
* Fix regressions with Button component after PostCSS.
* Fix issue with applied formats being lost.
* Fix unset background-color on sidebar headings.
* Fix case where inbetweenserter would linger if you clicked to insert and then clicked away.
* Fix issue with rich text toolbar being gone in captions.
* Fix padding and outline style for expander panel.
* Fix CodeEditor component not loading when WordPress is installed in a subfolder.
* Fix regression with sticky toolbar border.
* Fix some intermittent E2E test failures.
* Fix “no results” message within inserter.
* Fix visual issue with normal buttons with icons.
* Fix issue where the sidebar would remain open on mobile when the page loaded if it was opened before.
* Fix fileName not being respected when the image is uploaded via drag & drop.
* Fix regression in spacer block.
* Fix getInserterItems cache.
* Fix intermittent adding-blocks E2E test failure.
* Fix issue with shared block preview being rendered hidden.
* Fix alignment issue with hover label on wide and full-wide.
* Fix Windows-unfriendly theme.scss loader rule.
* Fix issue where pasting would fail in IE11.
* Fix issue with editing paragraph blocks in shared blocks.
* Address small code style fixes on the core-data module.
* Add support for getEntityRecords selectors/resolvers to the core data module to avoid duplication across the different entities.
* Remove drag handle from block breadcrumb.
* Improve Child Blocks code footprint.
* Address package issues with npm audit fix.
* Use Core’s TinyMCE version to avoid conflicts.
* Scope the rule adding a white background to the html element.
* Remove onFocus from core blocks’ RichText usage.
* Remove post type capabilities from the user object.
* Remove the dependency on the editor module code from blocks tests.
* Expose preview_link through the REST API and use within client.
* Only load Gutenberg Polyfill in editor pages.
* Refine code statement of image classes.
* Add support for the default_page_template_title filter in page-attributes meta-box.
* Add additional condition to “Available templates” meta-box logic.
* Ensure the wp-editor script is also enqueued soon using the enqueue_block_assets hook.
* Cleanup shared block tests.
* Provide cross-browser node containment checking.
* Add unit tests for core-blocks/more/edit.js components.
* Add documentation about ServerSideRender.
* Auto-generate human-readable version of Gutenberg block grammar.
* Doc Block cleanup for rich-text component.
* Address multiple typos in code comments.
* Skip test files when generating build folders for packages.
* Fail E2E tests when uncaught page error occurs.
* Extract new blob package out of utils module.
* Update the wait function name to discourage its use in E2E tests.
* Introduce new module with deprecation utility.
* Introduce insertBlock() utility for E2E tests.
* Move data module to the package maintained by Lerna.
* Avoid using spread for objects to work with all node 8x versions.
* Add lint rule to check that memize() is used.
* Add global guard against ZWSP in E2E content retrieval.
* Add building/watching support to Gutenberg packages.
* Add further explanation for why .normalize() is optional.
* Add new webpack plugin to handle library default export.
* Reload the page after webpack watch compile.
* Publish numerous WP packages updates from repository.
* Drop deprecations slated for 3.0 removal.
* Always publish main and module distributions in packages.
* Upgrade mousetrap to 1.6.2.
* Update all WordPress packages to the latest version.
* Bump WordPress requirements to 4.9.6.