### PR TITLE
Fix text wrapping in Firefox.

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -45,6 +45,7 @@ html.wp-toolbar {
 
 body.gutenberg-editor-page {
 	background: $white;
+	overflow-wrap: break-word;
 
 	#wpcontent {
 		padding-left: 0;

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -45,7 +45,6 @@ html.wp-toolbar {
 
 body.gutenberg-editor-page {
 	background: $white;
-	overflow-wrap: break-word;
 
 	#wpcontent {
 		padding-left: 0;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -136,7 +136,7 @@
 	padding-left: $block-padding;
 	padding-right: $block-padding;
 
-	// Break long spaceless words so they don't overflow the block.
+	// Break long strings of text without spaces so they don't overflow the block.
 	overflow-wrap: break-word;
 
 	@include break-small() {

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -136,6 +136,9 @@
 	padding-left: $block-padding;
 	padding-right: $block-padding;
 
+	// Break long spaceless words so they don't overflow the block.
+	overflow-wrap: break-word;
+
 	@include break-small() {
 		// The block mover needs to stay inside the block to allow clicks when hovering the block
 		padding-left: $block-padding + $block-side-ui-padding - $border-width;


### PR DESCRIPTION
This PR, maybe, fixes #6049. CC: @SuperGeniusZeb.

It is a one line code change, but this change is put into a highly unscoped and generic location, so I would appreciate both lots of testing and sanity checking that there are no adverse side-effects to doing this.

For reference, this is what we're using: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
We could also have used https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

Screenshot:

<img width="759" alt="screen shot 2018-06-22 at 13 01 08" src="https://user-images.githubusercontent.com/1204802/41773530-a5cec60c-761c-11e8-9845-9ab34478caed.png">
