### PR TITLE
Update README.md for RichText API

### DIFF
--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -1,6 +1,6 @@
 # `RichText`
 
-Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content), providing users the option to add emphasis to content or links to content. It behaves similarly to a [controlled component](https://facebook.github.io/react/docs/forms.html#controlled-components),except that `onChange` is triggered less frequently than would be expected from a traditional `input` field, usually when the user exits the field.
+Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content), providing users the option to add emphasis to content or links to content. It behaves similarly to a [controlled component](https://facebook.github.io/react/docs/forms.html#controlled-components), except that `onChange` is triggered less frequently than would be expected from a traditional `input` field, usually when the user exits the field.
 
 ## Properties
 

--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -1,12 +1,6 @@
 # `RichText`
 
-Render a rich
-[`contenteditable` input](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content),
-providing users the option to add emphasis to content or links to content. It
-behaves similarly to a
-[controlled component](https://facebook.github.io/react/docs/forms.html#controlled-components),
-except that `onChange` is triggered less frequently than would be expected from
-a traditional `input` field, usually when the user exits the field.
+Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content), providing users the option to add emphasis to content or links to content. It behaves similarly to a [controlled component](https://facebook.github.io/react/docs/forms.html#controlled-components),except that `onChange` is triggered less frequently than would be expected from a traditional `input` field, usually when the user exits the field.
 
 ## Properties
 


### PR DESCRIPTION
Fixed line breaks in introduction paragraph.

## Description
Fixed line breaks in introduction paragraph.


## How has this been tested?
n/a

## Types of changes
Bug Fix

## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
