### PR TITLE
Exclude focused block from block completer options

### DIFF
--- a/editor/components/autocompleters/block.js
+++ b/editor/components/autocompleters/block.js
@@ -15,7 +15,7 @@ import BlockIcon from '../block-icon';
  *
  * @return {string} The UID of the parent where a newly inserted block would be placed.
  */
-function defaultGetBlockInsertionParent() {
+function defaultGetBlockInsertionParentUID() {
 	return select( 'core/editor' ).getBlockInsertionPoint().rootUID;
 }
 
@@ -47,7 +47,7 @@ function defaultGetSelectedBlockName() {
  */
 export function createBlockCompleter( {
 	// Allow store-based selectors to be overridden for unit test.
-	getBlockInsertionParent = defaultGetBlockInsertionParent,
+	getBlockInsertionParentUID = defaultGetBlockInsertionParentUID,
 	getInserterItems = defaultGetInserterItems,
 	getSelectedBlockName = defaultGetSelectedBlockName,
 } = {} ) {
@@ -57,7 +57,7 @@ export function createBlockCompleter( {
 		triggerPrefix: '/',
 		options() {
 			const selectedBlockName = getSelectedBlockName();
-			return getInserterItems( getBlockInsertionParent() ).filter(
+			return getInserterItems( getBlockInsertionParentUID() ).filter(
 				// Avoid offering to replace the current block with a block of the same type.
 				( inserterItem ) => selectedBlockName !== inserterItem.name
 			);

--- a/editor/components/autocompleters/test/block.js
+++ b/editor/components/autocompleters/test/block.js
@@ -11,18 +11,33 @@ import blockCompleter, { createBlockCompleter } from '../block';
 describe( 'block', () => {
 	it( 'should retrieve block options for current insertion point', () => {
 		const expectedOptions = [ {}, {}, {} ];
-		const mockGetBlockInsertionPoint = jest.fn( () => 'expected-insertion-point' );
+		const mockGetBlockInsertionParent = jest.fn( () => 'expected-insertion-point' );
 		const mockGetInserterItems = jest.fn( () => expectedOptions );
 
 		const completer = createBlockCompleter( {
-			getBlockInsertionPoint: mockGetBlockInsertionPoint,
+			getBlockInsertionParent: mockGetBlockInsertionParent,
 			getInserterItems: mockGetInserterItems,
+			getSelectedBlockName: () => 'non-existent-block-name',
 		} );
 
 		const actualOptions = completer.options();
-		expect( mockGetBlockInsertionPoint ).toHaveBeenCalled();
+		expect( mockGetBlockInsertionParent ).toHaveBeenCalled();
 		expect( mockGetInserterItems ).toHaveBeenCalledWith( 'expected-insertion-point' );
-		expect( actualOptions ).toBe( expectedOptions );
+		expect( actualOptions ).toEqual( expectedOptions );
+	} );
+
+	it( 'should exclude the currently selected block from the options', () => {
+		const option1 = { name: 'block-1' };
+		const option2CurrentlySelected = { name: 'block-2-currently-selected' };
+		const option3 = { name: 'block-3' };
+
+		const completer = createBlockCompleter( {
+			getBlockInsertionParent: () => 'ignored',
+			getInserterItems: () => [ option1, option2CurrentlySelected, option3 ],
+			getSelectedBlockName: () => 'block-2-currently-selected',
+		} );
+
+		expect( completer.options() ).toEqual( [ option1, option3 ] );
 	} );
 
 	it( 'should derive option keywords from block keywords and block title', () => {

--- a/editor/components/autocompleters/test/block.js
+++ b/editor/components/autocompleters/test/block.js
@@ -11,17 +11,17 @@ import blockCompleter, { createBlockCompleter } from '../block';
 describe( 'block', () => {
 	it( 'should retrieve block options for current insertion point', () => {
 		const expectedOptions = [ {}, {}, {} ];
-		const mockGetBlockInsertionParent = jest.fn( () => 'expected-insertion-point' );
+		const mockGetBlockInsertionParentUID = jest.fn( () => 'expected-insertion-point' );
 		const mockGetInserterItems = jest.fn( () => expectedOptions );
 
 		const completer = createBlockCompleter( {
-			getBlockInsertionParent: mockGetBlockInsertionParent,
+			getBlockInsertionParentUID: mockGetBlockInsertionParentUID,
 			getInserterItems: mockGetInserterItems,
 			getSelectedBlockName: () => 'non-existent-block-name',
 		} );
 
 		const actualOptions = completer.options();
-		expect( mockGetBlockInsertionParent ).toHaveBeenCalled();
+		expect( mockGetBlockInsertionParentUID ).toHaveBeenCalled();
 		expect( mockGetInserterItems ).toHaveBeenCalledWith( 'expected-insertion-point' );
 		expect( actualOptions ).toEqual( expectedOptions );
 	} );
@@ -32,7 +32,7 @@ describe( 'block', () => {
 		const option3 = { name: 'block-3' };
 
 		const completer = createBlockCompleter( {
-			getBlockInsertionParent: () => 'ignored',
+			getBlockInsertionParentUID: () => 'ignored',
 			getInserterItems: () => [ option1, option2CurrentlySelected, option3 ],
 			getSelectedBlockName: () => 'block-2-currently-selected',
 		} );


### PR DESCRIPTION
## Description
Today, the block completer offers a Paragraph option when invoked from a Paragraph block, offering to replace the current block with another of the same type. It is odd to see and takes a menu slot that could be filled with a useful option. This PR updates the block completer to exclude the current block type from its list of options.

<!-- Please describe what you have changed or added -->

## How has this been tested?
I added a unit test and ran the unit tests successfully. I also manually tested the block completer, observed the absence of the Paragraph option when using the completer from a `core/paragraph` block (the only place it _is_ used today), and successfully used the completer to insert a Quote block.

## Screenshots

### Before

<img width="739" alt="screen shot 2018-06-11 at 1 17 08 pm" src="https://user-images.githubusercontent.com/530877/41255114-552e2e36-6d7a-11e8-949e-7ccd5eceafb9.png">

### After

<img width="718" alt="screen shot 2018-06-11 at 1 40 31 pm" src="https://user-images.githubusercontent.com/530877/41256211-c7db136a-6d7d-11e8-9528-a76c1fab026a.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/
 -->
