### PR TITLE
Link Preview block

### DIFF
--- a/block-library/index.js
+++ b/block-library/index.js
@@ -30,6 +30,7 @@ import * as embed from '../packages/block-library/src/embed';
 import * as file from '../packages/block-library/src/file';
 import * as latestComments from '../packages/block-library/src/latest-comments';
 import * as latestPosts from '../packages/block-library/src/latest-posts';
+import * as linkPreview from '../packages/block-library/src/link-preview';
 import * as list from '../packages/block-library/src/list';
 import * as more from '../packages/block-library/src/more';
 import * as nextpage from '../packages/block-library/src/nextpage';
@@ -80,6 +81,7 @@ export const registerCoreBlocks = () => {
 		html,
 		latestComments,
 		latestPosts,
+		linkPreview,
 		more,
 		nextpage,
 		preformatted,

--- a/lib/class-wp-rest-opengraph-controller.php
+++ b/lib/class-wp-rest-opengraph-controller.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * OpenGraph REST API: WP_REST_Block_OpenGraph_Controller class
+ *
+ * @package gutenberg
+ * @since 3.x
+ */
+
+/**
+ * Controller which provides REST endpoint for rendering a block.
+ *
+ * @since 3.x
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_OpenGraph_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructs the controller.
+	 */
+	public function __construct() {
+		$this->api_namespace    = 'gutenberg/v1';
+		$this->rest_base        = 'opengraph';
+		$this->min_resolution   = 128;
+		$this->thumb_resolution = 200;
+		$this->request_args     = array(
+			'user-agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36',
+		);
+	}
+
+	/**
+	 * Registers the necessary REST API routes.
+	 */
+	public function register_routes() {
+
+		register_rest_route( $this->api_namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_preview' ),
+				'permission_callback' => array( $this, 'get_preview_permissions_check' ),
+				'args'                => array(
+					'url' => array(
+						'description'       => __( 'The URL of the resource for which to fetch OpenGraph data.', 'gutenberg' ),
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'esc_url_raw',
+					),
+				),
+			),
+		) );
+	}
+
+	/**
+	 * Checks if current user can make an OpenGraph request.
+	 *
+	 * @since 3.x
+	 *
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_preview_permissions_check() {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to make OpenGraph requests.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Callback for the OpenGraph API endpoint.
+	 *
+	 * Returns the JSON object for the item .
+	 *
+	 * @since 3.x
+	 *
+	 * @see WP_REST_OpenGraph_Controller#generate_preview
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return object|WP_Error response data or WP_Error on failure.
+	 */
+	public function get_preview( $request ) {
+		$args = $request->get_params();
+
+		// Insert the blog id, because when we fetch the preview's images into the
+		// media library, the cached preview will reference their URLs and we'll need
+		// to cache this preview per blog.
+		$args['blog_id'] = get_current_blog_id();
+
+		// Serve data from cache if set.
+		unset( $args['_wpnonce'] );
+		$cache_key = 'gutenberg_opengraph_' . md5( serialize( $args ) );
+		$data      = get_transient( $cache_key );
+		$url       = $request['url'];
+
+		if ( ! empty( $data ) ) {
+			return $data;
+		}
+
+		$data = $this->generate_preview( $args );
+		if ( is_wp_error( $data ) ) {
+			return new WP_Error( 'opengraph_invalid_url', get_status_header_desc( 404 ), array( 'status' => 404 ) );
+		}
+
+		/**
+		 * Filters the OpenGraph TTL value (time to live).
+		 *
+		 * @since 3.x
+		 *
+		 * @param int    $time    Time to live (in seconds).
+		 * @param string $url     The attempted URL.
+		 */
+		$ttl = apply_filters( 'rest_opengraph_ttl', DAY_IN_SECONDS, $url );
+
+		set_transient( $cache_key, $data, $ttl );
+
+		return $data;
+	}
+
+	/**
+	 * Sideloads the remote image if all conditions are met and the image can be fetched.
+	 *
+	 * Returns the local URL of the uploaded image.
+	 *
+	 * @since 3.x
+	 *
+	 * @param string $url URL of the image.
+	 * @return string|WP_Error Local URL or WP_Error on failure.
+	 */
+	private function maybe_sideload_remote_image( $url ) {
+		// Need to require these files to get access to media_handle_sideload.
+		if ( ! function_exists( 'media_handle_upload' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/image.php' );
+			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+			require_once( ABSPATH . 'wp-admin/includes/media.php' );
+		}
+
+		$tmp_filename = tempnam( sys_get_temp_dir(), basename( $url ) );
+		$response     = wp_remote_get( $url, $this->request_args );
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'opengraph_cant_fetch_image', __( 'Could not fetch image.', 'gutenberg' ) );
+		}
+
+		file_put_contents( $tmp_filename, $response['body'] );
+		$image = wp_get_image_editor( $tmp_filename );
+		if ( is_wp_error( $image ) ) {
+			unlink( $tmp_filename );
+			return new WP_Error( 'opengraph_cant_get_image_editor', __( 'Could not get an image editor.', 'gutenberg' ) );
+		}
+
+		$img_size = $image->get_size();
+		if ( $img_size['width'] < $this->min_resolution && $img_size['height'] < $this->min_resolution ) {
+			unlink( $tmp_filename );
+			return new WP_Error( 'opengraph_image_too_small', __( 'Fetched image was too small.', 'gutenberg' ) );
+		}
+
+		$resize = $image->resize( $this->thumb_resolution, $this->thumb_resolution );
+		if ( is_wp_error( $resize ) ) {
+			unlink( $tmp_filename );
+			return new WP_Error( 'opengraph_image_resize_fail', __( 'Failed to resize the image.', 'gutenberg' ) );
+		}
+
+		$saved = $image->save();
+		unlink( $tmp_filename );
+		if ( is_wp_error( $saved ) ) {
+			return new WP_Error( 'opengraph_image_save_fail', __( 'Failed to save the image.', 'gutenberg' ) );
+		}
+
+		$mime_type = $response['headers']->offsetGet( 'content-type' );
+		$file      = array(
+			// Get rid of any query parameters, leaving just the file name, so we don't get
+			// security warnings when uploading images that look like 'screenshot.jpg?3'.
+			'name'     => preg_replace( '/\?.*/', '', basename( $url ) ),
+			'type'     => $mime_type,
+			'tmp_name' => $saved['path'],
+			'error'    => 0,
+			'size'     => filesize( $saved['path'] ),
+		);
+
+		$attachment_id = media_handle_sideload( $file, 0 );
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
+
+		return wp_get_attachment_url( $attachment_id );
+	}
+
+	/**
+	 * Makes sure a string is free from tags and escaped, so it's safe for embedding.
+	 *
+	 * @since 3.x
+	 *
+	 * @param string $content Content to sanitize.
+	 * @return string Safe content.
+	 */
+	private function sanitize_content( $content ) {
+		return esc_html( strip_tags( $content ) );
+	}
+
+	/**
+	 * Generates preview data.
+	 *
+	 * Returns an array of preview data.
+	 *
+	 * @since 3.x
+	 *
+	 * @param array $args Information about the URL, 'url' and 'blog_id' are required.
+	 * @return array|bool Array of preview data, or false on failure.
+	 */
+	private function generate_preview( $args ) {
+		$url     = $args['url'];
+		$blog_id = $args['blog_id'];
+
+		$response = wp_remote_get( $url, $this->request_args );
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'opengraph_fetch_fail', __( 'Failed to fetch the URL.', 'gutenberg' ) );
+		}
+
+		$response_obj = $response['http_response']->get_response_object();
+		if ( ! $response_obj->success ) {
+			return new WP_Error( 'opengraph_fetch_fail', __( 'Failed to fetch the URL.', 'gutenberg' ) );
+		}
+
+		// Get the URL from the response object, so we deal with the actual URL
+		// that we ended up on.
+		$url  = $response_obj->url;
+		$body = $response['body'];
+		$data = array(
+			'url' => $url,
+		);
+
+		// Extract any data from meta tags.
+		preg_match_all( '/<meta .*(name|property)="([a-z]+)" content="([^"]+)"/', $body, $matches );
+		foreach ( $matches[2] as $index => $property ) {
+			$data[ $property ] = $matches[3][ $index ];
+		}
+
+		// Extract any OpenGraph data.
+		$matches = array( 'image' => array() );
+		preg_match_all( '/<meta .*property="og:([a-z]+)" content="([^"]+)"/', $body, $matches );
+		foreach ( $matches[1] as $index => $property ) {
+			if ( 'image' === $property ) {
+				$data['image'][] = $matches[2][ $index ];
+			} else {
+				$data[ $property ] = $matches[2][ $index ];
+			}
+		}
+
+		if ( ! isset( $data['title'] ) || empty( $data['title'] ) ) {
+			$match = array();
+			preg_match( '|<title>(.+?)</title>|', $body, $match );
+			if ( $match ) {
+				$data['title'] = $match[1];
+			} else {
+				$data['title'] = $url;
+			}
+		}
+
+		if ( ! isset( $data['description'] ) || empty( $data['description'] ) ) {
+			$match = array();
+			preg_match( '|<p.*>.+?</p>|', $body, $match );
+			if ( $match ) {
+				// First bunch of words in the first paragraph.
+				$content             = $this->sanitize_content( $match[0] );
+				$extract             = substr( $content, 0, 500 );
+				$words               = str_word_count( $extract, 1 );
+				$data['description'] = join( ' ', array_slice( $words, 0, -1 ) ) . '...';
+			}
+		}
+
+		foreach ( $data as $index => $value ) {
+			if ( 'image' !== $index ) {
+				$data[ $index ] = $this->sanitize_content( $value );
+			}
+		}
+
+		if ( ! isset( $data['image'] ) || empty( $data['image'] ) ) {
+			$matches = array();
+			preg_match_all( '|<img [^>]*src=["\']([^"\']+)["\']|', $body, $matches );
+			if ( $matches ) {
+				$parsed_url    = parse_url( $url );
+				$path_segments = explode( '/', $parsed_url['path'] );
+				$base_path     = $parsed_url['scheme'] . '://' . $parsed_url['host'] . join( '/', array_slice( $path_segments, 0, -1 ) ) . '/';
+				$images        = array();
+				$imgsrcs       = array_slice( $matches[1], 0, 3 );
+				foreach ( $imgsrcs as $imgsrc ) {
+					// Make full urls out of the image src.
+					if ( '//' === substr( $imgsrc, 0, 2 ) ) {
+						$full_img_url = 'https:' . $imgsrc;
+					} elseif ( '/' === substr( $imgsrc, 0, 1 ) ) {
+						$full_img_url = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $imgsrc;
+					} elseif ( preg_match( '|^https?://.+|', $imgsrc ) ) {
+						$full_img_url = $imgsrc;
+					} else {
+						$full_img_url = $base_path . $imgsrc;
+					}
+					$local_url = $this->maybe_sideload_remote_image( $full_img_url );
+					if ( ! is_wp_error( $local_url ) ) {
+						$images[] = array( 'src' => $local_url );
+					}
+				}
+				$data['images'] = $images;
+			}
+		} else {
+			$data['images'] = array();
+			foreach ( $data['image'] as $imgsrc ) {
+				$local_url = $this->maybe_sideload_remote_image( $imgsrc );
+				if ( ! is_wp_error( $local_url ) ) {
+					$data['images'][] = array( 'src' => $local_url );
+				}
+			}
+			unset( $data['image'] );
+		}
+		return $data;
+	}
+}

