### PR TITLE
Block API: Deprecate `property` source

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -9,6 +9,7 @@ import { flow, castArray, mapValues, omit, stubFalse } from 'lodash';
  */
 import { autop } from '@wordpress/autop';
 import { applyFilters } from '@wordpress/hooks';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -105,6 +106,12 @@ export function matcherFromSource( sourceConfig ) {
 
 			return matcher;
 		case 'property':
+			deprecated( '`property` source', {
+				version: '3.4',
+				alternative: 'equivalent `text`, `html`, or `attribute` source, or comment attribute',
+				plugin: 'Gutenberg',
+			} );
+
 			return prop( sourceConfig.selector, sourceConfig.property );
 		case 'html':
 			return html( sourceConfig.selector );

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -211,18 +211,18 @@ export function getBlockAttributes( blockType, innerHTML, attributes ) {
 export function getMigratedBlock( block ) {
 	const blockType = getBlockType( block.name );
 
-	const { deprecated } = blockType;
-	if ( ! deprecated || ! deprecated.length ) {
+	const { deprecated: deprecatedDefinitions } = blockType;
+	if ( ! deprecatedDefinitions || ! deprecatedDefinitions.length ) {
 		return block;
 	}
 
 	const { originalContent, attributes, innerBlocks } = block;
 
-	for ( let i = 0; i < deprecated.length; i++ ) {
+	for ( let i = 0; i < deprecatedDefinitions.length; i++ ) {
 		// A block can opt into a migration even if the block is valid by
 		// defining isEligible on its deprecation. If the block is both valid
 		// and does not opt to migrate, skip.
-		const { isEligible = stubFalse } = deprecated[ i ];
+		const { isEligible = stubFalse } = deprecatedDefinitions[ i ];
 		if ( block.isValid && ! isEligible( attributes, innerBlocks ) ) {
 			continue;
 		}
@@ -232,7 +232,7 @@ export function getMigratedBlock( block ) {
 		// and must be explicitly provided.
 		const deprecatedBlockType = Object.assign(
 			omit( blockType, [ 'attributes', 'save', 'supports' ] ),
-			deprecated[ i ]
+			deprecatedDefinitions[ i ]
 		);
 
 		let migratedAttributes = getBlockAttributes(

--- a/core-blocks/code/index.js
+++ b/core-blocks/code/index.js
@@ -23,9 +23,8 @@ export const settings = {
 	attributes: {
 		content: {
 			type: 'string',
-			source: 'property',
+			source: 'text',
 			selector: 'code',
-			property: 'textContent',
 		},
 	},
 

--- a/core-blocks/heading/edit.js
+++ b/core-blocks/heading/edit.js
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { range } from 'lodash';
+
+/**
  * WordPress dependencies
  */
-
 import { __, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { PanelBody, Toolbar } from '@wordpress/components';
@@ -21,35 +25,29 @@ export default function HeadingEdit( {
 	onReplace,
 	className,
 } ) {
-	const { align, content, nodeName, placeholder } = attributes;
+	const { align, content, level, placeholder } = attributes;
+	const tagName = 'h' + level;
+
+	function createLevelControl( targetLevel ) {
+		return {
+			icon: 'heading',
+			// translators: %s: heading level e.g: "1", "2", "3"
+			title: sprintf( __( 'Heading %d' ), targetLevel ),
+			isActive: targetLevel === level,
+			onClick: () => setAttributes( { level: targetLevel } ),
+			subscript: String( targetLevel ),
+		};
+	}
 
 	return (
 		<Fragment>
 			<BlockControls>
-				<Toolbar
-					controls={ '234'.split( '' ).map( ( level ) => ( {
-						icon: 'heading',
-						// translators: %s: heading level e.g: "1", "2", "3"
-						title: sprintf( __( 'Heading %s' ), level ),
-						isActive: 'H' + level === nodeName,
-						onClick: () => setAttributes( { nodeName: 'H' + level } ),
-						subscript: level,
-					} ) ) }
-				/>
+				<Toolbar controls={ range( 2, 5 ).map( createLevelControl ) } />
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Heading Settings' ) }>
 					<p>{ __( 'Level' ) }</p>
-					<Toolbar
-						controls={ '123456'.split( '' ).map( ( level ) => ( {
-							icon: 'heading',
-							// translators: %s: heading level e.g: "1", "2", "3"
-							title: sprintf( __( 'Heading %s' ), level ),
-							isActive: 'H' + level === nodeName,
-							onClick: () => setAttributes( { nodeName: 'H' + level } ),
-							subscript: level,
-						} ) ) }
-					/>
+					<Toolbar controls={ range( 1, 7 ).map( createLevelControl ) } />
 					<p>{ __( 'Text Alignment' ) }</p>
 					<AlignmentToolbar
 						value={ align }
@@ -61,7 +59,7 @@ export default function HeadingEdit( {
 			</InspectorControls>
 			<RichText
 				wrapperClassName="wp-block-heading"
-				tagName={ nodeName.toLowerCase() }
+				tagName={ tagName }
 				value={ content }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }

--- a/core-blocks/heading/index.js
+++ b/core-blocks/heading/index.js
@@ -143,7 +143,7 @@ export const settings = {
 					default: 'H2',
 				},
 			},
-			migrate( { attributes } ) {
+			migrate( attributes ) {
 				const { nodeName, ...migratedAttributes } = attributes;
 
 				return {

--- a/core-blocks/heading/test/index.js
+++ b/core-blocks/heading/test/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { name, settings } from '../';
+import { name, settings, getLevelFromHeadingNodeName } from '../';
 import { blockEditRender } from '../../test/helpers';
 
 describe( 'core/heading', () => {
@@ -9,5 +9,13 @@ describe( 'core/heading', () => {
 		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
+	} );
+} );
+
+describe( 'getLevelFromHeadingNodeName()', () => {
+	it( 'should return a numeric value from nodeName', () => {
+		const level = getLevelFromHeadingNodeName( 'H4' );
+
+		expect( level ).toBe( 4 );
 	} );
 } );

--- a/core-blocks/list/index.js
+++ b/core-blocks/list/index.js
@@ -174,7 +174,7 @@ export const settings = {
 					default: 'UL',
 				},
 			},
-			migrate( { attributes } ) {
+			migrate( attributes ) {
 				const { nodeName, ...migratedAttributes } = attributes;
 
 				return {

--- a/core-blocks/test/fixtures/core__heading__h2-em.json
+++ b/core-blocks/test/fixtures/core__heading__h2-em.json
@@ -12,7 +12,7 @@
                 },
                 " Tool"
             ],
-            "nodeName": "H2"
+            "level": 2
         },
         "innerBlocks": [],
         "originalContent": "<h2>The <em>Inserter</em> Tool</h2>"

--- a/core-blocks/test/fixtures/core__heading__h2.json
+++ b/core-blocks/test/fixtures/core__heading__h2.json
@@ -7,7 +7,7 @@
             "content": [
                 "A picture is worth a thousand words, or so the saying goes"
             ],
-            "nodeName": "H2"
+            "level": 2
         },
         "innerBlocks": [],
         "originalContent": "<h2>A picture is worth a thousand words, or so the saying goes</h2>"

--- a/core-blocks/test/fixtures/core__list__ul.json
+++ b/core-blocks/test/fixtures/core__list__ul.json
@@ -4,7 +4,7 @@
         "name": "core/list",
         "isValid": true,
         "attributes": {
-            "nodeName": "UL",
+            "ordered": false,
             "values": [
                 {
                     "type": "li",

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -13,6 +13,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `blocks.BlockEdit` filter removed. Please use `editor.BlockEdit` instead.
  - `blocks.BlockListBlock` filter removed. Please use `editor.BlockListBlock` instead.
  - `blocks.MediaUpload` filter removed. Please use `editor.MediaUpload` instead.
+ - `property` source removed. Please use equivalent `text`, `html`, or `attribute` source, or comment attribute instead.
 
 ## 3.2.0
 

--- a/editor/components/block-switcher/test/index.js
+++ b/editor/components/block-switcher/test/index.js
@@ -18,7 +18,7 @@ describe( 'BlockSwitcher', () => {
 	const headingBlock1 = {
 		attributes: {
 			content: [ 'How are you?' ],
-			nodeName: 'H2',
+			level: 2,
 		},
 		isValid: true,
 		name: 'core/heading',
@@ -29,7 +29,6 @@ describe( 'BlockSwitcher', () => {
 	const textBlock = {
 		attributes: {
 			content: [ 'I am great!' ],
-			nodeName: 'P',
 		},
 		isValid: true,
 		name: 'core/text',
@@ -40,7 +39,7 @@ describe( 'BlockSwitcher', () => {
 	const headingBlock2 = {
 		attributes: {
 			content: [ 'I am the greatest!' ],
-			nodeName: 'H3',
+			level: 3,
 		},
 		isValid: true,
 		name: 'core/text',

--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -33,28 +33,6 @@ const multipleH1Headings = [
 	<em key="incorrect-message-multiple-h1">{ __( '(Multiple H1 headings are not recommended)' ) }</em>,
 ];
 
-const getHeadingLevel = ( heading ) => {
-	switch ( heading.attributes.nodeName ) {
-		case 'h1':
-		case 'H1':
-			return 1;
-		case 'h2':
-		case 'H2':
-			return 2;
-		case 'h3':
-		case 'H3':
-			return 3;
-		case 'h4':
-		case 'H4':
-			return 4;
-		case 'h5':
-		case 'H5':
-			return 5;
-		case 'h6':
-		case 'H6':
-			return 6;
-	}
-};
 /**
  * Returns an array of heading blocks enhanced with the following properties:
  * path    - An array of blocks that are ancestors of the heading starting from a top-level node.
@@ -73,7 +51,7 @@ const computeOutlineHeadings = ( blocks = [], path = [] ) => {
 			return {
 				...block,
 				path,
-				level: getHeadingLevel( block ),
+				level: block.attributes.level,
 				isEmpty: isEmptyHeading( block ),
 			};
 		}

--- a/editor/components/document-outline/test/index.js
+++ b/editor/components/document-outline/test/index.js
@@ -22,15 +22,15 @@ describe( 'DocumentOutline', () => {
 	const paragraph = createBlock( 'core/paragraph' );
 	const headingH1 = createBlock( 'core/heading', {
 		content: 'Heading 1',
-		nodeName: 'H1',
+		level: 1,
 	} );
 	const headingParent = createBlock( 'core/heading', {
 		content: 'Heading parent',
-		nodeName: 'H2',
+		level: 2,
 	} );
 	const headingChild = createBlock( 'core/heading', {
 		content: 'Heading child',
-		nodeName: 'H3',
+		level: 3,
 	} );
 
 	const nestedHeading = createBlock( 'core/columns', undefined, [ headingChild ] );

--- a/post-content.js
+++ b/post-content.js
@@ -25,7 +25,7 @@ window._wpGutenbergDefaultPost = {
 			'<p>Headings are separate blocks as well, which helps with the outline and organization of your content.</p>',
 			'<!-- /wp:paragraph -->',
 
-			'<!-- wp:heading -->',
+			'<!-- wp:heading {"level":2} -->',
 			'<h2>A Picture is worth a Thousand Words</h2>',
 			'<!-- /wp:heading -->',
 
@@ -41,7 +41,7 @@ window._wpGutenbergDefaultPost = {
 			'<p>Try selecting and removing or editing the caption, now you don\'t have to be careful about selecting the image or other text by mistake and ruining the presentation.</p>',
 			'<!-- /wp:paragraph -->',
 
-			'<!-- wp:heading -->',
+			'<!-- wp:heading {"level":2} -->',
 			'<h2>The <em>Inserter</em> Tool</h2>',
 			'<!-- /wp:heading -->',
 
@@ -61,7 +61,7 @@ window._wpGutenbergDefaultPost = {
 			'<hr class="wp-block-separator" />',
 			'<!-- /wp:separator -->',
 
-			'<!-- wp:heading -->',
+			'<!-- wp:heading {"level":2} -->',
 			'<h2>Visual Editing</h2>',
 			'<!-- /wp:heading -->',
 
@@ -93,7 +93,7 @@ window._wpGutenbergDefaultPost = {
 			'<p>You can change the amount of columns in your galleries by dragging a slider in the block inspector in the sidebar.</p>',
 			'<!-- /wp:paragraph -->',
 
-			'<!-- wp:heading -->',
+			'<!-- wp:heading {"level":2} -->',
 			'<h2>Media Rich</h2>',
 			'<!-- /wp:heading -->',
 

--- a/test/integration/fixtures/apple-out.html
+++ b/test/integration/fixtures/apple-out.html
@@ -22,7 +22,7 @@
 </ul>
 <!-- /wp:list -->
 
-<!-- wp:list -->
+<!-- wp:list {"ordered":true} -->
 <ol>
 	<li>One</li>
 	<li>Two</li>

--- a/test/integration/fixtures/evernote-out.html
+++ b/test/integration/fixtures/evernote-out.html
@@ -16,7 +16,7 @@
 </ul>
 <!-- /wp:list -->
 
-<!-- wp:list -->
+<!-- wp:list {"ordered":true} -->
 <ol>
 	<li>One</li>
 	<li>Two

--- a/test/integration/fixtures/google-docs-out.html
+++ b/test/integration/fixtures/google-docs-out.html
@@ -22,7 +22,7 @@
 </ul>
 <!-- /wp:list -->
 
-<!-- wp:list -->
+<!-- wp:list {"ordered":true} -->
 <ol>
 	<li>One</li>
 	<li>Two</li>

--- a/test/integration/fixtures/markdown-out.html
+++ b/test/integration/fixtures/markdown-out.html
@@ -1,4 +1,4 @@
-<!-- wp:heading -->
+<!-- wp:heading {"level":1} -->
 <h1>This is a heading with <em>italic</em></h1>
 <!-- /wp:heading -->
 
@@ -26,7 +26,7 @@
 </ul>
 <!-- /wp:list -->
 
-<!-- wp:list -->
+<!-- wp:list {"ordered":true} -->
 <ol>
 	<li>One</li>
 	<li>Two</li>

--- a/test/integration/fixtures/ms-word-online-out.html
+++ b/test/integration/fixtures/ms-word-online-out.html
@@ -15,7 +15,7 @@
 </ul>
 <!-- /wp:list -->
 
-<!-- wp:list -->
+<!-- wp:list {"ordered":true} -->
 <ol>
 	<li>One </li>
 	<li>Two </li>

--- a/test/integration/fixtures/ms-word-out.html
+++ b/test/integration/fixtures/ms-word-out.html
@@ -8,7 +8,7 @@
 </p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading -->
+<!-- wp:heading {"level":1} -->
 <h1>This is a heading level 1</h1>
 <!-- /wp:heading -->
 
@@ -32,7 +32,7 @@
 </ul>
 <!-- /wp:list -->
 
-<!-- wp:list -->
+<!-- wp:list {"ordered":true} -->
 <ol>
 	<li>One</li>
 	<li>Two</li>

--- a/test/integration/fixtures/wordpress-out.html
+++ b/test/integration/fixtures/wordpress-out.html
@@ -6,7 +6,7 @@
 <p>This is a paragraph.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading -->
+<!-- wp:heading {"level":3} -->
 <h3>More tag</h3>
 <!-- /wp:heading -->
 
@@ -14,7 +14,7 @@
 <!--more-->
 <!-- /wp:more -->
 
-<!-- wp:heading -->
+<!-- wp:heading {"level":3} -->
 <h3>Shortcode</h3>
 <!-- /wp:heading -->
 


### PR DESCRIPTION
Related: #2751

This pull request seeks to deprecate the `property` source type. This was never publicly documented since it was always discouraged for use, but has been leveraged by core block implementations since earliest version of the plugin. Thus, while it's not expected that many plugin blocks will have used this source, there may be those where the core blocks had been used as a reference. The source will be removed in ~3.2.0~ 3.3.0.

There was a single instance of the `property` source being used incorrectly when a more appropriate alternative exists (code). `textContent` and `innerHTML` can be substituted with the `text` and `html` sources respectively.

The heading and list blocks were not as simple to transition, since they use `nodeName` as an indicator of heading level and ordered vs. unordered lists. These have been updated to new `level` (number) and `ordered` (boolean) attributes, serialized by the block comment attributes, including deprecated migrations for each block. Alternatively, we could consider an equivalent source type for retrieving the `nodeName` (or tag name) of a node, but this did not seem strictly necessary or a common enough use-case to justify.

__Testing instructions:__

Verify that existing posts containing lists and/or heading and/or code blocks are migrated gracefully.

Verify that a deprecated warning is shown for blocks which use the `property` source.