### PR TITLE
Polish region focus style

### DIFF
--- a/components/higher-order/navigate-regions/style.scss
+++ b/components/higher-order/navigate-regions/style.scss
@@ -7,6 +7,7 @@
 		left: 0;
 		right: 0;
 		pointer-events: none;
-		border: 4px solid $blue-medium-400;
+		outline: 4px solid transparent; // Shown in Windows High Contrast mode.
+		@include region_focus( .1s );
 	}
 }

--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -30,3 +30,17 @@
 	animation: fade-in $speed ease-out;
 	animation-fill-mode: forwards;
 }
+
+@keyframes region-focus {
+	from {
+		box-shadow: inset 0 0 0 0 $blue-medium-400;
+	}
+	to {
+		box-shadow: inset 0 0 0 4px $blue-medium-400;
+	}
+}
+
+@mixin region_focus( $speed: 0.2s ) {
+	animation: region-focus $speed ease-out;
+	animation-fill-mode: forwards;
+}

--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -31,7 +31,7 @@
 	animation-fill-mode: forwards;
 }
 
-@keyframes region-focus {
+@keyframes editor_region_focus {
 	from {
 		box-shadow: inset 0 0 0 0 $blue-medium-400;
 	}
@@ -41,6 +41,6 @@
 }
 
 @mixin region_focus( $speed: 0.2s ) {
-	animation: region-focus $speed ease-out;
+	animation: editor_region_focus $speed ease-out;
 	animation-fill-mode: forwards;
 }


### PR DESCRIPTION
This is a small ✋ Friday PR! 🤚

It does one thing — adds a little animation flourish to the focus style we show when you navigate between regions. Press Ctrl + [the key below escape] to invoke this. Here's how it looks:

![regionfocus](https://user-images.githubusercontent.com/1204802/41765615-e39c585e-7604-11e8-8f56-b02b72b1b456.gif)

Sorry for the low-quality GIF, it's barely perceptible. But what happens is that the blue focus outline animates from 0px width to 4px width with a speed of .1s. 