### PR TITLE
FAQ link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Blocks are the unifying evolution of what is now covered, in different ways, by 
 
 Imagine a custom “employee” block that a client can drag to an About page to automatically display a picture, name, and bio. A whole universe of plugins that all extend WordPress in the same way. Simplified menus and widgets. Users who can instantly understand and use WordPress  -- and 90% of plugins. This will allow you to easily compose beautiful posts like <a href="http://moc.co/sandbox/example-post/">this example</a>.
 
-Check out the <a href="https://github.com/WordPress/gutenberg/blob/master/docs/faq.md">FAQ</a> for answers to the most common questions about the project.
+Check out the <a href="https://wordpress.org/gutenberg/handbook/reference/faq/">FAQ</a> for answers to the most common questions about the project.
 
 ## Compatibility
 


### PR DESCRIPTION
## Description
Replaced the FAQ link in the readme file.

## Types of changes
Changed the link from https://github.com/WordPress/gutenberg/blob/master/docs/faq.md to https://wordpress.org/gutenberg/handbook/reference/faq/
