### PR TITLE
Try/featured image improvements with alt text

### DIFF
--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -26,7 +26,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 			<div className="editor-post-featured-image">
 				{ !! featuredImageId &&
 					<MediaUpload
-						title={ postLabel.set_featured_image }
+						title={ __( 'Set featured image' ) }
 						onSelect={ onUpdateImage }
 						type="image"
 						modalClass="editor-post-featured-image__media-modal"
@@ -47,7 +47,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
 				<MediaUpload
-					title={ __( 'Replace Image' ) }
+					title={ __( 'Set featured image' ) }
 					onSelect={ onUpdateImage }
 					type="image"
 					modalClass="editor-post-featured-image__media-modal"

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -18,10 +18,6 @@ import './style.scss';
 import PostFeaturedImageCheck from './check';
 import MediaUpload from '../media-upload';
 
-// Used when labels from post type were not yet loaded or when they are not present.
-const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
-const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove featured image' );
-
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
 
@@ -51,13 +47,13 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
 				<MediaUpload
-					title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+					title={ __( 'Replace Image' ) }
 					onSelect={ onUpdateImage }
 					type="image"
 					modalClass="editor-post-featured-image__media-modal"
 					render={ ( { open } ) => (
 						<Button onClick={ open } isDefault isLarge>
-							{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							{ __( 'Replace Image' ) }
 						</Button>
 					) }
 				/>
@@ -65,24 +61,24 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				{ ! featuredImageId &&
 					<div>
 						<MediaUpload
-							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							title={ __( 'No image selected' ) }
 							onSelect={ onUpdateImage }
 							type="image"
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button className="editor-post-featured-image__toggle" onClick={ open }>
-									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+									{ __( 'No image selected' ) }
 								</Button>
 							) }
 						/>
 						<MediaUpload
-							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							title={ __( 'Add Image' ) }
 							onSelect={ onUpdateImage }
 							type="image"
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button onClick={ open } isDefault isLarge>
-									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+									{ __( 'Add Image' ) }
 								</Button>
 							) }
 						/>
@@ -90,7 +86,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				}
 				{ !! featuredImageId &&
 					<Button onClick={ onRemoveImage } isDefault isLarge>
-						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
+						{ __( 'Remove Image' ) }
 					</Button>
 				}
 			</div>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -18,6 +18,10 @@ import './style.scss';
 import PostFeaturedImageCheck from './check';
 import MediaUpload from '../media-upload';
 
+// Used when labels from post type were not yet loaded or when they are not present.
+const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
+const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove featured image' );
+
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
 
