### PR TITLE
Blocks: Update demo content to avoid dirtying embed

### DIFF
--- a/post-content.js
+++ b/post-content.js
@@ -124,9 +124,9 @@ window._wpGutenbergDefaultPost = {
 			'<p>Any block can opt into these alignments. The embed block has them also, and is responsive out of the box:</p>',
 			'<!-- /wp:paragraph -->',
 
-			'<!-- wp:embed {"url":"https://vimeo.com/22439234","align":"wide","type":"video","providerNameSlug":"vimeo"} -->',
-			'<figure class="wp-block-embed alignwide is-type-video is-provider-vimeo">https://vimeo.com/22439234</figure>',
-			'<!-- /wp:embed -->',
+			'<!-- wp:core-embed/vimeo {"url":"https://vimeo.com/22439234","align":"wide","type":"video","providerNameSlug":"vimeo"} -->',
+			'<figure class="wp-block-embed-vimeo wp-block-embed alignwide is-type-video is-provider-vimeo">https://vimeo.com/22439234</figure>',
+			'<!-- /wp:core-embed/vimeo -->',
 
 			'<!-- wp:paragraph -->',
 			'<p>You can build any block you like, static or dynamic, decorative or plain. Here\'s a pullquote block:</p>',


### PR DESCRIPTION
Related: #5315

This pull request seeks to update the demo post content to account for block replacement which would otherwise occur as a result of changes introduced in #5315, where a non-provider-specific embed will be replaced with its provider-specific variant if one exists. Without these changes, (a) the demo editor will present itself as dirtying and (b) will trigger an autosave to occur after 10 seconds.

__Testing instructions:__

1. Navigate to Gutenberg > Demo
2. Verify after a brief delay the reloading the page produces no "Changes exist" prompt