### PR TITLE
Tweak hover outline colors for Midnight & Sunrise

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,7 @@ const extractConfig = {
 								secondary: '#d9ab59',
 								toggle: '#82b4cb',
 								button: '#d9ab59',
-								outlines: '#417E9B',
+								outlines: '#417e9B',
 							},
 							'admin-color-coffee': {
 								primary: '#c2a68c',
@@ -84,14 +84,14 @@ const extractConfig = {
 								secondary: '#77a6b9',
 								toggle: '#77a6b9',
 								button: '#e14d43',
-								outlines: '#497B8D',
+								outlines: '#497b8d',
 							},
 							'admin-color-ocean': {
 								primary: '#a3b9a2',
 								secondary: '#a89d8a',
 								toggle: '#a3b9a2',
 								button: '#a3b9a2',
-								outlines: '#5E7D5E',
+								outlines: '#5e7d5e',
 							},
 							'admin-color-sunrise': {
 								primary: '#d1864a',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,7 +84,7 @@ const extractConfig = {
 								secondary: '#77a6b9',
 								toggle: '#77a6b9',
 								button: '#e14d43',
-								outlines: '#DC3428',
+								outlines: '#497B8D',
 							},
 							'admin-color-ocean': {
 								primary: '#a3b9a2',
@@ -98,7 +98,7 @@ const extractConfig = {
 								secondary: '#c8b03c',
 								toggle: '#c8b03c',
 								button: '#d1864a',
-								outlines: '#AA652C',
+								outlines: '#837425',
 							},
 						},
 					} ),


### PR DESCRIPTION
The hover outlines are colored according to your wp-admin theme.

In the Midnight and Sunrise themes they were red and orange. This wasn't ideal as they are warning colored. So this PR changes that to make them use the same color as toggles.

<img width="885" alt="screen shot 2018-06-07 at 09 53 06" src="https://user-images.githubusercontent.com/1204802/41086029-0e6ec936-6a39-11e8-99a2-fc8ba232e737.png">
