### PR TITLE
Fix colors of plugin icons.

### DIFF
--- a/components/menu-item/style.scss
+++ b/components/menu-item/style.scss
@@ -29,12 +29,17 @@
 		@include menu-style__focus;
 	}
 
-	// Forcefully colorize plugin icons to ensure contrast and cohesion.
+	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin devs to override.
 	svg,
-	g,
-	path {
-		stroke: $dark-gray-500 !important;
-		fill: $dark-gray-500 !important;
+	svg * {
+		stroke: $dark-gray-500;
+		fill: $dark-gray-500;
+	}
+
+	&:hover svg,
+	&:hover svg * {
+		stroke: $dark-gray-900 !important;
+		fill: $dark-gray-900 !important;
 	}
 }
 

--- a/components/menu-item/style.scss
+++ b/components/menu-item/style.scss
@@ -7,8 +7,9 @@
 	color: $dark-gray-500;
 
 	.dashicon,
-	.components-menu-items__item-icon {
-		margin-right: 5px;
+	.components-menu-items__item-icon,
+	> span > svg { // Also target plugin icons that can have arbitrary classes.
+		margin-right: 4px;
 	}
 
 	.components-menu-items__item-icon {
@@ -26,6 +27,14 @@
 
 	&:focus:not(:disabled):not([aria-disabled="true"]) {
 		@include menu-style__focus;
+	}
+
+	// Forcefully colorize plugin icons to ensure contrast and cohesion.
+	svg,
+	g,
+	path {
+		stroke: $dark-gray-500 !important;
+		fill: $dark-gray-500 !important;
 	}
 }
 

--- a/components/menu-item/style.scss
+++ b/components/menu-item/style.scss
@@ -6,9 +6,10 @@
 	padding-left: 25px;
 	color: $dark-gray-500;
 
+	// Target plugin icons that can have arbitrary classes by using an aggressive selector.
 	.dashicon,
 	.components-menu-items__item-icon,
-	> span > svg { // Also target plugin icons that can have arbitrary classes.
+	> span > svg {
 		margin-right: 4px;
 	}
 
@@ -29,7 +30,7 @@
 		@include menu-style__focus;
 	}
 
-	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin devs to override.
+	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin developers to override.
 	svg,
 	svg * {
 		stroke: $dark-gray-500;

--- a/edit-post/components/header/pinned-plugins/style.scss
+++ b/edit-post/components/header/pinned-plugins/style.scss
@@ -4,4 +4,26 @@
 	.components-icon-button {
 		margin-left: 4px;
 	}
+
+	// Forcefully colorize plugin icons to ensure contrast and cohesion.
+	.components-icon-button:not( .is-toggled ) svg,
+	.components-icon-button:not( .is-toggled ) g,
+	.components-icon-button:not( .is-toggled ) path {
+		stroke: $dark-gray-500 !important;
+		fill: $dark-gray-500 !important;
+	}
+
+	.components-icon-button.is-toggled svg,
+	.components-icon-button.is-toggled g,
+	.components-icon-button.is-toggled path {
+		stroke: $white !important;
+		fill: $white !important;
+	}
+
+	.components-icon-button:hover svg,
+	.components-icon-button:hover g,
+	.components-icon-button:hover path {
+		stroke: $dark-gray-900 !important;
+		fill: $dark-gray-900 !important;
+	}
 }

--- a/edit-post/components/header/pinned-plugins/style.scss
+++ b/edit-post/components/header/pinned-plugins/style.scss
@@ -5,14 +5,14 @@
 		margin-left: 4px;
 	}
 
-	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin devs to override.
+	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin developers to override.
 	.components-icon-button:not( .is-toggled ) svg,
 	.components-icon-button:not( .is-toggled ) svg * {
 		stroke: $dark-gray-500;
 		fill: $dark-gray-500;
 	}
 	
-	// Forcefully colorize hover & toggled plugin icon states to ensure legibility and consistency.
+	// Forcefully colorize hover and toggled plugin icon states to ensure legibility and consistency.
 	.components-icon-button.is-toggled svg,
 	.components-icon-button.is-toggled svg * {
 		stroke: $white !important;

--- a/edit-post/components/header/pinned-plugins/style.scss
+++ b/edit-post/components/header/pinned-plugins/style.scss
@@ -5,24 +5,22 @@
 		margin-left: 4px;
 	}
 
-	// Forcefully colorize plugin icons to ensure contrast and cohesion.
+	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin devs to override.
 	.components-icon-button:not( .is-toggled ) svg,
-	.components-icon-button:not( .is-toggled ) g,
-	.components-icon-button:not( .is-toggled ) path {
-		stroke: $dark-gray-500 !important;
-		fill: $dark-gray-500 !important;
+	.components-icon-button:not( .is-toggled ) svg * {
+		stroke: $dark-gray-500;
+		fill: $dark-gray-500;
 	}
-
+	
+	// Forcefully colorize hover & toggled plugin icon states to ensure legibility and consistency.
 	.components-icon-button.is-toggled svg,
-	.components-icon-button.is-toggled g,
-	.components-icon-button.is-toggled path {
+	.components-icon-button.is-toggled svg * {
 		stroke: $white !important;
 		fill: $white !important;
 	}
 
 	.components-icon-button:hover svg,
-	.components-icon-button:hover g,
-	.components-icon-button:hover path {
+	.components-icon-button:hover svg * {
 		stroke: $dark-gray-900 !important;
 		fill: $dark-gray-900 !important;
 	}


### PR DESCRIPTION
This PR does two things:

1. It forcefully colorizes any SVG icon used in the toolbar or More menu. This allows us to be sure the contrast is present, and that we can show a toggled and untoggled color.

2. It adds margin to plugin icons, this fixes #7464.

Yes. I'm using `!important` here. I know you're not supposed to do that. But aside from being the only way we can ensure the colors, I feel like this is actually a valid usecase for the modifier. 

Screenshots:

![button color](https://user-images.githubusercontent.com/1204802/41772945-c4e7821a-761a-11e8-9e92-41c7def21329.gif)

<img width="253" alt="screen shot 2018-06-22 at 12 48 51" src="https://user-images.githubusercontent.com/1204802/41772947-c674dcb8-761a-11e8-9668-fc74e8b1c87d.png">
