### PR TITLE
Try to improve the accessibility of featured images

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -24,6 +24,7 @@ export function Button( props, ref ) {
 		isBusy,
 		isDefault,
 		isLink,
+		isScary,
 		className,
 		disabled,
 		focus,
@@ -39,6 +40,7 @@ export function Button( props, ref ) {
 		'is-toggled': isToggled,
 		'is-busy': isBusy,
 		'is-link': isLink,
+		'is-scary': isScary,
 	} );
 
 	const tag = href !== undefined && ! disabled ? 'a' : 'button';

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -24,7 +24,7 @@ export function Button( props, ref ) {
 		isBusy,
 		isDefault,
 		isLink,
-		isScary,
+		isDestructive,
 		className,
 		disabled,
 		focus,
@@ -40,7 +40,7 @@ export function Button( props, ref ) {
 		'is-toggled': isToggled,
 		'is-busy': isBusy,
 		'is-link': isLink,
-		'is-scary': isScary,
+		'is-destructive': isDestructive,
 	} );
 
 	const tag = href !== undefined && ! disabled ? 'a' : 'button';

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -145,6 +145,11 @@
 		}
 	}
 
+	/* Buttons that look scary */
+	&.is-link.is-scary {
+		color: $alert-red;
+	}
+
 	&:active {
 		color: currentColor;
 	}

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -145,8 +145,8 @@
 		}
 	}
 
-	/* Buttons that look scary */
-	&.is-link.is-scary {
+	/* Link buttons that are red to indicate destructive behavior. */
+	&.is-link.is-destructive {
 		color: $alert-red;
 	}
 

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -26,7 +26,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 			<div className="editor-post-featured-image">
 				{ !! featuredImageId &&
 					<MediaUpload
-						title={ postLabel.set_featured_image }
+						title={ __( 'Set featured image' ) }
 						onSelect={ onUpdateImage }
 						type="image"
 						modalClass="editor-post-featured-image__media-modal"
@@ -47,7 +47,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
 				<MediaUpload
-					title={ __( 'Replace Image' ) }
+					title={ __( 'Set featured image' ) }
 					onSelect={ onUpdateImage }
 					type="image"
 					modalClass="editor-post-featured-image__media-modal"

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -18,6 +18,10 @@ import './style.scss';
 import PostFeaturedImageCheck from './check';
 import MediaUpload from '../media-upload';
 
+// Used when labels from post type were not yet loaded or when they are not present.
+const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
+const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
+
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
 
@@ -47,13 +51,13 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
 				<MediaUpload
-					title={ __( 'Set featured image' ) }
+					title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
 					onSelect={ onUpdateImage }
 					type="image"
 					modalClass="editor-post-featured-image__media-modal"
 					render={ ( { open } ) => (
 						<Button onClick={ open } isDefault isLarge>
-							{ __( 'Replace Image' ) }
+							{ __( 'Replace image' ) }
 						</Button>
 					) }
 				/>
@@ -61,7 +65,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				{ ! featuredImageId &&
 					<div>
 						<MediaUpload
-							title={ __( 'Set featured image' ) }
+							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
 							type="image"
 							modalClass="editor-post-featured-image__media-modal"
@@ -75,7 +79,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				}
 				{ !! featuredImageId &&
 					<Button onClick={ onRemoveImage } isDefault isLarge>
-						{ __( 'Remove Image' ) }
+						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
 					</Button>
 				}
 			</div>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -78,7 +78,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 					</div>
 				}
 				{ !! featuredImageId &&
-					<Button onClick={ onRemoveImage } isDefault isLarge>
+					<Button onClick={ onRemoveImage } isLink isScary>
 						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
 					</Button>
 				}

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -78,7 +78,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 					</div>
 				}
 				{ !! featuredImageId &&
-					<Button onClick={ onRemoveImage } isLink isScary>
+					<Button onClick={ onRemoveImage } isLink isDestructive>
 						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
 					</Button>
 				}

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -18,10 +18,6 @@ import './style.scss';
 import PostFeaturedImageCheck from './check';
 import MediaUpload from '../media-upload';
 
-// Used when labels from post type were not yet loaded or when they are not present.
-const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
-const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove featured image' );
-
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
 
@@ -51,13 +47,13 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
 				<MediaUpload
-					title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+					title={ __( 'Replace Image' ) }
 					onSelect={ onUpdateImage }
 					type="image"
 					modalClass="editor-post-featured-image__media-modal"
 					render={ ( { open } ) => (
 						<Button onClick={ open } isDefault isLarge>
-							{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							{ __( 'Replace Image' ) }
 						</Button>
 					) }
 				/>
@@ -65,24 +61,24 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				{ ! featuredImageId &&
 					<div>
 						<MediaUpload
-							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							title={ __( 'No image selected' ) }
 							onSelect={ onUpdateImage }
 							type="image"
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button className="editor-post-featured-image__toggle" onClick={ open }>
-									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+									{ __( 'No image selected' ) }
 								</Button>
 							) }
 						/>
 						<MediaUpload
