### PR TITLE
Convert strikethrough in Markdown

### DIFF
--- a/blocks/api/raw-handling/markdown-converter.js
+++ b/blocks/api/raw-handling/markdown-converter.js
@@ -10,6 +10,7 @@ const converter = new showdown.Converter( {
 	literalMidWordUnderscores: true,
 	omitExtraWLInCodeBlocks: true,
 	simpleLineBreaks: true,
+	strikethrough: true,
 } );
 
 /**

--- a/test/integration/fixtures/markdown-in.txt
+++ b/test/integration/fixtures/markdown-in.txt
@@ -1,6 +1,6 @@
 # This is a heading with *italic*
 
-This is a paragraph with a [link](https://w.org/) and **bold**.
+This is a paragraph with a [link](https://w.org/), **bold**, and ~~strikethrough~~.
 
 Preserve
 line breaks please.

--- a/test/integration/fixtures/markdown-out.html
+++ b/test/integration/fixtures/markdown-out.html
@@ -3,7 +3,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>This is a paragraph with a <a href="https://w.org/">link</a> and <strong>bold</strong>.</p>
+<p>This is a paragraph with a <a href="https://w.org/">link</a>, <strong>bold</strong>, and <del>strikethrough</del>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
## Description
This branch adds strikethrough support for Markdown conversion when pasting.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
