### PR TITLE
Improve publish panel accessibility; Add new publish landmark region;

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -30,7 +30,7 @@ $z-layers: (
 	// Side UI active buttons
 	'.editor-block-settings-remove': 1,
 	'.editor-block-mover__control': 1,
-	
+
 	// Should have lower index than anything else positioned inside the block containers
 	'.editor-block-list__block-draggable': 0,
 
@@ -77,6 +77,7 @@ $z-layers: (
 	'.components-autocomplete__results': 1000000,
 
 	'.skip-to-selected-block': 100000,
+	'.edit-post-toggle-publish-panel': 100000,
 
 	// Show NUX tips above popovers, wp-admin menus, submenus, and sidebar:
 	'.nux-dot-tip': 1000001,

--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -115,3 +115,29 @@
 .edit-post-layout .editor-post-publish-panel__header-publish-button {
 	margin-right: 52px; // This number is approximative to keep the publish button at the same position when opening the panel
 }
+
+.edit-post-toggle-publish-panel {
+	display: block;
+	position: relative;
+	float: right;
+	top: -9999em;
+	z-index: z-index( '.edit-post-toggle-publish-panel' );
+	padding: 20px 0 0 0;
+	width: $sidebar-width;
+	&:focus-within {
+		top: 0;
+	}
+
+	.edit-post-toggle-publish-panel__button {
+		float: right;
+		width: auto;
+		height: auto;
+		font-size: 14px;
+		font-weight: 600;
+		padding: 15px 23px 14px;
+		line-height: normal;
+		text-decoration: none;
+		outline: none;
+		background: #f1f1f1;
+	}
+}

--- a/editor/components/post-publish-button/index.js
+++ b/editor/components/post-publish-button/index.js
@@ -7,57 +7,70 @@ import { noop, get } from 'lodash';
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { compose } from '@wordpress/element';
+import { compose, Component, createRef } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import PublishButtonLabel from './label';
-
-export function PostPublishButton( {
-	isSaving,
-	onStatusChange,
-	onSave,
-	isBeingScheduled,
-	visibility,
-	isPublishable,
-	isSaveable,
-	hasPublishAction,
-	onSubmit = noop,
-	forceIsSaving,
-} ) {
-	const isButtonEnabled = isPublishable && isSaveable;
-
-	let publishStatus;
-	if ( ! hasPublishAction ) {
-		publishStatus = 'pending';
-	} else if ( isBeingScheduled ) {
-		publishStatus = 'future';
-	} else if ( visibility === 'private' ) {
-		publishStatus = 'private';
-	} else {
-		publishStatus = 'publish';
+export class PostPublishButton extends Component {
+	constructor( props ) {
+		super( props );
+		this.buttonNode = createRef();
+	}
+	componentDidMount() {
+		if ( this.props.focusOnMount ) {
+			this.buttonNode.current.focus();
+		}
 	}
 
-	const onClick = () => {
-		onSubmit();
-		onStatusChange( publishStatus );
-		onSave();
-	};
+	render() {
+		const {
+			isSaving,
+			onStatusChange,
+			onSave,
+			isBeingScheduled,
+			visibility,
+			isPublishable,
+			isSaveable,
+			hasPublishAction,
+			onSubmit = noop,
+			forceIsSaving,
+		} = this.props;
+		const isButtonEnabled = isPublishable && isSaveable;
 
-	return (
-		<Button
-			className="editor-post-publish-button"
-			isPrimary
-			isLarge
-			onClick={ onClick }
-			disabled={ ! isButtonEnabled }
-			isBusy={ isSaving }
-		>
-			<PublishButtonLabel forceIsSaving={ forceIsSaving } />
-		</Button>
-	);
+		let publishStatus;
+		if ( ! hasPublishAction ) {
+			publishStatus = 'pending';
+		} else if ( isBeingScheduled ) {
+			publishStatus = 'future';
+		} else if ( visibility === 'private' ) {
+			publishStatus = 'private';
+		} else {
+			publishStatus = 'publish';
+		}
+
+		const onClick = () => {
+			onSubmit();
+			onStatusChange( publishStatus );
+			onSave();
+		};
+
+		return (
+			<Button
+				ref={ this.buttonNode }
+				className="editor-post-publish-button"
+				isPrimary
+				isLarge
+				onClick={ onClick }
+				disabled={ ! isButtonEnabled }
+				isBusy={ isSaving }
+			>
+				<PublishButtonLabel forceIsSaving={ forceIsSaving } />
+			</Button>
+		);
+	}
 }
 
 export default compose( [

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -62,14 +62,14 @@ class PostPublishPanel extends Component {
 	}
 
 	render() {
-		const { isScheduled, onClose, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension } = this.props;
+		const { isScheduled, onClose, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension, ...additionalProps } = this.props;
 		const { loading, submitted } = this.state;
 		return (
-			<div className="editor-post-publish-panel">
+			<div className="editor-post-publish-panel" { ...additionalProps }>
 				<div className="editor-post-publish-panel__header">
 					{ ! submitted && (
 						<div className="editor-post-publish-panel__header-publish-button">
-							<PostPublishButton onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
+							<PostPublishButton focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
 						</div>
 					) }
 					{ submitted && (
@@ -78,6 +78,7 @@ class PostPublishPanel extends Component {
 						</div>
 					) }
 					<IconButton
+						aria-expanded={ true }
 						onClick={ onClose }
 						icon="no-alt"
 						label={ __( 'Close Publish Panel' ) }


### PR DESCRIPTION
## Description
This PR makes a series of changes to make publish panel more accessible. The PR tries to follow the ideas discussed during WCEU contributors day and Accessibility chats on Wordpress slack.
Tries to address most parts of https://github.com/WordPress/gutenberg/issues/4187.

## Types of changes
Adds a new Publish landmark. When publish panel is visible the publish landmark contains the Publish panel. When the panel is hidden nothing is visible, unless we focus the landmark using Gutenberg landmark navigation (control + < or control + `) or we focus the button using tab, in this cases a button to open publish panel appears.

We automatically focus the contents of the publish panel when we open it. The first element of the Panel is the publish button, so it gets focused.

We now don't render other sidebars if the publish panel is visible. The other sidebars were not visible, but they were tabbable making keyboard users experience sub-optimal.

Added aria-expanded true to the close button on publishing panel. This button allows collapsing the panel so I feel it should have this aria property.


![jun-26-2018 17-46-58](https://user-images.githubusercontent.com/11271197/41927129-33df06ec-7969-11e8-8cde-9c1940479803.gif)


![jun-26-2018 17-43-35](https://user-images.githubusercontent.com/11271197/41927134-39c1f510-7969-11e8-9060-98d1b88bc8eb.gif)

## How has this been tested?
I did some smoke testing and verified publish works as before.
I used voice over and verified the new publish landmark appears.
I used Gutenberg landmark navigation ( control + < or `) and checked I can now see a new zone that allows opening the publishing panel. I verified that if I press that button the publish panel appears and the publish button is focused.