### PR TITLE
Update the RichText documentation with an `onSetup` example

### DIFF
--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -37,6 +37,22 @@ a traditional `input` field, usually when the user exits the field.
 
 *Optional.* By default, a line break will be inserted on <kbd>Enter</kbd>. If the editable field can contain multiple paragraphs, this property can be set to `p` to create new paragraphs on <kbd>Enter</kbd>.
 
+### `onSetup( editor: Object ): Function`
+
+*Optional.* Called when the editor has been setup.
+
+If you want to use this to give focus to a new editor instance, you must wait until the editor has been rendered before calling `.focus` on it.
+
+An easy way to do this is to have an `onSetup` function that focuses the editor on the next screen repaint, using `requestAnimationFrame`:
+
+```js
+function onSetupFocusEditor( editor ) {
+	window.requestAnimationFrame( () => {
+		editor.focus();
+	} );
+}
+```
+
 ### `onSplit( before: Array|String, after: Array|String, ...blocks: Object ): Function`
 
 *Optional.* Called when the content can be split with `before` and `after`. There might be blocks present, which should be inserted in between.


### PR DESCRIPTION
## Description

Added some documentation about the `onSetup` prop, and an example of how to use it to set the focus on a newly created editor.
