### PR TITLE
Allow "disableAlpha" for color Picker component to be optional (replaces #5835)

### DIFF
--- a/components/color-palette/index.js
+++ b/components/color-palette/index.js
@@ -18,7 +18,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import './style.scss';
 import Button from '../button';
 
-export default function ColorPalette( { colors, disableCustomColors = false, value, onChange, disableAlpha = true } ) {
+export default function ColorPalette( { colors, disableAlpha = true, disableCustomColors = false, onChange, value } ) {
 	function applyOrUnset( color ) {
 		return () => onChange( value === color ? undefined : color );
 	}

--- a/components/color-palette/index.js
+++ b/components/color-palette/index.js
@@ -71,7 +71,7 @@ export default function ColorPalette( { colors, disableAlpha = true, disableCust
 									colorString = color.hex;
 								} else {
 									const { r, g, b, a } = color.rgb;
-									colorString = 'rgba(' + [ r, g, b, a ].join( ',' ) + ')';
+									colorString = `rgba(${ r }, ${ g }, ${ b }, ${ a })`;
 								}
 								onChange( colorString );
 							} }

--- a/components/color-palette/index.js
+++ b/components/color-palette/index.js
@@ -71,7 +71,7 @@ export default function ColorPalette( { colors, disableAlpha = true, disableCust
 									colorString = color.hex;
 								} else {
 									const { r, g, b, a } = color.rgb;
-									colorString = `rgba(${ r }, ${ g }, ${ b }, ${ a })`;
+									colorString = `rgba(${ r },${ g },${ b },${ a })`;
 								}
 								onChange( colorString );
 							} }

--- a/components/color-palette/index.js
+++ b/components/color-palette/index.js
@@ -18,7 +18,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import './style.scss';
 import Button from '../button';
 
-export default function ColorPalette( { colors, disableCustomColors = false, value, onChange } ) {
+export default function ColorPalette( { colors, disableCustomColors = false, value, onChange, disableAlpha = true } ) {
 	function applyOrUnset( color ) {
 		return () => onChange( value === color ? undefined : color );
 	}
@@ -65,8 +65,17 @@ export default function ColorPalette( { colors, disableCustomColors = false, val
 					renderContent={ () => (
 						<ChromePicker
 							color={ value }
-							onChangeComplete={ ( color ) => onChange( color.hex ) }
-							disableAlpha
+							onChangeComplete={ ( color ) => {
+								let colorString;
+								if ( typeof color.rgb === 'undefined' || color.rgb.a === 1 ) {
+									colorString = color.hex;
+								} else {
+									const { r, g, b, a } = color.rgb;
+									colorString = 'rgba(' + [ r, g, b, a ].join( ',' ) + ')';
+								}
+								onChange( colorString );
+							} }
+							disableAlpha={ disableAlpha }
 						/>
 					) }
 				/>

--- a/components/color-palette/test/__snapshots__/index.js.snap
+++ b/components/color-palette/test/__snapshots__/index.js.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ColorPalette Dropdown .renderContent should enable alpha channel inside color picker 1`] = `
+<Chrome
+  color="#f00"
+  disableAlpha={false}
+  hex="#ff0000"
+  hsl={
+    Object {
+      "a": 1,
+      "h": 0,
+      "l": 0.5,
+      "s": 1,
+    }
+  }
+  hsv={
+    Object {
+      "a": 1,
+      "h": 0,
+      "s": 1,
+      "v": 1,
+    }
+  }
+  oldHue={0}
+  onChange={[Function]}
+  onChangeComplete={[Function]}
+  rgb={
+    Object {
+      "a": 1,
+      "b": 0,
+      "g": 0,
+      "r": 255,
+    }
+  }
+/>
+`;
+
 exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`] = `
 <Chrome
   color="#f00"

--- a/components/color-palette/test/index.js
+++ b/components/color-palette/test/index.js
@@ -11,9 +11,12 @@ import ColorPalette from '../';
 describe( 'ColorPalette', () => {
 	const colors = [ { name: 'red', color: '#f00' }, { name: 'white', color: '#fff' }, { name: 'blue', color: '#00f' } ];
 	const currentColor = '#f00';
+	const currentColorWithAlpha = { r: 255, g: 0, b: 0, a: 0.5 };
+	const currentColorWithAlphaParsed = 'rgba(255,0,0,0.5)';
 	const onChange = jest.fn();
 
 	const wrapper = shallow( <ColorPalette colors={ colors } value={ currentColor } onChange={ onChange } /> );
+	const wrapperWithAlpha = shallow( <ColorPalette colors={ colors } value={ currentColor } onChange={ onChange } disableAlpha={ false } /> );
 	const buttons = wrapper.find( '.components-color-palette__item-wrapper button' );
 
 	beforeEach( () => {
@@ -84,6 +87,8 @@ describe( 'ColorPalette', () => {
 
 		describe( '.renderContent', () => {
 			const renderedContent = shallow( dropdown.props().renderContent() );
+			const dropdownWithAlpha = wrapperWithAlpha.find( 'Dropdown' );
+			const renderedContentWithAlpha = shallow( dropdownWithAlpha.props().renderContent() );
 
 			test( 'should render dropdown content', () => {
 				expect( renderedContent ).toMatchSnapshot();
@@ -94,6 +99,17 @@ describe( 'ColorPalette', () => {
 
 				expect( onChange ).toHaveBeenCalledTimes( 1 );
 				expect( onChange ).toHaveBeenCalledWith( currentColor );
+			} );
+
+			test( 'should enable alpha channel inside color picker', () => {
+				expect( renderedContentWithAlpha ).toMatchSnapshot();
+			} );
+
+			test( 'should return an rgba value on click.', () => {
+				renderedContentWithAlpha.simulate( 'changeComplete', { rgb: currentColorWithAlpha } );
+
+				expect( onChange ).toHaveBeenCalledTimes( 1 );
+				expect( onChange ).toHaveBeenCalledWith( currentColorWithAlphaParsed );
 			} );
 		} );
 	} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10030,7 +10030,7 @@
 			}
 		},
 		"node-sass": {
-			"version": "git://github.com/sass/node-sass.git#9bffd1bb5d21e6a6fd517a8daa5dc579ebb9773e",
+			"version": "git://github.com/sass/node-sass.git#a51eca7f8bafdc9bafab76d2305fedc64503304c",
 			"from": "git://github.com/sass/node-sass.git#v4.7.0",
 			"dev": true,
 			"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10030,7 +10030,7 @@
 			}
 		},
 		"node-sass": {
-			"version": "git://github.com/sass/node-sass.git#a51eca7f8bafdc9bafab76d2305fedc64503304c",
+			"version": "git://github.com/sass/node-sass.git#9bffd1bb5d21e6a6fd517a8daa5dc579ebb9773e",
 			"from": "git://github.com/sass/node-sass.git#v4.7.0",
 			"dev": true,
 			"requires": {


### PR DESCRIPTION
## Description
Currently, the `<ColorPalette />` component enforces the alpha channel from `react-color` to be disabled. Like described on #5811, there are benefits of giving developers the option to enable the alpha channel inside the color picker.

Previously #5835
Fixes #4726

## Tested With
WordPress 4.9.4
Gutenberg 2.4.0
PHP 7.0.3 / nginx
MySQL 5.5.55

## Types of changes
This PR introduces the ability to conditionally set a `disableAlpha` parameter for the `<ColorPallete />` component. It is set to `false` by default so it won't conflict with existing blocks that uses this component. Also, the returned color string depends on how the alpha channel inside the color picker is set. If opacity is 100%, we just return the `hex` value for the color. If opacity has a different level, then we return the `rgba()` value for the color. 