### PR TITLE
Remove React-related attributes from pullquote multi-paragraph block fixtures

### DIFF
--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.html
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.html
@@ -1,6 +1,6 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-    <p>Paragraph <strong>one</strong></p>
+    <p>Paragraph one</p>
     <p>Paragraph two</p>
     <cite>by whomever</cite>
 </blockquote>

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -11,19 +11,7 @@
                         "key": null,
                         "ref": null,
                         "props": {
-                            "children": [
-                                "Paragraph ",
-                                {
-                                    "type": "strong",
-                                    "key": "_domReact71",
-                                    "ref": null,
-                                    "props": {
-                                        "children": "one"
-                                    },
-                                    "_owner": null,
-                                    "_store": {}
-                                }
-                            ]
+                            "children": "Paragraph one"
                         },
                         "_owner": null,
                         "_store": {}
@@ -48,6 +36,6 @@
             "align": "none"
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph one</p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>"
     }
 ]

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/pullquote",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph one</p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-	<p>Paragraph <strong>one</strong></p>
+	<p>Paragraph one</p>
 	<p>Paragraph two</p><cite>by whomever</cite></blockquote>
 <!-- /wp:pullquote -->


### PR DESCRIPTION
This is a suggestion to improve the multi-paragraph pullquote test fixtures.

## Description
The tests for the multi-paragraph pullquote are storing React internal data in the fixtures. That's problematic because its values might change unexpectedly depending on the tests run before. Indeed, I had to deal with it in #6549 (see https://github.com/WordPress/gutenberg/pull/6549/files#r189686931).

To avoid it and make the test simpler we can remove the nested elements from the parsed content. Similar tests don't have nested elements either in the fixtures.

## How has this been tested?
It's a change to the fixtures of a single block, so running `npm test` should be enough.

## Types of changes
Test improvement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
