### PR TITLE
Data: Refactor withSelect to use getDerivedStateFromProps

### DIFF
--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -312,9 +312,12 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 					return;
 				}
 
-				this.setState( () => (
-					this.constructor.getDerivedStateFromProps( this.props )
-				) );
+				// Trigger an update. Behavior of `getDerivedStateFromProps` as
+				// of React 16.4.0 is such that it will be called by any update
+				// to the component, including state changes.
+				//
+				// See: https://reactjs.org/blog/2018/05/23/react-v-16-4.html#bugfix-for-getderivedstatefromprops
+				this.setState( () => ( {} ) );
 			} );
 		}
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -273,6 +273,8 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 		constructor() {
 			super( ...arguments );
 
+			this.subscribe();
+
 			this.state = {};
 		}
 
@@ -289,14 +291,11 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 		}
 
 		componentDidMount() {
-			this.unsubscribe = subscribe( () => {
-				this.setState( () => (
-					this.constructor.getDerivedStateFromProps( this.props )
-				) );
-			} );
+			this.canRunSelection = true;
 		}
 
 		componentWillUnmount() {
+			this.canRunSelection = false;
 			this.unsubscribe();
 		}
 
@@ -305,6 +304,18 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 				! isShallowEqual( this.props, nextProps ) ||
 				! isShallowEqual( this.state.mergeProps, nextState.mergeProps )
 			);
