### PR TITLE
Block API: Add block styles variations API

### DIFF
--- a/components/disabled/index.js
+++ b/components/disabled/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { includes, debounce } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -84,9 +85,14 @@ class Disabled extends Component {
 	}
 
 	render() {
+		const { className, ...props } = this.props;
 		return (
 			<Provider value={ true }>
-				<div ref={ this.bindNode } className="components-disabled">
+				<div
+					ref={ this.bindNode }
+					className={ classnames( className, 'components-disabled' ) }
+					{ ...props }
+				>
 					{ this.props.children }
 				</div>
 			</Provider>

--- a/core-blocks/button/editor.scss
+++ b/core-blocks/button/editor.scss
@@ -15,6 +15,7 @@
 
 	.editor-rich-text__tinymce {
 		cursor: text;
+		line-height: 1;
 	}
 }
 

--- a/core-blocks/button/index.js
+++ b/core-blocks/button/index.js
@@ -89,6 +89,7 @@ export const settings = {
 
 	styles: [
 		{ name: 'default', label: __( 'Rounded' ), isDefault: true },
+		{ name: 'outline', label: __( 'Outline' ) },
 		{ name: 'squared', label: __( 'Squared' ) },
 	],
 

--- a/core-blocks/button/index.js
+++ b/core-blocks/button/index.js
@@ -87,12 +87,10 @@ export const settings = {
 		return props;
 	},
 
-	transforms: {
-		styles: [
-			{ name: 'default', label: __( 'Rounded' ), isDefault: true },
-			{ name: 'squared', label: __( 'Squared' ) },
-		],
-	},
+	styles: [
+		{ name: 'default', label: __( 'Rounded' ), isDefault: true },
+		{ name: 'squared', label: __( 'Squared' ) },
+	],
 
 	edit,
 

--- a/core-blocks/button/index.js
+++ b/core-blocks/button/index.js
@@ -87,6 +87,13 @@ export const settings = {
 		return props;
 	},
 
+	transforms: {
+		styles: [
+			{ name: 'default', label: __( 'Rounded' ), isDefault: true },
+			{ name: 'squared', label: __( 'Squared' ) },
+		],
+	},
+
 	edit,
 
 	save( { attributes } ) {

--- a/core-blocks/button/style.scss
+++ b/core-blocks/button/style.scss
@@ -20,6 +20,10 @@ $blocks-button__line-height: $big-font-size + 6px;
 		word-break: break-all;
 	}
 
+	&.is-style-squared .wp-block-button__link {
+		border-radius: 0;
+	}
+
 	&.aligncenter {
 		text-align: center;
 	}

--- a/core-blocks/button/style.scss
+++ b/core-blocks/button/style.scss
@@ -42,6 +42,75 @@ $blocks-button__line-height: $big-font-size + 6px;
 	}
 }
 
