### PR TITLE
Make NUX tips stay open when the user clicks outside

### DIFF
--- a/nux/components/dot-tip/index.js
+++ b/nux/components/dot-tip/index.js
@@ -53,7 +53,6 @@ export class DotTip extends Component {
 				focusOnMount
 				role="dialog"
 				aria-label={ __( 'Gutenberg tips' ) }
-				onClose={ onDismiss }
 				onClick={ ( event ) => event.stopPropagation() }
 			>
 				<p>{ children }</p>


### PR DESCRIPTION
Fixes #7447.

![tips](https://user-images.githubusercontent.com/612155/41883414-e380c3ca-7931-11e8-9166-2858df4a8f04.gif)
