### PR TITLE
Hide disabled blocks from shortcut inserter

### DIFF
--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -23,9 +23,12 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 		return null;
 	}
 
-	const itemsWithoutDefaultBlock = filter( items, ( item ) =>
-		item.name !== getDefaultBlockName() || ! isEmpty( item.initialAttributes )
-	).slice( 0, 3 );
+	const itemsWithoutDefaultBlock = filter( items, ( item ) => {
+		return ! item.isDisabled && (
+			item.name !== getDefaultBlockName() ||
+			! isEmpty( item.initialAttributes )
+		);
+	} ).slice( 0, 3 );
 
 	return (
 		<div className="editor-inserter-with-shortcuts">


### PR DESCRIPTION
## Description
This PR hides blocks with `isDisabled` attribute from the shortcut inserter. For example if blocks with `multiple: false` are already inserted. There are only 3 Items so it does't make sense to just disable the button.
Fixes #3968

## Screenshots <!-- if applicable -->
![juni-17-2018 13-33-01](https://user-images.githubusercontent.com/695201/41507460-1353dd9a-7233-11e8-9608-842244f8396a.gif)

