### PR TITLE
Documentation: Generate Docs for the data module

### DIFF
--- a/docs/data/core-blocks.md
+++ b/docs/data/core-blocks.md
@@ -1,0 +1,86 @@
+# **core/blocks**: Block Types Data
+
+## Selectors 
+
+### getBlockType
+
+Returns a block type by name.
+
+*Parameters*
+
+ * state: Data state.
+ * name: Block type name.
+
+
+### getCategories
+
+Returns all the available categories.
+
+*Parameters*
+
+ * state: Data state.
+
+*Returns*
+
+Categories list.
+
+### getDefaultBlockName
+
+Returns the name of the default block name.
+
+*Parameters*
+
+ * state: Data state.
+
+*Returns*
+
+Default block name.
+
+### getFallbackBlockName
+
+Returns the name of the fallback block name.
+
+*Parameters*
+
+ * state: Data state.
+
+*Returns*
+
+Fallback block name.
+
+## Actions
+
+### addBlockTypes
+
+Returns an action object used in signalling that block types have been added.
+
+*Parameters*
+
+ * blockTypes: Block types received.
+
+
+### removeBlockTypes
+
+Returns an action object used to remove a registered block type.
+
+*Parameters*
+
+ * names: Block name.
+
+
+### setDefaultBlockName
+
+Returns an action object used to set the default block name.
+
+*Parameters*
+
+ * name: Block name.
+
+
+### setFallbackBlockName
+
+Returns an action object used to set the fallback block name.
+
+*Parameters*
+
+ * name: Block name.

--- a/docs/data/core-blocks.md
+++ b/docs/data/core-blocks.md
@@ -11,7 +11,6 @@ Returns a block type by name.
  * state: Data state.
  * name: Block type name.
 
-
 ### getCategories
 
 Returns all the available categories.
@@ -58,7 +57,6 @@ Returns an action object used in signalling that block types have been added.
 
  * blockTypes: Block types received.
 
-
 ### removeBlockTypes
 
 Returns an action object used to remove a registered block type.
@@ -67,7 +65,6 @@ Returns an action object used to remove a registered block type.
 
  * names: Block name.
 
-
 ### setDefaultBlockName
 
 Returns an action object used to set the default block name.
@@ -75,7 +72,6 @@ Returns an action object used to set the default block name.
 *Parameters*
 
  * name: Block name.
-
 
 ### setFallbackBlockName
 

--- a/docs/data/core-edit-post.md
+++ b/docs/data/core-edit-post.md
@@ -1,0 +1,271 @@
+# **core/edit-post**: The Editor's UI Data
+
+## Selectors 
+
+### getEditorMode
+
+Returns the current editing mode.
+
+*Parameters*
+
+ * state: Global application state.
+
+
+### isEditorSidebarOpened
+
+Returns true if the editor sidebar is opened.
+
+*Parameters*
+
+ * state: Global application state
+
+*Returns*
+
+Whether the editor sidebar is opened.
+
+### isPluginSidebarOpened
+
+Returns true if the plugin sidebar is opened.
+
+*Parameters*
+
+ * state: Global application state
+
+*Returns*
+
+Whether the plugin sidebar is opened.
+
+### getActiveGeneralSidebarName
+
+Returns the current active general sidebar name.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Active general sidebar name.
+
+### getPreferences
+
+Returns the preferences (these preferences are persisted locally).
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Preferences Object.
+
+### getPreference
+
+
+
+*Parameters*
+
+ * state: Global application state.
+ * preferenceKey: Preference Key.
+ * defaultValue: Default Value.
+
+*Returns*
+
+Preference Value.
+
+### isPublishSidebarOpened
+
+Returns true if the publish sidebar is opened.
+
+*Parameters*
+
+ * state: Global application state
+
+*Returns*
+
+Whether the publish sidebar is open.
+
+### isEditorSidebarPanelOpened
+
+Returns true if the editor sidebar panel is open, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+ * panel: Sidebar panel name.
+
+*Returns*
+
+Whether the sidebar panel is open.
+
+### isFeatureActive
+
+Returns whether the given feature is enabled or not.
+
+*Parameters*
+
+ * state: Global application state.
+ * feature: Feature slug.
+
+*Returns*
+
+Is active.
+
+### isPluginItemPinned
+
+Returns true if the the plugin item is pinned to the header.
+When the value is not set it defaults to true.
+
+*Parameters*
+
+ * state: Global application state.
+ * pluginName: Plugin item name.
+
+*Returns*
+
+Whether the plugin item is pinned.
+
+### getMetaBoxes
+
+Returns the state of legacy meta boxes.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+State of meta boxes.
+
+### getMetaBox
+
+Returns the state of legacy meta boxes.
+
+*Parameters*
+
+ * state: Global application state.
+ * location: Location of the meta box.
+
+*Returns*
+
+State of meta box at specified location.
+
+### isSavingMetaBoxes
+
+Returns true if the the Meta Boxes are being saved.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the metaboxes are being saved.
+
+## Actions
+
+### openGeneralSidebar
+
+Returns an action object used in signalling that the user opened an editor sidebar.
+
+*Parameters*
+
+ * name: Sidebar name to be opened.
+
+
+### closeGeneralSidebar
+
+Returns an action object signalling that the user closed the sidebar.
+
+
+
+
+### openPublishSidebar
+
+Returns an action object used in signalling that the user opened the publish
+sidebar.
+
+
+
+
+### closePublishSidebar
+
+Returns an action object used in signalling that the user closed the
+publish sidebar.
+
+
+
+
+### togglePublishSidebar
+
+Returns an action object used in signalling that the user toggles the publish sidebar.
+
+
+
+
+### toggleGeneralSidebarEditorPanel
+
+Returns an action object used in signalling that use toggled a panel in the editor.
+
+*Parameters*
+
+ * panel: The panel to toggle.
+
+
+### toggleFeature
+
+Returns an action object used to toggle a feature flag.
+
+*Parameters*
+
+ * feature: Feature name.
+
+
+### togglePinnedPluginItem
+
+Returns an action object used to toggle a plugin name flag.
+
+*Parameters*
+
+ * pluginName: Plugin name.
+
+
+### initializeMetaBoxState
+
+Returns an action object used to check the state of meta boxes at a location.
+
+This should only be fired once to initialize meta box state. If a meta box
+area is empty, this will set the store state to indicate that React should
+not render the meta box area.
+
+Example: metaBoxes = { side: true, normal: false }.
+
+This indicates that the sidebar has a meta box but the normal area does not.
+
+*Parameters*
+
+ * metaBoxes: Whether meta box locations are active.
+
+
+### requestMetaBoxUpdates
+
+Returns an action object used to request meta box update.
+
+
+
+
+### metaBoxUpdatesSuccess
+
+Returns an action object used signal a successfull meta box update.
+
+
+
+
+### setMetaBoxSavedData
+
+Returns an action object used to set the saved meta boxes data.
+This is used to check if the meta boxes have been touched when leaving the editor.
+
+*Parameters*
+
+ * dataPerLocation: Meta Boxes Data per location.

--- a/docs/data/core-edit-post.md
+++ b/docs/data/core-edit-post.md
@@ -10,7 +10,6 @@ Returns the current editing mode.
 
  * state: Global application state.
 
-
 ### isEditorSidebarOpened
 
 Returns true if the editor sidebar is opened.
@@ -60,8 +59,6 @@ Returns the preferences (these preferences are persisted locally).
 Preferences Object.
 
 ### getPreference
-
-
 
 *Parameters*
 
@@ -172,36 +169,23 @@ Returns an action object used in signalling that the user opened an editor sideb
 
  * name: Sidebar name to be opened.
 
-
 ### closeGeneralSidebar
 
 Returns an action object signalling that the user closed the sidebar.
-
-
-
 
 ### openPublishSidebar
 
 Returns an action object used in signalling that the user opened the publish
 sidebar.
 
