### PR TITLE
Fix file paste: cache file info

### DIFF
--- a/blocks/api/raw-handling/image-corrector.js
+++ b/blocks/api/raw-handling/image-corrector.js
@@ -6,7 +6,7 @@ import { createBlobURL } from '@wordpress/blob';
 /**
  * Browser dependencies
  */
-const { atob, Blob } = window;
+const { atob, File } = window;
 
 export default function( node ) {
 	if ( node.nodeName !== 'IMG' ) {
@@ -43,9 +43,10 @@ export default function( node ) {
 			uint8Array[ i ] = decoded.charCodeAt( i );
 		}
 
-		const blob = new Blob( [ uint8Array ], { type } );
+		const name = type.replace( '/', '.' );
+		const file = new File( [ uint8Array ], name, { type } );
 
-		node.src = createBlobURL( blob );
+		node.src = createBlobURL( file );
 	}
 
 	// Remove trackers and hardly visible images.

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -73,22 +73,19 @@ class ImageEdit extends Component {
 
 	componentDidMount() {
 		const { attributes, setAttributes } = this.props;
-		const { id, url = '', alt: fileName } = attributes;
+		const { id, url = '' } = attributes;
 
 		if ( ! id && url.indexOf( 'blob:' ) === 0 ) {
 			getBlobByURL( url )
-				.then(
-					( file ) => {
-						file.name = fileName;
-						editorMediaUpload( {
-							filesList: [ file ],
-							onFileChange: ( [ image ] ) => {
-								setAttributes( { ...image } );
-							},
-							allowedType: 'image',
-						} );
-					}
-				);
+				.then( ( file ) => {
+					editorMediaUpload( {
+						filesList: [ file ],
+						onFileChange: ( [ image ] ) => {
+							setAttributes( { ...image } );
+						},
+						allowedType: 'image',
+					} );
+				} );
 		}
 	}
 

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -76,16 +76,17 @@ class ImageEdit extends Component {
 		const { id, url = '' } = attributes;
 
 		if ( ! id && url.indexOf( 'blob:' ) === 0 ) {
-			getBlobByURL( url )
-				.then( ( file ) => {
-					editorMediaUpload( {
-						filesList: [ file ],
-						onFileChange: ( [ image ] ) => {
-							setAttributes( { ...image } );
-						},
-						allowedType: 'image',
-					} );
+			const file = getBlobByURL( url );
+
+			if ( file ) {
+				editorMediaUpload( {
+					filesList: [ file ],
+					onFileChange: ( [ image ] ) => {
+						setAttributes( { ...image } );
+					},
+					allowedType: 'image',
 				} );
+			}
 		}
 	}
 

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -14,6 +14,7 @@ import {
 	getPhrasingContentSchema,
 } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
+import { createBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -128,8 +129,7 @@ export const settings = {
 					// It's already done as part of the `componentDidMount`
 					// int the image block
 					const block = createBlock( 'core/image', {
-						alt: file.name,
-						url: window.URL.createObjectURL( file ),
+						url: createBlobURL( file ),
 					} );
 
 					return block;

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -261,16 +261,16 @@ export class RichText extends Component {
 		// Only process file if no HTML is present.
 		// Note: a pasted file may have the URL as plain text.
 		if ( item && ! HTML ) {
-			const blob = item.getAsFile ? item.getAsFile() : item;
+			const file = item.getAsFile ? item.getAsFile() : item;
 			const content = rawHandler( {
-				HTML: `<img src="${ createBlobURL( blob ) }">`,
+				HTML: `<img src="${ createBlobURL( file ) }">`,
 				mode: 'BLOCKS',
 				tagName: this.props.tagName,
 			} );
 			const shouldReplace = this.props.onReplace && this.isEmpty();
 
 			// Allows us to ask for this information when we get a report.
-			window.console.log( 'Received item:\n\n', blob );
+			window.console.log( 'Received item:\n\n', file );
 
 			if ( shouldReplace ) {
 				// Necessary to allow the paste bin to be removed without errors.

--- a/packages/blob/src/index.js
+++ b/packages/blob/src/index.js
@@ -1,22 +1,30 @@
 /**
  * Browser dependencies
  */
-const { fetch } = window;
+const { fetch, File } = window;
 const { createObjectURL, revokeObjectURL } = window.URL;
 
 const cache = {};
 
 export function createBlobURL( blob ) {
+	const { name, lastModified, type } = blob;
 	const url = createObjectURL( blob );
 
-	cache[ url ] = blob;
+	cache[ url ] = {
+		blob,
+		name,
+		lastModified,
+		type,
+	};
 
 	return url;
 }
 
 export function getBlobByURL( url ) {
 	if ( cache[ url ] ) {
-		return Promise.resolve( cache[ url ] );
+		const { blob, name, lastModified, type } = cache[ url ];
+		const file = new File( [ blob ], name, { lastModified, type } );
+		return Promise.resolve( file );
 	}
 
 	return fetch( url ).then( ( response ) => response.blob() );

--- a/packages/blob/src/index.js
+++ b/packages/blob/src/index.js
@@ -21,11 +21,13 @@ export function createBlobURL( file ) {
 }
 
 /**
- * Retrieve a file based on a blob URL.
+ * Retrieve a file based on a blob URL. The file must have been created by
+ * `createBlobURL` and not removed by `revokeBlobURL`, otherwise it will return
+ * `undefined`.
  *
  * @param {string} url The blob URL.
  *
- * @return {File} The file for the blob URL.
+ * @return {?File} The file for the blob URL.
  */
 export function getBlobByURL( url ) {
 	return cache[ url ];

--- a/packages/blob/src/index.js
+++ b/packages/blob/src/index.js
@@ -1,35 +1,41 @@
 /**
  * Browser dependencies
  */
-const { fetch, File } = window;
 const { createObjectURL, revokeObjectURL } = window.URL;
 
 const cache = {};
 
-export function createBlobURL( blob ) {
-	const { name, lastModified, type } = blob;
-	const url = createObjectURL( blob );
+/**
+ * Create a blob URL from a file.
+ *
+ * @param {File} file The file to create a blob URL for.
+ *
+ * @return {string} The blob URL.
+ */
+export function createBlobURL( file ) {
+	const url = createObjectURL( file );
 
-	cache[ url ] = {
-		blob,
-		name,
-		lastModified,
-		type,
-	};
+	cache[ url ] = file;
 
 	return url;
 }
 
+/**
+ * Retrieve a file based on a blob URL.
+ *
+ * @param {string} url The blob URL.
+ *
+ * @return {File} The file for the blob URL.
+ */
 export function getBlobByURL( url ) {
-	if ( cache[ url ] ) {
-		const { blob, name, lastModified, type } = cache[ url ];
-		const file = new File( [ blob ], name, { lastModified, type } );
-		return Promise.resolve( file );
-	}
-
-	return fetch( url ).then( ( response ) => response.blob() );
+	return cache[ url ];
 }
 
+/**
+ * Remove the resource and file cache from memory.
+ *
+ * @param {string} url The blob URL.
+ */
 export function revokeBlobURL( url ) {
 	if ( cache[ url ] ) {
 		revokeObjectURL( url );


### PR DESCRIPTION
## Description
See #6960. This change is causing errors for me when copy pasting images in Chrome.

## How has this been tested?
* Copy paste an image into Gutenberg.
* Drap and drop an image into Gutenberg.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->