### PR TITLE
Use color styles on the editor even if the classes were not set

### DIFF
--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -100,8 +100,8 @@ class ButtonEdit extends Component {
 							}
 						) }
 						style={ {
-							backgroundColor: backgroundColor.class ? undefined : backgroundColor.value,
-							color: textColor.class ? undefined : textColor.value,
+							backgroundColor: backgroundColor.value,
+							color: textColor.value,
 						} }
 						keepPlaceholderOnFocus
 					/>

--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -219,8 +219,8 @@ class ParagraphBlock extends Component {
 						[ textColor.class ]: textColor.class,
 					} ) }
 					style={ {
-						backgroundColor: backgroundColor.class ? undefined : backgroundColor.value,
-						color: textColor.class ? undefined : textColor.value,
+						backgroundColor: backgroundColor.value,
+						color: textColor.value,
 						fontSize: fontSize ? fontSize + 'px' : undefined,
 						textAlign: align,
 					} }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/6585
Before the editor just used the same classes on the frontend to apply color styles. If the classes were not set the editor would not apply them.

While for frontend view the current behaviour is the expected, on the editor is the themes passed us the color value we should use it even if the class was not created. 


## How has this been tested?
Add a palette that sets a color without implementing the class, verify the color was used in the editor.
e.g:
```
		add_theme_support( 'editor-color-palette',
			array(
				'name' => 'test red',
				'color' => '#f00',
			)
		);
```