-
-
-
 ### closePublishSidebar
 
 Returns an action object used in signalling that the user closed the
 publish sidebar.
 
-
-
-
 ### togglePublishSidebar
 
 Returns an action object used in signalling that the user toggles the publish sidebar.
-
-
-
 
 ### toggleGeneralSidebarEditorPanel
 
@@ -211,7 +195,6 @@ Returns an action object used in signalling that use toggled a panel in the edit
 
  * panel: The panel to toggle.
 
-
 ### toggleFeature
 
 Returns an action object used to toggle a feature flag.
@@ -220,7 +203,6 @@ Returns an action object used to toggle a feature flag.
 
  * feature: Feature name.
 
-
 ### togglePinnedPluginItem
 
 Returns an action object used to toggle a plugin name flag.
@@ -228,7 +210,6 @@ Returns an action object used to toggle a plugin name flag.
 *Parameters*
 
  * pluginName: Plugin name.
-
 
 ### initializeMetaBoxState
 
@@ -246,20 +227,13 @@ This indicates that the sidebar has a meta box but the normal area does not.
 
  * metaBoxes: Whether meta box locations are active.
 
-
 ### requestMetaBoxUpdates
 
 Returns an action object used to request meta box update.
 
-
-
-
 ### metaBoxUpdatesSuccess
 
 Returns an action object used signal a successfull meta box update.
-
-
-
 
 ### setMetaBoxSavedData
 

