### PR TITLE
Framework: Use clearer filenames for saved vendor scripts

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -648,14 +648,14 @@ function gutenberg_register_vendor_scripts() {
  * Retrieves a unique and reasonably short and human-friendly filename for a
  * vendor script based on a URL and the script handle.
  *
- * @param  string $src    Full URL of the external script.
  * @param  string $handle The name of the script.
+ * @param  string $src    Full URL of the external script.
  *
  * @return string         Script filename suitable for local caching.
  *
  * @since 0.1.0
  */
-function gutenberg_vendor_script_filename( $src, $handle = '' ) {
+function gutenberg_vendor_script_filename( $handle, $src ) {
 	$match_tinymce_plugin = preg_match(
 		'@tinymce.*/plugins/([^/]+)/plugin(\.min)?\.js$@',
 		$src,
@@ -668,8 +668,7 @@ function gutenberg_vendor_script_filename( $src, $handle = '' ) {
 		$filename = basename( $src );
 		$match    = preg_match(
 			'/^'
-			. '(?P<prefix>.*?)'
-			. '(?P<ignore>\.development|\.production)?'
+			. '(?P<ignore>.*?)'
 			. '(?P<suffix>\.min)?'
 			. '(?P<extension>\.js)'
 			. '(?P<extra>.*)'
@@ -678,13 +677,7 @@ function gutenberg_vendor_script_filename( $src, $handle = '' ) {
 			$filename_pieces
 		);
 
-		if ( $handle ) {
-			$prefix = $handle;
-		} elseif ( $match ) {
-			$prefix = $filename_pieces['prefix'];
-		} else {
-			$prefix = $filename;
-		}
+		$prefix = $handle;
 		$suffix = $match ? $filename_pieces['suffix'] : '';
 	}
 
@@ -710,7 +703,7 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 		return;
 	}
 
-	$filename = gutenberg_vendor_script_filename( $src, $handle );
+	$filename = gutenberg_vendor_script_filename( $handle, $src );
 
 	if ( defined( 'GUTENBERG_LIST_VENDOR_ASSETS' ) && GUTENBERG_LIST_VENDOR_ASSETS ) {
 		echo "$src|$filename\n";

--- a/phpunit/class-vendor-script-filename-test.php
+++ b/phpunit/class-vendor-script-filename-test.php
@@ -10,67 +10,61 @@ class Vendor_Script_Filename_Test extends WP_UnitTestCase {
 		return array(
 			// Development mode scripts.
 			array(
-				'https://unpkg.com/react@16.4.1/umd/react.development.js',
 				'react-handle',
+				'https://unpkg.com/react@16.4.1/umd/react.development.js',
 				'react-handle.HASH.js',
 			),
 			array(
-				'https://unpkg.com/react-dom@16.4.1/umd/react-dom.development.js',
 				'react-dom-handle',
+				'https://unpkg.com/react-dom@16.4.1/umd/react-dom.development.js',
 				'react-dom-handle.HASH.js',
 			),
 			array(
-				'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.js',
 				'tinymce-handle',
+				'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.js',
 				'tinymce-handle.HASH.js',
 			),
 			array(
-				'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin.js',
 				'tinymce-plugin-handle',
+				'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin.js',
 				'tinymce-plugin-lists.HASH.js',
 			),
 			// Production mode scripts.
 			array(
-				'https://unpkg.com/react@16.4.1/umd/react.production.min.js',
 				'react-handle',
+				'https://unpkg.com/react@16.4.1/umd/react.production.min.js',
 				'react-handle.min.HASH.js',
 			),
 			array(
-				'https://unpkg.com/react-dom@16.4.1/umd/react-dom.production.min.js',
 				'react-dom-handle',
+				'https://unpkg.com/react-dom@16.4.1/umd/react-dom.production.min.js',
 				'react-dom-handle.min.HASH.js',
 			),
 			array(
-				'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.min.js',
 				'tinymce-handle',
+				'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.min.js',
 				'tinymce-handle.min.HASH.js',
 			),
 			array(
-				'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin.min.js',
 				'tinymce-plugin-handle',
+				'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin.min.js',
 				'tinymce-plugin-lists.min.HASH.js',
 			),
 			// Other cases.
 			array(
-				'http://localhost/something.js?querystring',
 				'something-handle',
+				'http://localhost/something.js?querystring',
 				'something-handle.HASH.js',
 			),
 			array(
-				'http://localhost/something.min.js?querystring',
 				'something-handle',
+				'http://localhost/something.min.js?querystring',
 				'something-handle.min.HASH.js',
 			),
 			array(
-				'http://localhost/idkwhatthisis',
 				'idkwhatthisis-handle',
+				'http://localhost/idkwhatthisis',
 				'idkwhatthisis-handle.HASH.js',
-			),
-			array(
-				'http://localhost/idkwhatthatis',
-				// Test with unspecified `handle` param.
-				null,
-				'idkwhatthatis.HASH.js',
 			),
 		);
 	}
@@ -78,11 +72,9 @@ class Vendor_Script_Filename_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider vendor_script_filename_cases
 	 */
-	function test_gutenberg_vendor_script_filename( $url, $handle, $expected_filename_pattern ) {
+	function test_gutenberg_vendor_script_filename( $handle, $url, $expected_filename_pattern ) {
 		$hash                    = substr( md5( $url ), 0, 8 );
-		$actual_filename         = null === $handle ?
-			gutenberg_vendor_script_filename( $url ) :
-			gutenberg_vendor_script_filename( $url, $handle );
+		$actual_filename         = gutenberg_vendor_script_filename( $handle, $url );
 		$actual_filename_pattern = str_replace( $hash, 'HASH', $actual_filename );
 		$this->assertEquals(
 			$expected_filename_pattern,

--- a/phpunit/class-vendor-script-filename-test.php
+++ b/phpunit/class-vendor-script-filename-test.php
@@ -11,49 +11,66 @@ class Vendor_Script_Filename_Test extends WP_UnitTestCase {
 			// Development mode scripts.
 			array(
 				'https://unpkg.com/react@16.4.1/umd/react.development.js',
-				'react.HASH.js',
+				'react-handle',
+				'react-handle.HASH.js',
 			),
 			array(
 				'https://unpkg.com/react-dom@16.4.1/umd/react-dom.development.js',
-				'react-dom.HASH.js',
+				'react-dom-handle',
+				'react-dom-handle.HASH.js',
 			),
 			array(
 				'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.js',
-				'tinymce.HASH.js',
+				'tinymce-handle',
+				'tinymce-handle.HASH.js',
 			),
 			array(
 				'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin.js',
+				'tinymce-plugin-handle',
 				'tinymce-plugin-lists.HASH.js',
 			),
 			// Production mode scripts.
 			array(
 				'https://unpkg.com/react@16.4.1/umd/react.production.min.js',
-				'react.min.HASH.js',
+				'react-handle',
+				'react-handle.min.HASH.js',
 			),
 			array(
 				'https://unpkg.com/react-dom@16.4.1/umd/react-dom.production.min.js',
-				'react-dom.min.HASH.js',
+				'react-dom-handle',
+				'react-dom-handle.min.HASH.js',
 			),
 			array(
 				'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.min.js',
-				'tinymce.min.HASH.js',
+				'tinymce-handle',
+				'tinymce-handle.min.HASH.js',
 			),
 			array(
 				'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin.min.js',
+				'tinymce-plugin-handle',
 				'tinymce-plugin-lists.min.HASH.js',
 			),
 			// Other cases.
 			array(
 				'http://localhost/something.js?querystring',
-				'something.HASH.js',
+				'something-handle',
+				'something-handle.HASH.js',
 			),
 			array(
 				'http://localhost/something.min.js?querystring',
-				'something.min.HASH.js',
+				'something-handle',
+				'something-handle.min.HASH.js',
 			),
 			array(
 				'http://localhost/idkwhatthisis',
-				'idkwhatthisis.HASH.js',
+				'idkwhatthisis-handle',
+				'idkwhatthisis-handle.HASH.js',
+			),
+			array(
+				'http://localhost/idkwhatthatis',
+				// Test with unspecified `handle` param.
+				null,
+				'idkwhatthatis.HASH.js',
 			),
 		);
 	}
@@ -61,9 +78,11 @@ class Vendor_Script_Filename_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider vendor_script_filename_cases
 	 */
-	function test_gutenberg_vendor_script_filename( $url, $expected_filename_pattern ) {
+	function test_gutenberg_vendor_script_filename( $url, $handle, $expected_filename_pattern ) {
 		$hash                    = substr( md5( $url ), 0, 8 );
-		$actual_filename         = gutenberg_vendor_script_filename( $url );
+		$actual_filename         = null === $handle ?
+			gutenberg_vendor_script_filename( $url ) :
+			gutenberg_vendor_script_filename( $url, $handle );
 		$actual_filename_pattern = str_replace( $hash, 'HASH', $actual_filename );
 		$this->assertEquals(
 			$expected_filename_pattern,


### PR DESCRIPTION
## Description
Today, we save vendor scripts based on the filename contained in the script's external URL. This is OK but can lead to unclearly named files in the `./vendor` directory. For example, scripts from the Financial Times polyfill library have URL filenames of `polyfill.js`. If we use more than one of these polyfills, we will see multiple saved vendor scripts named `polyfill.<HASH>.js`. It would be a bit clearer if we saved vendor scripts by their script handle, and that's what this update does. Now, a polyfill script like the one mentioned above will have a clearer filename like `wp-polyfill-node-contains.<HASH>.js`.

It's not the most important change but will save people from wondering what things are.

One thing I think is strange about this change is that `gutenberg_register_vendor_script( $handle, $src, ...)` takes the `$handle` param before the `$src` param while `gutenberg_vendor_script_filename( $src, $handle )` takes them in the opposite order. If it's not important we maintain backward compatibility for that function, then I can switch them and remove the default value for the `$handle` param.

## How has this been tested?
This has been unit tested and manually tested by:
* Deleting saved vendor scripts
* Loading Gutenberg
* Observing successful load with no HTTP errors or related console errors
* Observing contents of `vendor` directory are prefixed by script handle

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
