### PR TITLE
Remove the componentWillReceiveProps lifecycle usage

### DIFF
--- a/components/date-time/time.js
+++ b/components/date-time/time.js
@@ -39,13 +39,13 @@ class TimePicker extends Component {
 		this.syncState( this.props );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const { currentTime, is12Hour } = nextProps;
+	componentDidUpdate( prevProps ) {
+		const { currentTime, is12Hour } = this.props;
 		if (
-			currentTime !== this.props.currentTime ||
-			is12Hour !== this.props.is12Hour
+			currentTime !== prevProps.currentTime ||
+			is12Hour !== prevProps.is12Hour
 		) {
-			this.syncState( nextProps );
+			this.syncState( this.props );
 		}
 	}
 

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -28,10 +28,10 @@ class Dropdown extends Component {
 		}
 	}
 
-	componentWillUpdate( nextProps, nextState ) {
-		const { isOpen } = nextState;
-		const { onToggle } = nextProps;
-		if ( this.state.isOpen !== isOpen && onToggle ) {
+	componentDidUpdate( prevProps, prevState ) {
+		const { isOpen } = this.state;
+		const { onToggle } = this.props;
+		if ( prevState.isOpen !== isOpen && onToggle ) {
 			onToggle( isOpen );
 		}
 	}

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -57,13 +57,15 @@ class FormTokenField extends Component {
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.disabled && this.state.isActive ) {
-			this.setState( {
-				isActive: false,
-				incompleteTokenValue: '',
-			} );
+	static getDerivedStateFromProps( props, state ) {
+		if ( ! props.disabled || ! state.isActive ) {
+			return null;
 		}
+
+		return {
+			isActive: false,
+			incompleteTokenValue: '',
+		};
 	}
 
 	bindInput( ref ) {

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -517,7 +517,6 @@ class FormTokenField extends Component {
 		} );
 
 		let tokenFieldProps = {
-			ref: 'main',
 			className: classes,
 			tabIndex: '-1',
 		};

--- a/components/server-side-render/index.js
+++ b/components/server-side-render/index.js
@@ -42,9 +42,9 @@ export class ServerSideRender extends Component {
 		this.isStillMounted = false;
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( nextProps, this.props ) ) {
-			this.fetch( nextProps );
+	componentDidUpdate( prevProps ) {
+		if ( ! isEqual( prevProps, this.props ) ) {
+			this.fetch( this.props );
 		}
 	}
 

--- a/components/slot-fill/fill.js
+++ b/components/slot-fill/fill.js
@@ -39,15 +39,15 @@ class Fill extends Component {
 		unregisterFill( this.props.name, this );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const { name } = nextProps;
+	componentDidUpdate( prevProps ) {
+		const { name } = this.props;
 		const {
 			unregisterFill = noop,
 			registerFill = noop,
 		} = this.context;
 
-		if ( this.props.name !== name ) {
-			unregisterFill( this.props.name, this );
+		if ( prevProps.name !== name ) {
+			unregisterFill( prevProps.name, this );
 			registerFill( name, this );
 		}
 	}

--- a/components/slot-fill/slot.js
+++ b/components/slot-fill/slot.js
@@ -27,15 +27,15 @@ class Slot extends Component {
 		unregisterSlot( this.props.name, this );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const { name } = nextProps;
+	componentDidUpdate( prevProps ) {
+		const { name } = this.props;
 		const {
 			unregisterSlot = noop,
 			registerSlot = noop,
 		} = this.context;
 
-		if ( this.props.name !== name ) {
-			unregisterSlot( this.props.name );
+		if ( prevProps.name !== name ) {
+			unregisterSlot( prevProps.name );
 			registerSlot( name, this );
 		}
 	}

--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -149,9 +149,9 @@ class GalleryEdit extends Component {
 		} );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		// Deselect images when deselecting the block
-		if ( ! nextProps.isSelected && this.props.isSelected ) {
+		if ( ! this.props.isSelected && prevProps.isSelected ) {
 			this.setState( {
 				selectedImage: null,
 				captionSelected: false,

--- a/core-blocks/gallery/gallery-image.js
+++ b/core-blocks/gallery/gallery-image.js
@@ -71,7 +71,8 @@ class GalleryImage extends Component {
 		}
 	}
 
-	componentWillReceiveProps( { isSelected, image, url } ) {
+	componentDidUpdate( prevProps ) {
+		const { isSelected, image, url } = this.props;
 		if ( image && ! url ) {
 			this.props.setAttributes( {
 				url: image.source_url,
@@ -81,7 +82,7 @@ class GalleryImage extends Component {
 
 		// unselect the caption so when the user selects other image and comeback
 		// the caption is not immediately selected
-		if ( this.state.captionSelected && ! isSelected && this.props.isSelected ) {
+		if ( this.state.captionSelected && ! isSelected && prevProps.isSelected ) {
 			this.setState( {
 				captionSelected: false,
 			} );

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -96,10 +96,8 @@ class ImageEdit extends Component {
 		if ( ! prevID && prevUrl.indexOf( 'blob:' ) === 0 && id && url.indexOf( 'blob:' ) === -1 ) {
 			revokeBlobURL( url );
 		}
-	}
 
-	componentWillReceiveProps( { isSelected } ) {
-		if ( ! isSelected && this.props.isSelected && this.state.captionFocused ) {
+		if ( ! this.props.isSelected && prevProps.isSelected && this.state.captionFocused ) {
 			this.setState( {
 				captionFocused: false,
 			} );

--- a/editor/components/block-list/block-html.js
+++ b/editor/components/block-list/block-html.js
@@ -22,10 +22,10 @@ class BlockHTML extends Component {
 		};
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( nextProps.block.attributes, this.props.block.attributes ) ) {
+	componentDidUpdate( prevProps ) {
+		if ( ! isEqual( this.props.block.attributes, prevProps.block.attributes ) ) {
 			this.setState( {
-				html: getBlockContent( nextProps.block ),
+				html: getBlockContent( this.props.block ),
 			} );
 		}
 	}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -89,13 +89,11 @@ export class BlockListBlock extends Component {
 		}
 	}
 
-	componentWillReceiveProps( newProps ) {
-		if ( newProps.isTypingWithinBlock || newProps.isSelected ) {
+	componentDidUpdate( prevProps ) {
+		if ( this.props.isTypingWithinBlock || this.props.isSelected ) {
 			this.hideHoverEffects();
 		}
-	}
 
-	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this.focusTabbable();
 		}

--- a/editor/components/document-title/index.js
+++ b/editor/components/document-title/index.js
@@ -14,22 +14,22 @@ class DocumentTitle extends Component {
 		this.originalDocumentTitle = document.title;
 	}
 
-	setDocumentTitle( title ) {
-		document.title = title + ' | ' + this.originalDocumentTitle;
-	}
-
 	componentDidMount() {
 		this.setDocumentTitle( this.props.title );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.title !== this.props.title ) {
-			this.setDocumentTitle( nextProps.title );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.title !== this.props.title ) {
+			this.setDocumentTitle( this.props.title );
 		}
 	}
 
 	componentWillUnmount() {
 		document.title = this.originalDocumentTitle;
+	}
+
+	setDocumentTitle( title ) {
+		document.title = title + ' | ' + this.originalDocumentTitle;
 	}
 
 	render() {

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -29,17 +29,19 @@ class PostPublishPanel extends Component {
 		};
 	}
 
-	componentWillReceiveProps( newProps ) {
+	static getDerivedStateFromProps( props, state ) {
 		if (
-			! this.state.submitted &&
-			! newProps.isSaving &&
-			( newProps.isPublished || newProps.isScheduled )
+			state.submitted ||
+			props.isSaving ||
+			( ! props.isPublished && ! props.isScheduled )
 		) {
-			this.setState( {
-				submitted: true,
-				loading: false,
-			} );
+			return null;
 		}
+
+		return {
+			submitted: true,
+			loading: false,
+		};
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -67,9 +67,9 @@ class FlatTermSelector extends Component {
 		invoke( this.searchRequest, [ 'abort' ] );
 	}
 
-	componentWillReceiveProps( newProps ) {
-		if ( newProps.terms !== this.props.terms ) {
-			this.updateSelectedTerms( newProps.terms );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.terms !== this.props.terms ) {
+			this.updateSelectedTerms( this.props.terms );
 		}
 	}
 

--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -18,6 +18,21 @@ import { withInstanceId } from '@wordpress/components';
  */
 import './style.scss';
 
+/**
+ * Returns the PostTextEditor state given a set of props.
+ *
+ * @param {Object} props Component props.
+ *
+ * @return {Object} State object.
+ */
+function computeDerivedState( props ) {
+	return {
+		persistedValue: props.value,
+		value: props.value,
+		isDirty: false,
+	};
+}
+
 class PostTextEditor extends Component {
 	constructor() {
 		super( ...arguments );
@@ -32,12 +47,14 @@ class PostTextEditor extends Component {
 		};
 	}
 
-	componentDidUpdate( prevProps ) {
+	static getDerivedPropsFromState( props, state ) {
 		// If we receive a new value while we're editing (but before we've made
 		// changes), go ahead and clobber the local state
-		if ( this.props.value !== prevProps.value && this.state.value && ! this.state.isDirty ) {
-			this.setState( { value: this.props.value } );
+		if ( state.persistedValue !== props.value && ! state.isDirty ) {
+			return computeDerivedState( props );
 		}
+
+		return null;
 	}
 
 	startEditing() {

--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -32,11 +32,11 @@ class PostTextEditor extends Component {
 		};
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		// If we receive a new value while we're editing (but before we've made
 		// changes), go ahead and clobber the local state
-		if ( this.props.value !== nextProps.value && this.state.value && ! this.state.isDirty ) {
-			this.setState( { value: nextProps.value } );
+		if ( this.props.value !== prevProps.value && this.state.value && ! this.state.isDirty ) {
+			this.setState( { value: this.props.value } );
 		}
 	}
 

--- a/editor/components/preserve-scroll-in-reorder/index.js
+++ b/editor/components/preserve-scroll-in-reorder/index.js
@@ -21,16 +21,18 @@ import { getBlockDOMNode } from '../../utils/dom';
  * ```
  */
 class PreserveScrollInReorder extends Component {
-	componentWillUpdate( nextProps ) {
-		const { blockOrder, selectionStart } = nextProps;
-		if ( blockOrder !== this.props.blockOrder && selectionStart ) {
-			this.setPreviousOffset( selectionStart );
+	getSnapshotBeforeUpdate( prevProps ) {
+		const { blockOrder, selectionStart } = this.props;
+		if ( blockOrder !== prevProps.blockOrder && selectionStart ) {
+			return this.getOffset( selectionStart );
 		}
+
+		return null;
 	}
 
-	componentDidUpdate() {
-		if ( this.previousOffset ) {
-			this.restorePreviousOffset();
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot ) {
+			this.restorePreviousOffset( snapshot );
 		}
 	}
 
@@ -39,32 +41,33 @@ class PreserveScrollInReorder extends Component {
 	 * top offset as an instance property before a reorder is to occur.
 	 *
 	 * @param {string} selectionStart UID of selected block.
+	 *
+	 * @return {number?} The scroll offset.
 	 */
-	setPreviousOffset( selectionStart ) {
+	getOffset( selectionStart ) {
 		const blockNode = getBlockDOMNode( selectionStart );
 		if ( ! blockNode ) {
-			return;
+			return null;
 		}
 
-		this.previousOffset = blockNode.getBoundingClientRect().top;
+		return blockNode.getBoundingClientRect().top;
 	}
 
 	/**
 	 * After a block reordering, restores the previous viewport top offset.
+	 *
+	 * @param {number} offset The scroll offset.
 	 */
-	restorePreviousOffset() {
+	restorePreviousOffset( offset ) {
 		const { selectionStart } = this.props;
 		const blockNode = getBlockDOMNode( selectionStart );
 		if ( blockNode ) {
 			const scrollContainer = getScrollContainer( blockNode );
 			if ( scrollContainer ) {
 				scrollContainer.scrollTop = scrollContainer.scrollTop +
-					blockNode.getBoundingClientRect().top -
-					this.previousOffset;
+					blockNode.getBoundingClientRect().top - offset;
 			}
 		}
-
-		delete this.previousOffset;
 	}
 
 	render() {

--- a/editor/components/rich-text/format-toolbar/index.js
+++ b/editor/components/rich-text/format-toolbar/index.js
@@ -93,11 +93,11 @@ class FormatToolbar extends Component {
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( this.props.selectedNodeId !== nextProps.selectedNodeId ) {
+	componentDidUpdate( prevProps ) {
+		if ( this.props.selectedNodeId !== prevProps.selectedNodeId ) {
 			this.setState( {
 				settingsVisible: false,
-				opensInNewWindow: !! nextProps.formats.link && !! nextProps.formats.link.target,
+				opensInNewWindow: !! this.props.formats.link && !! this.props.formats.link.target,
 				linkValue: '',
 			} );
 		}

--- a/editor/components/rich-text/format-toolbar/index.js
+++ b/editor/components/rich-text/format-toolbar/index.js
@@ -56,14 +56,26 @@ const DEFAULT_CONTROLS = [ 'bold', 'italic', 'strikethrough', 'link' ];
 // Stop the key event from propagating up to maybeStartTyping in BlockListBlock
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 
+/**
+ * Returns the Format Toolbar state given a set of props.
+ *
+ * @param {Object} props Component props.
+ *
+ * @return {Object} State object.
+ */
+function computeDerivedState( props ) {
+	return {
+		selectedNodeId: props.selectedNodeId,
+		settingsVisible: false,
+		opensInNewWindow: !! props.formats.link && !! props.formats.link.target,
+		linkValue: '',
+	};
+}
+
 class FormatToolbar extends Component {
 	constructor() {
 		super( ...arguments );
-		this.state = {
-			settingsVisible: false,
-			opensInNewWindow: false,
-			linkValue: '',
-		};
+		this.state = {};
 
 		this.addLink = this.addLink.bind( this );
 		this.editLink = this.editLink.bind( this );
@@ -93,14 +105,12 @@ class FormatToolbar extends Component {
 		}
 	}
 
-	componentDidUpdate( prevProps ) {
-		if ( this.props.selectedNodeId !== prevProps.selectedNodeId ) {
-			this.setState( {
-				settingsVisible: false,
-				opensInNewWindow: !! this.props.formats.link && !! this.props.formats.link.target,
-				linkValue: '',
-			} );
+	static getDerivedStateFromProps( props, state ) {
+		if ( state.selectedNodeId !== props.selectedNodeId ) {
+			return computeDerivedState( props );
 		}
+
+		return null;
 	}
 
 	onChangeLinkValue( value ) {

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -742,11 +742,9 @@ export class RichText extends Component {
 		) {
 			this.updateContent();
 		}
-	}
 
-	componentWillReceiveProps( nextProps ) {
 		if ( 'development' === process.env.NODE_ENV ) {
-			if ( ! isEqual( this.props.formatters, nextProps.formatters ) ) {
+			if ( ! isEqual( this.props.formatters, prevProps.formatters ) ) {
 				// eslint-disable-next-line no-console
 				console.error( 'Formatters passed via `formatters` prop will only be registered once. Formatters can be enabled/disabled via the `formattingControls` prop.' );
 			}

--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -116,13 +116,6 @@ export default class TinyMCE extends Component {
 		return false;
 	}
 
-	configureIsPlaceholderVisible( isPlaceholderVisible ) {
-		const isPlaceholderVisibleString = String( !! isPlaceholderVisible );
-		if ( this.editorNode.getAttribute( IS_PLACEHOLDER_VISIBLE_ATTR_NAME ) !== isPlaceholderVisibleString ) {
-			this.editorNode.setAttribute( IS_PLACEHOLDER_VISIBLE_ATTR_NAME, isPlaceholderVisibleString );
-		}
-	}
-
 	componentWillReceiveProps( nextProps ) {
 		this.configureIsPlaceholderVisible( nextProps.isPlaceholderVisible );
 
@@ -153,6 +146,13 @@ export default class TinyMCE extends Component {
 		this.editor.container = document.createDocumentFragment();
 		this.editor.destroy();
 		delete this.editor;
+	}
+
+	configureIsPlaceholderVisible( isPlaceholderVisible ) {
+		const isPlaceholderVisibleString = String( !! isPlaceholderVisible );
+		if ( this.editorNode.getAttribute( IS_PLACEHOLDER_VISIBLE_ATTR_NAME ) !== isPlaceholderVisibleString ) {
+			this.editorNode.setAttribute( IS_PLACEHOLDER_VISIBLE_ATTR_NAME, isPlaceholderVisibleString );
+		}
 	}
 
 	initialize() {

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -377,8 +377,8 @@ export const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent
 					this.setProxyProps( props );
 				}
 
-				componentWillUpdate( nextProps ) {
-					this.setProxyProps( nextProps );
+				componentDidUpdate() {
+					this.setProxyProps( this.props );
 				}
 
 				proxyDispatch( propName, ...args ) {

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -284,6 +284,12 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			 * @type {boolean}
 			 */
 			this.shouldComponentUpdate = false;
+			/**
+			 * Boolean tracking when can we run selection
+			 * The selection can be run only when the component is mounted.
+			 */
+			this.shouldRunSelection = false;
+
 			this.state = {
 				mergeProps: getNextMergeProps( props ),
 			};
@@ -297,9 +303,13 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			return this.shouldComponentUpdate;
 		}
 
-		componentWillReceiveProps( nextProps ) {
-			if ( ! isShallowEqual( nextProps, this.props ) ) {
-				this.runSelection( nextProps );
+		componentDidMount() {
+			this.shouldRunSelection = true;
+		}
+
+		componentDidUpdate( prevProps ) {
+			if ( ! isShallowEqual( prevProps, this.props ) ) {
+				this.runSelection( this.props );
 				this.shouldComponentUpdate = true;
 			}
 		}
@@ -311,7 +321,7 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			// are snapshotted before being invoked, so if unmounting occurs
 			// during a previous callback, we need to explicitly track and
 			// avoid the `runSelection` that is scheduled to occur.
-			this.isUnmounting = true;
+			this.shouldRunSelection = false;
 		}
 
 		subscribe() {
@@ -319,7 +329,7 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 		}
 
 		runSelection( props = this.props ) {
-			if ( this.isUnmounting ) {
+			if ( ! this.shouldRunSelection ) {
 				return;
 			}
 

--- a/packages/data/src/test/index.js
+++ b/packages/data/src/test/index.js
@@ -571,6 +571,7 @@ describe( 'withSelect', () => {
 		expect( wrapper.childAt( 0 ).props() ).toEqual( { foo: 'OK', propName: 'foo' } );
 
 		wrapper.setProps( { propName: 'bar' } );
+		wrapper.update();
 
 		expect( wrapper.childAt( 0 ).props() ).toEqual( { bar: 'OK', propName: 'bar' } );
 	} );


### PR DESCRIPTION
 use componentDidUpdate/getDerivedPropsFromState instead

There's one remaining usage of componentWillReceiveProps in the `TinyMCE` component but I'm not certain yet how to replace it since this component has `componentShouldUpdate` returning false.

Also `componentWillUpdate` in fills is not updated because I think it's important to keep the right order of fills. I'll defer to someone else here cc @aduth 

**Testing instructions**

It should be fine but there are a lot of things that behave a little bit differently:

 - Time picker
 - Dropdown onToggle callback
 - Tags input
 - Unselecting captions in galleries and images
 - Document title updates
 - Preview button
 - Post publish panel