### PR TITLE
Display media upload error message from server when one exists

### DIFF
--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { compact, forEach, get, includes, noop, startsWith } from 'lodash';
+import { compact, forEach, get, includes, isEmpty, noop, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -97,15 +97,19 @@ export function mediaUpload( {
 				};
 				setAndUpdateFiles( idx, mediaObject );
 			},
-			() => {
+			( response ) => {
 				// Reset to empty on failure.
 				setAndUpdateFiles( idx, null );
+				let message = sprintf(
+					__( 'Error while uploading file %s to the media library.' ),
+					mediaFile.name
+				);
+				if ( ! isEmpty( response.responseJSON.message ) ) {
+					message = response.responseJSON.message;
+				}
 				onError( {
 					code: 'GENERAL',
-					message: sprintf(
-						__( 'Error while uploading file %s to the media library.' ),
-						mediaFile.name
-					),
+					message,
 					file: mediaFile,
 				} );
 			}

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -100,12 +100,14 @@ export function mediaUpload( {
 			( response ) => {
 				// Reset to empty on failure.
 				setAndUpdateFiles( idx, null );
-				let message = sprintf(
-					__( 'Error while uploading file %s to the media library.' ),
-					mediaFile.name
-				);
+				let message;
 				if ( ! isEmpty( response.responseJSON.message ) ) {
 					message = response.responseJSON.message;
+				} else {
+					message = sprintf(
+						__( 'Error while uploading file %s to the media library.' ),
+						mediaFile.name
+					);
 				}
 				onError( {
 					code: 'GENERAL',


### PR DESCRIPTION
## Description

If the server rejects a media upload and includes a message, display that message in the error UI.

Requires #7386
Fixes #7137

## How has this been tested?

Add the following code snippet in `functions.php` or similar:

```
$force_upload_failure = function( $file ) {
	$file['error'] = 'This file upload has been forced to fail.';
	return $file;
};
add_filter( 'wp_handle_sideload_prefilter', $force_upload_failure );
add_filter( 'wp_handle_upload_prefilter', $force_upload_failure );
```

Attempt to upload an image into the image block. Observe `This file upload has been forced to fail.` as the error message.

## Screenshots

<img width="703" alt="image" src="https://user-images.githubusercontent.com/36432/41657267-a9cf3c7c-7447-11e8-93e5-0c033e8425d2.png">

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
