### PR TITLE
Allow double quotes and template string sometimes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -130,7 +130,7 @@ module.exports = {
 			},
 			{
 				selector: 'ImportDeclaration[source.value="lodash"] Identifier.imported[name="memoize"]',
-				message: 'Use memize instead of Lodash\'s memoize',
+				message: "Use memize instead of Lodash's memoize",
 			},
 			{
 				selector: 'CallExpression[callee.object.name="page"][callee.property.name="waitFor"]',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -130,7 +130,7 @@ module.exports = {
 			},
 			{
 				selector: 'ImportDeclaration[source.value="lodash"] Identifier.imported[name="memoize"]',
-				message: "Use memize instead of Lodash's memoize",
+				message: 'Use memize instead of Lodash’s memoize',
 			},
 			{
 				selector: 'CallExpression[callee.object.name="page"][callee.property.name="waitFor"]',

--- a/core-blocks/categories/index.js
+++ b/core-blocks/categories/index.js
@@ -14,7 +14,7 @@ export const name = 'core/categories';
 export const settings = {
 	title: __( 'Categories' ),
 
-	description: __( "Display a list of all your site's categories." ),
+	description: __( 'Display a list of all your site’s categories.' ),
 
 	icon: 'list-view',
 

--- a/core-blocks/categories/index.js
+++ b/core-blocks/categories/index.js
@@ -14,7 +14,7 @@ export const name = 'core/categories';
 export const settings = {
 	title: __( 'Categories' ),
 
-	description: __( 'Display a list of all your site\'s categories.' ),
+	description: __( "Display a list of all your site's categories." ),
 
 	icon: 'list-view',
 

--- a/core-blocks/columns/index.js
+++ b/core-blocks/columns/index.js
@@ -66,7 +66,7 @@ export const settings = {
 		},
 	},
 
-	description: __( 'Add a block that displays content in multiple columns, then add whatever content blocks you\'d like.' ),
+	description: __( "Add a block that displays content in multiple columns, then add whatever content blocks you'd like." ),
 
 	supports: {
 		align: [ 'wide', 'full' ],

--- a/core-blocks/columns/index.js
+++ b/core-blocks/columns/index.js
@@ -66,7 +66,7 @@ export const settings = {
 		},
 	},
 
-	description: __( "Add a block that displays content in multiple columns, then add whatever content blocks you'd like." ),
+	description: __( 'Add a block that displays content in multiple columns, then add whatever content blocks you’d like.' ),
 
 	supports: {
 		align: [ 'wide', 'full' ],

--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -14,7 +14,7 @@ export const name = 'core/freeform';
 export const settings = {
 	title: __( 'Classic' ),
 
-	description: __( 'It\'s the classic WordPress editor and it\'s a block! Drop the editor right in.' ),
+	description: __( "It's the classic WordPress editor and it's a block! Drop the editor right in." ),
 
 	icon: 'editor-kitchensink',
 

--- a/core-blocks/freeform/index.js
+++ b/core-blocks/freeform/index.js
@@ -14,7 +14,7 @@ export const name = 'core/freeform';
 export const settings = {
 	title: __( 'Classic' ),
 
-	description: __( "It's the classic WordPress editor and it's a block! Drop the editor right in." ),
+	description: __( 'It’s the classic WordPress editor and it’s a block! Drop the editor right in.' ),
 
 	icon: 'editor-kitchensink',
 

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -93,7 +93,7 @@ const schema = {
 export const settings = {
 	title: __( 'Image' ),
 
-	description: __( 'They\'re worth 1,000 words! Insert a single image.' ),
+	description: __( "They're worth 1,000 words! Insert a single image." ),
 
 	icon: 'format-image',
 

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -93,7 +93,7 @@ const schema = {
 export const settings = {
 	title: __( 'Image' ),
 
-	description: __( "They're worth 1,000 words! Insert a single image." ),
+	description: __( 'They’re worth 1,000 words! Insert a single image.' ),
 
 	icon: 'format-image',
 

--- a/core-blocks/more/index.js
+++ b/core-blocks/more/index.js
@@ -20,7 +20,7 @@ export const name = 'core/more';
 export const settings = {
 	title: __( 'More' ),
 
-	description: __( `Want to show only part of this post on your blog's home page? Insert a "More" block where you want the split.` ),
+	description: __( 'Want to show only part of this post on your blog’s home page? Insert a "More" block where you want the split.' ),
 
 	icon: 'editor-insertmore',
 

--- a/core-blocks/more/index.js
+++ b/core-blocks/more/index.js
@@ -20,7 +20,7 @@ export const name = 'core/more';
 export const settings = {
 	title: __( 'More' ),
 
-	description: __( 'Want to show only part of this post on your blog\'s home page? Insert a "More" block where you want the split.' ),
+	description: __( `Want to show only part of this post on your blog's home page? Insert a "More" block where you want the split.` ),
 
 	icon: 'editor-insertmore',
 

--- a/core-blocks/subhead/index.js
+++ b/core-blocks/subhead/index.js
@@ -21,7 +21,7 @@ export const name = 'core/subhead';
 export const settings = {
 	title: __( 'Subheading' ),
 
-	description: __( 'What\'s a subhead? Smaller than a headline, bigger than basic text.' ),
+	description: __( "What's a subhead? Smaller than a headline, bigger than basic text." ),
 
 	icon: 'text',
 

--- a/core-blocks/subhead/index.js
+++ b/core-blocks/subhead/index.js
@@ -21,7 +21,7 @@ export const name = 'core/subhead';
 export const settings = {
 	title: __( 'Subheading' ),
 
-	description: __( "What's a subhead? Smaller than a headline, bigger than basic text." ),
+	description: __( 'What’s a subhead? Smaller than a headline, bigger than basic text.' ),
 
 	icon: 'text',
 

--- a/core-blocks/test/full-content.js
+++ b/core-blocks/test/full-content.js
@@ -146,7 +146,7 @@ describe( 'full post content fixture', () => {
 				).toEqual( parserOutputExpected );
 			} catch ( err ) {
 				throw new Error( format(
-					'File \'%s.parsed.json\' does not match expected value:\n\n%s',
+					"File '%s.parsed.json' does not match expected value:\n\n%s",
 					f,
 					err.message
 				) );
@@ -188,7 +188,7 @@ describe( 'full post content fixture', () => {
 				).toEqual( blocksExpected );
 			} catch ( err ) {
 				throw new Error( format(
-					'File \'%s.json\' does not match expected value:\n\n%s',
+					"File '%s.json' does not match expected value:\n\n%s",
 					f,
 					err.message
 				) );
@@ -214,7 +214,7 @@ describe( 'full post content fixture', () => {
 				expect( serializedActual ).toEqual( serializedExpected );
 			} catch ( err ) {
 				throw new Error( format(
-					'File \'%s.serialized.html\' does not match expected value:\n\n%s',
+					"File '%s.serialized.html' does not match expected value:\n\n%s",
 					f,
 					err.message
 				) );
@@ -253,7 +253,7 @@ describe( 'full post content fixture', () => {
 
 			if ( ! foundFixtures.length ) {
 				errors.push( format(
-					'Expected a fixture file called \'%s.html\' or \'%s__*.html\'.',
+					"Expected a fixture file called '%s.html' or '%s__*.html'.",
 					nameToFilename,
 					nameToFilename
 				) );
@@ -262,7 +262,7 @@ describe( 'full post content fixture', () => {
 			foundFixtures.forEach( ( fixture ) => {
 				if ( name !== fixture.firstBlock ) {
 					errors.push( format(
-						'Expected fixture file \'%s\' to test the \'%s\' block.',
+						"Expected fixture file '%s' to test the '%s' block.",
 						fixture.filename,
 						name
 					) );

--- a/docs/reference/coding-guidelines.md
+++ b/docs/reference/coding-guidelines.md
@@ -170,7 +170,11 @@ In almost all cases, a constant should be defined in the top-most scope of a fil
 
 ### Strings
 
-String literals should be declared with single-quotes *unless* the string itself contains a single-quote that would need to be escaped–in that case: use a double-quote. If the string contains a single-quote *and* a double-quote, you can use ES6 template strings to avoid escaping the quotes. In general, avoid backslash escaping quotes:
+String literals should be declared with single-quotes *unless* the string itself contains a single-quote that would need to be escaped–in that case: use a double-quote. If the string contains a single-quote *and* a double-quote, you can use ES6 template strings to avoid escaping the quotes.
+
+**Note:** The single-quote character (`'`) should never be used in place of an apostrophe (`’`) for words like `it’s` or `haven’t` in user-facing strings. For test code it's still encouraged to use a real apostrophe.
+
+In general, avoid backslash-escaping quotes:
 
 ```js
 // Bad:
@@ -180,18 +184,23 @@ const name = 'Matt';
 
 // Bad:
 const pet = 'Matt\'s dog';
-// Good:
+// Also bad (not using an apostrophe): 
 const pet = "Matt's dog";
+// Good:
+const pet = 'Matt’s dog';
+// Also good:
+const oddString = "She said 'This is odd.'";
+
+You should use ES6 Template Strings over string concatenation whenever possible:
+
+```js
+const name = 'Stacey';
 
 // Bad:
-const quotes = "I haven't a \"clue\".";
+alert( 'My name is ' + name + '.' );
 // Good:
-const quotes = `I haven't a "clue".`; 
+alert( `My name is ${ name }.` );
 ```
-
-This keeps strings as readable as possible.
-
-**Note:** Technically speaking, the single-quote character (`'`) should not be used in place of an apostrophe (`’`) for words like `it’s` or `haven’t`. That said, in many places, especially test code, the single-quote is used in place of an apostrophe for convenience.
 
 ## PHP
 

--- a/docs/reference/coding-guidelines.md
+++ b/docs/reference/coding-guidelines.md
@@ -190,6 +190,7 @@ const pet = "Matt's dog";
 const pet = 'Matt’s dog';
 // Also good:
 const oddString = "She said 'This is odd.'";
+```
 
 You should use ES6 Template Strings over string concatenation whenever possible:
 

--- a/docs/reference/coding-guidelines.md
+++ b/docs/reference/coding-guidelines.md
@@ -168,6 +168,31 @@ An exception to camel case is made for constant values which are never intended 
 
 In almost all cases, a constant should be defined in the top-most scope of a file. It is important to note that [JavaScript's `const` assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) is conceptually more limited than what is implied here, where a value assigned by `const` in JavaScript can in-fact be mutated, and is only protected against reassignment. A constant as defined in these coding guidelines applies only to values which are expected to never change, and is a strategy for developers to communicate intent moreso than it is a technical restriction.
 
+### Strings
+
+String literals should be declared with single-quotes *unless* the string itself contains a single-quote that would need to be escaped–in that case: use a double-quote. If the string contains a single-quote *and* a double-quote, you can use ES6 template strings to avoid escaping the quotes. In general, avoid backslash escaping quotes:
+
+```js
+// Bad:
+const name = "Matt";
+// Good:
+const name = 'Matt';
+
+// Bad:
+const pet = 'Matt\'s dog';
+// Good:
+const pet = "Matt's dog";
+
+// Bad:
+const quotes = "I haven't a \"clue\".";
+// Good:
+const quotes = `I haven't a "clue".`; 
+```
+
+This keeps strings as readable as possible.
+
+**Note:** Technically speaking, the single-quote character (`'`) should not be used in place of an apostrophe (`’`) for words like `it’s` or `haven’t`. That said, in many places, especially test code, the single-quote is used in place of an apostrophe for convenience.
+
 ## PHP
 
 We use

--- a/docs/tool/config.js
+++ b/docs/tool/config.js
@@ -32,12 +32,12 @@ module.exports = {
 			actions: [ path.resolve( root, 'packages/blocks/src/store/actions.js' ) ],
 		},
 		'core/editor': {
-			title: 'The Editor\'s Data',
+			title: 'The Editor’s Data',
 			selectors: [ path.resolve( root, 'editor/store/selectors.js' ) ],
 			actions: [ path.resolve( root, 'editor/store/actions.js' ) ],
 		},
 		'core/edit-post': {
-			title: 'The Editor\'s UI Data',
+			title: 'The Editor’s UI Data',
 			selectors: [ path.resolve( root, 'edit-post/store/selectors.js' ) ],
 			actions: [ path.resolve( root, 'edit-post/store/actions.js' ) ],
 		},

--- a/editor/components/autocompleters/test/block.js
+++ b/editor/components/autocompleters/test/block.js
@@ -82,7 +82,7 @@ describe( 'block', () => {
 		expect( labelComponents.at( 1 ).text() ).toBe( 'expected-text' );
 	} );
 
-	it( 'should derive isOptionDisabled from the item\'s isDisabled', () => {
+	it( "should derive isOptionDisabled from the item's isDisabled", () => {
 		const disabledInserterItem = {
 			name: 'core/foo',
 			title: 'foo',

--- a/editor/components/block-settings-menu/test/block-mode-toggle.js
+++ b/editor/components/block-settings-menu/test/block-mode-toggle.js
@@ -9,7 +9,7 @@ import { shallow } from 'enzyme';
 import { BlockModeToggle } from '../block-mode-toggle';
 
 describe( 'BlockModeToggle', () => {
-	it( 'should not render the HTML mode button if the block doesn\'t support it', () => {
+	it( "should not render the HTML mode button if the block doesn't support it", () => {
 		const wrapper = shallow(
 			<BlockModeToggle blockType={ { supports: { html: false } } } />
 		);

--- a/editor/components/post-author/test/check.js
+++ b/editor/components/post-author/test/check.js
@@ -49,7 +49,7 @@ describe( 'PostAuthorCheck', () => {
 		expect( wrapper.type() ).toBe( null );
 	} );
 
-	it( 'should not render anything if doesn\'t have author action', () => {
+	it( "should not render anything if doesn't have author action", () => {
 		const wrapper = shallow(
 			<PostAuthorCheck authors={ users } hasAssignAuthorAction={ false }>
 				authors
@@ -58,7 +58,7 @@ describe( 'PostAuthorCheck', () => {
 		expect( wrapper.type() ).toBe( null );
 	} );
 
-	it( 'should render  control', () => {
+	it( 'should render control', () => {
 		const wrapper = shallow(
 			<PostAuthorCheck authors={ users } hasAssignAuthorAction={ true }>
 				authors

--- a/editor/components/post-pending-status/test/check.js
+++ b/editor/components/post-pending-status/test/check.js
@@ -9,7 +9,7 @@ import { shallow } from 'enzyme';
 import { PostPendingStatusCheck } from '../check';
 
 describe( 'PostPendingStatusCheck', () => {
-	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
+	it( "should not render anything if the user doesn't have the right capabilities", () => {
 		const wrapper = shallow(
 			<PostPendingStatusCheck hasPublishAction={ false }>
 				status

--- a/editor/components/post-publish-panel/postpublish.js
+++ b/editor/components/post-publish-panel/postpublish.js
@@ -56,7 +56,7 @@ class PostPublishPanelPostpublish extends Component {
 			__( 'is now live.' );
 		const postPublishBodyText = isScheduled ?
 			__( 'The post address will be:' ) :
-			__( 'What\'s next?' );
+			__( "What's next?" );
 
 		return (
 			<div className="post-publish-panel__postpublish">

--- a/editor/components/post-publish-panel/postpublish.js
+++ b/editor/components/post-publish-panel/postpublish.js
@@ -56,7 +56,7 @@ class PostPublishPanelPostpublish extends Component {
 			__( 'is now live.' );
 		const postPublishBodyText = isScheduled ?
 			__( 'The post address will be:' ) :
-			__( "What's next?" );
+			__( 'What’s next?' );
 
 		return (
 			<div className="post-publish-panel__postpublish">

--- a/editor/components/post-publish-panel/prepublish.js
+++ b/editor/components/post-publish-panel/prepublish.js
@@ -26,7 +26,7 @@ function PostPublishPanelPrepublish( {
 	return (
 		<div className="editor-post-publish-panel__prepublish">
 			<div><strong>{ hasPublishAction ? __( 'Are you ready to publish?' ) : __( 'Are you ready to submit for review?' ) }</strong></div>
-			<p>{ hasPublishAction ? __( 'Here, you can do a last-minute check up of your settings below, before you publish.' ) : __( 'When you\'re ready, submit your work for review, and an Editor will be able to approve it for you.' ) }</p>
+			<p>{ hasPublishAction ? __( 'Here, you can do a last-minute check up of your settings below, before you publish.' ) : __( "When you're ready, submit your work for review, and an Editor will be able to approve it for you." ) }</p>
 			{ hasPublishAction && (
 				<Fragment>
 					<PanelBody initialOpen={ false } title={ [

--- a/editor/components/post-publish-panel/prepublish.js
+++ b/editor/components/post-publish-panel/prepublish.js
@@ -26,7 +26,7 @@ function PostPublishPanelPrepublish( {
 	return (
 		<div className="editor-post-publish-panel__prepublish">
 			<div><strong>{ hasPublishAction ? __( 'Are you ready to publish?' ) : __( 'Are you ready to submit for review?' ) }</strong></div>
-			<p>{ hasPublishAction ? __( 'Here, you can do a last-minute check up of your settings below, before you publish.' ) : __( "When you're ready, submit your work for review, and an Editor will be able to approve it for you." ) }</p>
+			<p>{ hasPublishAction ? __( 'Here, you can do a last-minute check up of your settings below, before you publish.' ) : __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' ) }</p>
 			{ hasPublishAction && (
 				<Fragment>
 					<PanelBody initialOpen={ false } title={ [

--- a/editor/components/post-schedule/test/check.js
+++ b/editor/components/post-schedule/test/check.js
@@ -9,7 +9,7 @@ import { shallow } from 'enzyme';
 import { PostScheduleCheck } from '../check';
 
 describe( 'PostScheduleCheck', () => {
-	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
+	it( "should not render anything if the user doesn't have the right capabilities", () => {
 		const wrapper = shallow( <PostScheduleCheck hasPublishAction={ false } >yes</PostScheduleCheck> );
 		expect( wrapper.type() ).toBe( null );
 	} );

--- a/editor/components/post-sticky/test/index.js
+++ b/editor/components/post-sticky/test/index.js
@@ -18,7 +18,7 @@ describe( 'PostSticky', () => {
 		expect( wrapper.type() ).toBe( null );
 	} );
 
-	it( 'should not render anything if post doesn\'t support stickying', () => {
+	it( "should not render anything if post doesn't support stickying", () => {
 		const wrapper = shallow(
 			<PostStickyCheck postType="post" hasStickyAction={ false }>
 				Can Toggle Sticky

--- a/editor/components/post-visibility/test/check.js
+++ b/editor/components/post-visibility/test/check.js
@@ -11,7 +11,7 @@ import { PostVisibilityCheck } from '../check';
 describe( 'PostVisibilityCheck', () => {
 	const render = ( { canEdit } ) => ( canEdit ? 'yes' : 'no' );
 
-	it( 'should not render the edit link if the user doesn\'t have the right capability', () => {
+	it( "should not render the edit link if the user doesn't have the right capability", () => {
 		const wrapper = shallow( <PostVisibilityCheck hasPublishAction={ false } render={ render } /> );
 		expect( wrapper.text() ).toBe( 'no' );
 	} );

--- a/editor/components/template-validation-notice/index.js
+++ b/editor/components/template-validation-notice/index.js
@@ -25,7 +25,7 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 
 	return (
 		<Notice className="editor-template-validation-notice" isDismissible={ false } status="warning">
-			<p>{ __( "The content of your post doesn't match the template assigned to your post type." ) }</p>
+			<p>{ __( 'The content of your post doesn’t match the template assigned to your post type.' ) }</p>
 			<div>
 				<Button isDefault onClick={ props.resetTemplateValidity }>{ __( 'Keep it as is' ) }</Button>
 				<Button onClick={ confirmSynchronization } isPrimary>{ __( 'Reset the template' ) }</Button>

--- a/editor/components/template-validation-notice/index.js
+++ b/editor/components/template-validation-notice/index.js
@@ -25,7 +25,7 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 
 	return (
 		<Notice className="editor-template-validation-notice" isDismissible={ false } status="warning">
-			<p>{ __( 'The content of your post doesn\'t match the template assigned to your post type.' ) }</p>
+			<p>{ __( "The content of your post doesn't match the template assigned to your post type." ) }</p>
 			<div>
 				<Button isDefault onClick={ props.resetTemplateValidity }>{ __( 'Keep it as is' ) }</Button>
 				<Button onClick={ confirmSynchronization } isPrimary>{ __( 'Reset the template' ) }</Button>

--- a/editor/components/theme-support-check/test/index.js
+++ b/editor/components/theme-support-check/test/index.js
@@ -9,7 +9,7 @@ import { shallow } from 'enzyme';
 import { ThemeSupportCheck } from '../index';
 
 describe( 'ThemeSupportCheck', () => {
-	it( 'should not render if there\'s no support check provided', () => {
+	it( "should not render if there's no support check provided", () => {
 		const wrapper = shallow( <ThemeSupportCheck>foobar</ThemeSupportCheck> );
 		expect( wrapper.type() ).toBe( null );
 	} );
@@ -37,7 +37,7 @@ describe( 'ThemeSupportCheck', () => {
 		expect( wrapper.type() ).not.toBe( null );
 	} );
 
-	it( 'should not render if post-thumbnails aren\'t supported for the post type', () => {
+	it( "should not render if post-thumbnails aren't supported for the post type", () => {
 		const themeSupports = {
 			'post-thumbnails': [ 'post' ],
 		};
@@ -61,7 +61,7 @@ describe( 'ThemeSupportCheck', () => {
 		expect( wrapper.type() ).toBe( null );
 	} );
 
-	it( 'should not render if theme doesn\'t support post-thumbnails', () => {
+	it( "should not render if theme doesn't support post-thumbnails", () => {
 		const themeSupports = {
 			'post-thumbnails': false,
 		};

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1968,7 +1968,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should update the shared block\'s id if it was temporary', () => {
+		it( "should update the shared block's id if it was temporary", () => {
 			const initialState = {
 				data: {
 					shared1: { clientId: '', title: '' },

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -395,7 +395,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getEditedPostAttribute', () => {
-		it( "should return the current post's slug if no edits have been made", () => {
+		it( 'should return the current post’s slug if no edits have been made', () => {
 			const state = {
 				currentPost: { slug: 'post slug' },
 				editor: {
@@ -3870,7 +3870,7 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		it( "should return undefined if settings for the block don't exist", () => {
+		it( 'should return undefined if settings for the block don’t exist', () => {
 			const state = {
 				blockListSettings: {},
 			};

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -395,7 +395,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getEditedPostAttribute', () => {
-		it( 'should return the current post\'s slug if no edits have been made', () => {
+		it( "should return the current post's slug if no edits have been made", () => {
 			const state = {
 				currentPost: { slug: 'post slug' },
 				editor: {
@@ -3870,7 +3870,7 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		it( 'should return undefined if settings for the block don\'t exist', () => {
+		it( "should return undefined if settings for the block don't exist", () => {
 			const state = {
 				blockListSettings: {},
 			};

--- a/eslint/config.js
+++ b/eslint/config.js
@@ -99,6 +99,7 @@ module.exports = {
 		'no-whitespace-before-property': 'error',
 		'object-curly-spacing': [ 'error', 'always' ],
 		'padded-blocks': [ 'error', 'never' ],
+		quotes: [ 'error', 'single', { allowTemplateLiterals: true, avoidEscape: true } ],
 		'quote-props': [ 'error', 'as-needed' ],
 		'react/display-name': 'off',
 		'react/jsx-curly-spacing': [ 'error', {

--- a/lib/class-wp-rest-blocks-controller.php
+++ b/lib/class-wp-rest-blocks-controller.php
@@ -108,12 +108,12 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 					'readonly'    => true,
 				),
 				'title'   => array(
-					'description' => __( 'The block\'s title.', 'gutenberg' ),
+					'description' => __( 'The block’s title.', 'gutenberg' ),
 					'type'        => 'string',
 					'required'    => true,
 				),
 				'content' => array(
-					'description' => __( 'The block\'s HTML content.', 'gutenberg' ),
+					'description' => __( 'The block’s HTML content.', 'gutenberg' ),
 					'type'        => 'string',
 					'required'    => true,
 				),

--- a/packages/api-fetch/src/middlewares/test/http-v1.js
+++ b/packages/api-fetch/src/middlewares/test/http-v1.js
@@ -15,7 +15,7 @@ describe( 'HTTP v1 Middleware', () => {
 		httpV1Middleware( { method: 'PUT', data: {} }, callback );
 	} );
 
-	it( 'shouldn\'t touch the options for GET requests', () => {
+	it( "shouldn't touch the options for GET requests", () => {
 		expect.hasAssertions();
 
 		const requestOptions = { method: 'GET', path: '/wp/v2/posts' };

--- a/packages/autop/src/test/index.test.js
+++ b/packages/autop/src/test/index.test.js
@@ -76,7 +76,7 @@ done = 0;
 	str = `Look at this code\n\n<pre>${ code }</pre>\n\nIsn't that cool?`;
 
 	// Expected text after autop
-	let expected = '<p>Look at this code</p>\n<pre>' + code + '</pre>\n<p>Isn\'t that cool?</p>';
+	let expected = `<p>Look at this code</p>\n<pre>${ code }</pre>\n<p>Isn't that cool?</p>`;
 	expect( autop( str ).trim() ).toBe( expected );
 
 	// Make sure HTML breaks are maintained if manually inserted

--- a/packages/babel-plugin-makepot/test/index.js
+++ b/packages/babel-plugin-makepot/test/index.js
@@ -56,37 +56,37 @@ describe( 'babel-plugin', () => {
 		}
 
 		it( 'should not return translator comment on same line but after call expression', () => {
-			const comment = getCommentFromString( '__( \'Hello world\' ); // translators: Greeting' );
+			const comment = getCommentFromString( "__( 'Hello world' ); // translators: Greeting" );
 
 			expect( comment ).toBeUndefined();
 		} );
 
 		it( 'should return translator comment on leading comments', () => {
-			const comment = getCommentFromString( '// translators: Greeting\n__( \'Hello world\' );' );
+			const comment = getCommentFromString( "// translators: Greeting\n__( 'Hello world' );" );
 
 			expect( comment ).toBe( 'Greeting' );
 		} );
 
 		it( 'should be case insensitive to translator prefix', () => {
-			const comment = getCommentFromString( '// TrANslAtORs: Greeting\n__( \'Hello world\' );' );
+			const comment = getCommentFromString( "// TrANslAtORs: Greeting\n__( 'Hello world' );" );
 
 			expect( comment ).toBe( 'Greeting' );
 		} );
 
 		it( 'should traverse up parents until it encounters comment', () => {
-			const comment = getCommentFromString( '// translators: Greeting\nconst string = __( \'Hello world\' );' );
+			const comment = getCommentFromString( "// translators: Greeting\nconst string = __( 'Hello world' );" );
 
 			expect( comment ).toBe( 'Greeting' );
 		} );
 
 		it( 'should not consider comment if it does not end on same or previous line', () => {
-			const comment = getCommentFromString( '// translators: Greeting\n\n__( \'Hello world\' );' );
+			const comment = getCommentFromString( "// translators: Greeting\n\n__( 'Hello world' );" );
 
 			expect( comment ).toBeUndefined();
 		} );
 
 		it( 'should use multi-line comment starting many lines previous', () => {
-			const comment = getCommentFromString( '/* translators: Long comment\nspanning multiple \nlines */\nconst string = __( \'Hello world\' );' );
+			const comment = getCommentFromString( "/* translators: Long comment\nspanning multiple \nlines */\nconst string = __( 'Hello world' );" );
 
 			expect( comment ).toBe( 'Long comment spanning multiple lines' );
 		} );

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -629,7 +629,7 @@ describe( 'block factory', () => {
 			expect( availableBlocks ).toEqual( [] );
 		} );
 
-		it( 'for a non multiblock transform, the isMatch function receives the source block\'s attributes object as its first argument', () => {
+		it( 'for a non multiblock transform, the isMatch function receives the source block’s attributes object as its first argument', () => {
 			const isMatch = jest.fn();
 
 			registerBlockType( 'core/updated-text-block', {
@@ -661,7 +661,7 @@ describe( 'block factory', () => {
 			expect( isMatch ).toHaveBeenCalledWith( { value: 'ribs' } );
 		} );
 
-		it( 'for a multiblock transform, the isMatch function receives an array containing every source block\'s attributes as its first argument', () => {
+		it( 'for a multiblock transform, the isMatch function receives an array containing every source block’s attributes as its first argument', () => {
 			const isMatch = jest.fn();
 
 			registerBlockType( 'core/updated-text-block', {

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -137,7 +137,7 @@ describe( 'block parser', () => {
 	} );
 
 	describe( 'parseWithAttributeSchema', () => {
-		it( 'should return the matcher\'s attribute value', () => {
+		it( "should return the matcher's attribute value", () => {
 			const value = parseWithAttributeSchema(
 				'<div>chicken</div>',
 				{
@@ -216,7 +216,7 @@ describe( 'block parser', () => {
 			expect( value ).toBe( 10 );
 		} );
 
-		it( 'should return the matcher\'s attribute value', () => {
+		it( "should return the matcher's attribute value", () => {
 			const value = getBlockAttribute(
 				'content',
 				{
@@ -571,7 +571,7 @@ describe( 'block parser', () => {
 			} );
 
 			const parsed = parse(
-				'<!-- wp:core/test-block {"smoked":"yes","url":"http://google.com","chicken":"ribs & \'wings\'"} -->' +
+				`<!-- wp:core/test-block {"smoked":"yes","url":"http://google.com","chicken":"ribs & 'wings'"} -->` +
 				'Brisket' +
 				'<!-- /wp:core/test-block -->'
 			);
@@ -582,7 +582,7 @@ describe( 'block parser', () => {
 				content: 'Brisket',
 				smoked: 'yes',
 				url: 'http://google.com',
-				chicken: 'ribs & \'wings\'',
+				chicken: "ribs & 'wings'",
 			} );
 			expect( typeof parsed[ 0 ].clientId ).toBe( 'string' );
 		} );

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -137,7 +137,7 @@ describe( 'block parser', () => {
 	} );
 
 	describe( 'parseWithAttributeSchema', () => {
-		it( "should return the matcher's attribute value", () => {
+		it( 'should return the matcher’s attribute value', () => {
 			const value = parseWithAttributeSchema(
 				'<div>chicken</div>',
 				{

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -149,7 +149,7 @@ describe( 'block parser', () => {
 			expect( value ).toBe( 'chicken' );
 		} );
 
-		it( 'should return the matcher\'s string attribute value', () => {
+		it( 'should return the matcher’s string attribute value', () => {
 			const value = parseWithAttributeSchema(
 				'<audio src="#" loop>',
 				{
@@ -162,7 +162,7 @@ describe( 'block parser', () => {
 			expect( value ).toBe( '#' );
 		} );
 
-		it( 'should return the matcher\'s true boolean attribute value', () => {
+		it( 'should return the matcher’s true boolean attribute value', () => {
 			const value = parseWithAttributeSchema(
 				'<audio src="#" loop>',
 				{
@@ -175,7 +175,7 @@ describe( 'block parser', () => {
 			expect( value ).toBe( true );
 		} );
 
-		it( 'should return the matcher\'s true boolean attribute value on explicit attribute value', () => {
+		it( 'should return the matcher’s true boolean attribute value on explicit attribute value', () => {
 			const value = parseWithAttributeSchema(
 				'<audio src="#" loop="loop">',
 				{
@@ -188,7 +188,7 @@ describe( 'block parser', () => {
 			expect( value ).toBe( true );
 		} );
 
-		it( 'should return the matcher\'s false boolean attribute value', () => {
+		it( 'should return the matcher’s false boolean attribute value', () => {
 			const value = parseWithAttributeSchema(
 				'<audio src="#" autoplay>',
 				{

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -291,7 +291,7 @@ describe( 'block serializer', () => {
 	} );
 
 	describe( 'getBlockContent', () => {
-		it( 'should return the block\'s serialized inner HTML', () => {
+		it( "should return the block's serialized inner HTML", () => {
 			const blockType = {
 				attributes: {
 					content: {

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -73,7 +73,7 @@ describe( 'templates', () => {
 			expect( doBlocksMatchTemplate( blockList, template ) ).toBe( true );
 		} );
 
-		it( 'return false if the template length doesn\'t match the blocks length', () => {
+		it( "return false if the template length doesn't match the blocks length", () => {
 			const template = [
 				[ 'core/test-block' ],
 				[ 'core/test-block-2' ],
@@ -86,7 +86,7 @@ describe( 'templates', () => {
 			expect( doBlocksMatchTemplate( blockList, template ) ).toBe( false );
 		} );
 
-		it( 'return false if the nested template doesn\'t match the blocks', () => {
+		it( "return false if the nested template doesn't match the blocks", () => {
 			const template = [
 				[ 'core/test-block' ],
 				[ 'core/test-block-2', {}, [

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -177,7 +177,7 @@ describe( 'validation', () => {
 			it( 'returns true if the same style', () => {
 				const isEqual = isEqualAttributesOfName.style(
 					'background-image: url( "https://wordpress.org/img.png" ); color: red;',
-					'color: red;   background-image: url(\'https://wordpress.org/img.png\n);'
+					"color: red;   background-image: url('https://wordpress.org/img.png\n);"
 				);
 
 				expect( isEqual ).toBe( true );
@@ -186,7 +186,7 @@ describe( 'validation', () => {
 			it( 'returns false if not same style', () => {
 				const isEqual = isEqualAttributesOfName.style(
 					'background-image: url( "https://wordpress.org/img.png" ); color: red;',
-					'color: red;  font-size: 13px; background-image: url(\'https://wordpress.org/img.png\');'
+					"color: red;  font-size: 13px; background-image: url('https://wordpress.org/img.png');"
 				);
 
 				expect( isEqual ).toBe( false );

--- a/packages/components/src/autocomplete/test/index.js
+++ b/packages/components/src/autocomplete/test/index.js
@@ -723,7 +723,7 @@ describe( 'Autocomplete', () => {
 			} );
 		} );
 
-		it( 'doesn\'t otherwise interfere with keydown behavior', ( done ) => {
+		it( "doesn't otherwise interfere with keydown behavior", ( done ) => {
 			const wrapper = makeAutocompleter( [ slashCompleter ] );
 			// listen to keydown events on the editor to see if it gets them
 			const editorKeydown = jest.fn();

--- a/packages/components/src/disabled/test/index.js
+++ b/packages/components/src/disabled/test/index.js
@@ -122,13 +122,13 @@ describe( 'Disabled', () => {
 			}
 		}
 
-		test( 'lets components know that they\'re disabled via context', () => {
+		test( "lets components know that they're disabled via context", () => {
 			const wrapper = TestUtils.renderIntoDocument( <Disabled><DisabledStatus /></Disabled> );
 			const wrapperElement = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'p' );
 			expect( wrapperElement.textContent ).toBe( 'Disabled' );
 		} );
 
-		test( 'lets components know that they\'re not disabled via context', () => {
+		test( "lets components know that they're not disabled via context", () => {
 			const wrapper = TestUtils.renderIntoDocument( <DisabledStatus /> );
 			const wrapperElement = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'p' );
 			expect( wrapperElement.textContent ).toBe( 'Not disabled' );

--- a/packages/components/src/higher-order/with-focus-outside/test/index.js
+++ b/packages/components/src/higher-order/with-focus-outside/test/index.js
@@ -82,7 +82,7 @@ describe( 'withFocusOutside', () => {
 		expect( onFocusOutside ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should call handler if focus doesn\'t shift to element within component', () => {
+	it( 'should call handler if focus doesn’t shift to element within component', () => {
 		simulateEvent( 'focus' );
 		simulateEvent( 'blur' );
 

--- a/packages/components/src/popover/test/utils.js
+++ b/packages/components/src/popover/test/utils.js
@@ -8,7 +8,7 @@ import {
 } from '../utils';
 
 describe( 'computePopoverYAxisPosition', () => {
-	it( 'should leave the position as is there\'s enought space', () => {
+	it( "should leave the position as is there's enought space", () => {
 		const anchorRect = {
 			top: 10,
 			left: 10,
@@ -30,7 +30,7 @@ describe( 'computePopoverYAxisPosition', () => {
 		} );
 	} );
 
-	it( 'should switch to bottom position if there\'s not enough space', () => {
+	it( "should switch to bottom position if there's not enough space", () => {
 		const anchorRect = {
 			top: 10,
 			left: 10,
@@ -52,7 +52,7 @@ describe( 'computePopoverYAxisPosition', () => {
 		} );
 	} );
 
-	it( 'should set a maxHeight if there\'s not enough space in any direction', () => {
+	it( "should set a maxHeight if there's not enough space in any direction", () => {
 		const anchorRect = {
 			top: 400,
 			left: 10,
@@ -98,7 +98,7 @@ describe( 'computePopoverYAxisPosition', () => {
 } );
 
 describe( 'computePopoverXAxisPosition', () => {
-	it( 'should leave the position as is there\'s enought space', () => {
+	it( "should leave the position as is there's enought space", () => {
 		const anchorRect = {
 			top: 10,
 			left: 10,
@@ -120,7 +120,7 @@ describe( 'computePopoverXAxisPosition', () => {
 		} );
 	} );
 
-	it( 'should switch to right position if there\'s not enough space', () => {
+	it( "should switch to right position if there's not enough space", () => {
 		const anchorRect = {
 			top: 10,
 			left: 10,
@@ -142,7 +142,7 @@ describe( 'computePopoverXAxisPosition', () => {
 		} );
 	} );
 
-	it( 'should set a maxWidth if there\'s not enough space in any direction', () => {
+	it( "should set a maxWidth if there's not enough space in any direction", () => {
 		const anchorRect = {
 			top: 10,
 			left: 400,
@@ -166,7 +166,7 @@ describe( 'computePopoverXAxisPosition', () => {
 } );
 
 describe( 'computePopoverPosition', () => {
-	it( 'should leave the position as is there\'s enought space', () => {
+	it( "should leave the position as is there's enought space", () => {
 		const anchorRect = {
 			top: 10,
 			left: 10,

--- a/packages/components/src/popover/test/utils.js
+++ b/packages/components/src/popover/test/utils.js
@@ -8,7 +8,7 @@ import {
 } from '../utils';
 
 describe( 'computePopoverYAxisPosition', () => {
-	it( "should leave the position as is there's enought space", () => {
+	it( 'should leave the position as is there’s enought space', () => {
 		const anchorRect = {
 			top: 10,
 			left: 10,
@@ -98,7 +98,7 @@ describe( 'computePopoverYAxisPosition', () => {
 } );
 
 describe( 'computePopoverXAxisPosition', () => {
-	it( "should leave the position as is there's enought space", () => {
+	it( 'should leave the position as is there’s enought space', () => {
 		const anchorRect = {
 			top: 10,
 			left: 10,
@@ -166,7 +166,7 @@ describe( 'computePopoverXAxisPosition', () => {
 } );
 
 describe( 'computePopoverPosition', () => {
-	it( "should leave the position as is there's enought space", () => {
+	it( 'should leave the position as is there’s enought space', () => {
 		const anchorRect = {
 			top: 10,
 			left: 10,

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -83,7 +83,7 @@ describe( 'Slot', () => {
 		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation"><span></span><div></div>text</div>' );
 	} );
 
-	it( 'calls the functions passed as the Slot\'s fillProps in the Fill', () => {
+	it( "calls the functions passed as the Slot's fillProps in the Fill", () => {
 		const onClose = jest.fn();
 
 		const element = mount(

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -83,7 +83,7 @@ describe( 'Slot', () => {
 		expect( element.find( 'Slot > div' ).html() ).toBe( '<div role="presentation"><span></span><div></div>text</div>' );
 	} );
 
-	it( "calls the functions passed as the Slot's fillProps in the Fill", () => {
+	it( 'calls the functions passed as the Slot’s fillProps in the Fill', () => {
 		const onClose = jest.fn();
 
 		const element = mount(

--- a/packages/compose/src/remount-on-prop-change/test/index.js
+++ b/packages/compose/src/remount-on-prop-change/test/index.js
@@ -39,7 +39,7 @@ describe( 'remountOnPropChange', () => {
 		count = 0;
 	} );
 
-	it( 'Should not remount the inner component if the prop value doesn\'t change', () => {
+	it( 'Should not remount the inner component if the prop value doesn’t change', () => {
 		const Wrapped = remountOnPropChange( 'monitor' )( MountCounter );
 		const testRenderer = TestRenderer.create(
 			<Wrapped monitor="unchanged" other="1" />

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -10,31 +10,31 @@ import { getMethodName, defaultEntities, getKindEntities } from '../entities';
 import { addEntities } from '../actions';
 
 describe( 'getMethodName', () => {
-	it( 'Should return the right method name for an entity with the root kind', () => {
+	it( 'should return the right method name for an entity with the root kind', () => {
 		const methodName = getMethodName( 'root', 'postType' );
 
 		expect( methodName ).toEqual( 'getPostType' );
 	} );
 
-	it( 'Should use a different suffix', () => {
+	it( 'should use a different suffix', () => {
 		const methodName = getMethodName( 'root', 'postType', 'set' );
 
 		expect( methodName ).toEqual( 'setPostType' );
 	} );
 
-	it( 'Should use the plural form', () => {
+	it( 'should use the plural form', () => {
 		const methodName = getMethodName( 'root', 'postType', 'get', true );
 
 		expect( methodName ).toEqual( 'getPostTypes' );
 	} );
 
-	it( 'Should use the given plural form', () => {
+	it( 'should use the given plural form', () => {
 		const methodName = getMethodName( 'root', 'taxonomy', 'get', true );
 
 		expect( methodName ).toEqual( 'getTaxonomies' );
 	} );
 
-	it( 'Should include the kind in the method name', () => {
+	it( 'should include the kind in the method name', () => {
 		const id = defaultEntities.length;
 		defaultEntities[ id ] = { name: 'book', kind: 'postType' };
 		const methodName = getMethodName( 'postType', 'book' );
@@ -59,7 +59,7 @@ describe( 'getKindEntities', () => {
 		} );
 	} );
 
-	it( "shouldn't do anything if the entities have already been resolved", async () => {
+	it( 'shouldn’t do anything if the entities have already been resolved', async () => {
 		const state = {
 			entities: { config: [ { kind: 'postType' } ] },
 		};
@@ -68,7 +68,7 @@ describe( 'getKindEntities', () => {
 		expect( done ).toBe( true );
 	} );
 
-	it( "shouldn't do anything if there no defined kind config", async () => {
+	it( 'shouldn’t do anything if there no defined kind config', async () => {
 		const state = { entities: { config: [] } };
 		const fulfillment = getKindEntities( state, 'unknownKind' );
 		const done = ( await fulfillment.next() ).done;

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -59,7 +59,7 @@ describe( 'getKindEntities', () => {
 		} );
 	} );
 
-	it( 'shouldn\'t do anything if the entities have already been resolved', async () => {
+	it( "shouldn't do anything if the entities have already been resolved", async () => {
 		const state = {
 			entities: { config: [ { kind: 'postType' } ] },
 		};
@@ -68,7 +68,7 @@ describe( 'getKindEntities', () => {
 		expect( done ).toBe( true );
 	} );
 
-	it( 'shouldn\'t do anything if there no defined kind config', async () => {
+	it( "shouldn't do anything if there no defined kind config", async () => {
 		const state = { entities: { config: [] } };
 		const fulfillment = getKindEntities( state, 'unknownKind' );
 		const done = ( await fulfillment.next() ).done;

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -67,7 +67,7 @@ describe( 'isRequestingCategories()', () => {
 } );
 
 describe( 'getEntityRecord', () => {
-	it( "should return undefined for unknown record's key", () => {
+	it( 'should return undefined for unknown record’s key', () => {
 		const state = deepFreeze( {
 			entities: {
 				data: {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -67,7 +67,7 @@ describe( 'isRequestingCategories()', () => {
 } );
 
 describe( 'getEntityRecord', () => {
-	it( 'should return undefined for unknown record\'s key', () => {
+	it( "should return undefined for unknown record's key", () => {
 		const state = deepFreeze( {
 			entities: {
 				data: {

--- a/packages/data/src/test/persist.js
+++ b/packages/data/src/test/persist.js
@@ -56,7 +56,7 @@ describe( 'persiss registry', () => {
 			.toEqual( { storeKey: { chicken: true } } );
 	} );
 
-	it( 'should not trigger persistence if the value doesn\'t change', () => {
+	it( 'should not trigger persistence if the value doesn’t change', () => {
 		const storageKey = 'dumbStorageKey2';
 		let countCalls = 0;
 		const storage = {

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -46,7 +46,7 @@ describe( 'DOM', () => {
 			expect( isHorizontalEdge( input, false ) ).toBe( false );
 		} );
 
-		it( 'Should return false if we\'re not at the edge', () => {
+		it( "Should return false if we're not at the edge", () => {
 			const input = document.createElement( 'input' );
 			parent.appendChild( input );
 			input.value = 'value';

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -16,7 +16,7 @@ describe( 'DOM', () => {
 	} );
 
 	describe( 'isHorizontalEdge', () => {
-		it( 'Should return true for empty input', () => {
+		it( 'should return true for empty input', () => {
 			const input = document.createElement( 'input' );
 			parent.appendChild( input );
 			input.focus();
@@ -24,7 +24,7 @@ describe( 'DOM', () => {
 			expect( isHorizontalEdge( input, false ) ).toBe( true );
 		} );
 
-		it( 'Should return the right values if we focus the end of the input', () => {
+		it( 'should return the right values if we focus the end of the input', () => {
 			const input = document.createElement( 'input' );
 			parent.appendChild( input );
 			input.value = 'value';
@@ -35,7 +35,7 @@ describe( 'DOM', () => {
 			expect( isHorizontalEdge( input, false ) ).toBe( true );
 		} );
 
-		it( 'Should return the right values if we focus the start of the input', () => {
+		it( 'should return the right values if we focus the start of the input', () => {
 			const input = document.createElement( 'input' );
 			parent.appendChild( input );
 			input.value = 'value';
@@ -46,7 +46,7 @@ describe( 'DOM', () => {
 			expect( isHorizontalEdge( input, false ) ).toBe( false );
 		} );
 
-		it( "Should return false if we're not at the edge", () => {
+		it( 'should return false if we’re not at the edge', () => {
 			const input = document.createElement( 'input' );
 			parent.appendChild( input );
 			input.value = 'value';
@@ -57,7 +57,7 @@ describe( 'DOM', () => {
 			expect( isHorizontalEdge( input, false ) ).toBe( false );
 		} );
 
-		it( 'Should return false if the selection is not collapseds', () => {
+		it( 'should return false if the selection is not collapseds', () => {
 			const input = document.createElement( 'input' );
 			parent.appendChild( input );
 			input.value = 'value';
@@ -68,7 +68,7 @@ describe( 'DOM', () => {
 			expect( isHorizontalEdge( input, false ) ).toBe( false );
 		} );
 
-		it( 'Should always return true for non content editabless', () => {
+		it( 'should always return true for non content editabless', () => {
 			const div = document.createElement( 'div' );
 			parent.appendChild( div );
 			expect( isHorizontalEdge( div, true ) ).toBe( true );

--- a/packages/shortcode/src/test/index.js
+++ b/packages/shortcode/src/test/index.js
@@ -136,7 +136,7 @@ describe( 'shortcode', () => {
 
 	describe( 'attrs', () => {
 		it( 'should return named attributes created with single, double, and no quotes', () => {
-			const result = attrs( 'param="foo" another=\'bar\' andagain=baz' );
+			const result = attrs( `param="foo" another='bar' andagain=baz` );
 			const expected = {
 				named: {
 					param: 'foo',
@@ -172,7 +172,7 @@ describe( 'shortcode', () => {
 		} );
 
 		it( 'should return numeric attributes created with single, double, and no quotes', () => {
-			const result = attrs( 'foo "bar" \'baz\'' );
+			const result = attrs( `foo "bar" 'baz'` );
 			const expected = {
 				named: {},
 				numeric: [ 'foo', 'bar', 'baz' ],
@@ -182,7 +182,7 @@ describe( 'shortcode', () => {
 		} );
 
 		it( 'should return mixed attributes created with single, double, and no quotes', () => {
-			const result = attrs( 'a="foo" b=\'bar\' c=baz foo "bar" \'baz\'' );
+			const result = attrs( `a="foo" b='bar' c=baz foo "bar" 'baz'` );
 			const expected = {
 				named: {
 					a: 'foo',

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -33,49 +33,49 @@ describe( 'prependHTTP', () => {
 		expect( prependHTTP( url ) ).toBe( 'http://' + url );
 	} );
 
-	test( 'shouldn\'t prepend http to an email', () => {
+	test( 'shouldn’t prepend http to an email', () => {
 		const url = 'foo@wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	test( 'shouldn\'t prepend http to an absolute URL', () => {
+	test( 'shouldn’t prepend http to an absolute URL', () => {
 		const url = '/wordpress';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	test( 'shouldn\'t prepend http to a relative URL', () => {
+	test( 'shouldn’t prepend http to a relative URL', () => {
 		const url = './wordpress';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	test( 'shouldn\'t prepend http to an anchor URL', () => {
+	test( 'shouldn’t prepend http to an anchor URL', () => {
 		const url = '#wordpress';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	test( 'shouldn\'t prepend http to a URL that already has http', () => {
+	test( 'shouldn’t prepend http to a URL that already has http', () => {
 		const url = 'http://wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	test( 'shouldn\'t prepend http to a URL that already has https', () => {
+	test( 'shouldn’t prepend http to a URL that already has https', () => {
 		const url = 'https://wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	test( 'shouldn\'t prepend http to a URL that already has ftp', () => {
+	test( 'shouldn’t prepend http to a URL that already has ftp', () => {
 		const url = 'ftp://wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
 
-	test( 'shouldn\'t prepend http to a URL that already has mailto', () => {
+	test( 'shouldn’t prepend http to a URL that already has mailto', () => {
 		const url = 'mailto:foo@wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );

--- a/packages/wordcount/src/test/index.test.js
+++ b/packages/wordcount/src/test/index.test.js
@@ -44,7 +44,7 @@ describe( 'WordCounter', () => {
 		},
 		{
 			message: 'Punctuation.',
-			string: 'It\'s two three \u2026 4?',
+			string: 'It’s two three \u2026 4?',
 			words: 3,
 			characters_excluding_spaces: 15,
 			characters_including_spaces: 19,

--- a/post-content.js
+++ b/post-content.js
@@ -10,7 +10,7 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:cover-image -->',
 
 			'<!-- wp:paragraph -->',
-			'<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you\'ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>',
+			"<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you'll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>",
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:paragraph -->',
@@ -30,15 +30,15 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:heading -->',
 
 			'<!-- wp:paragraph -->',
-			'<p>Handling images and media with the utmost care is a primary focus of the new editor. Hopefully, you\'ll find aspects of adding captions or going full-width with your pictures much easier and robust than before.</p>',
+			"<p>Handling images and media with the utmost care is a primary focus of the new editor. Hopefully, you'll find aspects of adding captions or going full-width with your pictures much easier and robust than before.</p>",
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:image {"align":"center"} -->',
-			'<figure class="wp-block-image aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>If your theme supports it, you\'ll see the "wide" button on the image toolbar. Give it a try.</figcaption></figure>',
+			`<figure class="wp-block-image aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>If your theme supports it, you'll see the "wide" button on the image toolbar. Give it a try.</figcaption></figure>`,
 			'<!-- /wp:image -->',
 
 			'<!-- wp:paragraph -->',
-			'<p>Try selecting and removing or editing the caption, now you don\'t have to be careful about selecting the image or other text by mistake and ruining the presentation.</p>',
+			"<p>Try selecting and removing or editing the caption, now you don't have to be careful about selecting the image or other text by mistake and ruining the presentation.</p>",
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:heading {"level":2} -->',
@@ -46,11 +46,11 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:heading -->',
 
 			'<!-- wp:paragraph -->',
-			'<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That\'s the spirit behind the inserter—the <code>(+)</code> button you\'ll see around the editor—which allows you to browse all available content blocks and add them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>',
+			"<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That's the spirit behind the inserter—the <code>(+)</code> button you'll see around the editor—which allows you to browse all available content blocks and add them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>",
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:paragraph -->',
-			'<p>Go give it a try, you may discover things WordPress can already add into your posts that you didn\'t know about. Here\'s a short list of what you can currently find there:</p>',
+			"<p>Go give it a try, you may discover things WordPress can already add into your posts that you didn't know about. Here's a short list of what you can currently find there:</p>",
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:list -->',
@@ -74,7 +74,7 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:quote -->',
 
 			'<!-- wp:paragraph -->',
-			'<p>The information corresponding to the source of the quote is a separate text field, similar to captions under images, so the structure of the quote is protected even if you select, modify, or remove the source. It\'s always easy to add it back.</p>',
+			"<p>The information corresponding to the source of the quote is a separate text field, similar to captions under images, so the structure of the quote is protected even if you select, modify, or remove the source. It's always easy to add it back.</p>",
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:paragraph -->',
@@ -102,7 +102,7 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:image {"align":"full"} -->',
-			'<figure class="wp-block-image alignfull"><img src="https://cldup.com/8lhI-gKnI2.jpg" alt="Accessibility is important don\'t forget image alt attribute" /></figure>',
+			`<figure class="wp-block-image alignfull"><img src="https://cldup.com/8lhI-gKnI2.jpg" alt="Accessibility is important don't forget image alt attribute" /></figure>`,
 			'<!-- /wp:image -->',
 
 			'<!-- wp:paragraph -->',
@@ -117,7 +117,7 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:gallery -->',
 
 			'<!-- wp:paragraph -->',
-			'<p>The above is a gallery with just two images. It\'s an easier way to create visually appealing layouts, without having to deal with floats. You can also easily convert the gallery back to individual images again, by using the block switcher.</p>',
+			"<p>The above is a gallery with just two images. It's an easier way to create visually appealing layouts, without having to deal with floats. You can also easily convert the gallery back to individual images again, by using the block switcher.</p>",
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:paragraph -->',
@@ -129,7 +129,7 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:core-embed/vimeo -->',
 
 			'<!-- wp:paragraph -->',
-			'<p>You can build any block you like, static or dynamic, decorative or plain. Here\'s a pullquote block:</p>',
+			"<p>You can build any block you like, static or dynamic, decorative or plain. Here's a pullquote block:</p>",
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:pullquote -->',

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -90,7 +90,7 @@ describe( 'adding blocks', () => {
 
 		// Switch to Text Mode to check HTML Output
 		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
+		const codeEditorButton = ( await page.$x( "//button[contains(text(), 'Code Editor')]" ) )[ 0 ];
 		await codeEditorButton.click( 'button' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -192,7 +192,7 @@ describe( 'Change detection', () => {
 			pressWithModifier( 'Mod', 'S' ),
 
 			// Ensure save update fails and presents button.
-			page.waitForXPath( '//p[contains(text(), \'Updating failed\')]' ),
+			page.waitForXPath( "//p[contains(text(), 'Updating failed')]" ),
 			page.waitForSelector( '.editor-post-save-draft' ),
 		] );
 

--- a/test/e2e/specs/managing-links.test.js
+++ b/test/e2e/specs/managing-links.test.js
@@ -12,7 +12,7 @@ describe( 'Managing links', () => {
 
 	const setFixedToolbar = async ( b ) => {
 		await page.click( '.edit-post-more-menu button' );
-		const button = ( await page.$x( '//button[contains(text(), \'Fix Toolbar to Top\')]' ) )[ 0 ];
+		const button = ( await page.$x( "//button[contains(text(), 'Fix Toolbar to Top')]" ) )[ 0 ];
 		const buttonClassNameProperty = await button.getProperty( 'className' );
 		const buttonClassName = await buttonClassNameProperty.jsonValue();
 		const isSelected = buttonClassName.indexOf( 'is-selected' ) !== -1;

--- a/test/e2e/specs/nux.test.js
+++ b/test/e2e/specs/nux.test.js
@@ -59,7 +59,7 @@ describe( 'New User Experience (NUX)', () => {
 		await clickAllTips( page );
 
 		// Make sure "Got it" button appears on the last tip.
-		const gotItButton = await page.$x( '//button[contains(text(), \'Got it\')]' );
+		const gotItButton = await page.$x( "//button[contains(text(), 'Got it')]" );
 		expect( gotItButton ).toHaveLength( 1 );
 
 		// Click the "Got it button".

--- a/test/e2e/specs/nux.test.js
+++ b/test/e2e/specs/nux.test.js
@@ -48,7 +48,7 @@ describe( 'New User Experience (NUX)', () => {
 		const firstTipText = await page.$eval( '.nux-dot-tip', ( element ) => element.innerText );
 		expect( firstTipText ).toContain( 'Welcome to the wonderful world of blocks!' );
 
-		const [ nextTipButton ] = await page.$x( '//button[contains(text(), \'See next tip\')]' );
+		const [ nextTipButton ] = await page.$x( "//button[contains(text(), 'See next tip')]" );
 		await nextTipButton.click();
 
 		const secondTipText = await page.$eval( '.nux-dot-tip', ( element ) => element.innerText );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -140,7 +140,7 @@ export async function waitForPageDimensions( width, height ) {
 
 export async function switchToEditor( mode ) {
 	await page.click( '.edit-post-more-menu [aria-label="More"]' );
-	const [ button ] = await page.$x( `//button[contains(text(), \'${ mode } Editor\')]` );
+	const [ button ] = await page.$x( `//button[contains(text(), '${ mode } Editor')]` );
 	await button.click( 'button' );
 }
 
@@ -229,7 +229,7 @@ export async function pressWithModifier( modifier, key ) {
  */
 export async function clickOnMoreMenuItem( buttonLabel ) {
 	await page.click( '.edit-post-more-menu [aria-label="More"]' );
-	const itemButton = ( await page.$x( `//button[contains(text(), \'${ buttonLabel }\')]` ) )[ 0 ];
+	const itemButton = ( await page.$x( `//button[contains(text(), '${ buttonLabel }')]` ) )[ 0 ];
 	await itemButton.click( 'button' );
 }
 


### PR DESCRIPTION
## Description
Fixes #7366.

This PR is two commits:

1. A simple eslint change to fix #7366; allow double-quoted and template-string-quoted strings in JS _only when there is a single quote inside the string_. As mentioned in #7366, this leads to much more readable strings and I think is nicer. Also imagine the bytes we'll save omitting all those `\` 😉
2. A change of all _existing_ instances in JS that are covered by this to use double quotes

## How has this been tested?
Everything still works; eslint doesn't yell at you.

## Types of changes
Code quality.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

-----

Obviously this violates https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#strings, so I guess we should have a chat about this in `#core-js` or something first. 🤷‍♂️