### PR TITLE
Support 'Autoplay' and 'Loop' in Audio Block 'Playback Controls'

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -99,6 +99,9 @@ export function matcherFromSource( sourceConfig ) {
  */
 export function parseWithAttributeSchema( innerHTML, attributeSchema ) {
 	const attributeValue = hpqParse( innerHTML, matcherFromSource( attributeSchema ) );
+	// HTML attributes without a defined value (e.g. <audio loop>) are parsed
+	// to a value of '' (empty string), so return `true` if we know this should
+	// be boolean.
 	if ( 'attribute' === attributeSchema.source && 'boolean' === attributeSchema.type ) {
 		return '' === attributeValue;
 	}

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -98,11 +98,11 @@ export function matcherFromSource( sourceConfig ) {
  * @return {*} Attribute value.
  */
 export function parseWithAttributeSchema( innerHTML, attributeSchema ) {
-	const attrValue = hpqParse( innerHTML, matcherFromSource( attributeSchema ) );
+	const attributeValue = hpqParse( innerHTML, matcherFromSource( attributeSchema ) );
 	if ( 'attribute' === attributeSchema.source && 'boolean' === attributeSchema.type ) {
-		return '' === attrValue;
+		return '' === attributeValue;
 	}
-	return attrValue;
+	return attributeValue;
 }
 
 /**

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -98,7 +98,11 @@ export function matcherFromSource( sourceConfig ) {
  * @return {*} Attribute value.
  */
 export function parseWithAttributeSchema( innerHTML, attributeSchema ) {
-	return hpqParse( innerHTML, matcherFromSource( attributeSchema ) );
+	const attrValue = hpqParse( innerHTML, matcherFromSource( attributeSchema ) );
+	if ( 'attribute' === attributeSchema.source && 'boolean' === attributeSchema.type ) {
+		return '' === attrValue;
+	}
+	return attrValue;
 }
 
 /**

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -105,6 +105,45 @@ describe( 'block parser', () => {
 			);
 			expect( value ).toBe( 'chicken' );
 		} );
+
+		it( 'should return the matcher\'s string attribute value', () => {
+			const value = parseWithAttributeSchema(
+				'<audio src="#" loop>',
+				{
+					type: 'string',
+					source: 'attribute',
+					selector: 'audio',
+					attribute: 'src',
+				},
+			);
+			expect( value ).toBe( '#' );
+		} );
+
+		it( 'should return the matcher\'s true boolean attribute value', () => {
+			const value = parseWithAttributeSchema(
+				'<audio src="#" loop>',
+				{
+					type: 'boolean',
+					source: 'attribute',
+					selector: 'audio',
+					attribute: 'loop',
+				},
+			);
+			expect( value ).toBe( true );
+		} );
+
+		it( 'should return the matcher\'s false boolean attribute value', () => {
+			const value = parseWithAttributeSchema(
+				'<audio src="#" autoplay>',
+				{
+					type: 'boolean',
+					source: 'attribute',
+					selector: 'audio',
+					attribute: 'loop',
+				},
+			);
+			expect( value ).toBe( false );
+		} );
 	} );
 
 	describe( 'getBlockAttribute', () => {

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -2,12 +2,19 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, Toolbar, withNotices } from '@wordpress/components';
+import {
+	CheckboxControl,
+	IconButton,
+	PanelBody,
+	Toolbar,
+	withNotices,
+} from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import {
+	BlockControls,
+	InspectorControls,
 	MediaPlaceholder,
 	RichText,
-	BlockControls,
 } from '@wordpress/editor';
 
 /**
@@ -26,7 +33,7 @@ class AudioEdit extends Component {
 	}
 
 	render() {
-		const { caption, src } = this.props.attributes;
+		const { autoplay, caption, loop, src } = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
 		const switchToEditing = () => {
@@ -51,6 +58,14 @@ class AudioEdit extends Component {
 				setAttributes( { src: newSrc, id: undefined } );
 			}
 			this.setState( { editing: false } );
+		};
+
+		const onToggleAutoplay = ( newVal ) => {
+			setAttributes( { autoplay: newVal } );
+		};
+
+		const onToggleLoop = ( newVal ) => {
+			setAttributes( { loop: newVal } );
 		};
 
 		if ( editing ) {
@@ -86,6 +101,20 @@ class AudioEdit extends Component {
 						/>
 					</Toolbar>
 				</BlockControls>
+				<InspectorControls>
+					<PanelBody title={ __( 'Playback Controls' ) }>
+						<CheckboxControl
+							label={ __( 'Autoplay' ) }
+							onChange={ onToggleAutoplay }
+							checked={ autoplay }
+						/>
+						<CheckboxControl
+							label={ __( 'Loop' ) }
+							onChange={ onToggleLoop }
+							checked={ loop }
+						/>
+					</PanelBody>
+				</InspectorControls>
 				<figure className={ className }>
 					<audio controls="controls" src={ src } />
 					{ ( ( caption && caption.length ) || !! isSelected ) && (

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -122,7 +122,7 @@ class AudioEdit extends Component {
 							tagName="figcaption"
 							placeholder={ __( 'Write caption…' ) }
 							value={ caption }
-							onChange={ this.toggleAttribute( 'caption' ) }
+							onChange={ ( value ) => setAttributes( { caption: value } ) }
 							inlineToolbar
 						/>
 					) }

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -3,10 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	CheckboxControl,
 	IconButton,
 	PanelBody,
 	Toolbar,
+	ToggleControl,
 	withNotices,
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
@@ -103,12 +103,12 @@ class AudioEdit extends Component {
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Playback Controls' ) }>
-						<CheckboxControl
+						<ToggleControl
 							label={ __( 'Autoplay' ) }
 							onChange={ this.toggleAttribute( 'autoplay' ) }
 							checked={ autoplay }
 						/>
-						<CheckboxControl
+						<ToggleControl
 							label={ __( 'Loop' ) }
 							onChange={ this.toggleAttribute( 'loop' ) }
 							checked={ loop }

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -30,6 +30,14 @@ class AudioEdit extends Component {
 		this.state = {
 			editing: ! this.props.attributes.src,
 		};
+
+		this.toggleAttribute = this.toggleAttribute.bind( this );
+	}
+
+	toggleAttribute( attribute ) {
+		return ( newValue ) => {
+			this.props.setAttributes( { [ attribute ]: newValue } );
+		};
 	}
 
 	render() {
@@ -58,14 +66,6 @@ class AudioEdit extends Component {
 				setAttributes( { src: newSrc, id: undefined } );
 			}
 			this.setState( { editing: false } );
-		};
-
-		const onToggleAutoplay = ( newVal ) => {
-			setAttributes( { autoplay: newVal } );
-		};
-
-		const onToggleLoop = ( newVal ) => {
-			setAttributes( { loop: newVal } );
 		};
 
 		if ( editing ) {
@@ -105,12 +105,12 @@ class AudioEdit extends Component {
 					<PanelBody title={ __( 'Playback Controls' ) }>
 						<CheckboxControl
 							label={ __( 'Autoplay' ) }
-							onChange={ onToggleAutoplay }
+							onChange={ this.toggleAttribute( 'autoplay' ) }
 							checked={ autoplay }
 						/>
 						<CheckboxControl
 							label={ __( 'Loop' ) }
-							onChange={ onToggleLoop }
+							onChange={ this.toggleAttribute( 'loop' ) }
 							checked={ loop }
 						/>
 					</PanelBody>
@@ -122,7 +122,7 @@ class AudioEdit extends Component {
 							tagName="figcaption"
 							placeholder={ __( 'Write caption…' ) }
 							value={ caption }
-							onChange={ ( value ) => setAttributes( { caption: value } ) }
+							onChange={ this.toggleAttribute( 'caption' ) }
 							inlineToolbar
 						/>
 					) }

--- a/core-blocks/audio/index.js
+++ b/core-blocks/audio/index.js
@@ -36,6 +36,18 @@ export const settings = {
 		id: {
 			type: 'number',
 		},
+		autoplay: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'audio',
+			attribute: 'autoplay',
+		},
+		loop: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'audio',
+			attribute: 'loop',
+		},
 	},
 
 	supports: {
@@ -45,10 +57,10 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { src, caption } = attributes;
+		const { autoplay, caption, loop, src } = attributes;
 		return (
 			<figure>
-				<audio controls="controls" src={ src } />
+				<audio controls="controls" src={ src } autoPlay={ autoplay } loop={ loop } />
 				{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 			</figure>
 		);

--- a/core-blocks/test/fixtures/core__audio.json
+++ b/core-blocks/test/fixtures/core__audio.json
@@ -6,7 +6,9 @@
         "attributes": {
             "src": "https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3",
             "caption": [],
-            "align": "right"
+            "align": "right",
+            "autoplay": false,
+            "loop": false
         },
         "innerBlocks": [],
         "originalContent": "<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>"


### PR DESCRIPTION
## Description

Introduces support for 'Autoplay' and 'Loop' to the Audio Block:

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/36432/41873046-a7a397ce-7878-11e8-8def-6cc8e9d8cef5.png">

Notably, `autoplay` and `loop` are only applied on the frontend, not within Gutenberg.

See https://wordpress.slack.com/archives/C02QB2JS7/p1529950740000305 for discussion of boolean attribute handling.

See #6581

## How has this been tested?

1. Upload a MP3 file to the Media Library.
2. Create a new Audio Block from the MP3 file.
3. Check the "Autoplay" checkbox, flip to HTML mode, and observe the inclusion of the `autoplay` attribute.
4. Manually edit `<audio>` HTML to include a `loop` attribute.
5. Flip back to Visual mode and observe the checked state of the Loop checkbox.
6. Publish the post and view its frontend state to observe the application of the `autoplay` and `loop` attributes.

## Screenshots

New UI:

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/36432/41873123-ec52a978-7878-11e8-81ef-ae464d25534f.png">

GIF of the testing instructions:

![audiopost](https://user-images.githubusercontent.com/36432/41873128-f2c5233a-7878-11e8-9838-d297e9677c66.gif)

Classic Editor:

<img width="1268" alt="image" src="https://user-images.githubusercontent.com/36432/41873292-6cc6dd2c-7879-11e8-950c-f44a10b5846a.png">

## Types of changes

Enhancement to existing feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
