### PR TITLE
State: Trigger autosave as standard save for draft by current user

### DIFF
--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -17,24 +17,32 @@ export class PostPreviewButton extends Component {
 		super( ...arguments );
 
 		this.saveForPreview = this.saveForPreview.bind( this );
-
-		this.state = {
-			isAwaitingSave: false,
-		};
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const { modified, link } = nextProps;
-		const { isAwaitingSave } = this.state;
-		const hasFinishedSaving = (
-			isAwaitingSave &&
-			modified !== this.props.modified
-		);
+	componentDidUpdate( prevProps ) {
+		const { previewLink } = this.props;
 
-		if ( hasFinishedSaving && this.previewWindow ) {
-			this.previewWindow.location = link;
-			this.setState( { isAwaitingSave: false } );
+		// This relies on the window being responsible to unset itself when
+		// navigation occurs or a new preview window is opened, to avoid
+		// unintentional forceful redirects.
+		if ( previewLink && previewLink !== prevProps.previewLink ) {
+			this.setPreviewWindowLink( previewLink );
 		}
+	}
+
+	/**
+	 * Sets the preview window's location to the given URL, if a preview window
+	 * exists and is not already at that location.
+	 *
+	 * @param {string} url URL to assign as preview window location.
+	 */
+	setPreviewWindowLink( url ) {
+		const { previewWindow } = this;
+		if ( ! previewWindow || previewWindow.location.href === url ) {
+			return;
+		}
+
+		previewWindow.location = url;
 	}
 
 	getWindowTarget() {
@@ -44,6 +52,7 @@ export class PostPreviewButton extends Component {
 
 	saveForPreview( event ) {
 		const { isDirty, isNew } = this.props;
+
 		// Let default link behavior occur if no changes to saved post
 		if ( ! isDirty && ! isNew ) {
 			return;
@@ -51,9 +60,6 @@ export class PostPreviewButton extends Component {
 
 		// Save post prior to opening window
 		this.props.autosave();
-		this.setState( {
-			isAwaitingSave: true,
-		} );
 
 		// Open a popup, BUT: Set it to a blank page until save completes. This
 		// is necessary because popups can only be opened in response to user
@@ -63,10 +69,6 @@ export class PostPreviewButton extends Component {
 			'about:blank',
 			this.getWindowTarget()
 		);
-
-		// When popup is closed, delete reference to avoid later assignment of
-		// location in a post update.
-		this.previewWindow.onbeforeunload = () => delete this.previewWindow;
 
 		const markup = `
 			<div>
@@ -93,16 +95,20 @@ export class PostPreviewButton extends Component {
 
 		this.previewWindow.document.write( markup );
 		this.previewWindow.document.close();
+
+		// When popup is closed or redirected by setPreviewWindowLink, delete
+		// reference to avoid later assignment of location in a post update.
+		this.previewWindow.onbeforeunload = () => delete this.previewWindow;
 	}
 
 	render() {
-		const { link, isSaveable } = this.props;
+		const { currentPostLink, isSaveable } = this.props;
 
 		return (
 			<Button
 				className="editor-post-preview"
 				isLarge
-				href={ link }
+				href={ currentPostLink }
 				onClick={ this.saveForPreview }
 				target={ this.getWindowTarget() }
 				disabled={ ! isSaveable }
@@ -120,7 +126,8 @@ export default compose( [
 	withSelect( ( select ) => {
 		const {
 			getCurrentPostId,
-			getEditedPostPreviewLink,
+			getCurrentPostAttribute,
+			getAutosaveAttribute,
 			getEditedPostAttribute,
 			isEditedPostDirty,
 			isEditedPostNew,
@@ -132,12 +139,12 @@ export default compose( [
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		return {
 			postId: getCurrentPostId(),
-			link: getEditedPostPreviewLink(),
+			currentPostLink: getCurrentPostAttribute( 'link' ),
+			previewLink: getAutosaveAttribute( 'preview_link' ),
 			isDirty: isEditedPostDirty(),
 			isNew: isEditedPostNew(),
 			isSaveable: isEditedPostSaveable(),
 			isViewable: get( postType, [ 'viewable' ], false ),
-			modified: getEditedPostAttribute( 'modified' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/editor/components/post-preview-button/test/index.js
+++ b/editor/components/post-preview-button/test/index.js
@@ -9,11 +9,55 @@ import { shallow } from 'enzyme';
 import { PostPreviewButton } from '../';
 
 describe( 'PostPreviewButton', () => {
-	describe( 'constructor()', () => {
-		it( 'should initialize with non-awaiting-save', () => {
-			const instance = new PostPreviewButton( {} );
+	describe( 'setPreviewWindowLink()', () => {
+		it( 'should do nothing if there is no preview window', () => {
+			const url = 'https://wordpress.org';
+			const setter = jest.fn();
+			const wrapper = shallow( <PostPreviewButton /> );
 
-			expect( instance.state.isAwaitingSave ).toBe( false );
+			wrapper.instance().setPreviewWindowLink( url );
+
+			expect( setter ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should do nothing if the preview window is already at url location', () => {
+			const url = 'https://wordpress.org';
+			const setter = jest.fn();
+			const wrapper = shallow( <PostPreviewButton /> );
+			wrapper.instance().previewWindow = {
+				get location() {
+					return {
+						href: url,
+					};
+				},
+				set location( value ) {
+					setter( value );
+				},
+			};
+
+			wrapper.instance().setPreviewWindowLink( url );
+
+			expect( setter ).not.toHaveBeenCalled();
+		} );
+
+		it( 'set preview window location to url', () => {
+			const url = 'https://wordpress.org';
+			const setter = jest.fn();
+			const wrapper = shallow( <PostPreviewButton /> );
+			wrapper.instance().previewWindow = {
+				get location() {
+					return {
+						href: 'about:blank',
+					};
+				},
+				set location( value ) {
+					setter( value );
+				},
+			};
+
+			wrapper.instance().setPreviewWindowLink( url );
+
+			expect( setter ).toHaveBeenCalledWith( url );
 		} );
 	} );
 
@@ -28,23 +72,21 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	describe( 'componentDidUpdate()', () => {
-		it( 'should change popup location if save finishes', () => {
+		it( 'should change popup location if preview link is available', () => {
 			const wrapper = shallow(
 				<PostPreviewButton
 					postId={ 1 }
-					link="https://wordpress.org/?p=1"
+					currentPostLink="https://wordpress.org/?p=1"
 					isSaveable
 					modified="2017-08-03T15:05:50" />
 			);
-			wrapper.instance().previewWindow = {};
-			wrapper.setState( { isAwaitingSave: true } );
+			wrapper.instance().previewWindow = { location: {} };
 
-			wrapper.setProps( { modified: '2017-08-03T15:05:52' } );
+			wrapper.setProps( { previewLink: 'https://wordpress.org/?p=1' } );
 
 			expect(
 				wrapper.instance().previewWindow.location
 			).toBe( 'https://wordpress.org/?p=1' );
-			expect( wrapper.state( 'isAwaitingSave' ) ).toBe( false );
 		} );
 	} );
 
@@ -71,13 +113,11 @@ describe( 'PostPreviewButton', () => {
 			if ( isExpectingSave ) {
 				expect( autosave ).toHaveBeenCalled();
 				expect( preventDefault ).toHaveBeenCalled();
-				expect( wrapper.state( 'isAwaitingSave' ) ).toBe( true );
 				expect( window.open ).toHaveBeenCalled();
 				expect( wrapper.instance().previewWindow.document.write ).toHaveBeenCalled();
 			} else {
 				expect( autosave ).not.toHaveBeenCalled();
 				expect( preventDefault ).not.toHaveBeenCalled();
-				expect( wrapper.state( 'isAwaitingSave' ) ).not.toBe( true );
 				expect( window.open ).not.toHaveBeenCalled();
 			}
 
@@ -118,7 +158,7 @@ describe( 'PostPreviewButton', () => {
 				<PostPreviewButton
 					postId={ 1 }
 					isSaveable
-					link="https://wordpress.org/?p=1" />
+					currentPostLink="https://wordpress.org/?p=1" />
 			);
 
 			expect( wrapper.prop( 'href' ) ).toBe( 'https://wordpress.org/?p=1' );
@@ -130,7 +170,7 @@ describe( 'PostPreviewButton', () => {
 			const wrapper = shallow(
 				<PostPreviewButton
 					postId={ 1 }
-					link="https://wordpress.org/?p=1" />
+					currentPostLink="https://wordpress.org/?p=1" />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -391,7 +391,7 @@ export function editPost( edits ) {
  *
  * @return {Object} Action object.
  */
-export function savePost( options ) {
+export function savePost( options = {} ) {
 	return {
 		type: 'REQUEST_POST_UPDATE',
 		options,

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -60,6 +60,21 @@ export function resetAutosave( post ) {
 }
 
 /**
+ * Returns an action object used in signalling that a patch of updates for the
+ * latest version of the post have been received.
+ *
+ * @param {Object} edits Updated post fields.
+ *
+ * @return {Object} Action object.
+ */
+export function updatePost( edits ) {
+	return {
+		type: 'UPDATE_POST',
+		edits,
+	};
+}
+
+/**
  * Returns an action object used to setup the editor state when first opening an editor.
  *
  * @param {Object}  post            Post object.

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -1085,7 +1085,19 @@ export function autosave( state = null, action ) {
 				'content',
 			].map( ( field ) => getPostRawValue( post[ field ] ) );
 
-			return { title, excerpt, content };
+			return {
+				title,
+				excerpt,
+				content,
+				preview_link: post.preview_link,
+			};
+
+		case 'REQUEST_POST_UPDATE':
+			// Invalidate known preview link when autosave starts.
+			if ( state && action.options.autosave ) {
+				return omit( state, 'preview_link' );
+			}
+			break;
 	}
 
 	return state;

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -217,15 +217,15 @@ export const editor = flow( [
 	// Track undo history, starting at editor initialization.
 	withHistory( {
 		resetTypes: [ 'SETUP_EDITOR_STATE' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'UPDATE_POST' ],
 		shouldOverwriteState,
 	} ),
 
 	// Track whether changes exist, resetting at each post save. Relies on
 	// editor initialization firing post reset as an effect.
 	withChangeDetection( {
-		resetTypes: [ 'SETUP_EDITOR_STATE', 'UPDATE_POST' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST' ],
+		resetTypes: [ 'SETUP_EDITOR_STATE', 'REQUEST_POST_UPDATE_START' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'UPDATE_POST' ],
 	} ),
 ] )( {
 	edits( state = {}, action ) {

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -254,6 +254,9 @@ export const editor = flow( [
 
 				return state;
 
+			case 'DIRTY_ARTIFICIALLY':
+				return { ...state };
+
 			case 'UPDATE_POST':
 			case 'RESET_POST':
 				const getCanonicalValue = action.type === 'UPDATE_POST' ?

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -562,16 +562,6 @@ export function currentPost( state = {}, action ) {
 			}
 
 			return mapValues( post, getPostRawValue );
-
-		case 'RESET_AUTOSAVE':
-			// A post is no longer auto-draft (now draft) when autosave occurs.
-			if ( state.status === 'auto-draft' ) {
-				return {
-					...state,
-					status: 'draft',
-				};
-			}
-			break;
 	}
 
 	return state;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -183,6 +183,21 @@ export function getPostEdits( state ) {
 }
 
 /**
+ * Returns an attribute value of the saved post.
+ *
+ * @param {Object} state         Global application state.
+ * @param {string} attributeName Post attribute name.
+ *
+ * @return {*} Post attribute value.
+ */
+export function getCurrentPostAttribute( state, attributeName ) {
+	const post = getCurrentPost( state );
+	if ( post.hasOwnProperty( attributeName ) ) {
+		return post[ attributeName ];
+	}
+}
+
+/**
  * Returns a single attribute of the post being edited, preferring the unsaved
  * edit if one exists, but falling back to the attribute for the last known
  * saved state of the post.
@@ -201,9 +216,31 @@ export function getEditedPostAttribute( state, attributeName ) {
 			return getEditedPostContent( state );
 	}
 
-	return edits[ attributeName ] === undefined ?
-		state.currentPost[ attributeName ] :
-		edits[ attributeName ];
+	if ( ! edits.hasOwnProperty( attributeName ) ) {
+		return getCurrentPostAttribute( state, attributeName );
+	}
+
+	return edits[ attributeName ];
+}
+
+/**
+ * Returns an attribute value of the current autosave revision for a post, or
+ * null if there is no autosave for the post.
+ *
+ * @param {Object} state         Global application state.
+ * @param {string} attributeName Autosave attribute name.
+ *
+ * @return {*} Autosave attribute value.
+ */
+export function getAutosaveAttribute( state, attributeName ) {
+	if ( ! hasAutosave( state ) ) {
+		return null;
+	}
+
+	const autosave = getAutosave( state );
+	if ( autosave.hasOwnProperty( attributeName ) ) {
+		return autosave[ attributeName ];
+	}
 }
 
 /**

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -244,6 +244,14 @@ describe( 'actions', () => {
 		it( 'should return REQUEST_POST_UPDATE action', () => {
 			expect( savePost() ).toEqual( {
 				type: 'REQUEST_POST_UPDATE',
+				options: {},
+			} );
+		} );
+
+		it( 'should pass through options argument', () => {
+			expect( savePost( { autosave: true } ) ).toEqual( {
+				type: 'REQUEST_POST_UPDATE',
+				options: { autosave: true },
 			} );
 		} );
 	} );

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -34,6 +34,7 @@ import {
 	convertBlockToStatic,
 	convertBlockToShared,
 	setTemplateValidity,
+	editPost,
 } from '../actions';
 import effects, {
 	removeProvisionalBlock,
@@ -260,6 +261,16 @@ describe( 'effects', () => {
 	describe( '.REQUEST_POST_UPDATE_SUCCESS', () => {
 		const handler = effects.REQUEST_POST_UPDATE_SUCCESS;
 
+		function createGetState( hasLingeringEdits = false ) {
+			let state = reducer( undefined, {} );
+			if ( hasLingeringEdits ) {
+				state = reducer( state, editPost( { edited: true } ) );
+			}
+
+			const getState = () => state;
+			return getState;
+		}
+
 		const defaultPost = {
 			id: 1,
 			title: {
@@ -280,7 +291,7 @@ describe( 'effects', () => {
 
 		it( 'should dispatch notices when publishing or scheduling a post', () => {
 			const dispatch = jest.fn();
-			const store = { dispatch };
+			const store = { dispatch, getState: createGetState() };
 
 			const previousPost = getDraftPost();
 			const post = getPublishedPost();
@@ -302,7 +313,7 @@ describe( 'effects', () => {
 
 		it( 'should dispatch notices when reverting a published post to a draft', () => {
 			const dispatch = jest.fn();
-			const store = { dispatch };
+			const store = { dispatch, getState: createGetState() };
 
 			const previousPost = getPublishedPost();
 			const post = getDraftPost();
@@ -328,7 +339,7 @@ describe( 'effects', () => {
 
 		it( 'should dispatch notices when just updating a published post again', () => {
 			const dispatch = jest.fn();
-			const store = { dispatch };
+			const store = { dispatch, getState: createGetState() };
 
 			const previousPost = getPublishedPost();
 			const post = getPublishedPost();
@@ -350,7 +361,7 @@ describe( 'effects', () => {
 
 		it( 'should do nothing if the updated post was autosaved', () => {
 			const dispatch = jest.fn();
-			const store = { dispatch };
+			const store = { dispatch, getState: createGetState() };
 
 			const previousPost = getPublishedPost();
 			const post = { ...getPublishedPost(), id: defaultPost.id + 1 };
@@ -358,6 +369,19 @@ describe( 'effects', () => {
 			handler( { post, previousPost, isAutosave: true }, store );
 
 			expect( dispatch ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		it( 'should dispatch dirtying action if edits linger after autosave', () => {
+			const dispatch = jest.fn();
+			const store = { dispatch, getState: createGetState( true ) };
+
+			const previousPost = getPublishedPost();
+			const post = { ...getPublishedPost(), id: defaultPost.id + 1 };
+
+			handler( { post, previousPost, isAutosave: true }, store );
+
+			expect( dispatch ).toHaveBeenCalledTimes( 1 );
+			expect( dispatch ).toHaveBeenCalledWith( { type: 'DIRTY_ARTIFICIALLY' } );
 		} );
 	} );
 
@@ -531,7 +555,7 @@ describe( 'effects', () => {
 
 			expect( result ).toEqual( [
 				setTemplateValidity( true ),
-				setupEditorState( post, [], { title: 'A History of Pork', status: 'draft' } ),
+				setupEditorState( post, [], { title: 'A History of Pork' } ),
 			] );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -2298,6 +2298,7 @@ describe( 'state', () => {
 						raw: 'The Excerpt',
 					},
 					status: 'draft',
+					preview_link: 'https://wordpress.org/?p=1&preview=true',
 				},
 			} );
 
@@ -2305,6 +2306,7 @@ describe( 'state', () => {
 				title: 'The Title',
 				content: 'The Content',
 				excerpt: 'The Excerpt',
+				preview_link: 'https://wordpress.org/?p=1&preview=true',
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1273,24 +1273,6 @@ describe( 'state', () => {
 				status: 'publish',
 			} );
 		} );
-
-		it( 'should set status to draft if autosave reset while auto-draft', () => {
-			const original = deepFreeze( { title: '', status: 'auto-draft' } );
-
-			const state = currentPost( original, {
-				type: 'RESET_AUTOSAVE',
-				edits: {
-					title: 'Hello world',
-					content: '',
-					excerpt: '',
-				},
-			} );
-
-			expect( state ).toEqual( {
-				title: '',
-				status: 'draft',
-			} );
-		} );
 	} );
 
 	describe( 'isInsertionPointVisible', () => {

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -50,7 +50,9 @@ const {
 	getSelectedBlock,
 	getSelectedBlockUID,
 	getBlockRootUID,
+	getCurrentPostAttribute,
 	getEditedPostAttribute,
+	getAutosaveAttribute,
 	getGlobalBlockCount,
 	getMultiSelectedBlockUids,
 	getMultiSelectedBlocks,
@@ -365,6 +367,34 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( 'getCurrentPostAttribute', () => {
+		it( 'should return undefined for an attribute which does not exist', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( getCurrentPostAttribute( state, 'foo' ) ).toBeUndefined();
+		} );
+
+		it( 'should return undefined for object prototype member', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( getCurrentPostAttribute( state, 'valueOf' ) ).toBeUndefined();
+		} );
+
+		it( 'should return the value of an attribute', () => {
+			const state = {
+				currentPost: {
+					title: 'Hello World',
+				},
+			};
+
+			expect( getCurrentPostAttribute( state, 'title' ) ).toBe( 'Hello World' );
+		} );
+	} );
+
 	describe( 'getEditedPostAttribute', () => {
 		it( 'should return the current post\'s slug if no edits have been made', () => {
 			const state = {
@@ -422,6 +452,55 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'youcha' );
+		} );
+
+		it( 'should return undefined for object prototype member', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+			};
+
+			expect( getEditedPostAttribute( state, 'valueOf' ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'getAutosaveAttribute', () => {
+		it( 'returns null if there is no autosave', () => {
+			const state = {
+				autosave: null,
+			};
+
+			expect( getAutosaveAttribute( state, 'title' ) ).toBeNull();
+		} );
+
+		it( 'returns undefined for an attribute which is not set', () => {
+			const state = {
+				autosave: {},
+			};
+
+			expect( getAutosaveAttribute( state, 'foo' ) ).toBeUndefined();
+		} );
+
+		it( 'returns undefined for object prototype member', () => {
+			const state = {
+				autosave: {},
+			};
+
+			expect( getAutosaveAttribute( state, 'valueOf' ) ).toBeUndefined();
+		} );
+
+		it( 'returns the attribute value', () => {
+			const state = {
+				autosave: {
+					title: 'Hello World',
+				},
+			};
+
+			expect( getAutosaveAttribute( state, 'title' ) ).toBe( 'Hello World' );
 		} );
 	} );
 

--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -265,7 +265,17 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 * @return array Item schema data.
 	 */
 	public function get_item_schema() {
-		return $this->revisions_controller->get_item_schema();
+		$schema = $this->revisions_controller->get_item_schema();
+
+		$schema['properties']['preview_link'] = array(
+			'description' => __( 'Preview link for the post.', 'gutenberg' ),
+			'type'        => 'string',
+			'format'      => 'uri',
+			'context'     => array( 'edit' ),
+			'readonly'    => true,
+		);
+
+		return $schema;
 	}
 
 	/**
@@ -338,6 +348,24 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	public function prepare_item_for_response( $post, $request ) {
 
 		$response = $this->revisions_controller->prepare_item_for_response( $post, $request );
+
+		$schema = $this->get_item_schema();
+
+		if ( ! empty( $schema['properties']['preview_link'] ) ) {
+			$parent_id = wp_is_post_autosave( $post );
+			$preview_post_id = false === $parent_id ? $post->ID : $parent_id;
+			$preview_query_args = array();
+
+			if ( false !== $parent_id ) {
+				$preview_query_args['preview_id']    = $parent_id;
+				$preview_query_args['preview_nonce'] = wp_create_nonce( 'post_preview_' . $parent_id );
+			}
+
+			$response->data['preview_link'] = get_preview_post_link( $preview_post_id, $preview_query_args );
+		}
+
+		$context        = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$response->data = $this->filter_response_by_context( $response->data, $context );
 
 		/**
 		 * Filters a revision returned from the API.

--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -352,8 +352,8 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		$schema = $this->get_item_schema();
 
 		if ( ! empty( $schema['properties']['preview_link'] ) ) {
-			$parent_id = wp_is_post_autosave( $post );
-			$preview_post_id = false === $parent_id ? $post->ID : $parent_id;
+			$parent_id          = wp_is_post_autosave( $post );
+			$preview_post_id    = false === $parent_id ? $post->ID : $parent_id;
 			$preview_query_args = array();
 
 			if ( false !== $parent_id ) {

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -439,45 +439,6 @@ function gutenberg_register_rest_api_post_revisions() {
 add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_revisions' );
 
 /**
- * Get the preview link for the post object.
- *
- * @see https://github.com/WordPress/gutenberg/issues/4555
- *
- * @param WP_Post $post Post object.
- * @return string
- */
-function gutenberg_get_post_preview_link( $post ) {
-	return get_preview_post_link( $post['id'] );
-}
-
-/**
- * Adds the 'preview_link' attribute to the REST API response of a post.
- *
- * @see https://github.com/WordPress/gutenberg/issues/4555
- */
-function gutenberg_register_rest_api_post_preview_link() {
-	foreach ( get_post_types( array( 'show_in_rest' => true ), 'names' ) as $post_type ) {
-		if ( ! is_post_type_viewable( $post_type ) ) {
-			continue;
-		}
-		register_rest_field( $post_type,
-			'preview_link',
-			array(
-				'get_callback' => 'gutenberg_get_post_preview_link',
-				'schema'       => array(
-					'description' => __( 'Preview link for the post.', 'gutenberg' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'context'     => array( 'edit' ),
-					'readonly'    => true,
-				),
-			)
-		);
-	}
-}
-add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_preview_link' );
-
-/**
  * Ensure that the wp-json index contains the 'theme-supports' setting as
  * part of its site info elements.
  *

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -414,19 +414,4 @@ class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 		$data = $response->get_data();
 		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
 	}
-
-	public function test_get_page_edit_context_includes_preview() {
-		wp_set_current_user( $this->editor );
-		$page_id = $this->factory->post->create( array(
-			'post_type'   => 'page',
-			'post_status' => 'draft',
-		) );
-		$page    = get_post( $page_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/pages/' . $page_id );
-		$request->set_param( 'context', 'edit' );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$data = $response->get_data();
-		$this->assertEquals( get_preview_post_link( $page ), $data['preview_link'] );
-	}
 }

--- a/phpunit/class-rest-autosaves-controller-test.php
+++ b/phpunit/class-rest-autosaves-controller-test.php
@@ -239,7 +239,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 12, count( $properties ) );
+		$this->assertEquals( 13, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'content', $properties );
 		$this->assertArrayHasKey( 'date', $properties );
@@ -252,6 +252,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertArrayHasKey( 'parent', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
+		$this->assertArrayHasKey( 'preview_link', $properties );
 	}
 
 	public function test_create_item() {

--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -7,6 +7,7 @@ import {
 	newDesktopBrowserPage,
 	pressWithModifier,
 	ensureSidebarOpened,
+	publishPost,
 } from '../support/utils';
 
 describe( 'Change detection', () => {
@@ -112,20 +113,7 @@ describe( 'Change detection', () => {
 	it( 'Should prompt to confirm unsaved changes for autosaved published post', async () => {
 		await page.type( '.editor-post-title__input', 'Hello World' );
 
-		await Promise.all( [
-			page.waitForSelector( '.editor-post-publish-button' ),
-			page.click( '.editor-post-publish-panel__toggle' ),
-		] );
-
-		// Disable reason: Wait for animation to complete to avoid click
-		// occuring at wrong point.
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 100 );
-
-		await Promise.all( [
-			page.waitForSelector( '.editor-post-publish-panel__header-published' ),
-			page.click( '.editor-post-publish-button' ),
-		] );
+		await publishPost();
 
 		// Close publish panel.
 		await Promise.all( [

--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -76,10 +76,10 @@ describe( 'Change detection', () => {
 	it( 'Should autosave post', async () => {
 		await page.type( '.editor-post-title__input', 'Hello World' );
 
-		// Force autosave to occur immediately. It will occur as a normal save.
+		// Force autosave to occur immediately.
 		await Promise.all( [
 			page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() ),
-			page.waitForSelector( '.editor-post-saved-state.is-saving' ),
+			page.waitForSelector( '.editor-post-saved-state.is-autosaving' ),
 			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
 		] );
 

--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -95,6 +95,11 @@ describe( 'Change detection', () => {
 			page.click( '.editor-post-publish-panel__toggle' ),
 		] );
 
+		// Disable reason: Wait for animation to complete to avoid click
+		// occuring at wrong point.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 100 );
+
 		await Promise.all( [
 			page.waitForSelector( '.editor-post-publish-panel__header-published' ),
 			page.click( '.editor-post-publish-button' ),
@@ -111,9 +116,9 @@ describe( 'Change detection', () => {
 
 		await Promise.all( [
 			page.waitForSelector( '.editor-post-publish-button.is-busy' ),
+			page.waitForSelector( '.editor-post-publish-button:not( .is-busy )' ),
 			page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() ),
 		] );
-		await page.waitForSelector( '.editor-post-publish-button:not( .is-busy )' );
 
 		await assertIsDirty( true );
 	} );

--- a/test/e2e/specs/preview.test.js
+++ b/test/e2e/specs/preview.test.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import { parse } from 'url';
+
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import {
+	newPost,
+	newDesktopBrowserPage,
+	getUrl,
+	publishPost,
+} from '../support/utils';
+
+describe( 'Preview', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+	} );
+
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'Should open a preview window for a new post', async () => {
+		const editorPage = page;
+
+		// Disabled until content present.
+		const isPreviewDisabled = await page.$$eval(
+			'.editor-post-preview:not( :disabled )',
+			( enabledButtons ) => ! enabledButtons.length,
+		);
+		expect( isPreviewDisabled ).toBe( true );
+
+		await editorPage.type( '.editor-post-title__input', 'Hello World' );
+
+		// Don't proceed with autosave until preview window page is resolved.
+		await editorPage.setRequestInterception( true );
+
+		let [ , previewPage ] = await Promise.all( [
+			editorPage.click( '.editor-post-preview' ),
+			new Promise( ( resolve ) => {
+				browser.once( 'targetcreated', async ( target ) => {
+					resolve( await target.page() );
+				} );
+			} ),
+		] );
+
+		// Interstitial screen while save in progress.
+		expect( previewPage.url() ).toBe( 'about:blank' );
+
+		// Release request intercept should allow redirect to occur after save.
+		await Promise.all( [
+			previewPage.waitForNavigation(),
+			editorPage.setRequestInterception( false ),
+		] );
+
+		// When autosave completes for a new post, the URL of the editor should
+		// update to include the ID. Use this to assert on preview URL.
+		const [ , postId ] = await ( await editorPage.waitForFunction( () => {
+			return window.location.search.match( /[\?&]post=(\d+)/ );
+		} ) ).jsonValue();
+
+		let expectedPreviewURL = getUrl( '', `?p=${ postId }&preview=true` );
+		expect( previewPage.url() ).toBe( expectedPreviewURL );
+
+		// Title in preview should match input.
+		let previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'Hello World' );
+
+		// Return to editor to change title.
+		await editorPage.bringToFront();
+		await editorPage.type( '.editor-post-title__input', '!' );
+
+		// Second preview should reuse same popup frame, with interstitial.
+		await editorPage.setRequestInterception( true );
+		await Promise.all( [
+			editorPage.click( '.editor-post-preview' ),
+			// Note: `load` event is used since, while a `window.open` with
+			// `about:blank` is called, the target window doesn't actually
+			// navigate to `about:blank` (it is treated as noop). But when
+			// the `document.write` + `document.close` of the interstitial
+			// finishes, a `load` event is fired.
+			new Promise( ( resolve ) => previewPage.once( 'load', resolve ) ),
+		] );
+		await editorPage.setRequestInterception( false );
+
+		// Wait for preview to load.
+		await new Promise( ( resolve ) => {
+			previewPage.once( 'load', resolve );
+		} );
+
+		// Title in preview should match updated input.
+		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'Hello World!' );
+
+		// Pressing preview without changes should bring same preview window to
+		// front and reload, but should not show interstitial. Intercept editor
+		// requests in case a save attempt occurs, to avoid race condition on
+		// the load event and title retrieval.
+		await editorPage.bringToFront();
+		await editorPage.setRequestInterception( true );
+		await editorPage.click( '.editor-post-preview' );
+		await new Promise( ( resolve ) => previewPage.once( 'load', resolve ) );
+		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'Hello World!' );
+		await editorPage.setRequestInterception( false );
+
+		// Preview for published post (no unsaved changes) directs to canonical
+		// URL for post.
+		await editorPage.bringToFront();
+		await publishPost();
+		await Promise.all( [
+			page.waitForFunction( () => ! document.querySelector( '.editor-post-preview' ) ),
+			page.click( '.editor-post-publish-panel__header button' ),
+		] );
+		expectedPreviewURL = await editorPage.$eval( '.notice-success a', ( node ) => node.href );
+		// Note / Temporary: It's expected that Chrome should reuse the same
+		// tab with window name `wp-preview-##`, yet in this instance a new tab
+		// is unfortunately created.
+		previewPage = ( await Promise.all( [
+			editorPage.click( '.editor-post-preview' ),
+			new Promise( ( resolve ) => {
+				browser.once( 'targetcreated', async ( target ) => {
+					resolve( await target.page() );
+				} );
+			} ),
+		] ) )[ 1 ];
+		expect( previewPage.url() ).toBe( expectedPreviewURL );
+
+		// Return to editor to change title.
+		await editorPage.bringToFront();
+		await editorPage.type( '.editor-post-title__input', ' And more.' );
+
+		// Published preview should reuse same popup frame, with interstitial.
+		await editorPage.setRequestInterception( true );
+		await Promise.all( [
+			editorPage.click( '.editor-post-preview' ),
+			new Promise( ( resolve ) => previewPage.once( 'load', resolve ) ),
+		] );
+		await editorPage.setRequestInterception( false );
+
+		// Wait for preview to load.
+		await new Promise( ( resolve ) => {
+			previewPage.once( 'load', resolve );
+		} );
+
+		// Title in preview should match updated input.
+		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'Hello World! And more.' );
+
+		// Published preview URL should include ID and nonce parameters.
+		const { query } = parse( previewPage.url(), true );
+		expect( query ).toHaveProperty( 'preview_id' );
+		expect( query ).toHaveProperty( 'preview_nonce' );
+	} );
+} );

--- a/test/e2e/specs/publishing.test.js
+++ b/test/e2e/specs/publishing.test.js
@@ -5,6 +5,7 @@ import '../support/bootstrap';
 import {
 	newPost,
 	newDesktopBrowserPage,
+	publishPost,
 } from '../support/utils';
 
 describe( 'Publishing', () => {
@@ -19,18 +20,7 @@ describe( 'Publishing', () => {
 	it( 'Should publish a post and close the panel once we start editing again', async () => {
 		await page.type( '.editor-post-title__input', 'E2E Test Post' );
 
-		// Opens the publish panel
-		await page.click( '.editor-post-publish-panel__toggle' );
-
-		// Disable reason: Wait for a second ( wait for the animation )
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 1000 );
-
-		// Publish the post
-		await page.click( '.editor-post-publish-button' );
-
-		// A success notice should show up
-		page.waitForSelector( '.notice-success' );
+		await publishPost();
 
 		// The post publish panel is visible
 		expect( await page.$( '.editor-post-publish-panel' ) ).not.toBeNull();

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -26,7 +26,7 @@ const MOD_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
  */
 const REGEXP_ZWSP = /[\u200B\u200C\u200D\uFEFF]/;
 
-function getUrl( WPPath, query = '' ) {
+export function getUrl( WPPath, query = '' ) {
 	const url = new URL( WP_BASE_URL );
 
 	url.pathname = join( url.pathname, WPPath );
@@ -157,4 +157,26 @@ export async function toggleMoreMenuItem( buttonLabel ) {
 	await page.click( '.edit-post-more-menu [aria-label="More"]' );
 	const itemButton = ( await page.$x( `//button[contains(text(), \'${ buttonLabel }\')]` ) )[ 0 ];
 	await itemButton.click( 'button' );
+}
+
+/**
+ * Publishes the post, resolving once the request is complete (once a notice
+ * is displayed).
+ *
+ * @return {Promise} Promise resolving when publish is complete.
+ */
+export async function publishPost() {
+	// Opens the publish panel
+	await page.click( '.editor-post-publish-panel__toggle' );
+
+	// Disable reason: Wait for the animation to complete, since otherwise the
+	// click attempt may occur at the wrong point.
+	// eslint-disable-next-line no-restricted-syntax
+	await page.waitFor( 100 );
+
+	// Publish the post
+	await page.click( '.editor-post-publish-button' );
+
+	// A success notice should show up
+	return page.waitForSelector( '.notice-success' );
 }

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -113,6 +113,22 @@ export async function getHTMLFromCodeEditor() {
 }
 
 /**
+ * Verifies that the edit post sidebar is opened, and if it is not, opens it.
+ *
+ * @return {Promise} Promise resolving once the edit post sidebar is opened.
+ */
+export async function ensureSidebarOpened() {
+	// This try/catch flow relies on the fact that `page.$eval` throws an error
+	// if the element matching the given selector does not exist. Thus, if an
+	// error is thrown, it can be inferred that the sidebar is not opened.
+	try {
+		return page.$eval( '.edit-post-sidebar', () => {} );
+	} catch ( error ) {
+		return page.click( '.edit-post-header__settings [aria-label="Settings"]' );
+	}
+}
+
+/**
  * Opens the inserter, searches for the given term, then selects the first
  * result that appears.
  *


### PR DESCRIPTION
Closes #7124 

This pull request seeks to change an autosave request to occur as a standard save when the saved post is a draft or auto-draft, and the request is issued by the author of the post (i.e. current user is author).

This resolves two issues:

- Autosave a draft had shown that unsaved changes still exist (including prompt).
- Post preview would not work for drafts, unless first doing a full save
   - Note: Published post preview does not work and has never been implemented (#4099)

__Implementation notes:__

**Note:** This is a stub pull-request while I think through the implementation. 

We currently do not track the current user ID in Gutenberg. As a short-term fix, this introduces access on the `window.userSettings.uid` value. Obviously this value may or may not be present, depending on where Gutenberg is implemented, but is assumed to exist in wp-admin.

Alternatively, we could trigger the autosave request, and allow the server to perform the necessary logic, testing that `newPost.id !== post.id` to see whether it was effectively saved as autosave. There are two caveats to this:

- Change detection (dirty prompt) resets on `UPDATE_POST` which only occurs for full saves
- The autosave endpoint returns entity in a slightly different shape than a post schema entity, so we can't simply `resetPost` with the autosave response value.

