### PR TITLE
fix: Don't change cursor for disabled Button

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -54,7 +54,7 @@
 			background: #f7f7f7 !important;
 			box-shadow: none !important;
 			text-shadow: 0 1px 0 #fff !important;
-			cursor: not-allowed;
+			cursor: default;
 			-webkit-transform: none !important;
 			transform: none !important;
 		}
@@ -98,7 +98,7 @@
 			border-color: color( theme( button ) shade( 20% ) ) !important;
 			box-shadow: none !important;
 			text-shadow: 0 -1px 0 rgba( 0, 0, 0, 0.1 ) !important;
-			cursor: not-allowed;
+			cursor: default;
 		}
 
 		&.is-busy,
@@ -155,7 +155,7 @@
 	}
 
 	&:disabled {
-		cursor: not-allowed;
+		cursor: default;
 		opacity: 0.3;
 	}
 

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -54,7 +54,6 @@
 			background: #f7f7f7 !important;
 			box-shadow: none !important;
 			text-shadow: 0 1px 0 #fff !important;
-			cursor: default;
 			-webkit-transform: none !important;
 			transform: none !important;
 		}
@@ -98,7 +97,6 @@
 			border-color: color( theme( button ) shade( 20% ) ) !important;
 			box-shadow: none !important;
 			text-shadow: 0 -1px 0 rgba( 0, 0, 0, 0.1 ) !important;
-			cursor: default;
 		}
 
 		&.is-busy,
@@ -124,7 +122,6 @@
 		border-radius: 0;
 		background: none;
 		outline: none;
-		cursor: pointer;
 		text-align: left;
 		/* Mimics the default link style in common.css */
 		color: #0073aa;
@@ -154,13 +151,10 @@
 		color: currentColor;
 	}
 
-	&:disabled {
+	&:disabled,
+	&[disabled] {
 		cursor: default;
 		opacity: 0.3;
-	}
-
-	&:not( :disabled ):not( [aria-disabled="true"] ) {
-		cursor: pointer;
 	}
 
 	&:not( :disabled ):not( [aria-disabled="true"] ):focus {

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -155,6 +155,7 @@
 	}
 
 	&:disabled {
+		cursor: default;
 		opacity: 0.3;
 	}
 

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -54,7 +54,7 @@
 			background: #f7f7f7 !important;
 			box-shadow: none !important;
 			text-shadow: 0 1px 0 #fff !important;
-			cursor: default;
+			cursor: not-allowed;
 			-webkit-transform: none !important;
 			transform: none !important;
 		}
@@ -98,7 +98,7 @@
 			border-color: color( theme( button ) shade( 20% ) ) !important;
 			box-shadow: none !important;
 			text-shadow: 0 -1px 0 rgba( 0, 0, 0, 0.1 ) !important;
-			cursor: default;
+			cursor: not-allowed;
 		}
 
 		&.is-busy,
@@ -155,7 +155,7 @@
 	}
 
 	&:disabled {
-		cursor: default;
+		cursor: not-allowed;
 		opacity: 0.3;
 	}
 


### PR DESCRIPTION
Fixes #7428.

## Description
Prevent any disabled button from changing the cursor to pointer.

Originally I just made sure we didn't change from `default`. But then I realised we could also change any disabled button to `not-allowed`, so I did that.

@afercia: Is it okay/better to use `not-allowed` for disabled buttons like this over the existing `cursor: default;` we've been using?

## How has this been tested?
Created disabled buttons locally and made sure the cursor was correct.

## Screenshots

![2018-06-21 12 35 36](https://user-images.githubusercontent.com/90871/41721074-d8999bae-755c-11e8-824b-e3aa8ff72cbf.gif)

## Types of changes
CSS changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->