### PR TITLE
Add es5 samples to edit-post and plugins

### DIFF
--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -115,14 +115,14 @@ var __ = wp.i18n.__;
 var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
 var el = wp.element.createElement;
 
-function MySidebarMoreMenuItem(){
+function MySidebarMoreMenuItem() {
 	return el(
 		PluginSidebarMoreMenuItem,
 		{
 			target: 'my-sidebar',
 			icon: 'smiley',
 		},
-		'My sidebar title'
+		__( 'My sidebar title' )
 	)
 }
 ```
@@ -176,7 +176,7 @@ var __ = wp.i18n.__;
 var PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;
 var el = wp.element.createElement;
 
-function MyPluginPostStatusInfo(){
+function MyPluginPostStatusInfo() {
 	return el(
 		PluginPostStatusInfo,
 		{
@@ -225,7 +225,7 @@ var __ = wp.i18n.__;
 var PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;
 var el = wp.element.createElement;
 
-function MyPluginPrePublishPanel(){
+function MyPluginPrePublishPanel() {
 	return el(
 		PluginPrePublishPanel,
 		{
@@ -294,7 +294,7 @@ var __ = wp.i18n.__;
 var PluginPostPublishPanel = wp.editPost.PluginPostPublishPanel;
 var el = wp.element.createElement;
 
-function MyPluginPostPublishPanel(){
+function MyPluginPostPublishPanel() {
 	return el(
 		PluginPostPublishPanel,
 		{

--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -20,6 +20,34 @@ wp.data.dispatch( 'core/edit-post' ).openGeneralSidebar( 'plugin-name/sidebar-na
 
 _Example:_
 
+{% codetabs %}
+
+{% ES5 %}
+```js
+var __ = wp.i18n.__;
+var el = wp.element.createElement;
+var PanelBody = wp.components.PanelBody;
+var PluginSidebar = wp.editPost.PluginSidebar;
+
+
+function MyPluginSidebar() {
+	return el(
+			PluginSidebar,
+			{
+				name: 'my-sidebar',
+				title: 'My sidebar title',
+				icon: 'smiley',
+			},
+			el(
+				PanelBody,
+				{},
+				__( 'My sidebar content' )
+			)
+	);
+}
+```
+
+{% ESNext %}
 ```jsx
 const { __ } = wp.i18n;
 const { PanelBody } = wp.components;
@@ -37,6 +65,7 @@ const MyPluginSidebar = () => (
 	</PluginSidebar>
 );
 ```
+{% end %}
 
 #### Props
 
@@ -78,6 +107,27 @@ The text within the component appears as the menu item label.
 
 _Example:_
 
+{% codetabs %}
+
+{% ES5 %}
+```js
+var __ = wp.i18n.__;
+var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
+var el = wp.element.createElement;
+
+function MySidebarMoreMenuItem(){
+	return el(
+		PluginSidebarMoreMenuItem,
+		{
+			target: 'my-sidebar',
+			icon: 'smiley',
+		},
+		'My sidebar title'
+	)
+}
+```
+
+{% ESNext %}
 ```jsx
 const { __ } = wp.i18n;
 const { PluginSidebarMoreMenuItem } = wp.editPost;
@@ -91,6 +141,7 @@ const MySidebarMoreMenuItem = () => (
 	</PluginSidebarMoreMenuItem>
 );
 ```
+{% end %}
 
 #### Props
 
@@ -116,6 +167,27 @@ Renders a row in the Status & Visibility panel of the Document sidebar.
 It should be noted that this is named and implemented around the function it serves and not its location, which may change in future iterations.
 
 _Example:_
+
+{% codetabs %}
+
+{% ES5 %}
+```js
+var __ = wp.i18n.__;
+var PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;
+var el = wp.element.createElement;
+
+function MyPluginPostStatusInfo(){
+	return el(
+		PluginPostStatusInfo,
+		{
+			className: 'my-plugin-post-status-info',
+		},
+		__( 'My post status info' )
+	)
+}
+```
+
+{% ESNext %}
 ```jsx
 const { __ } = wp.i18n;
 const { PluginPostStatusInfo } = wp.editPost;
@@ -128,6 +200,7 @@ const MyPluginPostStatusInfo = () => (
 	</PluginPostStatusInfo>
 );
 ```
+{% end %}
 
 #### Props
 
@@ -144,6 +217,28 @@ Renders provided content to the pre-publish side panel in the publish flow (side
 
 _Example:_
 
+{% codetabs %}
+
+{% ES5 %}
+```js
+var __ = wp.i18n.__;
+var PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;
+var el = wp.element.createElement;
+
+function MyPluginPrePublishPanel(){
+	return el(
+		PluginPrePublishPanel,
+		{
+			className: 'my-plugin-pre-publish-panel',
+			title: __( 'My panel title' ),
+			initialOpen: true,
+		},
+		__( 'My panel content' )
+	);
+}
+```
+
+{% ESNext %}
 ```jsx
 const { __ } = wp.i18n;
 const { PluginPrePublishPanel } = wp.editPost;
@@ -158,6 +253,7 @@ const MyPluginPrePublishPanel = () => (
 	</PluginPrePublishPanel>
 );
 ```
+{% end %}
 
 #### Props
 
@@ -190,6 +286,28 @@ Renders provided content to the post-publish panel in the publish flow (side pan
 
 _Example:_
 
+{% codetabs %}
+
+{% ES5 %}
+```js
+var __ = wp.i18n.__;
+var PluginPostPublishPanel = wp.editPost.PluginPostPublishPanel;
+var el = wp.element.createElement;
+
+function MyPluginPostPublishPanel(){
+	return el(
+		PluginPostPublishPanel,
+		{
+			className: 'my-plugin-post-publish-panel',
+			title: __( 'My panel title' ),
+			initialOpen: true,
+		},
+		__( 'My panel content' )
+	);
+}
+```
+
+{% ESNext %}
 ```jsx
 const { __ } = wp.i18n;
 const { PluginPostPublishPanel } = wp.editPost;
@@ -204,6 +322,7 @@ const MyPluginPostPublishPanel = () => (
 	</PluginPostPublishPanel>
 );
 ```
+{% end %}
 
 #### Props
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -20,7 +20,43 @@ This method takes two arguments:
 See [the edit-post module documentation](../edit-post/) for available components.
 
 _Example:_
+{% codetabs %}
+{% ES5 %}
+```js
+var el = wp.element.createElement;
+var Fragment = wp.element.Fragment;
+var PluginSidebar = wp.editPost.PluginSidebar;
+var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
+var registerPlugin = wp.plugins.registerPlugin;
 
+function Component(){
+	return el(
+		Fragment,
+		{},
+		el(
+			PluginSidebarMoreMenuItem,
+			{
+				target: 'sidebar-name',
+			},
+			'My Sidebar'
+		),
+		el(
+			PluginSidebar,
+			{
+				name: 'sidebar-name',
+				title: 'My Sidebar',
+			},
+			'Content of the sidebar'
+		)
+	);
+}
+registerPlugin( 'plugin-name', {
+	icon: 'smiley',
+	render: Component,
+} );
+```
+
+{% ESNext %}
 ```jsx
 const { Fragment } = wp.element;
 const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
@@ -47,6 +83,7 @@ registerPlugin( 'plugin-name', {
 	render: Component,
 } );
 ```
+{% end %}
 
 #### `wp.plugins.unregisterPlugin( name: string )`
 
@@ -71,6 +108,24 @@ unregisterPlugin( 'plugin-name' );
 A component that renders all registered plugins in a hidden div.
 
 _Example:_
+{% codetabs %}
+
+{% ES5 %}
+```js
+var el = wp.element.createElement;
+var PluginArea = wp.plugins.PluginArea;
+
+function Layout(){
+	return el(
+		'div',
+		{},
+		'Content of the page',
+		PluginArea
+	);
+}
+```
+
+{% ESNext %}
 
 ```jsx
 const { PluginArea } = wp.plugins;
@@ -82,3 +137,4 @@ const Layout = () => (
 	</div>
 );
 ```
+{% end %}

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -29,7 +29,7 @@ var PluginSidebar = wp.editPost.PluginSidebar;
 var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
 var registerPlugin = wp.plugins.registerPlugin;
 
-function Component(){
+function Component() {
 	return el(
 		Fragment,
 		{},
@@ -95,11 +95,23 @@ This method takes one argument:
 
 _Example:_
 
+{% codetabs %}
+
+{% ES5 %}
+```js
+var unregisterPlugin = wp.plugins.unregisterPlugin;
+
+unregisterPlugin( 'plugin-name' );
+```
+
+{% ESNext %}
+
 ```js
 const { unregisterPlugin } = wp.plugins;
 
 unregisterPlugin( 'plugin-name' );
 ```
+{% end %}
 
 ### Components
 
@@ -115,7 +127,7 @@ _Example:_
 var el = wp.element.createElement;
 var PluginArea = wp.plugins.PluginArea;
 
-function Layout(){
+function Layout() {
 	return el(
 		'div',
 		{},


### PR DESCRIPTION
## Description
This PR adds es5 samples to edit-post/README.md and plugins/README.md so developers can easily test the samples without any build system.

## How has this been tested?
I verified in the browser console that the samples work as expected.

For some samples I add to add a final code block after the sample with the following format:
```
wp.plugins.registerPlugin( 'plugin-name', {
	icon: 'smiley',
	render: ###COMPONENT_TO_TEST###,
} );
```