### PR TITLE
Add a filter to modify the default content of a new post

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1033,12 +1033,24 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 			file_get_contents( gutenberg_dir_path() . 'post-content.js' )
 		);
 	} elseif ( $is_new_post ) {
+		$default_post = array(
+			'title' => array(
+				'raw'      => '',
+				/** This filter is documented in wp-includes/post-template.php */
+				'rendered' => apply_filters( 'the_title', '', $post->ID ),
+			),
+		);
+
+		/**
+		 * Filters the default post data for a new post
+		 *
+		 * @param array $default_post Array of key values to insert in the new post data
+		 * @param WP_Post $post       Post
+		 */
+		$default_post = apply_filters( 'gutenberg_default_post', $default_post, $post );
 		wp_add_inline_script(
 			'wp-edit-post',
-			sprintf( 'window._wpGutenbergDefaultPost = { title: %s };', wp_json_encode( array(
-				'raw'      => '',
-				'rendered' => apply_filters( 'the_title', '', $post->ID ),
-			) ) )
+			sprintf( 'window._wpGutenbergDefaultPost = %s;', wp_json_encode( $default_post ) )
 		);
 	}
 


### PR DESCRIPTION
## Description
I propose to add a new filter to allow 3rd party plugins to modify the content of a new post before it is sent to javascript (as already done by Gutenberg only for the title). For the context, see #7000. This filter is needed to help the plugin Polylang supporting Gutenberg.

## Types of changes
New feature (non-breaking change which adds functionality)