### PR TITLE
fix: Improve "add block" text in NUX onboarding

### DIFF
--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -59,7 +59,7 @@ export function DefaultBlockAppender( {
 			<InserterWithShortcuts rootUID={ rootUID } layout={ layout } />
 			<Inserter position="top right">
 				<DotTip id="core/editor.inserter">
-					{ __( 'Welcome to the wonderful world of blocks! Click the “+” button (highlighted) to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!' ) }
+					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!' ) }
 				</DotTip>
 			</Inserter>
 		</div>

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -59,7 +59,7 @@ export function DefaultBlockAppender( {
 			<InserterWithShortcuts rootUID={ rootUID } layout={ layout } />
 			<Inserter position="top right">
 				<DotTip id="core/editor.inserter">
-					{ __( 'Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.' ) }
+					{ __( 'Welcome to the wonderful world of blocks! Click the “+” button (highlighted) to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!' ) }
 				</DotTip>
 			</Inserter>
 		</div>

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -59,7 +59,7 @@ export function DefaultBlockAppender( {
 			<InserterWithShortcuts rootUID={ rootUID } layout={ layout } />
 			<Inserter position="top right">
 				<DotTip id="core/editor.inserter">
-					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!' ) }
+					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!' ) }
 				</DotTip>
 			</Inserter>
 		</div>

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -42,7 +42,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
+      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
@@ -72,7 +72,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
+      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
@@ -102,7 +102,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
+      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -42,7 +42,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click the “+” button (highlighted) to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
+      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
@@ -72,7 +72,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click the “+” button (highlighted) to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
+      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
@@ -102,7 +102,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click the “+” button (highlighted) to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
+      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -42,7 +42,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.
+      Welcome to the wonderful world of blocks! Click the “+” button (highlighted) to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
@@ -72,7 +72,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.
+      Welcome to the wonderful world of blocks! Click the “+” button (highlighted) to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
@@ -102,7 +102,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
-      Welcome to the wonderful world of blocks! Click ‘Add block’ to insert different kinds of content—text, images, quotes, video, lists, and much more.
+      Welcome to the wonderful world of blocks! Click the “+” button (highlighted) to insert different kinds of content using blocks. There are blocks for text, images, lists, and more!
     </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>


### PR DESCRIPTION
Fixes #7506

## Description
Updated the text to reference the "+" button instead of a non-existent "Add Block" button; also took the time to fix the British quotes and clarify the language. 🇺🇸!!!

## How has this been tested?
Ran locally and updated jest snapshots.

## Screenshots <!-- if applicable -->

### Before
![screen shot 2018-06-22 at 10 32 14 am](https://user-images.githubusercontent.com/39980/41800545-ff6ce834-7643-11e8-8b8b-6e3753f8c66e.png)

### After
<img width="615" alt="screenshot 2018-06-23 17 32 25" src="https://user-images.githubusercontent.com/90871/41811693-38bf5be4-770c-11e8-83ed-76dfad3e26b9.png">


## Types of changes
Text changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->