### PR TITLE
Make the button group button selector more specific

### DIFF
--- a/components/button-group/style.scss
+++ b/components/button-group/style.scss
@@ -1,9 +1,10 @@
 .components-button-group {
 	display: inline-block;
 
-	.components-button {
+	.components-button.is-button {
 		border-radius: 0;
-		& + .components-button {
+
+		& + .components-button.is-button {
 			margin-left: -1px;
 		}
 


### PR DESCRIPTION
## Description
Makes the button group nested button selector more specific, so the `border-radius` property is applied correctly. Fixes #7531.

## How has this been tested?
Manually in macOS Safari and Chrome

## Screenshots

Before:

![_untitled____add_new_page_ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/41850095-59c8705a-7851-11e8-95c2-05361e18e0b6.png)

After:

![_untitled____ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/41850253-e318bb6c-7851-11e8-8da2-0f3063dcfc8c.png)

## Types of changes

Modifies a CSS selector to be more specific, resolving an issue introduced in ce61b5933957fe7d11a7ebb69e9daf945d132bcd

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
