### PR TITLE
Fix svg block icons

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -143,7 +143,8 @@ export function registerBlockType( name, settings ) {
 	settings.icon = normalizeIconObject( settings.icon );
 	if ( ! isValidIcon( settings.icon.src ) ) {
 		console.error(
-			'The icon passed is invalid.'
+			'The icon passed is invalid. ' +
+			'The icon should be a string, an element, a function, or an object following the specifications documented in https://wordpress.org/gutenberg/handbook/block-api/#icon-optional'
 		);
 		return;
 	}

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -141,6 +141,12 @@ export function registerBlockType( name, settings ) {
 	}
 
 	settings.icon = normalizeIconObject( settings.icon );
+	if ( settings.icon === null ) {
+		console.error(
+			'The icon passed is invalid.'
+		);
+		return;
+	}
 
 	if ( 'isPrivate' in settings ) {
 		deprecated( 'isPrivate', {

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -15,7 +15,7 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
-import { normalizeIconObject } from './utils';
+import { isValidIcon, normalizeIconObject } from './utils';
 
 /**
  * Defined behavior of a block type.
@@ -141,7 +141,7 @@ export function registerBlockType( name, settings ) {
 	}
 
 	settings.icon = normalizeIconObject( settings.icon );
-	if ( settings.icon === null ) {
+	if ( ! isValidIcon( settings.icon.src ) ) {
 		console.error(
 			'The icon passed is invalid.'
 		);

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -182,20 +182,18 @@ describe( 'blocks', () => {
 
 		it( 'should validate the icon', () => {
 			const blockType = {
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',
 				icon: { chicken: 'ribs' },
 			};
 			const block = registerBlockType( 'core/test-block-icon-normalize-element', blockType );
-			expect( console ).toHaveErroredWith( 'The icon passed is invalid.' );
+			expect( console ).toHaveErrored();
 			expect( block ).toBeUndefined();
 		} );
 
 		it( 'should normalize the icon containing an element', () => {
 			const blockType = {
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',
@@ -205,10 +203,8 @@ describe( 'blocks', () => {
 				</svg> ),
 			};
 			registerBlockType( 'core/test-block-icon-normalize-element', blockType );
-			blockType.mutated = true;
 			expect( getBlockType( 'core/test-block-icon-normalize-element' ) ).toEqual( {
 				name: 'core/test-block-icon-normalize-element',
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',
@@ -223,17 +219,14 @@ describe( 'blocks', () => {
 
 		it( 'should normalize the icon containing a string', () => {
 			const blockType = {
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',
 				icon: 'foo',
 			};
 			registerBlockType( 'core/test-block-icon-normalize-string', blockType );
-			blockType.mutated = true;
 			expect( getBlockType( 'core/test-block-icon-normalize-string' ) ).toEqual( {
 				name: 'core/test-block-icon-normalize-string',
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',
@@ -251,17 +244,14 @@ describe( 'blocks', () => {
 				</svg>;
 			};
 			const blockType = {
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',
 				icon: MyTestIcon,
 			};
 			registerBlockType( 'core/test-block-icon-normalize-function', blockType );
-			blockType.mutated = true;
 			expect( getBlockType( 'core/test-block-icon-normalize-function' ) ).toEqual( {
 				name: 'core/test-block-icon-normalize-function',
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',
@@ -273,7 +263,6 @@ describe( 'blocks', () => {
 
 		it( 'should correctly register an icon with background and a custom svg', () => {
 			const blockType = {
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',
@@ -286,10 +275,8 @@ describe( 'blocks', () => {
 				},
 			};
 			registerBlockType( 'core/test-block-icon-normalize-background', blockType );
-			blockType.mutated = true;
 			expect( getBlockType( 'core/test-block-icon-normalize-background' ) ).toEqual( {
 				name: 'core/test-block-icon-normalize-background',
-				settingName: 'settingValue',
 				save: noop,
 				category: 'common',
 				title: 'block title',

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -180,11 +180,24 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		it( 'should validate the icon', () => {
+			const blockType = {
+				settingName: 'settingValue',
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: { chicken: 'ribs' },
+			};
+			const block = registerBlockType( 'core/test-block-icon-normalize-element', blockType );
+			expect( console ).toHaveErroredWith( 'The icon passed is invalid.' );
+			expect( block ).toBeUndefined();
+		} );
+
 		it( 'should normalize the icon containing an element', () => {
 			const blockType = {
 				settingName: 'settingValue',
-				save: noop, category:
-				'common',
+				save: noop,
+				category: 'common',
 				title: 'block title',
 				icon: ( <svg width="20" height="20" viewBox="0 0 20 20">
 					<circle cx="10" cy="10" r="10"
@@ -211,8 +224,8 @@ describe( 'blocks', () => {
 		it( 'should normalize the icon containing a string', () => {
 			const blockType = {
 				settingName: 'settingValue',
-				save: noop, category:
-				'common',
+				save: noop,
+				category: 'common',
 				title: 'block title',
 				icon: 'foo',
 			};
@@ -226,6 +239,68 @@ describe( 'blocks', () => {
 				title: 'block title',
 				icon: {
 					src: 'foo',
+				},
+			} );
+		} );
+
+		it( 'should normalize the icon containing a function', () => {
+			const MyTestIcon = () => {
+				return <svg width="20" height="20" viewBox="0 0 20 20">
+					<circle cx="10" cy="10" r="10"
+						fill="red" stroke="blue" strokeWidth="10" />
+				</svg>;
+			};
+			const blockType = {
+				settingName: 'settingValue',
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: MyTestIcon,
+			};
+			registerBlockType( 'core/test-block-icon-normalize-function', blockType );
+			blockType.mutated = true;
+			expect( getBlockType( 'core/test-block-icon-normalize-function' ) ).toEqual( {
+				name: 'core/test-block-icon-normalize-function',
+				settingName: 'settingValue',
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: {
+					src: MyTestIcon,
+				},
+			} );
+		} );
+
+		it( 'should correctly register an icon with background and a custom svg', () => {
+			const blockType = {
+				settingName: 'settingValue',
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: {
+					background: '#f00',
+					src: ( <svg width="20" height="20" viewBox="0 0 20 20">
+						<circle cx="10" cy="10" r="10"
+							fill="red" stroke="blue" strokeWidth="10" />
+					</svg> ),
+				},
+			};
+			registerBlockType( 'core/test-block-icon-normalize-background', blockType );
+			blockType.mutated = true;
+			expect( getBlockType( 'core/test-block-icon-normalize-background' ) ).toEqual( {
+				name: 'core/test-block-icon-normalize-background',
+				settingName: 'settingValue',
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: {
+					background: '#f00',
+					foreground: '#191e23',
+					shadowColor: 'rgba(255, 0, 0, 0.3)',
+					src: ( <svg width="20" height="20" viewBox="0 0 20 20">
+						<circle cx="10" cy="10" r="10"
+							fill="red" stroke="blue" strokeWidth="10" />
+					</svg> ),
 				},
 			} );
 		} );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -180,6 +180,56 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		it( 'should normalize the icon containing an element', () => {
+			const blockType = {
+				settingName: 'settingValue',
+				save: noop, category:
+				'common',
+				title: 'block title',
+				icon: ( <svg width="20" height="20" viewBox="0 0 20 20">
+					<circle cx="10" cy="10" r="10"
+						fill="red" stroke="blue" strokeWidth="10" />
+				</svg> ),
+			};
+			registerBlockType( 'core/test-block-icon-normalize-element', blockType );
+			blockType.mutated = true;
+			expect( getBlockType( 'core/test-block-icon-normalize-element' ) ).toEqual( {
+				name: 'core/test-block-icon-normalize-element',
+				settingName: 'settingValue',
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: {
+					src: ( <svg width="20" height="20" viewBox="0 0 20 20">
+						<circle cx="10" cy="10" r="10"
+							fill="red" stroke="blue" strokeWidth="10" />
+					</svg> ),
+				},
+			} );
+		} );
+
+		it( 'should normalize the icon containing a string', () => {
+			const blockType = {
+				settingName: 'settingValue',
+				save: noop, category:
+				'common',
+				title: 'block title',
+				icon: 'foo',
+			};
+			registerBlockType( 'core/test-block-icon-normalize-string', blockType );
+			blockType.mutated = true;
+			expect( getBlockType( 'core/test-block-icon-normalize-string' ) ).toEqual( {
+				name: 'core/test-block-icon-normalize-string',
+				settingName: 'settingValue',
+				save: noop,
+				category: 'common',
+				title: 'block title',
+				icon: {
+					src: 'foo',
+				},
+			} );
+		} );
+
 		it( 'should store a copy of block type', () => {
 			const blockType = { settingName: 'settingValue', save: noop, category: 'common', title: 'block title' };
 			registerBlockType( 'core/test-block-with-settings', blockType );

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -56,7 +56,7 @@ export function isUnmodifiedDefaultBlock( block ) {
  *
  * @param {*} icon  Parameter to be checked.
  *
- * @return {Boolean} True if the parameter is a valid icon and false otherwise.
+ * @return {boolean} True if the parameter is a valid icon and false otherwise.
  */
 
 export function isValidIcon( icon ) {

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -77,20 +77,14 @@ export function isValidIcon( icon ) {
  *                                          as the icon for the block in the
  *                                          inserter, or element or an object describing the icon.
  *
- * @return {?Object} Object describing the icon or null if the icon is invalid and impossible to normalize.
+ * @return {Object} Object describing the icon.
  */
 export function normalizeIconObject( icon ) {
 	if ( ! icon ) {
 		return { src: 'block-default' };
 	}
-	if (
-		isValidIcon( icon )
-	) {
+	if ( isValidIcon( icon ) ) {
 		return { src: icon };
-	}
-
-	if ( ! isValidIcon( icon.src ) ) {
-		return null;
 	}
 
 	if ( icon.background ) {

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { every, keys, isEqual } from 'lodash';
+import { every, keys, isEqual, isFunction, isString } from 'lodash';
 import { default as tinycolor, mostReadable } from 'tinycolor2';
 
 /**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
+import { Component, isValidElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -65,7 +66,12 @@ export function normalizeIconObject( icon ) {
 	if ( ! icon ) {
 		return { src: 'block-default' };
 	}
-	if ( ! icon.src ) {
+	if (
+		isString( icon ) ||
+		isFunction( icon ) ||
+		icon instanceof Component ||
+		isValidElement( icon )
+	) {
 		return { src: icon };
 	}
 

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -52,6 +52,23 @@ export function isUnmodifiedDefaultBlock( block ) {
 }
 
 /**
+ * Function that checks if the parameter is a valid icon.
+ *
+ * @param {*} icon  Parameter to be checked.
+ *
+ * @return {Boolean} True if the parameter is a valid icon and false otherwise.
+ */
+
+export function isValidIcon( icon ) {
+	return !! icon && (
+		isString( icon ) ||
+		isValidElement( icon ) ||
+		isFunction( icon ) ||
+		icon instanceof Component
+	);
+}
+
+/**
  * Function that receives an icon as set by the blocks during the registration
  * and returns a new icon object that is normalized so we can rely on just on possible icon structure
  * in the codebase.
@@ -60,19 +77,20 @@ export function isUnmodifiedDefaultBlock( block ) {
  *                                          as the icon for the block in the
  *                                          inserter, or element or an object describing the icon.
  *
- * @return {Object} Object describing the icon.
+ * @return {?Object} Object describing the icon or null if the icon is invalid and impossible to normalize.
  */
 export function normalizeIconObject( icon ) {
 	if ( ! icon ) {
 		return { src: 'block-default' };
 	}
 	if (
-		isString( icon ) ||
-		isFunction( icon ) ||
-		icon instanceof Component ||
-		isValidElement( icon )
+		isValidIcon( icon )
 	) {
 		return { src: icon };
+	}
+
+	if ( ! isValidIcon( icon.src ) ) {
+		return null;
 	}
 
 	if ( icon.background ) {

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { every, keys, isEqual, isFunction, isString } from 'lodash';
+import { every, keys, isEqual } from 'lodash';
 import { default as tinycolor, mostReadable } from 'tinycolor2';
 
 /**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
-import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -66,7 +65,7 @@ export function normalizeIconObject( icon ) {
 	if ( ! icon ) {
 		return { src: 'block-default' };
 	}
-	if ( isString( icon ) || isFunction( icon ) || icon instanceof Component ) {
+	if ( ! icon.src ) {
 		return { src: icon };
 	}
 

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -125,7 +125,7 @@ export { createContext };
  *
  * @param {Object} objectToCheck The object to be checked.
  *
- * @return {Boolean} true if objectToTest is a valid WPElement and false otherwise.
+ * @return {boolean} true if objectToTest is a valid WPElement and false otherwise.
  */
 export { isValidElement };
 

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -10,6 +10,7 @@ import {
 	cloneElement,
 	Children,
 	Fragment,
+	isValidElement,
 } from 'react';
 import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
 import {
@@ -118,6 +119,15 @@ export { Fragment };
  * @return {Object} Context object.
  */
 export { createContext };
+
+/**
+ * Checks if an object is a valid WPElement
+ *
+ * @param {Object} objectToTest A default data stored in the context.
+ *
+ * @return {Boolean} true if objectToTest is a valid WPElement and false otherwise.
+ */
+export { isValidElement };
 
 /**
  * Creates a portal into which a component can be rendered.

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -123,7 +123,7 @@ export { createContext };
 /**
  * Checks if an object is a valid WPElement
  *
- * @param {Object} objectToTest A default data stored in the context.
+ * @param {Object} objectToCheck The object to be checked.
  *
  * @return {Boolean} true if objectToTest is a valid WPElement and false otherwise.
  */


### PR DESCRIPTION
The condition to check SVG icons was not correct. Now we use a different condition: if icon is defined, but the source is not defined we assume the icon should be the source. This avoids the need to check for all the possible icon sources e.g: string, function and React element.

Fixes https://github.com/WordPress/gutenberg/issues/7139.
Regressed in https://github.com/WordPress/gutenberg/pull/7068.


## How has this been tested?
Go to existing blocks and change the icon to the following possibilities, verify in all the cases the result is the expected:
```
	icon: ( <svg width="20" height="20" viewBox="0 0 20 20">
		<circle cx="10" cy="10" r="10"
			fill="red" stroke="blue" strokeWidth="10" />
	</svg> ),
```

```
	icon: {
		background: '#f00',
		src: ( <svg width="20" height="20" viewBox="0 0 20 20">
			<circle cx="10" cy="10" r="10"
				fill="red" stroke="blue" strokeWidth="10" />
		</svg> ),
	},
```

```
	icon: () => ( <svg width="20" height="20" viewBox="0 0 20 20">
		<circle cx="10" cy="10" r="10"
			fill="red" stroke="blue" strokeWidth="10" />
	</svg> ),
```