+.wp-block-button.is-style-outline {
+	.wp-block-button__link {
+		background: transparent;
+		border: 2px solid transparent;
+
+		&.has-pale-pink-background-color {
+			border-color: #f78da7;
+		}
+
+		&.has-vivid-red-background-color {
+			border-color: #cf2e2e;
+		}
+
+		&.has-luminous-vivid-orange-background-color {
+			border-color: #ff6900;
+		}
+
+		&.has-luminous-vivid-amber-background-color {
+			border-color: #fcb900;
+		}
+
+		&.has-light-green-cyan-background-color {
+			border-color: #7bdcb5;
+		}
+
+		&.has-vivid-green-cyan-background-color {
+			border-color: #00d084;
+		}
+
+		&.has-pale-cyan-blue-background-color {
+			border-color: #8ed1fc;
+		}
+
+		&.has-vivid-cyan-blue-background-color {
+			border-color: #0693e3;
+		}
+
+		&.has-very-light-gray-background-color {
+			border-color: #eeeeee;
+		}
+
+		&.has-cyan-bluish-gray-background-color {
+			border-color: #abb8c3;
+		}
+
+		&.has-very-dark-gray-background-color {
+			border-color: #313131;
+		}
+	}
+
+	.wp-block-button__link:not(.has-background) {
+		border-color: $dark-gray-700;
+		&:hover,
+		&:focus,
+		&:active {
+			border-color: $dark-gray-700;
+		}
+	}
+
+	.wp-block-button__link:not(.has-text-color) {
+		color: $dark-gray-700;
+		&:hover,
+		&:focus,
+		&:active {
+			color: $dark-gray-700;
+		}
+	}
+}
+
 .wp-block-button__link:not(.has-text-color) {
 	color: $white;
 	&:hover,

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -61,8 +61,8 @@ export const settings = {
 
 	transforms: {
 		styles: [
-			{ name: 'default', label: '1', isDefault: true, icon: 'format-quote' },
-			{ name: 'large', label: '2', icon: 'testimonial' },
+			{ name: 'default', label: '1', isDefault: true },
+			{ name: 'large', label: '2' },
 		],
 		from: [
 			{

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -59,11 +59,12 @@ export const settings = {
 
 	attributes: blockAttributes,
 
+	styles: [
+		{ name: 'default', label: '1', isDefault: true },
+		{ name: 'large', label: '2' },
+	],
+
 	transforms: {
-		styles: [
-			{ name: 'default', label: '1', isDefault: true },
-			{ name: 'large', label: '2' },
-		],
 		from: [
 			{
 				type: 'block',

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -60,8 +60,8 @@ export const settings = {
 	attributes: blockAttributes,
 
 	styles: [
-		{ name: 'default', label: '1', isDefault: true },
-		{ name: 'large', label: '2' },
+		{ name: 'default', label: __( 'Style 1' ), isDefault: true },
+		{ name: 'large', label: __( 'Style 2' ) },
 	],
 
 	transforms: {

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -1,14 +1,12 @@
 /**
  * External dependencies
  */
-import { castArray, get, isString, isEmpty } from 'lodash';
-import classnames from 'classnames';
+import { castArray, get, isString, isEmpty, omit } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { Toolbar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
 import {
@@ -49,10 +47,6 @@ const blockAttributes = {
 	align: {
 		type: 'string',
 	},
-	style: {
-		type: 'number',
-		default: 1,
-	},
 };
 
 export const name = 'core/quote';
@@ -66,6 +60,10 @@ export const settings = {
 	attributes: blockAttributes,
 
 	transforms: {
+		styles: [
+			{ name: 'default', label: '1', isDefault: true, icon: 'format-quote' },
+			{ name: 'large', label: '2', icon: 'testimonial' },
+		],
 		from: [
 			{
 				type: 'block',
@@ -179,20 +177,11 @@ export const settings = {
 	},
 
 	edit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
-		const { align, value, citation, style } = attributes;
-		const containerClassname = classnames( className, style === 2 ? 'is-large' : '' );
+		const { align, value, citation } = attributes;
 
 		return (
 			<Fragment>
 				<BlockControls>
-					<Toolbar controls={ [ 1, 2 ].map( ( variation ) => ( {
-						icon: 1 === variation ? 'format-quote' : 'testimonial',
-						title: sprintf( __( 'Quote style %d' ), variation ),
-						isActive: Number( style ) === variation,
-						onClick() {
-							setAttributes( { style: variation } );
-						},
-					} ) ) } />
 					<AlignmentToolbar
 						value={ align }
 						onChange={ ( nextAlign ) => {
@@ -200,10 +189,7 @@ export const settings = {
 						} }
 					/>
 				</BlockControls>
-				<blockquote
-					className={ containerClassname }
-					style={ { textAlign: align } }
-				>
+				<blockquote className={ className } style={ { textAlign: align } }>
 					<RichText
 						multiline="p"
 						value={ toRichTextValue( value ) }
@@ -241,13 +227,10 @@ export const settings = {
 	},
 
 	save( { attributes } ) {
-		const { align, value, citation, style } = attributes;
+		const { align, value, citation } = attributes;
 
 		return (
-			<blockquote
-				className={ style === 2 ? 'is-large' : '' }
-				style={ { textAlign: align ? align : null } }
-			>
+			<blockquote style={ { textAlign: align ? align : null } }>
 				<RichText.Content value={ toRichTextValue( value ) } />
 				{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>
@@ -258,10 +241,48 @@ export const settings = {
 		{
 			attributes: {
 				...blockAttributes,
+				style: {
+					type: 'number',
+					default: 1,
+				},
+			},
+
+			migrate( attributes ) {
+				if ( attributes.style === 2 ) {
+					return {
+						...omit( attributes, [ 'style' ] ),
+						className: attributes.className ? attributes.className + ' is-style-large' : 'is-style-large',
+					};
+				}
+
+				return attributes;
+			},
+
+			save( { attributes } ) {
+				const { align, value, citation, style } = attributes;
+
+				return (
+					<blockquote
+						className={ style === 2 ? 'is-large' : '' }
+						style={ { textAlign: align ? align : null } }
+					>
+						<RichText.Content value={ toRichTextValue( value ) } />
+						{ citation && citation.length > 0 && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				);
+			},
+		},
+		{
+			attributes: {
+				...blockAttributes,
 				citation: {
 					type: 'array',
 					source: 'children',
 					selector: 'footer',
+				},
+				style: {
+					type: 'number',
+					default: 1,
 				},
 			},
 

--- a/core-blocks/quote/index.js
+++ b/core-blocks/quote/index.js
@@ -60,8 +60,8 @@ export const settings = {
 	attributes: blockAttributes,
 
 	styles: [
-		{ name: 'default', label: __( 'Style 1' ), isDefault: true },
-		{ name: 'large', label: __( 'Style 2' ) },
+		{ name: 'default', label: __( 'Regular' ), isDefault: true },
+		{ name: 'large', label: __( 'Large' ) },
 	],
 
 	transforms: {

--- a/core-blocks/quote/style.scss
+++ b/core-blocks/quote/style.scss
@@ -6,7 +6,7 @@
 		font-style: normal;
 	}
 
-	&.is-large {
+	&.is-style-large, &.is-large {
 		margin: 0 0 16px;
 		padding: 0 1em;
 

--- a/core-blocks/quote/theme.scss
+++ b/core-blocks/quote/theme.scss
@@ -12,7 +12,7 @@
 	}
 }
 
-.wp-block-quote:not(.is-large) {
+.wp-block-quote:not(.is-large):not(.is-style-large) {
 	border-left: 4px solid $black;
 	padding-left: 1em;
 }

--- a/core-blocks/separator/index.js
+++ b/core-blocks/separator/index.js
@@ -24,6 +24,11 @@ export const settings = {
 	keywords: [ __( 'horizontal-line' ), 'hr', __( 'divider' ) ],
 
 	transforms: {
+		styles: [
+			{ name: 'default', label: __( 'Short Line' ), isDefault: true },
+			{ name: 'wide', label: __( 'Wide Line' ) },
+			{ name: 'asterisks', label: __( 'Asterisks' ) },
+		],
 		from: [
 			{
 				type: 'pattern',

--- a/core-blocks/separator/index.js
+++ b/core-blocks/separator/index.js
@@ -26,7 +26,7 @@ export const settings = {
 	styles: [
 		{ name: 'default', label: __( 'Short Line' ), isDefault: true },
 		{ name: 'wide', label: __( 'Wide Line' ) },
-		{ name: 'asterisks', label: __( 'Dots' ) },
+		{ name: 'dots', label: __( 'Dots' ) },
 	],
 
 	transforms: {

--- a/core-blocks/separator/index.js
+++ b/core-blocks/separator/index.js
@@ -23,12 +23,13 @@ export const settings = {
 
 	keywords: [ __( 'horizontal-line' ), 'hr', __( 'divider' ) ],
 
+	styles: [
+		{ name: 'default', label: __( 'Short Line' ), isDefault: true },
+		{ name: 'wide', label: __( 'Wide Line' ) },
+		{ name: 'asterisks', label: __( 'Asterisks' ) },
+	],
+
 	transforms: {
-		styles: [
-			{ name: 'default', label: __( 'Short Line' ), isDefault: true },
-			{ name: 'wide', label: __( 'Wide Line' ) },
-			{ name: 'asterisks', label: __( 'Asterisks' ) },
-		],
 		from: [
 			{
 				type: 'pattern',

--- a/core-blocks/separator/index.js
+++ b/core-blocks/separator/index.js
@@ -26,7 +26,7 @@ export const settings = {
 	styles: [
 		{ name: 'default', label: __( 'Short Line' ), isDefault: true },
 		{ name: 'wide', label: __( 'Wide Line' ) },
-		{ name: 'asterisks', label: __( 'Asterisks' ) },
+		{ name: 'asterisks', label: __( 'Dots' ) },
 	],
 
 	transforms: {

--- a/core-blocks/separator/style.scss
+++ b/core-blocks/separator/style.scss
@@ -12,11 +12,12 @@
 		border: none;
 		text-align: center;
 
-		&::before {
+		&:before {
 			content: '* *';
 			color: $dark-gray-500;
-			font-size: 35px;
+			font-size: 36px;
 			font-family: serif;
+			line-height: 1;
 		}
 	}
 }

--- a/core-blocks/separator/style.scss
+++ b/core-blocks/separator/style.scss
@@ -6,18 +6,22 @@
 
 	&.is-style-wide {
 		max-width: 100%;
+		border-bottom-width: 1px;
 	}
 
 	&.is-style-asterisks {
 		border: none;
 		text-align: center;
+		max-width: none;
+		line-height: 1;
 
 		&:before {
-			content: '* *';
-			color: $dark-gray-500;
-			font-size: 36px;
+			content: '\00b7 \00b7 \00b7';
+			color: $dark-gray-700;
+			font-size: 20px;
+			letter-spacing: 2em;
+			padding-left: 2em;
 			font-family: serif;
-			line-height: 1;
 		}
 	}
 }

--- a/core-blocks/separator/style.scss
+++ b/core-blocks/separator/style.scss
@@ -3,4 +3,20 @@
 	border-bottom: 2px solid $dark-gray-100;
 	max-width: 100px;
 	margin: 1.65em auto;
+
+	&.is-style-wide {
+		max-width: 100%;
+	}
+
+	&.is-style-asterisks {
+		border: none;
+		text-align: center;
+
+		&::before {
+			content: '* *';
+			color: $dark-gray-500;
+			font-size: 35px;
+			font-family: serif;
+		}
+	}
 }

--- a/core-blocks/separator/style.scss
+++ b/core-blocks/separator/style.scss
@@ -1,19 +1,18 @@
 .wp-block-separator {
-	border: none;
-	border-bottom: 2px solid $dark-gray-100;
-	max-width: 100px;
-	margin: 1.65em auto;
+	// Default, thin style, is stored in theme.scss so it can be opted out of
 
+	// Wide style
 	&.is-style-wide {
-		max-width: 100%;
 		border-bottom-width: 1px;
 	}
 
-	&.is-style-asterisks {
+	// Dots style
+	&.is-style-dots {
 		border: none;
 		text-align: center;
 		max-width: none;
 		line-height: 1;
+		height: auto;
 
 		&:before {
 			content: '\00b7 \00b7 \00b7';

--- a/core-blocks/separator/theme.scss
+++ b/core-blocks/separator/theme.scss
@@ -1,2 +1,10 @@
-// TODO: Remove this comment when adding theme styles.
-// Including an empty file for now so webpack will build an aggregate build/core-blocks/theme.css.
+.wp-block-separator {
+	border: none;
+	border-bottom: 2px solid $dark-gray-100;
+	margin: 1.65em auto;
+
+	// Default, thin style
+	&:not( .is-style-wide ):not( .is-style-dots ) {
+		max-width: 100px;
+	}
+}

--- a/core-blocks/test/fixtures/core__quote__style-1.html
+++ b/core-blocks/test/fixtures/core__quote__style-1.html
@@ -1,3 +1,3 @@
-<!-- wp:core/quote {"style":"1"} -->
+<!-- wp:core/quote -->
 <blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:core/quote -->

--- a/core-blocks/test/fixtures/core__quote__style-1.json
+++ b/core-blocks/test/fixtures/core__quote__style-1.json
@@ -20,8 +20,7 @@
             ],
             "citation": [
                 "Matt Mullenweg, 2017"
-            ],
-            "style": 1
+            ]
         },
         "innerBlocks": [],
         "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"

--- a/core-blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/core-blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -1,9 +1,7 @@
 [
     {
         "blockName": "core/quote",
-        "attrs": {
-            "style": "1"
-        },
+        "attrs": null,
         "innerBlocks": [],
         "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
     },

--- a/core-blocks/test/fixtures/core__quote__style-2.html
+++ b/core-blocks/test/fixtures/core__quote__style-2.html
@@ -1,3 +1,3 @@
-<!-- wp:core/quote {"style":"2"} -->
-<blockquote class="wp-block-quote is-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<!-- wp:core/quote {"className":"is-style-large"} -->
+<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:core/quote -->

--- a/core-blocks/test/fixtures/core__quote__style-2.json
+++ b/core-blocks/test/fixtures/core__quote__style-2.json
@@ -21,9 +21,9 @@
             "citation": [
                 "Maya Angelou"
             ],
-            "style": 2
+            "className": "is-style-large"
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote is-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
     }
 ]

--- a/core-blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/core-blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -2,10 +2,10 @@
     {
         "blockName": "core/quote",
         "attrs": {
-            "style": "2"
+            "className": "is-style-large"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote is-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/core-blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:quote {"style":2} -->
-<blockquote class="wp-block-quote is-large">
+<!-- wp:quote {"className":"is-style-large"} -->
+<blockquote class="wp-block-quote is-style-large">
 	<p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:quote -->

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -18,7 +18,6 @@ $z-layers: (
 	'.edit-post-meta-boxes-area.is-loading:before': 1,
 	'.edit-post-meta-boxes-area .spinner': 5,
 	'.editor-block-contextual-toolbar': 21,
-	'.editor-block-switcher__menu': 5,
 	'.components-popover__close': 5,
 	'.editor-block-list__insertion-point': 5,
 	'.core-blocks-gallery-item__inline-menu': 20,
@@ -30,7 +29,7 @@ $z-layers: (
 	// Side UI active buttons
 	'.editor-block-settings-remove': 1,
 	'.editor-block-mover__control': 1,
-	
+
 	// Should have lower index than anything else positioned inside the block containers
 	'.editor-block-list__block-draggable': 0,
 

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -7,6 +7,7 @@
 		font-family: $editor-font;
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
+		color: $dark-gray-700;
 	}
 
 	& ul,

--- a/editor/components/block-icon/style.scss
+++ b/editor/components/block-icon/style.scss
@@ -4,7 +4,6 @@
 	display: flex;
 	height: $icon-button-size-small;
 	align-items: center;
-	margin-left: -2px;
-	margin-right: 10px;
+	margin: 0;
 	padding: 0 8px;
 }

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -38,3 +38,8 @@
 .editor-block-inspector__card-description {
 	font-size: $default-font-size;
 }
+
+.editor-block-inspector__card .editor-block-icon__colors {
+	margin-left: -2px;
+	margin-right: 10px;
+}

--- a/editor/components/block-preview/index.js
+++ b/editor/components/block-preview/index.js
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
+import { Disabled } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -26,9 +27,7 @@ function BlockPreview( props ) {
 	return (
 		<div className="editor-block-preview">
 			<div className="editor-block-preview__title">{ __( 'Preview' ) }</div>
-			<div className="editor-block-preview__content" aria-hidden>
-				<BlockPreviewContent { ...props } />
-			</div>
+			<BlockPreviewContent { ...props } />
 		</div>
 	);
 }
@@ -36,12 +35,14 @@ function BlockPreview( props ) {
 export function BlockPreviewContent( { name, attributes } ) {
 	const block = createBlock( name, attributes );
 	return (
-		<BlockEdit
-			name={ name }
-			focus={ false }
-			attributes={ block.attributes }
-			setAttributes={ noop }
-		/>
+		<Disabled className="editor-block-preview__content" aria-hidden>
+			<BlockEdit
+				name={ name }
+				focus={ false }
+				attributes={ block.attributes }
+				setAttributes={ noop }
+			/>
+		</Disabled>
 	);
 }
 

--- a/editor/components/block-preview/index.js
+++ b/editor/components/block-preview/index.js
@@ -26,7 +26,7 @@ function BlockPreview( props ) {
 	return (
 		<div className="editor-block-preview">
 			<div className="editor-block-preview__title">{ __( 'Preview' ) }</div>
-			<div className="editor-block-preview__content">
+			<div className="editor-block-preview__content" aria-hidden>
 				<BlockPreviewContent { ...props } />
 			</div>
 		</div>

--- a/editor/components/block-preview/index.js
+++ b/editor/components/block-preview/index.js
@@ -22,21 +22,26 @@ import './style.scss';
  *
  * @return {WPElement} Rendered element.
  */
-function BlockPreview( { name, attributes } ) {
-	const block = createBlock( name, attributes );
-
+function BlockPreview( props ) {
 	return (
 		<div className="editor-block-preview">
 			<div className="editor-block-preview__title">{ __( 'Preview' ) }</div>
 			<div className="editor-block-preview__content">
-				<BlockEdit
-					name={ name }
-					focus={ false }
-					attributes={ block.attributes }
-					setAttributes={ noop }
-				/>
+				<BlockPreviewContent { ...props } />
 			</div>
 		</div>
+	);
+}
+
+export function BlockPreviewContent( { name, attributes } ) {
+	const block = createBlock( name, attributes );
+	return (
+		<BlockEdit
+			name={ name }
+			focus={ false }
+			attributes={ block.attributes }
+			setAttributes={ noop }
+		/>
 	);
 }
 

--- a/editor/components/block-preview/style.scss
+++ b/editor/components/block-preview/style.scss
@@ -7,29 +7,29 @@
 	@include break-medium {
 		display: block;
 	}
+
+	.editor-block-preview__content {
+		padding: $block-padding;
+		border: 1px solid $light-gray-500;
+		font-family: $editor-font;
+
+		> div {
+			transform: scale( 0.9 );
+			transform-origin: center top;
+			font-family: $editor-font;
+		}
+
+		> div section {
+			height: auto;
+		}
+
+		> .shared-block-indicator {
+			display: none;
+		}
+	}
 }
 
 .editor-block-preview__title {
 	margin-bottom: 10px;
 	color: $dark-gray-300;
-}
-
-.editor-block-preview__content {
-	padding: $block-padding;
-	border: 1px solid $light-gray-500;
-	font-family: $editor-font;
-
-	> div {
-		transform: scale( 0.9 );
-		transform-origin: center top;
-		font-family: $editor-font;
-	}
-
-	> div section {
-		height: auto;
-	}
-
-	> .shared-block-indicator {
-		display: none;
-	}
 }

--- a/editor/components/block-preview/style.scss
+++ b/editor/components/block-preview/style.scss
@@ -17,6 +17,7 @@
 .editor-block-preview__content {
 	padding: $block-padding;
 	border: 1px solid $light-gray-500;
+	font-family: $editor-font;
 
 	> div {
 		transform: scale( 0.9 );

--- a/editor/components/block-styles/index.js
+++ b/editor/components/block-styles/index.js
@@ -70,7 +70,7 @@ export function replaceActiveStyle( className, activeStyle, newStyle ) {
 
 function BlockStyles( { styles, className, onChangeClassName } ) {
 	if ( ! styles ) {
-		return;
+		return null;
 	}
 
 	const activeStyle = getActiveStyle( styles, className );

--- a/editor/components/block-styles/index.js
+++ b/editor/components/block-styles/index.js
@@ -12,11 +12,15 @@ import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { getBlockType } from '@wordpress/blocks';
 
-function BlockStyles( { styles, className, onChangeClassName } ) {
-	if ( ! styles ) {
-		return;
-	}
-
+/**
+ * Returns the active style from the given className.
+ *
+ * @param {Array} styles Block style variations.
+ * @param {string} className  Class name
+ *
+ * @return {Object?} The active style.
+ */
+export function getActiveStyle( styles, className ) {
 	let activeStyle;
 	className
 		.split( ' ' )
@@ -33,21 +37,45 @@ function BlockStyles( { styles, className, onChangeClassName } ) {
 		activeStyle = find( styles, ( style ) => style.isDefault );
 	}
 
-	function updateClassName( style ) {
-		let added = false;
-		let updatedClassName = compact( className
-			.split( ' ' )
-			.map( ( current ) => {
-				const trimmed = current.trim();
-				if ( activeStyle && trimmed === 'is-style-' + activeStyle.name ) {
-					added = true;
-					return style.isDefault ? null : 'is-style-' + style.name;
-				}
-			} ) ).join( ' ' );
-		if ( ! added && ! style.isDefault ) {
-			updatedClassName = updatedClassName + ' is-style-' + style.name;
-		}
+	return activeStyle;
+}
 
+/**
+ * Replaces the active style in the block's className.
+ *
+ * @param {string}  className   Class name.
+ * @param {Object?} activeStyle The replaced style.
+ * @param {Object}  newStyle    The replacing style.
+ *
+ * @return {string} The updated className.
+ */
+export function replaceActiveStyle( className, activeStyle, newStyle ) {
+	let added = false;
+	let updatedClassName = compact( className
+		.split( ' ' )
+		.map( ( current ) => {
+			const trimmed = current.trim();
+			if ( activeStyle && trimmed === 'is-style-' + activeStyle.name ) {
+				added = true;
+				return newStyle.isDefault ? null : 'is-style-' + newStyle.name;
+			}
+			return trimmed;
+		} ) ).join( ' ' );
+	if ( ! added && ! newStyle.isDefault ) {
+		updatedClassName = updatedClassName + ' is-style-' + newStyle.name;
+	}
+
+	return updatedClassName;
+}
+
+function BlockStyles( { styles, className, onChangeClassName } ) {
+	if ( ! styles ) {
+		return;
+	}
+
+	const activeStyle = getActiveStyle( styles, className );
+	function updateClassName( style ) {
+		const updatedClassName = replaceActiveStyle( className, activeStyle, style );
 		onChangeClassName( updatedClassName );
 	}
 

--- a/editor/components/block-styles/index.js
+++ b/editor/components/block-styles/index.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { find, compact, get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Toolbar } from '@wordpress/components';
+import { compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { getBlockType } from '@wordpress/blocks';
+
+function BlockStyles( { styles, className, onChangeClassName } ) {
+	if ( ! styles ) {
+		return;
+	}
+
+	let activeStyle;
+	className
+		.split( ' ' )
+		.map( ( current ) => current.trim() )
+		.filter( ( current ) => current.indexOf( 'is-style-' ) === 0 )
+		.forEach( ( current ) => {
+			if ( activeStyle ) {
+				return;
+			}
+			const potentialStyleName = current.substring( 9 );
+			activeStyle = find( styles, ( style ) => style.name === potentialStyleName );
+		} );
+	if ( ! activeStyle ) {
+		activeStyle = find( styles, ( style ) => style.isDefault );
+	}
+
+	function updateClassName( style ) {
+		let added = false;
+		let updatedClassName = compact( className
+			.split( ' ' )
+			.map( ( current ) => {
+				const trimmed = current.trim();
+				if ( activeStyle && trimmed === 'is-style-' + activeStyle.name ) {
+					added = true;
+					return style.isDefault ? null : 'is-style-' + style.name;
+				}
+			} ) ).join( ' ' );
+		if ( ! added && ! style.isDefault ) {
+			updatedClassName = updatedClassName + ' is-style-' + style.name;
+		}
+
+		onChangeClassName( updatedClassName );
+	}
+
+	return (
+		<Toolbar controls={ styles.map( ( variation ) => ( {
+			icon: variation.icon,
+			title: sprintf( __( 'Style %s' ), variation.label || variation.name ),
+			isActive: activeStyle === variation,
+			onClick() {
+				updateClassName( variation );
+			},
+		} ) ) } />
+	);
+}
+
+export default compose( [
+	withSelect( ( select, { uid } ) => {
+		const block = select( 'core/editor' ).getBlock( uid );
+
+		return {
+			className: block.attributes.className || '',
+			styles: get( getBlockType( block.name ), [ 'transforms', 'styles' ] ),
+		};
+	} ),
+	withDispatch( ( dispatch, { uid } ) => {
+		return {
+			onChangeClassName( newClassName ) {
+				dispatch( 'core/editor' ).updateBlockAttributes( uid, { className: newClassName } );
+			},
+		};
+	} ),
+] )( BlockStyles );

--- a/editor/components/block-styles/index.js
+++ b/editor/components/block-styles/index.js
@@ -9,11 +9,11 @@ import { find, compact, get } from 'lodash';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { getBlockType } from '@wordpress/blocks';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import './style.scss';
 import { BlockPreviewContent } from '../block-preview';
 
 /**
@@ -96,13 +96,16 @@ function BlockStyles( {
 		<div className="editor-block-styles">
 			{ styles.map( ( style ) => {
 				const styleClassName = replaceActiveStyle( className, activeStyle, style );
+				/* eslint-disable jsx-a11y/click-events-have-key-events */
 				return (
-					<Button
+					<div
 						key={ style.name }
 						className="editor-block-styles__item"
 						onClick={ () => updateClassName( style ) }
 						onMouseEnter={ () => onHoverClassName( styleClassName ) }
 						onMouseLeave={ () => onHoverClassName( null ) }
+						role="button"
+						tabIndex="0"
 					>
 						<BlockPreviewContent
 							name={ name }
@@ -111,8 +114,9 @@ function BlockStyles( {
 								className: styleClassName,
 							} }
 						/>
-					</Button>
+					</div>
 				);
+				/* eslint-enable jsx-a11y/click-events-have-key-events */
 			} ) }
 		</div>
 	);

--- a/editor/components/block-styles/index.js
+++ b/editor/components/block-styles/index.js
@@ -9,6 +9,7 @@ import { find, compact, get } from 'lodash';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { getBlockType } from '@wordpress/blocks';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -106,6 +107,7 @@ function BlockStyles( {
 						onMouseLeave={ () => onHoverClassName( null ) }
 						role="button"
 						tabIndex="0"
+						aria-label={ sprintf( __( 'Apply style variation "%s"' ), style.label || style.name ) }
 					>
 						<BlockPreviewContent
 							name={ name }

--- a/editor/components/block-styles/index.js
+++ b/editor/components/block-styles/index.js
@@ -137,7 +137,7 @@ export default compose( [
 			name: block.name,
 			attributes: block.attributes,
 			className: block.attributes.className || '',
-			styles: get( getBlockType( block.name ), [ 'transforms', 'styles' ] ),
+			styles: get( getBlockType( block.name ), [ 'styles' ] ),
 		};
 	} ),
 	withDispatch( ( dispatch, { uid } ) => {

--- a/editor/components/block-styles/index.js
+++ b/editor/components/block-styles/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { find, compact, get } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -101,7 +102,11 @@ function BlockStyles( {
 				return (
 					<div
 						key={ style.name }
-						className="editor-block-styles__item"
+						className={ classnames(
+							'editor-block-styles__item', {
+								'is-active': activeStyle === style,
+							}
+						) }
 						onClick={ () => updateClassName( style ) }
 						onMouseEnter={ () => onHoverClassName( styleClassName ) }
 						onMouseLeave={ () => onHoverClassName( null ) }

--- a/editor/components/block-styles/index.js
+++ b/editor/components/block-styles/index.js
@@ -114,13 +114,18 @@ function BlockStyles( {
 						tabIndex="0"
 						aria-label={ sprintf( __( 'Apply style variation "%s"' ), style.label || style.name ) }
 					>
-						<BlockPreviewContent
-							name={ name }
-							attributes={ {
-								...attributes,
-								className: styleClassName,
-							} }
-						/>
+						<div className="editor-block-styles__item-preview">
+							<BlockPreviewContent
+								name={ name }
+								attributes={ {
+									...attributes,
+									className: styleClassName,
+								} }
+							/>
+						</div>
+						<div className="editor-block-styles__item-label">
+							{ style.label || style.name }
+						</div>
 					</div>
 				);
 				/* eslint-enable jsx-a11y/click-events-have-key-events */

--- a/editor/components/block-styles/style.scss
+++ b/editor/components/block-styles/style.scss
@@ -22,7 +22,7 @@
 	}
 
 	&:focus,
-	&.is-selected {
+	&.is-active {
 		@include block-style__focus-active();
 	}
 

--- a/editor/components/block-styles/style.scss
+++ b/editor/components/block-styles/style.scss
@@ -1,0 +1,28 @@
+.editor-block-styles {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-template-rows: 60px;
+	grid-gap: 5px;
+}
+
+.editor-block-styles__item {
+	cursor: pointer;
+	border: 1px solid $light-gray-500;
+	overflow: hidden;
+	padding: 5px;
+	text-align: initial;
+
+	> * {
+		transform: scale( 0.7 );
+		transform-origin: center center;
+		font-family: $editor-font;
+	}
+
+	&.is-selected {
+		@include formatting-button-style__active;
+	}
+
+	&:hover {
+		@include formatting-button-style__hover;
+	}
+}

--- a/editor/components/block-styles/style.scss
+++ b/editor/components/block-styles/style.scss
@@ -2,15 +2,22 @@
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	grid-template-rows: 60px;
-	grid-gap: 5px;
+	grid-gap: $item-spacing;
 }
 
 .editor-block-styles__item {
 	cursor: pointer;
-	border: 1px solid $light-gray-500;
+	outline: 1px solid transparent; // Shown in Windows High Contrast mode.
+	box-shadow: inset 0 0 0 1px rgba( $dark-gray-900, .2 );
 	overflow: hidden;
-	padding: 5px;
+	padding: 0;
 	text-align: initial;
+	border-radius: $button-style__radius-roundrect;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
 
 	> * {
 		transform: scale( 0.7 );
@@ -18,11 +25,17 @@
 		font-family: $editor-font;
 	}
 
+	// Make vertical centering easier.
+	> blockquote.wp-block-quote,
+	> * p:last-child {
+		margin-bottom: 0;
+	}
+
 	&.is-selected {
-		@include formatting-button-style__active;
+		@include block-style__focus-active();
 	}
 
 	&:hover {
-		@include formatting-button-style__hover;
+		@include block-style__hover;
 	}
 }

--- a/editor/components/block-styles/style.scss
+++ b/editor/components/block-styles/style.scss
@@ -13,11 +13,7 @@
 	padding: 0;
 	text-align: initial;
 	border-radius: $button-style__radius-roundrect;
-
 	display: flex;
-	justify-content: center;
-	align-items: center;
-	flex-direction: column;
 
 	> * {
 		transform: scale( 0.7 );
@@ -25,17 +21,16 @@
 		font-family: $editor-font;
 	}
 
-	// Make vertical centering easier.
-	> blockquote.wp-block-quote,
-	> * p:last-child {
-		margin-bottom: 0;
-	}
-
+	&:focus,
 	&.is-selected {
 		@include block-style__focus-active();
 	}
 
 	&:hover {
 		@include block-style__hover;
+	}
+
+	.editor-block-preview__content {
+		width: 100%;
 	}
 }

--- a/editor/components/block-styles/style.scss
+++ b/editor/components/block-styles/style.scss
@@ -13,11 +13,10 @@
 	padding: 0;
 	text-align: initial;
 	border-radius: $button-style__radius-roundrect;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: column;
 
 	> * {
 		transform: scale( 0.7 );

--- a/editor/components/block-styles/style.scss
+++ b/editor/components/block-styles/style.scss
@@ -1,12 +1,27 @@
 .editor-block-styles {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
-	grid-template-rows: 60px;
 	grid-gap: $item-spacing;
 }
 
 .editor-block-styles__item {
 	cursor: pointer;
+
+	&:focus,
+	&.is-active {
+		.editor-block-styles__item-preview {
+			@include block-style__focus-active();
+		}
+	}
+
+	&:hover {
+		.editor-block-styles__item-preview {
+			@include block-style__hover;
+		}
+	}
+}
+
+.editor-block-styles__item-preview {
 	outline: 1px solid transparent; // Shown in Windows High Contrast mode.
 	box-shadow: inset 0 0 0 1px rgba( $dark-gray-900, .2 );
 	overflow: hidden;
@@ -14,6 +29,7 @@
 	text-align: initial;
 	border-radius: $button-style__radius-roundrect;
 	display: flex;
+	height: 60px;
 
 	> * {
 		transform: scale( 0.7 );
@@ -21,16 +37,12 @@
 		font-family: $editor-font;
 	}
 
-	&:focus,
-	&.is-active {
-		@include block-style__focus-active();
-	}
-
-	&:hover {
-		@include block-style__hover;
-	}
-
 	.editor-block-preview__content {
 		width: 100%;
 	}
+}
+
+.editor-block-styles__item-label {
+	text-align: center;
+	padding: 4px 2px;
 }

--- a/editor/components/block-styles/style.scss
+++ b/editor/components/block-styles/style.scss
@@ -13,6 +13,7 @@
 	padding: 0;
 	text-align: initial;
 	border-radius: $button-style__radius-roundrect;
+
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/editor/components/block-styles/style.scss
+++ b/editor/components/block-styles/style.scss
@@ -6,6 +6,7 @@
 
 .editor-block-styles__item {
 	cursor: pointer;
+	overflow: hidden;
 
 	&:focus,
 	&.is-active {

--- a/editor/components/block-styles/test/index.js
+++ b/editor/components/block-styles/test/index.js
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import { getActiveStyle, replaceActiveStyle } from '../';
+
+describe( 'getActiveStyle', () => {
+	it( 'Should return the undefined if no active style', () => {
+		const styles = [
+			{ name: 'small' },
+			{ name: 'big' },
+		];
+		const className = 'custom-className';
+
+		expect( getActiveStyle( styles, className ) ).toBeUndefined();
+	} );
+
+	it( 'Should return the default style if no active style', () => {
+		const styles = [
+			{ name: 'small' },
+			{ name: 'big', isDefault: true },
+		];
+		const className = 'custom-className';
+
+		expect( getActiveStyle( styles, className ).name ).toBe( 'big' );
+	} );
+
+	it( 'Should return the active style', () => {
+		const styles = [
+			{ name: 'small' },
+			{ name: 'big', isDefault: true },
+		];
+		const className = 'this-is-custom is-style-small';
+
+		expect( getActiveStyle( styles, className ).name ).toBe( 'small' );
+	} );
+
+	it( 'Should return the first active style', () => {
+		const styles = [
+			{ name: 'small' },
+			{ name: 'big', isDefault: true },
+		];
+		const className = 'this-is-custom is-style-small is-style-big';
+
+		expect( getActiveStyle( styles, className ).name ).toBe( 'small' );
+	} );
+} );
+
+describe( 'replaceActiveStyle', () => {
+	it( 'Should add the new style if no active style', () => {
+		const activeStyle = undefined;
+		const newStyle = { name: 'small' };
+		const className = 'custom-class';
+
+		expect( replaceActiveStyle( className, activeStyle, newStyle ) )
+			.toBe( 'custom-class is-style-small' );
+	} );
+
+	it( 'Should replace the previous active style', () => {
+		const activeStyle = { name: 'large' };
+		const newStyle = { name: 'small' };
+		const className = 'custom-class is-style-large';
+
+		expect( replaceActiveStyle( className, activeStyle, newStyle ) )
+			.toBe( 'custom-class is-style-small' );
+	} );
+} );

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -43,6 +43,11 @@ export class BlockSwitcher extends Component {
 	render() {
 		const { blocks, onTransform, isLocked } = this.props;
 		const { hoveredClassName } = this.state;
+
+		if ( ! blocks || ! blocks.length ) {
+			return null;
+		}
+
 		const allowedBlocks = getPossibleBlockTransformations( blocks );
 		const sourceBlockName = blocks[ 0 ].name;
 		const blockType = getBlockType( sourceBlockName );

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -44,14 +44,13 @@ export class BlockSwitcher extends Component {
 		const { blocks, onTransform, isLocked } = this.props;
 		const { hoveredClassName } = this.state;
 		const allowedBlocks = getPossibleBlockTransformations( blocks );
-
-		if ( isLocked || ! allowedBlocks.length ) {
-			return null;
-		}
-
 		const sourceBlockName = blocks[ 0 ].name;
 		const blockType = getBlockType( sourceBlockName );
 		const hasStyles = blocks.length === 1 && get( blockType, [ 'transforms', 'styles' ], [] ).length !== 0;
+
+		if ( ! hasStyles && ( ! allowedBlocks.length || isLocked ) ) {
+			return null;
+		}
 
 		return (
 			<Dropdown
@@ -87,30 +86,32 @@ export class BlockSwitcher extends Component {
 				renderContent={ ( { onClose } ) => (
 					<Fragment>
 						{ hasStyles &&
-						<PanelBody
-							title={ __( 'Block Styles' ) }
-							initialOpen
-						>
-							<BlockStyles uid={ blocks[ 0 ].uid } onSwitch={ onClose } onHoverClassName={ this.onHoverClassName } />
-						</PanelBody>
+							<PanelBody
+								title={ __( 'Block Styles' ) }
+								initialOpen
+							>
+								<BlockStyles uid={ blocks[ 0 ].uid } onSwitch={ onClose } onHoverClassName={ this.onHoverClassName } />
+							</PanelBody>
 						}
-						<PanelBody
-							title={ __( 'Transform To:' ) }
-							initialOpen
-						>
-							<BlockTypesList
-								items={ allowedBlocks.map( ( destinationBlockType ) => ( {
-									id: destinationBlockType.name,
-									icon: destinationBlockType.icon,
-									title: destinationBlockType.title,
-									hasChildBlocks: hasChildBlocks( destinationBlockType.name ),
-								} ) ) }
-								onSelect={ ( item ) => {
-									onTransform( blocks, item.id );
-									onClose();
-								} }
-							/>
-						</PanelBody>
+						{ allowedBlocks.length !== 0 && ! isLocked &&
+							<PanelBody
+								title={ __( 'Transform To:' ) }
+								initialOpen
+							>
+								<BlockTypesList
+									items={ allowedBlocks.map( ( destinationBlockType ) => ( {
+										id: destinationBlockType.name,
+										icon: destinationBlockType.icon,
+										title: destinationBlockType.title,
+										hasChildBlocks: hasChildBlocks( destinationBlockType.name ),
+									} ) ) }
+									onSelect={ ( item ) => {
+										onTransform( blocks, item.id );
+										onClose();
+									} }
+								/>
+							</PanelBody>
+						}
 
 						{ ( hoveredClassName !== null ) &&
 							<BlockPreview

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -46,7 +46,7 @@ export class BlockSwitcher extends Component {
 		const allowedBlocks = getPossibleBlockTransformations( blocks );
 		const sourceBlockName = blocks[ 0 ].name;
 		const blockType = getBlockType( sourceBlockName );
-		const hasStyles = blocks.length === 1 && get( blockType, [ 'transforms', 'styles' ], [] ).length !== 0;
+		const hasStyles = blocks.length === 1 && get( blockType, [ 'styles' ], [] ).length !== 0;
 
 		if ( ! hasStyles && ( ! allowedBlocks.length || isLocked ) ) {
 			return null;

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -1,10 +1,15 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu } from '@wordpress/components';
+import { Dropdown, Dashicon, IconButton, Toolbar, PanelBody } from '@wordpress/components';
 import { getBlockType, getPossibleBlockTransformations, switchToBlockType } from '@wordpress/blocks';
-import { compose } from '@wordpress/element';
+import { compose, Component, Fragment } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -13,87 +18,116 @@ import { withSelect, withDispatch } from '@wordpress/data';
  */
 import './style.scss';
 import BlockIcon from '../block-icon';
+import BlockStyles from '../block-styles';
+import BlockPreview from '../block-preview';
 
 /**
  * Module Constants
  */
 const { DOWN } = keycodes;
 
-export function BlockSwitcher( { blocks, onTransform, isLocked } ) {
-	const allowedBlocks = getPossibleBlockTransformations( blocks );
-
-	if ( isLocked || ! allowedBlocks.length ) {
-		return null;
+export class BlockSwitcher extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			hoveredClassName: null,
+		};
+		this.onHoverClassName = this.onHoverClassName.bind( this );
 	}
 
-	const sourceBlockName = blocks[ 0 ].name;
-	const blockType = getBlockType( sourceBlockName );
+	onHoverClassName( className ) {
+		this.setState( { hoveredClassName: className } );
+	}
 
-	return (
-		<Dropdown
-			className="editor-block-switcher"
-			contentClassName="editor-block-switcher__popover"
-			renderToggle={ ( { onToggle, isOpen } ) => {
-				const openOnArrowDown = ( event ) => {
-					if ( ! isOpen && event.keyCode === DOWN ) {
-						event.preventDefault();
-						event.stopPropagation();
-						onToggle();
-					}
-				};
-				const label = __( 'Change block type' );
+	render() {
+		const { blocks, onTransform, isLocked } = this.props;
+		const { hoveredClassName } = this.state;
+		const allowedBlocks = getPossibleBlockTransformations( blocks );
 
-				return (
-					<Toolbar>
-						<IconButton
-							className="editor-block-switcher__toggle"
-							icon={ <BlockIcon icon={ blockType.icon && blockType.icon.src } /> }
-							onClick={ onToggle }
-							aria-haspopup="true"
-							aria-expanded={ isOpen }
-							label={ label }
-							tooltip={ label }
-							onKeyDown={ openOnArrowDown }
-						>
-							<Dashicon icon="arrow-down" />
-						</IconButton>
-					</Toolbar>
-				);
-			} }
-			renderContent={ ( { onClose } ) => (
-				<div>
-					<span
-						className="editor-block-switcher__menu-title"
-					>
-						{ __( 'Transform into:' ) }
-					</span>
-					<NavigableMenu
-						role="menu"
-						aria-label={ __( 'Block types' ) }
-					>
-						{ allowedBlocks.map( ( { name, title, icon } ) => (
+		if ( isLocked || ! allowedBlocks.length ) {
+			return null;
+		}
+
+		const sourceBlockName = blocks[ 0 ].name;
+		const blockType = getBlockType( sourceBlockName );
+		const hasStyles = blocks.length === 1 && get( blockType, [ 'transforms', 'styles' ], [] ).length !== 0;
+
+		return (
+			<Dropdown
+				position="bottom right"
+				className="editor-block-switcher"
+				contentClassName="editor-block-switcher__popover"
+				renderToggle={ ( { onToggle, isOpen } ) => {
+					const openOnArrowDown = ( event ) => {
+						if ( ! isOpen && event.keyCode === DOWN ) {
+							event.preventDefault();
+							event.stopPropagation();
+							onToggle();
+						}
+					};
+					const label = __( 'Change block type' );
+
+					return (
+						<Toolbar>
 							<IconButton
-								key={ name }
-								onClick={ () => {
-									onTransform( blocks, name );
-									onClose();
-								} }
-								className="editor-block-switcher__menu-item"
-								icon={ (
-									<span className="editor-block-switcher__block-icon">
-										<BlockIcon icon={ icon && icon.src } />
-									</span>
-								) }
-								role="menuitem"
+								className="editor-block-switcher__toggle"
+								icon={ <BlockIcon icon={ blockType.icon && blockType.icon.src } /> }
+								onClick={ onToggle }
+								aria-haspopup="true"
+								aria-expanded={ isOpen }
+								label={ label }
+								tooltip={ label }
+								onKeyDown={ openOnArrowDown }
 							>
-								{ title }
+								<Dashicon icon="arrow-down" />
 							</IconButton>
-						) ) }
-					</NavigableMenu>
-				</div>
-			) }
-		/>
-	);
+						</Toolbar>
+					);
+				} }
+				renderContent={ ( { onClose } ) => (
+					<Fragment>
+						{ hasStyles &&
+						<PanelBody
+							title={ __( 'Block Styles' ) }
+							initialOpen
+						>
+							<BlockStyles uid={ blocks[ 0 ].uid } onSwitch={ onClose } onHoverClassName={ this.onHoverClassName } />
+						</PanelBody>
+						}
+						<PanelBody
+							title={ __( 'Block transforms' ) }
+							initialOpen={ ! hasStyles }
+						>
+							{ allowedBlocks.map( ( { name, title, icon } ) => (
+								<IconButton
+									key={ name }
+									onClick={ () => {
+										onTransform( blocks, name );
+										onClose();
+									} }
+									className="editor-block-switcher__transform"
+									icon={ (
+										<span className="editor-block-switcher__block-icon">
+											<BlockIcon icon={ icon && icon.src } />
+										</span>
+									) }
+								>
+									{ title }
+								</IconButton>
+							) ) }
+						</PanelBody>
+
+						{ ( hoveredClassName !== null ) &&
+							<BlockPreview
+								name={ blocks[ 0 ].name }
+								attributes={ { ...blocks[ 0 ].attributes, className: hoveredClassName } }
+							/>
+						}
+					</Fragment>
+				) }
+			/>
+		);
+	}
 }
 
 export default compose(

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -96,7 +96,7 @@ export class BlockSwitcher extends Component {
 						}
 						<PanelBody
 							title={ __( 'Block transforms' ) }
-							initialOpen={ ! hasStyles }
+							initialOpen
 						>
 							{ allowedBlocks.map( ( { name, title, icon } ) => (
 								<IconButton

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, Dashicon, IconButton, Toolbar, PanelBody } from '@wordpress/components';
+import { Dropdown, IconButton, Toolbar, PanelBody } from '@wordpress/components';
 import { getBlockType, getPossibleBlockTransformations, switchToBlockType, hasChildBlocks } from '@wordpress/blocks';
 import { compose, Component, Fragment } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { Dropdown, Dashicon, IconButton, Toolbar, PanelBody } from '@wordpress/components';
-import { getBlockType, getPossibleBlockTransformations, switchToBlockType } from '@wordpress/blocks';
+import { getBlockType, getPossibleBlockTransformations, switchToBlockType, hasChildBlocks } from '@wordpress/blocks';
 import { compose, Component, Fragment } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -20,6 +20,7 @@ import './style.scss';
 import BlockIcon from '../block-icon';
 import BlockStyles from '../block-styles';
 import BlockPreview from '../block-preview';
+import BlockTypesList from '../block-types-list';
 
 /**
  * Module Constants
@@ -95,26 +96,21 @@ export class BlockSwitcher extends Component {
 						</PanelBody>
 						}
 						<PanelBody
-							title={ __( 'Block transforms' ) }
+							title={ __( 'Transform To:' ) }
 							initialOpen
 						>
-							{ allowedBlocks.map( ( { name, title, icon } ) => (
-								<IconButton
-									key={ name }
-									onClick={ () => {
-										onTransform( blocks, name );
-										onClose();
-									} }
-									className="editor-block-switcher__transform"
-									icon={ (
-										<span className="editor-block-switcher__block-icon">
-											<BlockIcon icon={ icon && icon.src } />
-										</span>
-									) }
-								>
-									{ title }
-								</IconButton>
-							) ) }
+							<BlockTypesList
+								items={ allowedBlocks.map( ( destinationBlockType ) => ( {
+									id: destinationBlockType.name,
+									icon: destinationBlockType.icon,
+									title: destinationBlockType.title,
+									hasChildBlocks: hasChildBlocks( destinationBlockType.name ),
+								} ) ) }
+								onSelect={ ( item ) => {
+									onTransform( blocks, item.id );
+									onClose();
+								} }
+							/>
 						</PanelBody>
 
 						{ ( hoveredClassName !== null ) &&

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -72,7 +72,6 @@ export class BlockSwitcher extends Component {
 						<Toolbar>
 							<IconButton
 								className="editor-block-switcher__toggle"
-								icon={ <BlockIcon icon={ blockType.icon && blockType.icon.src } /> }
 								onClick={ onToggle }
 								aria-haspopup="true"
 								aria-expanded={ isOpen }
@@ -80,7 +79,7 @@ export class BlockSwitcher extends Component {
 								tooltip={ label }
 								onKeyDown={ openOnArrowDown }
 							>
-								<Dashicon icon="arrow-down" />
+								<BlockIcon icon={ blockType.icon && blockType.icon.src } showColors />
 							</IconButton>
 						</Toolbar>
 					);

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -69,26 +69,6 @@
 	}
 }
 
-.editor-block-switcher__transform {
-	color: $dark-gray-500;
-	display: flex;
-	align-items: center;
-	width: calc( 100% + 16 * 2px);
-	padding: 6px;
-	margin: 0 -16px; // Remove the panel body padding while keeping it for the title
-	text-align: left;
-
-	.editor-block-switcher__block-icon {
-		margin-right: 8px;
-		height: 20px;
-	}
-
-	&:hover:not(:disabled):not([aria-disabled="true"]) {
-		@include menu-style__neutral;
-	}
-
-	&:focus:not(:disabled):not([aria-disabled="true"]) {
-		@include menu-style__focus;
-	}
-
+.editor-block-switcher__popover .editor-block-types-list {
+	margin: 8px -8px -8px;
 }

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -42,31 +42,6 @@
 
 .editor-block-switcher__popover .editor-block-styles {
 	margin: 0 -11px; // Remove the panel body padding while keeping it for the title
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-template-rows: 60px;
-	grid-gap: 5px;
-
-	.editor-block-styles__item {
-		border: 1px solid $light-gray-500;
-		overflow: hidden;
-		padding: 5px;
-		text-align: initial;
-
-		> * {
-			transform: scale( 0.7 );
-			transform-origin: center center;
-			font-family: $editor-font;
-		}
-
-		&.is-selected {
-			@include formatting-button-style__active;
-		}
-
-		&:hover {
-			@include formatting-button-style__hover;
-		}
-	}
 }
 
 .editor-block-switcher__popover .editor-block-types-list {

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -51,6 +51,8 @@
 		border: 1px solid $light-gray-500;
 		overflow: hidden;
 		padding: 5px;
+		text-align: initial;
+
 		> * {
 			transform: scale( 0.7 );
 			transform-origin: center top;

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -5,7 +5,7 @@
 .editor-block-switcher__toggle {
 	width: auto;
 	margin: 0;
-	padding: 8px;
+	padding: 6px;
 	border-radius: 0;
 
 	&:focus:before {

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -17,28 +17,63 @@
 }
 
 .editor-block-switcher__popover .components-popover__content {
-	width: 200px;
+	width: 300px;
+
+	@include break-medium {
+		position: relative;
+
+		.editor-block-preview {
+			border: 1px solid $light-gray-500;
+			box-shadow: $shadow-popover;
+			background: $white;
+			position: absolute;
+			left: 100%;
+			top: 0;
+			bottom: 0;
+			width: 300px;
+		}
+	}
 }
 
-.editor-block-switcher__menu {
-	box-shadow: $shadow-popover;
-	border: 1px solid $light-gray-500;
-	background: $white;
-	padding: 3px 3px 0;
+.editor-block-switcher__popover:not(.is-mobile) > .components-popover__content {
+	// Reset overflow to allow showing the preview on the left once an item is hovered.
+	overflow-y: initial;
 }
 
-.editor-block-switcher__menu-title {
-	display: block;
-	padding: 6px;
-	color: $dark-gray-300;
+.editor-block-switcher__popover .editor-block-styles {
+	margin: 0 -11px; // Remove the panel body padding while keeping it for the title
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-template-rows: 60px;
+	grid-gap: 5px;
+
+	.editor-block-styles__item {
+		border: 1px solid $light-gray-500;
+		overflow: hidden;
+		padding: 5px;
+		> * {
+			transform: scale( 0.7 );
+			transform-origin: center top;
+			font-family: $editor-font;
+		}
+
+		&.is-selected {
+			@include formatting-button-style__active;
+		}
+
+		&:hover {
+			@include formatting-button-style__hover;
+		}
+	}
 }
 
-.editor-block-switcher__menu-item {
+.editor-block-switcher__transform {
 	color: $dark-gray-500;
 	display: flex;
 	align-items: center;
-	width: 100%;
+	width: calc( 100% + 16 * 2px);
 	padding: 6px;
+	margin: 0 -16px; // Remove the panel body padding while keeping it for the title
 	text-align: left;
 
 	.editor-block-switcher__block-icon {

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -55,7 +55,7 @@
 
 		> * {
 			transform: scale( 0.7 );
-			transform-origin: center top;
+			transform-origin: center center;
 			font-family: $editor-font;
 		}
 

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -2,17 +2,31 @@
 	position: relative;
 }
 
-.editor-block-switcher__toggle {
+// Style this the same as the block buttons in the library.
+// Needs specificiity to override the icon button.
+.components-icon-button.editor-block-switcher__toggle {
 	width: auto;
 	margin: 0;
 	padding: 6px;
-	border-radius: 0;
 
-	&:focus:before {
-		top: -3px;
-		right: -3px;
-		bottom: -3px;
-		left: -3px;
+	// Unset icon button styles.
+	&:active,
+	&:not( :disabled ):not( [aria-disabled="true"] ):hover,
+	&:not( [aria-disabled="true"] ):focus {
+		outline: none;
+		box-shadow: none;
+		background: none;
+		border: none;
+	}
+
+	// Block hover style.
+	&:not( :disabled ):hover .editor-block-icon__colors {
+		@include block-style__hover();
+	}
+
+	// Block focus style.
+	&:not(:disabled):focus .editor-block-icon__colors {
+		@include block-style__focus-active();
 	}
 }
 
@@ -28,10 +42,20 @@
 			background: $white;
 			position: absolute;
 			left: 100%;
-			top: 0;
-			bottom: 0;
+			top: -1px;
+			bottom: -1px;
 			width: 300px;
+			height: auto;
 		}
+	}
+
+	// Hide the bottom border on the last panel so it stacks with the popover.
+	.components-panel__body {
+		border: 0;
+	}
+
+	.components-panel__body + .components-panel__body {
+		border-top: 1px solid $light-gray-500;
 	}
 }
 
@@ -41,7 +65,7 @@
 }
 
 .editor-block-switcher__popover .editor-block-styles {
-	margin: 0 -11px; // Remove the panel body padding while keeping it for the title
+	margin: 0 -3px; // Remove the panel body padding while keeping it for the title.
 }
 
 .editor-block-switcher__popover .editor-block-types-list {

--- a/editor/components/block-switcher/test/__snapshots__/index.js.snap
+++ b/editor/components/block-switcher/test/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`BlockSwitcher should render switcher with blocks 1`] = `
 <Dropdown
   className="editor-block-switcher"
   contentClassName="editor-block-switcher__popover"
+  position="bottom right"
   renderContent={[Function]}
   renderToggle={[Function]}
 />

--- a/editor/components/block-switcher/test/index.js
+++ b/editor/components/block-switcher/test/index.js
@@ -136,22 +136,11 @@ describe( 'BlockSwitcher', () => {
 		} );
 
 		describe( '.renderContent', () => {
-			const onCloseStub = jest.fn();
-
-			const getIconButtons = () => {
-				const content = shallow( getDropdown().props().renderContent( { onClose: onCloseStub } ) );
-				return content.find( 'IconButton' );
-			};
-
-			test( 'should create the iconButtons for the chosen block. A heading block will have 3 items', () => {
-				expect( getIconButtons() ).toHaveLength( 3 );
-			} );
-
-			test( 'should simulate the click event by closing the switcher and causing a block transform on iconButtons.', () => {
-				getIconButtons().first().simulate( 'click' );
-
-				expect( onCloseStub ).toHaveBeenCalledTimes( 1 );
-				expect( onTransformStub ).toHaveBeenCalledTimes( 1 );
+			test( 'should create the transform items for the chosen block. A heading block will have 3 items', () => {
+				const onCloseStub = jest.fn();
+				const content = shallow( <div>{ getDropdown().props().renderContent( { onClose: onCloseStub } ) }</div> );
+				const blockList = content.find( 'BlockTypesList' );
+				expect( blockList.prop( 'items' ) ).toHaveLength( 3 );
 			} );
 		} );
 	} );

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -10,6 +10,7 @@ import './style.scss';
 import BlockSwitcher from '../block-switcher';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
+import BlockStyles from '../block-styles';
 
 function BlockToolbar( { block, mode } ) {
 	if ( ! block || ! block.isValid || mode !== 'visual' ) {
@@ -19,6 +20,7 @@ function BlockToolbar( { block, mode } ) {
 	return (
 		<div className="editor-block-toolbar">
 			<BlockSwitcher uids={ [ block.uid ] } />
+			<BlockStyles uid={ block.uid } />
 			<BlockControls.Slot />
 			<BlockFormatControls.Slot />
 		</div>

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -10,7 +10,6 @@ import './style.scss';
 import BlockSwitcher from '../block-switcher';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
-import BlockStyles from '../block-styles';
 
 function BlockToolbar( { block, mode } ) {
 	if ( ! block || ! block.isValid || mode !== 'visual' ) {
@@ -20,7 +19,6 @@ function BlockToolbar( { block, mode } ) {
 	return (
 		<div className="editor-block-toolbar">
 			<BlockSwitcher uids={ [ block.uid ] } />
-			<BlockStyles uid={ block.uid } />
 			<BlockControls.Slot />
 			<BlockFormatControls.Slot />
 		</div>

--- a/editor/components/block-types-list/index.js
+++ b/editor/components/block-types-list/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,11 +13,12 @@ import { getBlockMenuDefaultClassName } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import BlockIcon from '../block-icon';
 
-class ItemList extends Component {
+class BlockTypesList extends Component {
 	render() {
-		const { items, onSelect, onHover } = this.props;
+		const { items, onSelect, onHover = noop } = this.props;
 
 		return (
 			/*
@@ -24,7 +26,7 @@ class ItemList extends Component {
 			 * Safari+VoiceOver won't announce the list otherwise.
 			 */
 			/* eslint-disable jsx-a11y/no-redundant-roles */
-			<ul role="list" className="editor-inserter__list">
+			<ul role="list" className="editor-block-types-list">
 				{ items.map( ( item ) => {
 					const itemIconStyle = item.icon ? {
 						backgroundColor: item.icon.background,
@@ -34,14 +36,14 @@ class ItemList extends Component {
 						backgroundColor: item.icon.shadowColor,
 					} : {};
 					return (
-						<li className="editor-inserter__list-item" key={ item.id }>
+						<li className="editor-block-types-list__list-item" key={ item.id }>
 							<button
 								className={
 									classnames(
-										'editor-inserter__item',
+										'editor-block-types-list__item',
 										getBlockMenuDefaultClassName( item.id ),
 										{
-											'editor-inserter__item-has-children': item.hasChildBlocks,
+											'editor-block-types-list__item-has-children': item.hasChildBlocks,
 										}
 									)
 								}
@@ -54,19 +56,19 @@ class ItemList extends Component {
 								aria-label={ item.title } // Fix for IE11 and JAWS 2018.
 							>
 								<span
-									className="editor-inserter__item-icon"
+									className="editor-block-types-list__item-icon"
 									style={ itemIconStyle }
 								>
 									<BlockIcon icon={ item.icon && item.icon.src } />
 									{ item.hasChildBlocks &&
 									<span
-										className="editor-inserter__item-icon-stack"
+										className="editor-block-types-list__item-icon-stack"
 										style={ itemIconStackStyle }
 									/>
 									}
 								</span>
 
-								<span className="editor-inserter__item-title">
+								<span className="editor-block-types-list__item-title">
 									{ item.title }
 								</span>
 							</button>
@@ -79,4 +81,4 @@ class ItemList extends Component {
 	}
 }
 
-export default ItemList;
+export default BlockTypesList;

--- a/editor/components/block-types-list/style.scss
+++ b/editor/components/block-types-list/style.scss
@@ -1,0 +1,100 @@
+
+.editor-block-types-list {
+	list-style: none;
+	padding: 0;
+}
+
+.editor-block-types-list__list-item {
+	display: inline;
+}
+
+.editor-block-types-list__item {
+	display: inline-flex;
+	flex-direction: column;
+	width: calc( 33.3% - 8px );
+	margin: 0 4px 8px 4px;
+	font-size: $default-font-size;
+	color: $dark-gray-700;
+	padding: 0;
+	align-items: stretch;
+	justify-content: center;
+	cursor: pointer;
+	background: transparent;
+	word-break: break-word;
+	border-radius: 4px;
+	border: 1px solid transparent;
+	transition: all 0.05s ease-in-out;
+
+	&:disabled {
+		@include block-style__disabled();
+	}
+
+	&:not(:disabled) {
+		&:hover {
+			.editor-block-types-list__item-icon {
+				@include block-style__hover();
+			}
+
+			.editor-block-types-list__item-title {
+				color: $dark-gray-900;
+			}
+		}
+		&:active,
+		&.is-active,
+		&:focus {
+			position: relative;
+
+			// Show the focus style in the icon inside instead.
+			outline: none;
+
+			.editor-block-types-list__item-icon {
+				@include block-style__focus-active();
+			}
+
+			.editor-block-types-list__item-title {
+				color: $dark-gray-900;
+			}
+		}
+	}
+}
+
+.editor-block-types-list__item-icon {
+	padding: 15px 20px;
+	background: $light-gray-200;
+	border-radius: 4px;
+	color: $dark-gray-500;
+	transition: all 0.05s ease-in-out;
+
+	svg {
+		width: 20px;
+		height: 20px;
+		transition: all 0.15s ease-out;
+	}
+}
+
+.editor-block-types-list__item-title {
+	padding: 4px 2px;
+}
+
+.editor-block-types-list__item-has-children {
+	.editor-block-types-list__item-icon {
+		margin-right: 3px;
+		position: relative;
+		top: -2px;
+		left: -2px;
+
+	}
+
+	// Show a "stacked card" below an item that has children.
+	.editor-block-types-list__item-icon-stack {
+		display: block;
+		background: rgba( $dark-gray-900, .3 );
+		width: 100%;
+		height: 100%;
+		position: absolute;
+		z-index: -1; // Show below the card as a shadow
+		bottom: -4px;
+		right: -4px;
+		border-radius: 4px;
+	}
+}

--- a/editor/components/block-types-list/style.scss
+++ b/editor/components/block-types-list/style.scss
@@ -21,7 +21,7 @@
 	cursor: pointer;
 	background: transparent;
 	word-break: break-word;
-	border-radius: 4px;
+	border-radius: $button-style__radius-roundrect;
 	border: 1px solid transparent;
 	transition: all 0.05s ease-in-out;
 

--- a/editor/components/inserter/child-blocks.js
+++ b/editor/components/inserter/child-blocks.js
@@ -9,7 +9,7 @@ import { ifCondition } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
-import ItemList from './item-list';
+import BlockTypesList from '../block-types-list';
 import BlockIcon from '../block-icon';
 
 function ChildBlocks( { rootBlockIcon, rootBlockTitle, items, ...props } ) {
@@ -21,7 +21,7 @@ function ChildBlocks( { rootBlockIcon, rootBlockTitle, items, ...props } ) {
 					{ rootBlockTitle && <h2>{ rootBlockTitle }</h2> }
 				</div>
 			) }
-			<ItemList items={ items } { ...props } />
+			<BlockTypesList items={ items } { ...props } />
 		</div>
 	);
 }

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -35,7 +35,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
  */
 import './style.scss';
 import BlockPreview from '../block-preview';
-import ItemList from './item-list';
+import BlockTypesList from '../block-types-list';
 import ChildBlocks from './child-blocks';
 
 const MAX_SUGGESTED_ITEMS = 9;
@@ -215,7 +215,7 @@ export class InserterMenu extends Component {
 							onToggle={ this.onTogglePanel( 'suggested' ) }
 							ref={ this.bindPanel( 'suggested' ) }
 						>
-							<ItemList items={ suggestedItems } onSelect={ onSelect } onHover={ this.onHover } />
+							<BlockTypesList items={ suggestedItems } onSelect={ onSelect } onHover={ this.onHover } />
 						</PanelBody>
 					}
 					{ map( getCategories(), ( category ) => {
@@ -231,7 +231,7 @@ export class InserterMenu extends Component {
 								onToggle={ this.onTogglePanel( category.slug ) }
 								ref={ this.bindPanel( category.slug ) }
 							>
-								<ItemList items={ categoryItems } onSelect={ onSelect } onHover={ this.onHover } />
+								<BlockTypesList items={ categoryItems } onSelect={ onSelect } onHover={ this.onHover } />
 							</PanelBody>
 						);
 					} ) }
@@ -243,7 +243,7 @@ export class InserterMenu extends Component {
 							icon="controls-repeat"
 							ref={ this.bindPanel( 'shared' ) }
 						>
-							<ItemList items={ sharedItems } onSelect={ onSelect } onHover={ this.onHover } />
+							<BlockTypesList items={ sharedItems } onSelect={ onSelect } onHover={ this.onHover } />
 						</PanelBody>
 					) }
 					{ isEmpty( suggestedItems ) && isEmpty( sharedItems ) && isEmpty( itemsPerCategory ) && (

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -97,111 +97,14 @@ $block-inserter-search-height: 38px;
 	}
 }
 
-.editor-inserter__list {
-	list-style: none;
+.editor-inserter__popover .editor-block-types-list {
 	margin: 0 -8px;
-	padding: 0;
-}
-
-.editor-inserter__list-item {
-	display: inline;
-}
-
-.editor-inserter__item {
-	display: inline-flex;
-	flex-direction: column;
-	width: calc( 33.3% - 8px );
-	margin: 0 4px 8px 4px;
-	font-size: $default-font-size;
-	color: $dark-gray-700;
-	padding: 0;
-	align-items: stretch;
-	justify-content: center;
-	cursor: pointer;
-	background: transparent;
-	word-break: break-word;
-	border-radius: 4px;
-	border: 1px solid transparent;
-	transition: all 0.05s ease-in-out;
-
-	&:disabled {
-		@include block-style__disabled();
-	}
-
-	&:not(:disabled) {
-		&:hover {
-			.editor-inserter__item-icon {
-				@include block-style__hover();
-			}
-
-			.editor-inserter__item-title {
-				color: $dark-gray-900;
-			}
-		}
-		&:active,
-		&.is-active,
-		&:focus {
-			position: relative;
-
-			// Show the focus style in the icon inside instead.
-			outline: none;
-
-			.editor-inserter__item-icon {
-				@include block-style__focus-active();
-			}
-
-			.editor-inserter__item-title {
-				color: $dark-gray-900;
-			}
-		}
-	}
-}
-
-.editor-inserter__item-icon {
-	padding: 15px 20px;
-	background: $light-gray-200;
-	border-radius: 4px;
-	color: $dark-gray-500;
-	transition: all 0.05s ease-in-out;
-
-	svg {
-		width: 20px;
-		height: 20px;
-		transition: all 0.15s ease-out;
-	}
-}
-
-.editor-inserter__item-title {
-	padding: 4px 2px;
 }
 
 .editor-inserter__no-results {
 	font-style: italic;
 	padding: 24px;
 	text-align: center;
-}
-
-.editor-inserter__item-has-children {
-	.editor-inserter__item-icon {
-		margin-right: 3px;
-		position: relative;
-		top: -2px;
-		left: -2px;
-
-	}
-
-	// Show a "stacked card" below an item that has children.
-	.editor-inserter__item-icon-stack {
-		display: block;
-		background: rgba( $dark-gray-900, .3 );
-		width: 100%;
-		height: 100%;
-		position: absolute;
-		z-index: -1; // Show below the card as a shadow
-		bottom: -4px;
-		right: -4px;
-		border-radius: 4px;
-	}
 }
 
 .editor-inserter__child-blocks {

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -123,7 +123,7 @@ describe( 'InserterMenu', () => {
 			/>
 		);
 
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		const visibleBlocks = wrapper.find( '.editor-block-types-list__item' );
 		expect( visibleBlocks ).toHaveLength( 0 );
 
 		const noResultsMessage = wrapper.find( '.editor-inserter__no-results' );
@@ -142,7 +142,7 @@ describe( 'InserterMenu', () => {
 			/>
 		);
 
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		const visibleBlocks = wrapper.find( '.editor-block-types-list__item' );
 		expect( visibleBlocks ).toHaveLength( 3 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );
@@ -162,7 +162,7 @@ describe( 'InserterMenu', () => {
 			/>
 		);
 
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		const visibleBlocks = wrapper.find( '.editor-block-types-list__item' );
 		expect( visibleBlocks ).toHaveLength( 2 );
 	} );
 
@@ -187,7 +187,7 @@ describe( 'InserterMenu', () => {
 		const activeCategory = wrapper.find( '.components-panel__body.is-opened > .components-panel__body-title' );
 		expect( activeCategory.text() ).toBe( 'Embeds' );
 
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		const visibleBlocks = wrapper.find( '.editor-block-types-list__item' );
 		expect( visibleBlocks ).toHaveLength( 2 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'YouTube' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'A Text Embed' );
@@ -217,7 +217,7 @@ describe( 'InserterMenu', () => {
 		const activeCategory = wrapper.find( '.components-panel__body.is-opened > .components-panel__body-title' );
 		expect( activeCategory.text() ).toBe( 'Shared' );
 
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		const visibleBlocks = wrapper.find( '.editor-block-types-list__item' );
 		expect( visibleBlocks ).toHaveLength( 1 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'My shared block' );
 
@@ -246,7 +246,7 @@ describe( 'InserterMenu', () => {
 		const activeCategory = wrapper.find( '.components-panel__body.is-opened > .components-panel__body-title' );
 		expect( activeCategory.text() ).toBe( 'Common Blocks' );
 
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		const visibleBlocks = wrapper.find( '.editor-block-types-list__item' );
 		expect( visibleBlocks ).toHaveLength( 3 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );
@@ -272,7 +272,7 @@ describe( 'InserterMenu', () => {
 			.filterWhere( ( node ) => node.text() === 'Layout Elements' );
 		layoutTab.simulate( 'click' );
 
-		const disabledBlocks = wrapper.find( '.editor-inserter__item[disabled=true]' );
+		const disabledBlocks = wrapper.find( '.editor-block-types-list__item[disabled=true]' );
 		expect( disabledBlocks ).toHaveLength( 1 );
 		expect( disabledBlocks.at( 0 ).text() ).toBe( 'More' );
 	} );
@@ -301,7 +301,7 @@ describe( 'InserterMenu', () => {
 		expect( matchingCategories.at( 1 ).text() ).toBe( 'Embeds' );
 
 		// Find blocks across panels
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		const visibleBlocks = wrapper.find( '.editor-block-types-list__item' );
 		expect( visibleBlocks ).toHaveLength( 3 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );
@@ -335,7 +335,7 @@ describe( 'InserterMenu', () => {
 		expect( matchingCategories.at( 1 ).text() ).toBe( 'Embeds' );
 
 		// Find blocks across panels
-		const visibleBlocks = wrapper.find( '.editor-inserter__item' );
+		const visibleBlocks = wrapper.find( '.editor-block-types-list__item' );
 		expect( visibleBlocks ).toHaveLength( 3 );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Advanced Text' );

--- a/test/e2e/specs/__snapshots__/style-variation.test.js.snap
+++ b/test/e2e/specs/__snapshots__/style-variation.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`adding blocks Should switch the style of the quote block 1`] = `
+"<!-- wp:quote {\\"className\\":\\" is-style-large\\"} -->
+<blockquote class=\\"wp-block-quote  is-style-large\\">
+	<p>Quote content</p>
+</blockquote>
+<!-- /wp:quote -->"
+`;

--- a/test/e2e/specs/style-variation.test.js
+++ b/test/e2e/specs/style-variation.test.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import { newPost, newDesktopBrowserPage, insertBlock, getHTMLFromCodeEditor } from '../support/utils';
+
+describe( 'adding blocks', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+	} );
+
+	it( 'Should switch the style of the quote block', async () => {
+		// Inserting a quote block
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'Quote content' );
+
+		// we need to trigger isTyping = false
+		await page.mouse.move( 200, 300 );
+		await page.mouse.move( 250, 350 );
+
+		// Use a different style variation
+		await page.click( 'button[aria-label="Change block type"]' );
+		const styleVariations = await page.$$( '.editor-block-styles__item' );
+		await styleVariations[ 1 ].click();
+
+		// Check the content
+		const content = await getHTMLFromCodeEditor();
+		expect( content ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This is the first step towards #783 

It adds a `transforms.styles` Block API to support style variations per block. It works by adding an `is-style-{styleName}`  className to the custom className per block. 

This PR replaces the style variations of the quote block by this new API. It keeps the UI similar for now.

**Testing instructions**

 - Add a quote block
 - Switch the quote style

### Visuals

![image](https://user-images.githubusercontent.com/548849/41768153-bc0831da-760b-11e8-808c-f01be68a6f14.png)
