### PR TITLE
Add support for Core Data Entities Actions

### DIFF
--- a/core-data/entities.js
+++ b/core-data/entities.js
@@ -7,11 +7,11 @@ import { upperFirst, camelCase, map, find } from 'lodash';
  * WordPress dependencies
  */
 import apiRequest from '@wordpress/api-request';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { getEntitiesByKind } from './selectors';
 import { addEntities } from './actions';
 
 export const defaultEntities = [
@@ -61,13 +61,12 @@ export const getMethodName = ( kind, name, prefix = 'get', usePlural = false ) =
 /**
  * Loads the kind entities into the store.
  *
- * @param {Object} state Global state
  * @param {string} kind  Kind
  *
  * @return {Array} Entities
  */
-export async function* getKindEntities( state, kind ) {
-	let entities = getEntitiesByKind( state, kind );
+export async function* getKindEntities( kind ) {
+	let entities = select( 'core' ).getEntitiesByKind( kind );
 
 	if ( entities && entities.length !== 0 ) {
 		return entities;

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -22,10 +22,15 @@ const createEntityRecordGetter = ( source ) => defaultEntities.reduce( ( result,
 
 const entityResolvers = createEntityRecordGetter( resolvers );
 const entitySelectors = createEntityRecordGetter( selectors );
+const entityActions = defaultEntities.reduce( ( result, entity ) => {
+	const { kind, name } = entity;
+	result[ getMethodName( kind, name, 'update' ) ] = actions.updateEntityRecord.bind( null, kind, name );
+	return result;
+}, {} );
 
 const store = registerStore( REDUCER_KEY, {
 	reducer,
-	actions,
+	actions: { ...actions, ...entityActions },
 	selectors: { ...selectors, ...entitySelectors },
 	resolvers: { ...resolvers, ...entityResolvers },
 } );

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -45,7 +45,7 @@ export async function* getAuthors() {
  * @param {number} key    Record's key
  */
 export async function* getEntityRecord( state, kind, name, key ) {
-	const entities = yield* await getKindEntities( state, kind );
+	const entities = yield* await getKindEntities( kind );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity ) {
 		return;
@@ -62,7 +62,7 @@ export async function* getEntityRecord( state, kind, name, key ) {
  * @param {string} name   Entity name.
  */
 export async function* getEntityRecords( state, kind, name ) {
-	const entities = yield* await getKindEntities( state, kind );
+	const entities = yield* await getKindEntities( kind );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity ) {
 		return;

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
+import { dispatch as dispatchAction } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -111,7 +112,7 @@ export default {
 			content: getEditedPostContent( state ),
 			id: post.id,
 		};
-		const basePath = wp.api.getPostTypeRoute( getCurrentPostType( state ) );
+		const postType = getCurrentPostType( state );
 
 		dispatch( {
 			type: 'REQUEST_POST_UPDATE_START',
@@ -130,6 +131,7 @@ export default {
 				parent: post.id,
 			};
 
+			const basePath = wp.api.getPostTypeRoute( postType );
 			request = wp.apiRequest( {
 				path: `/wp/v2/${ basePath }/${ post.id }/autosaves`,
 				method: 'POST',
@@ -145,11 +147,7 @@ export default {
 			dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
 			dispatch( removeNotice( AUTOSAVE_POST_NOTICE_ID ) );
 
-			request = wp.apiRequest( {
-				path: `/wp/v2/${ basePath }/${ post.id }`,
-				method: 'PUT',
-				data: toSend,
-			} );
+			request = dispatchAction( 'core' ).updateEntityRecord( 'postType', postType, toSend );
 		}
 
 		request.then(

--- a/packages/data/src/runtime.js
+++ b/packages/data/src/runtime.js
@@ -75,16 +75,20 @@ export default function createStoreRuntime( store ) {
 	return async ( actionCreator ) => {
 		if ( isActionLike( actionCreator ) ) {
 			store.dispatch( actionCreator );
-			return;
+			return actionCreator;
 		}
 
 		// Attempt to normalize the action creator as async iterable.
 		actionCreator = toAsyncIterable( actionCreator );
-		for await ( const maybeAction of actionCreator ) {
+		let ret;
+		do {
+			ret = await actionCreator.next();
 			// Dispatch if it quacks like an action.
-			if ( isActionLike( maybeAction ) ) {
-				store.dispatch( maybeAction );
+			if ( isActionLike( ret.value ) ) {
+				store.dispatch( ret.value );
 			}
-		}
+		} while ( ! ret.done );
+
+		return ret.value;
 	};
 }


### PR DESCRIPTION
Since Fetching Entities including Posts is happening in `core-data`, the logical thing to do is to move updating/removing posts to the the `core-data` module.

This is just a POC for the moment and it builds on #6999 

The idea is instead of calling the API request in the `editor` module directly when dispatch an async action to `core-data`. This surfaces a lot of things (more questions than answers)

 - A need for async actions to rely on async actions on other modules (or effects to rely on async effects in other modules). In the current PR, this is solved by the fact that async actions return a promise with the returned value from the generators. Whichever solution we end up using, we need something like that: calling side effects from other modules and acting on their result.

 - Questions about the `currentPost` state and whether it's wise to keep it in the `editor` state or if we should just rely on the `post` object already available in `core-data`.

 - Questions about the optimistic updates and whether it's a good fit for the entities because we can't optimistically update the post object, since we'll override the `title.rendered` and `content.rendered`. These might get used in other modules (other than the editor) and we can't just overwrite them. Maybe we should only send `{ title: raw }` to the API if the API supports updates this way but this is not perfect as well because we'd leave a `rendered` value not in sync with the `raw` value, so not certain if we should keep the optimistic updates.

