### PR TITLE
Fix IE11 formatting toolbar visibility

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -366,7 +366,7 @@
 			}
 		}
 
-		// The padding collapses, but the outline is still 1px to compensate for. 
+		// The padding collapses, but the outline is still 1px to compensate for.
 		.editor-block-contextual-toolbar {
 			margin-bottom: 1px;
 		}
@@ -468,7 +468,7 @@
 		> .editor-block-list__breadcrumb {
 			right: -$border-width;
 		}
-		
+
 		// Compensate for main container padding and subtract border.
 		@include break-small() {
 			margin-left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance - $border-width;
@@ -606,7 +606,7 @@
 	.editor-block-list__block-mobile-toolbar {
 		display: flex;
 		flex-direction: row;
-		margin-top: $item-spacing + $block-toolbar-height; // Make room for the height of the block toolbar above. 
+		margin-top: $item-spacing + $block-toolbar-height; // Make room for the height of the block toolbar above.
 		margin-right: -$block-padding;
 		margin-bottom: -$block-padding - $border-width;
 		margin-left: -$block-padding;
@@ -802,18 +802,26 @@
 	left: $block-padding;
 	right: $block-padding;
 
+	@include break-small() {
+		top: -$border-width;
+	}
+
 	// Position the contextual toolbar above the block.
 	@include break-mobile() {
-		position: sticky;
+		position: relative;
+		top: auto;
 		bottom: auto;
 		left: auto;
 		right: auto;
 		margin-top: -$block-toolbar-height - $border-width;
 		margin-bottom: $block-padding + $border-width;
-	}
 
-	@include break-small() {
-		top: -$border-width;
+		// IE11 does not support `position: sticky`.
+		@supports (position: sticky) {
+			position: sticky;
+			// Avoid appearance of double border when toolbar sticks at the top of the editor.
+			top: -$border-width;
+		}
 	}
 
 	// Floated items have special needs for the contextual toolbar position.
@@ -906,7 +914,7 @@
 		padding: 4px 4px;
 		background: theme( outlines );
 		color: $white;
-	
+
 		// Animate in
 		.editor-block-list__block:hover & {
 			@include fade_in( .1s );


### PR DESCRIPTION
## Description

IE11 does not support `position: sticky`, and we were using it to position the formatting toolbar. This resulted in a toolbar that was only partially visible in IE11. This PR updates our styles to start with `position: relative` which also provides a coordinate system but does not have the sticky behavior. Then we apply `position: sticky` for the browsers that support it.

All whitespace changes are due to VSCode applying policies set by our `.editorconfig`.

Fixes #7187.

<!-- Please describe what you have changed or added -->

## How has this been tested?
* Loaded a post in IE11 and observed the full visibility and position of right- and left-aligned toolbars.
* Loaded a post in Chrome, Firefox, and macOS Safari, observed the full visibility and position of right- and left-aligned toolbars, and tested sticky behavior when scrolling a left-aligned toolbar to the top.
* Loaded a post in iOS Safari and observed there were no apparent changes to toolbar display there.

## Screenshots <!-- if applicable -->

<img width="686" alt="screen shot 2018-06-20 at 8 07 48 am" src="https://user-images.githubusercontent.com/530877/41668628-98814d80-7464-11e8-8a97-aeb32b0ae186.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
