### PR TITLE
Add end 2 end test to blocks.BlockEdit filter

### DIFF
--- a/test/e2e/specs/hooks-api.test.js
+++ b/test/e2e/specs/hooks-api.test.js
@@ -24,7 +24,7 @@ describe( 'Using Hooks API', () => {
 	it( 'Should contain a reset block button on the sidebar', async () => {
 		await page.click( '.editor-default-block-appender__content' );
 		await page.keyboard.type( 'First paragraph' );
-		expect( await page.$( '.edit-post-sidebar .reset-block-button' ) ).not.toBeNull();
+		expect( await page.$( '.edit-post-sidebar .e2e-reset-block-button' ) ).not.toBeNull();
 	} );
 
 	it( 'Pressing reset block button resets the block', async () => {
@@ -32,7 +32,7 @@ describe( 'Using Hooks API', () => {
 		await page.keyboard.type( 'First paragraph' );
 		const paragraphContent = await page.$eval( 'div[data-type="core/paragraph"] p', ( element ) => element.textContent );
 		expect( paragraphContent ).toEqual( 'First paragraph' );
-		await page.click( '.edit-post-sidebar .reset-block-button' );
+		await page.click( '.edit-post-sidebar .e2e-reset-block-button' );
 		const newParagraphContent = await page.$eval( 'div[data-type="core/paragraph"] p', ( element ) => element.textContent );
 		expect( newParagraphContent ).toEqual( '' );
 	} );

--- a/test/e2e/specs/hooks-api.test.js
+++ b/test/e2e/specs/hooks-api.test.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage } from '../support/utils';
+import { activatePlugin, deactivatePlugin } from '../support/plugins';
+
+describe( 'Using Hooks API', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await activatePlugin( 'gutenberg-test-hooks-api' );
+	} );
+
+	afterAll( async () => {
+		await newDesktopBrowserPage();
+		await deactivatePlugin( 'gutenberg-test-hooks-api' );
+	} );
+
+	beforeEach( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+	} );
+
+	it( 'Should contain a reset block button on the sidebar', async () => {
+		await page.click( '.editor-default-block-appender__content' );
+		await page.keyboard.type( 'First paragraph' );
+		expect( await page.$( '.edit-post-sidebar .reset-block-button' ) ).not.toBeNull();
+	} );
+
+	it( 'Pressing reset block button resets the block', async () => {
+		await page.click( '.editor-default-block-appender__content' );
+		await page.keyboard.type( 'First paragraph' );
+		const paragraphContent = await page.$eval( 'div[data-type="core/paragraph"] p', ( element ) => element.textContent );
+		expect( paragraphContent ).toEqual( 'First paragraph' );
+		await page.click( '.edit-post-sidebar .reset-block-button' );
+		const newParagraphContent = await page.$eval( 'div[data-type="core/paragraph"] p', ( element ) => element.textContent );
+		expect( newParagraphContent ).toEqual( '' );
+	} );
+} );