--- a/lib/class-wp-rest-opengraph-controller.php
+++ b/lib/class-wp-rest-opengraph-controller.php
@@ -33,21 +33,25 @@ class WP_REST_OpenGraph_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( $this->api_namespace, '/' . $this->rest_base, array(
+		register_rest_route(
+			$this->api_namespace,
+			'/' . $this->rest_base,
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_preview' ),
-				'permission_callback' => array( $this, 'get_preview_permissions_check' ),
-				'args'                => array(
-					'url' => array(
-						'description'       => __( 'The URL of the resource for which to fetch OpenGraph data.', 'gutenberg' ),
-						'type'              => 'string',
-						'required'          => true,
-						'sanitize_callback' => 'esc_url_raw',
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_preview' ),
+					'permission_callback' => array( $this, 'get_preview_permissions_check' ),
+					'args'                => array(
+						'url' => array(
+							'description'       => __( 'The URL of the resource for which to fetch OpenGraph data.', 'gutenberg' ),
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'esc_url_raw',
+						),
 					),
 				),
-			),
-		) );
+			)
+		);
 	}
 
 	/**

--- a/lib/load.php
+++ b/lib/load.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // which this class will exist if that is the case.
 if ( class_exists( 'WP_REST_Controller' ) ) {
 	require dirname( __FILE__ ) . '/class-wp-rest-blocks-controller.php';
+	require dirname( __FILE__ ) . '/class-wp-rest-opengraph-controller.php';
 	require dirname( __FILE__ ) . '/class-wp-rest-autosaves-controller.php';
 	require dirname( __FILE__ ) . '/class-wp-rest-block-renderer-controller.php';
 	require dirname( __FILE__ ) . '/class-wp-rest-search-controller.php';

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -29,8 +29,10 @@ function gutenberg_register_rest_routes() {
 	 *                               Default is only a handler for posts.
 	 */
 	$search_handlers = apply_filters( 'wp_rest_search_handlers', array( new WP_REST_Post_Search_Handler() ) );
