### PR TITLE
Add back role textbox to the List block and improve aria-multiline usage

### DIFF
--- a/core-blocks/list/test/__snapshots__/index.js.snap
+++ b/core-blocks/list/test/__snapshots__/index.js.snap
@@ -17,6 +17,7 @@ exports[`core/list block edit matches snapshot 1`] = `
           class="editor-rich-text__tinymce"
           contenteditable="true"
           data-is-placeholder-visible="true"
+          role="textbox"
         />
         <ul
           class="editor-rich-text__tinymce"

--- a/core-blocks/table/test/__snapshots__/index.js.snap
+++ b/core-blocks/table/test/__snapshots__/index.js.snap
@@ -12,7 +12,6 @@ exports[`core/embed block edit matches snapshot 1`] = `
         <table
           aria-autocomplete="list"
           aria-expanded="false"
-          aria-multiline="true"
           class="editor-rich-text__tinymce"
           contenteditable="true"
         >

--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -63,12 +63,6 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 *Optional.* A list of autocompleters to use instead of the default.
 
-### `aria-multiline: Boolean`
-
-*Default: `true`.* [aria-multiline](https://www.w3.org/TR/wai-aria-1.1/#aria-multiline) indicates whether a text box accepts multiple lines of input or only a single line.
-If the context where the RichText is being used is closer to a `<textarea />` than to a `<input type="text">` (multiple lines can be rendered to represent the input) aria-multiline should be equal to true (default) otherwise false should be used.
-Note that aria-multiline gets applied only together with a role=textbox.
-
 ## RichText.Content
 
 When using RichText in the edit function of blocks, the usage of `RichText.Content` is recommended in the save function of your blocks to save the correct HTML.

--- a/editor/components/rich-text/README.md
+++ b/editor/components/rich-text/README.md
@@ -67,6 +67,7 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 *Default: `true`.* [aria-multiline](https://www.w3.org/TR/wai-aria-1.1/#aria-multiline) indicates whether a text box accepts multiple lines of input or only a single line.
 If the context where the RichText is being used is closer to a `<textarea />` than to a `<input type="text">` (multiple lines can be rendered to represent the input) aria-multiline should be equal to true (default) otherwise false should be used.
+Note that aria-multiline gets applied only together with a role=textbox.
 
 ## RichText.Content
 

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -852,7 +852,7 @@ export class RichText extends Component {
 			format,
 		} = this.props;
 
-		const ariaProps = { 'aria-multiline': true, ...pickAriaProps( this.props ) };
+		const ariaProps = pickAriaProps( this.props );
 
 		// Generating a key that includes `tagName` ensures that if the tag
 		// changes, we unmount and destroy the previous TinyMCE element, then

--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -202,8 +202,12 @@ export default class TinyMCE extends Component {
 	render() {
 		const { tagName = 'div', style, defaultValue, className, isPlaceholderVisible, format } = this.props;
 		const ariaProps = pickAriaProps( this.props );
+
 		if ( tagName !== 'table' ) {
 			ariaProps.role = 'textbox';
+		} else {
+			// The `aria-multiline` attribute must be used only together with `role=textbox`.
+			ariaProps[ 'aria-multiline' ] = null;
 		}
 
 		// If a default value is provided, render it into the DOM even before

--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -202,7 +202,7 @@ export default class TinyMCE extends Component {
 	render() {
 		const { tagName = 'div', style, defaultValue, className, isPlaceholderVisible, format } = this.props;
 		const ariaProps = pickAriaProps( this.props );
-		if ( [ 'ul', 'ol', 'table' ].indexOf( tagName ) === -1 ) {
+		if ( [ 'table' ].indexOf( tagName ) === -1 ) {
 			ariaProps.role = 'textbox';
 		}
 

--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -203,11 +203,14 @@ export default class TinyMCE extends Component {
 		const { tagName = 'div', style, defaultValue, className, isPlaceholderVisible, format } = this.props;
 		const ariaProps = pickAriaProps( this.props );
 
+		/*
+		 * The role=textbox and aria-multiline=true must always be used together
+		 * as TinyMCE always behaves like a sort of textarea where text wraps in
+		 * multiple lines. Only the table block editable element is excluded.
+		 */
 		if ( tagName !== 'table' ) {
 			ariaProps.role = 'textbox';
-		} else {
-			// The `aria-multiline` attribute must be used only together with `role=textbox`.
-			ariaProps[ 'aria-multiline' ] = null;
+			ariaProps[ 'aria-multiline' ] = true;
 		}
 
 		// If a default value is provided, render it into the DOM even before

--- a/editor/components/rich-text/tinymce.js
+++ b/editor/components/rich-text/tinymce.js
@@ -202,7 +202,7 @@ export default class TinyMCE extends Component {
 	render() {
 		const { tagName = 'div', style, defaultValue, className, isPlaceholderVisible, format } = this.props;
 		const ariaProps = pickAriaProps( this.props );
-		if ( [ 'table' ].indexOf( tagName ) === -1 ) {
+		if ( tagName !== 'table' ) {
 			ariaProps.role = 'textbox';
 		}
 


### PR DESCRIPTION
## Description
As discussed during WCEU contributor day, the best option for #5983 is to make the list block have the semantics of a textarea. This PR:
- adds back `role=textbox` to the list block editable element
- simplifies the condition, no more reason to use `indexOf()` as we're now checking only against a "table" `tagName`
- also, after #7306 ensures the `aria-multiline` attribute is used only when there's a `role=textbox`. According to the spec, [this attribute can be used only with a textbox role](https://www.w3.org/TR/wai-aria-1.1/#aria-multiline) so it should be omitted for the table element instead of being `false`

@jorgefilipecosta the last point works but maybe can be improved, please do feel free to jump in if you have a chance, thanks! 🙂 

## How has this been tested?
- npm test and updated snapshots

Fixes #5983