### PR TITLE
Add user for cli image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
 
   cli:
     image: wordpress:cli
+    user: xfs
     volumes:
       - wordpress:/var/www/html
       - .:/var/www/html/wp-content/plugins/gutenberg


### PR DESCRIPTION
## Description
Add user `xfs` for `cli` docker image.
cli user www-data. But user of mounted volume is `xfs`. So unable to create directory and file from cli commands.

see: https://github.com/docker-library/wordpress/issues/256

## How has this been tested?
```
$ docker-compose run cli wp plugin install wordpress-importer
```

## Screenshots <!-- if applicable -->

## Types of changes

Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
