### PR TITLE
fix: Correct the margins of embed block content

### DIFF
--- a/core-blocks/embed/editor.scss
+++ b/core-blocks/embed/editor.scss
@@ -17,7 +17,3 @@
 		}
 	}
 }
-
-.wp-block-embed__figure {
-	margin: 0;
-}

--- a/core-blocks/embed/editor.scss
+++ b/core-blocks/embed/editor.scss
@@ -17,3 +17,7 @@
 		}
 	}
 }
+
+.wp-block-embed__figure {
+	margin: 0;
+}

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -255,7 +255,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 				return (
 					<Fragment>
 						{ controls }
-						<figure className={ classnames( className, { 'is-video': 'video' === type } ) }>
+						<figure className={ classnames( className, 'wp-block-embed__figure', { 'is-video': 'video' === type } ) }>
 							{ ( cannotPreview ) ? (
 								<Placeholder icon={ icon } label={ __( 'Embed URL' ) }>
 									<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -255,7 +255,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 				return (
 					<Fragment>
 						{ controls }
-						<figure className={ classnames( className, 'wp-block-embed__figure', { 'is-video': 'video' === type } ) }>
+						<figure className={ classnames( className, 'wp-block-embed', { 'is-video': 'video' === type } ) }>
 							{ ( cannotPreview ) ? (
 								<Placeholder icon={ icon } label={ __( 'Embed URL' ) }>
 									<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>


### PR DESCRIPTION
Fixes #7150

## Description
Removed the margins around the `<figure>` element, which gets the content to expand to fill the content box.

## How has this been tested?
Tested in browser and things still work and display as they should. Tried with a YouTube and Vimeo embed.

## Screenshots (after)
<img width="730" alt="screenshot 2018-06-06 14 33 03" src="https://user-images.githubusercontent.com/90871/41019276-e599c7a4-6998-11e8-8fbb-6d9c8c35c0d3.png">
<img width="680" alt="screenshot 2018-06-06 14 32 56" src="https://user-images.githubusercontent.com/90871/41019277-e63ec150-6998-11e8-84c4-96f46a83520e.png">

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->