### PR TITLE
Fix: Drag & drop allows to move blocks to not allowed destinations

### DIFF
--- a/editor/components/block-drop-zone/index.js
+++ b/editor/components/block-drop-zone/index.js
@@ -105,6 +105,16 @@ class BlockDropZone extends Component {
 }
 
 export default compose(
+	withSelect( ( select ) => {
+		const { canInsertBlockType, getBlockName, getEditorSettings } = select( 'core/editor' );
+		const { templateLock } = getEditorSettings();
+
+		return {
+			isLocked: !! templateLock,
+			canInsertBlockType,
+			getBlockName,
+		};
+	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const {
 			insertBlocks,
@@ -132,16 +142,15 @@ export default compose(
 				updateBlockAttributes( ...args );
 			},
 			moveBlockToPosition( uid, fromRootUID, index ) {
-				const { rootUID, layout } = ownProps;
-				moveBlockToPosition( uid, fromRootUID, rootUID, layout, index );
+				const { canInsertBlockType, getBlockName, rootUID, layout } = ownProps;
+				const blockName = getBlockName( uid );
+				// currently the only constraint to move inside the same parent is locking
+				// locking was already handled
+				// it is not possible to use drag & drop if locking is active
+				if ( rootUID === fromRootUID || canInsertBlockType( blockName, rootUID ) ) {
+					moveBlockToPosition( uid, fromRootUID, rootUID, layout, index );
+				}
 			},
-		};
-	} ),
-	withSelect( ( select ) => {
-		const { templateLock } = select( 'core/editor' ).getEditorSettings();
-
-		return {
-			isLocked: !! templateLock,
 		};
 	} )
 )( BlockDropZone );

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <WithSelect(WithDispatch(BlockDropZone)) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -53,7 +53,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <WithSelect(WithDispatch(BlockDropZone)) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -83,7 +83,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <WithSelect(WithDispatch(BlockDropZone)) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/13099
Part of a general polishing to get #6993.

Currently via drag & drop unless there is a template lock we can always move blocks.
This allows a block to be moved inside a parent even if the parent does not support that block. This also allows a child block to be moved outside of the parent.

This PR makes sure a block can only be moved to a different parent if it is possible to insert blocks of that type inside it.

Child Blocks Test:
https://gist.github.com/noisysocks/9b9503bd6489ffa51088d35c7a2a8ba0

Test block (transforms): gist.github.com/jorgefilipecosta/b958239761a24664685d5efc7ab48fa6
Contains a block that only allows nesting of quotes and lists.

## How has this been tested?
I registered the test blocks (pasted the code in the browser console).
I inserted Product block (parent) with a  "Buy Button" inside. Then I verified we could not move with drag&drop "Buy Button" outside Product.
I used the "Test transforms" block and tried to move a block e.g.: button, inside the test block, checked it was not possible to do that.
