### PR TITLE
Fix PHP 5.2 notice by ensuring `$memo` is always an array

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -487,6 +487,11 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 
  * @return array        Modified reduce accumulator.
  */
 function gutenberg_preload_api_request( $memo, $path ) {
+
+	if ( ! is_array( $memo ) ) {
+		$memo = array();
+	}
+
 	if ( empty( $path ) ) {
 		return $memo;
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -488,6 +488,8 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 
  */
 function gutenberg_preload_api_request( $memo, $path ) {
 
+	// array_reduce() doesn't support passing an array in PHP 5.2
+	// so we need to make sure we start with one.
 	if ( ! is_array( $memo ) ) {
 		$memo = array();
 	}

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -151,4 +151,13 @@ class Admin_Test extends WP_UnitTestCase {
 		$link = apply_filters( 'wp_prepare_revision_for_js', array( 'restoreUrl' => 'http://test.com' ) );
 		$this->assertEquals( array( 'restoreUrl' => 'http://test.com' ), $link );
 	}
+
+	/**
+	 * Ensure gutenberg_preload_api_request() works without notices in PHP 5.2.
+	 *
+	 * The array_reduce() function only accepts mixed variables starting with PHP 5.3.
+	 */
+	function test_preload_api_request_no_notices_php_52() {
+		$this->assertTrue( is_array( gutenberg_preload_api_request( null, '/' ) ) );
+	}
 }

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -158,6 +158,6 @@ class Admin_Test extends WP_UnitTestCase {
 	 * The array_reduce() function only accepts mixed variables starting with PHP 5.3.
 	 */
 	function test_preload_api_request_no_notices_php_52() {
-		$this->assertTrue( is_array( gutenberg_preload_api_request( null, '/' ) ) );
+		$this->assertTrue( is_array( gutenberg_preload_api_request( 0, '/' ) ) );
 	}
 }


### PR DESCRIPTION
`array_reduce()` only permits `$initial` to be a mixed variable as of PHP 5.3

Fixes #4689