--- a/docs/data/core-editor.md
+++ b/docs/data/core-editor.md
@@ -1,0 +1,1460 @@
+# **core/editor**: The Editor's Data
+
+## Selectors 
+
+### hasEditorUndo
+
+Returns true if any past editor history snapshots exist, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+
+### hasEditorRedo
+
+Returns true if any future editor history snapshots exist, or false
+otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether redo history exists.
+
+### isEditedPostNew
+
+Returns true if the currently edited post is yet to be saved, or false if
+the post has been saved.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post is new.
+
+### isEditedPostDirty
+
+Returns true if there are unsaved values for the current edit session, or
+false if the editing state matches the saved or new post.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether unsaved values exist.
+
+### isCleanNewPost
+
+Returns true if there are no unsaved values for the current edit session and if
+the currently edited post is new (and has never been saved before).
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether new post and unsaved values exist.
+
+### getCurrentPost
+
+Returns the post currently being edited in its last known saved state, not
+including unsaved edits. Returns an object containing relevant default post
+values if the post has not yet been saved.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Post object.
+
+### getCurrentPostType
+
+Returns the post type of the post currently being edited.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Post type.
+
+### getCurrentPostId
+
+Returns the ID of the post currently being edited, or null if the post has
+not yet been saved.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+ID of current post.
+
+### getCurrentPostRevisionsCount
+
+Returns the number of revisions of the post currently being edited.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Number of revisions.
+
+### getCurrentPostLastRevisionId
+
+Returns the last revision ID of the post currently being edited,
+or null if the post has no revisions.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+ID of the last revision.
+
+### getPostEdits
+
+Returns any post values which have been changed in the editor but not yet
+been saved.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Object of key value pairs comprising unsaved edits.
+
+### getEditedPostAttribute
+
+Returns a single attribute of the post being edited, preferring the unsaved
+edit if one exists, but falling back to the attribute for the last known
+saved state of the post.
+
+*Parameters*
+
+ * state: Global application state.
+ * attributeName: Post attribute name.
+
+*Returns*
+
+Post attribute value.
+
+### getEditedPostVisibility
+
+Returns the current visibility of the post being edited, preferring the
+unsaved value if different than the saved post. The return value is one of
+"private", "password", or "public".
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Post visibility.
+
+### isCurrentPostPending
+
+Returns true if post is pending review.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether current post is pending review.
+
+### isCurrentPostPublished
+
+Return true if the current post has already been published.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post has been published.
+
+### isCurrentPostScheduled
+
+Returns true if post is already scheduled.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether current post is scheduled to be posted.
+
+### isEditedPostPublishable
+
+Return true if the post being edited can be published.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post can been published.
+
+### isEditedPostSaveable
+
+Returns true if the post can be saved, or false otherwise. A post must
+contain a title, an excerpt, or non-empty content to be valid for save.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post can be saved.
+
+### isEditedPostEmpty
+
+Returns true if the edited post has content. A post has content if it has at
+least one block or otherwise has a non-empty content property assigned.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether post has content.
+
+### isEditedPostAutosaveable
+
+Returns true if the post can be autosaved, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post can be autosaved.
+
+### getAutosave
+
+Returns the current autosave, or null if one is not set (i.e. if the post
+has yet to be autosaved, or has been saved or published since the last
+autosave).
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+Current autosave, if exists.
+
+### hasAutosave
+
+Returns the true if there is an existing autosave, otherwise false.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether there is an existing autosave.
+
+### isEditedPostBeingScheduled
+
+Return true if the post being edited is being scheduled. Preferring the
+unsaved status values.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post has been published.
+
+### getDocumentTitle
+
+Gets the document title to be used.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Document title.
+
+### getEditedPostExcerpt
+
+Returns the raw excerpt of the post being edited, preferring the unsaved
+value if different than the saved post.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Raw post excerpt.
+
+### getEditedPostPreviewLink
+
+Returns a URL to preview the post being edited.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Preview URL.
+
+### getBlockName
+
+Returns a block's name given its UID, or null if no block exists with the
+UID.
+
+*Parameters*
+
+ * state: Editor state.
+ * uid: Block unique ID.
+
+*Returns*
+
+Block name.
+
+### getBlockCount
+
+Returns the number of blocks currently present in the post.
+
+*Parameters*
+
+ * state: Global application state.
+ * rootUID: Optional root UID of block list.
+
+*Returns*
+
+Number of blocks in the post.
+
+### getBlockSelectionStart
+
+Returns the current block selection start. This value may be null, and it
+may represent either a singular block selection or multi-selection start.
+A selection is singular if its start and end match.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+UID of block selection start.
+
+### getBlockSelectionEnd
+
+Returns the current block selection end. This value may be null, and it
+may represent either a singular block selection or multi-selection end.
+A selection is singular if its start and end match.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+UID of block selection end.
+
+### getSelectedBlockCount
+
+Returns the number of blocks currently selected in the post.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Number of blocks selected in the post.
+
+### hasSelectedBlock
+
+Returns true if there is a single selected block, or false otherwise.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+Whether a single block is selected.
+
+### getSelectedBlockUID
+
+Returns the currently selected block UID, or null if there is no selected
+block.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Selected block UID.
+
+### getSelectedBlock
+
+Returns the currently selected block, or null if there is no selected block.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Selected block.
+
+### getBlockRootUID
+
+Given a block UID, returns the root block from which the block is nested, an
+empty string for top-level blocks, or null if the block does not exist.
+
+*Parameters*
+
+ * state: Global application state.
+ * uid: Block from which to find root UID.
+
+*Returns*
+
+Root UID, if exists
+
+### getAdjacentBlockUid
+
+Returns the UID of the block adjacent one at the given reference startUID and modifier
+directionality. Defaults start UID to the selected block, and direction as
+next block. Returns null if there is no adjacent block.
+
+*Parameters*
+
+ * state: Global application state.
+ * startUID: Optional UID of block from which to search.
+ * modifier: Directionality multiplier (1 next, -1 previous).
+
+*Returns*
+
+Return the UID of the block, or null if none exists.
+
+### getPreviousBlockUid
+
+Returns the previous block's UID from the given reference startUID. Defaults start
+UID to the selected block. Returns null if there is no previous block.
+
+*Parameters*
+
+ * state: Global application state.
+ * startUID: Optional UID of block from which to search.
+
+*Returns*
+
+Adjacent block's UID, or null if none exists.
+
+### getNextBlockUid
+
+Returns the next block's UID from the given reference startUID. Defaults start UID
+to the selected block. Returns null if there is no next block.
+
+*Parameters*
+
+ * state: Global application state.
+ * startUID: Optional UID of block from which to search.
+
+*Returns*
+
+Adjacent block's UID, or null if none exists.
+
+### getSelectedBlocksInitialCaretPosition
+
+Returns the initial caret position for the selected block.
+This position is to used to position the caret properly when the selected block changes.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Selected block.
+
+### getFirstMultiSelectedBlockUid
+
+Returns the unique ID of the first block in the multi-selection set, or null
+if there is no multi-selection.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+First unique block ID in the multi-selection set.
+
+### getLastMultiSelectedBlockUid
+
+Returns the unique ID of the last block in the multi-selection set, or null
+if there is no multi-selection.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Last unique block ID in the multi-selection set.
+
+### isFirstMultiSelectedBlock
+
+Returns true if a multi-selection exists, and the block corresponding to the
+specified unique ID is the first block of the multi-selection set, or false
+otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+ * uid: Block unique ID.
+
+*Returns*
+
+Whether block is first in mult-selection.
+
+### isBlockMultiSelected
+
+Returns true if the unique ID occurs within the block multi-selection, or
+false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+ * uid: Block unique ID.
+
+*Returns*
+
+Whether block is in multi-selection set.
+
+### getMultiSelectedBlocksStartUid
+
+Returns the unique ID of the block which begins the multi-selection set, or
+null if there is no multi-selection.
+
+N.b.: This is not necessarily the first uid in the selection. See
+getFirstMultiSelectedBlockUid().
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Unique ID of block beginning multi-selection.
+
+### getMultiSelectedBlocksEndUid
+
+Returns the unique ID of the block which ends the multi-selection set, or
+null if there is no multi-selection.
+
+N.b.: This is not necessarily the last uid in the selection. See
+getLastMultiSelectedBlockUid().
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Unique ID of block ending multi-selection.
+
+### getBlockOrder
+
+Returns an array containing all block unique IDs of the post being edited,
+in the order they appear in the post. Optionally accepts a root UID of the
+block list for which the order should be returned, defaulting to the top-
+level block order.
+
+*Parameters*
+
+ * state: Global application state.
+ * rootUID: Optional root UID of block list.
+
+*Returns*
+
+Ordered unique IDs of post blocks.
+
+### getBlockIndex
+
+Returns the index at which the block corresponding to the specified unique ID
+occurs within the post block order, or `-1` if the block does not exist.
+
+*Parameters*
+
+ * state: Global application state.
+ * uid: Block unique ID.
+ * rootUID: Optional root UID of block list.
+
+*Returns*
+
+Index at which block exists in order.
+
+### isBlockSelected
+
+Returns true if the block corresponding to the specified unique ID is
+currently selected and no multi-selection exists, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+ * uid: Block unique ID.
+
+*Returns*
+
+Whether block is selected and multi-selection exists.
+
+### hasSelectedInnerBlock
+
+Returns true if one of the block's inner blocks is selected.
+
+*Parameters*
+
+ * state: Global application state.
+ * uid: Block unique ID.
+
+*Returns*
+
+Whether the block as an inner block selected
+
+### isBlockWithinSelection
+
+Returns true if the block corresponding to the specified unique ID is
+currently selected but isn't the last of the selected blocks. Here "last"
+refers to the block sequence in the document, _not_ the sequence of
+multi-selection, which is why `state.blockSelection.end` isn't used.
+
+*Parameters*
+
+ * state: Global application state.
+ * uid: Block unique ID.
+
+*Returns*
+
+Whether block is selected and not the last in
+                   the selection.
+
+### hasMultiSelection
+
+Returns true if a multi-selection has been made, or false otherwise.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+Whether multi-selection has been made.
+
+### isMultiSelecting
+
+Whether in the process of multi-selecting or not. This flag is only true
+while the multi-selection is being selected (by mouse move), and is false
+once the multi-selection has been settled.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+True if multi-selecting, false if not.
+
+### isSelectionEnabled
+
+Whether is selection disable or not.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+True if multi is disable, false if not.
+
+### getBlockMode
+
+Returns thee block's editing mode.
+
+*Parameters*
+
+ * state: Global application state.
+ * uid: Block unique ID.
+
+*Returns*
+
+Block editing mode.
+
+### isTyping
+
+Returns true if the user is typing, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether user is typing.
+
+### getBlockInsertionPoint
+
+Returns the insertion point, the index at which the new inserted block would
+be placed. Defaults to the last index.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Insertion point object with `rootUID`, `layout`, `index`
+
+### isBlockInsertionPointVisible
+
+Returns true if we should show the block insertion point.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the insertion point is visible or not.
+
+### isValidTemplate
+
+Returns whether the blocks matches the template or not.
+
+*Parameters*
+
+ * state: null
+
+*Returns*
+
+Whether the template is valid or not.
+
+### getTemplate
+
+Returns the defined block template
+
+*Parameters*
+
+ * state: null
+
+*Returns*
+
+Block Template
+
+### getTemplateLock
+
+Returns the defined block template lock
+
+*Parameters*
+
+ * state: null
+
+*Returns*
+
+Block Template Lock
+
+### isSavingPost
+
+Returns true if the post is currently being saved, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether post is being saved.
+
+### didPostSaveRequestSucceed
+
+Returns true if a previous post save was attempted successfully, or false
+otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post was saved successfully.
+
+### didPostSaveRequestFail
+
+Returns true if a previous post save was attempted but failed, or false
+otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post save failed.
+
+### isAutosavingPost
+
+Returns true if the post is autosaving, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the post is autosaving.
+
+### getSuggestedPostFormat
+
+Returns a suggested post format for the current post, inferred only if there
+is a single block within the post and it is of a type known to match a
+default post format. Returns null if the format cannot be determined.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Suggested post format.
+
+### getNotices
+
+Returns the user notices array.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+List of notices.
+
+### getFrecentInserterItems
+
+Returns a list of items which the user is likely to want to insert. These
+are ordered by 'frecency', which is a heuristic that combines block usage
+frequency and recency.
+
+https://en.wikipedia.org/wiki/Frecency
+
+*Parameters*
+
+ * state: Global application state.
+ * allowedBlockTypes: Allowed block types, or true/false to enable/disable all types.
+ * maximum: Number of items to return.
+
+*Returns*
+
+Items that appear in the 'Recent' tab.
+
+### isSavingSharedBlock
+
+Returns whether or not the shared block with the given ID is being saved.
+
+*Parameters*
+
+ * state: Global application state.
+ * ref: The shared block's ID.
+
+*Returns*
+
+Whether or not the shared block is being saved.
+
+### isFetchingSharedBlock
+
+Returns true if the shared block with the given ID is being fetched, or
+false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+ * ref: The shared block's ID.
+
+*Returns*
+
+Whether the shared block is being fetched.
+
+### getSharedBlocks
+
+Returns an array of all shared blocks.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+An array of all shared blocks.
+
+### getStateBeforeOptimisticTransaction
+
+Returns state object prior to a specified optimist transaction ID, or `null`
+if the transaction corresponding to the given ID cannot be found.
+
+*Parameters*
+
+ * state: Current global application state.
+ * transactionId: Optimist transaction ID.
+
+*Returns*
+
+Global application state prior to transaction.
+
+### isPublishingPost
+
+Returns true if the post is being published, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether post is being published.
+
+### getProvisionalBlockUID
+
+Returns the provisional block UID, or null if there is no provisional block.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+Provisional block UID, if set.
+
+### isPermalinkEditable
+
+Returns whether the permalink is editable or not.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+Whether or not the permalink is editable.
+
+### getPermalink
+
+Returns the permalink for the post.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+The permalink.
+
+### getPermalinkParts
+
+Returns the permalink for a post, split into it's three parts: the prefix, the postName, and the suffix.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+The prefix, postName, and suffix for the permalink.
+
+### inSomeHistory
+
+Returns true if an optimistic transaction is pending commit, for which the
+before state satisfies the given predicate function.
+
+*Parameters*
+
+ * state: Editor state.
+ * predicate: Function given state, returning true if match.
+
+*Returns*
+
+Whether predicate matches for some history.
+
+### getBlockListSettings
+
+Returns the Block List settings of a block if any.
+
+*Parameters*
+
+ * state: Editor state.
+ * uid: Block UID.
+
+*Returns*
+
+Block settings of the block if set.
+
+### getSupportedBlocks
+
+eslint-disable-next-line no-unused-vars
+
+
+
+
+### getEditorSettings
+
+Returns the editor settings.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+The editor settings object
+
+## Actions
+
+### setupEditor
+
+Returns an action object used in signalling that editor has initialized with
+the specified post object and editor settings.
+
+*Parameters*
+
+ * post: Post object.
+ * autosaveStatus: The Post's autosave status.
+
+
+### resetPost
+
+Returns an action object used in signalling that the latest version of the
+post has been received, either by initialization or save.
+
+*Parameters*
+
+ * post: Post object.
+
+
+### resetAutosave
+
+Returns an action object used in signalling that the latest autosave of the
+post has been received, by initialization or autosave.
+
+*Parameters*
+
+ * post: Autosave post object.
+
+
+### setupEditorState
+
+Returns an action object used to setup the editor state when first opening an editor.
+
+*Parameters*
+
+ * post: Post object.
+ * blocks: Array of blocks.
+ * edits: Initial edited attributes object.
+
+
+### resetBlocks
+
+Returns an action object used in signalling that blocks state should be
+reset to the specified array of blocks, taking precedence over any other
+content reflected as an edit in state.
+
+*Parameters*
+
+ * blocks: Array of blocks.
+
+
+### receiveBlocks
+
+Returns an action object used in signalling that blocks have been received.
+Unlike resetBlocks, these should be appended to the existing known set, not
+replacing.
+
+*Parameters*
+
+ * blocks: Array of block objects.
+
+
+### updateBlockAttributes
+
+Returns an action object used in signalling that the block attributes with
+the specified UID has been updated.
+
+*Parameters*
+
+ * uid: Block UID.
+ * attributes: Block attributes to be merged.
+
+
+### updateBlock
+
+Returns an action object used in signalling that the block with the
+specified UID has been updated.
+
+*Parameters*
+
+ * uid: Block UID.
+ * updates: Block attributes to be merged.
+
+
+### toggleSelection
+
+Returns an action object that enables or disables block selection.
+
+*Parameters*
+
+ * boolean: [isSelectionEnabled=true] Whether block selection should
+                                           be enabled.
+
+
+### replaceBlocks
+
+Returns an action object signalling that a blocks should be replaced with
+one or more replacement blocks.
+
+*Parameters*
+
+ * uids: Block UID(s) to replace.
+ * blocks: Replacement block(s).
+
+
+### replaceBlock
+
+Returns an action object signalling that a single block should be replaced
+with one or more replacement blocks.
+
+*Parameters*
+
+ * uid: Block UID(s) to replace.
+ * block: Replacement block(s).
+
+
+### moveBlockToPosition
+
+Returns an action object signalling that an indexed block should be moved
+to a new index.
+
+*Parameters*
+
+ * uid: The UID of the block.
+ * fromRootUID: root UID source.
+ * toRootUID: root UID destination.
+ * layout: layout to move the block into.
+ * index: The index to move the block into.
+
+
+### insertBlock
+
+Returns an action object used in signalling that a single block should be
+inserted, optionally at a specific index respective a root block list.
+
+*Parameters*
+
+ * block: Block object to insert.
+ * index: Index at which block should be inserted.
+ * rootUID: Optional root UID of block list to insert.
+
+
+### insertBlocks
+
+Returns an action object used in signalling that an array of blocks should
+be inserted, optionally at a specific index respective a root block list.
+
+*Parameters*
+
+ * blocks: Block objects to insert.
+ * index: Index at which block should be inserted.
+ * rootUID: Optional root UID of block list to insert.
+
+
+### showInsertionPoint
+
+Returns an action object used in signalling that the insertion point should
+be shown.
+
+
+
+
+### hideInsertionPoint
+
+Returns an action object hiding the insertion point.
+
+
+
+
+### setTemplateValidity
+
+Returns an action object resetting the template validity.
+
+*Parameters*
+
+ * isValid: template validity flag.
+
+
+### checkTemplateValidity
+
+Returns an action object to check the template validity.
+
+
+
+
+### synchronizeTemplate
+
+Returns an action object synchronize the template with the list of blocks
+
+
+
+
+### savePost
+
+Returns an action object to save the post.
+
+*Parameters*
+
+ * options: Options for the save.
+ * options.autosave: Perform an autosave if true.
+
+
+### mergeBlocks
+
+Returns an action object used in signalling that two blocks should be merged
+
+*Parameters*
+
+ * blockAUid: UID of the first block to merge.
+ * blockBUid: UID of the second block to merge.
+
+
+### autosave
+
+Returns an action object used in signalling that the post should autosave.
+
+
+
+
+### redo
+
+Returns an action object used in signalling that undo history should
+restore last popped state.
+
+
+
+
+### undo
+
+Returns an action object used in signalling that undo history should pop.
+
+
+
+
+### createUndoLevel
+
+Returns an action object used in signalling that undo history record should
+be created.
+
+
+
+
+### removeBlocks
+
+Returns an action object used in signalling that the blocks
+corresponding to the specified UID set are to be removed.
+
+*Parameters*
+
+ * uids: Block UIDs.
+ * selectPrevious: True if the previous block should be selected when a block is removed.
+
+
+### removeBlock
+
+Returns an action object used in signalling that the block with the
+specified UID is to be removed.
+
+*Parameters*
+
+ * uid: Block UID.
+ * selectPrevious: True if the previous block should be selected when a block is removed.
+
+
+### toggleBlockMode
+
+Returns an action object used to toggle the block editing mode (visual/html).
+
+*Parameters*
+
+ * uid: Block UID.
+
+
+### startTyping
+
+Returns an action object used in signalling that the user has begun to type.
+
+
+
+
+### stopTyping
+
+Returns an action object used in signalling that the user has stopped typing.
+
+
+
+
+### createNotice
+
+Returns an action object used to create a notice.
+
+*Parameters*
+
+ * status: The notice status.
+ * content: The notice content.
+ * options: The notice options.  Available options:
+                             `id` (string; default auto-generated)
+                             `isDismissible` (boolean; default `true`).
+
+
+### removeNotice
+
+Returns an action object used to remove a notice.
+
+*Parameters*
+
+ * id: The notice id.
+
+
+### fetchSharedBlocks
+
+Returns an action object used to fetch a single shared block or all shared
+blocks from the REST API into the store.
+
+*Parameters*
+
+ * id: If given, only a single shared block with this ID will
+                    be fetched.
+
+
+### receiveSharedBlocks
+
+Returns an action object used in signalling that shared blocks have been
+received. `results` is an array of objects containing:
+ - `sharedBlock` - Details about how the shared block is persisted.
+ - `parsedBlock` - The original block.
+
+*Parameters*
+
+ * results: Shared blocks received.
+
+
+### saveSharedBlock
+
+Returns an action object used to save a shared block that's in the store to
+the REST API.
+
+*Parameters*
+
+ * id: The ID of the shared block to save.
+
+
+### deleteSharedBlock
+
+Returns an action object used to delete a shared block via the REST API.
+
+*Parameters*
+
+ * id: The ID of the shared block to delete.
+
+
+### updateSharedBlockTitle
+
+Returns an action object used in signalling that a shared block's title is
+to be updated.
+
+*Parameters*
+
+ * id: The ID of the shared block to update.
+ * title: The new title.
+
+
+### convertBlockToStatic
+
+Returns an action object used to convert a shared block into a static block.
+
+*Parameters*
+
+ * uid: The ID of the block to attach.
+
+
+### convertBlockToShared
+
+Returns an action object used to convert a static block into a shared block.
+
+*Parameters*
+
+ * uid: The ID of the block to detach.
+
+
+### insertDefaultBlock
+
+Returns an action object used in signalling that a new block of the default
+type should be added to the block list.
+
+*Parameters*
+
+ * attributes: Optional attributes of the block to assign.
+ * rootUID: Optional root UID of block list to append.
+ * index: Optional index where to insert the default block
+
+
+### updateBlockListSettings
+
+Returns an action object that changes the nested settings of a given block.
+
+*Parameters*
+
+ * id: UID of the block whose nested setting.
+ * settings: Object with the new settings for the nested block.
+
+
+### updateEditorSettings
+
+Returns an action object used in signalling that the editor settings have been updated.
+
+*Parameters*
+
+ * settings: Updated settings

