### PR TITLE
Fix getMimeTypesArray return documentation

### DIFF
--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -24,7 +24,7 @@ import apiRequest from '@wordpress/api-request';
  * @param {?Object} wpMimeTypesObject Mime type object received from the server.
  *                                    Extensions are keys separated by '|' and values are mime types associated with an extension.
  *
- * @return {?Array} Media Object Promise.
+ * @return {?Array} An array of mime types or the parameter passed if it was "falsy".
  */
 export function getMimeTypesArray( wpMimeTypesObject ) {
 	if ( ! wpMimeTypesObject ) {


### PR DESCRIPTION
Correction of a mistake made in https://github.com/WordPress/gutenberg/pull/7398. Thank you for the catch @aduth!