### PR TITLE
Fix issues with gallery in IE11.

### DIFF
--- a/core-blocks/gallery/editor.scss
+++ b/core-blocks/gallery/editor.scss
@@ -100,3 +100,14 @@
 	left: 50%;
 	transform: translate( -50%, -50% );
 }
+
+// IE11 doesn't support object-fit or flex very well, so we inline-block.
+@media all and ( -ms-high-contrast: none ) {
+	*::-ms-backdrop, .blocks-gallery-item {
+		display: inline-block;
+	}
+
+	*::-ms-backdrop, .blocks-gallery-item img {
+		width: 100%;
+	}
+}

--- a/core-blocks/gallery/style.scss
+++ b/core-blocks/gallery/style.scss
@@ -15,7 +15,6 @@
 		justify-content: center;
 		position: relative;
 
-
 		figure {
 			margin: 0;
 			height: 100%;
@@ -52,12 +51,6 @@
 			height: 100%;
 			object-fit: cover;
 
-		}
-
-		// Alas, IE11+ doesn't support object-fit
-		_:-ms-lang(x), figure {
-			height: auto;
-			width: auto;
 		}
 	}
 


### PR DESCRIPTION
IE 11 is a horrendous browser, and its support for flexbox is equally horrendous.

Galleries, as a result, had crazy stretched images. This PR fixes that.

Screenshot after this PR is applied:

<img width="766" alt="screen shot 2018-06-22 at 11 41 07" src="https://user-images.githubusercontent.com/1204802/41770027-570d2988-7611-11e8-9b81-355d89a74e1c.png">
