### PR TITLE
Avoid loading Gutenberg assets in other admin pages

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -80,6 +80,35 @@ function gutenberg_menu() {
 add_action( 'admin_menu', 'gutenberg_menu' );
 
 /**
+ * Checks whether we're currently loading a Gutenberg page
+ *
+ * @return boolean Whether Gutenberg is being loaded.
+ *
+ * @since 3.1.0
+ */
+function is_gutenberg_page() {
+	global $post;
+
+	if ( ! is_admin() ) {
+		return false;
+	}
+
+	if ( get_current_screen()->base !== 'post' ) {
+		return false;
+	}
+
+	if ( isset( $_GET['classic-editor'] ) ) {
+		return false;
+	}
+
+	if ( ! gutenberg_can_edit_post( $post ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Display a version notice and deactivate the Gutenberg plugin.
  *
  * @since 0.1.0
@@ -150,11 +179,7 @@ function gutenberg_init( $return, $post ) {
 		return $return;
 	}
 
-	if ( isset( $_GET['classic-editor'] ) ) {
-		return false;
-	}
-
-	if ( ! gutenberg_can_edit_post( $post ) ) {
+	if ( ! is_gutenberg_page() ) {
 		return false;
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -845,6 +845,10 @@ function gutenberg_prepare_blocks_for_js() {
  * @since 0.4.0
  */
 function gutenberg_common_scripts_and_styles() {
+	if ( ! is_gutenberg_page() && is_admin() ) {
+		return;
+	}
+
 	// Enqueue basic styles built out of Gutenberg through `npm build`.
 	wp_enqueue_style( 'wp-core-blocks' );
 
@@ -1160,21 +1164,7 @@ JS;
  * Remove this in Gutenberg 3.1
  */
 function polyfill_blocks_module_in_scripts() {
-	global $post;
-
-	if ( ! is_admin() ) {
-		return;
-	}
-
-	if ( get_current_screen()->base !== 'post' ) {
-		return;
-	}
-
-	if ( isset( $_GET['classic-editor'] ) ) {
-		return;
-	}
-
-	if ( ! gutenberg_can_edit_post( $post ) ) {
+	if ( ! is_gutenberg_page() ) {
 		return;
 	}
 


### PR DESCRIPTION
This introduces a `is_gutenberg_page` helper used to ensure Gutenberg assets are only loaded when necessary.

**Testing instructions**

- Open any admin page, check that Gutenberg assets are not being loaded.