### PR TITLE
Add Filter for registered blocks

### DIFF
--- a/lib/class-wp-block-type-registry.php
+++ b/lib/class-wp-block-type-registry.php
@@ -147,11 +147,11 @@ final class WP_Block_Type_Registry {
 	public function get_all_registered() {
 
 		/**
-		 * Adjust the blocks registered at runtime 
+		 * Adjust the blocks registered at runtime
 		 *
 		 * @param array WP_Block_Type[] Associative array of `$block_type_name => $block_type` pairs.
 		 */
-		return apply_filter( 'gutenberg_registered_blocks', $this->registered_block_types );
+		return apply_filters( 'gutenberg_registered_blocks', $this->registered_block_types );
 	}
 
 	/**

--- a/lib/class-wp-block-type-registry.php
+++ b/lib/class-wp-block-type-registry.php
@@ -145,7 +145,13 @@ final class WP_Block_Type_Registry {
 	 * @return WP_Block_Type[] Associative array of `$block_type_name => $block_type` pairs.
 	 */
 	public function get_all_registered() {
-		return $this->registered_block_types;
+
+		/**
+		 * Adjust the blocks registered at runtime 
+		 *
+		 * @param array WP_Block_Type[] Associative array of `$block_type_name => $block_type` pairs.
+		 */
+		return apply_filter( 'gutenberg_registered_blocks', $this->registered_block_types );
 	}
 
 	/**

--- a/phpunit/class-block-type-registry-test.php
+++ b/phpunit/class-block-type-registry-test.php
@@ -171,10 +171,8 @@ class Block_Type_Registry_Test extends WP_UnitTestCase {
 		$this->assertEqualSets( $block_names, array_keys( $registered ) );
 	}
 
-	function filter_get_all_registered_filter( $blocks ){
-
-		unset( $blocks[ 'test/image' ] ); 
-
+	function filter_get_all_registered_filter( $blocks ) {
+		unset( $blocks['test/image'] );
 		return $blocks;
 	}
 }

--- a/phpunit/class-block-type-registry-test.php
+++ b/phpunit/class-block-type-registry-test.php
@@ -150,4 +150,31 @@ class Block_Type_Registry_Test extends WP_UnitTestCase {
 		$registered = $this->registry->get_all_registered();
 		$this->assertEqualSets( $names, array_keys( $registered ) );
 	}
+
+	function test_get_all_registered_filter() {
+		$names    = array( 'test/paragraph', 'test/image', 'test/blockquote' );
+		$settings = array(
+			'icon' => 'random',
+		);
+
+		foreach ( $names as $name ) {
+			$this->registry->register( $name, $settings );
+		}
+
+		add_filter( 'gutenberg_registered_blocks', array( $this, 'filter_get_all_registered_filter' ) );
+
+		$registered = $this->registry->get_all_registered();
+
+		remove_filter( 'gutenberg_registered_blocks', array( $this, 'filter_get_all_registered_filter' ) );
+
+		$block_names = array( 'test/paragraph', 'test/blockquote' );
+		$this->assertEqualSets( $block_names, array_keys( $registered ) );
+	}
+
+	function filter_get_all_registered_filter( $blocks ){
+
+		unset( $blocks[ 'test/image' ] ); 
+
+		return $blocks;
+	}
 }


### PR DESCRIPTION
## Description
This adds a filter to allow the registry of blocks to be changed at runtime. Use cases include limiting the blocks registered for a specific post type or based on some other server known condition.

## How has this been tested?
This adds a new phpunit test for the filter. 

## Types of changes
This is not a breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
