### PR TITLE
Display server error message when one exists

### DIFF
--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { compact, forEach, get, includes, noop, startsWith } from 'lodash';
+import { compact, forEach, get, includes, isEmpty, noop, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -98,16 +98,22 @@ export function mediaUpload( {
 				};
 				setAndUpdateFiles( idx, mediaObject );
 			},
-			() => {
+			( response ) => {
 				// Reset to empty on failure.
 				setAndUpdateFiles( idx, null );
-				onError( {
-					code: 'GENERAL',
-					message: sprintf(
+				let message;
+				if ( ! isEmpty( response.responseJSON.message ) ) {
+					message = response.responseJSON.message;
+				} else {
+					message = sprintf(
 						// translators: %s: file name
 						__( 'Error while uploading file %s to the media library.' ),
 						mediaFile.name
-					),
+					);
+				}
+				onError( {
+					code: 'GENERAL',
+					message,
 					file: mediaFile,
 				} );
 			}

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { compact, forEach, get, includes, isEmpty, noop, startsWith } from 'lodash';
+import { compact, forEach, get, has, includes, noop, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -102,8 +102,8 @@ export function mediaUpload( {
 				// Reset to empty on failure.
 				setAndUpdateFiles( idx, null );
 				let message;
-				if ( ! isEmpty( response.responseJSON.message ) ) {
-					message = response.responseJSON.message;
+				if ( has( response, [ 'responseJSON', 'message' ] ) ) {
+					message = get( response, [ 'responseJSON', 'message' ] );
 				} else {
 					message = sprintf(
 						// translators: %s: file name


### PR DESCRIPTION
## Description

If the server rejects a media upload and includes a message, display that message in the error UI.

Fixes #7137

## How has this been tested?

Add the following code snippet in `functions.php` or similar:

```
$force_upload_failure = function( $file ) {
	$file['error'] = 'This file upload has been forced to fail.';
	return $file;
};
add_filter( 'wp_handle_sideload_prefilter', $force_upload_failure );
add_filter( 'wp_handle_upload_prefilter', $force_upload_failure );
```

Attempt to upload an image into the image block. Observe `This file upload has been forced to fail.` as the error message.

## Screenshots

<img width="703" alt="image" src="https://user-images.githubusercontent.com/36432/41657267-a9cf3c7c-7447-11e8-93e5-0c033e8425d2.png">

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
