### PR TITLE
Fix arrows navigation in the block more options menu

### DIFF
--- a/components/navigable-container/README.md
+++ b/components/navigable-container/README.md
@@ -18,15 +18,6 @@ A callback invoked when the menu navigates to one of its children passing the in
 - Type: `Function`
 - Required: No
 
-### deep
-
-A boolean to look for navigable children in the direct children or any descendant. True means that any descendant can be considered navigable, and false means only direct children are considered.
-
-- Type: `Boolean`
-- Required: No
-- default: false
-
-
 ### cycle
 
 A boolean which tells the component whether or not to cycle from the end back to the beginning and vice versa.

--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -41,11 +41,9 @@ class NavigableContainer extends Component {
 	}
 
 	getFocusableContext( target ) {
-		const { deep = false, onlyBrowserTabstops } = this.props;
+		const { onlyBrowserTabstops } = this.props;
 		const finder = onlyBrowserTabstops ? focus.tabbable : focus.focusable;
-		const focusables = finder
-			.find( this.container )
-			.filter( ( node ) => deep || node.parentElement === this.container );
+		const focusables = finder.find( this.container );
 
 		const index = this.getFocusableIndex( focusables, target );
 		if ( index > -1 && target ) {
@@ -114,7 +112,6 @@ class NavigableContainer extends Component {
 					'eventToOffset',
 					'onNavigate',
 					'cycle',
-					'deep',
 					'onlyBrowserTabstops',
 				] ) }
 				onKeyDown={ this.onKeyDown }

