### PR TITLE
RichText: Use a simplified format for rich text values

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -39,6 +39,7 @@ export {
 } from './registration';
 export {
 	isUnmodifiedDefaultBlock,
+	createSimpleElement,
 } from './utils';
 export {
 	doBlocksMatchTemplate,

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -39,7 +39,6 @@ export {
 } from './registration';
 export {
 	isUnmodifiedDefaultBlock,
-	createSimpleElement,
 } from './utils';
 export {
 	doBlocksMatchTemplate,

--- a/blocks/api/matchers.js
+++ b/blocks/api/matchers.js
@@ -1,13 +1,13 @@
 /**
- * WordPress dependencies
- */
-import { createElement } from '@wordpress/element';
-
-/**
  * External dependencies
  */
 import { nodeListToReact, nodeToReact } from 'dom-react';
 export { attr, prop, html, text, query } from 'hpq';
+
+/**
+ * Internal dependencies
+ */
+import { createSimpleElement } from './utils';
 
 export const children = ( selector ) => {
 	return ( domNode ) => {
@@ -18,7 +18,7 @@ export const children = ( selector ) => {
 		}
 
 		if ( match ) {
-			return nodeListToReact( match.childNodes || [], createElement );
+			return nodeListToReact( match.childNodes || [], createSimpleElement );
 		}
 
 		return [];
@@ -33,6 +33,6 @@ export const node = ( selector ) => {
 			match = domNode.querySelector( selector );
 		}
 
-		return nodeToReact( match, createElement );
+		return nodeToReact( match, createSimpleElement );
 	};
 };

--- a/blocks/api/matchers.js
+++ b/blocks/api/matchers.js
@@ -5,9 +5,9 @@ import { nodeListToReact, nodeToReact } from 'dom-react';
 export { attr, prop, html, text, query } from 'hpq';
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import { createSimpleElement } from './utils';
+import { createSimpleElement } from '@wordpress/element';
 
 export const children = ( selector ) => {
 	return ( domNode ) => {

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -118,21 +118,3 @@ export function normalizeIconObject( icon ) {
 	}
 	return icon;
 }
-
-/**
- * Creates a simplified element representation.
- *
- * @param {string} type
- * @param {Object} props
- * @param {Array?} children
- *
- * @return {Object} Element.
- */
-export function createSimpleElement( type, props, ...children ) {
-	return {
-		type, props: {
-			...omit( props, [ 'key' ] ),
-			children,
-		},
-	};
-}

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, keys, isEqual, isFunction, isString } from 'lodash';
+import { every, keys, isEqual, isFunction, isString, omit } from 'lodash';
 import { default as tinycolor, mostReadable } from 'tinycolor2';
 
 /**
@@ -117,4 +117,22 @@ export function normalizeIconObject( icon ) {
 		icon.shadowColor = tinyBgColor.setAlpha( 0.3 ).toRgbString();
 	}
 	return icon;
+}
+
+/**
+ * Creates a simplified element representation.
+ *
+ * @param {string} type
+ * @param {Object} props
+ * @param {Array?} children
+ *
+ * @return {Object} Element.
+ */
+export function createSimpleElement( type, props, ...children ) {
+	return {
+		type, props: {
+			...omit( props, [ 'key' ] ),
+			children,
+		},
+	};
 }

--- a/core-blocks/test/fixtures/core__heading__h2-em.json
+++ b/core-blocks/test/fixtures/core__heading__h2-em.json
@@ -8,7 +8,7 @@
                 "The ",
                 {
                     "type": "em",
-                    "children": "Inserter"
+                    "children": [ "Inserter" ]
                 },
                 " Tool"
             ],

--- a/core-blocks/test/fixtures/core__list__ul.json
+++ b/core-blocks/test/fixtures/core__list__ul.json
@@ -8,23 +8,23 @@
             "values": [
                 {
                     "type": "li",
-                    "children": "Text & Headings"
+                    "children": [ "Text & Headings" ]
                 },
                 {
                     "type": "li",
-                    "children": "Images & Videos"
+                    "children": [ "Images & Videos" ]
                 },
                 {
                     "type": "li",
-                    "children": "Galleries"
+                    "children": [ "Galleries" ]
                 },
                 {
                     "type": "li",
-                    "children": "Embeds, like YouTube, Tweets, or other WordPress posts."
+                    "children": [ "Embeds, like YouTube, Tweets, or other WordPress posts." ]
                 },
                 {
                     "type": "li",
-                    "children": "Layout blocks, like Buttons, Hero Images, Separators, etc."
+                    "children": [ "Layout blocks, like Buttons, Hero Images, Separators, etc." ]
                 },
                 {
                     "type": "li",
@@ -32,7 +32,7 @@
                         "And ",
                         {
                             "type": "em",
-                            "children": "Lists"
+                            "children": [ "Lists" ]
                         },
                         " like this one of course :)"
                     ]

--- a/core-blocks/test/fixtures/core__preformatted.json
+++ b/core-blocks/test/fixtures/core__preformatted.json
@@ -8,11 +8,12 @@
                 "Some ",
                 {
                     "type": "em",
-                    "children": "preformatted"
+                    "children": [ "preformatted" ]
                 },
                 " text...",
                 {
-                    "type": "br"
+					"type": "br",
+					"children": []
                 },
                 "And more!"
             ]

--- a/core-blocks/test/fixtures/core__pullquote.json
+++ b/core-blocks/test/fixtures/core__pullquote.json
@@ -8,13 +8,9 @@
                 {
                     "children": {
                         "type": "p",
-                        "key": null,
-                        "ref": null,
                         "props": {
-                            "children": "Testing pullquote block..."
-                        },
-                        "_owner": null,
-                        "_store": {}
+                            "children": [ "Testing pullquote block..." ]
+                        }
                     }
                 }
             ],

