### PR TITLE
React: Remove the usage of the componentWillMount lifecycle

### DIFF
--- a/components/higher-order/with-focus-return/index.js
+++ b/components/higher-order/with-focus-return/index.js
@@ -20,9 +20,6 @@ function withFocusReturn( WrappedComponent ) {
 
 			this.setIsFocusedTrue = () => this.isFocused = true;
 			this.setIsFocusedFalse = () => this.isFocused = false;
-		}
-
-		componentWillMount() {
 			this.activeElementOnMount = document.activeElement;
 		}
 

--- a/components/slot-fill/fill.js
+++ b/components/slot-fill/fill.js
@@ -11,7 +11,8 @@ import { Component, createPortal } from '@wordpress/element';
 let occurrences = 0;
 
 class Fill extends Component {
-	componentWillMount() {
+	constructor() {
+		super( ...arguments );
 		this.occurrence = ++occurrences;
 	}
 

--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -102,7 +102,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 				};
 			}
 
-			componentWillMount() {
+			componentDidMount() {
 				this.doServerSideRender();
 			}
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,7 +1,9 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
 ## 3.3.0
+
  - `useOnce: true` has been removed from the Block API. Please use `supports.multiple: false` instead.
+ - Serializing components using `componentWillMount` lifecycle method. Please use the constructor instead.
 
 ## 3.2.0
 

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@wordpress/deprecated": "^1.0.0-alpha.1",
 		"@wordpress/is-shallow-equal": "1.0.2",
 		"lodash": "4.17.5",
 		"react": "16.3.2",

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -31,6 +31,11 @@
 import { isEmpty, castArray, omit, kebabCase } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import { Fragment, RawHTML } from './';
@@ -440,6 +445,15 @@ export function renderNativeComponent( type, props, context = {} ) {
  */
 export function renderComponent( Component, props, context = {} ) {
 	const instance = new Component( props, context );
+
+	if ( typeof instance.componentWillMount === 'function' ) {
+		instance.componentWillMount();
+		deprecated( 'componentWillMount', {
+			version: '3.3',
+			alternative: 'the constructor',
+			plugin: 'Gutenberg',
+		} );
+	}
 
 	if ( typeof instance.getChildContext === 'function' ) {
 		Object.assign( context, instance.getChildContext() );

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -441,10 +441,6 @@ export function renderNativeComponent( type, props, context = {} ) {
 export function renderComponent( Component, props, context = {} ) {
 	const instance = new Component( props, context );
 
-	if ( typeof instance.componentWillMount === 'function' ) {
-		instance.componentWillMount();
-	}
-
 	if ( typeof instance.getChildContext === 'function' ) {
 		Object.assign( context, instance.getChildContext() );
 	}

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -303,7 +303,7 @@ describe( 'renderNativeComponent()', () => {
 } );
 
 describe( 'renderComponent()', () => {
-	it( 'calls constructor and componentWillMount', () => {
+	it( 'calls constructor', () => {
 		class Example extends Component {
 			constructor() {
 				super( ...arguments );
@@ -311,18 +311,14 @@ describe( 'renderComponent()', () => {
 				this.constructed = 'constructed';
 			}
 
-			componentWillMount() {
-				this.willMounted = 'willMounted';
-			}
-
 			render() {
-				return this.constructed + this.willMounted;
+				return this.constructed;
 			}
 		}
 
 		const result = renderComponent( Example, {} );
 
-		expect( result ).toBe( 'constructedwillMounted' );
+		expect( result ).toBe( 'constructed' );
 	} );
 
 	it( 'does not call componentDidMount', () => {

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -303,7 +303,7 @@ describe( 'renderNativeComponent()', () => {
 } );
 
 describe( 'renderComponent()', () => {
-	it( 'calls constructor', () => {
+	it( 'calls constructor and componentWillMount', () => {
 		class Example extends Component {
 			constructor() {
 				super( ...arguments );
@@ -311,14 +311,19 @@ describe( 'renderComponent()', () => {
 				this.constructed = 'constructed';
 			}
 
+			componentWillMount() {
+				this.willMounted = 'willMounted';
+			}
+
 			render() {
-				return this.constructed;
+				return this.constructed + this.willMounted;
 			}
 		}
 
 		const result = renderComponent( Example, {} );
 
-		expect( result ).toBe( 'constructed' );
+		expect( console ).toHaveWarned();
+		expect( result ).toBe( 'constructedwillMounted' );
 	} );
 
 	it( 'does not call componentDidMount', () => {


### PR DESCRIPTION
Together with #7280 #7206 This PR drops the componentWillMount lifecycle method from all our components.

**Testing instructions**

  - check that popovers return focus properly to the called (keyboard navigation)
  - check that fills show up properly (block toolbars for instance)
 