### PR TITLE
[Try] Alternate design for block side controls

### DIFF
--- a/edit-post/assets/stylesheets/_variables.scss
+++ b/edit-post/assets/stylesheets/_variables.scss
@@ -47,8 +47,8 @@ $block-padding: 14px; // padding of nested blocks
 $block-spacing: 4px; // vertical space between blocks
 
 $block-side-ui-width: 28px; // width of the side UI, matches half matches half of a single line of text, so two buttons stacke matches 1
-$block-side-ui-clearance: 2px; // space between side UI and block
-$block-side-ui-padding: $block-side-ui-width + $block-side-ui-clearance; // total space used to accommodate side UI
+$block-side-ui-clearance: 4px; // space between side UI and block
+$block-side-ui-padding: $block-side-ui-width + $block-side-ui-clearance + 2px; // total space used to accommodate side UI
 $block-parent-side-ui-clearance: $parent-block-padding - $block-padding; // space between side UI and block on top level blocks
 
 // Buttons & UI Widgets

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -446,7 +446,7 @@
 		> .editor-block-list__breadcrumb {
 			right: -1px;
 		}
-		
+
 		// compensate for main container padding, subtract border
 		@include break-small() {
 			margin-left: -$block-side-ui-padding + 1px;
@@ -514,11 +514,10 @@
 	// Left and right
 	> .editor-block-settings-menu,
 	> .editor-block-mover {
+		padding: $block-side-ui-clearance;
 		position: absolute;
-		top: 0;
-		width: $block-side-ui-width + $block-side-ui-clearance;
-		height: 100%; // stretch to fill half of the available space to increase hoverable area
-		max-height: $block-side-ui-width * 4; // stretch to fill half of the available space to increase hoverable area
+		width: $block-side-ui-width + ( $block-side-ui-clearance * 2 );
+		background: $white;
 	}
 
 	// Elevate when selected or hovered
@@ -528,7 +527,15 @@
 		&.is-hovered {
 			.editor-block-settings-menu,
 			.editor-block-mover {
+				outline: 1px solid $dark-opacity-light-500;
 				z-index: z-index( '.editor-block-list__block.is-{selected,hovered} .editor-block-{settings-menu,mover}' );
+			}
+		}
+
+		&.is-hovered {
+			.editor-block-settings-menu,
+			.editor-block-mover {
+				outline: 1px solid theme( outlines );
 			}
 		}
 	}
@@ -555,8 +562,6 @@
 
 	// Left side UI
 	> .editor-block-mover {
-		padding-right: $block-side-ui-clearance;
-
 		// Position for top level blocks
 		left: -$block-side-ui-width - $block-side-ui-clearance - $block-parent-side-ui-clearance;
 
@@ -829,7 +834,7 @@
 	z-index: z-index( '.editor-block-list__breadcrumb' );
 
 	// Position in the top right of the border
-	right: -$block-parent-side-ui-clearance;
+	right: -10px;
 	top: 0;
 
 	// Nested
@@ -847,7 +852,7 @@
 		padding: 4px 4px;
 		background: theme( outlines );
 		color: $white;
-	
+
 		// Animate in
 		.editor-block-list__block:hover & {
 			@include fade_in( .1s );

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -46,13 +46,10 @@
 	// Apply a background in nested contexts, only on desktop
 	@include break-small() {
 		.editor-block-list__layout .editor-block-list__layout & {
-			background: $white;
-			box-shadow: inset 0 0 0 1px $light-gray-500;
-
 			&:first-child {
 				margin-bottom: -1px;
 			}
-		
+
 			&:hover,
 			&:active,
 			&:focus {

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -26,13 +26,11 @@
 	// Apply a background in nested contexts, only on desktop
 	@include break-small() {
 		.editor-block-list__layout .editor-block-list__layout & {
-			background: $white;
-			box-shadow: inset 0 0 0 1px $light-gray-500;
-			color: $dark-gray-500; // always show dark gray in nested contexts
-	
+			//color: $dark-gray-500; // always show dark gray in nested contexts
+
 			&:first-child {
 				margin-bottom: -1px;
-			}	
+			}
 
 			&:hover,
 			&:active,


### PR DESCRIPTION
## Description
Tries out an alternate design for block side controls, as described in #7182.

## How has this been tested?
Hover over the sides of a block to view block controls

## Screenshots
![_untitled____ _mindful_org_ _wordpress](https://user-images.githubusercontent.com/1231306/41111099-0ac5f876-6a49-11e8-96bd-d3891c27247f.png)

## Types of changes
This tweaks the UI of the side block controls to add a border to the entire control area, similar to the look of the toolbar.

**It should not be merged in this state.** This has not been thoroughly tested across browsers (outside Safari and Chrome on macOS), and the CSS changes are… messy. There is also an issue with the overlapping outlines with selected blocks displaying as a darker color (because the borders overlap and are a semi-transparent gray, not fully opaque).

However, it is useful as a quick way to try it out and see how you feel about the design. If folks like it, I can clean up/improve the CSS so it can be merged.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows the accessibility standards.
- [ ] My code has proper inline documentation.
