### PR TITLE
add ability to ignore block validation with blockType.ignoreValidation

### DIFF
--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -459,7 +459,7 @@ export function isValidBlock( innerHTML, blockType, attributes ) {
 		);
 	}
 	if ( blockType.ignoreValidation ) {
-		return true
+		return true;
 	}
 	return isValid;
 }

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -458,6 +458,8 @@ export function isValidBlock( innerHTML, blockType, attributes ) {
 			innerHTML
 		);
 	}
-
+	if ( blockType.ignoreValidation ) {
+		return true
+	}
 	return isValid;
 }


### PR DESCRIPTION
## Description
Ability to ignore block validation for use with https://github.com/royboy789/gutenberg-object-plugin

## How has this been tested?
I'm only using gutenberg to build out an API and rendering out the blocks elsewhere. I have only tested this in a headless wordpress environment.

## Screenshots <!-- if applicable -->

## Types of changes
New feature - for anyone who wants to disable validation they can pass `ignoreValidation: true` when registering their block type. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
