### PR TITLE
Fix columns block style on the frontend

### DIFF
--- a/core-blocks/columns/editor.scss
+++ b/core-blocks/columns/editor.scss
@@ -37,3 +37,18 @@
 		margin-right: $block-side-ui-padding;
 	}
 }
+
+.wp-block-columns {
+	display: block;
+
+	.editor-inner-blocks {
+		display: grid;
+		grid-auto-flow: dense;
+	}
+
+	@for $i from 2 through 6 {
+		&.has-#{ $i }-columns .editor-inner-blocks {
+			grid-auto-columns: #{ 100% / $i };
+		}
+	}
+}

--- a/core-blocks/columns/style.scss
+++ b/core-blocks/columns/style.scss
@@ -1,12 +1,9 @@
 .wp-block-columns {
-
-	.editor-inner-blocks {
-		display: grid;
-		grid-auto-flow: dense;
-	}
+	display: grid;
+	grid-auto-flow: dense;
 
 	@for $i from 2 through 6 {
-		&.has-#{ $i }-columns .editor-inner-blocks {
+		&.has-#{ $i }-columns {
 			grid-auto-columns: #{ 100% / $i };
 		}
 	}


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/7127.


## How has this been tested?
Use the columns block verify things work as expected on the editor, posts with columns block and see that on the front end the columns appear as expected.