--- a/core-blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/core-blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -8,37 +8,25 @@
                 {
                     "children": {
                         "type": "p",
-                        "key": null,
-                        "ref": null,
                         "props": {
                             "children": [
                                 "Paragraph ",
                                 {
                                     "type": "strong",
-                                    "key": "_domReact71",
-                                    "ref": null,
                                     "props": {
-                                        "children": "one"
-                                    },
-                                    "_owner": null,
-                                    "_store": {}
+                                        "children": [ "one" ]
+                                    }
                                 }
                             ]
-                        },
-                        "_owner": null,
-                        "_store": {}
+                        }
                     }
                 },
                 {
                     "children": {
                         "type": "p",
-                        "key": null,
-                        "ref": null,
                         "props": {
-                            "children": "Paragraph two"
-                        },
-                        "_owner": null,
-                        "_store": {}
+                            "children": [ "Paragraph two" ]
+                        }
                     }
                 }
             ],

--- a/core-blocks/test/fixtures/core__quote__style-1.json
+++ b/core-blocks/test/fixtures/core__quote__style-1.json
@@ -8,13 +8,9 @@
                 {
                     "children": {
                         "type": "p",
-                        "key": null,
-                        "ref": null,
                         "props": {
-                            "children": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
-                        },
-                        "_owner": null,
-                        "_store": {}
+                            "children": [ "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery." ]
+                        }
                     }
                 }
             ],

--- a/core-blocks/test/fixtures/core__quote__style-2.json
+++ b/core-blocks/test/fixtures/core__quote__style-2.json
@@ -8,13 +8,9 @@
                 {
                     "children": {
                         "type": "p",
-                        "key": null,
-                        "ref": null,
                         "props": {
-                            "children": "There is no greater agony than bearing an untold story inside you."
-                        },
-                        "_owner": null,
-                        "_store": {}
+                            "children": [ "There is no greater agony than bearing an untold story inside you." ]
+                        }
                     }
                 }
             ],

--- a/core-blocks/test/fixtures/core__subhead.json
+++ b/core-blocks/test/fixtures/core__subhead.json
@@ -8,7 +8,7 @@
                 "This is a ",
                 {
                     "type": "em",
-                    "children": "subhead"
+                    "children": [ "subhead" ]
                 },
                 "."
             ]