-							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							title={ __( 'Add Image' ) }
 							onSelect={ onUpdateImage }
 							type="image"
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button onClick={ open } isDefault isLarge>
-									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+									{ __( 'Add Image' ) }
 								</Button>
 							) }
 						/>
@@ -90,7 +86,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				}
 				{ !! featuredImageId &&
 					<Button onClick={ onRemoveImage } isDefault isLarge>
-						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
+						{ __( 'Remove Image' ) }
 					</Button>
 				}
 			</div>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -67,18 +67,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button className="editor-post-featured-image__toggle" onClick={ open }>
-									{ __( 'No image selected' ) }
-								</Button>
-							) }
-						/>
-						<MediaUpload
-							title={ __( 'Add Image' ) }
-							onSelect={ onUpdateImage }
-							type="image"
-							modalClass="editor-post-featured-image__media-modal"
-							render={ ( { open } ) => (
-								<Button onClick={ open } isDefault isLarge>
-									{ __( 'Add Image' ) }
+									{ __( 'Set featured image' ) }
 								</Button>
 							) }
 						/>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, Button, Spinner, ResponsiveWrapper } from '@wordpress/components';
+import { Button, Spinner, ResponsiveWrapper } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -28,14 +28,6 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 	return (
 		<PostFeaturedImageCheck>
 			<div className="editor-post-featured-image">
-				{ !! featuredImageId &&
-				<IconButton
-					className="editor-post-featured-image__remove"
-					onClick={ onRemoveImage }
-					label={ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
-					icon="no-alt"
-				/>
-				}
 				{ !! featuredImageId &&
 					<MediaUpload
 						title={ __( 'Set featured image' ) }
@@ -84,6 +76,11 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 							) }
 						/>
 					</div>
+				}
+				{ !! featuredImageId &&
+					<Button onClick={ onRemoveImage } isDefault isLarge>
+						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
+					</Button>
 				}
 			</div>
 		</PostFeaturedImageCheck>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -35,7 +35,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 						type="image"
 						modalClass="editor-post-featured-image__media-modal"
 						render={ ( { open } ) => (
-							<Button className="editor-post-featured-image__preview" onClick={ open } isLink>
+							<Button className="editor-post-featured-image__preview" onClick={ open }>
 								{ media &&
 									<ResponsiveWrapper
 										naturalWidth={ media.media_details.width }
@@ -50,25 +50,46 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 					/>
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
-					<p className="editor-post-featured-image__howto">
-						{ __( 'Click the image to edit or update' ) }
-					</p>
+				<MediaUpload
+					title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+					onSelect={ onUpdateImage }
+					type="image"
+					modalClass="editor-post-featured-image__media-modal"
+					render={ ( { open } ) => (
+						<Button onClick={ open } isDefault isLarge>
+							{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+						</Button>
+					) }
+				/>
 				}
 				{ ! featuredImageId &&
-					<MediaUpload
-						title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
-						onSelect={ onUpdateImage }
-						type="image"
-						modalClass="editor-post-featured-image__media-modal"
-						render={ ( { open } ) => (
-							<Button className="editor-post-featured-image__toggle" onClick={ open } isLink>
-								{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
-							</Button>
-						) }
-					/>
+					<div>
+						<MediaUpload
+							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							onSelect={ onUpdateImage }
+							type="image"
+							modalClass="editor-post-featured-image__media-modal"
+							render={ ( { open } ) => (
+								<Button className="editor-post-featured-image__toggle" onClick={ open }>
+									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+								</Button>
+							) }
+						/>
+						<MediaUpload
+							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							onSelect={ onUpdateImage }
+							type="image"
+							modalClass="editor-post-featured-image__media-modal"
+							render={ ( { open } ) => (
+								<Button onClick={ open } isDefault isLarge>
+									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+								</Button>
+							) }
+						/>
+					</div>
 				}
 				{ !! featuredImageId &&
-					<Button className="editor-post-featured-image__toggle" onClick={ onRemoveImage } isLink>
+					<Button onClick={ onRemoveImage } isDefault isLarge>
 						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
 					</Button>
 				}

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -61,7 +61,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				{ ! featuredImageId &&
 					<div>
 						<MediaUpload
-							title={ __( 'No image selected' ) }
+							title={ __( 'Set featured image' ) }
 							onSelect={ onUpdateImage }
 							type="image"
 							modalClass="editor-post-featured-image__media-modal"

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Spinner, ResponsiveWrapper } from '@wordpress/components';
+import { IconButton, Button, Spinner, ResponsiveWrapper } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -28,6 +28,14 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 	return (
 		<PostFeaturedImageCheck>
 			<div className="editor-post-featured-image">
+				{ !! featuredImageId &&
+				<IconButton
+					className="editor-post-featured-image__remove"
+					onClick={ onRemoveImage }
+					label={ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
+					icon="no-alt"
+				/>
+				}
 				{ !! featuredImageId &&
 					<MediaUpload
 						title={ __( 'Set featured image' ) }
@@ -76,11 +84,6 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 							) }
 						/>
 					</div>
-				}
-				{ !! featuredImageId &&
-					<Button onClick={ onRemoveImage } isDefault isLarge>
-						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
-					</Button>
 				}
 			</div>
 		</PostFeaturedImageCheck>

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -7,6 +7,7 @@
 
 	// Space consecutive buttons evenly.
 	.components-button + .components-button {
+		display: block;
 		margin-top: 1em;
 	}
 
@@ -34,8 +35,4 @@
 	&:hover {
 		background-color: $light-gray-100;
 	}
-}
-
-.editor-post-featured-image__preview {
-
 }

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -7,8 +7,8 @@
 
 	// Space consecutive buttons evenly.
 	.components-button + .components-button {
-		display: block;
 		margin-top: 1em;
+		margin-right: 8px;
 	}
 
 	// Don't size up images beyond their intrinsic size.

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -1,33 +1,41 @@
 .editor-post-featured-image {
-	padding: 10px 0 0;
+	padding: 0;
 
 	.spinner {
 		margin: 0;
 	}
+
+	// Space consecutive buttons evenly.
+	.components-button + .components-button {
+		margin-top: 1em;
+	}
+
+	// Don't size up images beyond their intrinsic size.
+	.components-responsive-wrapper__content {
+		max-width: 100%;
+		width: auto;
+	}
+}
+
+.editor-post-featured-image__toggle,
+.editor-post-featured-image__preview {
+	display: block;
+	width: 100%;
+	padding: 0;
 }
 
 .editor-post-featured-image__toggle {
-	text-decoration: underline;
-	color: theme( secondary );
-
-	&:focus {
-		box-shadow: none;
-		outline: none;
-	}
+	border: 1px dashed $light-gray-900;
+	background-color: $light-gray-300;
+	line-height: 20px;
+	padding: $item-spacing 0;
+	text-align: center;
 
 	&:hover {
-		color: theme( primary );
+		background-color: $light-gray-100;
 	}
 }
 
 .editor-post-featured-image__preview {
-	display: block;
-	width: 100%;
-}
 
-.editor-post-featured-image__howto {
-	color: $dark-gray-300;
-	font-style: italic;
-	margin: 10px 0;
 }
-

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -1,5 +1,6 @@
 .editor-post-featured-image {
 	padding: 0;
+	position: relative;
 
 	.spinner {
 		margin: 0;
@@ -17,6 +18,17 @@
 		max-width: 100%;
 		width: auto;
 	}
+
+	// Show Remove button
+	.editor-post-featured-image__remove {
+		position: absolute;
+		z-index: 1;
+		top: -8px;
+		right: -8px;
+		border-radius: 50%;
+		background-color: $white;
+		box-shadow: inset 0 0 0 1px $light-gray-500;
+	}
 }
 
 .editor-post-featured-image__toggle,
@@ -24,6 +36,12 @@
 	display: block;
 	width: 100%;
 	padding: 0;
+	transition: all .1s ease-out;
+	box-shadow: 0 0 0 0 $blue-medium-500;
+}
+
+.editor-post-featured-image__preview:not(:disabled):not([aria-disabled="true"]):focus {
+	box-shadow: 0 0 0 4px $blue-medium-500;
 }
 
 .editor-post-featured-image__toggle {

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -11,7 +11,8 @@
 		margin-right: 8px;
 	}
 
-	// Don't size up images beyond their intrinsic size.
+	// This keeps images at their intrinsic size (eg. a 50px
+	// image will never be wider than 50px).
 	.components-responsive-wrapper__content {
 		max-width: 100%;
 		width: auto;

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -1,6 +1,5 @@
 .editor-post-featured-image {
 	padding: 0;
-	position: relative;
 
 	.spinner {
 		margin: 0;
@@ -17,17 +16,6 @@
 	.components-responsive-wrapper__content {
 		max-width: 100%;
 		width: auto;
-	}
-
-	// Show Remove button
-	.editor-post-featured-image__remove {
-		position: absolute;
-		z-index: 1;
-		top: -8px;
-		right: -8px;
-		border-radius: 50%;
-		background-color: $white;
-		box-shadow: inset 0 0 0 1px $light-gray-500;
 	}
 }
 


### PR DESCRIPTION
The goal of this PR is to fix #1116. It replaces #3829 as this is better code, and the rebase was also too complex. 

This PR consists of two commits. 

The first commit, https://github.com/WordPress/gutenberg/commit/76f19466b6e12e7ad7ab2cbaedb5e5e2ea1e7e97, is mostly a copy of the old PR (#3829), but relies on the exact same labels that we receive from `postLabel`. 

The 2nd commit, https://github.com/WordPress/gutenberg/commit/6a408274ff4a5171e4abb4dbb284833732a27c86, removes the reliance on the labels we receive frmo `postLabel` entirely, because they do not match what we are doing with multiple buttons, and in my understanding, those separate and multiple buttons are key to improving accessibility.

I would like comments on both approaches, and the approach of this PR overall. Here's a GIF:

![featured](https://user-images.githubusercontent.com/1204802/41090728-38c21af6-6a45-11e8-91cf-38745ad96a5f.gif)
