### PR TITLE
Implement core style of including revisions data on Post response

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -155,7 +155,7 @@ export function getCurrentPostId( state ) {
  * @return {number} Number of revisions.
  */
 export function getCurrentPostRevisionsCount( state ) {
-	return get( getCurrentPost( state ), [ 'revisions', 'count' ], 0 );
+	return get( getCurrentPost( state ), [ '_links', 'version-history', 0, 'count' ], 0 );
 }
 
 /**
@@ -167,7 +167,7 @@ export function getCurrentPostRevisionsCount( state ) {
  * @return {?number} ID of the last revision.
  */
 export function getCurrentPostLastRevisionId( state ) {
-	return get( getCurrentPost( state ), [ 'revisions', 'last_id' ], null );
+	return get( getCurrentPost( state ), [ '_links', 'predecessor', 0, 'id' ], null );
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -167,7 +167,7 @@ export function getCurrentPostRevisionsCount( state ) {
  * @return {?number} ID of the last revision.
  */
 export function getCurrentPostLastRevisionId( state ) {
-	return get( getCurrentPost( state ), [ '_links', 'predecessor', 0, 'id' ], null );
+	return get( getCurrentPost( state ), [ '_links', 'predecessor-version', 0, 'id' ], null );
 }
 
 /**

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -516,7 +516,7 @@ describe( 'selectors', () => {
 			const state = {
 				currentPost: {
 					_links: {
-						predecessor: [
+						'predecessor-version': [
 							{
 								id: 123,
 							},

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -515,8 +515,12 @@ describe( 'selectors', () => {
 		it( 'should return the last revision ID', () => {
 			const state = {
 				currentPost: {
-					revisions: {
-						last_id: 123,
+					_links: {
+						predecessor: [
+							{
+								id: 123,
+							},
+						],
 					},
 				},
 			};
@@ -537,8 +541,12 @@ describe( 'selectors', () => {
 		it( 'should return the number of revisions', () => {
 			const state = {
 				currentPost: {
-					revisions: {
-						count: 5,
+					_links: {
+						'version-history': [
+							{
+								count: 5,
+							},
+						],
 					},
 				},
 			};

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -369,7 +369,7 @@ function gutenberg_add_revisions_data_to_links( $response, $post, $request ) {
 		if ( $revisions_count > 0 ) {
 			$last_revision = array_shift( $revisions );
 
-			$new_links['predecessor'] = array(
+			$new_links['predecessor-version'] = array(
 				'href' => $orig_href . '/revisions/' . $last_revision,
 				'id'   => $last_revision,
 			);

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -353,16 +353,16 @@ function gutenberg_add_revisions_data_to_links( $response, $post, $request ) {
 	$new_links  = array();
 	$orig_links = $response->get_links();
 
-	if ( in_array( $post->post_type, array( 'post', 'page' ), true ) || post_type_supports( $post->post_type, 'revisions' ) ) {
+	if ( ! empty( $orig_links['version-history'] ) ) {
+		$version_history_link = array_shift( $orig_links['version-history'] );
 		// 'version-history' already exists and we don't want to duplicate it.
 		$response->remove_link( 'version-history' );
 
-		$orig_href       = ! empty( $orig_links['self'][0]['href'] ) ? $orig_links['self'][0]['href'] : null;
 		$revisions       = wp_get_post_revisions( $post->ID, array( 'fields' => 'ids' ) );
 		$revisions_count = count( $revisions );
 
 		$new_links['version-history'] = array(
-			'href'  => $orig_href . '/revisions',
+			'href'  => $version_history_link['href'],
 			'count' => $revisions_count,
 		);
 
@@ -370,7 +370,7 @@ function gutenberg_add_revisions_data_to_links( $response, $post, $request ) {
 			$last_revision = array_shift( $revisions );
 
 			$new_links['predecessor-version'] = array(
-				'href' => $orig_href . '/revisions/' . $last_revision,
+				'href' => $version_history_link['href'] . '/' . $last_revision,
 				'id'   => $last_revision,
 			);
 		}

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -414,4 +414,27 @@ class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 		$data = $response->get_data();
 		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
 	}
+
+	public function test_get_post_links_predecessor() {
+		$post_id = $this->factory->post->create();
+		wp_update_post(
+			array(
+				'post_content' => 'This content is marvelous.',
+				'ID'           => $post_id,
+			)
+		);
+		$revisions  = wp_get_post_revisions( $post_id );
+		$revision_1 = array_pop( $revisions );
+
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $post_id ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$links = $response->get_links();
+
+		$this->assertEquals( rest_url( '/wp/v2/posts/' . $post_id . '/revisions' ), $links['version-history'][0]['href'] );
+		$this->assertEquals( 1, $links['version-history'][0]['attributes']['count'] );
+
+		$this->assertEquals( rest_url( '/wp/v2/posts/' . $post_id . '/revisions/' . $revision_1->ID ), $links['predecessor'][0]['href'] );
+		$this->assertEquals( $revision_1->ID, $links['predecessor'][0]['attributes']['id'] );
+	}
 }

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -415,7 +415,7 @@ class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 		$this->assertEquals( 'rest_forbidden_per_page', $data['code'] );
 	}
 
-	public function test_get_post_links_predecessor() {
+	public function test_get_post_links_predecessor_version() {
 		$post_id = $this->factory->post->create();
 		wp_update_post(
 			array(
@@ -434,7 +434,7 @@ class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 		$this->assertEquals( rest_url( '/wp/v2/posts/' . $post_id . '/revisions' ), $links['version-history'][0]['href'] );
 		$this->assertEquals( 1, $links['version-history'][0]['attributes']['count'] );
 
-		$this->assertEquals( rest_url( '/wp/v2/posts/' . $post_id . '/revisions/' . $revision_1->ID ), $links['predecessor'][0]['href'] );
-		$this->assertEquals( $revision_1->ID, $links['predecessor'][0]['attributes']['id'] );
+		$this->assertEquals( rest_url( '/wp/v2/posts/' . $post_id . '/revisions/' . $revision_1->ID ), $links['predecessor-version'][0]['href'] );
+		$this->assertEquals( $revision_1->ID, $links['predecessor-version'][0]['attributes']['id'] );
 	}
 }


### PR DESCRIPTION
## Description

Incorporates core pattern of including revisions data on Post response

See https://core.trac.wordpress.org/ticket/44321#comment:9
Fixes #3258

## How has this been tested?

1. Create a new post.
2. Hit "Save Draft" a couple of times.
3. See revisions UI in post settings:

<img width="325" alt="image" src="https://user-images.githubusercontent.com/36432/41794972-0c387674-7616-11e8-9b5a-c35aa027f181.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
