### PR TITLE
fix: Don't focus link in new NUX tooltip

### DIFF
--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -51,6 +51,16 @@ render(
 
 The component accepts the following props. Props not included in this set will be applied to the element wrapping Popover content.
 
+### focusFirstElement
+
+Focus the *first tabblable element* inside the `Popover` if `focusOnMount` is enabled. This is the default behaviour; set this flag to `false` to focus the container, requiring the user to manually tab to the first element inside the `Popover`.
+
+Has no effect if `focusOnMount` is set to `false`.
+
+- Type: `Boolean`
+- Required: No
+- Default: `true`
+
 ### focusOnMount
 
 By default, the popover will receive focus when it mounts. To suppress this behavior, assign `focusOnMount` to `false`. This should only be assigned when an appropriately accessible substitute behavior exists.

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -63,11 +63,15 @@ Has no effect if `focusOnMount` is set to `false`.
 
 ### focusOnMount
 
-By default, the popover will receive focus when it mounts. To suppress this behavior, assign `focusOnMount` to `false`. This should only be assigned when an appropriately accessible substitute behavior exists.
+By default, the *first tabblable element* in the popover will receive focus when it mounts. This is the same as setting `focusOnMount` to `"firstElement"`. If you want to focus the container instead, you can set `focusOnMount` to `"container"`.
 
-- Type: `Boolean`
+Set this prop to `false` to disable focus changing entirely. This should only be set when an appropriately accessible substitute behavior exists.
+
+**Deprecation notice:** Before Gutenberg 3.2 this value was `Boolean` and the value `true` was equivalent to `"firstElement"`. This behaviour is deprecated and will cause a console warning message.
+
+- Type: `String` or `Boolean`
 - Required: No
-- Default: `true`
+- Default: `"firstElement"`
 
 ### position
 

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -51,16 +51,6 @@ render(
 
 The component accepts the following props. Props not included in this set will be applied to the element wrapping Popover content.
 
-### focusFirstElement
-
-Focus the *first tabblable element* inside the `Popover` if `focusOnMount` is enabled. This is the default behaviour; set this flag to `false` to focus the container, requiring the user to manually tab to the first element inside the `Popover`.
-
-Has no effect if `focusOnMount` is set to `false`.
-
-- Type: `Boolean`
-- Required: No
-- Default: `true`
-
 ### focusOnMount
 
 By default, the *first tabblable element* in the popover will receive focus when it mounts. This is the same as setting `focusOnMount` to `"firstElement"`. If you want to focus the container instead, you can set `focusOnMount` to `"container"`.

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -8,7 +8,6 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
-import { focus } from '@wordpress/dom';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -109,10 +108,9 @@ class Popover extends Component {
 		// Related https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
 		const focusNode = ( domNode ) => setTimeout( () => domNode.focus() );
 
-		// Find first tabbable node within content and shift focus, falling
-		// back to the popover panel itself.
-		const firstTabbable = focus.tabbable.find( this.contentNode.current )[ 0 ];
-		focusNode( firstTabbable ? firstTabbable : this.contentNode.current );
+		// Focus the popover panel so further tips are easily navigated to via the
+		// keyboard.
+		focusNode( this.contentNode.current );
 	}
 
 	getAnchorRect() {

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 import { focus } from '@wordpress/dom';
 import { keycodes } from '@wordpress/utils';
 
@@ -98,9 +99,12 @@ class Popover extends Component {
 	focus() {
 		const { focusOnMount } = this.props;
 
-		// Boolean values for focusOnMount deprecated in 3.2.
 		if ( focusOnMount === true ) {
-			window.console.warn( '<Popover> component: focusOnMount should be false or a string as of Gutenberg 3.2. See: https://github.com/WordPress/gutenberg/tree/master/components/popover/README.md' );
+			deprecated( 'focusOnMount={ true }', {
+				version: '3.4',
+				alternative: 'focusOnMount="firstElement"',
+				plugin: 'Gutenberg',
+			} );
 		}
 
 		if ( ! focusOnMount || ! this.contentNode.current ) {
@@ -111,6 +115,8 @@ class Popover extends Component {
 		// Related https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
 		const focusNode = ( domNode ) => setTimeout( () => domNode.focus() );
 
+		// Boolean values for focusOnMount deprecated in 3.2–remove
+		// `focusOnMount === true` check in 3.4.
 		if ( focusOnMount === 'firstElement' || focusOnMount === true ) {
 			// Find first tabbable node within content and shift focus, falling
 			// back to the popover panel itself.

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -108,8 +108,8 @@ class Popover extends Component {
 		// Related https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
 		const focusNode = ( domNode ) => setTimeout( () => domNode.focus() );
 
-		// Focus the popover panel so further tips are easily navigated to via the
-		// keyboard.
+		// Focus the popover panel itself so items in the popover are easily
+		// accessed via keyboard navigation.
 		focusNode( this.contentNode.current );
 	}
 

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
+import { focus } from '@wordpress/dom';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -95,18 +96,23 @@ class Popover extends Component {
 	}
 
 	focus() {
-		const { focusOnMount = true } = this.props;
-		if ( ! focusOnMount ) {
-			return;
-		}
-
-		if ( ! this.contentNode.current ) {
+		const { focusFirstElement, focusOnMount } = this.props;
+		if ( ! focusOnMount || ! this.contentNode.current ) {
 			return;
 		}
 
 		// Without the setTimeout, the dom node is not being focused
 		// Related https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
 		const focusNode = ( domNode ) => setTimeout( () => domNode.focus() );
+
+		if ( focusFirstElement ) {
+			// Find first tabbable node within content and shift focus, falling
+			// back to the popover panel itself.
+			const firstTabbable = focus.tabbable.find( this.contentNode.current )[ 0 ];
+			focusNode( firstTabbable ? firstTabbable : this.contentNode.current );
+
+			return;
+		}
 
 		// Focus the popover panel itself so items in the popover are easily
 		// accessed via keyboard navigation.
@@ -193,12 +199,13 @@ class Popover extends Component {
 			children,
 			className,
 			onClickOutside = onClose,
-			noArrow = false,
+			noArrow,
 			// Disable reason: We generate the `...contentProps` rest as remainder
 			// of props which aren't explicitly handled by this component.
 			/* eslint-disable no-unused-vars */
 			position,
 			range,
+			focusFirstElement,
 			focusOnMount,
 			getAnchorRect,
 			expandOnMobile,
@@ -286,6 +293,12 @@ class Popover extends Component {
 		</span>;
 	}
 }
+
+Popover.defaultProps = {
+	focusFirstElement: true,
+	focusOnMount: true,
+	noArrow: false,
+};
 
 const PopoverContainer = Popover;
 

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -96,7 +96,13 @@ class Popover extends Component {
 	}
 
 	focus() {
-		const { focusFirstElement, focusOnMount } = this.props;
+		const { focusOnMount } = this.props;
+
+		// Boolean values for focusOnMount deprecated in 3.2.
+		if ( focusOnMount === true ) {
+			window.console.warn( '<Popover> component: focusOnMount should be false or a string as of Gutenberg 3.2. See: https://github.com/WordPress/gutenberg/tree/master/components/popover/README.md' );
+		}
+
 		if ( ! focusOnMount || ! this.contentNode.current ) {
 			return;
 		}
@@ -105,7 +111,7 @@ class Popover extends Component {
 		// Related https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
 		const focusNode = ( domNode ) => setTimeout( () => domNode.focus() );
 
-		if ( focusFirstElement ) {
+		if ( focusOnMount === 'firstElement' || focusOnMount === true ) {
 			// Find first tabbable node within content and shift focus, falling
 			// back to the popover panel itself.
 			const firstTabbable = focus.tabbable.find( this.contentNode.current )[ 0 ];
@@ -114,9 +120,15 @@ class Popover extends Component {
 			return;
 		}
 
-		// Focus the popover panel itself so items in the popover are easily
-		// accessed via keyboard navigation.
-		focusNode( this.contentNode.current );
+		if ( focusOnMount === 'container' ) {
+			// Focus the popover panel itself so items in the popover are easily
+			// accessed via keyboard navigation.
+			focusNode( this.contentNode.current );
+
+			return;
+		}
+
+		window.console.warn( `<Popover> component: focusOnMount argument "${ focusOnMount }" not recognized.` );
 	}
 
 	getAnchorRect() {
@@ -205,7 +217,6 @@ class Popover extends Component {
 			/* eslint-disable no-unused-vars */
 			position,
 			range,
-			focusFirstElement,
 			focusOnMount,
 			getAnchorRect,
 			expandOnMobile,
@@ -276,7 +287,7 @@ class Popover extends Component {
 
 		// Apply focus return behavior except when default focus on open
 		// behavior is disabled.
-		if ( false !== focusOnMount ) {
+		if ( ! focusOnMount ) {
 			content = <FocusManaged>{ content }</FocusManaged>;
 		}
 
@@ -295,8 +306,7 @@ class Popover extends Component {
 }
 
 Popover.defaultProps = {
-	focusFirstElement: true,
-	focusOnMount: true,
+	focusOnMount: 'firstElement',
 	noArrow: false,
 };
 

--- a/editor/components/rich-text/format-toolbar/index.js
+++ b/editor/components/rich-text/format-toolbar/index.js
@@ -221,7 +221,7 @@ class FormatToolbar extends Component {
 						<div className="editor-format-toolbar__link-container" style={ { ...focusPosition } }>
 							<Popover
 								position="bottom center"
-								focusOnMount={ !! isAddingLink ? 'firstElement' : false }
+								focusOnMount={ isAddingLink ? 'firstElement' : false }
 								key={ selectedNodeId /* Used to force rerender on change */ }
 							>
 								{ isAddingLink && (

--- a/editor/components/rich-text/format-toolbar/index.js
+++ b/editor/components/rich-text/format-toolbar/index.js
@@ -221,7 +221,7 @@ class FormatToolbar extends Component {
 						<div className="editor-format-toolbar__link-container" style={ { ...focusPosition } }>
 							<Popover
 								position="bottom center"
-								focusOnMount={ !! isAddingLink }
+								focusOnMount={ !! isAddingLink ? 'firstElement' : false }
 								key={ selectedNodeId /* Used to force rerender on change */ }
 							>
 								{ isAddingLink && (

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -50,7 +50,7 @@ export class DotTip extends Component {
 				className="nux-dot-tip"
 				position="middle right"
 				noArrow
-				focusOnMount
+				focusFirstElement={ false }
 				role="dialog"
 				aria-label={ __( 'Gutenberg tips' ) }
 				onClose={ onDismiss }

--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -50,7 +50,7 @@ export class DotTip extends Component {
 				className="nux-dot-tip"
 				position="middle right"
 				noArrow
-				focusFirstElement={ false }
+				focusOnMount="container"
 				role="dialog"
 				aria-label={ __( 'Gutenberg tips' ) }
 				onClose={ onDismiss }

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -4,8 +4,7 @@ exports[`DotTip should render correctly 1`] = `
 <Popover
   aria-label="Gutenberg tips"
   className="nux-dot-tip"
-  focusFirstElement={false}
-  focusOnMount={true}
+  focusOnMount="container"
   noArrow={true}
   onClick={[Function]}
   position="middle right"

--- a/nux/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/nux/components/dot-tip/test/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`DotTip should render correctly 1`] = `
 <Popover
   aria-label="Gutenberg tips"
   className="nux-dot-tip"
+  focusFirstElement={false}
   focusOnMount={true}
   noArrow={true}
   onClick={[Function]}


### PR DESCRIPTION
## Description
Changed the focus from the first element in the popover to the container. This is a good compromise between accessibility and style, plus I think it's a bit more intuitive.

Fix #7452.

## How has this been tested?
Tabbed and clicked through elements and container was always focused after creation.

## Screenshots
![2018-06-22 21 37 56](https://user-images.githubusercontent.com/90871/41798366-4c33e232-7665-11e8-9150-cd921d3c7639.gif)

## Types of changes
Bug fix I suppose; @karmatosed considered this undesired behaviour 😄

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->