### PR TITLE
Block API: Move useOnce to supports.useOnce

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -161,10 +161,11 @@ export function registerBlockType( name, settings ) {
 	if ( 'useOnce' in settings ) {
 		deprecated( 'useOnce', {
 			version: '3.3',
-			alternative: 'supports.useOnce',
+			alternative: 'supports.multiple',
 			plugin: 'Gutenberg',
+			hint: 'useOnce property in the settings param passed to wp.block.registerBlockType.',
 		} );
-		set( settings, [ 'supports', 'useOnce' ], settings.useOnce );
+		set( settings, [ 'supports', 'multiple' ], ! settings.useOnce );
 	}
 
 	dispatch( 'core/blocks' ).addBlockTypes( settings );

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -158,6 +158,15 @@ export function registerBlockType( name, settings ) {
 		set( settings, [ 'supports', 'inserter' ], ! settings.isPrivate );
 	}
 
+	if ( 'useOnce' in settings ) {
+		deprecated( 'useOnce', {
+			version: '3.3',
+			alternative: 'supports.useOnce',
+			plugin: 'Gutenberg',
+		} );
+		set( settings, [ 'supports', 'useOnce' ], settings.useOnce );
+	}
+
 	dispatch( 'core/blocks' ).addBlockTypes( settings );
 
 	return settings;

--- a/core-blocks/more/index.js
+++ b/core-blocks/more/index.js
@@ -26,12 +26,11 @@ export const settings = {
 
 	category: 'layout',
 
-	useOnce: true,
-
 	supports: {
 		customClassName: false,
 		className: false,
 		html: false,
+		useOnce: true,
 	},
 
 	attributes: {

--- a/core-blocks/more/index.js
+++ b/core-blocks/more/index.js
@@ -30,7 +30,7 @@ export const settings = {
 		customClassName: false,
 		className: false,
 		html: false,
-		useOnce: true,
+		multiple: false,
 	},
 
 	attributes: {

--- a/core-blocks/subhead/index.js
+++ b/core-blocks/subhead/index.js
@@ -27,7 +27,9 @@ export const settings = {
 
 	category: 'common',
 
-	useOnce: true,
+	supports: {
+		useOnce: true,
+	},
 
 	attributes: {
 		content: {

--- a/core-blocks/subhead/index.js
+++ b/core-blocks/subhead/index.js
@@ -28,7 +28,7 @@ export const settings = {
 	category: 'common',
 
 	supports: {
-		useOnce: true,
+		multiple: false,
 	},
 
 	attributes: {

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -322,11 +322,11 @@ html: false,
 inserter: false,
 ```
 
-- `useOnce` (default `false`): A once-only block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A once-only block's icon is automatically dimmed (unclickable) to prevent multiple instances.
+- `multiple` (default `true`): A non-multiple block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A non-multiple block's icon is automatically dimmed (unclickable) to prevent multiple instances.
 
 ```js
 // Use the block just once per post
-useOnce: true,
+multiple: false,
 ```
 
 ## Edit and Save

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -267,17 +267,6 @@ transforms: {
 
 To control the priority with which a transform is applied, define a `priority` numeric property on your transform object, where a lower value will take precedence over higher values. This behaves much like a [WordPress hook](https://codex.wordpress.org/Plugin_API#Hook_to_WordPress). Like hooks, the default priority is `10` when not otherwise set.
 
-#### useOnce (optional)
-
-* **Type:** `Bool`
-* **Default:** `false`
-
-A once-only block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A once-only block's icon is automatically dimmed (unclickable) to prevent multiple instances.
-
-```js
-// Use the block just once per post
-useOnce: true,
-```
 
 #### parent (optional)
 
@@ -331,6 +320,13 @@ html: false,
 ```js
 // Hide this block from the inserter.
 inserter: false,
+```
+
+- `useOnce` (default `false`): A once-only block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A once-only block's icon is automatically dimmed (unclickable) to prevent multiple instances.
+
+```js
+// Use the block just once per post
+useOnce: true,
 ```
 
 ## Edit and Save

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,7 +1,7 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
 ## 3.3.0
- - `useOnce: true` has been moved into the `supports` object. Please use `supports.useOnce: true` instead.
+ - `useOnce: true` has been removed from the Block API. Please use `supports.multiple: false` instead.
 
 
 ## 3.2.0

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,5 +1,9 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 3.3.0
+ - `useOnce: true` has been moved into the `supports` object. Please use `supports.useOnce: true` instead.
+
+
 ## 3.2.0
 
  - `wp.data.withRehydratation` has been renamed to `wp.data.withRehydration`.

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -3,7 +3,6 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 ## 3.3.0
  - `useOnce: true` has been removed from the Block API. Please use `supports.multiple: false` instead.
 
-
 ## 3.2.0
 
  - `wp.data.withRehydratation` has been renamed to `wp.data.withRehydration`.

--- a/edit-post/hooks/index.js
+++ b/edit-post/hooks/index.js
@@ -3,4 +3,4 @@
  */
 import './blocks';
 import './more-menu';
-import './validate-use-once';
+import './validate-multiple-use';

--- a/edit-post/hooks/validate-multiple-use/index.js
+++ b/edit-post/hooks/validate-multiple-use/index.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 
 const enhance = compose(
 	/*
-	 * For blocks whose block type supports `useOnce`, provides the wrapped
+	 * For blocks whose block type doesn't support `multiple`, provides the wrapped
 	 * component with `originalBlockUid` -- a reference to the first block of
 	 * the same type in the content -- if and only if that "original" block is
 	 * not the current one. Thus, an inexisting `originalBlockUid` prop signals
@@ -34,11 +34,11 @@ const enhance = compose(
 	 */
 	withSelect( ( select, block ) => {
 		const blocks = select( 'core/editor' ).getBlocks();
-		const useOnce = hasBlockSupport( block.name, 'useOnce', false );
+		const multiple = hasBlockSupport( block.name, 'multiple', false );
 
-		// For block types with no `useOnce` support, there is no "original
+		// For block types with `multiple` support, there is no "original
 		// block" to be found in the content, as the block itself is valid.
-		if ( ! useOnce ) {
+		if ( multiple ) {
 			return {};
 		}
 
@@ -55,7 +55,7 @@ const enhance = compose(
 	} ) ),
 );
 
-const withUseOnceValidation = createHigherOrderComponent( ( BlockEdit ) => {
+const withMultipleValidation = createHigherOrderComponent( ( BlockEdit ) => {
 	return enhance( ( {
 		originalBlockUid,
 		selectFirst,
@@ -73,7 +73,7 @@ const withUseOnceValidation = createHigherOrderComponent( ( BlockEdit ) => {
 				<BlockEdit key="block-edit" { ...props } />
 			</div>,
 			<Warning
-				key="use-once-warning"
+				key="multiple-use-warning"
 				actions={ [
 					<Button key="find-original" isLarge onClick={ selectFirst }>
 						{ __( 'Find original' ) }
@@ -100,7 +100,7 @@ const withUseOnceValidation = createHigherOrderComponent( ( BlockEdit ) => {
 			</Warning>,
 		];
 	} );
-}, 'withUseOnceValidation' );
+}, 'withMultipleValidation' );
 
 /**
  * Given a base block name, returns the default block type to which to offer
@@ -126,6 +126,6 @@ function getOutboundType( blockName ) {
 
 addFilter(
 	'blocks.BlockEdit',
-	'core/validation/useOnce',
-	withUseOnceValidation
+	'core/validation/multiple',
+	withMultipleValidation
 );

--- a/edit-post/hooks/validate-multiple-use/index.js
+++ b/edit-post/hooks/validate-multiple-use/index.js
@@ -34,7 +34,7 @@ const enhance = compose(
 	 */
 	withSelect( ( select, block ) => {
 		const blocks = select( 'core/editor' ).getBlocks();
-		const multiple = hasBlockSupport( block.name, 'multiple', false );
+		const multiple = hasBlockSupport( block.name, 'multiple', true );
 
 		// For block types with `multiple` support, there is no "original
 		// block" to be found in the content, as the block itself is valid.

--- a/edit-post/hooks/validate-use-once/index.js
+++ b/edit-post/hooks/validate-use-once/index.js
@@ -6,7 +6,13 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createBlock, getBlockType, findTransform, getBlockTransforms } from '@wordpress/blocks';
+import {
+	createBlock,
+	findTransform,
+	getBlockTransforms,
+	getBlockType,
+	hasBlockSupport,
+} from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Warning } from '@wordpress/editor';
@@ -16,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 
 const enhance = compose(
 	/*
-	 * For blocks whose block type defines `useOnce`, provides the wrapped
+	 * For blocks whose block type supports `useOnce`, provides the wrapped
 	 * component with `originalBlockUid` -- a reference to the first block of
 	 * the same type in the content -- if and only if that "original" block is
 	 * not the current one. Thus, an inexisting `originalBlockUid` prop signals
@@ -28,9 +34,9 @@ const enhance = compose(
 	 */
 	withSelect( ( select, block ) => {
 		const blocks = select( 'core/editor' ).getBlocks();
-		const { useOnce } = getBlockType( block.name );
+		const useOnce = hasBlockSupport( block.name, 'useOnce', false );
 
-		// For block types with no `useOnce` restriction, there is no "original
+		// For block types with no `useOnce` support, there is no "original
 		// block" to be found in the content, as the block itself is valid.
 		if ( ! useOnce ) {
 			return {};

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -14,7 +14,7 @@ import { cloneBlock, hasBlockSupport } from '@wordpress/blocks';
 
 export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, role } ) {
 	const canDuplicate = every( blocks, ( block ) => {
-		return hasBlockSupport( block.name, 'multiple', false );
+		return hasBlockSupport( block.name, 'multiple', true );
 	} );
 	if ( isLocked || ! canDuplicate ) {
 		return null;

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -10,12 +10,11 @@ import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { cloneBlock, getBlockType } from '@wordpress/blocks';
+import { cloneBlock, hasBlockSupport } from '@wordpress/blocks';
 
 export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, role } ) {
 	const canDuplicate = every( blocks, ( block ) => {
-		const type = getBlockType( block.name );
-		return ! type.useOnce;
+		return ! hasBlockSupport( block.name, 'useOnce', false );
 	} );
 	if ( isLocked || ! canDuplicate ) {
 		return null;

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -14,7 +14,7 @@ import { cloneBlock, hasBlockSupport } from '@wordpress/blocks';
 
 export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isLocked, small = false, role } ) {
 	const canDuplicate = every( blocks, ( block ) => {
-		return ! hasBlockSupport( block.name, 'useOnce', false );
+		return hasBlockSupport( block.name, 'multiple', false );
 	} );
 	if ( isLocked || ! canDuplicate ) {
 		return null;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1474,7 +1474,7 @@ export const getInserterItems = createSelector(
 			const id = blockType.name;
 
 			let isDisabled = false;
-			if ( ! hasBlockSupport( blockType.name, 'multiple', false ) ) {
+			if ( ! hasBlockSupport( blockType.name, 'multiple', true ) ) {
 				isDisabled = some( getBlocks( state ), { name: blockType.name } );
 			}
 

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1474,7 +1474,7 @@ export const getInserterItems = createSelector(
 			const id = blockType.name;
 
 			let isDisabled = false;
-			if ( blockType.useOnce ) {
+			if ( hasBlockSupport( blockType.name, 'useOnce', false ) ) {
 				isDisabled = some( getBlocks( state ), { name: blockType.name } );
 			}
 

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1474,7 +1474,7 @@ export const getInserterItems = createSelector(
 			const id = blockType.name;
 
 			let isDisabled = false;
-			if ( hasBlockSupport( blockType.name, 'useOnce', false ) ) {
+			if ( ! hasBlockSupport( blockType.name, 'multiple', false ) ) {
 				isDisabled = some( getBlocks( state ), { name: blockType.name } );
 			}
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -125,7 +125,9 @@ describe( 'selectors', () => {
 			title: 'Test Block B',
 			icon: 'test',
 			keywords: [ 'testing' ],
-			useOnce: true,
+			supports: {
+				useOnce: true,
+			},
 		} );
 
 		registerBlockType( 'core/test-block-c', {

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -126,7 +126,7 @@ describe( 'selectors', () => {
 			icon: 'test',
 			keywords: [ 'testing' ],
 			supports: {
-				useOnce: true,
+				multiple: false,
 			},
 		} );
 
@@ -3106,7 +3106,7 @@ describe( 'selectors', () => {
 			] );
 		} );
 
-		it( 'should set isDisabled when a block with useOnce has been used', () => {
+		it( 'should set isDisabled when a block with `multiple: false` has been used', () => {
 			const state = {
 				editor: {
 					present: {


### PR DESCRIPTION
## Description
This PR moves the Block API `useOnce` property into the `supports` object.
I added a deprecated message at the block registration, added a notice to the handbook and updated the docs.
Fixes #6795 


