### PR TITLE
Add NUX E2E tests

### DIFF
--- a/test/e2e/specs/nux.test.js
+++ b/test/e2e/specs/nux.test.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newDesktopBrowserPage, newPost } from '../support/utils';
+
+describe( 'NUX', () => {
+	it( 'should show tips to a first-time user', async () => {
+		await newDesktopBrowserPage();
+		await newPost( undefined, false );
+
+		const firstTipText = await page.$eval( '.nux-dot-tip', ( element ) => element.innerText );
+		expect( firstTipText ).toContain( 'Welcome to the wonderful world of blocks!' );
+
+		const [ nextTipButton ] = await page.$x( '//button[contains(text(), \'See next tip\')]' );
+		await nextTipButton.click();
+
+		const secondTipText = await page.$eval( '.nux-dot-tip', ( element ) => element.innerText );
+		expect( secondTipText ).toContain( 'You’ll find more settings for your page and blocks in the sidebar.' );
+	} );
+} );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -66,13 +66,15 @@ export async function visitAdmin( adminPath, query ) {
 	}
 }
 
-export async function newPost( postType ) {
+export async function newPost( postType, disableTips = true ) {
 	await visitAdmin( 'post-new.php', postType ? 'post_type=' + postType : '' );
 
-	// Disable new user tips so that their UI doesn't get in the way
-	await page.evaluate( () => {
-		wp.data.dispatch( 'core/nux' ).disableTips();
-	} );
+	if ( disableTips ) {
+		// Disable new user tips so that their UI doesn't get in the way
+		await page.evaluate( () => {
+			wp.data.dispatch( 'core/nux' ).disableTips();
+		} );
+	}
 }
 
 export async function newDesktopBrowserPage() {


### PR DESCRIPTION
Closes #7037. 

Add a simple integration test which checks that a new user sees NUX tips.

## How has this been tested?

```
npm run test-e2e
```