### PR TITLE
Block API: Add new bindAttribute helper for editor inputs

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -156,7 +156,6 @@ class ParagraphBlock extends Component {
 
 		const {
 			align,
-			content,
 			dropCap,
 			placeholder,
 		} = attributes;

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -225,12 +225,7 @@ class ParagraphBlock extends Component {
 							fontSize: fontSize ? fontSize + 'px' : undefined,
 							textAlign: align,
 						} }
-						value={ content }
-						onChange={ ( nextContent ) => {
-							setAttributes( {
-								content: nextContent,
-							} );
-						} }
+						bindAttribute="content"
 						onSplit={ insertBlocksAfter ?
 							( before, after, ...blocks ) => {
 								if ( after ) {

--- a/docs/blocks/block-controls-toolbars-and-inspector.md
+++ b/docs/blocks/block-controls-toolbars-and-inspector.md
@@ -38,12 +38,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 	},
 
 	edit: function( props ) {
-		var content = props.attributes.content,
-			alignment = props.attributes.alignment;
-
-		function onChangeContent( newContent ) {
-			props.setAttributes( { content: newContent } );
-		}
+		var alignment = props.attributes.alignment;
 
 		function onChangeAlignment( newAlignment ) {
 			props.setAttributes( { alignment: newAlignment } );
@@ -68,8 +63,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 					tagName: 'p',
 					className: props.className,
 					style: { textAlign: alignment },
-					onChange: onChangeContent,
-					value: content,
+					bindAttribute: 'content',
 				}
 			)
 		];
@@ -115,11 +109,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 	},
 
 	edit( { attributes, className, setAttributes } ) {
-		const { content, alignment } = attributes;
-
-		function onChangeContent( newContent ) {
-			setAttributes( { content: newContent } );
-		}
+		const { alignment } = attributes;
 
 		function onChangeAlignment( newAlignment ) {
 			setAttributes( { alignment: newAlignment } );
@@ -137,8 +127,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 				tagName="p"
 				className={ className }
 				style={ { textAlign: alignment } }
-				onChange={ onChangeContent }
-				value={ content }
+				bindAttribute="content"
 			/>
 		];
 	},

--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -31,19 +31,12 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 	},
 
 	edit: function( props ) {
-		var content = props.attributes.content;
-
-		function onChangeContent( newContent ) {
-			props.setAttributes( { content: newContent } );
-		}
-
 		return el(
 			RichText,
 			{
 				tagName: 'p',
 				className: props.className,
-				onChange: onChangeContent,
-				value: content,
+				bindAttribute: 'content',
 			}
 		);
 	},
@@ -80,18 +73,11 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 	},
 
 	edit( { attributes, className, setAttributes } ) {
-		const { content } = attributes;
-
-		function onChangeContent( newContent ) {
-			setAttributes( { content: newContent } );
-		}
-
 		return (
 			<RichText
 				tagName="p"
 				className={ className }
-				onChange={ onChangeContent }
-				value={ content }
+				bindAttribute="content"
 			/>
 		);
 	},

--- a/editor/components/block-edit/context.js
+++ b/editor/components/block-edit/context.js
@@ -13,6 +13,8 @@ const { Consumer, Provider } = createContext( {
 	isSelected: false,
 	focusedElement: null,
 	setFocusedElement: noop,
+	attributes: {},
+	setAttributes: noop,
 } );
 
 export { Provider as BlockEditContextProvider };

--- a/editor/components/block-edit/index.js
+++ b/editor/components/block-edit/index.js
@@ -19,10 +19,14 @@ import { BlockEditContextProvider } from './context';
 export class BlockEdit extends Component {
 	constructor( props ) {
 		super( props );
+
 		this.setFocusedElement = this.setFocusedElement.bind( this );
+
 		this.state = {
 			focusedElement: null,
 			setFocusedElement: this.setFocusedElement,
+			attributes: {},
+			setAttributes: noop,
 		};
 	}
 
@@ -52,7 +56,7 @@ export class BlockEdit extends Component {
 		} );
 	}
 
