### PR TITLE
React: Enable Strict Mode

### DIFF
--- a/edit-post/editor.js
+++ b/edit-post/editor.js
@@ -3,6 +3,7 @@
  */
 import { withSelect } from '@wordpress/data';
 import { EditorProvider, ErrorBoundary } from '@wordpress/editor';
+import { StrictMode } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,11 +21,13 @@ function Editor( { settings, hasFixedToolbar, post, overridePost, onError, ...pr
 	};
 
 	return (
-		<EditorProvider settings={ editorSettings } post={ { ...post, ...overridePost } } { ...props }>
-			<ErrorBoundary onError={ onError }>
-				<Layout />
-			</ErrorBoundary>
-		</EditorProvider>
+		<StrictMode>
+			<EditorProvider settings={ editorSettings } post={ { ...post, ...overridePost } } { ...props }>
+				<ErrorBoundary onError={ onError }>
+					<Layout />
+				</ErrorBoundary>
+			</EditorProvider>
+		</StrictMode>
 	);
 }
 

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -11,6 +11,7 @@ import {
 	Children,
 	Fragment,
 	isValidElement,
+	StrictMode,
 } from 'react';
 import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
 import {
@@ -105,6 +106,8 @@ export { cloneElement };
 export { findDOMNode };
 
 export { Children };
+
+export { StrictMode };
 
 /**
  * A component which renders its children without any wrapping element.


### PR DESCRIPTION
In preparation for Future React updates (Async mode), let's enable StrictMode in dev mode to avoid using deprecated APIs in Core and plugins.

This will create a ton of warnings in the console at the moment, but we should make sure to fix them in follow-up PRs.