### PR TITLE
Preview: Enable published posts preview

### DIFF
--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -24,7 +24,7 @@ export class PostPreviewButton extends Component {
 		// This relies on the window being responsible to unset itself when
 		// navigation occurs or a new preview window is opened, to avoid
 		// unintentional forceful redirects.
-		if ( previewLink && ! prevProps.previewLink ) {
+		if ( previewLink && previewLink !== prevProps.previewLink ) {
 			this.setPreviewWindowLink( previewLink );
 		}
 	}

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -16,24 +16,32 @@ export class PostPreviewButton extends Component {
 		super( ...arguments );
 
 		this.saveForPreview = this.saveForPreview.bind( this );
-
-		this.state = {
-			isAwaitingSave: false,
-		};
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const { modified, link } = nextProps;
-		const { isAwaitingSave } = this.state;
-		const hasFinishedSaving = (
-			isAwaitingSave &&
-			modified !== this.props.modified
-		);
+	componentDidUpdate( prevProps ) {
+		const { previewLink } = this.props;
 
-		if ( hasFinishedSaving && this.previewWindow ) {
-			this.previewWindow.location = link;
-			this.setState( { isAwaitingSave: false } );
+		// This relies on the window being responsible to unset itself when
+		// navigation occurs or a new preview window is opened, to avoid
+		// unintentional forceful redirects.
+		if ( previewLink && ! prevProps.previewLink ) {
+			this.setPreviewWindowLink( previewLink );
 		}
+	}
+
+	/**
+	 * Sets the preview window's location to the given URL, if a preview window
+	 * exists and is not already at that location.
+	 *
+	 * @param {string} url URL to assign as preview window location.
+	 */
+	setPreviewWindowLink( url ) {
+		const { previewWindow } = this;
+		if ( ! previewWindow || previewWindow.location === url ) {
+			return;
+		}
+
+		previewWindow.location = url;
 	}
 
 	getWindowTarget() {
@@ -50,9 +58,6 @@ export class PostPreviewButton extends Component {
 
 		// Save post prior to opening window
 		this.props.autosave();
-		this.setState( {
-			isAwaitingSave: true,
-		} );
 
 		// Open a popup, BUT: Set it to a blank page until save completes. This
 		// is necessary because popups can only be opened in response to user
@@ -95,13 +100,13 @@ export class PostPreviewButton extends Component {
 	}
 
 	render() {
-		const { link, isSaveable } = this.props;
+		const { currentPostLink, isSaveable } = this.props;
 
 		return (
 			<Button
 				className="editor-post-preview"
 				isLarge
-				href={ link }
+				href={ currentPostLink }
 				onClick={ this.saveForPreview }
 				target={ this.getWindowTarget() }
 				disabled={ ! isSaveable }
@@ -116,7 +121,8 @@ export default compose( [
 	withSelect( ( select ) => {
 		const {
 			getCurrentPostId,
-			getEditedPostPreviewLink,
+			getCurrentPostAttribute,
+			getAutosaveAttribute,
 			getEditedPostAttribute,
 			isEditedPostDirty,
 			isEditedPostNew,
@@ -128,12 +134,12 @@ export default compose( [
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		return {
 			postId: getCurrentPostId(),
-			link: getEditedPostPreviewLink(),
+			currentPostLink: getCurrentPostAttribute( 'link' ),
+			previewLink: getAutosaveAttribute( 'preview_link' ),
 			isDirty: isEditedPostDirty(),
 			isNew: isEditedPostNew(),
 			isSaveable: isEditedPostSaveable(),
 			isViewable: get( postType, [ 'viewable' ], false ),
-			modified: getEditedPostAttribute( 'modified' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -75,10 +75,6 @@ export class PostPreviewButton extends Component {
 			this.getWindowTarget()
 		);
 
-		// When popup is closed, delete reference to avoid later assignment of
-		// location in a post update.
-		this.previewWindow.onbeforeunload = () => delete this.previewWindow;
-
 		const markup = `
 			<div>
 				<p>Please wait&hellip;</p>
@@ -104,6 +100,10 @@ export class PostPreviewButton extends Component {
 
 		this.previewWindow.document.write( markup );
 		this.previewWindow.document.close();
+
+		// When popup is closed or redirected by setPreviewWindowLink, delete
+		// reference to avoid later assignment of location in a post update.
+		this.previewWindow.onbeforeunload = () => delete this.previewWindow;
 	}
 
 	render() {

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -50,16 +50,10 @@ export class PostPreviewButton extends Component {
 	}
 
 	saveForPreview( event ) {
-		const { previewLink, isDirty, isNew } = this.props;
+		const { isDirty, isNew } = this.props;
 
 		// Let default link behavior occur if no changes to saved post
 		if ( ! isDirty && ! isNew ) {
-			return;
-		}
-
-		// Likewise, if a preview URL is available and already assigned as
-		// the href of the clicked link, there's no need for the interstitial.
-		if ( previewLink && event.target.href === previewLink ) {
 			return;
 		}
 
@@ -107,13 +101,13 @@ export class PostPreviewButton extends Component {
 	}
 
 	render() {
-		const { previewLink, currentPostLink, isSaveable } = this.props;
+		const { currentPostLink, isSaveable } = this.props;
 
 		return (
 			<Button
 				className="editor-post-preview"
 				isLarge
-				href={ previewLink || currentPostLink }
+				href={ currentPostLink }
 				onClick={ this.saveForPreview }
 				target={ this.getWindowTarget() }
 				disabled={ ! isSaveable }

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -37,7 +37,7 @@ export class PostPreviewButton extends Component {
 	 */
 	setPreviewWindowLink( url ) {
 		const { previewWindow } = this;
-		if ( ! previewWindow || previewWindow.location === url ) {
+		if ( ! previewWindow || previewWindow.location.href === url ) {
 			return;
 		}
 

--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -50,9 +50,16 @@ export class PostPreviewButton extends Component {
 	}
 
 	saveForPreview( event ) {
-		const { isDirty, isNew } = this.props;
+		const { previewLink, isDirty, isNew } = this.props;
+
 		// Let default link behavior occur if no changes to saved post
 		if ( ! isDirty && ! isNew ) {
+			return;
+		}
+
+		// Likewise, if a preview URL is available and already assigned as
+		// the href of the clicked link, there's no need for the interstitial.
+		if ( previewLink && event.target.href === previewLink ) {
 			return;
 		}
 
@@ -100,13 +107,13 @@ export class PostPreviewButton extends Component {
 	}
 
 	render() {
-		const { currentPostLink, isSaveable } = this.props;
+		const { previewLink, currentPostLink, isSaveable } = this.props;
 
 		return (
 			<Button
 				className="editor-post-preview"
 				isLarge
-				href={ currentPostLink }
+				href={ previewLink || currentPostLink }
 				onClick={ this.saveForPreview }
 				target={ this.getWindowTarget() }
 				disabled={ ! isSaveable }

--- a/editor/components/post-preview-button/test/index.js
+++ b/editor/components/post-preview-button/test/index.js
@@ -9,6 +9,58 @@ import { shallow } from 'enzyme';
 import { PostPreviewButton } from '../';
 
 describe( 'PostPreviewButton', () => {
+	describe( 'setPreviewWindowLink()', () => {
+		it( 'should do nothing if there is no preview window', () => {
+			const url = 'https://wordpress.org';
+			const setter = jest.fn();
+			const wrapper = shallow( <PostPreviewButton /> );
+
+			wrapper.instance().setPreviewWindowLink( url );
+
+			expect( setter ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should do nothing if the preview window is already at url location', () => {
+			const url = 'https://wordpress.org';
+			const setter = jest.fn();
+			const wrapper = shallow( <PostPreviewButton /> );
+			wrapper.instance().previewWindow = {
+				get location() {
+					return {
+						href: url,
+					};
+				},
+				set location( value ) {
+					setter( value );
+				},
+			};
+
+			wrapper.instance().setPreviewWindowLink( url );
+
+			expect( setter ).not.toHaveBeenCalled();
+		} );
+
+		it( 'set preview window location to url', () => {
+			const url = 'https://wordpress.org';
+			const setter = jest.fn();
+			const wrapper = shallow( <PostPreviewButton /> );
+			wrapper.instance().previewWindow = {
+				get location() {
+					return {
+						href: 'about:blank',
+					};
+				},
+				set location( value ) {
+					setter( value );
+				},
+			};
+
+			wrapper.instance().setPreviewWindowLink( url );
+
+			expect( setter ).toHaveBeenCalledWith( url );
+		} );
+	} );
+
 	describe( 'getWindowTarget()', () => {
 		it( 'returns a string unique to the post id', () => {
 			const instance = new PostPreviewButton( {
@@ -28,7 +80,7 @@ describe( 'PostPreviewButton', () => {
 					isSaveable
 					modified="2017-08-03T15:05:50" />
 			);
-			wrapper.instance().previewWindow = {};
+			wrapper.instance().previewWindow = { location: {} };
 
 			wrapper.setProps( { previewLink: 'https://wordpress.org/?p=1' } );
 

--- a/editor/components/post-preview-button/test/index.js
+++ b/editor/components/post-preview-button/test/index.js
@@ -114,16 +114,6 @@ describe( 'PostPreviewButton', () => {
 			expect( wrapper.prop( 'target' ) ).toBe( 'wp-preview-1' );
 		} );
 
-		it( 'should render with preview link as href if available', () => {
-			const wrapper = shallow(
-				<PostPreviewButton
-					currentPostLink="https://wordpress.org/?p=1"
-					previewLink="https://wordpress.org/?p=1&preview=true" />
-			);
-
-			expect( wrapper.prop( 'href' ) ).toBe( 'https://wordpress.org/?p=1&preview=true' );
-		} );
-
 		it( 'should be disabled if post is not saveable', () => {
 			const wrapper = shallow(
 				<PostPreviewButton

--- a/editor/components/post-preview-button/test/index.js
+++ b/editor/components/post-preview-button/test/index.js
@@ -9,14 +9,6 @@ import { shallow } from 'enzyme';
 import { PostPreviewButton } from '../';
 
 describe( 'PostPreviewButton', () => {
-	describe( 'constructor()', () => {
-		it( 'should initialize with non-awaiting-save', () => {
-			const instance = new PostPreviewButton( {} );
-
-			expect( instance.state.isAwaitingSave ).toBe( false );
-		} );
-	} );
-
 	describe( 'getWindowTarget()', () => {
 		it( 'returns a string unique to the post id', () => {
 			const instance = new PostPreviewButton( {
@@ -28,23 +20,21 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	describe( 'componentDidUpdate()', () => {
-		it( 'should change popup location if save finishes', () => {
+		it( 'should change popup location if preview link is available', () => {
 			const wrapper = shallow(
 				<PostPreviewButton
 					postId={ 1 }
-					link="https://wordpress.org/?p=1"
+					currentPostLink="https://wordpress.org/?p=1"
 					isSaveable
 					modified="2017-08-03T15:05:50" />
 			);
 			wrapper.instance().previewWindow = {};
-			wrapper.setState( { isAwaitingSave: true } );
 
-			wrapper.setProps( { modified: '2017-08-03T15:05:52' } );
+			wrapper.setProps( { previewLink: 'https://wordpress.org/?p=1' } );
 
 			expect(
 				wrapper.instance().previewWindow.location
 			).toBe( 'https://wordpress.org/?p=1' );
-			expect( wrapper.state( 'isAwaitingSave' ) ).toBe( false );
 		} );
 	} );
 
@@ -71,13 +61,11 @@ describe( 'PostPreviewButton', () => {
 			if ( isExpectingSave ) {
 				expect( autosave ).toHaveBeenCalled();
 				expect( preventDefault ).toHaveBeenCalled();
-				expect( wrapper.state( 'isAwaitingSave' ) ).toBe( true );
 				expect( window.open ).toHaveBeenCalled();
 				expect( wrapper.instance().previewWindow.document.write ).toHaveBeenCalled();
 			} else {
 				expect( autosave ).not.toHaveBeenCalled();
 				expect( preventDefault ).not.toHaveBeenCalled();
-				expect( wrapper.state( 'isAwaitingSave' ) ).not.toBe( true );
 				expect( window.open ).not.toHaveBeenCalled();
 			}
 
@@ -118,7 +106,7 @@ describe( 'PostPreviewButton', () => {
 				<PostPreviewButton
 					postId={ 1 }
 					isSaveable
-					link="https://wordpress.org/?p=1" />
+					currentPostLink="https://wordpress.org/?p=1" />
 			);
 
 			expect( wrapper.prop( 'href' ) ).toBe( 'https://wordpress.org/?p=1' );
@@ -130,7 +118,7 @@ describe( 'PostPreviewButton', () => {
 			const wrapper = shallow(
 				<PostPreviewButton
 					postId={ 1 }
-					link="https://wordpress.org/?p=1" />
+					currentPostLink="https://wordpress.org/?p=1" />
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );

--- a/editor/components/post-preview-button/test/index.js
+++ b/editor/components/post-preview-button/test/index.js
@@ -114,6 +114,16 @@ describe( 'PostPreviewButton', () => {
 			expect( wrapper.prop( 'target' ) ).toBe( 'wp-preview-1' );
 		} );
 
+		it( 'should render with preview link as href if available', () => {
+			const wrapper = shallow(
+				<PostPreviewButton
+					currentPostLink="https://wordpress.org/?p=1"
+					previewLink="https://wordpress.org/?p=1&preview=true" />
+			);
+
+			expect( wrapper.prop( 'href' ) ).toBe( 'https://wordpress.org/?p=1&preview=true' );
+		} );
+
 		it( 'should be disabled if post is not saveable', () => {
 			const wrapper = shallow(
 				<PostPreviewButton

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -391,7 +391,7 @@ export function editPost( edits ) {
  *
  * @return {Object} Action object.
  */
-export function savePost( options ) {
+export function savePost( options = {} ) {
 	return {
 		type: 'REQUEST_POST_UPDATE',
 		options,

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -157,48 +157,13 @@ export default {
 
 		request.then(
 			( newPost ) => {
+				const reset = isAutosave ? resetAutosave : resetPost;
+				dispatch( reset( newPost ) );
+
 				// An autosave may be processed by the server as a regular save
 				// when its update is requested by the author and the post was
 				// draft or auto-draft.
 				const isRevision = newPost.id !== post.id;
-
-				// Thus, the following behaviors occur:
-				//
-				//  - If it was a revision, it is treated as latest autosave
-				//    and updates optimistically applied are reverted.
-				//  - If it was an autosave but not revision under the above
-				//    noted conditions, cherry-pick updated properties since
-				//    the received revision entity shares some but not all
-				//    properties of a post.
-				//  - Otherwise, it was a full save and the received entity
-				//    can be considered the new reset post.
-				let updateAction;
-				if ( isRevision ) {
-					updateAction = resetAutosave( newPost );
-				} else if ( isAutosave ) {
-					const revisionEdits = pick( newPost, [
-						// Autosave content fields.
-						'title',
-						'content',
-						'excerpt',
-
-						// UI considers save to have occurred if modified date
-						// of post changes (e.g. PostPreviewButton).
-						//
-						// TODO: Consider formalized pattern for identifying a
-						// save as having completed.
-						'date',
-						'date_gmt',
-						'modified',
-						'modified_gmt',
-					] );
-
-					updateAction = updatePost( revisionEdits );
-				} else {
-					updateAction = resetPost( newPost );
-				}
-
-				dispatch( updateAction );
 
 				dispatch( {
 					type: 'REQUEST_POST_UPDATE_SUCCESS',

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -98,7 +98,7 @@ export default {
 		const { dispatch, getState } = store;
 		const state = getState();
 		const post = getCurrentPost( state );
-		const isAutosave = get( action.options, [ 'autosave' ], false );
+		const isAutosave = !! action.options.autosave;
 
 		// Prevent save if not saveable.
 		const isSaveable = isAutosave ? isEditedPostAutosaveable : isEditedPostSaveable;

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -1091,6 +1091,13 @@ export function autosave( state = null, action ) {
 				content,
 				preview_link: post.preview_link,
 			};
+
+		case 'REQUEST_POST_UPDATE':
+			// Invalidate known preview link when autosave starts.
+			if ( state && action.options.autosave ) {
+				return omit( state, 'preview_link' );
+			}
+			break;
 	}
 
 	return state;

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -1085,7 +1085,12 @@ export function autosave( state = null, action ) {
 				'content',
 			].map( ( field ) => getPostRawValue( post[ field ] ) );
 
-			return { title, excerpt, content };
+			return {
+				title,
+				excerpt,
+				content,
+				preview_link: post.preview_link,
+			};
 	}
 
 	return state;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -183,6 +183,21 @@ export function getPostEdits( state ) {
 }
 
 /**
+ * Returns an attribute value of the saved post.
+ *
+ * @param {Object} state         Global application state.
+ * @param {string} attributeName Post attribute name.
+ *
+ * @return {*} Post attribute value.
+ */
+export function getCurrentPostAttribute( state, attributeName ) {
+	const post = getCurrentPost( state );
+	if ( post.hasOwnProperty( attributeName ) ) {
+		return post[ attributeName ];
+	}
+}
+
+/**
  * Returns a single attribute of the post being edited, preferring the unsaved
  * edit if one exists, but falling back to the attribute for the last known
  * saved state of the post.
@@ -201,9 +216,31 @@ export function getEditedPostAttribute( state, attributeName ) {
 			return getEditedPostContent( state );
 	}
 
-	return edits[ attributeName ] === undefined ?
-		state.currentPost[ attributeName ] :
-		edits[ attributeName ];
+	if ( ! edits.hasOwnProperty( attributeName ) ) {
+		return getCurrentPostAttribute( state, attributeName );
+	}
+
+	return edits[ attributeName ];
+}
+
+/**
+ * Returns an attribute value of the current autosave revision for a post, or
+ * null if there is no autosave for the post.
+ *
+ * @param {Object} state         Global application state.
+ * @param {string} attributeName Autosave attribute name.
+ *
+ * @return {*} Autosave attribute value.
+ */
+export function getAutosaveAttribute( state, attributeName ) {
+	if ( ! hasAutosave( state ) ) {
+		return null;
+	}
+
+	const autosave = getAutosave( state );
+	if ( autosave.hasOwnProperty( attributeName ) ) {
+		return autosave[ attributeName ];
+	}
 }
 
 /**

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -244,6 +244,14 @@ describe( 'actions', () => {
 		it( 'should return REQUEST_POST_UPDATE action', () => {
 			expect( savePost() ).toEqual( {
 				type: 'REQUEST_POST_UPDATE',
+				options: {},
+			} );
+		} );
+
+		it( 'should pass through options argument', () => {
+			expect( savePost( { autosave: true } ) ).toEqual( {
+				type: 'REQUEST_POST_UPDATE',
+				options: { autosave: true },
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -2298,7 +2298,7 @@ describe( 'state', () => {
 						raw: 'The Excerpt',
 					},
 					status: 'draft',
-					preview_link: 'https://wordpress.org/?p=1',
+					preview_link: 'https://wordpress.org/?p=1&preview=true',
 				},
 			} );
 
@@ -2306,7 +2306,7 @@ describe( 'state', () => {
 				title: 'The Title',
 				content: 'The Content',
 				excerpt: 'The Excerpt',
-				preview_link: 'https://wordpress.org/?p=1',
+				preview_link: 'https://wordpress.org/?p=1&preview=true',
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -2298,6 +2298,7 @@ describe( 'state', () => {
 						raw: 'The Excerpt',
 					},
 					status: 'draft',
+					preview_link: 'https://wordpress.org/?p=1',
 				},
 			} );
 
@@ -2305,6 +2306,7 @@ describe( 'state', () => {
 				title: 'The Title',
 				content: 'The Content',
 				excerpt: 'The Excerpt',
+				preview_link: 'https://wordpress.org/?p=1',
 			} );
 		} );
 	} );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -50,7 +50,9 @@ const {
 	getSelectedBlock,
 	getSelectedBlockUID,
 	getBlockRootUID,
+	getCurrentPostAttribute,
 	getEditedPostAttribute,
+	getAutosaveAttribute,
 	getGlobalBlockCount,
 	getMultiSelectedBlockUids,
 	getMultiSelectedBlocks,
@@ -363,6 +365,34 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( 'getCurrentPostAttribute', () => {
+		it( 'should return undefined for an attribute which does not exist', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( getCurrentPostAttribute( state, 'foo' ) ).toBeUndefined();
+		} );
+
+		it( 'should return undefined for object prototype member', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( getCurrentPostAttribute( state, 'valueOf' ) ).toBeUndefined();
+		} );
+
+		it( 'should return the value of an attribute', () => {
+			const state = {
+				currentPost: {
+					title: 'Hello World',
+				},
+			};
+
+			expect( getCurrentPostAttribute( state, 'title' ) ).toBe( 'Hello World' );
+		} );
+	} );
+
 	describe( 'getEditedPostAttribute', () => {
 		it( 'should return the current post\'s slug if no edits have been made', () => {
 			const state = {
@@ -415,6 +445,55 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'youcha' );
+		} );
+
+		it( 'should return undefined for object prototype member', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+			};
+
+			expect( getEditedPostAttribute( state, 'valueOf' ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'getAutosaveAttribute', () => {
+		it( 'returns null if there is no autosave', () => {
+			const state = {
+				autosave: null,
+			};
+
+			expect( getAutosaveAttribute( state, 'title' ) ).toBeNull();
+		} );
+
+		it( 'returns undefined for an attribute which is not set', () => {
+			const state = {
+				autosave: {},
+			};
+
+			expect( getAutosaveAttribute( state, 'foo' ) ).toBeUndefined();
+		} );
+
+		it( 'returns undefined for object prototype member', () => {
+			const state = {
+				autosave: {},
+			};
+
+			expect( getAutosaveAttribute( state, 'valueOf' ) ).toBeUndefined();
+		} );
+
+		it( 'returns the attribute value', () => {
+			const state = {
+				autosave: {
+					title: 'Hello World',
+				},
+			};
+
+			expect( getAutosaveAttribute( state, 'title' ) ).toBe( 'Hello World' );
 		} );
 	} );
 

--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -352,10 +352,16 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		$schema = $this->get_item_schema();
 
 		if ( ! empty( $schema['properties']['preview_link'] ) ) {
-			$response->data['preview_link'] = get_preview_post_link( $post->post_parent, array(
-				'preview_id'    => $post->post_parent,
-				'preview_nonce' => wp_create_nonce( 'post_preview_' . $post->post_parent )
-			) );
+			$parent_id = wp_is_post_autosave( $post );
+			$preview_post_id = false === $parent_id ? $post->ID : $parent_id;
+			$preview_query_args = array();
+
+			if ( false !== $parent_id ) {
+				$preview_query_args['preview_id']    = $parent_id;
+				$preview_query_args['preview_nonce'] = wp_create_nonce( 'post_preview_' . $parent_id );
+			}
+
+			$response->data['preview_link'] = get_preview_post_link( $preview_post_id, $preview_query_args );
 		}
 
 		$context        = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -439,45 +439,6 @@ function gutenberg_register_rest_api_post_revisions() {
 add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_revisions' );
 
 /**
- * Get the preview link for the post object.
- *
- * @see https://github.com/WordPress/gutenberg/issues/4555
- *
- * @param WP_Post $post Post object.
- * @return string
- */
-function gutenberg_get_post_preview_link( $post ) {
-	return get_preview_post_link( $post['id'] );
-}
-
-/**
- * Adds the 'preview_link' attribute to the REST API response of a post.
- *
- * @see https://github.com/WordPress/gutenberg/issues/4555
- */
-function gutenberg_register_rest_api_post_preview_link() {
-	foreach ( get_post_types( array( 'show_in_rest' => true ), 'names' ) as $post_type ) {
-		if ( ! is_post_type_viewable( $post_type ) ) {
-			continue;
-		}
-		register_rest_field( $post_type,
-			'preview_link',
-			array(
-				'get_callback' => 'gutenberg_get_post_preview_link',
-				'schema'       => array(
-					'description' => __( 'Preview link for the post.', 'gutenberg' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'context'     => array( 'edit' ),
-					'readonly'    => true,
-				),
-			)
-		);
-	}
-}
-add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_preview_link' );
-
-/**
  * Ensure that the wp-json index contains the 'theme-supports' setting as
  * part of its site info elements.
  *

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -445,19 +445,4 @@ class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 		$data = $response->get_data();
 		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
 	}
-
-	public function test_get_page_edit_context_includes_preview() {
-		wp_set_current_user( $this->editor );
-		$page_id = $this->factory->post->create( array(
-			'post_type'   => 'page',
-			'post_status' => 'draft',
-		) );
-		$page    = get_post( $page_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/pages/' . $page_id );
-		$request->set_param( 'context', 'edit' );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$data = $response->get_data();
-		$this->assertEquals( get_preview_post_link( $page ), $data['preview_link'] );
-	}
 }

--- a/phpunit/class-rest-autosaves-controller-test.php
+++ b/phpunit/class-rest-autosaves-controller-test.php
@@ -239,7 +239,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 12, count( $properties ) );
+		$this->assertEquals( 13, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'content', $properties );
 		$this->assertArrayHasKey( 'date', $properties );
@@ -252,6 +252,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertArrayHasKey( 'parent', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
+		$this->assertArrayHasKey( 'preview_link', $properties );
 	}
 
 	public function test_create_item() {

--- a/test/e2e/specs/preview.test.js
+++ b/test/e2e/specs/preview.test.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import { parse } from 'url';
+
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import {
+	newPost,
+	newDesktopBrowserPage,
+	getUrl,
+	publishPost,
+} from '../support/utils';
+
+describe( 'Publishing', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+	} );
+
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'Should open a preview window for a new post', async () => {
+		const editorPage = page;
+
+		// Disabled until content present.
+		const isPreviewDisabled = await page.$$eval(
+			'.editor-post-preview:not( :disabled )',
+			( enabledButtons ) => ! enabledButtons.length,
+		);
+		expect( isPreviewDisabled ).toBe( true );
+
+		await editorPage.type( '.editor-post-title__input', 'Hello World' );
+
+		// Don't proceed with autosave until preview window page is resolved.
+		await editorPage.setRequestInterception( true );
+
+		let [ , previewPage ] = await Promise.all( [
+			editorPage.click( '.editor-post-preview' ),
+			new Promise( ( resolve ) => {
+				browser.once( 'targetcreated', async ( target ) => {
+					resolve( await target.page() );
+				} );
+			} ),
+		] );
+
+		// Interstitial screen while save in progress.
+		expect( previewPage.url() ).toBe( 'about:blank' );
+
+		// Release request intercept should allow redirect to occur after save.
+		await Promise.all( [
+			previewPage.waitForNavigation(),
+			editorPage.setRequestInterception( false ),
+		] );
+
+		// When autosave completes for a new post, the URL of the editor should
+		// update to include the ID. Use this to assert on preview URL.
+		const [ , postId ] = await ( await editorPage.waitForFunction( () => {
+			return window.location.search.match( /[\?&]post=(\d+)/ );
+		} ) ).jsonValue();
+
+		let expectedPreviewURL = getUrl( '', `?p=${ postId }&preview=true` );
+		expect( previewPage.url() ).toBe( expectedPreviewURL );
+
+		// Title in preview should match input.
+		let previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'Hello World' );
+
+		// Return to editor to change title.
+		await editorPage.bringToFront();
+		await editorPage.type( '.editor-post-title__input', '!' );
+
+		// Second preview should reuse same popup frame, with interstitial.
+		await editorPage.setRequestInterception( true );
+		await Promise.all( [
+			editorPage.click( '.editor-post-preview' ),
+			// Note: `load` event is used since, while a `window.open` with
+			// `about:blank` is called, the target window doesn't actually
+			// navigate to `about:blank` (it is treated as noop). But when
+			// the `document.write` + `document.close` of the interstitial
+			// finishes, a `load` event is fired.
+			new Promise( ( resolve ) => previewPage.once( 'load', resolve ) ),
+		] );
+		await editorPage.setRequestInterception( false );
+
+		// Wait for preview to load.
+		await new Promise( ( resolve ) => {
+			previewPage.once( 'load', resolve );
+		} );
+
+		// Title in preview should match updated input.
+		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'Hello World!' );
+
+		// Pressing preview without changes should bring same preview window to
+		// front and reload, but should not show interstitial. Intercept editor
+		// requests in case a save attempt occurs, to avoid race condition on
+		// the load event and title retrieval.
+		await editorPage.bringToFront();
+		await editorPage.setRequestInterception( true );
+		await editorPage.click( '.editor-post-preview' );
+		await new Promise( ( resolve ) => previewPage.once( 'load', resolve ) );
+		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'Hello World!' );
+		await editorPage.setRequestInterception( false );
+
+		// Preview for published post (no unsaved changes) directs to canonical
+		// URL for post.
+		await editorPage.bringToFront();
+		await publishPost();
+		await Promise.all( [
+			page.waitForFunction( () => ! document.querySelector( '.editor-post-preview' ) ),
+			page.click( '.editor-post-publish-panel__header button' ),
+		] );
+		expectedPreviewURL = await editorPage.$eval( '.notice-success a', ( node ) => node.href );
+		// Note / Temporary: It's expected that Chrome should reuse the same
+		// tab with window name `wp-preview-##`, yet in this instance a new tab
+		// is unfortunately created.
+		previewPage = ( await Promise.all( [
+			editorPage.click( '.editor-post-preview' ),
+			new Promise( ( resolve ) => {
+				browser.once( 'targetcreated', async ( target ) => {
+					resolve( await target.page() );
+				} );
+			} ),
+		] ) )[ 1 ];
+		expect( previewPage.url() ).toBe( expectedPreviewURL );
+
+		// Return to editor to change title.
+		await editorPage.bringToFront();
+		await editorPage.type( '.editor-post-title__input', ' And more.' );
+
+		// Published preview should reuse same popup frame, with interstitial.
+		await editorPage.setRequestInterception( true );
+		await Promise.all( [
+			editorPage.click( '.editor-post-preview' ),
+			new Promise( ( resolve ) => previewPage.once( 'load', resolve ) ),
+		] );
+		await editorPage.setRequestInterception( false );
+
+		// Wait for preview to load.
+		await new Promise( ( resolve ) => {
+			previewPage.once( 'load', resolve );
+		} );
+
+		// Title in preview should match updated input.
+		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'Hello World! And more.' );
+
+		// Published preview URL should include ID and nonce parameters.
+		const { query } = parse( previewPage.url(), true );
+		expect( query ).toHaveProperty( 'preview_id' );
+		expect( query ).toHaveProperty( 'preview_nonce' );
+	} );
+} );

--- a/test/e2e/specs/preview.test.js
+++ b/test/e2e/specs/preview.test.js
@@ -14,7 +14,7 @@ import {
 	publishPost,
 } from '../support/utils';
 
-describe( 'Publishing', () => {
+describe( 'Preview', () => {
 	beforeAll( async () => {
 		await newDesktopBrowserPage();
 	} );

--- a/test/e2e/specs/publishing.test.js
+++ b/test/e2e/specs/publishing.test.js
@@ -5,6 +5,7 @@ import '../support/bootstrap';
 import {
 	newPost,
 	newDesktopBrowserPage,
+	publishPost,
 } from '../support/utils';
 
 describe( 'Publishing', () => {
@@ -19,18 +20,7 @@ describe( 'Publishing', () => {
 	it( 'Should publish a post and close the panel once we start editing again', async () => {
 		await page.type( '.editor-post-title__input', 'E2E Test Post' );
 
-		// Opens the publish panel
-		await page.click( '.editor-post-publish-panel__toggle' );
-
-		// Disable reason: Wait for a second ( wait for the animation )
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 1000 );
-
-		// Publish the post
-		await page.click( '.editor-post-publish-button' );
-
-		// A success notice should show up
-		page.waitForSelector( '.notice-success' );
+		await publishPost();
 
 		// The post publish panel is visible
 		expect( await page.$( '.editor-post-publish-panel' ) ).not.toBeNull();

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -26,7 +26,7 @@ const MOD_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
  */
 const REGEXP_ZWSP = /[\u200B\u200C\u200D\uFEFF]/;
 
-function getUrl( WPPath, query = '' ) {
+export function getUrl( WPPath, query = '' ) {
 	const url = new URL( WP_BASE_URL );
 
 	url.pathname = join( url.pathname, WPPath );
@@ -139,4 +139,26 @@ export async function pressWithModifier( modifier, key ) {
 	await page.keyboard.down( modifier );
 	await page.keyboard.press( key );
 	return page.keyboard.up( modifier );
+}
+
+/**
+ * Publishes the post, resolving once the request is complete (once a notice
+ * is displayed).
+ *
+ * @return {Promise} Promise resolving when publish is complete.
+ */
+export async function publishPost() {
+	// Opens the publish panel
+	await page.click( '.editor-post-publish-panel__toggle' );
+
+	// Disable reason: Wait for the animation to complete, since otherwise the
+	// click attempt may occur at the wrong point.
+	// eslint-disable-next-line no-restricted-syntax
+	await page.waitFor( 100 );
+
+	// Publish the post
+	await page.click( '.editor-post-publish-button' );
+
+	// A success notice should show up
+	return page.waitForSelector( '.notice-success' );
 }


### PR DESCRIPTION
Closes (when #7130 is merged): #7179
Closes (when #7130 is merged): #2544
Related: #6257, #6882

**Note:** Merges to `fix/autosave-preview` (#7130) as base branch.
**Note:** As best I can tell, this branch is fully functional, but I have plans to include new end-to-end tests for various preview circumstances prior to merge.

This pull request seeks to allow the user to preview changes to a published post without first updating the post (i.e. the autosave revision preview).

In doing so, it...

- Refactors the `PostPreviewButton` component to avoid relying on a specific save workflow, and instead leverage the mere availability of a preview link
- Removes `preview_link` from the posts endpoints and adds instead to the autosaves endpoint (see #7179)

To the latter point, I landed at the conclusion that `preview_link` only makes sense in the context of autsosaves on consideration of:

- The post endpoints reflect the value of the canonical saved post. If there are no unsaved changes, the user should be directed to `post.link` as its preview.
- It does not belong in the revisions endpoints because it is not the case that any revision can be previewed. A preview only occurs for the latest revision of a post ([`_set_preview`](https://github.com/WordPress/WordPress/blob/6fd8080e7ee7599b36d4528f72a8ced612130b8c/wp-includes/revision.php#L556), [`wp_get_post_autosave`](https://github.com/WordPress/WordPress/blob/6fd8080e7ee7599b36d4528f72a8ced612130b8c/wp-includes/revision.php#L232-L246)).

Related Trac tickets:

- [REST API: Support autosaves](https://core.trac.wordpress.org/ticket/43316) (43316)
- [REST API: Expose 'preview_link' for viewable post types](https://core.trac.wordpress.org/ticket/44180) (44180)

Thus, if there are no unsaved changes for a post, the Preview button is effectively a link to `post.link`. If there are unsaved changes, the autosave is triggered and once its responses' `autosave.preview_link` becomes accessible, it is used in the redirect (regardless of whether or not the autosave occurred as a full save as described in #7124).