--- a/docs/data/core-editor.md
+++ b/docs/data/core-editor.md
@@ -10,7 +10,6 @@ Returns true if any past editor history snapshots exist, or false otherwise.
 
  * state: Global application state.
 
-
 ### hasEditorRedo
 
 Returns true if any future editor history snapshots exist, or false
@@ -1030,9 +1029,6 @@ Block settings of the block if set.
 
 eslint-disable-next-line no-unused-vars
 
-
-
-
 ### getEditorSettings
 
 Returns the editor settings.
@@ -1057,7 +1053,6 @@ the specified post object and editor settings.
  * post: Post object.
  * autosaveStatus: The Post's autosave status.
 
-
 ### resetPost
 
 Returns an action object used in signalling that the latest version of the
@@ -1067,7 +1062,6 @@ post has been received, either by initialization or save.
 
  * post: Post object.
 
-
 ### resetAutosave
 
 Returns an action object used in signalling that the latest autosave of the
@@ -1076,7 +1070,6 @@ post has been received, by initialization or autosave.
 *Parameters*
 
  * post: Autosave post object.
-
 
 ### setupEditorState
 
@@ -1088,7 +1081,6 @@ Returns an action object used to setup the editor state when first opening an ed
  * blocks: Array of blocks.
  * edits: Initial edited attributes object.
 