--- a/test/e2e/test-plugins/hooks-api.php
+++ b/test/e2e/test-plugins/hooks-api.php
@@ -10,12 +10,12 @@ wp_enqueue_script(
 	'gutenberg-test-hooks-api',
 	plugins_url( 'hooks-api/index.js', __FILE__ ),
 	array(
+		'wp-blocks',
 		'wp-components',
-		'wp-data',
 		'wp-element',
-		'wp-edit-post',
-		'wp-i18n',
-		'wp-plugins',
+		'wp-editor',
+		'wp-hooks',
+		'wp-i18n'
 	),
 	filemtime( plugin_dir_path( __FILE__ ) . 'hooks-api/index.js' ),
 	true

--- a/test/e2e/test-plugins/hooks-api.php
+++ b/test/e2e/test-plugins/hooks-api.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Hooks API
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-hooks-api
+ */
+wp_enqueue_script(
+	'gutenberg-test-hooks-api',
+	plugins_url( 'hooks-api/index.js', __FILE__ ),
+	array(
+		'wp-components',
+		'wp-data',
+		'wp-element',
+		'wp-edit-post',
+		'wp-i18n',
+		'wp-plugins',
+	),
+	filemtime( plugin_dir_path( __FILE__ ) . 'hooks-api/index.js' ),
+	true
+);

--- a/test/e2e/test-plugins/hooks-api/index.js
+++ b/test/e2e/test-plugins/hooks-api/index.js
@@ -1,0 +1,37 @@
+( function() {
+	var el = wp.element.createElement;
+	var Fragment = wp.element.Fragment;
+	var Button = wp.components.Button;
+	var InspectorControls = wp.editor.InspectorControls;
+	var addFilter = wp.hooks.addFilter;
+	var createBlock = wp.blocks.createBlock;
+	var __ = wp.i18n.__;
+
+	function ResetBlockUI( props ){
+		return el(
+			Button,
+			{
+				className: 'reset-block-button',
+				isDefault: true,
+				isLarge: true,
+				onClick: function(){
+					var emptyBlock = createBlock( props.name );
+					props.onReplace( emptyBlock );
+				}
+			},
+			__( 'Reset Block' )
+		);
+	}
+
+	function resetBlockFilter( BlockEdit ){
+		return function( props ){
+			return el(
+				Fragment,
+				{},
+				el( InspectorControls, {}, el( ResetBlockUI, props )  ),
+				el( BlockEdit, props )
+			);
+		};
+	}
+	addFilter( 'blocks.BlockEdit', 'demo/resetBlock', resetBlockFilter, 100 );
+} )();

--- a/test/e2e/test-plugins/hooks-api/index.js
+++ b/test/e2e/test-plugins/hooks-api/index.js
@@ -2,6 +2,7 @@
 	var el = wp.element.createElement;
 	var Fragment = wp.element.Fragment;
 	var Button = wp.components.Button;
+	var PanelBody = wp.components.PanelBody;
 	var InspectorControls = wp.editor.InspectorControls;
 	var addFilter = wp.hooks.addFilter;
 	var createBlock = wp.blocks.createBlock;
@@ -9,17 +10,21 @@
 
 	function ResetBlockButton( props ) {
 		return el(
-			Button,
-			{
-				className: 'e2e-reset-block-button',
-				isDefault: true,
-				isLarge: true,
-				onClick: function() {
-					var emptyBlock = createBlock( props.name );
-					props.onReplace( emptyBlock );
-				}
-			},
-			__( 'Reset Block' )
+			PanelBody,
+			{},
+			el(
+				Button,
+				{
+					className: 'e2e-reset-block-button',
+					isDefault: true,
+					isLarge: true,
+					onClick: function() {
+						var emptyBlock = createBlock( props.name );
+						props.onReplace( emptyBlock );
+					}
+				},
+				__( 'Reset Block' )
+			)
 		);
 	}
 
@@ -34,7 +39,8 @@
 					el(
 						ResetBlockButton,
 						{
-							name: props.name
+							name: props.name,
+							onReplace: props.onReplace
 						}
 					)
 				),

--- a/test/e2e/test-plugins/hooks-api/index.js
+++ b/test/e2e/test-plugins/hooks-api/index.js
@@ -7,14 +7,14 @@
 	var createBlock = wp.blocks.createBlock;
 	var __ = wp.i18n.__;
 
-	function ResetBlockUI( props ){
+	function ResetBlockButton( props ) {
 		return el(
 			Button,
 			{
-				className: 'reset-block-button',
+				className: 'e2e-reset-block-button',
 				isDefault: true,
 				isLarge: true,
-				onClick: function(){
+				onClick: function() {
 					var emptyBlock = createBlock( props.name );
 					props.onReplace( emptyBlock );
 				}
@@ -23,15 +23,33 @@
 		);
 	}
 
-	function resetBlockFilter( BlockEdit ){
-		return function( props ){
+	function addResetBlockButton( BlockEdit ) {
+		return function( props ) {
 			return el(
 				Fragment,
 				{},
-				el( InspectorControls, {}, el( ResetBlockUI, props )  ),
-				el( BlockEdit, props )
+				el(
+					InspectorControls,
+					{},
+					el(
+						ResetBlockButton,
+						{
+							name: props.name
+						}
+					)
+				),
+				el(
+					BlockEdit,
+					props
+				)
 			);
 		};
 	}
-	addFilter( 'blocks.BlockEdit', 'demo/resetBlock', resetBlockFilter, 100 );
+
+	addFilter(
+		'blocks.BlockEdit',
+		'e2e/hooks-api/add-reset-block-button',
+		addResetBlockButton,
+		100
+	);
 } )();


### PR DESCRIPTION
## Description
Test PR adds and e2e test to blocks.BlockEdit. We test a sample plugin that adds a Reset Block button in the inspector to all blocks. When pressed this button resets a block to the default values.

## How has this been tested?
I Verified the new end 2 end passes with success and that the test plugin works well.
