### PR TITLE
Fix gallery attachment page link

### DIFF
--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -89,7 +89,7 @@ class GalleryEdit extends Component {
 
 	onSelectImages( images ) {
 		this.props.setAttributes( {
-			images: images.map( ( image ) => pick( image, [ 'alt', 'caption', 'id', 'url' ] ) ),
+			images: images.map( ( image ) => pick( image, [ 'alt', 'caption', 'id', 'link', 'url' ] ) ),
 		} );
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/6896

## Description
A simple fix we were not setting the link attribute. The link to attachment page was not working because the link attribute was not being set.

## How has this been tested?
Add a gallery block; Add some images from the media gallery; On the block inspector, set the "Link to" option to the attachment page. Save the post. Verify the images correctly link to the attachment page.
