### PR TITLE
Blocks: Remove wrapping div from paragraph block

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -210,49 +210,47 @@ class ParagraphBlock extends Component {
 						isLargeText={ fontSize >= 18 }
 					/>
 				</InspectorControls>
-				<div>
-					<RichText
-						tagName="p"
-						className={ classnames( 'wp-block-paragraph', className, {
-							'has-background': backgroundColor.value,
-							'has-drop-cap': dropCap,
-							[ backgroundColor.class ]: backgroundColor.class,
-							[ textColor.class ]: textColor.class,
-						} ) }
-						style={ {
-							backgroundColor: backgroundColor.class ? undefined : backgroundColor.value,
-							color: textColor.class ? undefined : textColor.value,
-							fontSize: fontSize ? fontSize + 'px' : undefined,
-							textAlign: align,
-						} }
-						value={ content }
-						onChange={ ( nextContent ) => {
-							setAttributes( {
-								content: nextContent,
-							} );
-						} }
-						onSplit={ insertBlocksAfter ?
-							( before, after, ...blocks ) => {
-								if ( after ) {
-									blocks.push( createBlock( name, { content: after } ) );
-								}
+				<RichText
+					tagName="p"
+					className={ classnames( 'wp-block-paragraph', className, {
+						'has-background': backgroundColor.value,
+						'has-drop-cap': dropCap,
+						[ backgroundColor.class ]: backgroundColor.class,
+						[ textColor.class ]: textColor.class,
+					} ) }
+					style={ {
+						backgroundColor: backgroundColor.class ? undefined : backgroundColor.value,
+						color: textColor.class ? undefined : textColor.value,
+						fontSize: fontSize ? fontSize + 'px' : undefined,
+						textAlign: align,
+					} }
+					value={ content }
+					onChange={ ( nextContent ) => {
+						setAttributes( {
+							content: nextContent,
+						} );
+					} }
+					onSplit={ insertBlocksAfter ?
+						( before, after, ...blocks ) => {
+							if ( after ) {
+								blocks.push( createBlock( name, { content: after } ) );
+							}
 
-								insertBlocksAfter( blocks );
+							insertBlocksAfter( blocks );
 
-								if ( before ) {
-									setAttributes( { content: before } );
-								} else {
-									onReplace( [] );
-								}
-							} :
-							undefined
-						}
-						onMerge={ mergeBlocks }
-						onReplace={ this.onReplace }
-						onRemove={ () => onReplace( [] ) }
-						placeholder={ placeholder || __( 'Add text or type / to add content' ) }
-					/>
-				</div>
+							if ( before ) {
+								setAttributes( { content: before } );
+							} else {
+								onReplace( [] );
+							}
+						} :
+						undefined
+					}
+					onMerge={ mergeBlocks }
+					onReplace={ this.onReplace }
+					onRemove={ () => onReplace( [] ) }
+					placeholder={ placeholder || __( 'Add text or type / to add content' ) }
+				/>
 			</Fragment>
 		);
 	}

--- a/core-blocks/paragraph/test/__snapshots__/index.js.snap
+++ b/core-blocks/paragraph/test/__snapshots__/index.js.snap
@@ -3,31 +3,29 @@
 exports[`core/paragraph block edit matches snapshot 1`] = `
 <div>
    
-  <div>
-    <div
-      class="editor-rich-text"
-    >
+  <div
+    class="editor-rich-text"
+  >
+    <div>
       <div>
-        <div>
-          <div
-            class="components-autocomplete"
+        <div
+          class="components-autocomplete"
+        >
+          <p
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Add text or type / to add content"
+            aria-multiline="true"
+            class="wp-block-paragraph editor-rich-text__tinymce"
+            contenteditable="true"
+            data-is-placeholder-visible="true"
+            role="textbox"
+          />
+          <p
+            class="editor-rich-text__tinymce wp-block-paragraph"
           >
-            <p
-              aria-autocomplete="list"
-              aria-expanded="false"
-              aria-label="Add text or type / to add content"
-              aria-multiline="true"
-              class="wp-block-paragraph editor-rich-text__tinymce"
-              contenteditable="true"
-              data-is-placeholder-visible="true"
-              role="textbox"
-            />
-            <p
-              class="editor-rich-text__tinymce wp-block-paragraph"
-            >
-              Add text or type / to add content
-            </p>
-          </div>
+            Add text or type / to add content
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request is part of a performance audit of the paragraph block. It seeks to remove a wrapping `div` element which serves no purpose. It appears to have been originally used for assigning a node `ref` for use in a previous implementation of the contrast checker, which was later removed in #6088.

**Implementation notes:**

The changes may appear substantial, but it is merely the removal of the flattening of `RichText` by the removal of its `div` wrapper. No other changes are included.

**Testing instructions:**

Verify there are no regressions in the behavior of the paragraph block.