### PR TITLE
Add allowedBlocksMiddleware

### DIFF
--- a/packages/editor/src/components/inner-blocks/index.js
+++ b/packages/editor/src/components/inner-blocks/index.js
@@ -154,9 +154,9 @@ InnerBlocks = compose( [
 			replaceInnerBlocks( blocks ) {
 				const clientIds = map( block.innerBlocks, 'clientId' );
 				if ( clientIds.length ) {
-					replaceBlocks( clientIds, blocks );
+					replaceBlocks( clientIds, blocks, true );
 				} else {
-					insertBlocks( blocks, undefined, clientId, templateInsertUpdatesSelection );
+					insertBlocks( blocks, undefined, clientId, templateInsertUpdatesSelection, true );
 				}
 			},
 			updateNestedSettings( settings ) {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -217,17 +217,19 @@ export function toggleSelection( isSelectionEnabled = true ) {
  * Returns an action object signalling that a blocks should be replaced with
  * one or more replacement blocks.
  *
- * @param {(string|string[])} clientIds Block client ID(s) to replace.
- * @param {(Object|Object[])} blocks    Replacement block(s).
+ * @param {(string|string[])} clientIds                     Block client ID(s) to replace.
+ * @param {(Object|Object[])} blocks                        Replacement block(s).
+ * @param {?boolean}          ignoreAllowedBlocksValidation If true the replacement will occur even if some of the new blocks were not allowed e.g: because of allowed blocks restrictions.
  *
  * @return {Object} Action object.
  */
-export function replaceBlocks( clientIds, blocks ) {
+export function replaceBlocks( clientIds, blocks, ignoreAllowedBlocksValidation = false ) {
 	return {
 		type: 'REPLACE_BLOCKS',
 		clientIds: castArray( clientIds ),
 		blocks: castArray( blocks ),
 		time: Date.now(),
+		ignoreAllowedBlocksValidation,
 	};
 }
 
@@ -305,14 +307,21 @@ export function insertBlock( block, index, rootClientId, updateSelection = true 
  * Returns an action object used in signalling that an array of blocks should
  * be inserted, optionally at a specific index respective a root block list.
  *
- * @param {Object[]} blocks          Block objects to insert.
- * @param {?number}  index           Index at which block should be inserted.
- * @param {?string}  rootClientId    Optional root cliente ID of block list on which to insert.
- * @param {?boolean} updateSelection If true block selection will be updated.  If false, block selection will not change. Defaults to true.
+ * @param {Object[]} blocks                        Block objects to insert.
+ * @param {?number}  index                         Index at which block should be inserted.
+ * @param {?string}  rootClientId                  Optional root client ID of block list on which to insert.
+ * @param {?boolean} updateSelection               If true block selection will be updated.  If false, block selection will not change. Defaults to true.
+ * @param {?boolean} ignoreAllowedBlocksValidation If true the block will be inserted even if the insertion was not allowed e.g: because of allowed blocks restrictions.
  *
  * @return {Object} Action object.
  */
-export function insertBlocks( blocks, index, rootClientId, updateSelection = true ) {
+export function insertBlocks(
+	blocks,
+	index,
+	rootClientId,
+	updateSelection = true,
+	ignoreAllowedBlocksValidation = false
+) {
 	return {
 		type: 'INSERT_BLOCKS',
 		blocks: castArray( blocks ),
@@ -320,6 +329,7 @@ export function insertBlocks( blocks, index, rootClientId, updateSelection = tru
 		rootClientId,
 		time: Date.now(),
 		updateSelection,
+		ignoreAllowedBlocksValidation,
 	};
 }
 

--- a/packages/editor/src/store/middlewares.js
+++ b/packages/editor/src/store/middlewares.js
@@ -3,12 +3,82 @@
  */
 import refx from 'refx';
 import multi from 'redux-multi';
-import { flowRight } from 'lodash';
+import { every, filter, first, flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import effects from './effects';
+import { canInsertBlockType, getBlockName, getBlockRootClientId, getTemplateLock } from './selectors';
+
+/**
+ * The allowedBlocksMiddleware middleware makes sure we never add a block when that addition is not possible.
+ * In order to accomplish this validation allowedBlocksMiddleware makes use of canInsertBlockType selector
+ * and custom logic for replace, move and multi-block insertion.
+ * The primary objective of middleware is to make sure the store never gets in an inconsistent state with a block
+ * added inside in a forbidden area. So for example, if an external plugin tries to insert blocks when a locking exists
+ * the action will be discarded.
+ *
+ * @param  {Object}   store Middleware Store Object.
+ * @return {Function}       Redux Middleware.
+ */
+const allowedBlocksMiddleware = ( store ) => ( next ) => ( action ) => {
+	if ( action.ignoreAllowedBlocksValidation ) {
+		next( action );
+		return;
+	}
+	switch ( action.type ) {
+		// When inserting we allow the action if at least one of the blocks can be inserted.
+		// Blocks that can not be inserted are removed from the action.
+		case 'INSERT_BLOCKS': {
+			const allowedBlocks = filter( action.blocks, ( block ) =>
+				block &&
+				canInsertBlockType( store.getState(), block.name, action.rootClientId )
+			);
+			if ( allowedBlocks.length ) {
+				next( {
+					...action,
+					blocks: allowedBlocks,
+				} );
+			}
+			return;
+		}
+		case 'MOVE_BLOCK_TO_POSITION': {
+			const { fromRootClientId, toRootClientId, clientId } = action;
+			const state = store.getState();
+			const blockName = getBlockName( state, clientId );
+
+			// If locking is equal to all on the original clientId (fromRootClientId) it is not possible to move the block to any other position.
+			// In the other cases (locking !== all ), if moving inside the same block the move is always possible
+			// if moving to other parent block, the move is possible if we can insert a block of the same type inside the new parent block.
+			if (
+				getTemplateLock( state, fromRootClientId ) !== 'all' &&
+				( fromRootClientId === toRootClientId || canInsertBlockType( store.getState(), blockName, toRootClientId ) )
+			) {
+				next( action );
+			}
+			return;
+		}
+		case 'REPLACE_BLOCKS': {
+			const clientId = getBlockRootClientId( store.getState(), first( action.clientIds ) );
+			// Replace is valid if the new blocks can be inserted in the root block
+			// or if we had a block of the same type in the position of the block being replaced.
+			const isOperationValid = every( action.blocks, ( block, index ) => {
+				if ( canInsertBlockType( store.getState(), block.name, clientId ) ) {
+					return true;
+				}
+				const clientIdToReplace = action.clientIds[ index ];
+				const nameOfBlockToReplace = clientIdToReplace && getBlockName( store.getState(), clientIdToReplace );
+				return nameOfBlockToReplace && nameOfBlockToReplace === block.name;
+			} );
+			if ( isOperationValid ) {
+				next( action );
+			}
+			return;
+		}
+	}
+	next( action );
+};
 
 /**
  * Applies the custom middlewares used specifically in the editor module.
@@ -21,6 +91,7 @@ function applyMiddlewares( store ) {
 	const middlewares = [
 		refx( effects ),
 		multi,
+		allowedBlocksMiddleware,
 	];
 
 	let enhancedDispatch = () => {


### PR DESCRIPTION
The PR fixes the following list of issues:

- Clicking enter when non-textual blocks are selected creates a new paragraph even if not allowed. https://github.com/WordPress/gutenberg/issues/10186, an alternative to PR https://github.com/WordPress/gutenberg/pull/7265.
- Copy paste may insert unallowed blocks. Alternative to https://github.com/WordPress/gutenberg/pull/7230.
- Drag & drop allows moving blocks to not allowed destinations alternative to https://github.com/WordPress/gutenberg/pull/7212.

This PR adds a middleware to the editor store whose objective is to make sure we never get into a situation where a block should not have been added to an area.
Props to @aduth for referring the middleware as an option.

This PR's aims to simplify some existing PR's, avoid code duplication and reduce the need for allowed blocks checking in the UI. Some checks will still be required thought to provide a better user experience, e.g., don't allow drag to even start in some cases, don't show unallowed transforms, etc...

Instead of middleware, we could have tried to use a top-level editor higher order reducer ( "top level" because we need different branches of the editor state tree). I felt the higher order reducer approach would not be a good idea because to make this verification we use information from blocks store (inside canInsertBlockType selector), so we would make our reducers impure. 

This middleware watches 3 actions: INSERT_BLOCKS, MOVE_BLOCK_TO_POSITION, and REPLACE_BLOCKS.
On INSERT_BLOCKS we filter the blocks to insert to make sure all of them are allowed. If at least one of the blocks we are trying to add is permitted the action is dispatched with the filtered allowed blocks if none of the blocks are allowed the action is discarded.
For the actions MOVE_BLOCK_TO_POSITION and REPLACE_BLOCKS we verify if it is possible to contain all the blocks in the root UID if it is not possible the action is discarded.

Supersedes: https://github.com/WordPress/gutenberg/pull/7265, https://github.com/WordPress/gutenberg/pull/7212
Simplifies: https://github.com/WordPress/gutenberg/pull/7230/files

Todo: Automated tests & extensive docs tests were not yet added, I would like to get some feedback on this approach and if we think it is something we should follow I will add them before the merge.

## How has this been tested?

Test block: https://gist.github.com/jorgefilipecosta/b7194daac3ce26827522694fb4252c1c#file-testallowedblocksmiddleware-js

I pasted the test block referred in the browser console.
I added the Product block.
I verified I cannot move using drag & drop the Buy button out of the Product block. (child block restriction.
I verified I cannot move using drag & drop a paragraph created outside of the Product block inside the product block. (allowed blocks restriction).
I verified that if I press enter in the buy button or image inside the product block, a paragraph is not created (allowed blocks restriction).
I added two galleries outside the product block, multi-selected them, and copied them ( ctrl + c ), I pasted them inside the list block inside the Product block and I verified they were not added (allowed blocks restriction).

I verified that when we have a template lock and we press enter on the title we now do not insert unallowed blocks.
Template lock code:
```
add_filter( 'allowed_block_types', function( $allowed_block_types, $post ) {
	if ( $post->post_type === 'post' ) {
	    return $allowed_block_types;
	}
	return [ 'core/image', 'core/button' ];
}, 10, 2 );
```

I verified that if we disable the paragraph, e.g., with a filter or inside the test block, pressing enter on the title or in placeholders does not add paragraph blocks. Pressing the sibling inserter also does not insert the paragraph (PR https://github.com/WordPress/gutenberg/pull/7226).
Code to disable paragraph:
```
function myplugin_register_book_lock_post_type() {
    $args = array(
        'public' => true,
	  	'template_lock' => 'all',
        'label'  => 'Books Lock',
        'show_in_rest' => true,
        'template' => array(
            array( 'core/image', array(
            ) ),
            array( 'core/heading', array(
                'placeholder' => 'Add Author...',
            ) ),
            array( 'core/paragraph', array(
                'placeholder' => 'Add Description...',
            ) ),
        ),
    );
    register_post_type( 'book_lock', $args );
}
add_action( 'init', 'myplugin_register_book_lock_post_type' );
```

I added two image blocks, multi-selected them, copied them and tried to paste them on the list inside the test block. I checked the image blocks were not added inside the test block.

All these actions are possible in master.


Todo: If we accept this approach, end 2 end tests will be created before the merge that replicate this manual tests.
