### PR TITLE
Updating broken FAQ link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Blocks are the unifying evolution of what is now covered, in different ways, by 
 
 Imagine a custom “employee” block that a client can drag to an About page to automatically display a picture, name, and bio. A whole universe of plugins that all extend WordPress in the same way. Simplified menus and widgets. Users who can instantly understand and use WordPress  -- and 90% of plugins. This will allow you to easily compose beautiful posts like <a href="http://moc.co/sandbox/example-post/">this example</a>.
 
-Check out the <a href="https://github.com/WordPress/gutenberg/blob/master/docs/faq.md">FAQ</a> for answers to the most common questions about the project.
+Check out the <a href="https://github.com/WordPress/gutenberg/blob/master/docs/reference/faq.md">FAQ</a> for answers to the most common questions about the project.
 
 ## Compatibility
 


### PR DESCRIPTION
The docs file structure was updated in #6161. This broke the FAQ link in the README. This PR updates the link with the correct destination.

Previous link: https://github.com/WordPress/gutenberg/blob/master/docs/faq.md
New link: https://github.com/WordPress/gutenberg/blob/master/docs/reference/faq.md

_Note: I wasn't sure if I should adopt a relative path, like those in #6161 — I decided against it because we don't use relative paths elsewhere in this particular file. But happy to change that if we'd prefer._ 