### PR TITLE
Only save metaboxes when it's not an autosave

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -54,9 +54,20 @@ const effects = {
 		store.dispatch( setMetaBoxSavedData( dataPerLocation ) );
 
 		// Saving metaboxes when saving posts
+		const { isAutosavingPost } = select( 'core/editor' );
+		let shouldRequestMetaBoxUpdates = false;
 		subscribe( onChangeListener( select( 'core/editor' ).isSavingPost, ( isSavingPost ) => {
-			if ( ! isSavingPost ) {
+			// Only save metaboxes when this isn't an autosave.
+			if ( isSavingPost && ! isAutosavingPost( store.getState() ) ) {
+				shouldRequestMetaBoxUpdates = true;
+			}
+			// If a full save just completed, trigger metabox save.
+			if ( ! isSavingPost && shouldRequestMetaBoxUpdates ) {
 				store.dispatch( requestMetaBoxUpdates() );
+			}
+			// Regardless of which save just occurred, reset metabox save state.
+			if ( ! isSavingPost ) {
+				shouldRequestMetaBoxUpdates = false;
 			}
 		} ) );
 	},


### PR DESCRIPTION
## Description

Improves autosave behavior to disable accidental saving of metaboxes. Metaboxes should only be saved on full saves.

See conversation in https://wordpress.slack.com/archives/C02QB2JS7/p1529698040000346

Fixes #7135

## How has this been tested?

1. Open a new post in Gutenberg. Make sure your editor includes a metabox.
2. Type some text and wait for an autosave.
3. Type additional text and wait for a second autosave.
4. Hit "Save Draft" a first time.
5. Hit "Save Draft" a second time.

When the revision UI appears in Post Settings after step 5, it should indicate 2 revisions, not 4:

<img width="436" alt="image" src="https://user-images.githubusercontent.com/36432/41798211-ad93ac0e-7621-11e8-8704-7fdb2a84c085.png">

Previously, the two autosave events would trigger full save events / revision creation.

## Screenshots

![autosaving](https://user-images.githubusercontent.com/36432/41798189-9c42211a-7621-11e8-8f72-40189763b536.gif)

## Types of changes

Bug fix.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