-
 ### resetBlocks
 
 Returns an action object used in signalling that blocks state should be
@@ -1098,7 +1090,6 @@ content reflected as an edit in state.
 *Parameters*
 
  * blocks: Array of blocks.
-
 
 ### receiveBlocks
 
@@ -1110,7 +1101,6 @@ replacing.
 
  * blocks: Array of block objects.
 
-
 ### updateBlockAttributes
 
 Returns an action object used in signalling that the block attributes with
@@ -1120,7 +1110,6 @@ the specified UID has been updated.
 
  * uid: Block UID.
  * attributes: Block attributes to be merged.
-
 
 ### updateBlock
 
@@ -1132,7 +1121,6 @@ specified UID has been updated.
  * uid: Block UID.
  * updates: Block attributes to be merged.
 
-
 ### toggleSelection
 
 Returns an action object that enables or disables block selection.
@@ -1141,7 +1129,6 @@ Returns an action object that enables or disables block selection.
 
  * boolean: [isSelectionEnabled=true] Whether block selection should
                                            be enabled.
-
 
 ### replaceBlocks
 
@@ -1153,7 +1140,6 @@ one or more replacement blocks.
  * uids: Block UID(s) to replace.
  * blocks: Replacement block(s).
 
-
 ### replaceBlock
 
 Returns an action object signalling that a single block should be replaced
@@ -1163,7 +1149,6 @@ with one or more replacement blocks.
 
  * uid: Block UID(s) to replace.
  * block: Replacement block(s).
-
 
 ### moveBlockToPosition
 
@@ -1178,7 +1163,6 @@ to a new index.
  * layout: layout to move the block into.
  * index: The index to move the block into.
 
-
 ### insertBlock
 
 Returns an action object used in signalling that a single block should be
@@ -1189,7 +1173,6 @@ inserted, optionally at a specific index respective a root block list.
  * block: Block object to insert.
  * index: Index at which block should be inserted.
  * rootUID: Optional root UID of block list to insert.
-
 
 ### insertBlocks
 
@@ -1202,21 +1185,14 @@ be inserted, optionally at a specific index respective a root block list.
  * index: Index at which block should be inserted.
  * rootUID: Optional root UID of block list to insert.
 
-
 ### showInsertionPoint
 
 Returns an action object used in signalling that the insertion point should
 be shown.
 
-
-
-
 ### hideInsertionPoint
 
 Returns an action object hiding the insertion point.
-
-
-
 
 ### setTemplateValidity
 
@@ -1226,20 +1202,13 @@ Returns an action object resetting the template validity.
 
  * isValid: template validity flag.
 
-
 ### checkTemplateValidity
 
 Returns an action object to check the template validity.
 
-
-
-
 ### synchronizeTemplate
 
 Returns an action object synchronize the template with the list of blocks
-
-
-
 
 ### savePost
 
@@ -1250,7 +1219,6 @@ Returns an action object to save the post.
  * options: Options for the save.
  * options.autosave: Perform an autosave if true.
 
-
 ### mergeBlocks
 
 Returns an action object used in signalling that two blocks should be merged
@@ -1260,36 +1228,23 @@ Returns an action object used in signalling that two blocks should be merged
  * blockAUid: UID of the first block to merge.
  * blockBUid: UID of the second block to merge.
 
-
 ### autosave
 
 Returns an action object used in signalling that the post should autosave.
-
-
-
 
 ### redo
 
 Returns an action object used in signalling that undo history should
 restore last popped state.
 
-
-
-
 ### undo
 
 Returns an action object used in signalling that undo history should pop.
-
-
-
 
 ### createUndoLevel
 
 Returns an action object used in signalling that undo history record should
 be created.
-
-
-
 
 ### removeBlocks
 
@@ -1301,7 +1256,6 @@ corresponding to the specified UID set are to be removed.
  * uids: Block UIDs.
  * selectPrevious: True if the previous block should be selected when a block is removed.
 
-
 ### removeBlock
 
 Returns an action object used in signalling that the block with the
@@ -1312,7 +1266,6 @@ specified UID is to be removed.
  * uid: Block UID.
  * selectPrevious: True if the previous block should be selected when a block is removed.
 
-
 ### toggleBlockMode
 
 Returns an action object used to toggle the block editing mode (visual/html).
@@ -1321,20 +1274,13 @@ Returns an action object used to toggle the block editing mode (visual/html).
 
  * uid: Block UID.
 
-
 ### startTyping
 
 Returns an action object used in signalling that the user has begun to type.
 
-
-
-
 ### stopTyping
 
 Returns an action object used in signalling that the user has stopped typing.
-
-
-
 
 ### createNotice
 
@@ -1348,7 +1294,6 @@ Returns an action object used to create a notice.
                              `id` (string; default auto-generated)
                              `isDismissible` (boolean; default `true`).
 
-
 ### removeNotice
 
 Returns an action object used to remove a notice.
@@ -1356,7 +1301,6 @@ Returns an action object used to remove a notice.
 *Parameters*
 
  * id: The notice id.
-
 
 ### fetchSharedBlocks
 
@@ -1367,7 +1311,6 @@ blocks from the REST API into the store.
 
  * id: If given, only a single shared block with this ID will
                     be fetched.
-
 
 ### receiveSharedBlocks
 
@@ -1380,7 +1323,6 @@ received. `results` is an array of objects containing:
 
  * results: Shared blocks received.
 
-
 ### saveSharedBlock
 
 Returns an action object used to save a shared block that's in the store to
