### PR TITLE
RTL: Fix block inserter popver in RTL mode by telling RTLCSS to ignore the relevent props

### DIFF
--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -75,6 +75,7 @@ $arrow-size: 8px;
 		}
 
 		&.is-middle.is-left {
+			/*!rtl:begin:ignore*/
 			margin-left: -$arrow-size;
 
 			&:before {
@@ -92,9 +93,11 @@ $arrow-size: 8px;
 				border-right: none;
 				border-top-color: transparent;
 			}
+			/*!rtl:end:ignore*/
 		}
 
 		&.is-middle.is-right {
+			/*!rtl:begin:ignore*/
 			margin-left: $arrow-size;
 
 			&:before {
@@ -112,6 +115,7 @@ $arrow-size: 8px;
 				border-right-style: solid;
 				border-top-color: transparent;
 			}
+			/*!rtl:end:ignore*/
 		}
 	}
 
@@ -161,19 +165,23 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile).is-right & {
 		position: absolute;
+		/*!rtl:ignore*/
 		left: 100%;
 	}
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-right & {
+		/*!rtl:ignore*/
 		margin-left: -24px;
 	}
 
 	.components-popover:not(.is-mobile).is-left & {
 		position: absolute;
+		/*!rtl:ignore*/
 		right: 100%;
 	}
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-left & {
+		/*!rtl:ignore*/
 		margin-right: -24px;
 	}
 }


### PR DESCRIPTION
## Description
Prevent RTLCSS from reversing specific CSS rules related to left/right alignment of the popover component
Similar to #3911

## Screenshots
Before:
<img width="303" alt="screen shot 2018-06-21 at 14 19 51" src="https://user-images.githubusercontent.com/844866/41716158-330e41f6-755e-11e8-9546-4cc7df383015.png">

After:
<img width="611" alt="screen shot 2018-06-21 at 14 19 16" src="https://user-images.githubusercontent.com/844866/41716141-271bf848-755e-11e8-8270-c72133841236.png">

## Types of changes
CSS comments to prevent automatic flipping of CSS properties.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.