### PR TITLE
Button: Component documentation

### DIFF
--- a/components/button/README.md
+++ b/components/button/README.md
@@ -7,6 +7,9 @@ The presence of a `href` prop determines whether an `anchor` element is rendere
 ## Usage
 
 ```jsx
+/**
+ * WordPress dependencies
+ */
 import { Button } from "@wordpress/components";
 
 export default function ClickMeButton() {
@@ -26,8 +29,8 @@ Name | Type | Default | Description
 `target` | `string` | `undefined` | Context in which the `href` resource will open.
 `isDefault` | `bool` | `false` | Renders a default button style.
 `isPrimary` | `bool` | `false` | Renders a primary button style.
-`isLarge` | `bool` | `false` | Increases the size of the button
-`isSmall` | `bool` | `false` | Decreases the size of the button
+`isLarge` | `bool` | `false` | Increases the size of the button.
+`isSmall` | `bool` | `false` | Decreases the size of the button.
 `isToggled` | `bool` | `false` | Renders a toggled button style.
 `isBusy` | `bool` | `false` | Indicates activity while a action is being performed.
 `isLink` | `bool` | `false` | Renders a button with an anchor style.

--- a/components/button/README.md
+++ b/components/button/README.md
@@ -6,6 +6,8 @@ The presence of a `href` prop determines whether an `anchor` element is rendere
 
 ## Usage
 
+Renders a button with default style.
+
 ```jsx
 /**
  * WordPress dependencies

--- a/components/button/README.md
+++ b/components/button/README.md
@@ -1,8 +1,48 @@
-This component is used to implement dang sweet buttons.
+# Button
 
-#### Props
+Buttons express what action will occur when the user clicks or taps it. Buttons are used to trigger an action, and they can be used for any type of action, including navigation.
 
-The following props are used to control the display of the component. Any additional props will be passed to the rendered `<a />` or `<button />` element. The presence of a `href` prop determines whether an anchor element is rendered instead of a button.
+The presence of a `href` prop determines whether an `anchor` element is rendered instead of a `button`.
 
-* `isPrimary`: (bool) whether the button is styled as a primary button.
-* `href`: (string) if this property is added, it will use an `a` rather than a `button` element.
+## Usage
+
+```jsx
+import { Button } from "@wordpress/components";
+
+export default function ClickMeButton() {
+	return (
+		<Button isDefault>
+			Click me!
+		</Button>
+	);
+}
+```
+
+## Props
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`href` | `string` | `undefined` | If provided, renders `a` instead of `button`.
+`target` | `string` | `undefined` | Context in which the `href` resource will open.
+`isDefault` | `bool` | `false` | Renders a default button style.
+`isPrimary` | `bool` | `false` | Renders a primary button style.
+`isLarge` | `bool` | `false` | Increases the size of the button
+`isSmall` | `bool` | `false` | Decreases the size of the button
+`isToggled` | `bool` | `false` | Renders a toggled button style.
+`isBusy` | `bool` | `false` | Indicates activity while a action is being performed.
+`isLink` | `bool` | `false` | Renders a button with an anchor style.
+`className` | `string` | | Additional classes.
+`disabled` | `bool` | `false` | Disables the Button.
+`focus` | `bool` | `false` | Whether the button is focused.
+
+## General guidelines
+
+* Use clear and accurate labels. Use sentence-style capitalization.
+* Lead with strong, concise, and actionable verbs.
+* When the customer is confirming an action, use specific labels, such as **Save** or **Trash**, instead of using **OK** and **Cancel**.
+* Prioritize the most important actions. Too many calls to action can cause confusion and make customers unsure of what to do next.
+
+## Related components
+
+* To group buttons together, use the `button-group` component.
+* To display an icon inside the button, use the `icon-button` component.


### PR DESCRIPTION
## Description
The PR updates the `Button` component doc. 

I copied some texts and the structure from `wp-calypso` (https://github.com/Automattic/wp-calypso/tree/master/client/components/button), is this okay or should we us another structure for the component readmes?

Should we add a `Required` column for the props table?
