### PR TITLE
Fix regression with formatting toolbar

### DIFF
--- a/edit-post/components/header/header-toolbar/style.scss
+++ b/edit-post/components/header/header-toolbar/style.scss
@@ -11,8 +11,10 @@
 	display: inline-flex;
 	align-items: center;
 
-	.editor-block-switcher .components-toolbar {
-		border: none;
+	@include break-large() {
+		.editor-block-switcher .components-toolbar {
+			border-left: 1px solid $light-gray-500;
+		}
 	}
 }
 

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -803,11 +803,8 @@
 .editor-block-contextual-toolbar .editor-block-toolbar {
 	width: 100%;
 	background: $white;
-
-	// use opacity to work in various editor styles
-	background-clip: padding-box;
-	box-sizing: padding-box;
 	border: 1px solid $light-gray-500;
+	border-right: none;
 
 	// this prevents floats from messing up the position
 	position: absolute;

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -1,9 +1,5 @@
 .editor-block-switcher {
 	position: relative;
-
-	.components-toolbar {
-		border-left: none;
-	}
 }
 
 .editor-block-switcher__toggle {
@@ -11,9 +7,6 @@
 	margin: 0;
 	padding: 8px;
 	border-radius: 0;
-
-	// Add a right border to show as separator in the block toolbar.
-	border-right: 1px solid $light-gray-700;
 
 	&:focus:before {
 		top: -3px;

--- a/editor/components/block-toolbar/style.scss
+++ b/editor/components/block-toolbar/style.scss
@@ -13,6 +13,9 @@
 
 	.components-toolbar {
 		border: none;
+
+		// Add a right border to show as separator in the block toolbar.
+		border-right: 1px solid $light-gray-500;
 	}
 
 	// this should probably have its own class


### PR DESCRIPTION
The right-border on the alignments was missing. This PR changes how we paint separators, so it gets fixed.

Verify this paints the right grouping borders for toolbar sections, both on mobile and desktop breakpoints, and with both the top-fixed toolbar and the block-fixed toolbar.

<img width="416" alt="screen shot 2018-06-06 at 11 01 18" src="https://user-images.githubusercontent.com/1204802/41028137-0b5df052-6979-11e8-8c06-8c9fe52ab1c4.png">

----

<img width="443" alt="screen shot 2018-06-06 at 11 01 37" src="https://user-images.githubusercontent.com/1204802/41028139-0cc67dec-6979-11e8-9b35-06e9209a08ad.png">

----

<img width="382" alt="screen shot 2018-06-06 at 11 01 44" src="https://user-images.githubusercontent.com/1204802/41028141-0e27243e-6979-11e8-8b2f-0e385fad808d.png">
