### PR TITLE
Polish library just a teeeeensy bit

### DIFF
--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -99,10 +99,8 @@
 }
 
 .components-panel__icon {
-	color: $dark-gray-400;
-	margin-right: 5px;
-	position: relative;
-	top: -2px;
+	color: $dark-gray-500;
+	margin: -2px 6px -2px 0;
 }
 
 .components-panel__body-toggle-icon {

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -84,12 +84,16 @@ $block-inserter-search-height: 38px;
 
 	@include break-medium {
 		height: $block-inserter-content-height + $block-inserter-tabs-height;
-		box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
 	}
 
 	// Don't show the top border on the first panel, let the Search border be the border.
 	.components-panel__body:first-child {
 		border-top: none;
+	}
+
+	// Don't show the bottom border on the last panel, let hte library itself show the border.
+	.components-panel__body:last-child {
+		border-bottom: none;
 	}
 }
 


### PR DESCRIPTION
This PR does a few small things:

- It removes the "scroll shadow" that sat at the bottom. This was always created for MacOS hiding scrollbars to indicate more content, but was more an issue before there were collapsible panels. It also broke the physics of the shadow.
- It removes the bottom border on the last collapsible panel. That way it doesn't show a double border with the popover.
- It tweaks the color of the Shared icon to be the same as all other icons, and it positions it so a panel with an icon is no taller than a panel without one.

Before:

<img width="444" alt="screen shot 2018-06-25 at 09 28 32" src="https://user-images.githubusercontent.com/1204802/41836562-63626b02-785b-11e8-91dd-619b3a080e80.png">

After:

<img width="409" alt="screen shot 2018-06-25 at 09 34 15" src="https://user-images.githubusercontent.com/1204802/41836570-69909666-785b-11e8-852d-29cd55bf1d0c.png">

