### PR TITLE
Fix: when enter is pressed on title unallowed blocks may be inserted

### DIFF
--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -126,19 +126,22 @@ class PostTitle extends Component {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getEditedPostAttribute, getEditorSettings } = select( 'core/editor' );
+	const { canInsertBlockType, getEditedPostAttribute, getEditorSettings } = select( 'core/editor' );
 	const { getPostType } = select( 'core' );
+	const { getDefaultBlockName } = select( 'core/blocks' );
 	const postType = getPostType( getEditedPostAttribute( 'type' ) );
 	const { titlePlaceholder } = getEditorSettings();
+	const defaultBlockName = getDefaultBlockName();
 
 	return {
 		title: getEditedPostAttribute( 'title' ),
 		isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 		placeholder: titlePlaceholder,
+		canInsertDefaultBlock: canInsertBlockType( defaultBlockName ),
 	};
 } );
 
-const applyWithDispatch = withDispatch( ( dispatch ) => {
+const applyWithDispatch = withDispatch( ( dispatch, { canInsertDefaultBlock } ) => {
 	const {
 		insertDefaultBlock,
 		editPost,
@@ -149,7 +152,9 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 
 	return {
 		onEnterPress() {
-			insertDefaultBlock( undefined, undefined, 0 );
+			if ( canInsertDefaultBlock ) {
+				insertDefaultBlock( undefined, undefined, 0 );
+			}
 		},
 		onUpdate( title ) {
 			editPost( { title } );


### PR DESCRIPTION
## Description
When pressing enter in the title, the default block was always inserted. Even if it should not be possible to insert the default block because of a template lock or an allowed blocks change.

## How has this been tested?
I verified that in normal post/situations pressing enter on the title still inserts the default block (the paragraph).
I verified that if a template lock exists pressing enter on the title does not insert blocks.
Template lock code used:
e.g:
```
function myplugin_register_book_lock_post_type() {
    $args = array(
        'public' => true,
	  	'template_lock' => 'all',
        'label'  => 'Books Lock',
        'show_in_rest' => true,
        'template' => array(
            array( 'core/image', array(
            ) ),
            array( 'core/heading', array(
                'placeholder' => 'Add Author...',
            ) ),
            array( 'core/paragraph', array(
                'placeholder' => 'Add Description...',
            ) ),
        ),
    );
    register_post_type( 'book_lock', $args );
}
add_action( 'init', 'myplugin_register_book_lock_post_type' );
```

I verified that if the default block is not allowed because of a filter in the allowed blocks, pressing when on the titles does nothing.
Block filter code used.
```
add_filter( 'allowed_block_types', function( $allowed_block_types, $post ) {
	if ( $post->post_type === 'post' ) {
	    return $allowed_block_types;
	}
	return [ 'core/image', 'core/button' ];
}, 10, 2 );
```