### PR TITLE
Only show transforms to blocks that can be inserted on the root block; Order transforms by frecency;

### DIFF
--- a/packages/editor/src/components/block-switcher/test/index.js
+++ b/packages/editor/src/components/block-switcher/test/index.js
@@ -92,7 +92,11 @@ describe( 'BlockSwitcher', () => {
 		const blocks = [
 			headingBlock1,
 		];
-		const wrapper = shallow( <BlockSwitcher blocks={ blocks } /> );
+		const inserterItems = [
+			{ name: 'core/paragraph', frecency: 1 },
+		];
+
+		const wrapper = shallow( <BlockSwitcher blocks={ blocks } inserterItems={ inserterItems } /> );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
@@ -122,9 +126,17 @@ describe( 'BlockSwitcher', () => {
 			headingBlock1,
 		];
 
+		const inserterItems = [
+			{ name: 'core/quote', frecency: 1 },
+			{ name: 'core/cover-image', frecency: 2 },
+			{ name: 'core/paragraph', frecency: 3 },
+			{ name: 'core/heading', frecency: 4 },
+			{ name: 'core/text', frecency: 5 },
+		];
+
 		const onTransformStub = jest.fn();
 		const getDropdown = () => {
-			const blockSwitcher = shallow( <BlockSwitcher blocks={ blocks } onTransform={ onTransformStub } /> );
+			const blockSwitcher = shallow( <BlockSwitcher blocks={ blocks } onTransform={ onTransformStub } inserterItems={ inserterItems } /> );
 			return blockSwitcher.find( 'Dropdown' );
 		};
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/6363
Part of a general polishing to get #6993.
Relates to: https://github.com/WordPress/gutenberg/issues/7227

This PR makes sure we can only transform to blocks that can be inserted in the root block.
The transformations are also sorted by frecency (a heuristic used by the inserter)  so items transformations should appear in the same order as they appear on the inserter.

Test block: https://gist.github.com/jorgefilipecosta/b958239761a24664685d5efc7ab48fa6
(can be pasted in the browser console)
## How has this been tested?
Use a block that sets allowed blocks in the nested area (test block). Verify it is only possible to transform blocks to the allowed blocks (list and quote).
Test both single and multi-block transforms and verify the restriction applies to transforms rendered on the block toolbar and to transforms presented on the side menu.
Verify that if the allowed blocks restriction is applied via PHP filters, the transforms also respect it.
e.g:
```
add_filter( 'allowed_block_types', function( $allowed_block_types, $post ) {
	if ( $post->post_type === 'post' ) {
	    return $allowed_block_types;
	}
	return [ 'core/paragraph' ];
}, 10, 2 );
```

Verify the order blocks appear on the transformations list is the same as the order they appear on the inserted.