### PR TITLE
Try fixing the sibling inserter

### DIFF
--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -21,7 +21,7 @@ class BlockInsertionPoint extends Component {
 
 		this.onBlurInserter = this.onBlurInserter.bind( this );
 		this.onFocusInserter = this.onFocusInserter.bind( this );
-		this.onClick = this.onClick.bind( this );
+		this.onMouseDown = this.onMouseDown.bind( this );
 	}
 
 	onFocusInserter( event ) {
@@ -40,7 +40,7 @@ class BlockInsertionPoint extends Component {
 		} );
 	}
 
-	onClick() {
+	onMouseDown() {
 		const { layout, rootUID, index, ...props } = this.props;
 		props.insertDefaultBlock( { layout }, rootUID, index );
 		props.startTyping();
@@ -62,7 +62,7 @@ class BlockInsertionPoint extends Component {
 						<IconButton
 							icon="insert"
 							className="editor-block-list__insertion-point-button"
-							onClick={ this.onClick }
+							onMouseDown={ this.onMouseDown }
 							label={ __( 'Insert block' ) }
 							onFocus={ this.onFocusInserter }
 							onBlur={ this.onBlurInserter }


### PR DESCRIPTION
This PR partially fixes #7508.

In #7220 we introduced a new behavior for the sibling inserter, which requires a click on the plus in the center as opposed to just clicking between two blocks. 

Turns out it was sort of a race condition between onClick and onMouseDown, the latter which fires first. So in a way, the Firefox and Safari behavior of selecting the block (which is selected onMouseDown) as opposed to clicking the sibling inserter was the correct one.

This PR "fixes" it by also making the sibling inserter use onMouseDown. But it's still labelled a try branch, as I'm not sure this is a kosher approach. If it is, we need to fix a regression this branch introduces on its own, which is that it doesn't set focus properly on the newly inserted block. 

Thoughts?