### PR TITLE
Possibility to filter the editor settings #7400

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1161,6 +1161,14 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 } )();
 JS;
 
+	/**
+	 * Filters the Gutenberg Editor Settings
+	 *
+	 * @param array $editor_settings The default Gutenberg Editor Settings
+	 *
+	 */
+	$editor_settings = apply_filters( 'editor_settings', $editor_settings );
+
 	$script = sprintf( $init_script, wp_json_encode( $editor_settings ), $post->post_type, $post->ID );
 	wp_add_inline_script( 'wp-edit-post', $script );
 


### PR DESCRIPTION
## Description
For local development, you don't want Gutenberg to save a post every 10 seconds. So I've wrapped an apply_filters around $editor_settings in /lib/client-assets.php. See: #7400 

## How has this been tested?
Checked in local environment with:

```
add_filter( 'editor_settings', function( $editor_settings ) {
    $editor_settings['autosaveInterval'] = 3600;
} );
```
In the file /lib/client-assets.php, I var_dumped the $editor_settings to see if the outcome was 3600.

## Types of changes
It adds a filter around the $editor_settings var in /lib/client-assets.php

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. 
- [x] My code has proper inline documentation. 