+		}
+
+		subscribe() {
+			this.unsubscribe = subscribe( () => {
+				if ( ! this.canRunSelection ) {
+					return;
+				}
+
+				this.setState( () => (
+					this.constructor.getDerivedStateFromProps( this.props )
+				) );
+			} );
 		}
 
 		render() {

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -267,87 +267,47 @@ export function dispatch( reducerKey ) {
  * @return {Component} Enhanced component with merged state data props.
  */
 export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( WrappedComponent ) => {
-	const defaultMergeProps = {};
-	function getNextMergeProps( props ) {
-		return mapStateToProps( select, props ) || defaultMergeProps;
-	}
+	const DEFAULT_MERGE_PROPS = {};
 
 	return class ComponentWithSelect extends Component {
-		constructor( props ) {
+		constructor() {
 			super( ...arguments );
-			this.runSelection = this.runSelection.bind( this );
 
-			/**
-			 * Boolean tracking known render conditions (own props or merged
-			 * props update) for `shouldComponentUpdate`.
-			 *
-			 * @type {boolean}
-			 */
-			this.shouldComponentUpdate = false;
-			/**
-			 * Boolean tracking when can we run selection
-			 * The selection can be run only when the component is mounted.
-			 */
-			this.shouldRunSelection = false;
-
-			this.state = {
-				mergeProps: getNextMergeProps( props ),
-			};
-
-			// Subscribtion should happen in the constructor
-			// Parent components should subscribe before children.
-			this.subscribe();
+			this.state = {};
 		}
 
-		shouldComponentUpdate() {
-			return this.shouldComponentUpdate;
+		static getDerivedStateFromProps( props ) {
+			// A constant value is used as the fallback since it can be more
+			// efficiently shallow compared in case component is repeatedly
+			// rendered without its own merge props.
+			const mergeProps = (
+				mapStateToProps( select, props ) ||
+				DEFAULT_MERGE_PROPS
+			);
+
+			return { mergeProps };
 		}
 
 		componentDidMount() {
-			this.shouldRunSelection = true;
-		}
-
-		componentDidUpdate( prevProps ) {
-			if ( ! isShallowEqual( prevProps, this.props ) ) {
-				this.runSelection( this.props );
-				this.shouldComponentUpdate = true;
-			}
+			this.unsubscribe = subscribe( () => {
+				this.setState( () => (
+					this.constructor.getDerivedStateFromProps( this.props )
+				) );
+			} );
 		}
 
 		componentWillUnmount() {
 			this.unsubscribe();
-
-			// While above unsubscribe avoids future listener calls, callbacks
-			// are snapshotted before being invoked, so if unmounting occurs
-			// during a previous callback, we need to explicitly track and
-			// avoid the `runSelection` that is scheduled to occur.
-			this.shouldRunSelection = false;
 		}
 
-		subscribe() {
-			this.unsubscribe = subscribe( this.runSelection );
-		}
-
-		runSelection( props = this.props ) {
-			if ( ! this.shouldRunSelection ) {
-				return;
-			}
-
-			const { mergeProps } = this.state;
-			const nextMergeProps = getNextMergeProps( props );
-
-			if ( ! isShallowEqual( nextMergeProps, mergeProps ) ) {
-				this.setState( {
-					mergeProps: nextMergeProps,
-				} );
-
-				this.shouldComponentUpdate = true;
-			}
+		shouldComponentUpdate( nextProps, nextState ) {
+			return (
+				! isShallowEqual( this.props, nextProps ) ||
+				! isShallowEqual( this.state.mergeProps, nextState.mergeProps )
+			);
 		}
 
 		render() {
-			this.shouldComponentUpdate = false;
-
 			return <WrappedComponent { ...this.props } { ...this.state.mergeProps } />;
 		}
 	};

--- a/packages/data/src/test/index.js
+++ b/packages/data/src/test/index.js
@@ -571,7 +571,6 @@ describe( 'withSelect', () => {
 		expect( wrapper.childAt( 0 ).props() ).toEqual( { foo: 'OK', propName: 'foo' } );
 
 		wrapper.setProps( { propName: 'bar' } );
-		wrapper.update();
 
 		expect( wrapper.childAt( 0 ).props() ).toEqual( { bar: 'OK', propName: 'bar' } );
 	} );

--- a/packages/data/src/test/index.js
+++ b/packages/data/src/test/index.js
@@ -394,24 +394,12 @@ describe( 'select', () => {
 describe( 'withSelect', () => {
 	let wrapper, store;
 
-	const unsubscribes = [];
 	afterEach( () => {
-		let unsubscribe;
-		while ( ( unsubscribe = unsubscribes.shift() ) ) {
-			unsubscribe();
-		}
-
 		if ( wrapper ) {
 			wrapper.unmount();
 			wrapper = null;
 		}
 	} );
-
-	function subscribeWithUnsubscribe( ...args ) {
-		const unsubscribe = store.subscribe( ...args );
-		unsubscribes.push( unsubscribe );
-		return unsubscribe;
-	}
 
 	it( 'passes the relevant data to the component', () => {
 		registerReducer( 'reactReducer', () => ( { reactKey: 'reactState' } ) );
@@ -426,11 +414,20 @@ describe( 'withSelect', () => {
 		// including both `withSelect` and `select` in the same scope, which
 		// shouldn't occur for a typical component, and if it did might wrongly
 		// encourage the developer to use `select` within the component itself.
-		const Component = withSelect( ( _select, ownProps ) => ( {
+		const mapSelectToProps = jest.fn().mockImplementation( ( _select, ownProps ) => ( {
 			data: _select( 'reactReducer' ).reactSelector( ownProps.keyName ),
-		} ) )( ( props ) => <div>{ props.data }</div> );
+		} ) );
+
+		const OriginalComponent = jest.fn().mockImplementation( ( props ) => (
+			<div>{ props.data }</div>
+		) );
+
+		const Component = withSelect( mapSelectToProps )( OriginalComponent );
 
 		wrapper = mount( <Component keyName="reactKey" /> );
+
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		// Wrapper is the enhanced component. Find props on the rendered child.
 		const child = wrapper.childAt( 0 );
@@ -458,26 +455,43 @@ describe( 'withSelect', () => {
 			increment: () => ( { type: 'increment' } ),
 		} );
 
-		const Component = compose( [
-			withSelect( ( _select ) => ( {
-				count: _select( 'counter' ).getCount(),
-			} ) ),
-			withDispatch( ( _dispatch ) => ( {
-				increment: _dispatch( 'counter' ).increment,
-			} ) ),
-		] )( ( props ) => (
+		const mapSelectToProps = jest.fn().mockImplementation( ( _select ) => ( {
+			count: _select( 'counter' ).getCount(),
+		} ) );
+
+		const mapDispatchToProps = jest.fn().mockImplementation( ( _dispatch ) => ( {
+			increment: _dispatch( 'counter' ).increment,
+		} ) );
+
+		const OriginalComponent = jest.fn().mockImplementation( ( props ) => (
 			<button onClick={ props.increment }>
 				{ props.count }
 			</button>
 		) );
 
+		const Component = compose( [
+			withSelect( mapSelectToProps ),
+			withDispatch( mapDispatchToProps ),
+		] )( OriginalComponent );
+
 		wrapper = mount( <Component /> );
+
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( mapDispatchToProps ).toHaveBeenCalledTimes( 1 );
 
 		const button = wrapper.find( 'button' );
 
 		button.simulate( 'click' );
 
 		expect( button.text() ).toBe( '1' );
+		// 3 times =
+		//  1. Initial mount
+		//  2. When click handler is called
+		//  3. After select updates its merge props
+		expect( mapDispatchToProps ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
 
 	it( 'should rerun selection on props changes', () => {
@@ -493,45 +507,52 @@ describe( 'withSelect', () => {
 			getCount: ( state, offset ) => state + offset,
 		} );
 
-		const Component = withSelect( ( _select, ownProps ) => ( {
+		const mapSelectToProps = jest.fn().mockImplementation( ( _select, ownProps ) => ( {
 			count: _select( 'counter' ).getCount( ownProps.offset ),
-		} ) )( ( props ) => <div>{ props.count }</div> );
+		} ) );
+
+		const OriginalComponent = jest.fn().mockImplementation( ( props ) => (
+			<div>{ props.count }</div>
+		) );
+
+		const Component = withSelect( mapSelectToProps )( OriginalComponent );
 
 		wrapper = mount( <Component offset={ 0 } /> );
+
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		wrapper.setProps( { offset: 10 } );
 
 		expect( wrapper.childAt( 0 ).text() ).toBe( '10' );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	it( 'ensures component is still mounted before setting state', () => {
-		// This test verifies that even though unsubscribe doesn't take effect
-		// until after the current listener stack is called, we don't attempt
-		// to setState on an unmounting `withSelect` component. It will fail if
-		// an attempt is made to `setState` on an unmounted component.
-		store = registerReducer( 'counter', ( state = 0, action ) => {
-			if ( action.type === 'increment' ) {
-				return state + 1;
-			}
+	it( 'should render if props have changed but not state', () => {
+		store = registerReducer( 'unchanging', ( state = {} ) => state );
 
-			return state;
+		registerSelectors( 'unchanging', {
+			getState: ( state ) => state,
 		} );
 
-		registerSelectors( 'counter', {
-			getCount: ( state, offset ) => state + offset,
-		} );
+		const mapSelectToProps = jest.fn();
 
-		subscribeWithUnsubscribe( () => {
-			wrapper.unmount();
-		} );
+		const OriginalComponent = jest.fn().mockImplementation( () => <div /> );
 
-		const Component = withSelect( ( _select, ownProps ) => ( {
-			count: _select( 'counter' ).getCount( ownProps.offset ),
-		} ) )( ( props ) => <div>{ props.count }</div> );
+		const Component = compose( [
+			withSelect( mapSelectToProps ),
+		] )( OriginalComponent );
 
-		wrapper = mount( <Component offset={ 0 } /> );
+		wrapper = mount( <Component /> );
 
-		store.dispatch( { type: 'increment' } );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
+
+		wrapper.setProps( { propName: 'foo' } );
+
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
 
 	it( 'should not rerun selection on unchanging state', () => {
@@ -543,15 +564,21 @@ describe( 'withSelect', () => {
 
 		const mapSelectToProps = jest.fn();
 
+		const OriginalComponent = jest.fn().mockImplementation( () => <div /> );
+
 		const Component = compose( [
 			withSelect( mapSelectToProps ),
-		] )( () => <div /> );
+		] )( OriginalComponent );
 
 		wrapper = mount( <Component /> );
+
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		store.dispatch( { type: 'dummy' } );
 
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'omits props which are not returned on subsequent mappings', () => {
@@ -560,18 +587,26 @@ describe( 'withSelect', () => {
 			getValue: ( state ) => state,
 		} );
 
-		const Component = withSelect( ( _select, ownProps ) => {
+		const mapSelectToProps = jest.fn().mockImplementation( ( _select, ownProps ) => {
 			return {
 				[ ownProps.propName ]: _select( 'demo' ).getValue(),
 			};
-		} )( () => <div /> );
+		} );
+
+		const OriginalComponent = jest.fn().mockImplementation( () => <div /> );
+
+		const Component = withSelect( mapSelectToProps )( OriginalComponent );
 
 		wrapper = mount( <Component propName="foo" /> );
 
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( wrapper.childAt( 0 ).props() ).toEqual( { foo: 'OK', propName: 'foo' } );
 
 		wrapper.setProps( { propName: 'bar' } );
 
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 		expect( wrapper.childAt( 0 ).props() ).toEqual( { bar: 'OK', propName: 'bar' } );
 	} );
 
@@ -581,24 +616,36 @@ describe( 'withSelect', () => {
 			getValue: ( state ) => state,
 		} );
 
-		const Component = withSelect( ( _select, ownProps ) => {
+		const mapSelectToProps = jest.fn().mockImplementation( ( _select, ownProps ) => {
 			if ( ownProps.pass ) {
 				return {
 					count: _select( 'demo' ).getValue(),
 				};
 			}
-		} )( ( props ) => <div>{ props.count || 'Unknown' }</div> );
+		} );
+
+		const OriginalComponent = jest.fn().mockImplementation( (
+			( props ) => <div>{ props.count || 'Unknown' }</div>
+		) );
+
+		const Component = withSelect( mapSelectToProps )( OriginalComponent );
 
 		wrapper = mount( <Component pass={ false } /> );
 
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( wrapper.childAt( 0 ).text() ).toBe( 'Unknown' );
 
 		wrapper.setProps( { pass: true } );
 
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 		expect( wrapper.childAt( 0 ).text() ).toBe( 'OK' );
 
 		wrapper.setProps( { pass: false } );
 
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 3 );
 		expect( wrapper.childAt( 0 ).text() ).toBe( 'Unknown' );
 	} );
 
@@ -614,22 +661,31 @@ describe( 'withSelect', () => {
 		} );
 
 		const childMapStateToProps = jest.fn();
-
-		const Child = withSelect( childMapStateToProps )( () => {
-			return <div />;
-		} );
-
-		const Parent = withSelect( ( _select ) => ( {
+		const parentMapStateToProps = jest.fn().mockImplementation( ( _select ) => ( {
 			isRenderingChild: _select( 'childRender' ).getValue(),
-		} ) )( ( props ) => ( <div>{ props.isRenderingChild ? <Child /> : null }</div> ) );
+		} ) );
+
+		const ChildOriginalComponent = jest.fn().mockImplementation( () => <div /> );
+		const ParentOriginalComponent = jest.fn().mockImplementation( ( props ) => (
+			<div>{ props.isRenderingChild ? <Child /> : null }</div>
+		) );
+
+		const Child = withSelect( childMapStateToProps )( ChildOriginalComponent );
+		const Parent = withSelect( parentMapStateToProps )( ParentOriginalComponent );
 
 		wrapper = mount( <Parent /> );
 
 		expect( childMapStateToProps ).toHaveBeenCalledTimes( 1 );
+		expect( parentMapStateToProps ).toHaveBeenCalledTimes( 1 );
+		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
+		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		dispatch( 'childRender' ).toggleRender();
 
 		expect( childMapStateToProps ).toHaveBeenCalledTimes( 1 );
+		expect( parentMapStateToProps ).toHaveBeenCalledTimes( 2 );
+		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
+		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
 } );
 


### PR DESCRIPTION
Related: #7395

This pull request seeks to refactor the higher-order component returned by `withSelect` to simplify its generating of merge props using [`static getDerivedStateFromProps`](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops). This is to avoid calling `setState` during `componentDidUpdate`, which itself occurs after a render and would incur a second render, thus introducing a performance overhead for a component which is used broadly through the application. With these changes, it should still be the case that the component is rendered once on either a props change or store change.

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/data/src/test/index.js
```