### PR TITLE
Data Module: Refactor Higher-order components to avoid the use of componentWillMount

### DIFF
--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -267,8 +267,9 @@ export function dispatch( reducerKey ) {
  * @return {Component} Enhanced component with merged state data props.
  */
 export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( WrappedComponent ) => {
+	const defaultMergeProps = {};
 	function getNextMergeProps( props ) {
-		return mapStateToProps( select, props ) || {};
+		return mapStateToProps( select, props ) || defaultMergeProps;
 	}
 
 	return class ComponentWithSelect extends Component {

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -267,6 +267,10 @@ export function dispatch( reducerKey ) {
  * @return {Component} Enhanced component with merged state data props.
  */
 export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( WrappedComponent ) => {
+	function getNextMergeProps( props ) {
+		return mapStateToProps( select, props ) || {};
+	}
+
 	return class ComponentWithSelect extends Component {
 		constructor( props ) {
 			super( ...arguments );
@@ -280,7 +284,7 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			 */
 			this.shouldComponentUpdate = false;
 			this.state = {
-				mergeProps: mapStateToProps( select, props ) || {},
+				mergeProps: getNextMergeProps( props ),
 			};
 
 			// Subscribtion should happen in the constructor
@@ -323,7 +327,7 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			}
 
 			const { mergeProps } = this.state;
-			const nextMergeProps = mapStateToProps( select, props ) || {};
+			const nextMergeProps = getNextMergeProps( props );
 
 			if ( ! isShallowEqual( nextMergeProps, mergeProps ) ) {
 				this.setState( {

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -303,10 +303,6 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			}
 		}
 
-		componentDidMount() {
-			this.canRunSelection = true;
-		}
-
 		componentWillUnmount() {
 			this.unsubscribe();
 
@@ -314,7 +310,7 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			// are snapshotted before being invoked, so if unmounting occurs
 			// during a previous callback, we need to explicitly track and
 			// avoid the `runSelection` that is scheduled to occur.
-			this.canRunSelection = false;
+			this.isUnmounting = true;
 		}
 
 		subscribe() {
@@ -322,7 +318,7 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 		}
 
 		runSelection( props = this.props ) {
-			if ( ! this.canRunSelection ) {
+			if ( this.isUnmounting ) {
 				return;
 			}
 


### PR DESCRIPTION
In #7202 I'm trying to enable StrictMode and this surfaces a big number of files we're relying on deprecated Lifecycle methods.

This PR updates the data module HoC to avoid using `componentWillMount` lifecycle method.

**Testing instructions**

 - Unit/E2e tests pass
 - Gutenberg works