### PR TITLE
Document Outline: Restructured buttons to anchors

### DIFF
--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -96,7 +96,13 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 	// when clicking on a heading item from the list.
 	const onSelectHeading = ( uid ) => onSelect( uid );
 	const titleNode = document.querySelector( '.editor-post-title__input' );
-	const titleId = titleNode.getAttribute( 'id' );
+	const titleId = () => {
+		if ( typeof titleNode.getAttribute( 'id' ) ) {
+			titleNode.setAttribute( 'id', 'id-' + titleNode.innerHTML );
+		}
+
+		return titleNode.getAttribute( 'id' );
+	};
 	const focusTitle = () => {
 		// Not great but it's the simplest way to focus the title right now.
 		if ( titleNode ) {

--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -97,7 +97,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 	const onSelectHeading = ( uid ) => onSelect( uid );
 	const titleNode = document.querySelector( '.editor-post-title__input' );
 	const titleId = titleNode.getAttribute( 'id' );
-	const onClick = () => {
+	const focusTitle = () => {
 		// Not great but it's the simplest way to focus the title right now.
 		if ( titleNode ) {
 			titleNode.focus();
@@ -115,7 +115,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 					<DocumentOutlineItem
 						level="Title"
 						isValid
-						onClick={ onClick }
+						onClick={ focusTitle }
 						titleId={ titleId }
 					>
 						{ title }

--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -95,9 +95,10 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 	// Select the corresponding block in the main editor
 	// when clicking on a heading item from the list.
 	const onSelectHeading = ( uid ) => onSelect( uid );
-	const focusTitle = () => {
+	const titleNode = document.querySelector( '.editor-post-title__input' );
+	const titleId = titleNode.getAttribute( 'id' );
+	const onClick = () => {
 		// Not great but it's the simplest way to focus the title right now.
-		const titleNode = document.querySelector( '.editor-post-title__input' );
 		if ( titleNode ) {
 			titleNode.focus();
 		}
@@ -114,7 +115,8 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 					<DocumentOutlineItem
 						level="Title"
 						isValid
-						onClick={ focusTitle }
+						onClick={ onClick }
+						titleId={ titleId }
 					>
 						{ title }
 					</DocumentOutlineItem>

--- a/editor/components/document-outline/item.js
+++ b/editor/components/document-outline/item.js
@@ -19,6 +19,7 @@ const TableOfContentsItem = ( {
 	level,
 	onClick,
 	path = [],
+	titleId,
 } ) => (
 	<li
 		className={ classnames(
@@ -29,11 +30,7 @@ const TableOfContentsItem = ( {
 			}
 		) }
 	>
-		<a
-			className="document-outline__button"
-			onClick={ onClick }
-			href="#"
-		>
+		<a onClick={ onClick } href={ '#' + titleId }>
 			<span className="document-outline__emdash" aria-hidden="true"></span>
 			{
 				// path is an array of nodes that are ancestors of the heading starting in the top level node.

--- a/editor/components/document-outline/item.js
+++ b/editor/components/document-outline/item.js
@@ -30,7 +30,11 @@ const TableOfContentsItem = ( {
 			}
 		) }
 	>
-		<a onClick={ onClick } href={ '#' + titleId }>
+		<a
+			onClick={ onClick }
+			className="document-outline__trigger"
+			href={ '#' + titleId }
+		>
 			<span className="document-outline__emdash" aria-hidden="true"></span>
 			{
 				// path is an array of nodes that are ancestors of the heading starting in the top level node.

--- a/editor/components/document-outline/item.js
+++ b/editor/components/document-outline/item.js
@@ -29,9 +29,10 @@ const TableOfContentsItem = ( {
 			}
 		) }
 	>
-		<button
+		<a
 			className="document-outline__button"
 			onClick={ onClick }
+			href="#"
 		>
 			<span className="document-outline__emdash" aria-hidden="true"></span>
 			{
@@ -50,7 +51,7 @@ const TableOfContentsItem = ( {
 				{ children }
 			</span>
 			<span className="screen-reader-text">{ __( '(Click to focus this heading)' ) }</span>
-		</button>
+		</a>
 	</li>
 );
 

--- a/editor/components/document-outline/style.scss
+++ b/editor/components/document-outline/style.scss
@@ -37,7 +37,7 @@
 	}
 }
 
-.document-outline__button {
+.document-outline__trigger {
 	cursor: pointer;
 	background: none;
 	border: none;
@@ -45,9 +45,14 @@
 	align-items: flex-start;
 	color: $dark-gray-800;
 	text-align: left;
+	text-decoration: none;
 
 	&:focus {
 		@include button-style__focus-active;
+	}
+
+	.document-outline__item-content {
+	  text-decoration: underline;
 	}
 }
 


### PR DESCRIPTION
## Description
Buttons inside the Document Outline component have been replaced with anchor tags in response to #7142.

## How has this been tested?
* The Document Outline component still performs the behaviour of moving focus to the block textarea. We are currently missing tests that check whether focus has indeed been moved, but this is an existing issue.
* Tests pass from `npm run test`

## Types of changes
* Class name change;
* Refactoring of variables;
* Added hyperlink path functionality.

## Checklist:
- My code is tested.
- My code follows the WordPress code style.
- My code follows the accessibility standards.