### PR TITLE
Newly created paragraph block is not showing the font size.

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -59,6 +59,7 @@ const FONT_SIZES = [
 		size: 14,
 	},
 	{
+		default: true,
 		name: 'regular',
 		shortName: 'M',
 		size: 16,
@@ -118,7 +119,9 @@ class ParagraphBlock extends Component {
 
 		if ( customFontSize ) {
 			return customFontSize;
-		}
+		} else {
+            return find( FONT_SIZES, { default: true } ).size;
+        }
 	}
 
 	setFontSize( fontSizeValue ) {

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -120,8 +120,8 @@ class ParagraphBlock extends Component {
 		if ( customFontSize ) {
 			return customFontSize;
 		} else {
-            return find( FONT_SIZES, { default: true } ).size;
-        }
+            		return find( FONT_SIZES, { default: true } ).size;
+        	}
 	}
 
 	setFontSize( fontSizeValue ) {

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -119,9 +119,9 @@ class ParagraphBlock extends Component {
 
 		if ( customFontSize ) {
 			return customFontSize;
-		} else {
-            		return find( FONT_SIZES, { default: true } ).size;
-        	}
+		}
+            	
+		return find( FONT_SIZES, { default: true } ).size;
 	}
 
 	setFontSize( fontSizeValue ) {


### PR DESCRIPTION
Newly added paragraph block is not showing the font size. 

The font size is not set for components-range-control__number element. This commit fixes the issue.