-	static getDerivedStateFromProps( { name, isSelected }, prevState ) {
+	static getDerivedStateFromProps( { name, isSelected, attributes, setAttributes }, prevState ) {
 		if (
 			name === prevState.name &&
 			isSelected === prevState.isSelected
@@ -64,6 +68,8 @@ export class BlockEdit extends Component {
 			...prevState,
 			name,
 			isSelected,
+			attributes,
+			setAttributes,
 		};
 	}
 

--- a/editor/components/higher-order/with-bind-attribute/README.md
+++ b/editor/components/higher-order/with-bind-attribute/README.md
@@ -1,0 +1,20 @@
+withBindAttribute
+=================
+
+Higher-order component which augments a base component that is expected to
+receive `value` and `onChange` props, augmenting the component to receive a
+`bindAttribute` component where a string is passed to automatically handle
+changes as setting attributes for the current block context.
+
+## Example
+
+```jsx
+import { withBindAttribute } from '@wordpress/editor';
+
+const MyInput = ( { value, onChange } ) => <input value={ value } onChange={ onChange } />;
+const MyEnhancedInput = withBindAttribute( MyInput );
+
+// Usage:
+//
+//  <MyEnhancedInput bindAttribute="content" />
+```

--- a/editor/components/higher-order/with-bind-attribute/index.js
+++ b/editor/components/higher-order/with-bind-attribute/index.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	createHigherOrderComponent,
+	Component,
+	createElement,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { withBlockEditContext } from '../../block-edit/context';
+
+/**
+ * Higher-order component which augments a base component that is expected to
+ * receive `value` and `onChange` props, augmenting the component to receive
+ * a `bindAttribute` component where a string is passed to automatically handle
+ * changes as setting attributes for the current block context.
+ *
+ * @param {WPComponent} WrappedComponent Original component.
+ *
+ * @return {WPComponent} Enhanced component.
+ */
+const withBindAttribute = createHigherOrderComponent(
+	( WrappedComponent ) => {
+		class EnhancedComponent extends Component {
+			constructor() {
+				super( ...arguments );
+
+				this.setAttributes = this.setAttributes.bind( this );
+			}
+
+			setAttributes( nextValue ) {
+				const { bindAttribute, setAttributes } = this.props;
+
+				setAttributes( {
+					[ bindAttribute ]: nextValue,
+				} );
+			}
+
+			render() {
+				return (
+					<WrappedComponent
+						{ ...omit( this.props, [
+							'bindAttribute',
+							'setAttributes',
+						] ) }
+						onChange={ this.setAttributes }
+					/>
+				);
+			}
+		}
+
+		EnhancedComponent = withBlockEditContext( ( context, ownProps ) => {
+			const { attributes, setAttributes } = context;
+			const { bindAttribute } = ownProps;
+
+			return {
+				setAttributes: setAttributes,
+				value: attributes[ bindAttribute ],
+			};
+		} )( EnhancedComponent );
+
+		return ( props ) => {
+			const isEnhanced = props.hasOwnProperty( 'bindAttribute' );
+			const RenderedComponent = isEnhanced ? EnhancedComponent : WrappedComponent;
+
+			return createElement( RenderedComponent, props );
+		};
+	},
+	'withBindAttribute'
+);
+
+export default withBindAttribute;

--- a/editor/components/higher-order/with-bind-attribute/test/index.js
+++ b/editor/components/higher-order/with-bind-attribute/test/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { BlockEditContextProvider } from '../../../block-edit/context';
+import withBindAttribute from '../';
+
+// Disable reason: Enzyme does not yet support React.createContext necessary
+// for testing with BlockEditContextProvider.
+//
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip( 'withBindAttribute', () => {
+	const Input = ( { value, onChange } ) => <input value={ value } onChange={ onChange } />;
+	const EnhancedInput = withBindAttribute( Input );
+	const setAttributes = () => {};
+	const attributes = { content: 'foo' };
+
+	const context = { setAttributes, attributes };
+	function mountWithBlockEditContext( props ) {
+		return mount(
+			<BlockEditContextProvider value={ context }>
+				<EnhancedInput { ...props } />
+			</BlockEditContextProvider>
+		);
+	}
+
+	it( 'should do nothing if bindAttribute is not passed', () => {
+		const wrapper = mountWithBlockEditContext( {} );
+
+		expect( wrapper.prop( 'value' ) ).toBeUndefined();
+		expect( wrapper.prop( 'onChange' ) ).toBeUndefined();
+	} );
+
+	it( 'should provide value and onChange parameters', () => {
+		const wrapper = mountWithBlockEditContext( { bindAttribute: 'content' } );
+
+		expect( wrapper.prop( 'value' ) ).toBe( 'foo' );
+		expect( wrapper.prop( 'onChange' ) ).not.toBeUndefined();
+	} );
+} );

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -101,3 +101,6 @@ export { default as WritingFlow } from './writing-flow';
 
 // State Related Components
 export { default as EditorProvider } from './provider';
+
+// Higher-Order Components
+export { default as withBindAttribute } from './higher-order/with-bind-attribute';

--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -2,7 +2,7 @@
 
 Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content), providing users the option to add emphasis to content or links to content. It behaves similarly to a [controlled component](https://facebook.github.io/react/docs/forms.html#controlled-components), except that `onChange` is triggered less frequently than would be expected from a traditional `input` field, usually when the user exits the field.
 
-## Properties
+## Props
 
 ### `format: String`
 
@@ -10,13 +10,25 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 *Default: `element`*.
 
+### `bindAttribute: string`
+
+*Optional.* As an alternative to passing `value` and `onChange` to managing the
+attribute value for a given attribute name, pass `bindAttribute`. Only one or
+the other of `bindAttribute` and `value` + `onChange` are required.
+
 ### `value: Array|String`
 
-*Required.* Depending on the format prop, this value could be an array of React DOM to make editable or an HTML string. The rendered HTML should be valid, and valid with respect to the `tagName` and `inline` property.
+*Optional.* Depending on the format prop, this value could be an array of React
+DOM to make editable or an HTML string. The rendered HTML should be valid, and
+valid with respect to the `tagName` and `inline` property. Can be omitted if
+using `bindAttribute`, since only one or the other of `bindAttribute` and
+`value` + `onChange` are required.
 
 ### `onChange( value: Array|String ): Function`
 
-*Required.* Called when the value changes.
+*Optional.* Called when the value changes. Can be omitted if using
+`bindAttribute`, since only one or the other of `bindAttribute` and `value` +
+`onChange` are required.
 
 ### `tagName: String`
 

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -41,6 +41,7 @@ import TinyMCE from './tinymce';
 import { pickAriaProps } from './aria';
 import patterns from './patterns';
 import { withBlockEditContext } from '../block-edit/context';
+import withBindAttribute from '../higher-order/with-bind-attribute';
 import { domToFormat, valueToString } from './format';
 
 const { BACKSPACE, DELETE, ENTER, rawShortcut } = keycodes;
@@ -941,6 +942,7 @@ RichText.defaultProps = {
 
 const RichTextContainer = compose( [
 	withInstanceId,
+	withBindAttribute,
 	withBlockEditContext( ( context, ownProps ) => {
 		// When explicitly set as not selected, do nothing.
 		if ( ownProps.isSelected === false ) {


### PR DESCRIPTION
Related: #5739

This pull request seeks to explore a developer experience optimization for implementations of blocks, reducing the effort necessary to support value changing of an attribute via a new optional `bindAttribute` prop for use in editor input components.

_Before:_

```js
function MyBlockEdit( props ) {
	var value = props.attributes.content;

	function onChangeContent( nextContent ) {
		props.setAttributes( { content: nextContent } );
	}

	return wp.element.createElement( wp.editor.RichText, {
		value: value,
		onChange: onChangeContent,
	} );
}
```

_After:_

```js
function MyBlockEdit( props ) {
	return wp.element.createElement( wp.editor.RichText, {
		bindAttribute: 'content',
	} );
}
```

This is intended to be very similar to React's now-deprecated [`LinkedStateMixin`](https://reactjs.org/docs/two-way-binding-helpers.html), a pattern for two-way data binding. While it sacrifices explicitness, it does so in a way intentionally for promoting a simplified developer experience for block implementers, in a consistent fashion to the automatic handling of `RichText` focus and `isSelected` conditional rendering.

**Implementation notes:**

Attribute binding is achieved with a new `withBindAttribute` higher-order component, which can be applied to any editor input component to optionally accept the `bindAttribute` prop as an alternative to the `value` and `onChange` pairing.

Currently, this is only implemented for `RichText`. **It has proven to be difficult to implement for other components because `context` is lost in Slot/Fill for non-`bubblesVirtually` slots** (including toolbars and inspector controls). This will need to be addressed separately as a general issue, either updating all existing slots to use `bubblesVirtually` or a way for context to be preserved in non-virtual-bubbling slots rendering.

**Testing instructions:**

Verify that there are no regressions in the display and editing of a paragraph block's value.