### PR TITLE
add/hoverable-tooltips: Added fix for non-tinymce tooltips

### DIFF
--- a/components/tooltip/style.scss
+++ b/components/tooltip/style.scss
@@ -1,5 +1,4 @@
 .components-tooltip.components-popover {
-	pointer-events: none;
 
 	&:before {
 		border-color: transparent;


### PR DESCRIPTION
## Description
Allowed tooltips to be hoverable (for mouse over events);.

This partially resolves #7004.


## How has this been tested?
The tooltip functionality persists as before with no JS change. 

## Types of changes
* 1 line change of CSS style.

## Checklist:
- My code is tested.
- My code follows the WordPress code style. 
- My code follows the accessibility standards.
