### PR TITLE
add depends_on prop for images.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,17 @@ services:
       - .:/var/www/html/wp-content/plugins/gutenberg
       - ./test/e2e/test-plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
       - ./test/e2e/test-mu-plugins:/var/www/html/wp-content/mu-plugins
+    depends_on:
+      - mysql
 
   cli:
     image: wordpress:cli
     volumes:
       - wordpress:/var/www/html
       - .:/var/www/html/wp-content/plugins/gutenberg
+    depends_on:
+      - mysql
+      - wordpress
 
   mysql:
     image: mysql:5.7
@@ -34,6 +39,8 @@ services:
     volumes:
       - .:/app
       - testsuite:/tmp
+    depends_on:
+      - mysql
 
   composer:
     image: composer


### PR DESCRIPTION
## Description
Setup order of service startup. create MySQL container before WordPress container.

see: [Control startup order in Compose | Docker Documentation](https://docs.docker.com/compose/startup-order/)

## How has this been tested?
Run `docker-compose up` .  Check  the order in which containers are created.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
