### PR TITLE
Verify if block icon background and foreground colors are readable

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -15,7 +15,7 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
-import { isValidIcon, normalizeIconObject } from './utils';
+import { isIconUnreadable, isValidIcon, normalizeIconObject } from './utils';
 
 /**
  * Defined behavior of a block type.
@@ -147,6 +147,13 @@ export function registerBlockType( name, settings ) {
 			'The icon should be a string, an element, a function, or an object following the specifications documented in https://wordpress.org/gutenberg/handbook/block-api/#icon-optional'
 		);
 		return;
+	}
+
+	if ( isIconUnreadable( settings.icon ) && window ) {
+		window.console.warn(
+			`The icon background color ${ settings.icon.background } and the foreground color ${ settings.icon.foreground } are not readable together. ` +
+			'Please try to increase the brightness and/or contrast difference between background and foreground.'
+		);
 	}
 
 	if ( 'useOnce' in settings ) {

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -292,6 +292,38 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		it( 'should warn if the icon background and foreground are not readable', () => {
+			const blockType = {
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: {
+					background: '#f00',
+					foreground: '#d00',
+					src: 'block-default',
+				},
+			};
+			registerBlockType( 'core/test-block-icon-unreadable', blockType );
+			expect( console ).toHaveWarned();
+		} );
+
+		it( 'should  not warn if the icon background and foreground are readable', () => {
+			const blockType = {
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: {
+					background: '#f00',
+					foreground: '#000',
+					src: 'block-default',
+				},
+			};
+			registerBlockType( 'core/test-block-icon-readable', blockType );
+			expect( getBlockType( 'core/test-block-icon-readable' ).name ).toEqual(
+				'core/test-block-icon-readable'
+			);
+		} );
+
 		it( 'should store a copy of block type', () => {
 			const blockType = { settingName: 'settingValue', save: noop, category: 'common', title: 'block title' };
 			registerBlockType( 'core/test-block-with-settings', blockType );

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -69,6 +69,23 @@ export function isValidIcon( icon ) {
 }
 
 /**
+ * Function that returns true if the background and foreground colors of the icon are unreadable.
+ *
+ * @param {*} icon  Parameter to be checked.
+ *
+ * @return {boolean} True if the background and foreground colors of the icon are unreadable.
+ */
+
+export function isIconUnreadable( icon ) {
+	return !! ( icon && icon.background && icon.foreground ) &&
+		! tinycolor.isReadable(
+			tinycolor( icon.background ),
+			tinycolor( icon.foreground ),
+			{ level: 'AA', size: 'large' }
+		);
+}
+
+/**
  * Function that receives an icon as set by the blocks during the registration
  * and returns a new icon object that is normalized so we can rely on just on possible icon structure
  * in the codebase.


### PR DESCRIPTION
If the color combination is not readable, a warning is shown in the developer console.

## How has this been tested?
Verify that if the block just sets a background color like https://gist.github.com/jorgefilipecosta/2dd281f9f5f078258f7c8d4ba4cc34cd things work as before.

Verify that if the blocks set a pair of unreadable colors e.g: https://gist.github.com/jorgefilipecosta/3118c641e46fe0bea146877109ccb3af a warning is shown.

Verify that if the blocks set background and foreground colors that are readable no warning is shown https://gist.github.com/jorgefilipecosta/a2eb7c940e008e351f96aadf7ccbd999.