--- a/components/navigable-container/test/index.js
+++ b/components/navigable-container/test/index.js
@@ -47,39 +47,6 @@ describe( 'NavigableMenu', () => {
 	it( 'vertical: should navigate by up and down', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
-			<NavigableMenu onNavigate={ ( index ) => currentIndex = index }>
-				<button id="btn1">One</button>
-				<button id="btn2">Two</button>
-				<button id="btn3">Three</button>
-			</NavigableMenu >
-		) );
-
-		simulateVisible( wrapper, '*' );
-
-		const container = wrapper.find( 'div' );
-		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
-
-		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
-			const interaction = fireKeyDown( container, keyCode );
-			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( interaction.stopped ).toBe( expectedStop );
-		}
-
-		assertKeyDown( DOWN, 1, true );
-		assertKeyDown( DOWN, 2, true );
-		assertKeyDown( DOWN, 0, true );
-		assertKeyDown( UP, 2, true );
-		assertKeyDown( UP, 1, true );
-		assertKeyDown( UP, 0, true );
-		assertKeyDown( LEFT, 0, false );
-		assertKeyDown( RIGHT, 0, false );
-		assertKeyDown( SPACE, 0, false );
-	} );
-
-	it( 'vertical: should navigate by up and down, and skip deep candidates', () => {
-		let currentIndex = 0;
-		const wrapper = mount( (
 			<NavigableMenu orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
 				<span tabIndex="-1" id="btn1">One</span>
 				<span tabIndex="-1" id="btn2">Two</span>
@@ -87,43 +54,7 @@ describe( 'NavigableMenu', () => {
 					<span id="btn-deep" tabIndex="-1">Deep</span>
 				</span>
 				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
-		) );
-
-		simulateVisible( wrapper, '*' );
-
-		const container = wrapper.find( 'div' );
-		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
-
-		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
-			const interaction = fireKeyDown( container, keyCode, false );
-			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( interaction.stopped ).toBe( expectedStop );
-		}
-
-		assertKeyDown( DOWN, 1, true );
-		assertKeyDown( DOWN, 2, true );
-		assertKeyDown( DOWN, 0, true );
-		assertKeyDown( UP, 2, true );
-		assertKeyDown( UP, 1, true );
-		assertKeyDown( UP, 0, true );
-		assertKeyDown( LEFT, 0, false );
-		assertKeyDown( RIGHT, 0, false );
-		assertKeyDown( SPACE, 0, false );
-	} );
-
-	it( 'vertical: should navigate by up and down, and explore deep candidates', () => {
-		let currentIndex = 0;
-		const wrapper = mount( (
-			<NavigableMenu deep={ true } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
-				<span tabIndex="-1" id="btn1">One</span>
-				<span tabIndex="-1" id="btn2">Two</span>
-				<span id="btn-deep-wrapper">
-					<span id="btn-deep" tabIndex="-1">Deep</span>
-				</span>
-				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			</NavigableMenu>
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -158,7 +89,7 @@ describe( 'NavigableMenu', () => {
 				<span tabIndex="-1" id="btn1">One</span>
 				<span tabIndex="-1" id="btn2">Two</span>
 				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			</NavigableMenu>
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -188,82 +119,13 @@ describe( 'NavigableMenu', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
 			<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-				<button id="btn1">One</button>
-				<button id="btn2">Two</button>
-				<button id="btn3">Three</button>
-			</NavigableMenu >
-		) );
-
-		simulateVisible( wrapper, '*' );
-
-		const container = wrapper.find( 'div' );
-		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
-
-		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
-			const interaction = fireKeyDown( container, keyCode, false );
-			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( interaction.stopped ).toBe( expectedStop );
-		}
-
-		assertKeyDown( RIGHT, 1, true );
-		assertKeyDown( RIGHT, 2, true );
-		assertKeyDown( RIGHT, 0, true );
-		assertKeyDown( LEFT, 2, true );
-		assertKeyDown( LEFT, 1, true );
-		assertKeyDown( LEFT, 0, true );
-		assertKeyDown( UP, 0, false );
-		assertKeyDown( DOWN, 0, false );
-		assertKeyDown( SPACE, 0, false );
-	} );
-
-	it( 'horizontal: should navigate by left and right, and skip deep candidates', () => {
-		let currentIndex = 0;
-		const wrapper = mount( (
-			<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
 				<span tabIndex="-1" id="btn1">One</span>
 				<span tabIndex="-1" id="btn2">Two</span>
 				<span id="btn-deep-wrapper">
 					<span id="btn-deep" tabIndex="-1">Deep</span>
 				</span>
 				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
-		) );
-
-		simulateVisible( wrapper, '*' );
-
-		const container = wrapper.find( 'div' );
-		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
-
-		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
-			const interaction = fireKeyDown( container, keyCode, false );
-			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( interaction.stopped ).toBe( expectedStop );
-		}
-
-		assertKeyDown( RIGHT, 1, true );
-		assertKeyDown( RIGHT, 2, true );
-		assertKeyDown( RIGHT, 0, true );
-		assertKeyDown( LEFT, 2, true );
-		assertKeyDown( LEFT, 1, true );
-		assertKeyDown( LEFT, 0, true );
-		assertKeyDown( UP, 0, false );
-		assertKeyDown( DOWN, 0, false );
-		assertKeyDown( SPACE, 0, false );
-	} );
-
-	it( 'horizontal: should navigate by left and right, and explore deep candidates', () => {
-		let currentIndex = 0;
-		const wrapper = mount( (
-			<NavigableMenu deep={ true } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-				<span tabIndex="-1" id="btn1">One</span>
-				<span tabIndex="-1" id="btn2">Two</span>
-				<span id="btn-deep-wrapper">
-					<span id="btn-deep" tabIndex="-1">Deep</span>
-				</span>
-				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			</NavigableMenu>
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -298,7 +160,7 @@ describe( 'NavigableMenu', () => {
 				<span tabIndex="-1" id="btn1">One</span>
 				<span tabIndex="-1" id="btn2">Two</span>
 				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			</NavigableMenu>
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -331,7 +193,7 @@ describe( 'NavigableMenu', () => {
 				<button id="btn1">One</button>
 				<button id="btn2">Two</button>
 				<button id="btn3">Three</button>
-			</NavigableMenu >
+			</NavigableMenu>
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -368,78 +230,12 @@ describe( 'TabbableContainer', () => {
 		const wrapper = mount( (
 			<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
 				<div className="section" id="section1" tabIndex="0">Section One</div>
-				<div className="section" id="section2a" tabIndex="0">Section Two</div>
-				<div className="section" id="section2b" tabIndex="-1">Section to Skip</div>
-				<div className="section" id="section3" tabIndex="0">Section Three</div>
-			</TabbableContainer >
-		) );
-
-		simulateVisible( wrapper, '*' );
-
-		const container = wrapper.find( 'div.wrapper' );
-		wrapper.getDOMNode().querySelector( '#section1' ).focus();
-
-		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedStop ) {
-			const interaction = fireKeyDown( container, keyCode, shiftKey );
-			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( interaction.stopped ).toBe( expectedStop );
-		}
-
-		assertKeyDown( TAB, false, 1, true );
-		assertKeyDown( TAB, false, 2, true );
-		assertKeyDown( TAB, false, 0, true );
-		assertKeyDown( TAB, true, 2, true );
-		assertKeyDown( TAB, true, 1, true );
-		assertKeyDown( TAB, true, 0, true );
-		assertKeyDown( SPACE, false, 0, false );
-	} );
-
-	it( 'should navigate by keypresses and overlook deep candidates', () => {
-		let currentIndex = 0;
-		const wrapper = mount( (
-			<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-				<div className="section" id="section1" tabIndex="0">Section One</div>
-				<div className="section" id="section2" tabIndex="0">Section Two</div>
-				<div className="deep-section">
-					<div className="section" id="section-deep" tabIndex="0">Section to Skip</div>
-				</div>
-				<div className="section" id="section3" tabIndex="0">Section Three</div>
-			</TabbableContainer >
-		) );
-
-		simulateVisible( wrapper, '*' );
-
-		const container = wrapper.find( 'div.wrapper' );
-		wrapper.getDOMNode().querySelector( '#section1' ).focus();
-
-		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedStop ) {
-			const interaction = fireKeyDown( container, keyCode, shiftKey );
-			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( interaction.stopped ).toBe( expectedStop );
-		}
-
-		assertKeyDown( TAB, false, 1, true );
-		assertKeyDown( TAB, false, 2, true );
-		assertKeyDown( TAB, false, 0, true );
-		assertKeyDown( TAB, true, 2, true );
-		assertKeyDown( TAB, true, 1, true );
-		assertKeyDown( TAB, true, 0, true );
-		assertKeyDown( SPACE, false, 0, false );
-	} );
-
-	it( 'should navigate by keypresses and explore deep candidates', () => {
-		let currentIndex = 0;
-		const wrapper = mount( (
-			<TabbableContainer deep={ true } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-				<div className="section" id="section1" tabIndex="0">Section One</div>
 				<div className="section" id="section2" tabIndex="0">Section Two</div>
 				<div className="deep-section-wrapper">
 					<div className="section" id="section-deep" tabIndex="0">Section to <strong>not</strong> skip</div>
 				</div>
 				<div className="section" id="section3" tabIndex="0">Section Three</div>
-			</TabbableContainer >
+			</TabbableContainer>
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -472,7 +268,7 @@ describe( 'TabbableContainer', () => {
 				<div className="section" id="section1" tabIndex="0">Section One</div>
 				<div className="section" id="section2" tabIndex="0">Section Two</div>
 				<div className="section" id="section3" tabIndex="0">Section Three</div>
-			</TabbableContainer >
+			</TabbableContainer>
 		) );
 
 		simulateVisible( wrapper, '*' );

--- a/components/slot-fill/slot.js
+++ b/components/slot-fill/slot.js
@@ -71,7 +71,7 @@ class Slot extends Component {
 		} );
 
 		return (
-			<div ref={ this.bindNode }>
+			<div ref={ this.bindNode } role="presentation">
 				{ isFunction( children ) ? children( fills.filter( Boolean ) ) : fills }
 			</div>
 		);

--- a/components/slot-fill/test/slot.js
+++ b/components/slot-fill/test/slot.js
@@ -41,7 +41,7 @@ describe( 'Slot', () => {
 			</Provider>
 		);
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div></div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation"></div>' );
 	} );
 
 	it( 'should render a string Fill', () => {
@@ -54,7 +54,7 @@ describe( 'Slot', () => {
 			</Provider>
 		);
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div>content</div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation">content</div>' );
 	} );
 
 	it( 'should render a Fill containing an element', () => {
@@ -67,7 +67,7 @@ describe( 'Slot', () => {
 			</Provider>
 		);
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div><span></span></div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation"><span></span></div>' );
 	} );
 
 	it( 'should render a Fill containing an array', () => {
@@ -80,7 +80,7 @@ describe( 'Slot', () => {
 			</Provider>
 		);
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div><span></span><div></div>text</div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation"><span></span><div></div>text</div>' );
 	} );
 
 	it( 'calls the functions passed as the Slot\'s fillProps in the Fill', () => {
@@ -118,7 +118,7 @@ describe( 'Slot', () => {
 			</Provider>
 		);
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div></div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation"></div>' );
 	} );
 
 	it( 'should render a string Fill with HTML wrapper when render props used', () => {
@@ -137,7 +137,7 @@ describe( 'Slot', () => {
 			</Provider>
 		);
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div><blockquote>content</blockquote></div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation"><blockquote>content</blockquote></div>' );
 	} );
 
 	it( 'should re-render Slot when not bubbling virtually', () => {
@@ -148,11 +148,11 @@ describe( 'Slot', () => {
 			</Provider>
 		);
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div>1</div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation">1</div>' );
 
 		element.find( 'button' ).simulate( 'click' );
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div>2</div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation">2</div>' );
 	} );
 
 	it( 'should render in expected order', () => {
@@ -185,6 +185,6 @@ describe( 'Slot', () => {
 			],
 		} );
 
-		expect( element.find( 'Slot > div' ).html() ).toBe( '<div>firstsecond</div>' );
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation">firstsecond</div>' );
 	} );
 } );

--- a/edit-post/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PluginPostPublishPanel renders fill properly 1`] = `
-<div>
+<div
+  role="presentation"
+>
   <PanelBody
     className="my-plugin-post-publish-panel"
     initialOpen={true}

--- a/edit-post/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PluginPostStatusInfo renders fill properly 1`] = `
-<div>
+<div
+  role="presentation"
+>
   <PanelRow
     className="my-plugin-post-status-info"
     key="1---0/.0"

--- a/edit-post/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
+++ b/edit-post/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PluginPrePublishPanel renders fill properly 1`] = `
-<div>
+<div
+  role="presentation"
+>
   <PanelBody
     className="my-plugin-pre-publish-panel"
     initialOpen={true}

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -93,7 +93,7 @@ export class BlockSettingsMenu extends Component {
 					} }
 					renderContent={ ( { onClose } ) => (
 						// Should this just use a DropdownMenu instead of a DropDown ?
-						<NavigableMenu className="editor-block-settings-menu__content">
+						<NavigableMenu className="editor-block-settings-menu__content" deep>
 							<_BlockSettingsMenuFirstItem.Slot fillProps={ { onClose } } />
 							{ count === 1 && <BlockModeToggle uid={ firstBlockUID } onToggle={ onClose } role="menuitem" /> }
 							{ count === 1 && <UnknownConverter uid={ firstBlockUID } role="menuitem" /> }

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -93,7 +93,7 @@ export class BlockSettingsMenu extends Component {
 					} }
 					renderContent={ ( { onClose } ) => (
 						// Should this just use a DropdownMenu instead of a DropDown ?
-						<NavigableMenu className="editor-block-settings-menu__content" deep>
+						<NavigableMenu className="editor-block-settings-menu__content">
 							<_BlockSettingsMenuFirstItem.Slot fillProps={ { onClose } } />
 							{ count === 1 && <BlockModeToggle uid={ firstBlockUID } onToggle={ onClose } role="menuitem" /> }
 							{ count === 1 && <UnknownConverter uid={ firstBlockUID } role="menuitem" /> }

--- a/editor/components/navigable-toolbar/index.js
+++ b/editor/components/navigable-toolbar/index.js
@@ -79,7 +79,6 @@ class NavigableToolbar extends Component {
 			<NavigableMenu
 				orientation="horizontal"
 				role="toolbar"
-				deep
 				ref={ this.bindNode }
 				onKeyDown={ this.switchOnKeyDown }
 				{ ...props }


### PR DESCRIPTION
## Description

Fixes the arrows navigation in the blocks More Options menu after recent changes in #7199 

The new slot/fill implementation of the first menu item broke arrows navigation, for more details please refer to the related issue #7443 

This PR tries to fix it passing the `deep` prop, which makes the menu get also the focusable element that are not direct children of the menu.

Also, to make sure the `<div>` element used by Slot is ignored by assistive technologies and the accessibility tree is "flattened" and made only by menu > menuitem, it uses a `role="presentation"` on the div. As with all the ARIA things, this doesn't affect anything for browsers as it's only used by assistive technologies. See the ARIA Authoring Practices, where `role="none"` (alias of `presentation`) is used to flatten the tree:
- https://www.w3.org/TR/wai-aria-practices/#menu
- https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-2/menubar-2.html
- https://www.w3.org/TR/wai-aria-1.1/#presentation

Ensuring to flatten the tree structure is important for the way assistive technologies perceive a menu, for example one of the reasons is they calculate and announce the number of items in the menu and their position:

![screenshot 11](https://user-images.githubusercontent.com/1682452/41782400-6b5b4e32-763a-11e8-8c49-416603e9e8f5.png)

## How has this been tested?
- npm test and updated snapshots
- tested with different browser / screen reader combos

To test:
- open a block More Option menu either by clicking on it or using the keyboard
- using the arrow keys, navigate through the menu items and check navigation works correctly


Fixes #7443 