### PR TITLE
Store: Avoid returning prototype member from getEditedPostAttribute

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -200,10 +200,14 @@ export function getEditedPostAttribute( state, attributeName ) {
 	}
 
 	const edits = getPostEdits( state );
+	if ( edits.hasOwnProperty( attributeName ) ) {
+		return edits[ attributeName ];
+	}
 
-	return edits[ attributeName ] === undefined ?
-		state.currentPost[ attributeName ] :
-		edits[ attributeName ];
+	const currentPost = getCurrentPost( state );
+	if ( currentPost.hasOwnProperty( attributeName ) ) {
+		return currentPost[ attributeName ];
+	}
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -193,13 +193,13 @@ export function getPostEdits( state ) {
  * @return {*} Post attribute value.
  */
 export function getEditedPostAttribute( state, attributeName ) {
-	const edits = getPostEdits( state );
-
 	// Special cases
 	switch ( attributeName ) {
 		case 'content':
 			return getEditedPostContent( state );
 	}
+
+	const edits = getPostEdits( state );
 
 	return edits[ attributeName ] === undefined ?
 		state.currentPost[ attributeName ] :

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -418,6 +418,19 @@ describe( 'selectors', () => {
 
 			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'youcha' );
 		} );
+
+		it( 'should not return by object prototype member', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+			};
+
+			expect( getEditedPostAttribute( state, 'valueOf' ) ).toBeUndefined();
+		} );
 	} );
 
 	describe( 'getCurrentPostLastRevisionId', () => {


### PR DESCRIPTION
This pull request seeks to improve the `getEditedPostAttribute`, avoiding wasteful calls to `getPostEdits` where it is not intended to be used, and improves a case where the wrong return value may be returned for object prototype members.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit editor/store/test/selectors.js
```