### PR TITLE
Add Show Tips toggle

### DIFF
--- a/edit-post/components/header/more-menu/index.js
+++ b/edit-post/components/header/more-menu/index.js
@@ -11,6 +11,7 @@ import './style.scss';
 import ModeSwitcher from '../mode-switcher';
 import FixedToolbarToggle from '../fixed-toolbar-toggle';
 import PluginMoreMenuGroup from '../plugins-more-menu-group';
+import TipsToggle from '../tips-toggle';
 
 const MoreMenu = () => (
 	<Dropdown
@@ -27,7 +28,13 @@ const MoreMenu = () => (
 		renderContent={ ( { onClose } ) => (
 			<div className="edit-post-more-menu__content">
 				<ModeSwitcher onSelect={ onClose } />
-				<FixedToolbarToggle onToggle={ onClose } />
+				<MenuGroup
+					label={ __( 'Settings' ) }
+					filterName="editPost.MoreMenu.settings"
+				>
+					<FixedToolbarToggle onToggle={ onClose } />
+					<TipsToggle onToggle={ onClose } />
+				</MenuGroup>
 				<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />
 				<MenuGroup
 					label={ __( 'Tools' ) }

--- a/edit-post/components/header/tips-toggle/index.js
+++ b/edit-post/components/header/tips-toggle/index.js
@@ -9,29 +9,32 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/element';
 import { MenuItem } from '@wordpress/components';
-import { ifViewportMatches } from '@wordpress/viewport';
 
-function FixedToolbarToggle( { onToggle, isActive } ) {
+function TipsToggle( { onToggle, isActive } ) {
 	return (
 		<MenuItem
 			icon={ isActive && 'yes' }
 			isSelected={ isActive }
 			onClick={ onToggle }
 		>
-			{ __( 'Fix Toolbar to Top' ) }
+			{ __( 'Show Tips' ) }
 		</MenuItem>
 	);
 }
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		isActive: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+		isActive: select( 'core/nux' ).areTipsEnabled(),
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		onToggle() {
-			dispatch( 'core/edit-post' ).toggleFeature( 'fixedToolbar' );
+			const { disableTips, enableTips } = dispatch( 'core/nux' );
+			if ( ownProps.isActive ) {
+				disableTips();
+			} else {
+				enableTips();
+			}
 			ownProps.onToggle();
 		},
 	} ) ),
-	ifViewportMatches( 'medium' ),
-] )( FixedToolbarToggle );
+] )( TipsToggle );

--- a/nux/README.md
+++ b/nux/README.md
@@ -42,24 +42,33 @@ console.log( isVisible ); // true or false
 <button
 	onClick={ () => {
 		dispatch( 'core/nux' ).dismissTip( 'acme/add-to-cart' );
-	}
+	} }
 >
 	Dismiss tip
 </button>
 ```
 
-## Manually disabling tips
+## Disabling and enabling tips
 
-`disableTips` is a dispatch method that allows you to programmatically disable all tips.
+Tips can be programatically disabled or enabled using the `disableTips` and `enableTips` dispatch methods. You can query the current setting by using the `areTipsEnabled` select method.
+
+Calling `enableTips` will also un-dismiss all previously dismissed tips.
 
 ```jsx