@@ -26,18 +30,21 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 			<div className="editor-post-featured-image">
 				{ !! featuredImageId &&
 					<MediaUpload
-						title={ __( 'Set featured image' ) }
+						title={ postLabel.set_featured_image }
 						onSelect={ onUpdateImage }
 						type="image"
 						modalClass="editor-post-featured-image__media-modal"
 						render={ ( { open } ) => (
-							<Button className="editor-post-featured-image__preview" onClick={ open }>
+							<Button className="editor-post-featured-image__preview" onClick={ open } isLink>
 								{ media &&
 									<ResponsiveWrapper
 										naturalWidth={ media.media_details.width }
 										naturalHeight={ media.media_details.height }
 									>
-										<img src={ media.source_url } alt={ __( 'Featured image' ) } />
+										<img
+											alt={ __( 'Replace ' + media.alt_text + ' featured image' ) }
+											src={ media.source_url }
+										/>
 									</ResponsiveWrapper>
 								}
 								{ ! media && <Spinner /> }
@@ -46,36 +53,26 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 					/>
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
-				<MediaUpload
-					title={ __( 'Set featured image' ) }
-					onSelect={ onUpdateImage }
-					type="image"
-					modalClass="editor-post-featured-image__media-modal"
-					render={ ( { open } ) => (
-						<Button onClick={ open } isDefault isLarge>
-							{ __( 'Replace Image' ) }
-						</Button>
-					) }
-				/>
+					<p className="editor-post-featured-image__howto">
+						{ __( 'Click the image to edit or update' ) }
+					</p>
 				}
 				{ ! featuredImageId &&
-					<div>
-						<MediaUpload
-							title={ __( 'Set featured image' ) }
-							onSelect={ onUpdateImage }
-							type="image"
-							modalClass="editor-post-featured-image__media-modal"
-							render={ ( { open } ) => (
-								<Button className="editor-post-featured-image__toggle" onClick={ open }>
-									{ __( 'Set featured image' ) }
-								</Button>
-							) }
-						/>
-					</div>
+					<MediaUpload
+						title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+						onSelect={ onUpdateImage }
+						type="image"
+						modalClass="editor-post-featured-image__media-modal"
+						render={ ( { open } ) => (
+							<Button className="editor-post-featured-image__toggle" onClick={ open } isLink>
+								{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							</Button>
+						) }
+					/>
 				}
 				{ !! featuredImageId &&
-					<Button onClick={ onRemoveImage } isDefault isLarge>
-						{ __( 'Remove Image' ) }
+					<Button className="editor-post-featured-image__toggle" onClick={ onRemoveImage } isLink>
+						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
 					</Button>
 				}
 			</div>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -67,18 +67,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button className="editor-post-featured-image__toggle" onClick={ open }>
-									{ __( 'No image selected' ) }
-								</Button>
-							) }
-						/>
-						<MediaUpload
-							title={ __( 'Add Image' ) }
-							onSelect={ onUpdateImage }
-							type="image"
-							modalClass="editor-post-featured-image__media-modal"
-							render={ ( { open } ) => (
-								<Button onClick={ open } isDefault isLarge>
-									{ __( 'Add Image' ) }
+									{ __( 'Set featured image' ) }
 								</Button>
 							) }
 						/>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -35,7 +35,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 						type="image"
 						modalClass="editor-post-featured-image__media-modal"
 						render={ ( { open } ) => (
-							<Button className="editor-post-featured-image__preview" onClick={ open } isLink>
+							<Button className="editor-post-featured-image__preview" onClick={ open }>
 								{ media &&
 									<ResponsiveWrapper
 										naturalWidth={ media.media_details.width }
@@ -50,25 +50,46 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 					/>
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
-					<p className="editor-post-featured-image__howto">
-						{ __( 'Click the image to edit or update' ) }
-					</p>
+				<MediaUpload
+					title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+					onSelect={ onUpdateImage }
+					type="image"
+					modalClass="editor-post-featured-image__media-modal"
+					render={ ( { open } ) => (
+						<Button onClick={ open } isDefault isLarge>
+							{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+						</Button>
+					) }
+				/>
 				}
 				{ ! featuredImageId &&
-					<MediaUpload
-						title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
-						onSelect={ onUpdateImage }
-						type="image"
-						modalClass="editor-post-featured-image__media-modal"
-						render={ ( { open } ) => (
-							<Button className="editor-post-featured-image__toggle" onClick={ open } isLink>
-								{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
-							</Button>
-						) }
-					/>
+					<div>
+						<MediaUpload
+							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							onSelect={ onUpdateImage }
+							type="image"
+							modalClass="editor-post-featured-image__media-modal"
+							render={ ( { open } ) => (
+								<Button className="editor-post-featured-image__toggle" onClick={ open }>
+									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+								</Button>
+							) }
+						/>
+						<MediaUpload
+							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							onSelect={ onUpdateImage }
+							type="image"
+							modalClass="editor-post-featured-image__media-modal"
+							render={ ( { open } ) => (
+								<Button onClick={ open } isDefault isLarge>
+									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+								</Button>
+							) }
+						/>
+					</div>
 				}
 				{ !! featuredImageId &&
-					<Button className="editor-post-featured-image__toggle" onClick={ onRemoveImage } isLink>
+					<Button onClick={ onRemoveImage } isDefault isLarge>
 						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
 					</Button>
 				}

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -24,6 +24,9 @@ const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove featured image' );
 
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
+	const featuredImageAltText = ( altText ) => {
+		return altText ? ' Current image: ' + altText : '';
+	};
 
 	return (
 		<PostFeaturedImageCheck>
@@ -42,7 +45,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 										naturalHeight={ media.media_details.height }
 									>
 										<img
-											alt={ __( 'Replace ' + media.alt_text + ' featured image' ) }
+											alt={ __( 'Replace featured image.' + featuredImageAltText( media.alt_text ) ) }
 											src={ media.source_url }
 										/>
 									</ResponsiveWrapper>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -25,7 +25,7 @@ const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove featured image' );
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
 	const featuredImageAltText = ( altText ) => {
-		return altText ? ' Current image: ' + altText : '';
+		return altText ? __( ' Current image: ' ) + altText : '';
 	};
 
 	return (
@@ -45,7 +45,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 										naturalHeight={ media.media_details.height }
 									>
 										<img
-											alt={ __( 'Replace featured image.' + featuredImageAltText( media.alt_text ) ) }
+											alt={ __( 'Replace featured image.' ) + featuredImageAltText( media.alt_text ) }
 											src={ media.source_url }
 										/>
 									</ResponsiveWrapper>

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -61,7 +61,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 				{ ! featuredImageId &&
 					<div>
 						<MediaUpload
-							title={ __( 'No image selected' ) }
+							title={ __( 'Set featured image' ) }
 							onSelect={ onUpdateImage }
 							type="image"
 							modalClass="editor-post-featured-image__media-modal"

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -7,6 +7,7 @@
 
 	// Space consecutive buttons evenly.
 	.components-button + .components-button {
+		display: block;
 		margin-top: 1em;
 	}
 
@@ -34,8 +35,4 @@
 	&:hover {
 		background-color: $light-gray-100;
 	}
-}
-
-.editor-post-featured-image__preview {
-
 }

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -7,8 +7,8 @@
 
 	// Space consecutive buttons evenly.
 	.components-button + .components-button {
-		display: block;
 		margin-top: 1em;
+		margin-right: 8px;
 	}
 
 	// Don't size up images beyond their intrinsic size.

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -1,33 +1,41 @@
 .editor-post-featured-image {
-	padding: 10px 0 0;
+	padding: 0;
 
 	.spinner {
 		margin: 0;
 	}
+
+	// Space consecutive buttons evenly.
+	.components-button + .components-button {
+		margin-top: 1em;
+	}
+
+	// Don't size up images beyond their intrinsic size.
+	.components-responsive-wrapper__content {
+		max-width: 100%;
+		width: auto;
+	}
+}
+
+.editor-post-featured-image__toggle,
+.editor-post-featured-image__preview {
+	display: block;
+	width: 100%;
+	padding: 0;
 }
 
 .editor-post-featured-image__toggle {
-	text-decoration: underline;
-	color: theme( secondary );
-
-	&:focus {
-		box-shadow: none;
-		outline: none;
-	}
+	border: 1px dashed $light-gray-900;
+	background-color: $light-gray-300;
+	line-height: 20px;
+	padding: $item-spacing 0;
+	text-align: center;
 
 	&:hover {
-		color: theme( primary );
+		background-color: $light-gray-100;
 	}
 }
 
 .editor-post-featured-image__preview {
-	display: block;
-	width: 100%;
-}
 
-.editor-post-featured-image__howto {
-	color: $dark-gray-300;
-	font-style: italic;
-	margin: 10px 0;
 }
-


### PR DESCRIPTION
## Description
Improved alternative text of featured images to describe the action of the button that wraps it, as well as identifies the featured image.

Branched off PR: #7200

## How has this been tested?
* Passes `npm run test`

## Types of changes
* JavaScript change

## Checklist:
- My code is tested.
- My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
