### PR TITLE
Fix enter and copy past behaviour not respects allowedBlocks and child blocks restrictions

### DIFF
--- a/core-blocks/heading/edit.js
+++ b/core-blocks/heading/edit.js
@@ -15,6 +15,7 @@ import './editor.scss';
 
 export default function HeadingEdit( {
 	attributes,
+	canInsertSibling,
 	setAttributes,
 	mergeBlocks,
 	insertBlocksAfter,
@@ -66,6 +67,13 @@ export default function HeadingEdit( {
 				onSplit={
 					insertBlocksAfter ?
 						( before, after, ...blocks ) => {
+							if ( ! canInsertSibling( 'core/paragraph' ) ) {
+								// If it is not possible to insert a paragraph
+								// don't split the block just try to insert pasted blocks after it.
+								// Unsupported blocks are ignored.
+								insertBlocksAfter( blocks );
+								return;
+							}
 							setAttributes( { content: before } );
 							insertBlocksAfter( [
 								...blocks,

--- a/core-blocks/list/index.js
+++ b/core-blocks/list/index.js
@@ -252,6 +252,7 @@ export const settings = {
 		render() {
 			const {
 				attributes,
+				canInsertSibling,
 				insertBlocksAfter,
 				setAttributes,
 				mergeBlocks,
@@ -302,6 +303,13 @@ export const settings = {
 						onSplit={
 							insertBlocksAfter ?
 								( before, after, ...blocks ) => {
+									if ( ! canInsertSibling( 'core/list' ) ) {
+										// If it is not possible to insert a list
+										// don't split the block just try to insert pasted blocks after it.
+										// Unsupported blocks are ignored.
+										insertBlocksAfter( blocks );
+										return;
+									}
 									if ( ! blocks.length ) {
 										blocks.push( createBlock( 'core/paragraph' ) );
 									}

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -139,6 +139,7 @@ class ParagraphBlock extends Component {
 
 	render() {
 		const {
+			canInsertSibling,
 			attributes,
 			setAttributes,
 			insertBlocksAfter,
@@ -233,6 +234,13 @@ class ParagraphBlock extends Component {
 						} }
 						onSplit={ insertBlocksAfter ?
 							( before, after, ...blocks ) => {
+								if ( ! canInsertSibling( name ) ) {
+									// If it is not possible to insert block of the same type
+									// don't split the block just try to insert pasted blocks after it.
+									// Unsupported blocks are ignored.
+									insertBlocksAfter( blocks );
+									return;
+								}
 								if ( after ) {
 									blocks.push( createBlock( name, { content: after } ) );
 								}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, reduce, size, castArray, first, last, noop } from 'lodash';
+import { get, reduce, size, castArray, filter, first, last, noop } from 'lodash';
 import tinymce from 'tinymce';
 
 /**
@@ -60,6 +60,7 @@ export class BlockListBlock extends Component {
 
 		this.setBlockListRef = this.setBlockListRef.bind( this );
 		this.bindBlockNode = this.bindBlockNode.bind( this );
+		this.canInsertSibling = this.canInsertSibling.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
 		this.hideHoverEffects = this.hideHoverEffects.bind( this );
@@ -121,6 +122,11 @@ export class BlockListBlock extends Component {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this.focusTabbable();
 		}
+	}
+
+	canInsertSibling( blockName ) {
+		const { canInsertBlockType, rootUID } = this.props;
+		return canInsertBlockType( blockName, rootUID );
 	}
 
 	setBlockListRef( node ) {
@@ -562,6 +568,7 @@ export class BlockListBlock extends Component {
 								id={ uid }
 								isSelectionEnabled={ this.props.isSelectionEnabled }
 								toggleSelection={ this.props.toggleSelection }
+								canInsertSibling={ this.canInsertSibling }
 							/>
 						) }
 						{ isValid && mode === 'html' && (
@@ -607,6 +614,7 @@ export class BlockListBlock extends Component {
 
 const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 	const {
+		canInsertBlockType,
 		isBlockSelected,
 		getPreviousBlockUid,
 		getNextBlockUid,
@@ -651,6 +659,7 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		block,
 		isSelected,
 		hasFixedToolbar,
+		canInsertBlockType,
 	};
 } );
 
@@ -674,7 +683,8 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 			selectBlock( uid, initialPosition );
 		},
 		onInsertBlocks( blocks, index ) {
-			const { rootUID, layout } = ownProps;
+			const { canInsertBlockType, rootUID, layout } = ownProps;
+			blocks = filter( blocks, ( { name } ) => canInsertBlockType( name, rootUID ) );
 			blocks = blocks.map( ( block ) => cloneBlock( block, { layout } ) );
 			insertBlocks( blocks, index, rootUID );
 		},


### PR DESCRIPTION
## Description
Fixes part of https://github.com/WordPress/gutenberg/issues/6569
Part of a general polishing to get #6993.

When pasting or pressing enter the allowedBlocks property was not enforced.
E.g., pressing enter most of the times created a paragraph even if the paragraph block was not allowed.

This PR makes two main changes:

- In onInsertBlocks, we now verify if it is possible to insert the blocks passed as the argument. Not allowed blocks are ignored. This change handles pasting unallowed blocks and makes pressing enter on placeholders and similar areas not create a paragraph block if the paragraph is not allowed.

- onSplit now checks if the split can occur (a block of a given type e.g: a paragraph can be inserted) if the division cannot happen we try to add the pasted blocks without splitting the original block.

Test block: https://gist.github.com/jorgefilipecosta/be3c487d10af57838f90e3227225c6d7 allows nesting of lists and quotes. Contains a template that inserts other blocks so we can test.

Child blocks test:
https://gist.github.com/noisysocks/9b9503bd6489ffa51088d35c7a2a8ba0

## How has this been tested?
I used the block in the gist and verified that if I press enter on the placeholder inside the block, a paragraph block is not created, because the paragraph is not supported.

I verified that's it is not possible to split paragraphs and headings by pressing enter (another paragraph block cannot be inserted).

I added an image and a quote outside the block, multi-selected them and copied (command +c ). "Pasted" the content in the heading, paragraph, and list inside the test block. In all the cases the image was ignored, and the quote added. In the paragraph and heading because the split was not possible the quote was pasted after the blocks. In the list, the split was possible (because we can insert another list) so the list block was divided, and the quote was added in the middle.

I added a Product block (from Child blocks test), with two Buy buttons inside, multi-selected them and copied. I checked that they could not be pasted in paragraphs outside the Product block.

In master, it was always possible to split unless a template lock existed. And it was always possible to paste blocks even if they were not allowed in the place they are pasted.
