### PR TITLE
Always show "new gallery item" below the gallery

### DIFF
--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -263,7 +263,7 @@ class GalleryEdit extends Component {
 						</li>
 					) ) }
 					{ isSelected &&
-						<li className="blocks-gallery-item">
+						<li className="blocks-gallery-item has-add-item-button">
 							<FormFileUpload
 								multiple
 								isLarge

--- a/core-blocks/gallery/style.scss
+++ b/core-blocks/gallery/style.scss
@@ -74,6 +74,13 @@
 		}
 	}
 
+	// Apply max-width to gallery item that contains the add new gallery item button
+	.blocks-gallery-item {
+		&.has-add-item-button {
+			width: 100%;
+		}
+	}
+
 	// Apply max-width to floated items that have no intrinsic width
 	[data-align="left"] &,
 	[data-align="right"] &,

--- a/core-blocks/gallery/style.scss
+++ b/core-blocks/gallery/style.scss
@@ -44,8 +44,8 @@
 	// Cropped
 	&.is-cropped .blocks-gallery-image,
 	&.is-cropped .blocks-gallery-item {
-      a,
-      img {
+		a,
+		img {
 			flex: 1;
 			width: 100%;
 			height: 100%;
@@ -74,7 +74,8 @@
 		}
 	}
 
-	// Apply max-width to gallery item that contains the add new gallery item button
+	// Make the "Add new Gallery item" button full-width (so it always appears
+	// below other items).
 	.blocks-gallery-item {
 		&.has-add-item-button {
 			width: 100%;


### PR DESCRIPTION
Added `has-add-item-button` class to the corresponding `li` element.
Added `has-add-item-button` class css for the desired effect.

## Description
Selecting a gallery won't shift the layout presentation to accommodate the extra placeholder item anymore.

Fixes #7300.

## How has this been tested?
Ran `npm test` using the docker-compose setup.

## Screenshots 
Before:
![not_below](https://user-images.githubusercontent.com/3190666/41644515-de8b26c4-7433-11e8-832a-e8aa1e6b0eaf.jpg)
After:
![always_below](https://user-images.githubusercontent.com/3190666/41644518-e208fa74-7433-11e8-97eb-effdb448f112.jpg)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
Visual change

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
