### PR TITLE
Ensure that only the latest promise updates the autocompleter state

### DIFF
--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -348,10 +348,22 @@ export class Autocomplete extends Component {
 		/*
 		 * We support both synchronous and asynchronous retrieval of completer options
 		 * but internally treat all as async so we maintain a single, consistent code path.
+		 *
+		 * Because networks can be slow, and the internet is wonderfully unpredictable,
+		 * we don't want two promises updating the state at once. This ensures that only
+		 * the most recent promise will act on `optionsData`. This doesn't use the state
+		 * because `setState` is batched, and so there's no guarantee that setting
+		 * `activePromise` in the state would result in it actually being in `this.state`
+		 * before the promise resolves and we check to see if this is the active promise or not.
 		 */
-		Promise.resolve(
+		const promise = this.activePromise = Promise.resolve(
 			typeof options === 'function' ? options( query ) : options
 		).then( ( optionsData ) => {
+			if ( promise !== this.activePromise ) {
+				// Another promise has become active since this one was asked to resolve, so do nothing,
+				// or else we might end triggering a race condition updating the state.
+				return;
+			}
 			const keyedOptions = optionsData.map( ( optionData, optionIndex ) => ( {
 				key: `${ completer.idx }-${ optionIndex }`,
 				value: optionData,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/7317

## Description

Multiple promises can be resolving when using an autocompleter, and network conditions can determine which one actually gets to update the state. We only want the most recently created promise to update the state.

This keeps track of the most recent (or, active) promise, and only processes the result if the promise is still the most recent one.

## How has this been tested?

I followed the following:

1) put "sleep(5)" on the server side to simulate a slow network.
2) set up two users with the following usernames and real names: admin - "Jamjam", james - "James Jamison"
3) Carry out the typing test as described in https://github.com/WordPress/gutenberg/issues/7317

The list of users updated correctly, and slow API requests didn't end up interfering with each other.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
