### PR TITLE
Ensure editor color palette generated CSS classes are locale-agnostic

### DIFF
--- a/editor/components/colors/utils.js
+++ b/editor/components/colors/utils.js
@@ -50,8 +50,8 @@ export const setColorValue = ( colors, colorAttributeName, customColorAttributeN
 	( colorValue ) => {
 		const colorObj = find( colors, { color: colorValue } );
 		setAttributes( {
-			[ colorAttributeName ]: colorObj && colorObj.name ? colorObj.name : undefined,
-			[ customColorAttributeName ]: colorObj && colorObj.name ? undefined : colorValue,
+			[ colorAttributeName ]: colorObj && ( colorObj.slug || colorObj.name ) ? colorObj.slug || colorObj.name : undefined,
+			[ customColorAttributeName ]: colorObj && ( colorObj.slug || colorObj.name ) ? undefined : colorValue,
 		} );
 	};
 


### PR DESCRIPTION
## Description
This PR adds support for a `slug` property to the colors that theme authors can specify when adding `editor-color-palette` support. The reason this is necessary is that the `name` property currently used is a human-readable translatable string, but it is also used to generate the CSS class name for that color. That means that when changing the language, the new class names would change, and it would be incredibly hard to style those. Class names should be based on immutable identifiers or slugs.

This topic was briefly discussed on Slack (see https://wordpress.slack.com/archives/C02QB2JS7/p1527850407000401), and it was agreed that we should be using a `slug` property to fix the issue.

Once this is merged, we should update the documentation to state that colors now require three properties each:
* `slug`, an identifier for the color
* `name`, a human-readable, localized label for the color
* `color`, the hex-code for the color

For example:
```php
function my_theme_gutenberg_color_palette() {
	add_theme_support(
		'editor-color-palette',
		array(
			'slug'  => 'black',
			'name'  => __( 'Black', 'my-textdomain' ),
			'color' => '#2a2a2a',
		),
		array(
			'slug'  => 'gray',
			'name'  => __( 'Gray', 'my-textdomain' ),
			'color' => '#727477',
		)
	);
}
add_action( 'after_setup_theme', 'my_theme_gutenberg_color_palette' );
```

To stay backward-compatible, if no `slug` is given, Gutenberg will fall back to use `name`, like before. It should be strongly encouraged though to specify both.

## How has this been tested?
I tested with a custom theme where I added theme support for `editor-color-palette` in the new and the old way, and it works as expected. Going forward, we should however encourage to always specify both `slug` and `name` for each color.

## Types of changes
The `setColorValue()` function used by the Colors editor component has been adjusted to use the `slug` if provided.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

cc @mtias @jorgefilipecosta 