@@ -1390,7 +1332,6 @@ the REST API.
 
  * id: The ID of the shared block to save.
 
-
 ### deleteSharedBlock
 
 Returns an action object used to delete a shared block via the REST API.
@@ -1398,7 +1339,6 @@ Returns an action object used to delete a shared block via the REST API.
 *Parameters*
 
  * id: The ID of the shared block to delete.
-
 
 ### updateSharedBlockTitle
 
@@ -1410,7 +1350,6 @@ to be updated.
  * id: The ID of the shared block to update.
  * title: The new title.
 
-
 ### convertBlockToStatic
 
 Returns an action object used to convert a shared block into a static block.
@@ -1419,7 +1358,6 @@ Returns an action object used to convert a shared block into a static block.
 
  * uid: The ID of the block to attach.
 
-
 ### convertBlockToShared
 
 Returns an action object used to convert a static block into a shared block.
@@ -1427,7 +1365,6 @@ Returns an action object used to convert a static block into a shared block.
 *Parameters*
 
  * uid: The ID of the block to detach.
-
 
 ### insertDefaultBlock
 
@@ -1440,7 +1377,6 @@ type should be added to the block list.
  * rootUID: Optional root UID of block list to append.
  * index: Optional index where to insert the default block
 
-
 ### updateBlockListSettings
 
 Returns an action object that changes the nested settings of a given block.
@@ -1449,7 +1385,6 @@ Returns an action object that changes the nested settings of a given block.
 
  * id: UID of the block whose nested setting.
  * settings: Object with the new settings for the nested block.
-
 
 ### updateEditorSettings
 

--- a/docs/data/core-nux.md
+++ b/docs/data/core-nux.md
@@ -1,0 +1,44 @@
+# **core/nux**: The NUX module Data
+
+## Selectors 
+
+### isTipVisible
+
+Determines whether or not the given tip is showing. Tips are hidden if they
+are disabled, have been dismissed, or are not the current tip in any
+guide that they have been added to.
+
+*Parameters*
+
+ * state: Global application state.
+ * id: The tip to query.
+
+
+## Actions
+
+### triggerGuide
+
+Returns an action object that, when dispatched, presents a guide that takes
+the user through a series of tips step by step.
+
+*Parameters*
+
+ * tipIds: Which tips to show in the guide.
+
+
+### dismissTip
+
+Returns an action object that, when dispatched, dismisses the given tip. A
+dismissed tip will not show again.
+
+*Parameters*
+
+ * id: The tip to dismiss.
+
+
+### disableTips
+
+Returns an action object that, when dispatched, prevents all tips from
+showing again.
+
+

--- a/docs/data/core-nux.md
+++ b/docs/data/core-nux.md
@@ -13,7 +13,6 @@ guide that they have been added to.
  * state: Global application state.
  * id: The tip to query.
 
-
 ## Actions
 
 ### triggerGuide
@@ -25,7 +24,6 @@ the user through a series of tips step by step.
 
  * tipIds: Which tips to show in the guide.
 
-
 ### dismissTip
 
 Returns an action object that, when dispatched, dismisses the given tip. A
@@ -35,10 +33,7 @@ dismissed tip will not show again.
 
  * id: The tip to dismiss.
 
-
 ### disableTips
 
 Returns an action object that, when dispatched, prevents all tips from
 showing again.
-
-

--- a/docs/data/core-viewport.md
+++ b/docs/data/core-viewport.md
@@ -12,7 +12,6 @@ Returns true if the viewport matches the given query, or false otherwise.
  * query: Query string. Includes operator and breakpoint name,
                       space separated. Operator defaults to >=.
 
-
 ## Actions
 
 ### setIsMatching

--- a/docs/data/core-viewport.md
+++ b/docs/data/core-viewport.md
@@ -1,0 +1,26 @@
+# **core/viewport**: The viewport module Data
+
+## Selectors 
+
+### isViewportMatch
+
+Returns true if the viewport matches the given query, or false otherwise.
+
+*Parameters*
+
+ * state: Viewport state object.
+ * query: Query string. Includes operator and breakpoint name,
+                      space separated. Operator defaults to >=.
+
+
+## Actions
+
+### setIsMatching
+
+Returns an action object used in signalling that viewport queries have been
+updated. Values are specified as an object of breakpoint query keys where
+value represents whether query matches.
+
+*Parameters*
+
+ * values: Breakpoint query matches.

--- a/docs/data/core.md
+++ b/docs/data/core.md
@@ -11,7 +11,6 @@ Returns all the available terms for the given taxonomy.
  * state: Data state.
  * taxonomy: Taxonomy name.
 
-
 ### getCategories
 
 Returns all the available categories.
@@ -129,7 +128,6 @@ for a given taxonomy.
  * taxonomy: Taxonomy name.
  * terms: Terms received.
 
-
 ### receiveUserQuery
 
 Returns an action object used in signalling that authors have been received.
@@ -139,7 +137,6 @@ Returns an action object used in signalling that authors have been received.
  * queryID: Query ID.
  * users: Users received.
 
-
 ### addEntities
 
 Returns an action object used in adding new entities.
@@ -147,7 +144,6 @@ Returns an action object used in adding new entities.
 *Parameters*
 
  * entities: Entities received.
-
 
 ### receiveEntityRecords
 
@@ -158,7 +154,6 @@ Returns an action object used in signalling that entity records have been receiv
  * kind: Kind of the received entity.
  * name: Name of the received entity.
  * records: Records received.
-
 
 ### receiveThemeSupportsFromIndex
 

