### PR TITLE
Add event handler name in raw TinyMCE event error

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -165,7 +165,7 @@ export class RichText extends Component {
 				return;
 			}
 
-			deprecated( 'Raw TinyMCE event handlers for RichText', {
+			deprecated( 'Raw TinyMCE event handler on' + name + ' for RichText', {
 				version: '3.0',
 				alternative: (
 					'Documented props, ancestor event handler, or onSetup ' +


### PR DESCRIPTION
I got the “Raw TinyMCE event handlers for RichText” error and it was not obvious from my code which event handler was it for and had to make this change to figure out, so I thought it may be useful to others, too.