-<button
-	onClick={ () => {
-		dispatch( 'core/nux' ).disableTips();
-	}
->
-	Disable tips
-</button>
+const areTipsEnabled = select( 'core/nux' ).areTipsEnabled();
+return (
+	<button
+		onClick={ () => {
+			if ( areTipsEnabled ) {
+				dispatch( 'core/nux' ).disableTips();
+			} else {
+				dispatch( 'core/nux' ).enableTips();
+			}
+		} }
+	>
+		{ areTipsEnabled ? 'Disable tips' : 'Enable tips' }
+	</button>
+);
 ```
 
 ## Triggering a guide

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -40,7 +40,7 @@ export class DotTip extends Component {
 	}
 
 	render() {
-		const { children, isVisible, hasNextTip, onDismiss } = this.props;
+		const { children, isVisible, hasNextTip, onDismiss, onDisable } = this.props;
 
 		if ( ! isVisible ) {
 			return null;
@@ -67,8 +67,8 @@ export class DotTip extends Component {
 				<IconButton
 					className="nux-dot-tip__disable"
 					icon="no-alt"
-					label={ __( 'Dismiss tip' ) }
-					onClick={ onDismiss }
+					label={ __( 'Disable tips' ) }
+					onClick={ onDisable }
 				/>
 			</Popover>
 		);
@@ -85,10 +85,13 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch, { id } ) => {
-		const { dismissTip } = dispatch( 'core/nux' );
+		const { dismissTip, disableTips } = dispatch( 'core/nux' );
 		return {
 			onDismiss() {
 				dismissTip( id );
+			},
+			onDisable() {
+				disableTips();
 			},
 		};
 	} ),

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -23,7 +23,7 @@ exports[`DotTip should render correctly 1`] = `
   <IconButton
     className="nux-dot-tip__disable"
     icon="no-alt"
-    label="Dismiss tip"
+    label="Disable tips"
   />
 </Popover>
 `;

--- a/nux/components/dot-tip/test/index.js
+++ b/nux/components/dot-tip/test/index.js
@@ -38,14 +38,14 @@ describe( 'DotTip', () => {
 		expect( onDismiss ).toHaveBeenCalled();
 	} );
 
-	it( 'should call onDismiss when the X button is clicked', () => {
-		const onDismiss = jest.fn();
+	it( 'should call onDisable when the X button is clicked', () => {
+		const onDisable = jest.fn();
 		const wrapper = shallow(
-			<DotTip isVisible onDismiss={ onDismiss }>
+			<DotTip isVisible onDisable={ onDisable }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
-		wrapper.find( 'IconButton[label="Dismiss tip"]' ).first().simulate( 'click' );
-		expect( onDismiss ).toHaveBeenCalled();
+		wrapper.find( 'IconButton[label="Disable tips"]' ).first().simulate( 'click' );
+		expect( onDisable ).toHaveBeenCalled();
 	} );
 } );

--- a/nux/store/actions.js
+++ b/nux/store/actions.js
@@ -39,3 +39,14 @@ export function disableTips() {
 		type: 'DISABLE_TIPS',
 	};
 }
+
+/**
+ * Returns an action object that, when dispatched, makes all tips show again.
+ *
+ * @return {Object} Action object.
+ */
+export function enableTips() {
+	return {
+		type: 'ENABLE_TIPS',
+	};
+}

--- a/nux/store/reducer.js
+++ b/nux/store/reducer.js
@@ -25,16 +25,19 @@ export function guides( state = [], action ) {
 }
 
 /**
- * Reducer that tracks whether or not tips are globally disabled.
+ * Reducer that tracks whether or not tips are globally enabled.
  *
  * @param {boolean} state Current state.
  * @param {Object} action Dispatched action.
  *
  * @return {boolean} Updated state.
  */
-export function areTipsDisabled( state = false, action ) {
+export function areTipsEnabled( state = true, action ) {
 	switch ( action.type ) {
 		case 'DISABLE_TIPS':
+			return false;
+
+		case 'ENABLE_TIPS':
 			return true;
 	}
 
@@ -57,11 +60,14 @@ export function dismissedTips( state = {}, action ) {
 				...state,
 				[ action.id ]: true,
 			};
+
+		case 'ENABLE_TIPS':
+			return {};
 	}
 
 	return state;
 }
 
-const preferences = combineReducers( { areTipsDisabled, dismissedTips } );
+const preferences = combineReducers( { areTipsEnabled, dismissedTips } );
 
 export default combineReducers( { guides, preferences } );

--- a/nux/store/selectors.js
+++ b/nux/store/selectors.js
@@ -51,7 +51,7 @@ export const getAssociatedGuide = createSelector(
  * @return {boolean} Whether or not the given tip is showing.
  */
 export function isTipVisible( state, id ) {
-	if ( state.preferences.areTipsDisabled ) {
+	if ( ! state.preferences.areTipsEnabled ) {
 		return false;
 	}
 
@@ -65,4 +65,15 @@ export function isTipVisible( state, id ) {
 	}
 
 	return true;
+}
+
+/**
+ * Returns whether or not tips are globally enabled.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether tips are globally enabled.
+ */
+export function areTipsEnabled( state ) {
+	return state.preferences.areTipsEnabled;
 }

--- a/nux/store/test/actions.js
+++ b/nux/store/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { triggerGuide, dismissTip, disableTips } from '../actions';
+import { triggerGuide, dismissTip, disableTips, enableTips } from '../actions';
 
 describe( 'actions', () => {
 	describe( 'triggerGuide', () => {
@@ -26,6 +26,14 @@ describe( 'actions', () => {
 		it( 'should return an DISABLE_TIPS action', () => {
 			expect( disableTips() ).toEqual( {
 				type: 'DISABLE_TIPS',
+			} );
+		} );
+	} );
+
+	describe( 'enableTips', () => {
+		it( 'should return an ENABLE_TIPS action', () => {
+			expect( enableTips() ).toEqual( {
+				type: 'ENABLE_TIPS',
 			} );
 		} );
 	} );

--- a/nux/store/test/reducer.js
+++ b/nux/store/test/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { guides, areTipsDisabled, dismissedTips } from '../reducer';
+import { guides, areTipsEnabled, dismissedTips } from '../reducer';
 
 describe( 'reducer', () => {
 	describe( 'guides', () => {
@@ -20,14 +20,21 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( 'areTipsDisabled', () => {
-		it( 'should default to false', () => {
-			expect( areTipsDisabled( undefined, {} ) ).toBe( false );
+	describe( 'areTipsEnabled', () => {
+		it( 'should default to true', () => {
+			expect( areTipsEnabled( undefined, {} ) ).toBe( true );
 		} );
 
 		it( 'should flip when tips are disabled', () => {
-			const state = areTipsDisabled( false, {
+			const state = areTipsEnabled( true, {
 				type: 'DISABLE_TIPS',
+			} );
+			expect( state ).toBe( false );
+		} );
+
+		it( 'sholud flip when tips are enabled', () => {
+			const state = areTipsEnabled( false, {
+				type: 'ENABLE_TIPS',
 			} );
 			expect( state ).toBe( true );
 		} );
@@ -46,6 +53,16 @@ describe( 'reducer', () => {
 			expect( state ).toEqual( {
 				'test/tip': true,
 			} );
+		} );
+
+		it( 'should reset if tips are enabled', () => {
+			const initialState = {
+				'test/tip': true,
+			};
+			const state = dismissedTips( initialState, {
+				type: 'ENABLE_TIPS',
+			} );
+			expect( state ).toEqual( {} );
 		} );
 	} );
 } );

--- a/nux/store/test/reducer.js
+++ b/nux/store/test/reducer.js
@@ -32,7 +32,7 @@ describe( 'reducer', () => {
 			expect( state ).toBe( false );
 		} );
 
-		it( 'sholud flip when tips are enabled', () => {
+		it( 'should flip when tips are enabled', () => {
 			const state = areTipsEnabled( false, {
 				type: 'ENABLE_TIPS',
 			} );

--- a/nux/store/test/selectors.js
+++ b/nux/store/test/selectors.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getAssociatedGuide, isTipVisible } from '../selectors';
+import { getAssociatedGuide, isTipVisible, areTipsEnabled } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( 'getAssociatedGuide', () => {
@@ -57,7 +57,7 @@ describe( 'selectors', () => {
 			const state = {
 				guides: [],
 				preferences: {
-					areTipsDisabled: false,
+					areTipsEnabled: true,
 					dismissedTips: {},
 				},
 			};
@@ -68,7 +68,7 @@ describe( 'selectors', () => {
 			const state = {
 				guides: [],
 				preferences: {
-					areTipsDisabled: true,
+					areTipsEnabled: false,
 					dismissedTips: {},
 				},
 			};
@@ -79,7 +79,7 @@ describe( 'selectors', () => {
 			const state = {
 				guides: [],
 				preferences: {
-					areTipsDisabled: false,
+					areTipsEnabled: true,
 					dismissedTips: {
 						'test/tip': true,
 					},
@@ -94,11 +94,35 @@ describe( 'selectors', () => {
 					[ 'test/tip-1', 'test/tip-2', 'test/tip-3' ],
 				],
 				preferences: {
-					areTipsDisabled: false,
+					areTipsEnabled: true,
 					dismissedTips: {},
 				},
 			};
 			expect( isTipVisible( state, 'test/tip-2' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'areTipsEnabled', () => {
+		it( 'should return true if tips are enabled', () => {
+			const state = {
+				guides: [],
+				preferences: {
+					areTipsEnabled: true,
+					dismissedTips: {},
+				},
+			};
+			expect( areTipsEnabled( state ) ).toBe( true );
+		} );
+
+		it( 'should return false if tips are disabled', () => {
+			const state = {
+				guides: [],
+				preferences: {
+					areTipsEnabled: false,
+					dismissedTips: {},
+				},
+			};
+			expect( areTipsEnabled( state ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
Closes #7039. 

![tips-toggle](https://user-images.githubusercontent.com/612155/41017676-49c8650a-6999-11e8-8f24-7a9cfc955707.gif)

Lets the user re-enable tips via a Show Tips toggle in the More menu. Re-enabling tips will also make previously dismissed tips appear again.

Since there's way to get tips back, I've made the X button in the tip popup disable all tips instead of dismissing the current tip.

## How has this been tested?

1. Create a new post
2. Step through or dismiss the guide if it appears
3. Re-enable tips via the More menu
4. Disable tips via the More menu