### PR TITLE
Post author selector: try downshift

### DIFF
--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -32,7 +32,10 @@ export class PostAuthor extends Component {
 		onUpdateAuthor( Number( id ) );
 	}
 
-	suggestAuthors( query ) {
+	suggestAuthors( query, args ) {
+		if ( ! args.isOpen ) {
+			return;
+		}
 		const payload = '?search=' + encodeURIComponent( query );
 		this.setState( { searching: true } );
 		apiRequest( { path: '/wp/v2/users' + payload } ).done( ( results ) => {

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -55,7 +55,6 @@ export class PostAuthor extends Component {
 		return (
 			currentPostAuthor && allAuthors &&
 			<PostAuthorCheck>
-				<label htmlFor={ selectId }>{ __( 'Author' ) }</label>
 				<Downshift
 					onChange={ this.setAuthorId }
 					itemToString={ ( author ) => ( author ? author.value : '' ) }
@@ -65,6 +64,7 @@ export class PostAuthor extends Component {
 					{ ( {
 						getInputProps,
 						getItemProps,
+						getLabelProps,
 						getMenuProps,
 						isOpen,
 						inputValue,
@@ -72,15 +72,13 @@ export class PostAuthor extends Component {
 						selectedItem,
 					} ) => (
 						<div>
-
-							<div>
-								<input id={ selectId } { ...getInputProps() } />
-								<span
-									className={ 'spinner' + ( isSearching ? ' is-active' : '' ) }
-									style={ { position: 'absolute', right: '10px' } }
-								/>
-							</div>
-							<ul className="editor-post-author__select" { ...getMenuProps() } >
+							<label { ...getLabelProps() }>{ __( 'Author' ) }</label>
+							<input { ...getInputProps() } />
+							<span
+								className={ 'spinner' + ( isSearching ? ' is-active' : '' ) }
+								style={ { position: 'absolute', right: '10px' } }
+							/>
+							<ul { ...getMenuProps() } >
 								{ isOpen ?
 									allAuthors
 										.map( ( author ) => ( { id: author.id, value: author.name } ) )
@@ -89,7 +87,6 @@ export class PostAuthor extends Component {
 											author.value.toLowerCase().includes( inputValue.toLowerCase() ) )
 										.map( ( author, index ) => (
 											<li
-												key={ author.id }
 												{ ...getItemProps( {
 													key: author.id,
 													index,

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -11,6 +11,11 @@ import { withSelect, withDispatch } from '@wordpress/data';
  */
 import PostAuthorCheck from './check';
 
+/**
+ * External dependencies
+ */
+import Downshift from 'downshift'
+
 export class PostAuthor extends Component {
 	constructor() {
 		super( ...arguments );
@@ -18,32 +23,70 @@ export class PostAuthor extends Component {
 		this.setAuthorId = this.setAuthorId.bind( this );
 	}
 
-	setAuthorId( event ) {
+	setAuthorId( selected ) {
+		console.log( selected );
 		const { onUpdateAuthor } = this.props;
-		const { value } = event.target;
-		onUpdateAuthor( Number( value ) );
+		const { id } = selected;
+		onUpdateAuthor( Number( id ) );
 	}
 
 	render() {
 		const { postAuthor, instanceId, authors } = this.props;
 		const selectId = 'post-author-selector-' + instanceId;
 
-		// Disable reason: A select with an onchange throws a warning
+		const authorName = authors
+			.filter( author => author.id === postAuthor )[0]
+			.name
 
 		/* eslint-disable jsx-a11y/no-onchange */
 		return (
 			<PostAuthorCheck>
 				<label htmlFor={ selectId }>{ __( 'Author' ) }</label>
-				<select
-					id={ selectId }
-					value={ postAuthor }
-					onChange={ this.setAuthorId }
-					className="editor-post-author__select"
+				<Downshift
+					onChange={this.setAuthorId}
+					itemToString={author => (author ? author.value : '')}
+					defaultInputValue={ authorName }
 				>
-					{ authors.map( ( author ) => (
-						<option key={ author.id } value={ author.id }>{ author.name }</option>
-					) ) }
-				</select>
+					{({
+						getInputProps,
+						getItemProps,
+						getLabelProps,
+						getMenuProps,
+						isOpen,
+						inputValue,
+						highlightedIndex,
+						selectedItem,
+					}) => (
+						<div>
+						<input id={ selectId } {...getInputProps()} />
+						<ul className="editor-post-author__select" {...getMenuProps()}>
+							{isOpen
+							? authors
+								.map( author => ( { id: author.id, value: author.name} ) )
+								.filter( author =>
+									! inputValue ||
+									author.value.toLowerCase().includes(inputValue.toLowerCase() ) )
+								.map( ( author, index) => (
+									<li
+									{ ...getItemProps( {
+										key: author.id,
+										index,
+										item: author,
+										style: {
+										backgroundColor:
+											highlightedIndex === index ? 'lightgray' : 'white',
+										fontWeight: selectedItem === author ? 'bold' : 'normal',
+										},
+									} ) }
+									>
+									{author.value}
+									</li>
+								))
+							: null}
+						</ul>
+						</div>
+					) }
+				</Downshift>
 			</PostAuthorCheck>
 		);
 		/* eslint-enable jsx-a11y/no-onchange */

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -33,12 +33,11 @@ export class PostAuthor extends Component {
 	}
 
 	suggestAuthors( query, populateResults ) {
-		if ( query.length < 2 ) {
-			return;
-		}
 		const payload = '?search=' + encodeURIComponent( query );
+		this.setState( { searching: true } );
 		apiRequest( { path: '/wp/v2/users' + payload } ).done( ( results ) => {
-			this.setState( results.map( ( author ) => ( author.name ) ) );
+			this.setState( { searching: false } );
+			this.setState( { authors: results.map( author => ( { id: author.id, name: author.name} ) ) } );
 		} );
  	}
 
@@ -47,10 +46,11 @@ export class PostAuthor extends Component {
 		const selectId = 'post-author-selector-' + instanceId;
 		const currentPostAuthor = author.length > 0 ? author[0].name : '';
 		const allAuthors = this.state && this.state.authors ? this.state.authors : authors;
+		const isSearching = this.state && this.state.searching;
 
 		/* eslint-disable jsx-a11y/no-onchange */
 		return (
-			currentPostAuthor &&
+			currentPostAuthor && allAuthors &&
 			<PostAuthorCheck>
 				<label htmlFor={ selectId }>{ __( 'Author' ) }</label>
 				<Downshift
@@ -70,32 +70,39 @@ export class PostAuthor extends Component {
 						selectedItem,
 					}) => (
 						<div>
-						<input id={ selectId } {...getInputProps()} />
-						<ul className="editor-post-author__select" {...getMenuProps()}>
-							{isOpen
-							? allAuthors
-								.map( author => ( { id: author.id, value: author.name} ) )
-								.filter( author =>
-									! inputValue ||
-									author.value.toLowerCase().includes(inputValue.toLowerCase() ) )
-								.map( ( author, index) => (
-									<li
-									{ ...getItemProps( {
-										key: author.id,
-										index,
-										item: author,
-										style: {
-										backgroundColor:
-											highlightedIndex === index ? 'lightgray' : 'white',
-										fontWeight: selectedItem === author ? 'bold' : 'normal',
-										},
-									} ) }
-									>
-									{author.value}
-									</li>
-								))
-							: null}
-						</ul>
+
+							<div>
+								<input id={ selectId } {...getInputProps()}  />
+								<span
+									className={ 'spinner' + ( isSearching ? ' is-active' : '' ) }
+									style={ { position: 'absolute', right: '10px' } }
+								/>
+							</div>
+							<ul className="editor-post-author__select" {...getMenuProps()}>
+								{isOpen
+								? allAuthors
+									.map( author => ( { id: author.id, value: author.name} ) )
+									.filter( author =>
+										! inputValue ||
+										author.value.toLowerCase().includes(inputValue.toLowerCase() ) )
+									.map( ( author, index) => (
+										<li
+										{ ...getItemProps( {
+											key: author.id,
+											index,
+											item: author,
+											style: {
+											backgroundColor:
+												highlightedIndex === index ? 'lightgray' : 'white',
+											fontWeight: selectedItem === author ? 'bold' : 'normal',
+											},
+										} ) }
+										>
+										{author.value}
+										</li>
+									))
+								: null}
+							</ul>
 						</div>
 					) }
 				</Downshift>

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -32,19 +32,19 @@ export class PostAuthor extends Component {
 		onUpdateAuthor( Number( id ) );
 	}
 
-	suggestAuthors( query, populateResults ) {
+	suggestAuthors( query ) {
 		const payload = '?search=' + encodeURIComponent( query );
 		this.setState( { searching: true } );
 		apiRequest( { path: '/wp/v2/users' + payload } ).done( ( results ) => {
 			this.setState( { searching: false } );
-			this.setState( { authors: results.map( author => ( { id: author.id, name: author.name} ) ) } );
+			this.setState( { authors: results.map( ( author ) => ( { id: author.id, name: author.name } ) ) } );
 		} );
- 	}
+	}
 
 	render() {
-		const { postAuthor, instanceId, authors, author } = this.props;
+		const { instanceId, authors, postAuthor } = this.props;
 		const selectId = 'post-author-selector-' + instanceId;
-		const currentPostAuthor = author.length > 0 ? author[0].name : '';
+		const currentPostAuthor = postAuthor.length > 0 ? postAuthor[ 0 ].name : '';
 		const allAuthors = this.state && this.state.authors ? this.state.authors : authors;
 		const isSearching = this.state && this.state.searching;
 
@@ -54,54 +54,54 @@ export class PostAuthor extends Component {
 			<PostAuthorCheck>
 				<label htmlFor={ selectId }>{ __( 'Author' ) }</label>
 				<Downshift
-					onChange={this.setAuthorId}
-					itemToString={author => (author ? author.value : '')}
+					onChange={ this.setAuthorId }
+					itemToString={ ( author ) => ( author ? author.value : '' ) }
 					defaultInputValue={ currentPostAuthor }
 					onInputValueChange={ debounce( this.suggestAuthors, 300 ) }
 				>
-					{({
+					{ ( {
 						getInputProps,
 						getItemProps,
-						getLabelProps,
 						getMenuProps,
 						isOpen,
 						inputValue,
 						highlightedIndex,
 						selectedItem,
-					}) => (
+					} ) => (
 						<div>
 
 							<div>
-								<input id={ selectId } {...getInputProps()}  />
+								<input id={ selectId } { ...getInputProps() } />
 								<span
 									className={ 'spinner' + ( isSearching ? ' is-active' : '' ) }
 									style={ { position: 'absolute', right: '10px' } }
 								/>
 							</div>
-							<ul className="editor-post-author__select" {...getMenuProps()}>
-								{isOpen
-								? allAuthors
-									.map( author => ( { id: author.id, value: author.name} ) )
-									.filter( author =>
-										! inputValue ||
-										author.value.toLowerCase().includes(inputValue.toLowerCase() ) )
-									.map( ( author, index) => (
-										<li
-										{ ...getItemProps( {
-											key: author.id,
-											index,
-											item: author,
-											style: {
-											backgroundColor:
-												highlightedIndex === index ? 'lightgray' : 'white',
-											fontWeight: selectedItem === author ? 'bold' : 'normal',
-											},
-										} ) }
-										>
-										{author.value}
-										</li>
-									))
-								: null}
+							<ul className="editor-post-author__select" { ...getMenuProps() } >
+								{ isOpen ?
+									allAuthors
+										.map( ( author ) => ( { id: author.id, value: author.name } ) )
+										.filter( ( author ) =>
+											! inputValue ||
+											author.value.toLowerCase().includes( inputValue.toLowerCase() ) )
+										.map( ( author, index ) => (
+											<li
+												key={ author.id }
+												{ ...getItemProps( {
+													key: author.id,
+													index,
+													item: author,
+													style: {
+														backgroundColor:
+															highlightedIndex === index ? 'lightgray' : 'white',
+														fontWeight: selectedItem === author ? 'bold' : 'normal',
+													},
+												} ) }
+											>
+												{ author.value }
+											</li>
+										) ) :
+									null }
 							</ul>
 						</div>
 					) }
@@ -115,9 +115,8 @@ export class PostAuthor extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			postAuthor: select( 'core/editor' ).getEditedPostAttribute( 'author' ),
+			postAuthor: select( 'core' ).getAuthor( select( 'core/editor' ).getEditedPostAttribute( 'author' ) ),
 			authors: select( 'core' ).getAuthors(),
-			author: select( 'core' ).getAuthor( select( 'core/editor' ).getEditedPostAttribute( 'author' ) ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4387,6 +4387,27 @@
 				"is-obj": "^1.0.0"
 			}
 		},
+		"downshift": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/downshift/-/downshift-2.0.7.tgz",
+			"integrity": "sha512-JMRUWhArX8QQZD63tZRNCayVQ4XjsnU4THcoM+kkHjKZ5Ce0dd1tXD+/oI1V5w6hRixcrS2Y9R/3CGvaBxcvIQ==",
+			"dev": true,
+			"requires": {
+				"prop-types": "^15.6.0"
+			},
+			"dependencies": {
+				"prop-types": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				}
+			}
+		},
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"cross-env": "3.2.4",
 		"deep-freeze": "0.0.1",
 		"doctrine": "2.1.0",
+		"downshift": "2.0.7",
 		"eslint": "4.16.0",
 		"eslint-config-wordpress": "2.0.0",
 		"eslint-plugin-jest": "21.5.0",

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -38,6 +38,9 @@ export async function* getAuthors() {
 
 /**
  * Requests author details from the REST API.
+ *
+ * @param {Object} state  State tree
+ * @param {number} id Author id.
  */
 export async function* getAuthor( state, id ) {
 	const author = await apiRequest( { path: `/wp/v2/users/${ id }` } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -32,8 +32,16 @@ export async function* getCategories() {
  * Requests authors from the REST API.
  */
 export async function* getAuthors() {
-	const users = await apiRequest( { path: '/wp/v2/users/?who=authors&per_page=-1' } );
+	const users = await apiRequest( { path: '/wp/v2/users/?who=authors&per_page=100' } );
 	yield receiveUserQuery( 'authors', users );
+}
+
+/**
+ * Requests author details from the REST API.
+ */
+export async function* getAuthor( state, id ) {
+	const author = await apiRequest( { path: `/wp/v2/users/${ id }` } );
+	yield receiveUserQuery( 'author', author );
 }
 
 /**

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -87,6 +87,17 @@ export function getAuthors( state ) {
 }
 
 /**
+ * Returns all the post author.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Array} Authors list.
+ */
+export function getAuthor( state ) {
+	return getUserQueryResults( state, 'author' );
+}
+
+/**
  * Returns all the users returned by a query ID.
  *
  * @param {Object} state   Data state.


### PR DESCRIPTION
## Description
This PR adds a selector implementation built with [downshift](https://github.com/paypal/downshift), an MIT licensed  `downshift` from PayPal which aims to provide "Primitives to build simple, flexible, WAI-ARIA compliant React autocomplete/dropdown/select/combobox components"

Addresses https://github.com/WordPress/gutenberg/issues/7384

## How has this been tested?
* Tried with small number and large number of users, added with `wp user generate --role=editor --count=12000`
* Tested using only keyboard to interact.
* Tested with voiceover, checking results announcements

## Screenshots <!-- if applicable -->
![](https://cl.ly/2R422W1i3k3g/Screen%20Recording%202018-06-22%20at%2008.56%20AM.gif)

## Types of changes
* include downshift, replacing author select
* grab 100 users by default from REST API, 

## Questions / Todo
* no special handling for smaller numbers of users, should we add that? eg use regular select element when < 50 users?
* aria strings should be passed thru our i18n function

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
