### PR TITLE
Don't error if autosave runs and there are no changes to save

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -230,7 +230,14 @@ export default {
 		}
 	},
 	REQUEST_POST_UPDATE_FAILURE( action, store ) {
-		const { post, edits } = action;
+		const { post, edits, error } = action;
+
+		if ( error && 'rest_autosave_no_changes' === error.code ) {
+			// Autosave requested a new autosave, but there were no changes. This shouldn't
+			// result in an error notice for the user.
+			return;
+		}
+
 		const { dispatch } = store;
 
 		const publishStatus = [ 'publish', 'private', 'future' ];

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -389,6 +389,35 @@ describe( 'effects', () => {
 			expect( dispatch ).toHaveBeenCalledWith( createErrorNotice( 'Publishing failed', { id: 'SAVE_POST_NOTICE_ID' } ) );
 		} );
 
+		it( 'should not dispatch a notice when there were no changes for autosave to save.', () => {
+			const handler = effects.REQUEST_POST_UPDATE_FAILURE;
+			const dispatch = jest.fn();
+			const store = { getState: () => {}, dispatch };
+
+			const action = {
+				post: {
+					id: 1,
+					title: {
+						raw: 'A History of Pork',
+					},
+					content: {
+						raw: '',
+					},
+					status: 'draft',
+				},
+				edits: {
+					status: 'publish',
+				},
+				error: {
+					code: 'rest_autosave_no_changes',
+				},
+			};
+
+			handler( action, store );
+
+			expect( dispatch ).toHaveBeenCalledTimes( 0 );
+		} );
+
 		it( 'should dispatch a notice on failure when trying to update a draft.', () => {
 			const handler = effects.REQUEST_POST_UPDATE_FAILURE;
 			const dispatch = jest.fn();

--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -309,7 +309,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 
 			if ( ! $autosave_is_different ) {
 				wp_delete_post_revision( $old_autosave->ID );
-				return new WP_Error( 'rest_autosave_no_changes', __( 'There is nothing to save. The autosave and the post content are the same.', 'gutenberg' ) );
+				return new WP_Error( 'rest_autosave_no_changes', __( 'There is nothing to save. The autosave and the post content are the same.', 'gutenberg' ), array( 'status' => 200 ) );
 			}
 
 			/**

--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -309,7 +309,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 
 			if ( ! $autosave_is_different ) {
 				wp_delete_post_revision( $old_autosave->ID );
-				return new WP_Error( 'rest_autosave_no_changes', __( 'There is nothing to save. The autosave and the post content are the same.', 'gutenberg' ), array( 'status' => 200 ) );
+				return new WP_Error( 'rest_autosave_no_changes', __( 'There is nothing to save. The autosave and the post content are the same.', 'gutenberg' ), array( 'status' => 400 ) );
 			}
 
 			/**


### PR DESCRIPTION
## Description

If autosave runs and there are no changes, the user gets an error banner. This happens when there's an autosave newer than the post content you're editing, and autosave runs again.

![errorerror](https://user-images.githubusercontent.com/3314354/41535871-c190b810-72fb-11e8-87fb-891b6b79a613.png)

This change sets the status code of the error to 200, because the fact that there are no changes since the last autosave shouldn't be an error we alert users to.

## Types of changes
Bug fix