--- a/docs/data/core.md
+++ b/docs/data/core.md
@@ -1,0 +1,169 @@
+# **core**: WordPress Core Data
+
+## Selectors 
+
+### getTerms
+
+Returns all the available terms for the given taxonomy.
+
+*Parameters*
+
+ * state: Data state.
+ * taxonomy: Taxonomy name.
+
+
+### getCategories
+
+Returns all the available categories.
+
+*Parameters*
+
+ * state: Data state.
+
+*Returns*
+
+Categories list.
+
+### isRequestingTerms
+
+Returns true if a request is in progress for terms data of a given taxonomy,
+or false otherwise.
+
+*Parameters*
+
+ * state: Data state.
+ * taxonomy: Taxonomy name.
+
+*Returns*
+
+Whether a request is in progress for taxonomy's terms.
+
+### isRequestingCategories
+
+Returns true if a request is in progress for categories data, or false
+otherwise.
+
+*Parameters*
+
+ * state: Data state.
+
+*Returns*
+
+Whether a request is in progress for categories.
+
+### getAuthors
+
+Returns all available authors.
+
+*Parameters*
+
+ * state: Data state.
+
+*Returns*
+
+Authors list.
+
+### getEntitiesByKind
+
+Returns whether the entities for the give kind are loaded.
+
+*Parameters*
+
+ * state: Data state.
+ * kind: Entity kind.
+
+*Returns*
+
+Whether the entities are loaded
+
+### getEntity
+
+Returns the entity object given its kind and name.
+
+*Parameters*
+
+ * state: Data state.
+ * kind: Entity kind.
+ * name: Entity name.
+
+*Returns*
+
+Entity
+
+### getEntityRecord
+
+Returns the Entity's record object by key.
+
+*Parameters*
+
+ * state: State tree
+ * kind: Entity kind.
+ * name: Entity name.
+ * key: Record's key
+
+*Returns*
+
+Record.
+
+### getThemeSupports
+
+Return theme suports data in the index.
+
+*Parameters*
+
+ * state: Data state.
+
+*Returns*
+
+Index data.
+
+## Actions
+
+### receiveTerms
+
+Returns an action object used in signalling that terms have been received
+for a given taxonomy.
+
+*Parameters*
+
+ * taxonomy: Taxonomy name.
+ * terms: Terms received.
+
+
+### receiveUserQuery
+
+Returns an action object used in signalling that authors have been received.
+
+*Parameters*
+
+ * queryID: Query ID.
+ * users: Users received.
+
+
+### addEntities
+
+Returns an action object used in adding new entities.
+
+*Parameters*
+
+ * entities: Entities received.
+
+
+### receiveEntityRecords
+
+Returns an action object used in signalling that entity records have been received.
+
+*Parameters*
+
+ * kind: Kind of the received entity.
+ * name: Name of the received entity.
+ * records: Records received.
+
+
+### receiveThemeSupportsFromIndex
+
+Returns an action object used in signalling that the index has been received.
+
+*Parameters*
+
+ * index: Index received.

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -1,0 +1,8 @@
+# Data Module Reference
+
+ - [**core**: WordPress Core Data](./core.md)
+ - [**core/blocks**: Block Types Data](./core-blocks.md)
+ - [**core/editor**: The Editor's Data](./core-editor.md)
+ - [**core/edit-post**: The Editor's UI Data](./core-edit-post.md)
+ - [**core/viewport**: The viewport module Data](./core-viewport.md)
+ - [**core/nux**: The NUX module Data](./core-nux.md)

--- a/docs/data/tool/config.js
+++ b/docs/data/tool/config.js
@@ -1,0 +1,44 @@
+/**
+ * Node dependencies
+ */
+const path = require( 'path' );
+
+const root = path.resolve( __dirname, '../../../' );
+
+module.exports = {
+	namespaces: {
+		core: {
+			title: 'WordPress Core Data',
+			// Figures out a way to generate docs for the dynamic actions/selectors
+			selectors: [ path.resolve( root, 'packages/core-data/src/selectors.js' ) ],
+			actions: [ path.resolve( root, 'packages/core-data/src/actions.js' ) ],
+		},
+		'core/blocks': {
+			title: 'Block Types Data',
+			selectors: [ path.resolve( root, 'blocks/store/selectors.js' ) ],
+			actions: [ path.resolve( root, 'blocks/store/actions.js' ) ],
+		},
+		'core/editor': {
+			title: 'The Editor\'s Data',
+			selectors: [ path.resolve( root, 'editor/store/selectors.js' ) ],
+			actions: [ path.resolve( root, 'editor/store/actions.js' ) ],
+		},
+		'core/edit-post': {
+			title: 'The Editor\'s UI Data',
+			selectors: [ path.resolve( root, 'edit-post/store/selectors.js' ) ],
+			actions: [ path.resolve( root, 'edit-post/store/actions.js' ) ],
+		},
+		'core/viewport': {
+			title: 'The viewport module Data',
+			selectors: [ path.resolve( root, 'viewport/store/selectors.js' ) ],
+			actions: [ path.resolve( root, 'viewport/store/actions.js' ) ],
+		},
+		'core/nux': {
+			title: 'The NUX module Data',
+			selectors: [ path.resolve( root, 'nux/store/selectors.js' ) ],
+			actions: [ path.resolve( root, 'nux/store/actions.js' ) ],
+		},
+	},
+
+	output: path.resolve( __dirname, '../' ),
+};

--- a/docs/data/tool/config.js
+++ b/docs/data/tool/config.js
@@ -9,7 +9,7 @@ module.exports = {
 	namespaces: {
 		core: {
 			title: 'WordPress Core Data',
-			// Figures out a way to generate docs for the dynamic actions/selectors
+			// TODO: Figure out a way to generate docs for dynamic actions/selectors
 			selectors: [ path.resolve( root, 'packages/core-data/src/selectors.js' ) ],
 			actions: [ path.resolve( root, 'packages/core-data/src/actions.js' ) ],
 		},
@@ -34,7 +34,7 @@ module.exports = {
 			actions: [ path.resolve( root, 'viewport/store/actions.js' ) ],
 		},
 		'core/nux': {
-			title: 'The NUX module Data',
+			title: 'The NUX (New User Experience) module Data',
 			selectors: [ path.resolve( root, 'nux/store/selectors.js' ) ],
 			actions: [ path.resolve( root, 'nux/store/actions.js' ) ],
 		},

--- a/docs/data/tool/generator.js
+++ b/docs/data/tool/generator.js
@@ -33,23 +33,25 @@ function generateTableOfContent( parsed ) {
 function generateFunctionDocs( parsedFunc, generateDocsForReturn = true ) {
 	return [
 		`### ${ parsedFunc.name }`,
-		'',
-		parsedFunc.description,
-		'',
+		parsedFunc.description ? [
+			'',
+			parsedFunc.description,
+		].join( '\n' ) : null,
 		parsedFunc.params.length ? [
+			'',
 			'*Parameters*',
 			'',
 			parsedFunc.params.map( ( param ) => (
 				` * ${ param.name }: ${ param.description }`
 			) ).join( '\n' ),
-		].join( '\n' ) : '',
+		].join( '\n' ) : null,
 		parsedFunc.return && generateDocsForReturn ? [
 			'',
 			'*Returns*',
 			'',
 			parsedFunc.return.description,
-		].join( '\n' ) : '',
-	].join( '\n' );
+		].join( '\n' ) : null,
+	].filter( ( row ) => row !== null ).join( '\n' );
 }
 
 /**

--- a/docs/data/tool/generator.js
+++ b/docs/data/tool/generator.js
@@ -8,15 +8,15 @@ const lodash = require( 'lodash' );
 /**
  * Generates the table of contents' markdown.
  *
- * @param {Object} parsed Parsed Namespace Object
+ * @param {Object} parsedNamespaces Parsed Namespace Object
  *
  * @return {string} Markdown string
  */
-function generateTableOfContent( parsed ) {
+function generateTableOfContent( parsedNamespaces ) {
 	return [
 		'# Data Module Reference',
 		'',
-		Object.values( parsed ).map( ( parsedNamespace ) => {
+		Object.values( parsedNamespaces ).map( ( parsedNamespace ) => {
 			return ` - [**${ parsedNamespace.name }**: ${ parsedNamespace.title }](./${ lodash.kebabCase( parsedNamespace.name ) }.md)`;
 		} ).join( '\n' ),
 	].join( '\n' );
@@ -77,14 +77,14 @@ function generateNamespaceDocs( parsedNamespace ) {
 	].join( '\n' );
 }
 
-module.exports = function( parsed, rootFolder ) {
-	const tableOfContent = generateTableOfContent( parsed );
+module.exports = function( parsedNamespaces, rootFolder ) {
+	const tableOfContent = generateTableOfContent( parsedNamespaces );
 	fs.writeFileSync(
 		path.join( rootFolder, 'index.md' ),
 		tableOfContent
 	);
 
-	Object.values( parsed ).forEach( ( parsedNamespace ) => {
+	Object.values( parsedNamespaces ).forEach( ( parsedNamespace ) => {
 		const namespaceDocs = generateNamespaceDocs( parsedNamespace );
 		fs.writeFileSync(
 			path.join( rootFolder, lodash.kebabCase( parsedNamespace.name ) + '.md' ),

--- a/docs/data/tool/generator.js
+++ b/docs/data/tool/generator.js
@@ -1,0 +1,92 @@
+/**
+ * Node dependencies
+ */
+const path = require( 'path' );
+const fs = require( 'fs' );
+const lodash = require( 'lodash' );
+
+/**
+ * Generates the table of contents' markdown.
+ *
+ * @param {Object} parsed Parsed Namespace Object
+ *
+ * @return {string} Markdown string
+ */
+function generateTableOfContent( parsed ) {
+	return [
+		'# Data Module Reference',
+		'',
+		Object.values( parsed ).map( ( parsedNamespace ) => {
+			return ` - [**${ parsedNamespace.name }**: ${ parsedNamespace.title }](./${ lodash.kebabCase( parsedNamespace.name ) }.md)`;
+		} ).join( '\n' ),
+	].join( '\n' );
+}
+
+/**
+ * Generates the table of contents' markdown.
+ *
+ * @param {Object}  parsedFunc            Parsed Function
+ * @param {boolean} generateDocsForReturn Whether to generate docs for the return value.
+ *
+ * @return {string} Markdown string
+ */
+function generateFunctionDocs( parsedFunc, generateDocsForReturn = true ) {
+	return [
+		`### ${ parsedFunc.name }`,
+		'',
+		parsedFunc.description,
+		'',
+		parsedFunc.params.length ? [
+			'*Parameters*',
+			'',
+			parsedFunc.params.map( ( param ) => (
+				` * ${ param.name }: ${ param.description }`
+			) ).join( '\n' ),
+		].join( '\n' ) : '',
+		parsedFunc.return && generateDocsForReturn ? [
+			'',
+			'*Returns*',
+			'',
+			parsedFunc.return.description,
+		].join( '\n' ) : '',
+	].join( '\n' );
+}
+
+/**
+ * Generates the namespace selectors/actions markdown.
+ *
+ * @param {Object} parsedNamespace Parsed Namespace
+ *
+ * @return {string} Markdown string
+ */
+function generateNamespaceDocs( parsedNamespace ) {
+	return [
+		`# **${ parsedNamespace.name }**: ${ parsedNamespace.title }`,
+		'',
+		'## Selectors ',
+		'',
+		( parsedNamespace.selectors.map( generateFunctionDocs ) ).join( '\n\n' ),
+		'',
+		'## Actions',
+		'',
+		parsedNamespace.actions.map(
+			( action ) => generateFunctionDocs( action, false )
+		).join( '\n\n' ),
+	].join( '\n' );
+}
+
+module.exports = function( parsed, rootFolder ) {
+	const tableOfContent = generateTableOfContent( parsed );
+	fs.writeFileSync(
+		path.join( rootFolder, 'index.md' ),
+		tableOfContent
+	);
+
+	Object.values( parsed ).forEach( ( parsedNamespace ) => {
+		const namespaceDocs = generateNamespaceDocs( parsedNamespace );
+		fs.writeFileSync(
+			path.join( rootFolder, lodash.kebabCase( parsedNamespace.name ) + '.md' ),
+			namespaceDocs
+		);
+	} );
+};

--- a/docs/data/tool/index.js
+++ b/docs/data/tool/index.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+const config = require( './config' );
+const parser = require( './parser' );
+const generator = require( './generator' );
+
+const parsedModules = parser( config.namespaces );
+generator( parsedModules, config.output );

--- a/docs/data/tool/parser.js
+++ b/docs/data/tool/parser.js
@@ -25,6 +25,7 @@ module.exports = function( config ) {
 				const code = fs.readFileSync( file, 'utf8' );
 				const parsedCode = espree.parse( code, {
 					attachComment: true,
+					// This should ideally match our babel config, but espree doesn't support it.
 					ecmaVersion: 9,
 					sourceType: 'module',
 				} );

--- a/docs/data/tool/parser.js
+++ b/docs/data/tool/parser.js
@@ -1,0 +1,60 @@
+/**
+ * Node dependencies
+ */
+const fs = require( 'fs' );
+
+/**
+ * External dependencies
+ */
+const lodash = require( 'lodash' );
+const espree = require( 'espree' );
+const doctrine = require( 'doctrine' );
+
+module.exports = function( config ) {
+	const result = {};
+	Object.entries( config ).forEach( ( [ namespace, namespaceConfig ] ) => {
+		const namespaceResult = {
+			name: namespace,
+			title: namespaceConfig.title,
+			selectors: [],
+			actions: [],
+		};
+
+		[ 'selectors', 'actions' ].forEach( ( type ) => {
+			namespaceConfig[ type ].forEach( ( file ) => {
+				const code = fs.readFileSync( file, 'utf8' );
+				const parsedCode = espree.parse( code, {
+					attachComment: true,
+					ecmaVersion: 9,
+					sourceType: 'module',
+				} );
+
+				parsedCode.body.forEach( ( node ) => {
+					if (
+						node.type === 'ExportNamedDeclaration' &&
+						node.declaration.type === 'FunctionDeclaration' &&
+						node.leadingComments &&
+						node.leadingComments.length !== 0
+					) {
+						const docBlock = doctrine.parse(
+							lodash.last( node.leadingComments ).value,
+							{ unwrap: true, recoverable: true }
+						);
+						const func = {
+							name: node.declaration.id.name,
+							description: docBlock.description,
+							params: docBlock.tags.filter( ( tag ) => tag.title === 'param' ),
+							return: docBlock.tags.find( ( tag ) => tag.title === 'return' ),
+						};
+
+						namespaceResult[ type ].push( func );
+					}
+				} );
+			} );
+		} );
+
+		result[ namespace ] = namespaceResult;
+	} );
+
+	return result;
+};

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
 		"predev": "npm run check-engines",
 		"dev": "npm run build:packages && concurrently \"cross-env webpack --watch\" \"npm run dev:packages\"",
 		"dev:packages": "node ./bin/packages/watch.js",
+		"docs:generate-data-reference": "node docs/data/tool",
 		"fixtures:clean": "rimraf \"core-blocks/test/fixtures/*.+(json|serialized.html)\"",
 		"fixtures:server-registered": "docker-compose run -w /var/www/html/wp-content/plugins/gutenberg --rm wordpress ./bin/get-server-blocks.php > core-blocks/test/server-registered.json",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
@@ -173,7 +174,6 @@
 		"test-unit:coverage-ci": "npm run test-unit -- --coverage --maxWorkers 1 && codecov",
 		"test-unit:watch": "npm run test-unit -- --watch",
 		"test-unit-php": "docker-compose run --rm wordpress_phpunit phpunit",
-		"test-unit-php-multisite": "docker-compose run -e WP_MULTISITE=1 --rm wordpress_phpunit phpunit",
-		"docs:generate-data-reference": "node docs/data/tool"
+		"test-unit-php-multisite": "docker-compose run -e WP_MULTISITE=1 --rm wordpress_phpunit phpunit"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -78,11 +78,13 @@
 		"core-js": "2.5.3",
 		"cross-env": "3.2.4",
 		"deep-freeze": "0.0.1",
+		"doctrine": "2.1.0",
 		"eslint": "4.16.0",
 		"eslint-config-wordpress": "2.0.0",
 		"eslint-plugin-jest": "21.5.0",
 		"eslint-plugin-jsx-a11y": "6.0.2",
 		"eslint-plugin-react": "7.7.0",
+		"espree": "3.5.4",
 		"extract-text-webpack-plugin": "4.0.0-beta.0",
 		"node-sass": "git://github.com/sass/node-sass.git#v4.7.0",
 		"pegjs": "0.10.0",
@@ -171,6 +173,7 @@
 		"test-unit:coverage-ci": "npm run test-unit -- --coverage --maxWorkers 1 && codecov",
 		"test-unit:watch": "npm run test-unit -- --watch",
 		"test-unit-php": "docker-compose run --rm wordpress_phpunit phpunit",
-		"test-unit-php-multisite": "docker-compose run -e WP_MULTISITE=1 --rm wordpress_phpunit phpunit"
+		"test-unit-php-multisite": "docker-compose run -e WP_MULTISITE=1 --rm wordpress_phpunit phpunit",
+		"docs:generate-data-reference": "node docs/data/tool"
 	}
 }


### PR DESCRIPTION
This PR adds docs generation for the data module's selectors/actions.

 * The docs live in `docs/data/*.md`
 * To regenerate the docs, we run `npm run docs:generate-data-reference`
 * It doesn't support the dynamic selectors/actions from the `core-data` module.
 * The output is printed as markdown.

It doesn't integrate with the Handbook yet but it should be possible to add a step to call this command line before doing the synchronization cc @pento 

Its output is markdown to ease integration into other docs systems like the handbook.

The docs can be gitignored at some point but I think it's fine to do the generation manually as a start.