+	$controller      = new WP_REST_Search_Controller( $search_handlers );
+	$controller->register_routes();
 
-	$controller = new WP_REST_Search_Controller( $search_handlers );
+	$controller = new WP_REST_OpenGraph_Controller();
 	$controller->register_routes();
 
 	foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -69,7 +69,17 @@ export function getEmbedEdit( title, icon ) {
 			}
 
 			if ( ( hasPreview && ! hadPreview ) || switchedPreview ) {
-				if ( this.props.previewIsFallback ) {
+				if ( this.props.previewIsFallback && 'core/embed' === this.props.name ) {
+					// We couldn't find a block that handled the URL, and oEmbed
+					// provided a fallback response, so switch to a link preview block.
+					const { url } = this.props.attributes;
+					this.props.onReplace(
+						[
+							createBlock( 'core/paragraph', { content: <a href={ url } key={ url }>{ url }</a> } ),
+							createBlock( 'core-embed/link-preview', { url } ),
+						]
+					);
+				} else if ( this.props.previewIsFallback ) {
 					this.setState( { editingURL: true } );
 					return;
 				}

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -27,6 +27,7 @@ import * as embed from './embed';
 import * as file from './file';
 import * as latestComments from './latest-comments';
 import * as latestPosts from './latest-posts';
+import * as linkPreview from './link-preview';
 import * as list from './list';
 import * as more from './more';
 import * as nextpage from './nextpage';
@@ -69,6 +70,7 @@ export const registerCoreBlocks = () => {
 		file,
 		latestComments,
 		latestPosts,
+		linkPreview,
 		more,
 		nextpage,
 		preformatted,

--- a/packages/block-library/src/link-preview/editor.scss
+++ b/packages/block-library/src/link-preview/editor.scss
@@ -1,0 +1,31 @@
+.wp-block-embed-link-preview {
+	&.is-loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 1em;
+		min-height: 200px;
+		text-align: center;
+		p {
+			font-family: $default-font;
+			font-size: $default-font-size;
+		}
+	}
+	.wp-block-embed-link-preview__image {
+		text-align: center;
+		img {
+			display: block;
+		}
+		.wp-block-embed-link-preview__image__selected {
+			height: 200px;
+		}
+		.wp-block-embed-link-preview__image__tools {
+			display: flex;
+			button {
+				display: inline;
+				flex-grow: 1;
+			}
+		}
+	}
+}

--- a/packages/block-library/src/link-preview/index.js
+++ b/packages/block-library/src/link-preview/index.js
@@ -1,0 +1,291 @@
+/**
+ * External dependencies
+ */
+import { stringify } from 'querystring';
+import { uniq, indexOf } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment, RawHTML } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { Button, IconButton, Placeholder, Spinner, Toolbar } from '@wordpress/components';
+import { BlockControls } from '@wordpress/editor';
+
+import './style.scss';
+import './editor.scss';
+
+export const name = 'core-embed/link-preview';
+
+const edit = class extends Component {
+	constructor() {
+		super( ...arguments );
+		this.MODES = {
+			INPUT_URL: 1,
+			FETCH: 2,
+			EDITING: 3,
+			CANT_FETCH: 4,
+		};
+		this.state = {
+			url: '',
+			mode: this.MODES.INPUT_URL,
+			images: [],
+			selectedImage: undefined,
+		};
+		this.setupState = this.setupState.bind( this );
+		this.setURL = this.setURL.bind( this );
+		this.switchBackToURLInput = this.switchBackToURLInput.bind( this );
+		this.previousImage = this.previousImage.bind( this );
+		this.nextImage = this.nextImage.bind( this );
+		this.removeImage = this.removeImage.bind( this );
+	}
+
+	componentWillMount() {
+		this.setupState( this.props );
+	}
+
+	componentWillReceiveProps( newProps ) {
+		this.setupState( newProps );
+	}
+
+	nextImage() {
+		const { images, selectedImage } = this.state;
+		const currentIndex = indexOf( images, selectedImage );
+		let nextImage;
+		if ( images.length === currentIndex + 1 ) {
+			nextImage = images[ 0 ];
+		} else {
+			nextImage = images[ currentIndex + 1 ];
+		}
+		this.setState( { selectedImage: nextImage } );
+		this.props.setAttributes( { images: [ nextImage ] } );
+	}
+
+	previousImage() {
+		const { images, selectedImage } = this.state;
+		const currentIndex = indexOf( images, selectedImage );
+		let prevImage;
+		if ( 0 === currentIndex ) {
+			prevImage = images[ images.length - 1 ];
+		} else {
+			prevImage = images[ currentIndex - 1 ];
+		}
+		this.setState( { selectedImage: prevImage } );
+		this.props.setAttributes( { images: [ prevImage ] } );
+	}
+
+	removeImage() {
+		this.setState( { selectedImage: undefined, images: [] } );
+		this.props.setAttributes( { images: [] } );
+	}
+
+	setupState( newProps ) {
+		const { url, images, title, description } = newProps.attributes;
+		const hasPreviewData = images.length > 0 || title || description;
+
+		if ( 0 === this.state.images.length && images.length > 0 ) {
+			// set up the images with the first image as the selected image
+			this.setState( {
+				images: uniq( images ),
+				selectedImage: images[ 0 ],
+			} );
+			this.props.setAttributes( { images: [ images[ 0 ] ] } );
+		}
+
+		if ( ! url ) {
+			this.setState( { mode: this.MODES.INPUT_URL } );
+			return;
+		}
+
+		this.setState( { url } );
+
+		if ( url && ! hasPreviewData ) {
+			// we've only got a url, so fetch the rest from the API
+			const apiURL = `/gutenberg/v1/opengraph?${ stringify( { url } ) }`;
+			this.setState( { mode: this.MODES.FETCH } );
+			apiFetch( { path: apiURL } )
+				.then(
+					( obj ) => {
+						if ( this.unmounting ) {
+							return;
+						}
+						this.props.setAttributes( obj );
+						this.setState( { mode: this.MODES.EDITING } );
+					},
+					() => {
+						this.setState( { mode: this.MODES.CANT_FETCH } );
+					}
+				);
+			return;
+		}
+
+		this.setState( { mode: this.MODES.EDITING } );
+	}
+
+	componentWillUnmount() {
+		// can't abort the promise, so let it know we will unmount
+		this.unmounting = true;
+	}
+
+	setURL( event ) {
+		const { url } = this.state;
+
+		if ( url === this.props.attributes.url ) {
+			this.setupState( this.props );
+			return;
+		}
+
+		this.props.setAttributes( { url } );
+		if ( event ) {
+			event.preventDefault();
+		}
+	}
+
+	switchBackToURLInput() {
+		this.setState( { mode: this.MODES.INPUT_URL } );
+	}
+
+	render() {
+		const { attributes, isSelected } = this.props;
+		const { mode, url, selectedImage, images } = this.state;
+		const { FETCH, CANT_FETCH, INPUT_URL } = this.MODES;
+		const isEditing = mode === INPUT_URL || mode === CANT_FETCH || mode === FETCH;
+		const hasMultipleImages = images.length > 1;
+		const label = __( 'Link preview' );
+		const controls = (
+			<BlockControls>
+				<Toolbar>
+					{ <IconButton
+						className="components-toolbar__control"
+						label={ __( 'Edit URL' ) }
+						icon="edit"
+						onClick={ this.switchBackToURLInput }
+					/> }
+				</Toolbar>
+			</BlockControls>
+		);
+
+		if ( isEditing ) {
+			return (
+				<Fragment>
+					{ controls }
+					<Placeholder label={ label } className="wp-block-embed">
+						<form onSubmit={ this.setURL }>
+							{ mode !== FETCH && (
+								<Fragment>
+									<input
+										type="url"
+										value={ url || '' }
+										className="components-placeholder__input"
+										aria-label={ label }
+										placeholder={ __( 'Enter URL here…' ) }
+										onChange={ ( event ) => this.setState( { url: event.target.value } ) } />
+									<Button
+										isLarge
+										type="submit">
+										{ __( 'Preview' ) }
+									</Button>
+								</Fragment>
+							) }
+							{ mode === FETCH && (
+								<div className="wp-block-embed-link-preview is-loading">
+									<Spinner />
+									<p>{ __( 'Generating preview…' ) }</p>
+								</div>
+							) }
+							{ mode === CANT_FETCH && <p className="components-placeholder__error">{ __( 'Sorry, we could not generate a preview for that URL.' ) }</p> }
+						</form>
+					</Placeholder>
+				</Fragment>
+			);
+		}
+
+		return (
+			<div className="wp-block-embed-link-preview">
+				{ controls }
+				<div className="wp-block-embed-link-preview__textinfo">
+					<p><a href={ attributes.url }><RawHTML>{ attributes.title }</RawHTML></a></p>
+					<p className="wp-block-embed-link-preview__description"><RawHTML>{ attributes.description }</RawHTML></p>
+				</div>
+				{ selectedImage && (
+					<div className="wp-block-embed-link-preview__image">
+						<div className="wp-block-embed-link-preview__image__selected">
+							<img src={ selectedImage.src } alt="" />
+						</div>
+						{ isSelected &&
+						<div className="wp-block-embed-link-preview__image__tools">
+							{ hasMultipleImages &&
+								<IconButton
+									aria-label={ __( 'Previous image' ) }
+									icon="arrow-left-alt2"
+									onClick={ this.previousImage } />
+							}
+							<IconButton
+								icon="no"
+								aria-label={ __( 'Remove image' ) }
+								onClick={ this.removeImage } />
+							{ hasMultipleImages &&
+								<IconButton
+									aria-label={ __( 'Next image' ) }
+									icon="arrow-right-alt2"
+									onClick={ this.nextImage } />
+							}
+						</div>
+						}
+					</div>
+				) }
+			</div>
+		);
+	}
+};
+
+const save = function( { attributes } ) {
+	return (
+		<div className="wp-block-embed-link-preview">
+			<div className="wp-block-embed-link-preview__textinfo">
+				<p><a href={ attributes.url }><RawHTML>{ attributes.title }</RawHTML></a></p>
+				<p className="wp-block-embed-link-preview__description"><RawHTML>{ attributes.description }</RawHTML></p>
+			</div>
+			{ attributes.images.length > 0 && (
+				<div className="wp-block-embed-link-preview__image">
+					{ attributes.images.map(
+						( image ) => <img src={ image.src } alt="" key={ image.src } />
+					) }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export const settings = {
+	title: __( 'Link preview' ),
+	description: __( 'Add a preview for a link.' ),
+	category: 'embed',
+	icon: 'admin-links',
+	attributes: {
+		images: {
+			source: 'query',
+			selector: 'img',
+			query: {
+				src: { source: 'attribute', attribute: 'src' },
+			},
+			default: [],
+		},
+		url: {
+			source: 'attribute',
+			selector: 'a',
+			attribute: 'href',
+		},
+		title: {
+			source: 'text',
+			selector: 'a',
+		},
+		description: {
+			source: 'text',
+			selector: 'p.wp-block-embed-link-preview__description',
+		},
+	},
+	edit,
+	save,
+};

--- a/packages/block-library/src/link-preview/style.scss
+++ b/packages/block-library/src/link-preview/style.scss
@@ -1,0 +1,16 @@
+.wp-block-embed-link-preview {
+	display: flex;
+	.wp-block-embed-link-preview__textinfo {
+		flex-grow: 2;
+	}
+	.wp-block-embed-link-preview__image {
+		width: 200px;
+		margin-left: 16px;
+		img {
+			max-width: 200px;
+			max-height: 200px;
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
+}

--- a/packages/block-library/src/link-preview/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/link-preview/test/__snapshots__/index.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core-embed/link-preview block edit matches snapshot 1`] = `
+<div
+  class="components-placeholder wp-block-embed"
+>
+  <div
+    class="components-placeholder__label"
+  >
+    Link preview
+  </div>
+  <div
+    class="components-placeholder__fieldset"
+  >
+    <form>
+      <input
+        aria-label="Link preview"
+        class="components-placeholder__input"
+        placeholder="Enter URL here…"
+        type="url"
+        value=""
+      />
+      <button
+        class="components-button is-button is-default is-large"
+        type="submit"
+      >
+        Preview
+      </button>
+    </form>
+  </div>
+</div>
+`;

--- a/packages/block-library/src/link-preview/test/index.js
+++ b/packages/block-library/src/link-preview/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { name, settings } from '../';
+import { blockEditRender } from '../../test/helpers';
+
+describe( 'core-embed/link-preview', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( name, settings );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/packages/block-library/src/test/fixtures/core-embed__link-preview.html
+++ b/packages/block-library/src/test/fixtures/core-embed__link-preview.html
@@ -1,0 +1,3 @@
+<!-- wp:core-embed/link-preview -->
+<div class="wp-block-embed-link-preview"><div class="wp-block-embed-link-preview__textinfo"><p><a href="https://tabs.ultimate-guitar.com/tab/misc_cartoons/steven_universe_-_whats_the_use_of_feeling_blue_ukulele_2155897">Misc Cartoons - Steven Universe - Whats The Use Of Feeling Blue (Ukulele)</a></p><p class="wp-block-embed-link-preview__description">UKULELE by Misc Cartoons</p></div><div class="wp-block-embed-link-preview__image"><img src="https://tabs.ultimate-guitar.com/static/_img/ug-logo-fb.png" alt="" /></div></div>
+<!-- /wp:core-embed/link-preview -->

--- a/packages/block-library/src/test/fixtures/core-embed__link-preview.json
+++ b/packages/block-library/src/test/fixtures/core-embed__link-preview.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "core-embed/link-preview",
+        "isValid": true,
+        "attributes": {
+            "url": "https://tabs.ultimate-guitar.com/tab/misc_cartoons/steven_universe_-_whats_the_use_of_feeling_blue_ukulele_2155897",
+            "title": "Misc Cartoons - Steven Universe - Whats The Use Of Feeling Blue (Ukulele)",
+            "description": "UKULELE by Misc Cartoons",
+            "images": [
+                {
+                    "src": "https://tabs.ultimate-guitar.com/static/_img/ug-logo-fb.png"
+                }
+            ]
+        },
+        "clientId": "_clientId_0",
+        "innerBlocks": [],
+        "originalContent": "<div class=\"wp-block-embed-link-preview\"><div class=\"wp-block-embed-link-preview__textinfo\"><p><a href=\"https://tabs.ultimate-guitar.com/tab/misc_cartoons/steven_universe_-_whats_the_use_of_feeling_blue_ukulele_2155897\">Misc Cartoons - Steven Universe - Whats The Use Of Feeling Blue (Ukulele)</a></p><p class=\"wp-block-embed-link-preview__description\">UKULELE by Misc Cartoons</p></div><div class=\"wp-block-embed-link-preview__image\"><img src=\"https://tabs.ultimate-guitar.com/static/_img/ug-logo-fb.png\" alt=\"\" /></div></div>"
+    }
+]

--- a/packages/block-library/src/test/fixtures/core-embed__link-preview.parsed.json
+++ b/packages/block-library/src/test/fixtures/core-embed__link-preview.parsed.json
@@ -1,0 +1,12 @@
+[
+    {
+        "blockName": "core-embed/link-preview",
+        "attrs": null,
+        "innerBlocks": [],
+        "innerHTML": "\n<div class=\"wp-block-embed-link-preview\"><div class=\"wp-block-embed-link-preview__textinfo\"><p><a href=\"https://tabs.ultimate-guitar.com/tab/misc_cartoons/steven_universe_-_whats_the_use_of_feeling_blue_ukulele_2155897\">Misc Cartoons - Steven Universe - Whats The Use Of Feeling Blue (Ukulele)</a></p><p class=\"wp-block-embed-link-preview__description\">UKULELE by Misc Cartoons</p></div><div class=\"wp-block-embed-link-preview__image\"><img src=\"https://tabs.ultimate-guitar.com/static/_img/ug-logo-fb.png\" alt=\"\" /></div></div>\n"
+    },
+    {
+        "attrs": {},
+        "innerHTML": "\n"
+    }
+]

--- a/packages/block-library/src/test/fixtures/core-embed__link-preview.serialized.html
+++ b/packages/block-library/src/test/fixtures/core-embed__link-preview.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:core-embed/link-preview -->
+<div class="wp-block-embed-link-preview"><div class="wp-block-embed-link-preview__textinfo"><p><a href="https://tabs.ultimate-guitar.com/tab/misc_cartoons/steven_universe_-_whats_the_use_of_feeling_blue_ukulele_2155897">Misc Cartoons - Steven Universe - Whats The Use Of Feeling Blue (Ukulele)</a></p><p class="wp-block-embed-link-preview__description">UKULELE by Misc Cartoons</p></div><div class="wp-block-embed-link-preview__image"><img src="https://tabs.ultimate-guitar.com/static/_img/ug-logo-fb.png" alt=""/></div></div>
+<!-- /wp:core-embed/link-preview -->


### PR DESCRIPTION
## Description

Adds a "Link Preview" block, in the style of the preview that Facebook gives when you put a URL in a status update.

If the Embed block fails to embed a URL, it falls back to the Link Preview block. The block can be used separately too, as some pages look better using the OpenGraph content than they do with what oEmbed returns.

If this is not wanted, then a fallback to a paragraph block would give us parity with the current editor for URLs that can't be embedded.

A demo! This shows the block being used as an oEmbed fallback (which gives a preview block and a paragraph block with a link in it, for maximum user options!) and using the preview block as a standalone thing.

![preview](https://user-images.githubusercontent.com/3314354/41677756-2dd3156a-74c1-11e8-8512-3512c186cd75.gif)


There's a new API endpoint. Why a new API?

I wanted to cover these use cases:

1) User wants to embed a URL not supported by oEmbed
2) User does not want the oEmbed content, just wants a preview of the link instead

We want to be able to give information about a URL, either using the OpenGraph metadata,
or using content from the page, to generate a preview for the link.

The user might want to make changes to this preview before publishing. For example,
if we're generating preview data from the content of the page, we'll want to display
a range of images so that the user can choose which one best represents the page
they're linking to. This will happen when the page doesn't have OpenGraph metadata.
The user might want to remove the image altogether, if there's nothing suitable there.

This means that we can't just have a HTML fallback, using the `embed_maybe_make_link` filter.
We want to be able to return data that the Link Preview block will use in its editing
UI, and what the user chooses there will determine the HTML saved.

So I've considered the following approaches:

HTML fallback - not suitable because we need data about the page we're previewing so
the user can make a decision about what HTML ends up in their post.

Inject data into `embed/proxy` response - this would change the signature of the
response in an undocumented way, and also either introduce an extra HTTP request
for every embed proxy request if we presented the data with every embed call,
or render the user unable to use the link preview as an alternative to the
embed block if we only generated the data for URLs that oEmbed did not support.

New API - Means an extra API call if oEmbed does not support the URL, but gives
us the flexibility in editing and allowing the user to choose a preview instead
of an embed. This gives us more future flexibility to create link preview blocks
for links that appear in paragraphs, in the same way Facebook do when you put
a URL in a status update.

## How has this been tested?

Test with:

1) A URL with OpenGraph information (e.g. https://tabs.ultimate-guitar.com/tab/misc_cartoons/steven_universe_-_whats_the_use_of_feeling_blue_ukulele_2155897 )
2) A URL with no OpenGraph information, and a range of images to choose from (e.g. https://wordpress.org/ )
3) A URL that would be embeddable with oEmbed (e.g. https://css-tricks.com/snippets/css/a-guide-to-flexbox/ )


## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
