### PR TITLE
fix: Show permalink editor in editor

### DIFF
--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -60,7 +60,7 @@ class PostPermalink extends Component {
 		const { isCopied, isEditingPermalink } = this.state;
 		const ariaLabel = isCopied ? __( 'Permalink copied' ) : __( 'Copy the permalink' );
 
-		if ( isNew || ! previewLink ) {
+		if ( isNew ) {
 			return null;
 		}
 
@@ -123,7 +123,13 @@ class PostPermalink extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isEditedPostNew, isPermalinkEditable, getEditedPostPreviewLink, getPermalink, isCurrentPostPublished } = select( 'core/editor' );
+		const {
+			isEditedPostNew,
+			isPermalinkEditable,
+			getEditedPostPreviewLink,
+			getPermalink,
+			isCurrentPostPublished,
+		} = select( 'core/editor' );
 		return {
 			isNew: isEditedPostNew(),
 			previewLink: getEditedPostPreviewLink(),

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -56,11 +56,11 @@ class PostPermalink extends Component {
 	}
 
 	render() {
-		const { isNew, previewLink, isEditable, samplePermalink, isPublished } = this.props;
+		const { isNew, postLink, isEditable, samplePermalink, isPublished } = this.props;
 		const { isCopied, isEditingPermalink } = this.state;
 		const ariaLabel = isCopied ? __( 'Permalink copied' ) : __( 'Copy the permalink' );
 
-		if ( isNew ) {
+		if ( isNew || ! postLink ) {
 			return null;
 		}
 
@@ -80,7 +80,7 @@ class PostPermalink extends Component {
 				{ ! isEditingPermalink &&
 					<Button
 						className="editor-post-permalink__link"
-						href={ ! isPublished ? previewLink : samplePermalink }
+						href={ ! isPublished ? postLink : samplePermalink }
 						target="_blank"
 						ref={ ( permalinkButton ) => this.permalinkButton = permalinkButton }
 					>
@@ -126,13 +126,16 @@ export default compose( [
 		const {
 			isEditedPostNew,
 			isPermalinkEditable,
-			getEditedPostPreviewLink,
+			getCurrentPost,
 			getPermalink,
 			isCurrentPostPublished,
 		} = select( 'core/editor' );
+
+		const { link } = getCurrentPost();
+
 		return {
 			isNew: isEditedPostNew(),
-			previewLink: getEditedPostPreviewLink(),
+			postLink: link,
 			isEditable: isPermalinkEditable(),
 			samplePermalink: getPermalink(),
 			isPublished: isCurrentPostPublished(),

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -445,17 +445,6 @@ export function getDocumentTitle( state ) {
 }
 
 /**
- * Returns a URL to preview the post being edited.
- *
- * @param {Object} state Global application state.
- *
- * @return {string} Preview URL.
- */
-export function getEditedPostPreviewLink( state ) {
-	return getCurrentPost( state ).preview_link || null;
-}
-
-/**
  * Returns a new reference when the inner blocks of a given block UID change.
  * This is used exclusively as a memoized selector dependant, relying on this
  * selector's shared return value and recursively those of its inner blocks

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -39,7 +39,6 @@ const {
 	hasAutosave,
 	isEditedPostEmpty,
 	isEditedPostBeingScheduled,
-	getEditedPostPreviewLink,
 	getBlockDependantsCacheBust,
 	getBlockName,
 	getBlock,
@@ -1311,26 +1310,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( isEditedPostBeingScheduled( state ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'getEditedPostPreviewLink', () => {
-		it( 'should return null if the post has not link yet', () => {
-			const state = {
-				currentPost: {},
-			};
-
-			expect( getEditedPostPreviewLink( state ) ).toBeNull();
-		} );
-
-		it( 'should return the correct url when the post object has a preview_link', () => {
-			const state = {
-				currentPost: {
-					preview_link: 'https://andalouses.com/?p=1&preview=true',
-				},
-			};
-
-			expect( getEditedPostPreviewLink( state ) ).toBe( 'https://andalouses.com/?p=1&preview=true' );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
Fixed the permalink editor not appearing. Fix #7467.

## How has this been tested?
Tested locally and saw the permalink editor appear as it used to in `v3.0.1`.

## Screenshots
![2018-06-22 19 29 21](https://user-images.githubusercontent.com/90871/41794011-e72796cc-7655-11e8-84ec-04cabd2242ab.gif)

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->