### PR TITLE
Fix a tiny typographical nicety

### DIFF
--- a/core-blocks/cover-image/index.js
+++ b/core-blocks/cover-image/index.js
@@ -63,7 +63,7 @@ export const name = 'core/cover-image';
 export const settings = {
 	title: __( 'Cover Image' ),
 
-	description: __( 'Add a full-width image, and layer text over it -- great for headers.' ),
+	description: __( 'Add a full-width image, and layer text over it — great for headers.' ),
 
 	icon: 'cover-image',
 


### PR DESCRIPTION
## Description

This may be my smallest PR yet. But it is still a PR dangit, and it deserves the same thorough and exhaustive reviews as any other PRs do. It deserves CPU time on travis to run thousands of unrelated tests. It deserves this because it is right.

As such, this pull request aims to fix an issue with the Cover Image block. Specifically, if you look at the description of the block in the sidebar block inspector, you will notice that the description features a --, two dashes, where it should feature an emdash, i.e. —. I can't believe an issue for this hasn't been opened, but in any case, now it's fixed.

## Steps to reproduce:

- Insert a Cover Image block
- Add an image and title to it, or don't
- Open the sidebar, or in case it's already opened, leave it open
- Select the cover image block, or in case it's already selected, leave it selected
- Note that the description shows a -- instead of a —

## Tests:

- Apply this PR
- Repeat the steps above
- Now verify the -- is inded a — instead
- Verify that there are no regressions as a result of this PR

## Screenshots

Before:

![screen shot 2018-06-05 at 16 58 16](https://user-images.githubusercontent.com/1204802/41084487-a6b766ee-6a34-11e8-8408-f7d39263481d.png)

After:

<img width="276" alt="screen shot 2018-06-07 at 09 18 40" src="https://user-images.githubusercontent.com/1204802/41084516-b8dfb65a-6a34-11e8-9cfb-3f73d66278dd.png">

GIF:

![gif](https://user-images.githubusercontent.com/1204802/41084496-abfb28ac-6a34-11e8-95c0-1dd1de952e3e.gif)

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
