### PR TITLE
Try Layout half image half vertical center content

### DIFF
--- a/block-library/index.js
+++ b/block-library/index.js
@@ -28,6 +28,9 @@ import * as column from '../packages/block-library/src/columns/column';
 import * as coverImage from '../packages/block-library/src/cover-image';
 import * as embed from '../packages/block-library/src/embed';
 import * as file from '../packages/block-library/src/file';
+import * as halfMediaText from '../packages/block-library/src/layout-half-media-text';
+import * as halfMediaTextContent from '../packages/block-library/src/layout-half-media-text/content-area';
+import * as halfMediaTextMedia from '../packages/block-library/src/layout-half-media-text/media-area';
 import * as latestComments from '../packages/block-library/src/latest-comments';
 import * as latestPosts from '../packages/block-library/src/latest-posts';
 import * as list from '../packages/block-library/src/list';
@@ -77,6 +80,9 @@ export const registerCoreBlocks = () => {
 		...embed.others,
 		file,
 		freeform,
+		halfMediaText,
+		halfMediaTextContent,
+		halfMediaTextMedia,
 		html,
 		latestComments,
 		latestPosts,

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -11,6 +11,7 @@
 @import "./image/editor.scss";
 @import "./latest-comments/editor.scss";
 @import "./latest-posts/editor.scss";
+@import "./layout-half-media-text/editor.scss";
 @import "./list/editor.scss";
 @import "./more/editor.scss";
 @import "./nextpage/editor.scss";

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -24,6 +24,9 @@ import * as column from './columns/column';
 import * as coverImage from './cover-image';
 import * as embed from './embed';
 import * as file from './file';
+import * as halfMediaText from './layout-half-media-text';
+import * as halfMediaTextContent from './layout-half-media-text/content-area';
+import * as halfMediaTextMedia from './layout-half-media-text/media-area';
 import * as latestComments from './latest-comments';
 import * as latestPosts from './latest-posts';
 import * as list from './list';
@@ -66,6 +69,9 @@ export const registerCoreBlocks = () => {
 		...embed.common,
 		...embed.others,
 		file,
+		halfMediaText,
+		halfMediaTextContent,
+		halfMediaTextMedia,
 		latestComments,
 		latestPosts,
 		more,

--- a/packages/block-library/src/layout-half-media-text/content-area.js
+++ b/packages/block-library/src/layout-half-media-text/content-area.js
@@ -23,6 +23,7 @@ export const settings = {
 		hoverMarks: false,
 		selectionMarks: false,
 		settingsMenu: false,
+		inserter: false,
 	},
 
 	edit() {

--- a/packages/block-library/src/layout-half-media-text/content-area.js
+++ b/packages/block-library/src/layout-half-media-text/content-area.js
@@ -30,8 +30,7 @@ export const settings = {
 			<div className="half-media__content">
 				<InnerBlocks
 					template={ [
-						[ 'core/heading', { level: 4 } ],
-						[ 'core/paragraph' ],
+						[ 'core/paragraph', { fontSize: 'large', placeholder: 'Content...' } ],
 					] }
 					allowedBlocks={ ALLOWED_BLOCKS }
 					templateLock={ false }

--- a/packages/block-library/src/layout-half-media-text/content-area.js
+++ b/packages/block-library/src/layout-half-media-text/content-area.js
@@ -19,6 +19,12 @@ export const settings = {
 
 	category: 'common',
 
+	supports: {
+		hoverMarks: false,
+		selectionMarks: false,
+		settingsMenu: false,
+	},
+
 	edit() {
 		return (
 			<div className="half-media__content">

--- a/packages/block-library/src/layout-half-media-text/content-area.js
+++ b/packages/block-library/src/layout-half-media-text/content-area.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/editor';
+
+export const name = 'core/half-media-content-area';
+
+const ALLOWED_BLOCKS = [ 'core/button', 'core/paragraph', 'core/heading', 'core/list' ];
+
+export const settings = {
+	attributes: {},
+
+	title: __( 'Content Area' ),
+
+	parent: [ 'core/half-media' ],
+
+	icon: 'format-image',
+
+	category: 'common',
+
+	edit() {
+		return (
+			<div className="half-media__content">
+				<InnerBlocks
+					template={ [
+						[ 'core/heading', { level: 4 } ],
+						[ 'core/paragraph' ],
+					] }
+					allowedBlocks={ ALLOWED_BLOCKS }
+					templateLock={ false }
+				/>
+			</div>
+		);
+	},
+
+	save() {
+		return <div className="half-media__content"><InnerBlocks.Content /></div>;
+	},
+};

--- a/packages/block-library/src/layout-half-media-text/editor.scss
+++ b/packages/block-library/src/layout-half-media-text/editor.scss
@@ -1,0 +1,37 @@
+.half-media__media .block-alignment-toolbar {
+	display: none;
+}
+
+.half-media {
+	display: block;
+	.half-media__media {
+		padding: 0;
+	}
+}
+
+.half-media > .editor-inner-blocks > .editor-block-list__layout {
+	display: flex;
+	> [data-type="core/half-media-media-area"],
+	> [data-type="core/half-media-content-area"] {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		width: 0;
+		.editor-block-list__block-edit {
+			flex-basis: 100%;
+		}
+	}
+	> [data-type="core/half-media-media-area"] > .editor-block-list__block-edit {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+	> [data-type="core/half-media-content-area"] > .editor-block-list__block-edit {
+		display: flex;
+	}
+}
+
+.half-media.has-media-on-the-right > .editor-inner-blocks > .editor-block-list__layout {
+	flex-direction: row-reverse;
+}
+
+

--- a/packages/block-library/src/layout-half-media-text/editor.scss
+++ b/packages/block-library/src/layout-half-media-text/editor.scss
@@ -10,19 +10,44 @@
 	.half-media__content {
 		text-align: initial;
 	}
+	.components-placeholder {
+		background-color: #f3f3f4;
+	}
+	.editor-block-placeholder {
+		margin-bottom: 14px;
+	}
+}
+
+.half-media.has-media-on-the-right .components-placeholder {
+	margin-left: 2px;
+}
+
+.half-media:not(.has-media-on-the-right) .components-placeholder {
+	margin-left: -2px;
 }
 
 .half-media > .editor-inner-blocks > .editor-block-list__layout {
 	display: flex;
+	> [data-type="core/half-media-media-area"] {
+		flex-basis: 50%;
+	}
+	> [data-type="core/half-media-content-area"] {
+		flex-basis: 50%;
+	}
 	> [data-type="core/half-media-media-area"],
 	> [data-type="core/half-media-content-area"] {
 		display: flex;
 		flex-direction: column;
-		flex: 1;
 		width: 0;
+
 		.editor-block-list__block-edit {
 			flex-basis: 100%;
 		}
+	}
+	> [data-type="core/half-media-media-area"] {
+		margin-top: auto;
+		margin-bottom: auto;
+
 	}
 	> [data-type="core/half-media-media-area"] > .editor-block-list__block-edit {
 		margin-top: 0;

--- a/packages/block-library/src/layout-half-media-text/editor.scss
+++ b/packages/block-library/src/layout-half-media-text/editor.scss
@@ -27,39 +27,30 @@
 }
 
 .half-media > .editor-inner-blocks > .editor-block-list__layout {
-	display: flex;
-	> [data-type="core/half-media-media-area"] {
-		flex-basis: 50%;
-	}
-	> [data-type="core/half-media-content-area"] {
-		flex-basis: 50%;
-	}
-	> [data-type="core/half-media-media-area"],
-	> [data-type="core/half-media-content-area"] {
-		display: flex;
-		flex-direction: column;
-		width: 0;
+	display: grid;
+	grid-template-columns: fit-content(70%) minmax(200px, 70%);
+	grid-template-rows: auto;
+	grid-template-areas: "half-media-media half-media-content";
+	align-items: center;
 
-		.editor-block-list__block-edit {
-			flex-basis: 100%;
-		}
+	[data-type="core/half-media-media-area"],
+	[data-type="core/half-media-content-area"] {
+		word-break: break-word;
+		width: 100%;
 	}
-	> [data-type="core/half-media-media-area"] {
-		margin-top: auto;
-		margin-bottom: auto;
 
+	[data-type="core/half-media-content-area"] {
+		grid-area: half-media-content;
+		margin-left: unset;
+		margin-right: unset;
 	}
-	> [data-type="core/half-media-media-area"] > .editor-block-list__block-edit {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-	> [data-type="core/half-media-content-area"] > .editor-block-list__block-edit {
-		display: flex;
+
+	[data-type="core/half-media-media-area"] {
+		grid-area: half-media-media;
 	}
 }
 
 .half-media.has-media-on-the-right > .editor-inner-blocks > .editor-block-list__layout {
-	flex-direction: row-reverse;
+	grid-template-areas: "half-media-content half-media-media";
+	grid-template-columns: minmax(200px, 70%) fit-content(70%);
 }
-
-

--- a/packages/block-library/src/layout-half-media-text/editor.scss
+++ b/packages/block-library/src/layout-half-media-text/editor.scss
@@ -7,6 +7,9 @@
 	.half-media__media {
 		padding: 0;
 	}
+	.half-media__content {
+		text-align: initial;
+	}
 }
 
 .half-media > .editor-inner-blocks > .editor-block-list__layout {

--- a/packages/block-library/src/layout-half-media-text/index.js
+++ b/packages/block-library/src/layout-half-media-text/index.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	BlockControls,
+	BlockAlignmentToolbar,
+	InnerBlocks,
+} from '@wordpress/editor';
+
+const MEDIA_POSITIONS = [ 'left', 'right' ];
+
+export const name = 'core/half-media';
+
+export const settings = {
+	title: __( 'Half Media' ),
+
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><rect x="11" y="7" width="6" height="2" /><rect x="11" y="11" width="6" height="2" /><rect x="11" y="15" width="6" height="2" /><rect x="7" y="7" width="2" height="2" /><rect x="7" y="11" width="2" height="2" /><rect x="7" y="15" width="2" height="2" /><path d="M20.1,3H3.9C3.4,3,3,3.4,3,3.9v16.2C3,20.5,3.4,21,3.9,21h16.2c0.4,0,0.9-0.5,0.9-0.9V3.9C21,3.4,20.5,3,20.1,3z M19,19H5V5h14V19z" /></svg>,
+
+	category: 'layout',
+
+	attributes: {
+		mediaPosition: {
+			type: 'string',
+			default: 'left',
+		},
+	},
+
+	supports: {
+		align: [ 'wide', 'full' ],
+	},
+
+	edit( { attributes, setAttributes } ) {
+		return (
+			<div className={ classnames(
+				'half-media',
+				{ 'has-media-on-the-right': 'right' === attributes.mediaPosition }
+			) }>
+				<BlockControls>
+					<BlockAlignmentToolbar
+						controls={ MEDIA_POSITIONS }
+						value={ attributes.mediaPosition }
+						onChange={ ( mediaPosition ) => setAttributes( { mediaPosition } ) }
+					/>
+				</BlockControls>
+				<InnerBlocks
+					template={ [
+						[ 'core/half-media-media-area' ],
+						[ 'core/half-media-content-area' ],
+					] }
+					templateLock="all"
+				/>
+			</div>
+		);
+	},
+
+	save( { attributes } ) {
+		return (
+			<div className={ classnames(
+				'half-media',
+				{ 'has-media-on-the-right': 'right' === attributes.mediaPosition }
+			) }>
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
+};

--- a/packages/block-library/src/layout-half-media-text/index.js
+++ b/packages/block-library/src/layout-half-media-text/index.js
@@ -12,6 +12,8 @@ import {
 	BlockAlignmentToolbar,
 	InnerBlocks,
 } from '@wordpress/editor';
+import { Component } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 const MEDIA_POSITIONS = [ 'left', 'right' ];
 
@@ -32,32 +34,47 @@ export const settings = {
 	},
 
 	supports: {
-		align: [ 'wide', 'full' ],
+		align: [ 'center', 'wide', 'full' ],
 	},
 
-	edit( { attributes, setAttributes } ) {
-		return (
-			<div className={ classnames(
-				'half-media',
-				{ 'has-media-on-the-right': 'right' === attributes.mediaPosition }
-			) }>
-				<BlockControls>
-					<BlockAlignmentToolbar
-						controls={ MEDIA_POSITIONS }
-						value={ attributes.mediaPosition }
-						onChange={ ( mediaPosition ) => setAttributes( { mediaPosition } ) }
-					/>
-				</BlockControls>
-				<InnerBlocks
-					template={ [
-						[ 'core/half-media-media-area' ],
-						[ 'core/half-media-content-area' ],
-					] }
-					templateLock="all"
-				/>
-			</div>
-		);
-	},
+	edit: withSelect( ( select ) => {
+		return {
+			wideControlsEnabled: select( 'core/editor' ).getEditorSettings().alignWide,
+		};
+	} )(
+		class extends Component {
+			componentWillMount() {
+				if ( this.props.wideControlsEnabled && ! this.props.attributes.align ) {
+					this.props.setAttributes( {
+						align: 'wide',
+					} );
+				}
+			}
+			render() {
+				const { attributes, setAttributes } = this.props;
+				return (
+					<div className={ classnames(
+						'half-media',
+						{ 'has-media-on-the-right': 'right' === attributes.mediaPosition }
+					) }>
+						<BlockControls>
+							<BlockAlignmentToolbar
+								controls={ MEDIA_POSITIONS }
+								value={ attributes.mediaPosition }
+								onChange={ ( mediaPosition ) => setAttributes( { mediaPosition } ) }
+							/>
+						</BlockControls>
+						<InnerBlocks
+							template={ [
+								[ 'core/half-media-media-area' ],
+								[ 'core/half-media-content-area' ],
+							] }
+							templateLock="all"
+						/>
+					</div>
+				);
+			}
+		} ),
 
 	save( { attributes } ) {
 		return (

--- a/packages/block-library/src/layout-half-media-text/index.js
+++ b/packages/block-library/src/layout-half-media-text/index.js
@@ -11,9 +11,14 @@ import {
 	BlockControls,
 	BlockAlignmentToolbar,
 	InnerBlocks,
+	InspectorControls,
+	getColorClass,
+	PanelColorSettings,
+	withColors,
 } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 
 const MEDIA_POSITIONS = [ 'left', 'right' ];
 
@@ -27,6 +32,12 @@ export const settings = {
 	category: 'layout',
 
 	attributes: {
+		backgroundColor: {
+			type: 'string',
+		},
+		customBackgroundColor: {
+			type: 'string',
+		},
 		mediaPosition: {
 			type: 'string',
 			default: 'left',
@@ -37,11 +48,14 @@ export const settings = {
 		align: [ 'center', 'wide', 'full' ],
 	},
 
-	edit: withSelect( ( select ) => {
-		return {
-			wideControlsEnabled: select( 'core/editor' ).getEditorSettings().alignWide,
-		};
-	} )(
+	edit: compose( [
+		withColors( 'backgroundColor' ),
+		withSelect( ( select ) => {
+			return {
+				wideControlsEnabled: select( 'core/editor' ).getEditorSettings().alignWide,
+			};
+		} ),
+	] )(
 		class extends Component {
 			componentWillMount() {
 				if ( this.props.wideControlsEnabled && ! this.props.attributes.align ) {
@@ -51,12 +65,33 @@ export const settings = {
 				}
 			}
 			render() {
-				const { attributes, setAttributes } = this.props;
+				const { attributes, backgroundColor, setAttributes, setBackgroundColor } = this.props;
 				return (
-					<div className={ classnames(
-						'half-media',
-						{ 'has-media-on-the-right': 'right' === attributes.mediaPosition }
-					) }>
+					<div
+						className={ classnames(
+							'half-media',
+							{
+								'has-media-on-the-right': 'right' === attributes.mediaPosition,
+								[ backgroundColor.class ]: backgroundColor.class,
+							}
+						) }
+						style={ {
+							backgroundColor: backgroundColor.value,
+						} }
+					>
+						<InspectorControls>
+							<PanelColorSettings
+								title={ __( 'Color Settings' ) }
+								initialOpen={ false }
+								colorSettings={ [
+									{
+										value: backgroundColor.value,
+										onChange: setBackgroundColor,
+										label: __( 'Background Color' ),
+									},
+								] }
+							/>
+						</InspectorControls>
 						<BlockControls>
 							<BlockAlignmentToolbar
 								controls={ MEDIA_POSITIONS }
@@ -77,11 +112,24 @@ export const settings = {
 		} ),
 
 	save( { attributes } ) {
+		const {
+			backgroundColor,
+			customBackgroundColor,
+		} = attributes;
+		const backgroundClass = getColorClass( 'background-color', backgroundColor );
 		return (
-			<div className={ classnames(
-				'half-media',
-				{ 'has-media-on-the-right': 'right' === attributes.mediaPosition }
-			) }>
+			<div
+				className={ classnames(
+					'half-media',
+					{
+						'has-media-on-the-right': 'right' === attributes.mediaPosition,
+						[ backgroundClass ]: backgroundClass,
+					}
+				) }
+				style={ {
+					backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+				} }
+			>
 				<InnerBlocks.Content />
 			</div>
 		);

--- a/packages/block-library/src/layout-half-media-text/media-area.js
+++ b/packages/block-library/src/layout-half-media-text/media-area.js
@@ -30,6 +30,7 @@ export const settings = {
 		hoverMarks: false,
 		selectionMarks: false,
 		settingsMenu: false,
+		inserter: false,
 	},
 
 	edit: withSelect( ( select, { clientId } ) => {

--- a/packages/block-library/src/layout-half-media-text/media-area.js
+++ b/packages/block-library/src/layout-half-media-text/media-area.js
@@ -26,6 +26,12 @@ export const settings = {
 
 	category: 'common',
 
+	supports: {
+		hoverMarks: false,
+		selectionMarks: false,
+		settingsMenu: false,
+	},
+
 	edit: withSelect( ( select, { clientId } ) => {
 		const { getBlockOrder } = select( 'core/editor' );
 		const blocksInside = getBlockOrder( clientId );

--- a/packages/block-library/src/layout-half-media-text/media-area.js
+++ b/packages/block-library/src/layout-half-media-text/media-area.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks, BlockPlaceholder } from '@wordpress/editor';
+import { withSelect } from '@wordpress/data';
+
+export const name = 'core/half-media-media-area';
+const ALLOWED_BLOCKS = [
+	'core/image',
+	'core/video',
+	'core-embed/flickr',
+	'core-embed/youtube',
+	'core-embed/vimeo',
+	'core-embed/videopress',
+];
+
+export const settings = {
+	attributes: {},
+
+	title: __( 'Media Area' ),
+
+	parent: [ 'core/half-media' ],
+
+	icon: 'format-image',
+
+	category: 'common',
+
+	edit: withSelect( ( select, { clientId } ) => {
+		const { getBlockOrder } = select( 'core/editor' );
+		const blocksInside = getBlockOrder( clientId );
+		return {
+			hasInnerBlocks: blocksInside && blocksInside.length > 0,
+		};
+	} )(
+		( { clientId, hasInnerBlocks } ) => {
+			return (
+				<InnerBlocks
+					className="half-media__media"
+					allowedBlocks={ hasInnerBlocks ? [] : ALLOWED_BLOCKS }
+					templateLock={ false }
+					showWhenEmpty={ (
+						<BlockPlaceholder
+							rootClientId={ clientId }
+						/>
+					) }
+				/>
+			);
+		}
+	),
+
+	save() {
+		return <div className="half-media__media"><InnerBlocks.Content /></div>;
+	},
+};

--- a/packages/block-library/src/layout-half-media-text/style.scss
+++ b/packages/block-library/src/layout-half-media-text/style.scss
@@ -4,27 +4,28 @@
 
 .half-media,
 .half-media.aligncenter {
-	display: flex;
+	display: grid;
+	align-items: center;
+	column-gap: 10px;
+}
+
+.half-media {
+	grid-template-areas: "half-media-media half-media-content";
+	grid-template-columns: fit-content(70%) minmax(200px, 70%);
+	grid-template-rows: auto;
 }
 
 .half-media__content {
-	flex: 1;
+	grid-area: half-media-content;
 	word-break: break-word;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	padding: 0;
 }
 
 .half-media__media {
-	flex: 1;
-	margin-top: auto;
-	margin-bottom: auto;
+	grid-area: half-media-media;
+	justify-self: center;
 }
 
 .half-media.has-media-on-the-right {
-	flex-direction: row-reverse;
-	.half-media__media > * {
-		float: right;
-	}
+	grid-template-areas: "half-media-content half-media-media";
+	grid-template-columns: minmax(200px, 70%) fit-content(70%);
 }

--- a/packages/block-library/src/layout-half-media-text/style.scss
+++ b/packages/block-library/src/layout-half-media-text/style.scss
@@ -1,0 +1,25 @@
+.half-image__content-area {
+	margin-left: 28px;
+}
+
+.half-media {
+	display: flex;
+}
+
+.half-media__content {
+	flex: 1;
+	word-break: break-word;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 5px;
+}
+
+.half-media__media {
+	flex: 1;
+	padding: 5px;
+}
+
+.half-media.has-media-on-the-right {
+	flex-direction: row-reverse;
+}

--- a/packages/block-library/src/layout-half-media-text/style.scss
+++ b/packages/block-library/src/layout-half-media-text/style.scss
@@ -2,7 +2,8 @@
 	margin-left: 28px;
 }
 
-.half-media {
+.half-media,
+.half-media.aligncenter {
 	display: flex;
 }
 
@@ -12,14 +13,18 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	padding: 5px;
+	padding: 0;
 }
 
 .half-media__media {
 	flex: 1;
-	padding: 5px;
+	margin-top: auto;
+	margin-bottom: auto;
 }
 
 .half-media.has-media-on-the-right {
 	flex-direction: row-reverse;
+	.half-media__media > * {
+		float: right;
+	}
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -11,6 +11,7 @@
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";
 @import "./latest-posts/style.scss";
+@import "./layout-half-media-text/style.scss";
 @import "./paragraph/style.scss";
 @import "./pullquote/style.scss";
 @import "./quote/style.scss";

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { filter, includes, map } from 'lodash';
+import { filter, includes, map, some } from 'lodash';
+import { hasBlockSupport } from '../api/';
 
 /**
  * Returns all the available block types.
@@ -86,7 +87,7 @@ export const getChildBlockNames = createSelector(
 );
 
 /**
- * Returns a boolean indicating if a block has child blocks or not.
+ * Returns a boolean indicating if a block has child blocks available on the inserter or not.
  *
  * @param {Object} state     Data state.
  * @param {string} blockName Block type name.
@@ -94,5 +95,7 @@ export const getChildBlockNames = createSelector(
  * @return {boolean} True if a block contains child blocks and false otherwise.
  */
 export const hasChildBlocks = ( state, blockName ) => {
-	return getChildBlockNames( state, blockName ).length > 0;
+	return some( getChildBlockNames( state, blockName ), ( currentBlockName ) => {
+		return hasBlockSupport( currentBlockName, 'inserter', true );
+	} );
 };

--- a/packages/editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/editor/src/components/block-alignment-toolbar/index.js
@@ -42,6 +42,7 @@ export function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CON
 
 	return (
 		<Toolbar
+			className="block-alignment-toolbar"
 			controls={
 				enabledControls.map( ( control ) => {
 					return {

--- a/packages/editor/src/components/block-alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/block-alignment-toolbar/test/__snapshots__/index.js.snap
@@ -2,6 +2,7 @@
 
 exports[`BlockAlignmentToolbar should match snapshot 1`] = `
 <Toolbar
+  className="block-alignment-toolbar"
   controls={
     Array [
       Object {

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -19,6 +19,7 @@ import {
 	cloneBlock,
 	getBlockType,
 	getSaveElement,
+	hasBlockSupport,
 	isReusableBlock,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
@@ -389,12 +390,14 @@ export class BlockListBlock extends Component {
 		// Empty paragraph blocks should always show up as unselected.
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
-		const shouldAppearSelected = ! showSideInserter && isSelected && ! isTypingWithinBlock;
-		const shouldAppearSelectedParent = ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
+		const supportsHoverMarks = hasBlockSupport( blockName, 'hoverMarks', true );
+		const supportsSelectionMarks = hasBlockSupport( blockName, 'selectionMarks', true );
+		const shouldAppearSelected = supportsSelectionMarks && ! showSideInserter && isSelected && ! isTypingWithinBlock;
+		const shouldAppearSelectedParent = supportsSelectionMarks && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection;
-		const shouldShowBreadcrumb = isHovered && ! isEmptyDefaultBlock;
+		const shouldShowBreadcrumb = supportsHoverMarks && isHovered && ! isEmptyDefaultBlock;
 		const shouldShowContextualToolbar = ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected ) && ( ! hasFixedToolbar || ! isLargeViewport );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
@@ -411,7 +414,7 @@ export class BlockListBlock extends Component {
 			'is-selected': shouldAppearSelected,
 			'is-multi-selected': isPartOfMultiSelection,
 			'is-selected-parent': shouldAppearSelectedParent,
-			'is-hovered': isHovered && ! isEmptyDefaultBlock,
+			'is-hovered': supportsHoverMarks && isHovered && ! isEmptyDefaultBlock,
 			'is-reusable': isReusableBlock( blockType ),
 			'is-hidden': dragging,
 			'is-typing': isTypingWithinBlock,

--- a/packages/editor/src/components/block-placeholder/index.js
+++ b/packages/editor/src/components/block-placeholder/index.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Inserter from '../inserter';
+import IgnoreNestedEvents from '../block-list/ignore-nested-events';
+
+export class BlockPlaceholder extends Component {
+	static getDerivedStateFromProps( { index, rootClientId, layout } ) {
+		return {
+			insertionPoint: {
+				index,
+				rootClientId,
+				layout,
+			},
+		};
+	}
+
+	render() {
+		const {
+			className,
+		} = this.props;
+		return (
+			<IgnoreNestedEvents
+				childHandledEvents={ [
+					'onDragStart',
+					'onMouseDown',
+				] }
+			>
+				<Placeholder
+					instructions={ __( 'Click the “+” (“Add block”) button to add a media block.' ) }
+					className={ classnames( 'editor-block-placeholder', className ) }
+				>
+					<Inserter
+						insertionPoint={ this.state.insertionPoint }
+						position="bottom right"
+					/>
+				</Placeholder>
+			</IgnoreNestedEvents>
+		);
+	}
+}
+
+export default BlockPlaceholder;

--- a/packages/editor/src/components/block-placeholder/style.scss
+++ b/packages/editor/src/components/block-placeholder/style.scss
@@ -1,0 +1,3 @@
+.editor-block-placeholder {
+	margin-bottom: 14px;
+}

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { IconButton, Dropdown, NavigableMenu, MenuItem, KeyboardShortcuts } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { compose, ifCondition } from '@wordpress/compose';
 import { cloneBlock, hasBlockSupport } from '@wordpress/blocks';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
 
@@ -230,11 +230,16 @@ export default compose( [
 
 		const blocks = getBlocksByClientId( clientIds );
 
+		const isSupported = every( blocks, ( block ) => {
+			return !! block && hasBlockSupport( block.name, 'settingsMenu', true );
+		} );
+
 		const canDuplicate = every( blocks, ( block ) => {
 			return !! block && hasBlockSupport( block.name, 'multiple', true );
 		} );
 
 		return {
+			isSupported,
 			firstSelectedIndex: getBlockIndex( first( castArray( clientIds ) ), rootClientId ),
 			lastSelectedIndex: getBlockIndex( last( castArray( clientIds ) ), rootClientId ),
 			isLocked: !! getTemplateLock( rootClientId ),
@@ -243,6 +248,7 @@ export default compose( [
 			shortcuts,
 		};
 	} ),
+	ifCondition( ( { isSupported } ) => isSupported ),
 	withDispatch( ( dispatch, props ) => {
 		const {
 			clientIds,

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -7,6 +7,7 @@ export { default as BlockControls } from './block-controls';
 export { default as BlockEdit } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
+export { default as BlockPlaceholder } from './block-placeholder';
 export { default as ColorPalette } from './color-palette';
 export { default as withColorContext } from './color-palette/with-color-context';
 export * from './colors';

--- a/packages/editor/src/components/inner-blocks/index.js
+++ b/packages/editor/src/components/inner-blocks/index.js
@@ -84,16 +84,20 @@ class InnerBlocks extends Component {
 			allowedBlocks,
 			templateLock,
 			template,
+			isEmpty,
 			isSmallScreen,
 			isSelectedBlockInRoot,
+			showWhenEmpty,
+			className,
 		} = this.props;
 
-		const classes = classnames( 'editor-inner-blocks', {
+		const classes = classnames( className, 'editor-inner-blocks', {
 			'has-overlay': isSmallScreen && ! isSelectedBlockInRoot,
 		} );
 
 		return (
 			<div className={ classes }>
+				{ isEmpty && showWhenEmpty }
 				<BlockList
 					rootClientId={ clientId }
 					{ ...{ layouts, allowedBlocks, templateLock, template } }
@@ -114,14 +118,17 @@ InnerBlocks = compose( [
 			getBlockListSettings,
 			getBlockRootClientId,
 			getTemplateLock,
+			getBlockOrder,
 		} = select( 'core/editor' );
 		const { clientId } = ownProps;
 		const parentClientId = getBlockRootClientId( clientId );
+		const blocksInside = getBlockOrder( clientId );
 		return {
 			isSelectedBlockInRoot: isBlockSelected( clientId ) || hasSelectedInnerBlock( clientId ),
 			block: getBlock( clientId ),
 			blockListSettings: getBlockListSettings( clientId ),
 			parentLock: getTemplateLock( parentClientId ),
+			isEmpty: blocksInside && blocksInside.length === 0,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -86,14 +86,16 @@ class Inserter extends Component {
 }
 
 export default compose( [
-	withSelect( ( select ) => {
+	withSelect( ( select, { insertionPoint } ) => {
 		const {
 			getEditedPostAttribute,
 			getBlockInsertionPoint,
 			getSelectedBlock,
 			getInserterItems,
 		} = select( 'core/editor' );
-		const insertionPoint = getBlockInsertionPoint();
+		if ( ! insertionPoint ) {
+			insertionPoint = getBlockInsertionPoint();
+		}
 		const { rootClientId } = insertionPoint;
 		return {
 			title: getEditedPostAttribute( 'title' ),


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/6993
This PR is a first draft to implement more advanced Layout blocks. The main objective is to discover what is lacking on the "engine" to make the creation of this blocks as simple as possible.
It shows how the usage of child-blocks + locking + allowedBlocks allows us to implement blocks that just make use of other blocks (like legos) (without having attributes or their specific logic).

Inside the block, we use columns to divide content in half. We could have done that with CSS and not use columns but I feel using columns is a better approach as it forces us to have a UI for layout blocks with other layout blocks inside working well. In the long term, I fell achieving layouts by nesting layout blocks inside other layout blocks is better than using CSS rules.

## Improvements / changes needed:

The columns block CSS applies to grid styles not only to the first inner-area but all descendant inner-area. So if we have two columns and on the second one a block with InnerBlocks the inner blocks area will be 25% instead of 50% (50% set on the column * 50% set for the descend layout area). I used a CSS rule to avoid that for now, as this problem will probably get solved after we refactor column.

We may need a mechanism to allow to disable some settings from blocks when they are in nested contexts. E.g., the align option in the image still appear even though in this layout block they are not required. The result is not as wrong as I expected (screenshots available).


Blocks may take advantage of child blocks, to define subareas of the layout with specific prefilled blocks, specific locking levels, and/or specific allowed blocks. Child blocks may be used a lot and we may have complex trees of child blocks.
It may make sense to refactor registerBlockType to accept an object of { name, settings, children }. This makes developers life easier because with just one call to it is possible to register a complex tree of nested child blocks. Now we need to call a registerBlockType per child block we have.


For very simple blocks that just set an area for InnerBlocks ( with some settings for the InnerBlocks area ) like "core/half-image-content-area" it may make sense to provide a helper that generates the edit and save function or even all the block.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/11271197/41669734-63e3d106-74aa-11e8-844b-148c30ddc453.png)


<img width="521" alt="screen shot 2018-06-20 at 16 00 29" src="https://user-images.githubusercontent.com/11271197/41669856-aae54fee-74aa-11e8-9383-e44ed1ea2328.png">


![image](https://user-images.githubusercontent.com/11271197/41669757-7622d006-74aa-11e8-9ef3-27970b93bff9.png)

<img width="643" alt="screen shot 2018-06-20 at 14 59 03" src="https://user-images.githubusercontent.com/11271197/41669844-a0b70760-74aa-11e8-8a18-aafb3406b0e6.png">
<img width="564" alt="screen shot 2018-06-20 at 16 02 56" src="https://user-images.githubusercontent.com/11271197/41670267-ba268fc6-74ab-11e8-9471-1af98f2d929c.png">

<img width="527" alt="screen shot 2018-06-20 at 16 03 22" src="https://user-images.githubusercontent.com/11271197/41670245-ab884824-74ab-11e8-89aa-0733983ee93f.png">

cc: @mtias, @karmatosed, @jasmussen 