### PR TITLE
Hide insertion point if it is not possible to insert the default block

### DIFF
--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -76,13 +76,16 @@ class BlockInsertionPoint extends Component {
 export default compose(
 	withSelect( ( select, { uid, rootUID, canShowInserter } ) => {
 		const {
+			canInsertBlockType,
 			getBlockIndex,
 			getBlockInsertionPoint,
 			getBlock,
 			isBlockInsertionPointVisible,
 			isTyping,
-			getTemplateLock,
 		} = select( 'core/editor' );
+		const {
+			getDefaultBlockName,
+		} = select( 'core/blocks' );
 		const blockIndex = uid ? getBlockIndex( uid, rootUID ) : -1;
 		const insertIndex = blockIndex;
 		const insertionPoint = getBlockInsertionPoint();
@@ -94,14 +97,15 @@ export default compose(
 			( ! block || ! isUnmodifiedDefaultBlock( block ) )
 		);
 
+		const defaultBlockName = getDefaultBlockName();
 		return {
-			isLocked: !! getTemplateLock( insertionPoint.rootUID ),
+			canInsertDefaultBlock: canInsertBlockType( defaultBlockName, rootUID ),
 			showInserter: ! isTyping() && canShowInserter,
 			index: insertIndex,
 			showInsertionPoint,
 		};
 	} ),
-	ifCondition( ( { isLocked } ) => ! isLocked ),
+	ifCondition( ( { canInsertDefaultBlock } ) => canInsertDefaultBlock ),
 	withDispatch( ( dispatch ) => {
 		const { insertDefaultBlock, startTyping } = dispatch( 'core/editor' );
 		return {


### PR DESCRIPTION
Fixes part of https://github.com/WordPress/gutenberg/issues/6569.
Part of a general polishing to get #6993.

Insertion point was violating the allowedBlocks restriction of the parent block. The insertion point always inserts the default block and it may not be possible to insert the default block.

This PR makes sure insertion point only appears if it is possible to insert the default block.

Test block (transforms): gist.github.com/jorgefilipecosta/b958239761a24664685d5efc7ab48fa6

## How has this been tested?
I used the "Test Transforms" block ( does not allow paragraphs ) and I verified that the insertion point does not appear inside the block.
I added a Column block, and I verified insertion point appears there.
