### PR TITLE
Add snapshot test about `MoreMenu` component

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -99,3 +99,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @noisysocks | @noisysocks |
 | @omarreiss | @omarreiss |
 | @hedgefield | @hedgefield |
+| @hideokamoto | @hideokamoto |

--- a/edit-post/components/header/more-menu/test/__snapshots__/index.js.snap
+++ b/edit-post/components/header/more-menu/test/__snapshots__/index.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MoreMenu should match snapshot 1`] = `
+<MoreMenu>
+  <Dropdown
+    className="edit-post-more-menu"
+    position="bottom left"
+    renderContent={[Function]}
+    renderToggle={[Function]}
+  >
+    <div
+      className="edit-post-more-menu"
+    >
+      <div>
+        <IconButton
+          aria-expanded={false}
+          icon="ellipsis"
+          label="More"
+          onClick={[Function]}
+        >
+          <Tooltip
+            text="More"
+          >
+            <Button
+              aria-expanded={false}
+              aria-label="More"
+              className="components-icon-button"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              <button
+                aria-expanded={false}
+                aria-label="More"
+                className="components-button components-icon-button"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                type="button"
+              >
+                <Dashicon
+                  icon="ellipsis"
+                  key="0,0"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="dashicon dashicons-ellipsis"
+                    focusable="false"
+                    height={20}
+                    role="img"
+                    viewBox="0 0 20 20"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5 10c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm12-2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-7 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                    />
+                  </svg>
+                </Dashicon>
+              </button>
+            </Button>
+          </Tooltip>
+        </IconButton>
+      </div>
+    </div>
+  </Dropdown>
+</MoreMenu>
+`;

--- a/edit-post/components/header/more-menu/test/index.js
+++ b/edit-post/components/header/more-menu/test/index.js
@@ -9,11 +9,11 @@ import { mount } from 'enzyme';
 import MoreMenu from '../index';
 
 describe( 'MoreMenu', () => {
-	it('should match snapshot', () => {
+	it( 'should match snapshot', () => {
 		const wrapper = mount(
 			<MoreMenu />
 		);
 
-		expect(wrapper).toMatchSnapshot();
-	});
-});
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/edit-post/components/header/more-menu/test/index.js
+++ b/edit-post/components/header/more-menu/test/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import MoreMenu from '../index';
+
+describe( 'MoreMenu', () => {
+	it('should match snapshot', () => {
+		const wrapper = mount(
+			<MoreMenu />
+		);
+
+		expect(wrapper).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
## Description
Related to progress on the issue -> Unit Testing Components #641

Added some unit test scripts for [MoreMenu](https://github.com/WordPress/gutenberg/blob/master/edit-post/components/header/more-menu/index.js) component.
## How has this been tested?

Run unit test command.

```
 PASS  edit-post/components/header/more-menu/test/index.js
  MoreMenu
    ✓ should match snapshot (87ms)
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
