### PR TITLE
Gutenberg shouldn't force all Plugins to use its wp-api-request override

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -177,6 +177,8 @@ function gutenberg_init( $return, $post ) {
 		return false;
 	}
 
+	add_action( 'wp_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
+	add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
 	add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );
 	add_filter( 'screen_options_show_screen', '__return_false' );
 	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -518,8 +518,6 @@ function gutenberg_register_scripts_and_styles() {
 		);
 	}
 }
-add_action( 'wp_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
-add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
 
 /**
  * Append result of internal request to REST API for purpose of preloading


### PR DESCRIPTION
## Description
Deregistering WordPress `wp-api-request` to override it with Gutenberg version should only be done when on a Gutenberg page. Otherwise, plugins using the apiRequest elsewhere in the administration are failing because `wpApiSettings` is not defined.

## How has this been tested?
This has been tested activating Gutenberg and 2 of my plugins using the WP API Request

## Types of changes
it's a Bug fix change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
