### PR TITLE
Blocks: Render columns as nested column (wrapper)

### DIFF
--- a/blocks/api/templates.js
+++ b/blocks/api/templates.js
@@ -42,7 +42,12 @@ export function doBlocksMatchTemplate( blocks = [], template = [] ) {
  *
  * @return {Array}          Updated Block list.
  */
-export function synchronizeBlocksWithTemplate( blocks = [], template = [] ) {
+export function synchronizeBlocksWithTemplate( blocks = [], template ) {
+	// If no template is provided, return blocks unmodified.
+	if ( ! template ) {
+		return blocks;
+	}
+
 	return map( template, ( [ name, attributes, innerBlocksTemplate ], index ) => {
 		const block = blocks[ index ];
 

--- a/blocks/api/test/templates.js
+++ b/blocks/api/test/templates.js
@@ -166,6 +166,14 @@ describe( 'templates', () => {
 			] );
 		} );
 
+		it( 'should return original blocks if no template provided', () => {
+			let template;
+			const block1 = createBlock( 'core/test-block' );
+			const block2 = createBlock( 'core/test-block' );
+			const blockList = [ block1, block2 ];
+			expect( synchronizeBlocksWithTemplate( blockList, template ) ).toBe( blockList );
+		} );
+
 		it( 'should remove blocks if extra blocks are found', () => {
 			const template = [
 				[ 'core/test-block' ],

--- a/core-blocks/columns/column.js
+++ b/core-blocks/columns/column.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import './editor.scss';
+
+export const name = 'core/column';
+
+export const settings = {
+	title: __( 'Column' ),
+
+	parent: [ 'core/columns' ],
+
+	icon: 'columns',
+
+	description: __( 'A single column within a columns block.' ),
+
+	category: 'common',
+
+	edit() {
+		return <InnerBlocks templateLock={ false } />;
+	},
+
+	save() {
+		return <div><InnerBlocks.Content /></div>;
+	},
+};

--- a/core-blocks/columns/editor.scss
+++ b/core-blocks/columns/editor.scss
@@ -34,14 +34,18 @@
 .wp-block-columns {
 	display: block;
 
-	.editor-inner-blocks {
-		display: grid;
-		grid-auto-flow: dense;
-	}
+	> .editor-inner-blocks > .editor-block-list__layout {
+		display: flex;
 
-	@for $i from 2 through 6 {
-		&.has-#{ $i }-columns .editor-inner-blocks {
-			grid-auto-columns: #{ 100% / $i };
+		> [data-type="core/column"] {
+			display: flex;
+			flex-direction: column;
+			flex: 1;
+			width: 0;
+
+			.editor-block-list__block-edit {
+				flex-basis: 100%;
+			}
 		}
 	}
 }

--- a/core-blocks/columns/index.js
+++ b/core-blocks/columns/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { times } from 'lodash';
+import { times, property, omit } from 'lodash';
 import classnames from 'classnames';
 import memoize from 'memize';
 
@@ -11,6 +11,7 @@ import memoize from 'memize';
 import { __, sprintf } from '@wordpress/i18n';
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
+import { createBlock } from '@wordpress/blocks';
 import {
 	InspectorControls,
 	InnerBlocks,
@@ -59,6 +60,65 @@ export const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 	},
+
+	deprecated: [
+		{
+			attributes: {
+				columns: {
+					type: 'number',
+					default: 2,
+				},
+			},
+			isEligible( attributes, innerBlocks ) {
+				return innerBlocks.some( property( [ 'attributes', 'layout' ] ) );
+			},
+			migrate( attributes, innerBlocks ) {
+				function withoutLayout( block ) {
+					return {
+						...block,
+						attributes: omit( block.attributes, [ 'layout' ] ),
+					};
+				}
+
+				const columns = innerBlocks.reduce( ( result, innerBlock ) => {
+					const { layout } = innerBlock.attributes;
+
+					let columnIndex, columnMatch;
+					if ( layout && ( columnMatch = layout.match( /^column-(\d+)$/ ) ) ) {
+						columnIndex = Number( columnMatch[ 1 ] ) - 1;
+					} else {
+						columnIndex = 0;
+					}
+
+					if ( ! result[ columnIndex ] ) {
+						result[ columnIndex ] = [];
+					}
+
+					result[ columnIndex ].push( withoutLayout( innerBlock ) );
+
+					return result;
+				}, [] );
+
+				const migratedInnerBlocks = columns.map( ( columnBlocks ) => (
+					createBlock( 'core/column', {}, columnBlocks )
+				) );
+
+				return [
+					attributes,
+					migratedInnerBlocks,
+				];
+			},
+			save( { attributes } ) {
+				const { columns } = attributes;
+
+				return (
+					<div className={ `has-${ columns }-columns` }>
+						<InnerBlocks.Content />
+					</div>
+				);
+			},
+		},
+	],
 
 	edit( { attributes, setAttributes, className } ) {
 		const { columns } = attributes;

--- a/core-blocks/columns/index.js
+++ b/core-blocks/columns/index.js
@@ -29,12 +29,8 @@ import './editor.scss';
  *
  * @return {Object[]} Columns layout configuration.
  */
-const getColumnLayouts = memoize( ( columns ) => {
-	return times( columns, ( n ) => ( {
-		name: `column-${ n + 1 }`,
-		label: sprintf( __( 'Column %d' ), n + 1 ),
-		icon: 'columns',
-	} ) );
+const getColumnsTemplate = memoize( ( columns ) => {
+	return times( columns, () => [ 'core/column' ] );
 } );
 
 export const name = 'core/columns';
@@ -86,7 +82,10 @@ export const settings = {
 					</PanelBody>
 				</InspectorControls>
 				<div className={ classes }>
-					<InnerBlocks layouts={ getColumnLayouts( columns ) } />
+					<InnerBlocks
+						template={ getColumnsTemplate( columns ) }
+						templateLock="all"
+						allowedBlocks={ [ 'core/column' ] } />
 				</div>
 			</Fragment>
 		);

--- a/core-blocks/columns/style.scss
+++ b/core-blocks/columns/style.scss
@@ -1,16 +1,7 @@
 .wp-block-columns {
-	display: grid;
-	grid-auto-flow: dense;
+	display: flex;
+}
 
-	@for $i from 2 through 6 {
-		&.has-#{ $i }-columns {
-			grid-auto-columns: #{ 100% / $i };
-		}
-	}
-
-	@for $i from 1 through 6 {
-		.layout-column-#{ $i } {
-			grid-column: #{ $i };
-		}
-	}
+.wp-block-column {
+	flex: 1;
 }

--- a/core-blocks/index.js
+++ b/core-blocks/index.js
@@ -21,6 +21,7 @@ import * as button from './button';
 import * as categories from './categories';
 import * as code from './code';
 import * as columns from './columns';
+import * as column from './columns/column';
 import * as coverImage from './cover-image';
 import * as embed from './embed';
 import * as file from './file';
@@ -60,6 +61,7 @@ export const registerCoreBlocks = () => {
 		categories,
 		code,
 		columns,
+		column,
 		coverImage,
 		embed,
 		...embed.common,

--- a/core-blocks/test/fixtures/core__column.html
+++ b/core-blocks/test/fixtures/core__column.html
@@ -1,0 +1,10 @@
+<!-- wp:column -->
+<div class="wp-block-column">
+	<!-- wp:paragraph -->
+	<p>Column One, Paragraph One</p>
+	<!-- /wp:paragraph -->
+	<!-- wp:paragraph -->
+	<p>Column One, Paragraph Two</p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:columns -->

--- a/core-blocks/test/fixtures/core__column.json
+++ b/core-blocks/test/fixtures/core__column.json
@@ -1,0 +1,37 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/column",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [
+            {
+                "uid": "_uid_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Column One, Paragraph One"
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Column One, Paragraph One</p>"
+            },
+            {
+                "uid": "_uid_1",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Column One, Paragraph Two"
+                    ],
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Column One, Paragraph Two</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-column\">\n\t\n\t\n</div>"
+    }
+]

--- a/core-blocks/test/fixtures/core__column.parsed.json
+++ b/core-blocks/test/fixtures/core__column.parsed.json
@@ -1,0 +1,25 @@
+[
+    {
+        "blockName": "core/column",
+        "attrs": null,
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>Column One, Paragraph One</p>\n\t"
+            },
+            {
+                "blockName": "core/paragraph",
+                "attrs": null,
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>Column One, Paragraph Two</p>\n\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-column\">\n\t\n\t\n</div>\n"
+    },
+    {
+        "attrs": {},
+        "innerHTML": "\n"
+    }
+]

--- a/core-blocks/test/fixtures/core__column.serialized.html
+++ b/core-blocks/test/fixtures/core__column.serialized.html
@@ -1,0 +1,11 @@
+<!-- wp:column -->
+<div class="wp-block-column">
+	<!-- wp:paragraph -->
+	<p>Column One, Paragraph One</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Column One, Paragraph Two</p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:column -->

--- a/core-blocks/test/fixtures/core__columns.html
+++ b/core-blocks/test/fixtures/core__columns.html
@@ -1,16 +1,24 @@
 <!-- wp:columns {"columns":3} -->
 <div class="wp-block-columns has-3-columns">
-	<!-- wp:paragraph {"layout":"column-1"} -->
-	<p class="layout-column-1">Column One, Paragraph One</p>
-	<!-- /wp:paragraph -->
-	<!-- wp:paragraph {"layout":"column-1"} -->
-	<p class="layout-column-1">Column One, Paragraph Two</p>
-	<!-- /wp:paragraph -->
-	<!-- wp:paragraph {"layout":"column-2"} -->
-	<p class="layout-column-2">Column Two, Paragraph One</p>
-	<!-- /wp:paragraph -->
-	<!-- wp:paragraph {"layout":"column-3"} -->
-	<p class="layout-column-3">Column Three, Paragraph One</p>
-	<!-- /wp:paragraph -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>Column One, Paragraph One</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>Column One, Paragraph Two</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>Column Two, Paragraph One</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>Column Three, Paragraph One</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 </div>
 <!-- /wp:columns -->

--- a/core-blocks/test/fixtures/core__columns.json
+++ b/core-blocks/test/fixtures/core__columns.json
@@ -9,61 +9,75 @@
         "innerBlocks": [
             {
                 "uid": "_uid_0",
-                "name": "core/paragraph",
+                "name": "core/column",
                 "isValid": true,
-                "attributes": {
-                    "content": [
-                        "Column One, Paragraph One"
-                    ],
-                    "dropCap": false,
-                    "layout": "column-1"
-                },
-                "innerBlocks": [],
-                "originalContent": "<p class=\"layout-column-1\">Column One, Paragraph One</p>"
+                "attributes": {},
+                "innerBlocks": [
+                    {
+                        "uid": "_uid_0",
+                        "name": "core/paragraph",
+                        "isValid": true,
+                        "attributes": {
+                            "content": [
+                                "Column One, Paragraph One"
+                            ],
+                            "dropCap": false
+                        },
+                        "innerBlocks": [],
+                        "originalContent": "<p>Column One, Paragraph One</p>"
+                    },
+                    {
+                        "uid": "_uid_1",
+                        "name": "core/paragraph",
+                        "isValid": true,
+                        "attributes": {
+                            "content": [
+                                "Column One, Paragraph Two"
+                            ],
+                            "dropCap": false
+                        },
+                        "innerBlocks": [],
+                        "originalContent": "<p>Column One, Paragraph Two</p>"
+                    }
+                ],
+                "originalContent": "<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>"
             },
             {
                 "uid": "_uid_1",
-                "name": "core/paragraph",
+                "name": "core/column",
                 "isValid": true,
-                "attributes": {
-                    "content": [
-                        "Column One, Paragraph Two"
-                    ],
-                    "dropCap": false,
-                    "layout": "column-1"
-                },
-                "innerBlocks": [],
-                "originalContent": "<p class=\"layout-column-1\">Column One, Paragraph Two</p>"
-            },
-            {
-                "uid": "_uid_2",
-                "name": "core/paragraph",
-                "isValid": true,
-                "attributes": {
-                    "content": [
-                        "Column Two, Paragraph One"
-                    ],
-                    "dropCap": false,
-                    "layout": "column-2"
-                },
-                "innerBlocks": [],
-                "originalContent": "<p class=\"layout-column-2\">Column Two, Paragraph One</p>"
-            },
-            {
-                "uid": "_uid_3",
-                "name": "core/paragraph",
-                "isValid": true,
-                "attributes": {
-                    "content": [
-                        "Column Three, Paragraph One"
-                    ],
-                    "dropCap": false,
-                    "layout": "column-3"
-                },
-                "innerBlocks": [],
-                "originalContent": "<p class=\"layout-column-3\">Column Three, Paragraph One</p>"
+                "attributes": {},
+                "innerBlocks": [
+                    {
+                        "uid": "_uid_0",
+                        "name": "core/paragraph",
+                        "isValid": true,
+                        "attributes": {
+                            "content": [
+                                "Column Two, Paragraph One"
+                            ],
+                            "dropCap": false
+                        },
+                        "innerBlocks": [],
+                        "originalContent": "<p>Column Two, Paragraph One</p>"
+                    },
+                    {
+                        "uid": "_uid_1",
+                        "name": "core/paragraph",
+                        "isValid": true,
+                        "attributes": {
+                            "content": [
+                                "Column Three, Paragraph One"
+                            ],
+                            "dropCap": false
+                        },
+                        "innerBlocks": [],
+                        "originalContent": "<p>Column Three, Paragraph One</p>"
+                    }
+                ],
+                "originalContent": "<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>"
             }
         ],
-        "originalContent": "<div class=\"wp-block-columns has-3-columns\">\n\t\n\t\n\t\n\t\n</div>"
+        "originalContent": "<div class=\"wp-block-columns has-3-columns\">\n\t\n\t\n</div>"
     }
 ]

--- a/core-blocks/test/fixtures/core__columns.parsed.json
+++ b/core-blocks/test/fixtures/core__columns.parsed.json
@@ -6,39 +6,45 @@
         },
         "innerBlocks": [
             {
-                "blockName": "core/paragraph",
-                "attrs": {
-                    "layout": "column-1"
-                },
-                "innerBlocks": [],
-                "innerHTML": "\n\t<p class=\"layout-column-1\">Column One, Paragraph One</p>\n\t"
+                "blockName": "core/column",
+                "attrs": null,
+                "innerBlocks": [
+                    {
+                        "blockName": "core/paragraph",
+                        "attrs": null,
+                        "innerBlocks": [],
+                        "innerHTML": "\n\t\t<p>Column One, Paragraph One</p>\n\t\t"
+                    },
+                    {
+                        "blockName": "core/paragraph",
+                        "attrs": null,
+                        "innerBlocks": [],
+                        "innerHTML": "\n\t\t<p>Column One, Paragraph Two</p>\n\t\t"
+                    }
+                ],
+                "innerHTML": "\n\t<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>\n\t"
             },
             {
-                "blockName": "core/paragraph",
-                "attrs": {
-                    "layout": "column-1"
-                },
-                "innerBlocks": [],
-                "innerHTML": "\n\t<p class=\"layout-column-1\">Column One, Paragraph Two</p>\n\t"
-            },
-            {
-                "blockName": "core/paragraph",
-                "attrs": {
-                    "layout": "column-2"
-                },
-                "innerBlocks": [],
-                "innerHTML": "\n\t<p class=\"layout-column-2\">Column Two, Paragraph One</p>\n\t"
-            },
-            {
-                "blockName": "core/paragraph",
-                "attrs": {
-                    "layout": "column-3"
-                },
-                "innerBlocks": [],
-                "innerHTML": "\n\t<p class=\"layout-column-3\">Column Three, Paragraph One</p>\n\t"
+                "blockName": "core/column",
+                "attrs": null,
+                "innerBlocks": [
+                    {
+                        "blockName": "core/paragraph",
+                        "attrs": null,
+                        "innerBlocks": [],
+                        "innerHTML": "\n\t\t<p>Column Two, Paragraph One</p>\n\t\t"
+                    },
+                    {
+                        "blockName": "core/paragraph",
+                        "attrs": null,
+                        "innerBlocks": [],
+                        "innerHTML": "\n\t\t<p>Column Three, Paragraph One</p>\n\t\t"
+                    }
+                ],
+                "innerHTML": "\n\t<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>\n\t"
             }
         ],
-        "innerHTML": "\n<div class=\"wp-block-columns has-3-columns\">\n\t\n\t\n\t\n\t\n</div>\n"
+        "innerHTML": "\n<div class=\"wp-block-columns has-3-columns\">\n\t\n\t\n</div>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__columns.serialized.html
+++ b/core-blocks/test/fixtures/core__columns.serialized.html
@@ -1,19 +1,27 @@
 <!-- wp:columns {"columns":3} -->
 <div class="wp-block-columns has-3-columns">
-	<!-- wp:paragraph {"layout":"column-1"} -->
-	<p class="layout-column-1">Column One, Paragraph One</p>
-	<!-- /wp:paragraph -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>Column One, Paragraph One</p>
+		<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph {"layout":"column-1"} -->
-	<p class="layout-column-1">Column One, Paragraph Two</p>
-	<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>Column One, Paragraph Two</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 
-	<!-- wp:paragraph {"layout":"column-2"} -->
-	<p class="layout-column-2">Column Two, Paragraph One</p>
-	<!-- /wp:paragraph -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>Column Two, Paragraph One</p>
+		<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph {"layout":"column-3"} -->
-	<p class="layout-column-3">Column Three, Paragraph One</p>
-	<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>Column Three, Paragraph One</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 </div>
 <!-- /wp:columns -->

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -15,7 +15,7 @@
                                 "Paragraph ",
                                 {
                                     "type": "strong",
-                                    "key": "_domReact71",
+                                    "key": "_domReact73",
                                     "ref": null,
                                     "props": {
                                         "children": "one"

--- a/docs/block-api/deprecated-blocks.md
+++ b/docs/block-api/deprecated-blocks.md
@@ -5,9 +5,17 @@ When updating static blocks markup and attributes, block authors need to conside
  - Do not deprecate the block and create a new one (a different name)
  - Provide a "deprecated" version of the block allowing users opening these blocks in Gutenberg to edit them using the updated block.
 
-A block can have several deprecated versions. Gutenberg will try them one after another until finding the one that matches the saved markup.
+A block can have several deprecated versions. A deprecation will be tried if a parsed block appears to be invalid, or if there is a deprecation defined for which its `isEligible` property function returns true.
 
-To declare a deprecated version, you need to copy the old `attributes`, `support` and `save` properties from the old definition to the `deprecated` property of the updated block.
+Deprecations are defined on a block type as its `deprecated` property, an array of deprecation objects where each object takes the form:
+
+- `attributes` (Object): The [attributes definition](../docs/block-api/attributes.md) of the deprecated form of the block.
+- `support` (Object): The [supports definition](../docs/block-api.md) of the deprecated form of the block.
+- `save` (Function): The [save implementation](../docs/block-api/block-edit-save.md) of the deprecated form of the block.
+- `migrate` (Function, Optional): A function which, given the attributes and inner blocks of the parsed block, is expected to return either the attributes compatible with the deprecated block, or a tuple array of `[ attributes, innerBlocks ]`.
+- `isEligible` (Function, Optional): A function which, given the attributes and inner blocks of the parsed block, returns true if the deprecation can handle the block migration. This is particularly useful in cases where a block is technically valid even once deprecated, and requires updates to its attributes or inner blocks.
+
+It's important to note that `attributes`, `support`, and `save` are not automatically inherited from the current version, since they can impact parsing and serialization of a block, so they must be defined on the deprecated object in order to be processed during a migration.
 
 ### Example:
 

--- a/editor/components/inner-blocks/index.js
+++ b/editor/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick } from 'lodash';
+import { pick, isEqual, map } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -22,21 +22,40 @@ import BlockList from '../block-list';
 import { withBlockEditContext } from '../block-edit/context';
 
 class InnerBlocks extends Component {
-	componentDidUpdate() {
-		this.updateNestedSettings();
-	}
-
 	componentDidMount() {
 		this.updateNestedSettings();
-		this.insertTemplateBlocks( this.props.template );
+		this.synchronizeBlocksWithTemplate();
 	}
 
-	insertTemplateBlocks( template ) {
-		const { block, insertBlocks } = this.props;
-		if ( template && ! block.innerBlocks.length ) {
-			// synchronizeBlocksWithTemplate( [], template ) parses the template structure,
-			// and returns/creates the necessary blocks to represent it.
-			insertBlocks( synchronizeBlocksWithTemplate( [], template ) );
+	componentDidUpdate( prevProps ) {
+		const { template, block } = this.props;
+
+		this.updateNestedSettings();
+
+		const hasTemplateChanged = ! isEqual( template, prevProps.template );
+		const isTemplateInnerBlockMismatch = (
+			template &&
+			block.innerBlocks.length !== template.length
+		);
+
+		if ( hasTemplateChanged || isTemplateInnerBlockMismatch ) {
+			this.synchronizeBlocksWithTemplate();
+		}
+	}
+
+	/**
+	 * Called on mount or when a mismatch exists between the templates and
+	 * inner blocks, synchronizes inner blocks with the template, replacing
+	 * current blocks.
+	 */
+	synchronizeBlocksWithTemplate() {
+		const { template, block, replaceInnerBlocks } = this.props;
+		const { innerBlocks } = block;
+
+		// Synchronize with templates. If the next set differs, replace.
+		const nextBlocks = synchronizeBlocksWithTemplate( innerBlocks, template );
+		if ( ! isEqual( nextBlocks, innerBlocks	) ) {
+			replaceInnerBlocks( nextBlocks );
 		}
 	}
 
@@ -107,12 +126,16 @@ InnerBlocks = compose( [
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
-		const { insertBlocks, updateBlockListSettings } = dispatch( 'core/editor' );
-		const { uid } = ownProps;
+		const {
+			replaceBlocks,
+			updateBlockListSettings,
+		} = dispatch( 'core/editor' );
+		const { block, uid } = ownProps;
 
 		return {
-			insertBlocks( blocks ) {
-				dispatch( insertBlocks( blocks, undefined, uid ) );
+			replaceInnerBlocks( blocks ) {
+				const uids = map( block.innerBlocks, 'uid' );
+				replaceBlocks( uids, blocks );
 			},
 			updateNestedSettings( settings ) {
 				dispatch( updateBlockListSettings( uid, settings ) );

--- a/editor/components/inner-blocks/index.js
+++ b/editor/components/inner-blocks/index.js
@@ -128,6 +128,7 @@ InnerBlocks = compose( [
 	withDispatch( ( dispatch, ownProps ) => {
 		const {
 			replaceBlocks,
+			insertBlocks,
 			updateBlockListSettings,
 		} = dispatch( 'core/editor' );
 		const { block, uid } = ownProps;
@@ -135,7 +136,11 @@ InnerBlocks = compose( [
 		return {
 			replaceInnerBlocks( blocks ) {
 				const uids = map( block.innerBlocks, 'uid' );
-				replaceBlocks( uids, blocks );
+				if ( uids.length ) {
+					replaceBlocks( uids, blocks );
+				} else {
+					insertBlocks( blocks, undefined, uid );
+				}
 			},
 			updateNestedSettings( settings ) {
 				dispatch( updateBlockListSettings( uid, settings ) );

--- a/test/e2e/specs/__snapshots__/templates.test.js.snap
+++ b/test/e2e/specs/__snapshots__/templates.test.js.snap
@@ -15,13 +15,21 @@ exports[`Using a CPT with a predefined template Should add a custom post types w
 
 <!-- wp:columns -->
 <div class=\\"wp-block-columns has-2-columns\\">
-	<!-- wp:image {\\"layout\\":\\"column-1\\"} -->
-	<figure class=\\"wp-block-image layout-column-1\\"><img alt=\\"\\" /></figure>
-	<!-- /wp:image -->
+	<!-- wp:column -->
+	<div class=\\"wp-block-column\\">
+		<!-- wp:image -->
+		<figure class=\\"wp-block-image\\"><img alt=\\"\\" /></figure>
+		<!-- /wp:image -->
+	</div>
+	<!-- /wp:column -->
 
-	<!-- wp:paragraph {\\"placeholder\\":\\"Add a inner paragraph\\",\\"layout\\":\\"column-2\\"} -->
-	<p class=\\"layout-column-2\\"></p>
-	<!-- /wp:paragraph -->
+	<!-- wp:column -->
+	<div class=\\"wp-block-column\\">
+		<!-- wp:paragraph {\\"placeholder\\":\\"Add a inner paragraph\\"} -->
+		<p></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 </div>
 <!-- /wp:columns -->"
 `;

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -7,13 +7,21 @@ exports[`adding blocks Should navigate inner blocks with arrow keys 1`] = `
 
 <!-- wp:columns -->
 <div class=\\"wp-block-columns has-2-columns\\">
-	<!-- wp:paragraph {\\"layout\\":\\"column-1\\"} -->
-	<p class=\\"layout-column-1\\">First column paragraph</p>
-	<!-- /wp:paragraph -->
+	<!-- wp:column -->
+	<div class=\\"wp-block-column\\">
+		<!-- wp:paragraph -->
+		<p>First column paragraph</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 
-	<!-- wp:paragraph {\\"layout\\":\\"column-2\\"} -->
-	<p class=\\"layout-column-2\\">Second column paragraph</p>
-	<!-- /wp:paragraph -->
+	<!-- wp:column -->
+	<div class=\\"wp-block-column\\">
+		<!-- wp:paragraph -->
+		<p>Second column paragraph</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 </div>
 <!-- /wp:columns -->
 

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -28,7 +28,9 @@ describe( 'adding blocks', () => {
 		await page.keyboard.type( 'First column paragraph' );
 
 		// Arrow down should navigate through layouts in columns block (to
-		// its default appender).
+		// its default appender). Two key presses are required since the first
+		// will land user on the Column wrapper block.
+		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.type( 'Second column paragraph' );
 
@@ -42,15 +44,23 @@ describe( 'adding blocks', () => {
 		activeElementText = await page.evaluate( () => document.activeElement.textContent );
 		expect( activeElementText ).toBe( 'Second column paragraph' );
 
-		// Arrow up in inner blocks should navigate through text fields.
+		// Arrow up in inner blocks should navigate through (1) column wrapper,
+		// (2) text fields.
+		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );
 		activeElementText = await page.evaluate( () => document.activeElement.textContent );
 		expect( activeElementText ).toBe( 'First column paragraph' );
 
-		// Arrow up from first text field in nested context focuses wrapper
-		// before escaping out.
+		// Arrow up from first text field in nested context focuses column and
+		// columns wrappers before escaping out.
+		let activeElementBlockType;
 		await page.keyboard.press( 'ArrowUp' );
-		const activeElementBlockType = await page.evaluate( () => (
+		activeElementBlockType = await page.evaluate( () => (
+			document.activeElement.getAttribute( 'data-type' )
+		) );
+		expect( activeElementBlockType ).toBe( 'core/column' );
+		await page.keyboard.press( 'ArrowUp' );
+		activeElementBlockType = await page.evaluate( () => (
 			document.activeElement.getAttribute( 'data-type' )
 		) );
 		expect( activeElementBlockType ).toBe( 'core/columns' );

--- a/test/e2e/test-plugins/templates.php
+++ b/test/e2e/test-plugins/templates.php
@@ -28,12 +28,23 @@ function gutenberg_test_templates_register_book_type() {
 				'core/columns',
 				array(),
 				array(
-					array( 'core/image', array( 'layout' => 'column-1' ) ),
 					array(
-						'core/paragraph',
+						'core/column',
+						array(),
 						array(
-							'placeholder' => 'Add a inner paragraph',
-							'layout' => 'column-2',
+							array( 'core/image' ),
+						),
+					),
+					array(
+						'core/column',
+						array(),
+						array(
+							array(
+								'core/paragraph',
+								array(
+									'placeholder' => 'Add a inner paragraph',
+								),
+							),
 						),
 					),
 				),


### PR DESCRIPTION
Closes #5351

This pull request seeks to address an issue where the current Columns block implementation using grid is insufficient for supporting columns of varying height where it is expected for blocks within a column to stack atop each other, thus resulting in undesirable empty space.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/41172752-d45101b6-6b22-11e8-9619-4ade4c3d4315.png)|![After](https://user-images.githubusercontent.com/1779930/41172652-83195ff0-6b22-11e8-98eb-c417771c4c14.png)

**Implementation notes:**

This explores one option of addressing #5351 which was considered at https://github.com/WordPress/gutenberg/issues/5351#issuecomment-375795651, where in order to introduce a wrapper element for each column, the columns themselves are an intermediary block. This is possible through new APIs for `supportedBlocks` of a block type (#6753) and `allowedBlocks` and `template` of an `InnerBlocks` (#6546). Thus, a "Column" block is only valid within a Columns wrapper, and conversely a Column block is the only valid child of a Columns block. This will require that the Columns block fully manages its own template, which is only partially implemented thus far.

This may allow for the eventual removal of `layouts` concept altogether.

The primary alternative here is to keep the distinction of "grouped" and "ungrouped" layouts ([documentation](https://github.com/WordPress/gutenberg/tree/master/editor/components/inner-blocks)), and automatically insert a wrapper element for grouped layouts. This is challenging both in the further inconsistency between the two types of layouts, and in the current unavailability of `layouts` anywhere outside of the `edit` implementation where it is passed (it would likely need to become a top-level property of the block).

**Testing instructions:**

Verify that you can create columns, insert blocks within (via slash insertion), and that within columns, the individual blocks stack neatly atop each other when previewed on the front of your site.