### PR TITLE
Date package: Keep updated localeData in momentLib

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -213,6 +213,7 @@ function gutenberg_register_scripts_and_styles() {
 				/* translators: %s: duration */
 				'past'   => __( '%s ago', 'default' ),
 			),
+			'start_of_week' => get_option( 'start_of_week', 0 ),
 		),
 		'formats'  => array(
 			'time'     => get_option( 'time_format', __( 'g:i a', 'default' ) ),

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -71,8 +71,10 @@ export function setSettings( dateSettings ) {
 			y: 'a year',
 			yy: '%d years',
 		},
+		week: {
+			dow: dateSettings.l10n.start_of_week,
+		},
 	} );
-	momentLib.locale( currentLocale );
 
 	setupWPTimezone();
 }


### PR DESCRIPTION
## Description
This PR modifies `wp.date.setSettings` such that `momentLib` retains updated `i18n` data when a page initially sets settings.

Currently the code correctly updates `momentLib` with locale data from settings but simply switches back to the `currentLocale` which will always be the default "en". 

I'm not entirely sure why this code was there in the first place. Git blame didn't reveal much so I can't see the history there. 

## Testing instructions

1. Switch languages to something other than English
2. Open the console to any page with Gutenberg
3. Copy/paste the following code into the console
```js
var dateFormat = wp.date.getSettings().formats.date;
var today = wp.date.moment();
wp.date.date( dateFormat, today );
```
If using French, the output should be `"26 juin 2018"`. 
The master branch will output the default language "en" `"26 June 2018"`.

Alternatively, you can paste `moment.localeData()` and view `momentLib`'s data. It should reflect the language setting in site settings.

## Types of changes
This changes introduced allow the `moment` global to reflect language settings in site settings

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

cc @gziolo 