### PR TITLE
Effects: Move trash post URL change to the BrowserUrl component

### DIFF
--- a/edit-post/components/browser-url/index.js
+++ b/edit-post/components/browser-url/index.js
@@ -46,16 +46,23 @@ export class BrowserURL extends Component {
 		const { historyId } = this.state;
 
 		if ( postStatus === 'trash' ) {
-			window.location.href = getPostTrashedURL( postId, postType );
-		}
-
-		if ( postId === prevProps.postId && postId === historyId ) {
+			this.setTrashURL( postId, postType );
 			return;
 		}
 
-		if ( postStatus !== 'auto-draft' ) {
+		if ( ( postId !== prevProps.postId || postId !== historyId ) && postStatus !== 'auto-draft' ) {
 			this.setBrowserURL( postId );
 		}
+	}
+
+	/**
+	 * Navigates the browser to the post trashed URL to show a notice about the trashed post.
+	 *
+	 * @param {number} postId    Post ID.
+	 * @param {string} postType  Post Type.
+	 */
+	setTrashURL( postId, postType ) {
+		window.location.href = getPostTrashedURL( postId, postType );
 	}
 
 	/**

--- a/edit-post/components/browser-url/index.js
+++ b/edit-post/components/browser-url/index.js
@@ -45,7 +45,7 @@ export class BrowserURL extends Component {
 		const { postId, postStatus, postType } = this.props;
 		const { historyId } = this.state;
 
-		if ( postStatus === 'trashed' ) {
+		if ( postStatus === 'trash' ) {
 			window.location.href = getPostTrashedURL( postId, postType );
 		}
 

--- a/edit-post/components/browser-url/index.js
+++ b/edit-post/components/browser-url/index.js
@@ -16,6 +16,22 @@ export function getPostEditURL( postId ) {
 	return addQueryArgs( 'post.php', { post: postId, action: 'edit' } );
 }
 
+/**
+ * Returns the Post's Trashedd URL.
+ *
+ * @param {number} postId    Post ID.
+ * @param {string} postType Post Type.
+ *
+ * @return {string} Post trashed URL.
+ */
+export function getPostTrashedURL( postId, postType ) {
+	return addQueryArgs( 'edit.php', {
+		trashed: 1,
+		post_type: postType,
+		ids: postId,
+	} );
+}
+
 export class BrowserURL extends Component {
 	constructor() {
 		super( ...arguments );
@@ -26,8 +42,13 @@ export class BrowserURL extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { postId, postStatus } = this.props;
+		const { postId, postStatus, postType } = this.props;
 		const { historyId } = this.state;
+
+		if ( postStatus === 'trashed' ) {
+			window.location.href = getPostTrashedURL( postId, postType );
+		}
+
 		if ( postId === prevProps.postId && postId === historyId ) {
 			return;
 		}
@@ -65,10 +86,11 @@ export class BrowserURL extends Component {
 
 export default withSelect( ( select ) => {
 	const { getCurrentPost } = select( 'core/editor' );
-	const { id, status } = getCurrentPost();
+	const { id, status, type } = getCurrentPost();
 
 	return {
 		postId: id,
 		postStatus: status,
+		postType: type,
 	};
 } )( BrowserURL );

--- a/edit-post/components/browser-url/test/index.js
+++ b/edit-post/components/browser-url/test/index.js
@@ -6,13 +6,21 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { getPostEditURL, BrowserURL } from '../';
+import { getPostEditURL, getPostTrashedURL, BrowserURL } from '../';
 
 describe( 'getPostEditURL', () => {
 	it( 'should generate relative path with post and action arguments', () => {
 		const url = getPostEditURL( 1 );
 
 		expect( url ).toBe( 'post.php?post=1&action=edit' );
+	} );
+} );
+
+describe( 'getPostTrashedURL', () => {
+	it( 'should generate relative path with post and action arguments', () => {
+		const url = getPostTrashedURL( 1, 'page' );
+
+		expect( url ).toBe( 'edit.php?trashed=1&post_type=page&ids=1' );
 	} );
 } );
 

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -254,11 +254,10 @@ export default {
 		apiRequest( { path: `/wp/v2/${ basePath }/${ postId }`, method: 'DELETE' } ).then(
 			() => {
 				const post = getCurrentPost( getState() );
+
+				// TODO: This should be an updatePost action (updating subsets of post properties),
+				// But right now editPost is tied with change detection.
 				dispatch( resetPost( { ...post, status: 'trash' } ) );
-				dispatch( {
-					...action,
-					type: 'TRASH_POST_SUCCESS',
-				} );
 			},
 			( err ) => {
 				dispatch( {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -25,7 +25,6 @@ import apiRequest from '@wordpress/api-request';
 /**
  * Internal dependencies
  */
-import { getWPAdminURL } from '../utils/url';
 import {
 	setupEditorState,
 	resetAutosave,
@@ -254,6 +253,8 @@ export default {
 		dispatch( removeNotice( TRASH_POST_NOTICE_ID ) );
 		apiRequest( { path: `/wp/v2/${ basePath }/${ postId }`, method: 'DELETE' } ).then(
 			() => {
+				const post = getCurrentPost( getState() );
+				dispatch( resetPost( { ...post, status: 'trashed' } ) );
 				dispatch( {
 					...action,
 					type: 'TRASH_POST_SUCCESS',
@@ -270,15 +271,6 @@ export default {
 				} );
 			}
 		);
-	},
-	TRASH_POST_SUCCESS( action ) {
-		const { postId, postType } = action;
-
-		window.location.href = getWPAdminURL( 'edit.php', {
-			trashed: 1,
-			post_type: postType,
-			ids: postId,
-		} );
 	},
 	TRASH_POST_FAILURE( action, store ) {
 		const message = action.error.message && action.error.code !== 'unknown_error' ? action.error.message : __( 'Trashing failed' );

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -254,7 +254,7 @@ export default {
 		apiRequest( { path: `/wp/v2/${ basePath }/${ postId }`, method: 'DELETE' } ).then(
 			() => {
 				const post = getCurrentPost( getState() );
-				dispatch( resetPost( { ...post, status: 'trashed' } ) );
+				dispatch( resetPost( { ...post, status: 'trash' } ) );
 				dispatch( {
 					...action,
 					type: 'TRASH_POST_SUCCESS',


### PR DESCRIPTION
Related #7096

This PR consolidates all browser navigation (url changes and actual navigation) in the `BrowserUrl` component of the `edit-post` module making.

**Testing instructions**

 - Click "Trash Post"
 - Once the removal succeeds, you should be redirected to the post list.
