### PR TITLE
Make sure autocompleted values make it into the block's saved content

### DIFF
--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { escapeRegExp, find, filter, map, debounce } from 'lodash';
+import 'element-closest';
 
 /**
  * WordPress dependencies

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -265,8 +265,6 @@ export class Autocomplete extends Component {
 			return;
 		}
 
-		this.reset();
-
 		if ( getOptionCompletion ) {
 			const completion = getOptionCompletion( option.value, range, query );
 
@@ -289,10 +287,20 @@ export class Autocomplete extends Component {
 				}
 			}
 		}
+
+		// Reset autocomplete state after insertion rather than before
+		// so insertion events don't cause the completion menu to redisplay.
+		this.reset();
 	}
 
 	reset() {
-		this.setState( this.constructor.getInitialState() );
+		const isMounted = !! this.node;
+
+		// Autocompletions may replace the block containing this component,
+		// so we make sure it is mounted before resetting the state.
+		if ( isMounted ) {
+			this.setState( this.constructor.getInitialState() );
+		}
 	}
 
 	resetWhenSuppressed() {

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -243,6 +243,16 @@ export class Autocomplete extends Component {
 			range.setStartAfter( child );
 		}
 		range.deleteContents();
+
+		let inputEvent;
+		if ( undefined !== window.InputEvent ) {
+			inputEvent = new window.InputEvent( 'input', { bubbles: true, cancelable: false } );
+		} else {
+			// IE11 doesn't provide an InputEvent constructor.
+			inputEvent = document.createEvent( 'UIEvent' );
+			inputEvent.initEvent( 'input', true /* bubbles */, false /* cancelable */ );
+		}
+		range.commonAncestorContainer.closest( '[contenteditable=true]' ).dispatchEvent( inputEvent );
 	}
 
 	select( option ) {


### PR DESCRIPTION
## Description

Potential fix for https://github.com/WordPress/gutenberg/issues/7444

When an autocompleter does an insert-at-caret, the block isn't notified of the change,
and so the content doesn't get updated unless the user carries on typing.

This change dispatches an input event, which the editable component listens for and updates the block's attributes.

## How has this been tested?

Carry out the steps shown in https://github.com/WordPress/gutenberg/issues/7444
and the username should be saved correctly.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
