### PR TITLE
Fix box sizing for pseudo elements.

### DIFF
--- a/core-blocks/image/editor.scss
+++ b/core-blocks/image/editor.scss
@@ -30,7 +30,6 @@
 	height: 16px !important;
 	position: absolute;
 	background: theme( primary );
-	box-sizing: border-box;
 
 	.wp-block-image.is-focused & {
 		display: block;

--- a/core-blocks/spacer/editor.scss
+++ b/core-blocks/spacer/editor.scss
@@ -17,7 +17,6 @@
 	position: absolute;
 	background: theme( primary );
 	padding: 0 3px 3px 0;
-	box-sizing: border-box;
 	cursor: se-resize;
 	left: 50% !important;
 	margin-left: -7.5px;

--- a/core-blocks/text-columns/style.scss
+++ b/core-blocks/text-columns/style.scss
@@ -6,7 +6,6 @@
 	}
 
 	.wp-block-column {
-		box-sizing: border-box;
 		margin: 0 16px;
 		padding: 0;
 

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -76,10 +76,12 @@ body.gutenberg-editor-page {
 }
 
 .gutenberg {
+	box-sizing: border-box;
+
 	*,
 	*:before,
 	*:after {
-		box-sizing: border-box;
+		box-sizing: inherit;
 	}
 
 	select {

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -76,7 +76,9 @@ body.gutenberg-editor-page {
 }
 
 .gutenberg {
-	* {
+	*,
+	*:before,
+	*:after {
 		box-sizing: border-box;
 	}
 

--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -9,7 +9,8 @@
 	 * other elements (such as .button) are unaffected by Gutenberg's style
 	 * because of their higher specificity.
 	 */
-	* {
+	&__container,
+	.inside {
 		box-sizing: content-box;
 	}
 

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -12,7 +12,6 @@
 	border: 1px solid $dark-opacity-light-500;
 	border-bottom: none;
 	background-clip: padding-box;
-	box-sizing: padding-box;
 
 	// put toolbar snugly to edge on mobile
 	margin-left: -$block-padding - 1px;	// stack borders

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -118,7 +118,6 @@ $color-palette-circle-spacing: 14px;
 }
 
 .components-color-palette__custom-color .components-color-palette__custom-color-gradient:before {
-	box-sizing: border-box;
 	content: '';
 	filter: blur( 6px ) saturate( 0.7 ) brightness( 1.1 );
 	display: block;

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -27,7 +27,6 @@ $toggle-border-width: 2px;
 		content: '';
 		display: inline-block;
 		vertical-align: top;
-		box-sizing: border-box;
 		background-color: $white;
 		border: $toggle-border-width solid $dark-gray-300;
 		width: $toggle-width;

--- a/packages/components/src/range-control/style.scss
+++ b/packages/components/src/range-control/style.scss
@@ -31,7 +31,6 @@
 	background: $dark-gray-500;
 	border: 4px solid transparent;
 	background-clip: padding-box;
-	box-sizing: border-box;
 }
 
 @mixin range-track() {


### PR DESCRIPTION
This PR tries to fix #6513.

In my testing, this has no adverse side-effects, but like the original ticket reporter suggests, we need to verify that there are no visual regressions. It would be good to test:

- metaboxes
- plugins
- all breakpoints
- browsers
- IE

The point of this is to ensure consistent behavior. If we're changing the box sizing behavior for basic elements, we should do it for pseudo elements also.