### PR TITLE
update/InserterWithShortcuts.opacity: Increased opacity contrast

### DIFF
--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -32,12 +32,12 @@ $empty-paragraph-height: $text-editor-font-size * 4;
 
 	// Show quick insertion icons faded until hover
 	.editor-inserter-with-shortcuts {
-		opacity: .5;
+		opacity: .7;
 		transition: opacity 0.2s;
 
 		.components-icon-button:not( :hover ) {
 			// use opacity to work in various editor styles
-			color: $dark-opacity-500;
+			color: $dark-gray-900;
 
 			.is-dark-theme & {
 				color: $light-opacity-500;

--- a/editor/components/inserter-with-shortcuts/style.scss
+++ b/editor/components/inserter-with-shortcuts/style.scss
@@ -14,7 +14,7 @@
 	padding-top: 8px;
 
 	// use opacity to work in various editor styles
-	color: $dark-opacity-light-700;
+	color: $dark-gray-900;
 
 	.is-dark-theme & {
 		color: $light-opacity-light-700;


### PR DESCRIPTION
## Description
The opacity and colour has been increased on the InserterWithShortcuts component. Before this change, the component looked disabled where it was actually fully functional.

Resolves #7177

## How has this been tested?
* Passes `npm run test`

## Types of changes
* CSS changes

## Checklist:
- My code is tested.
- My code follows the WordPress code style. 
- My code follows the accessibility standards.
- My code has proper inline documentation.