### PR TITLE
Components: Avoid wrapping div for Slot

### DIFF
--- a/edit-post/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
@@ -1,57 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PluginPostPublishPanel renders fill properly 1`] = `
-<div
-  role="presentation"
+<PanelBody
+  className="my-plugin-post-publish-panel"
+  initialOpen={true}
+  key="1---0/.0"
+  title="My panel title"
 >
-  <PanelBody
-    className="my-plugin-post-publish-panel"
-    initialOpen={true}
-    key="1---0/.0"
-    title="My panel title"
+  <div
+    className="components-panel__body my-plugin-post-publish-panel is-opened"
   >
-    <div
-      className="components-panel__body my-plugin-post-publish-panel is-opened"
+    <h2
+      className="components-panel__body-title"
     >
-      <h2
-        className="components-panel__body-title"
+      <Button
+        aria-expanded={true}
+        className="components-panel__body-toggle"
+        onClick={[Function]}
       >
-        <Button
+        <button
           aria-expanded={true}
-          className="components-panel__body-toggle"
+          className="components-button components-panel__body-toggle"
           onClick={[Function]}
+          type="button"
         >
-          <button
-            aria-expanded={true}
-            className="components-button components-panel__body-toggle"
-            onClick={[Function]}
-            type="button"
+          <svg
+            className="components-panel__arrow"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              className="components-panel__arrow"
-              height="24px"
-              viewBox="0 0 24 24"
-              width="24px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g>
-                <path
-                  d="M0,0h24v24H0V0z"
-                  fill="none"
-                />
-              </g>
-              <g>
-                <path
-                  d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
-                />
-              </g>
-            </svg>
-            My panel title
-          </button>
-        </Button>
-      </h2>
-      My panel content
-    </div>
-  </PanelBody>
-</div>
+            <g>
+              <path
+                d="M0,0h24v24H0V0z"
+                fill="none"
+              />
+            </g>
+            <g>
+              <path
+                d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
+              />
+            </g>
+          </svg>
+          My panel title
+        </button>
+      </Button>
+    </h2>
+    My panel content
+  </div>
+</PanelBody>
 `;

--- a/edit-post/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
@@ -1,18 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PluginPostStatusInfo renders fill properly 1`] = `
-<div
-  role="presentation"
+<PanelRow
+  className="my-plugin-post-status-info"
+  key="1---0/.0"
 >
-  <PanelRow
-    className="my-plugin-post-status-info"
-    key="1---0/.0"
+  <div
+    className="components-panel__row my-plugin-post-status-info"
   >
-    <div
-      className="components-panel__row my-plugin-post-status-info"
-    >
-      My plugin post status info
-    </div>
-  </PanelRow>
-</div>
+    My plugin post status info
+  </div>
+</PanelRow>
 `;

--- a/edit-post/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
@@ -1,57 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PluginPrePublishPanel renders fill properly 1`] = `
-<div
-  role="presentation"
+<PanelBody
+  className="my-plugin-pre-publish-panel"
+  initialOpen={true}
+  key="1---0/.0"
+  title="My panel title"
 >
-  <PanelBody
-    className="my-plugin-pre-publish-panel"
-    initialOpen={true}
-    key="1---0/.0"
-    title="My panel title"
+  <div
+    className="components-panel__body my-plugin-pre-publish-panel is-opened"
   >
-    <div
-      className="components-panel__body my-plugin-pre-publish-panel is-opened"
+    <h2
+      className="components-panel__body-title"
     >
-      <h2
-        className="components-panel__body-title"
+      <Button
+        aria-expanded={true}
+        className="components-panel__body-toggle"
+        onClick={[Function]}
       >
-        <Button
+        <button
           aria-expanded={true}
-          className="components-panel__body-toggle"
+          className="components-button components-panel__body-toggle"
           onClick={[Function]}
+          type="button"
         >
-          <button
-            aria-expanded={true}
-            className="components-button components-panel__body-toggle"
-            onClick={[Function]}
-            type="button"
+          <svg
+            className="components-panel__arrow"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              className="components-panel__arrow"
-              height="24px"
-              viewBox="0 0 24 24"
-              width="24px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g>
-                <path
-                  d="M0,0h24v24H0V0z"
-                  fill="none"
-                />
-              </g>
-              <g>
-                <path
-                  d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
-                />
-              </g>
-            </svg>
-            My panel title
-          </button>
-        </Button>
-      </h2>
-      My panel content
-    </div>
-  </PanelBody>
-</div>
+            <g>
+              <path
+                d="M0,0h24v24H0V0z"
+                fill="none"
+              />
+            </g>
+            <g>
+              <path
+                d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
+              />
+            </g>
+          </svg>
+          My panel title
+        </button>
+      </Button>
+    </h2>
+    My panel content
+  </div>
+</PanelBody>
 `;

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -6,13 +6,19 @@ import { noop, map, isString, isFunction } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, Children, cloneElement } from '@wordpress/element';
+import {
+	Component,
+	Children,
+	Fragment,
+	cloneElement,
+	createRef,
+} from '@wordpress/element';
 
 class Slot extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.bindNode = this.bindNode.bind( this );
+		this.virtualTarget = createRef();
 	}
 
 	componentDidMount() {
@@ -40,16 +46,15 @@ class Slot extends Component {
 		}
 	}
 
-	bindNode( node ) {
-		this.node = node;
-	}
-
 	render() {
-		const { children, name, bubblesVirtually = false, fillProps = {} } = this.props;
+		const { children, name, bubblesVirtually, fillProps = {} } = this.props;
 		const { getFills = noop } = this.context;
 
 		if ( bubblesVirtually ) {
-			return <div ref={ this.bindNode } />;
+			// When bubbling virtually, createPortal requires a DOM node in
+			// which to render the fill elements. This `div` serves no purpose
+			// other than to act as the target container.
+			return <div ref={ this.virtualTarget } role="presentation" />;
 		}
 
 		const fills = map( getFills( name ), ( fill ) => {
@@ -67,9 +72,9 @@ class Slot extends Component {
 		} );
 
 		return (
-			<div ref={ this.bindNode } role="presentation">
+			<Fragment>
 				{ isFunction( children ) ? children( fills.filter( Boolean ) ) : fills }
-			</div>
+			</Fragment>
 		);
 	}
 }


### PR DESCRIPTION
Closes #6839, #6632.
Supersedes #6920 

This pull request seeks to update `<Slot />` to avoid the need for a permanent `div` element wrapper. While a DOM node is needed for virtual-event-bubbling slots, based on the behavior of `createPortal`, it is acceptable to assign the node as the parent in which the Slot is rendered. This requires a `div`, albeit temporarily, until the parent can be determined.

**Testing instructions:**

Verify that there are no regressions in the behavior of Slot/Fill, both with and without `bubblesVirtually`.

Examples:

- Plugin sidebar (non-virtual)
- Popovers (virtual)

cc @ryanwelcher 