### PR TITLE
update/block-settings-menu.expanded-label: Made label descriptive

### DIFF
--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -72,7 +72,7 @@ export class BlockSettingsMenu extends Component {
 						const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
 							'is-opened': isOpen,
 						} );
-						const label = isOpen ? 'Hide Options' : 'More Options';
+						const label = isOpen ? __( 'Hide Options' ) : __( 'More Options' );
 
 						return (
 							<IconButton
@@ -84,7 +84,7 @@ export class BlockSettingsMenu extends Component {
 									onToggle();
 								} }
 								icon="ellipsis"
-								label={ __( label ) }
+								label={ label }
 								aria-expanded={ isOpen }
 								focus={ focus }
 								onFocus={ this.onFocus }

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -72,6 +72,7 @@ export class BlockSettingsMenu extends Component {
 						const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
 							'is-opened': isOpen,
 						} );
+						const label = isOpen ? 'Hide Options' : 'More Options';
 
 						return (
 							<IconButton
@@ -83,7 +84,7 @@ export class BlockSettingsMenu extends Component {
 									onToggle();
 								} }
 								icon="ellipsis"
-								label={ __( 'More Options' ) }
+								label={ __( label ) }
 								aria-expanded={ isOpen }
 								focus={ focus }
 								onFocus={ this.onFocus }


### PR DESCRIPTION
## Description
The "More Options" changes its behaviour when its options are shown and the behaviour is changed to hide those options. This change of action now been reflected in the label of the button to say "Hide options".

Resolves #7204

## How has this been tested?
* Passes `npm run test`

## Types of changes
* JavaScript change

## Checklist:
- My code is tested.
- My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->