### PR TITLE
Improve translatable strings containing "%s" to have a translator comment

### DIFF
--- a/components/color-palette/index.js
+++ b/components/color-palette/index.js
@@ -31,13 +31,21 @@ export default function ColorPalette( { colors, disableCustomColors = false, val
 
 				return (
 					<div key={ color } className="components-color-palette__item-wrapper">
-						<Tooltip text={ name || sprintf( __( 'Color code: %s' ), color ) }>
+						<Tooltip
+							text={ name ||
+								// translators: %s: color hex code e.g: "#f00".
+								sprintf( __( 'Color code: %s' ), color )
+							}>
 							<button
 								type="button"
 								className={ className }
 								style={ style }
 								onClick={ applyOrUnset( color ) }
-								aria-label={ name ? sprintf( __( 'Color: %s' ), name ) : sprintf( __( 'Color code: %s' ), color ) }
+								aria-label={ name ?
+									// translators: %s: The name of the color e.g: "vivid red".
+									sprintf( __( 'Color: %s' ), name ) :
+									// translators: %s: color hex code e.g: "#f00".
+									sprintf( __( 'Color code: %s' ), color ) }
 								aria-pressed={ value === color }
 							/>
 						</Tooltip>

--- a/components/server-side-render/index.js
+++ b/components/server-side-render/index.js
@@ -78,8 +78,10 @@ export class ServerSideRender extends Component {
 				<Placeholder><Spinner /></Placeholder>
 			);
 		} else if ( response.error ) {
+			// translators: %s: error message describing the problem
+			const errorMessage = sprintf( __( 'Error loading block: %s' ), response.errorMsg );
 			return (
-				<Placeholder>{ sprintf( __( 'Error loading block: %s' ), response.errorMsg ) }</Placeholder>
+				<Placeholder>{ errorMessage }</Placeholder>
 			);
 		} else if ( ! response.length ) {
 			return (

--- a/core-blocks/block/indicator/index.js
+++ b/core-blocks/block/indicator/index.js
@@ -10,8 +10,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import './style.scss';
 
 function SharedBlockIndicator( { title } ) {
+	// translators: %s: title/name of the shared block
+	const tooltipText = sprintf( __( 'Shared Block: %s' ), title );
 	return (
-		<Tooltip text={ sprintf( __( 'Shared Block: %s' ), title ) }>
+		<Tooltip text={ tooltipText }>
 			<span className="shared-block-indicator">
 				<Dashicon icon="controls-repeat" />
 			</span>

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -209,6 +209,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 				}
 
 				if ( ! html ) {
+					// translators: %s: type of embed e.g: "YouTube", "Twitter", etc. "Embed" is used when no specific type exists
 					const label = sprintf( __( '%s URL' ), title );
 
 					return (
@@ -237,6 +238,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 
 				const parsedUrl = parse( url );
 				const cannotPreview = includes( HOSTS_NO_PREVIEWS, parsedUrl.host.replace( /^www\./, '' ) );
+				// translators: %s: host providing embed content e.g: www.youtube.com
 				const iframeTitle = sprintf( __( 'Embedded content from %s' ), parsedUrl.host );
 				const embedWrapper = 'wp-embed' === type ? (
 					<div

--- a/core-blocks/heading/edit.js
+++ b/core-blocks/heading/edit.js
@@ -29,6 +29,7 @@ export default function HeadingEdit( {
 				<Toolbar
 					controls={ '234'.split( '' ).map( ( level ) => ( {
 						icon: 'heading',
+						// translators: %s: heading level e.g: "1", "2", "3"
 						title: sprintf( __( 'Heading %s' ), level ),
 						isActive: 'H' + level === nodeName,
 						onClick: () => setAttributes( { nodeName: 'H' + level } ),
@@ -42,6 +43,7 @@ export default function HeadingEdit( {
 					<Toolbar
 						controls={ '123456'.split( '' ).map( ( level ) => ( {
 							icon: 'heading',
+							// translators: %s: heading level e.g: "1", "2", "3"
 							title: sprintf( __( 'Heading %s' ), level ),
 							isActive: 'H' + level === nodeName,
 							onClick: () => setAttributes( { nodeName: 'H' + level } ),

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -37,6 +37,7 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 					key={ item.id }
 					className="editor-inserter-with-shortcuts__block"
 					onClick={ () => onInsert( item ) }
+					// translators: %s: block title/name to be added
 					label={ sprintf( __( 'Add %s' ), item.title ) }
 					icon={ (
 						<BlockIcon icon={ item.icon && item.icon.src } />

--- a/editor/components/media-placeholder/index.js
+++ b/editor/components/media-placeholder/index.js
@@ -107,6 +107,7 @@ class MediaPlaceholder extends Component {
 			<Placeholder
 				icon={ icon }
 				label={ labels.title }
+				// translators: %s: media name label e.g: "an audio","an image", "a video"
 				instructions={ sprintf( __( 'Drag %s, upload a new one or select a file from your library.' ), labels.name ) }
 				className={ classnames( 'editor-media-placeholder', className ) }
 				notices={ <Fragment>{ additionalNotices }{ noticeUI }</Fragment> }

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -73,6 +73,7 @@ export function mediaUpload( {
 			onError( {
 				code: 'SIZE_ABOVE_LIMIT',
 				message: sprintf(
+					// translators: %s: file name
 					__( '%s exceeds the maximum upload size for this site.' ),
 					mediaFile.name
 				),
@@ -103,6 +104,7 @@ export function mediaUpload( {
 				onError( {
 					code: 'GENERAL',
 					message: sprintf(
+						// translators: %s: file name
 						__( 'Error while uploading file %s to the media library.' ),
 						mediaFile.name
 					),


### PR DESCRIPTION
When we use %s in a string and it is not totally obvious what %s means when reading the rest of the string, we should provide a translator comment.

Tries to address: https://github.com/WordPress/gutenberg/issues/5361


## How has this been tested?
Only comments were added to the translations was added in this changes, some smoke testing, and the automated tests should be enough to catch problems.
