### PR TITLE
Let screen readers announce the block aria label

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -486,6 +486,7 @@ export class BlockListBlock extends Component {
 				onClick={ this.onClick }
 				onKeyDown={ this.deleteOrInsertAfterWrapper }
 				tabIndex="0"
+				aria-label={ blockLabel }
 				childHandledEvents={ [
 					'onDragStart',
 					'onMouseDown',
@@ -542,7 +543,6 @@ export class BlockListBlock extends Component {
 					onDragStart={ this.preventDrag }
 					onMouseDown={ this.onPointerDown }
 					className="editor-block-list__block-edit"
-					aria-label={ blockLabel }
 					data-block={ uid }
 				>
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Let screen readers announce the block aria label. The aria label of the blocks used to be on an unfocusable div. We've moved it to the focussable parent div. As a result, the aria-label will be announced by screen readers when tabbing through the blocks.

_I've paired on this with [enejb](https://github.com/enejb)_

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Use a screen reader, for example VoiceOver in combination with Safari.
- Tab through the Gutenblocks of your post.
- The screenreader should announce the block and its type.

## Screenshots
![schermafbeelding 2018-06-14 om 12 46 09](https://user-images.githubusercontent.com/17744553/41407850-f8d71612-6fd0-11e8-84df-d0668e8a5c95.png)
_'groep' is Dutch for 'group'. It still has to be decided which role is most suitable. That's not part of this fix. (/cc @afercia )_


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