--- a/core-blocks/test/fixtures/core__table.json
+++ b/core-blocks/test/fixtures/core__table.json
@@ -7,23 +7,23 @@
             "content": [
                 {
                     "type": "thead",
-                    "children": {
+                    "children": [ {
                         "type": "tr",
                         "children": [
                             {
                                 "type": "th",
-                                "children": "Version"
+                                "children": [ "Version" ]
                             },
                             {
                                 "type": "th",
-                                "children": "Musician"
+                                "children": [ "Musician" ]
                             },
                             {
                                 "type": "th",
-                                "children": "Date"
+                                "children": [ "Date" ]
                             }
                         ]
-                    }
+                    } ]
                 },
                 {
                     "type": "tbody",
@@ -33,21 +33,21 @@
                             "children": [
                                 {
                                     "type": "td",
-                                    "children": {
+                                    "children": [ {
                                         "type": "a",
                                         "attributes": {
                                             "href": "https://wordpress.org/news/2003/05/wordpress-now-available/"
                                         },
-                                        "children": ".70"
-                                    }
+                                        "children": [ ".70" ]
+                                    } ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "No musician chosen."
+                                    "children": [ "No musician chosen." ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "May 27, 2003"
+                                    "children": [ "May 27, 2003" ]
                                 }
                             ]
                         },
@@ -56,21 +56,21 @@
                             "children": [
                                 {
                                     "type": "td",
-                                    "children": {
+                                    "children": [ {
                                         "type": "a",
                                         "attributes": {
                                             "href": "https://wordpress.org/news/2004/01/wordpress-10/"
                                         },
-                                        "children": "1.0"
-                                    }
+                                        "children": [ "1.0" ]
+                                    } ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "Miles Davis"
+                                    "children": [ "Miles Davis" ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "January 3, 2004"
+                                    "children": [ "January 3, 2004" ]
                                 }
                             ]
                         },
@@ -86,17 +86,17 @@
                                             "attributes": {
                                                 "href": "https://codex.wordpress.org/WordPress_Versions"
                                             },
-                                            "children": "the full list"
+                                            "children": [ "the full list" ]
                                         }
                                     ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "…"
+                                    "children": [ "…" ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "…"
+                                    "children": [ "…" ]
                                 }
                             ]
                         },
@@ -105,21 +105,21 @@
                             "children": [
                                 {
                                     "type": "td",
-                                    "children": {
+                                    "children": [ {
                                         "type": "a",
                                         "attributes": {
                                             "href": "https://wordpress.org/news/2015/12/clifford/"
                                         },
-                                        "children": "4.4"
-                                    }
+                                        "children": [ "4.4" ]
+                                    } ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "Clifford Brown"
+                                    "children": [ "Clifford Brown" ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "December 8, 2015"
+                                    "children": [ "December 8, 2015" ]
                                 }
                             ]
                         },
@@ -128,21 +128,21 @@
                             "children": [
                                 {
                                     "type": "td",
-                                    "children": {
+                                    "children": [ {
                                         "type": "a",
                                         "attributes": {
                                             "href": "https://wordpress.org/news/2016/04/coleman/"
                                         },
-                                        "children": "4.5"
-                                    }
+                                        "children": [ "4.5" ]
+                                    } ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "Coleman Hawkins"
+                                    "children": [ "Coleman Hawkins" ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "April 12, 2016"
+                                    "children": [ "April 12, 2016" ]
                                 }
                             ]
                         },
@@ -151,21 +151,21 @@
                             "children": [
                                 {
                                     "type": "td",
-                                    "children": {
+                                    "children": [ {
                                         "type": "a",
                                         "attributes": {
                                             "href": "https://wordpress.org/news/2016/08/pepper/"
                                         },
-                                        "children": "4.6"
-                                    }
+                                        "children": [ "4.6" ]
+                                    } ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "Pepper Adams"
+                                    "children": [ "Pepper Adams" ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "August 16, 2016"
+                                    "children": [ "August 16, 2016" ]
                                 }
                             ]
                         },
@@ -174,21 +174,21 @@
                             "children": [
                                 {
                                     "type": "td",
-                                    "children": {
+                                    "children": [ {
                                         "type": "a",
                                         "attributes": {
                                             "href": "https://wordpress.org/news/2016/12/vaughan/"
                                         },
-                                        "children": "4.7"
-                                    }
+                                        "children": [ "4.7" ]
+                                    } ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "Sarah Vaughan"
+                                    "children": [ "Sarah Vaughan" ]
                                 },
                                 {
                                     "type": "td",
-                                    "children": "December 6, 2016"
+                                    "children": [ "December 6, 2016" ]
                                 }
                             ]
                         }

--- a/core-blocks/test/fixtures/core__text__converts-to-paragraph.json
+++ b/core-blocks/test/fixtures/core__text__converts-to-paragraph.json
@@ -8,7 +8,7 @@
                 "This is an old-style text block.  Changed to ",
                 {
                     "type": "code",
-                    "children": "paragraph"
+                    "children": [ "paragraph" ]
                 },
                 " in #2135."
             ],

--- a/core-blocks/test/fixtures/core__verse.json
+++ b/core-blocks/test/fixtures/core__verse.json
@@ -8,11 +8,12 @@
                 "A ",
                 {
                     "type": "em",
-                    "children": "verse"
+                    "children": [ "verse" ]
                 },
                 "…",
                 {
-                    "type": "br"
+					"type": "br",
+					"children": []
                 },
                 "And more!"
             ]

--- a/editor/components/rich-text/format.js
+++ b/editor/components/rich-text/format.js
@@ -7,8 +7,7 @@ import { nodeListToReact } from 'dom-react';
 /**
  * WordPress dependencies
  */
-import { renderToString } from '@wordpress/element';
-import { createSimpleElement } from '@wordpress/blocks';
+import { renderToString, createSimpleElement } from '@wordpress/element';
 
 /**
  * Transforms a WP Element to its corresponding HTML string.

--- a/editor/components/rich-text/format.js
+++ b/editor/components/rich-text/format.js
@@ -7,7 +7,8 @@ import { nodeListToReact } from 'dom-react';
 /**
  * WordPress dependencies
  */
-import { createElement, renderToString } from '@wordpress/element';
+import { renderToString } from '@wordpress/element';
+import { createSimpleElement } from '@wordpress/blocks';
 
 /**
  * Transforms a WP Element to its corresponding HTML string.
@@ -55,7 +56,7 @@ export function createTinyMCEElement( type, props, ...children ) {
 		return children;
 	}
 
-	return createElement(
+	return createSimpleElement(
 		type,
 		omitBy( props, ( _, key ) => key.indexOf( 'data-mce-' ) === 0 ),
 		...children

--- a/editor/components/rich-text/test/__snapshots__/format.js.snap
+++ b/editor/components/rich-text/test/__snapshots__/format.js.snap
@@ -12,12 +12,21 @@ exports[`createTinyMCEElement should render a TinyMCE element 1`] = `
 
 exports[`domToElement should return the corresponding element  1`] = `
 Array [
-  <div
-    className="container"
-  >
-    <strong>
-      content
-    </strong>
-  </div>,
+  Object {
+    "props": Object {
+      "children": Array [
+        Object {
+          "props": Object {
+            "children": Array [
+              "content",
+            ],
+          },
+          "type": "strong",
+        },
+      ],
+      "className": "container",
+    },
+    "type": "div",
+  },
 ]
 `;

--- a/editor/components/rich-text/test/format.js
+++ b/editor/components/rich-text/test/format.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * WordPress dependencies
  */
-import { createSimpleElement } from '@wordpress/blocks';
+import { createSimpleElement } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/editor/components/rich-text/test/format.js
+++ b/editor/components/rich-text/test/format.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * WordPress dependencies
  */
-import { createElement } from '@wordpress/element';
+import { createSimpleElement } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -59,8 +59,8 @@ describe( 'elementToString', () => {
 	} );
 
 	test( 'should return the HTML content ', () => {
-		const element = createElement( 'div', { className: 'container' },
-			createElement( 'strong', {}, 'content' )
+		const element = createSimpleElement( 'div', { className: 'container' },
+			createSimpleElement( 'strong', {}, 'content' )
 		);
 		expect( elementToString( element ) ).toBe( '<div class="container"><strong>content</strong></div>' );
 	} );

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -19,6 +19,7 @@ import {
 	flowRight,
 	isString,
 	upperFirst,
+	omit,
 } from 'lodash';
 
 /**
@@ -44,6 +45,24 @@ import serialize from './serialize';
  * @return {WPElement} Element.
  */
 export { createElement };
+
+/**
+ * Creates a simplified element representation.
+ *
+ * @param {string} type
+ * @param {Object} props
+ * @param {Array?} children
+ *
+ * @return {Object} Element.
+ */
+export function createSimpleElement( type, props, ...children ) {
+	return {
+		type, props: {
+			...omit( props, [ 'key' ] ),
+			children,
+		},
+	};
+}
 
 /**
  * Returns an object tracking a reference to a rendered element via its


### PR DESCRIPTION
This PR updates the RichText "element" format to use a simplified version of a React element instead of the whole object. This has the advantages:

 - Well defined format `{ type, props: { ...props, children }`
 - The Children prop is consistent: always an array
 - This is a serializable format: It can be used as a comment attribute, it can also be used in templates from PHP.

**Testing instructions**

 - Check that writing in text blocks (heading, paragraph, list, tables...) still works as expected
 - Save and reload these blocks
 - Check some transforms.

closes #4489

related #771 
