### PR TITLE
Remove 'who'=>'authors' compatibility shim

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -515,26 +515,16 @@ add_filter( 'rest_index', 'gutenberg_ensure_wp_json_has_theme_supports' );
  */
 function gutenberg_handle_early_callback_checks( $response, $handler, $request ) {
 	if ( 0 === strpos( $request->get_route(), '/wp/v2/' ) ) {
-		$can_view_authors    = false;
 		$can_unbounded_query = false;
 		$types               = get_post_types( array( 'show_in_rest' => true ), 'objects' );
 		foreach ( $types as $type ) {
 			if ( current_user_can( $type->cap->edit_posts ) ) {
 				$can_unbounded_query = true;
-				if ( post_type_supports( $type->name, 'author' ) ) {
-					$can_view_authors = true;
-				}
 			}
 		}
 		if ( $request['per_page'] < 0 ) {
 			if ( ! $can_unbounded_query ) {
 				return new WP_Error( 'rest_forbidden_per_page', __( 'Sorry, you are not allowed make unbounded queries.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
-			}
-		}
-		if ( '/wp/v2/users' === $request->get_route()
-			&& ! empty( $request['who'] ) && 'authors' === $request['who'] ) {
-			if ( ! $can_view_authors ) {
-				return new WP_Error( 'rest_forbidden_who', __( 'Sorry, you are not allowed to query users by this parameter.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 		}
 	}
@@ -633,7 +623,6 @@ function gutenberg_filter_term_query_arguments( $prepared_args, $request ) {
 /**
  * Include additional query parameters on the user query endpoint.
  *
- * @see https://core.trac.wordpress.org/ticket/42202
  * @see https://core.trac.wordpress.org/ticket/43998
  *
  * @param array $query_params JSON Schema-formatted collection parameters.
@@ -646,37 +635,9 @@ function gutenberg_filter_user_collection_parameters( $query_params ) {
 		// Default sanitize callback is 'absint', which won't work in our case.
 		$query_params['per_page']['sanitize_callback'] = 'rest_sanitize_request_arg';
 	}
-	// Support for 'who' query param.
-	$query_params['who'] = array(
-		'description' => __( 'Limit result set to users who are considered authors.', 'gutenberg' ),
-		'type'        => 'string',
-		'enum'        => array(
-			'authors',
-		),
-	);
 	return $query_params;
 }
 add_filter( 'rest_user_collection_params', 'gutenberg_filter_user_collection_parameters' );
-
-/**
- * Filter user collection query parameters to include specific behavior.
- *
- * @see https://core.trac.wordpress.org/ticket/42202
- *
- * @param array           $prepared_args Array of arguments for WP_User_Query.
- * @param WP_REST_Request $request       The current request.
- * @return array
- */
-function gutenberg_filter_user_query_arguments( $prepared_args, $request ) {
-	if ( ! empty( $request['who'] ) && 'authors' === $request['who'] ) {
-		$prepared_args['who'] = 'authors';
-		if ( isset( $prepared_args['has_published_posts'] ) ) {
-			unset( $prepared_args['has_published_posts'] );
-		}
-	}
-	return $prepared_args;
-}
-add_filter( 'rest_user_query', 'gutenberg_filter_user_query_arguments', 10, 2 );
 
 /**
  * Overload taxonomy and term permission handling to address our new necessary behavior.

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -278,23 +278,6 @@ class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 		$this->assertTrue( in_array( 'standard', $result['theme_supports']['formats'] ) );
 	}
 
-	public function test_get_items_who_author_query() {
-		wp_set_current_user( $this->administrator );
-		// First request should include subscriber in the set.
-		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
-		$request->set_param( 'search', 'subscriber' );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 1, $response->get_data() );
-		// Second request should exclude subscriber.
-		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
-		$request->set_param( 'who', 'authors' );
-		$request->set_param( 'search', 'subscriber' );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 0, $response->get_data() );
-	}
-
 	public function test_get_taxonomies_context_edit() {
 		wp_set_current_user( $this->contributor );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
@@ -372,20 +355,6 @@ class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 		$this->assertEquals( 'My Awesome Term', $data['name'] );
 		$this->assertEquals( 'This term is so awesome.', $data['description'] );
 		$this->assertEquals( 'so-awesome', $data['slug'] );
-	}
-
-	/**
-	 * Any user with 'edit_posts' on a show_in_rest post type
-	 * can view authors. Others (e.g. subscribers) cannot.
-	 */
-	public function test_get_items_who_unauthorized_query() {
-		wp_set_current_user( $this->subscriber );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
-		$request->set_param( 'who', 'authors' );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 403, $response->get_status() );
-		$data = $response->get_data();
-		$this->assertEquals( 'rest_forbidden_who', $data['code'] );
 	}
 
 	public function test_get_items_unbounded_per_page() {


### PR DESCRIPTION
This patch landed in WordPress 4.9.6, which is now Gutenberg's minimum
supported version. See https://core.trac.wordpress.org/ticket/42202

Removing code, woo hoo!