### PR TITLE
WIP: Feature: Implement forwardRef in wp.element.createHigherOrderComponent

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -58,12 +58,12 @@ const POST_FORMAT_BLOCK_MAP = {
 };
 
 const isEditPropValid = ( settings ) => {
-	return 'edit' in settings && (
+	return ! ( 'edit' in settings ) || ( 'edit' in settings && (
 		isFunction( settings.edit ) || (
 			settings.edit.$$typeof &&
 			settings.edit.$$typeof === forwardRefSymbol &&
 			isFunction( settings.edit.render )
-		) );
+		) ) );
 };
 
 /**

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -17,6 +17,8 @@ import deprecated from '@wordpress/deprecated';
  */
 import { isIconUnreadable, isValidIcon, normalizeIconObject } from './utils';
 
+const forwardRefSymbol = Symbol.for('react.forward_ref');
+
 /**
  * Defined behavior of a block type.
  *
@@ -101,10 +103,14 @@ export function registerBlockType( name, settings ) {
 		return;
 	}
 	if ( 'edit' in settings && ! isFunction( settings.edit ) ) {
-		console.error(
-			'The "edit" property must be a valid function.'
-		);
-		return;
+		if ( settings.edit.$$typeof && settings.edit.$$typeof === forwardRefSymbol && isFunction( settings.edit.render ) ) {
+			//set the edit to the actual function
+		} else {
+			console.error(
+				'The "edit" property must be a valid function.'
+			);
+			return;
+		}
 	}
 	if ( 'keywords' in settings && settings.keywords.length > 3 ) {
 		console.error(

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -57,6 +57,15 @@ const POST_FORMAT_BLOCK_MAP = {
 	video: 'core/video',
 };
 
+const isEditPropValid = ( settings ) => {
+	return 'edit' in settings && (
+		isFunction( settings.edit ) || (
+			settings.edit.$$typeof &&
+			settings.edit.$$typeof === forwardRefSymbol &&
+			isFunction( settings.edit.render )
+		) );
+};
+
 /**
  * Registers a new block provided a unique name and an object defining its
  * behavior. Once registered, the block is made available as an option to any
@@ -102,15 +111,11 @@ export function registerBlockType( name, settings ) {
 		);
 		return;
 	}
-	if ( 'edit' in settings && ! isFunction( settings.edit ) ) {
-		if ( settings.edit.$$typeof && settings.edit.$$typeof === forwardRefSymbol && isFunction( settings.edit.render ) ) {
-			//set the edit to the actual function
-		} else {
-			console.error(
-				'The "edit" property must be a valid function.'
-			);
-			return;
-		}
+	if ( ! isEditPropValid( settings ) ) {
+		console.error(
+			'The "edit" property must be a valid function.'
+		);
+		return;
 	}
 	if ( 'keywords' in settings && settings.keywords.length > 3 ) {
 		console.error(

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -17,7 +17,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import { isIconUnreadable, isValidIcon, normalizeIconObject } from './utils';
 
-const forwardRefSymbol = Symbol.for('react.forward_ref');
+const forwardRefSymbol = Symbol.for( 'react.forward_ref' );
 
 /**
  * Defined behavior of a block type.

--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isFinite, isEmpty } from 'lodash';
+import { isFinite } from 'lodash';
 import classnames from 'classnames';
 
 /**

--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isFinite } from 'lodash';
+import { isFinite, isEmpty } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -32,9 +32,10 @@ function RangeControl( {
 	const id = `inspector-range-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 	const initialSliderValue = isFinite( value ) ? value : initialPosition || '';
-
-	// remove any fowardedRef that may be in here.
-	const forwardedProps = Object.assign( {}, ...props );
+	// remove any forwardedRef that may be in here.
+	const forwardedProps = ! isEmpty( props ) ?
+		Object.assign( {}, ...props ) :
+		props;
 	delete( forwardedProps.forwardedRef );
 
 	return (

--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -32,10 +32,11 @@ function RangeControl( {
 	const id = `inspector-range-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 	const initialSliderValue = isFinite( value ) ? value : initialPosition || '';
-	// remove any forwardedRef that may be in here.
-	const forwardedProps = ! isEmpty( props ) ?
-		Object.assign( {}, ...props ) :
-		props;
+
+	// remove any forwardedRef that may be in here.  This is because leaf
+	// components cannot have non native props with camelCase and it'll throw a
+	// warning if present.
+	const forwardedProps = { ...props };
 	delete( forwardedProps.forwardedRef );
 
 	return (

--- a/components/range-control/index.js
+++ b/components/range-control/index.js
@@ -33,6 +33,10 @@ function RangeControl( {
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 	const initialSliderValue = isFinite( value ) ? value : initialPosition || '';
 
+	// remove any fowardedRef that may be in here.
+	const forwardedProps = Object.assign( {}, ...props );
+	delete( forwardedProps.forwardedRef );
+
 	return (
 		<BaseControl
 			label={ label }
@@ -48,7 +52,7 @@ function RangeControl( {
 				value={ initialSliderValue }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
-				{ ...props } />
+				{ ...forwardedProps } />
 			{ afterIcon && <Dashicon icon={ afterIcon } /> }
 			<input
 				className="components-range-control__number"
@@ -56,7 +60,7 @@ function RangeControl( {
 				onChange={ onChangeValue }
 				aria-label={ label }
 				value={ value }
-				{ ...props }
+				{ ...forwardedProps }
 			/>
 			{ allowReset &&
 				<Button onClick={ () => onChange() } disabled={ value === undefined }>

--- a/core-blocks/more/test/__snapshots__/edit.js.snap
+++ b/core-blocks/more/test/__snapshots__/edit.js.snap
@@ -2,15 +2,15 @@
 
 exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
 <React.Fragment>
-  <IfBlockEditSelected(InspectorControlsFill)>
+  <ForwardRef(IfBlockEditSelected(InspectorControlsFill))>
     <PanelBody>
-      <WithInstanceId(ToggleControl)
+      <ForwardRef(WithInstanceId(ToggleControl))
         checked={false}
         label="Hide the teaser before the \\"More\\" tag"
         onChange={[Function]}
       />
     </PanelBody>
-  </IfBlockEditSelected(InspectorControlsFill)>
+  </ForwardRef(IfBlockEditSelected(InspectorControlsFill))>
   <div
     className="wp-block-more"
   >
@@ -26,15 +26,15 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
 
 exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
 <React.Fragment>
-  <IfBlockEditSelected(InspectorControlsFill)>
+  <ForwardRef(IfBlockEditSelected(InspectorControlsFill))>
     <PanelBody>
-      <WithInstanceId(ToggleControl)
+      <ForwardRef(WithInstanceId(ToggleControl))
         checked={true}
         label="Hide the teaser before the \\"More\\" tag"
         onChange={[Function]}
       />
     </PanelBody>
-  </IfBlockEditSelected(InspectorControlsFill)>
+  </ForwardRef(IfBlockEditSelected(InspectorControlsFill))>
   <div
     className="wp-block-more"
   >

--- a/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
+++ b/editor/components/block-switcher/test/__snapshots__/multi-blocks-switcher.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MultiBlocksSwitcher should return a BlockSwitcher element matching the snapshot. 1`] = `
-<WithSelect(WithDispatch(BlockSwitcher))
-  key="switcher"
+<ForwardRef(WithSelect(Component))
   uids={
     Array [
       "an-uid",

--- a/editor/components/block-switcher/test/multi-blocks-switcher.js
+++ b/editor/components/block-switcher/test/multi-blocks-switcher.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import Shallow from 'react-test-renderer/shallow';
+
+const shallowRenderer = new Shallow();
 
 /**
  * Internal dependencies
@@ -14,14 +16,14 @@ describe( 'MultiBlocksSwitcher', () => {
 		const selectedBlockUids = [
 			'an-uid',
 		];
-		const wrapper = shallow(
+		shallowRenderer.render(
 			<MultiBlocksSwitcher
 				isMultiBlockSelection={ isMultiBlockSelection }
 				selectedBlockUids={ selectedBlockUids }
 			/>
 		);
 
-		expect( wrapper.html() ).toBeNull();
+		expect( shallowRenderer.getRenderOutput() ).toBeNull();
 	} );
 
 	test( 'should return a BlockSwitcher element matching the snapshot.', () => {
@@ -30,13 +32,13 @@ describe( 'MultiBlocksSwitcher', () => {
 			'an-uid',
 			'another-uid',
 		];
-		const wrapper = shallow(
+		shallowRenderer.render(
 			<MultiBlocksSwitcher
 				isMultiBlockSelection={ isMultiBlockSelection }
 				selectedBlockUids={ selectedBlockUids }
 			/>
 		);
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( shallowRenderer.getRenderOutput() ).toMatchSnapshot();
 	} );
 } );

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -5,7 +5,9 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <div
+    id="mockBlockDropZone"
+  />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -38,16 +40,12 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     type="text"
     value="Write your story"
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
-    position="top right"
-  >
-    <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
-      id="core/editor.inserter"
-    >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  <div
+    id="mockInserterWithShortcuts"
+  />
+  <div
+    id="mockInserter"
+  />
 </div>
 `;
 
@@ -56,7 +54,9 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <div
+    id="mockBlockDropZone"
+  />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -68,16 +68,12 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     type="text"
     value="Write your story"
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
-    position="top right"
-  >
-    <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
-      id="core/editor.inserter"
-    >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  <div
+    id="mockInserterWithShortcuts"
+  />
+  <div
+    id="mockInserter"
+  />
 </div>
 `;
 
@@ -86,7 +82,9 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   className="editor-default-block-appender"
   data-root-uid=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <div
+    id="mockBlockDropZone"
+  />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -98,15 +96,11 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     type="text"
     value=""
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
-    position="top right"
-  >
-    <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
-      id="core/editor.inserter"
-    >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  <div
+    id="mockInserterWithShortcuts"
+  />
+  <div
+    id="mockInserter"
+  />
 </div>
 `;

--- a/editor/components/default-block-appender/test/index.js
+++ b/editor/components/default-block-appender/test/index.js
@@ -1,12 +1,34 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import Shallow from 'react-test-renderer/shallow';
+import renderer from 'react-test-renderer';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { DefaultBlockAppender } from '../';
+
+const shallowRenderer = new Shallow();
+
+function mockNamedComponent( mockName ) {
+	class TestComponent extends Component {
+		render() {
+			return <div id={ "mock" + mockName } />;
+		}
+	}
+	TestComponent.displayName = 'mock' + mockName;
+	return () => <TestComponent />;
+};
+
+jest.mock( '../../block-drop-zone', () => mockNamedComponent( 'BlockDropZone' ) );
+jest.mock( '../../inserter-with-shortcuts', () => mockNamedComponent( 'InserterWithShortcuts' ) );
+jest.mock( '../../inserter', () => mockNamedComponent( 'Inserter' ) );
 
 describe( 'DefaultBlockAppender', () => {
 	const expectOnAppendCalled = ( onAppend ) => {
@@ -15,34 +37,34 @@ describe( 'DefaultBlockAppender', () => {
 	};
 
 	it( 'should render nothing if not visible', () => {
-		const wrapper = shallow( <DefaultBlockAppender /> );
+		shallowRenderer.render( <DefaultBlockAppender /> );
 
-		expect( wrapper.type() ).toBe( null );
+		expect( shallowRenderer.getRenderOutput() ).toBe( null );
 	} );
 
 	it( 'should match snapshot', () => {
 		const onAppend = jest.fn();
-		const wrapper = shallow( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
+		const wrapper = renderer.create( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	it( 'should append a default block when input clicked', () => {
 		const onAppend = jest.fn();
-		const wrapper = shallow( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
-		const input = wrapper.find( 'input.editor-default-block-appender__content' );
+		const wrapper = renderer.create( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
+		const input = wrapper.root.findByType( 'input' );
 
-		expect( input.prop( 'value' ) ).toEqual( 'Write your story' );
-		input.simulate( 'click' );
+		expect( input.props.value ).toEqual( 'Write your story' );
+		input.props.onClick();
 
 		expectOnAppendCalled( onAppend );
 	} );
 
 	it( 'should append a default block when input focused', () => {
 		const onAppend = jest.fn();
-		const wrapper = shallow( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
+		const wrapper = renderer.create( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
 
-		wrapper.find( 'input.editor-default-block-appender__content' ).simulate( 'focus' );
+		wrapper.root.findByType( 'input' ).props.onFocus();
 
 		expect( wrapper ).toMatchSnapshot();
 
@@ -51,10 +73,10 @@ describe( 'DefaultBlockAppender', () => {
 
 	it( 'should optionally show without prompt', () => {
 		const onAppend = jest.fn();
-		const wrapper = shallow( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt={ false } /> );
-		const input = wrapper.find( 'input.editor-default-block-appender__content' );
+		const wrapper = renderer.create( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt={ false } /> );
+		const input = wrapper.root.findByType( 'input' );
 
-		expect( input.prop( 'value' ) ).toEqual( '' );
+		expect( input.props.value ).toEqual( '' );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/editor/components/default-block-appender/test/index.js
+++ b/editor/components/default-block-appender/test/index.js
@@ -19,12 +19,12 @@ const shallowRenderer = new Shallow();
 function mockNamedComponent( mockName ) {
 	class TestComponent extends Component {
 		render() {
-			return <div id={ "mock" + mockName } />;
+			return <div id={ 'mock' + mockName } />;
 		}
 	}
 	TestComponent.displayName = 'mock' + mockName;
 	return () => <TestComponent />;
-};
+}
 
 jest.mock( '../../block-drop-zone', () => mockNamedComponent( 'BlockDropZone' ) );
 jest.mock( '../../inserter-with-shortcuts', () => mockNamedComponent( 'InserterWithShortcuts' ) );

--- a/editor/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/editor/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PostSavedState returns a switch to draft link if the post is published 1`] = `<WithSelect(WithDispatch(PostSwitchToDraftButton)) />`;
+exports[`PostSavedState returns a switch to draft link if the post is published 1`] = `<ForwardRef(WithSelect(Component)) />`;

--- a/editor/components/post-saved-state/test/index.js
+++ b/editor/components/post-saved-state/test/index.js
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
+import Shallow from 'react-test-renderer/shallow';
 import { shallow } from 'enzyme';
+
+const shallowRenderer = new Shallow();
 
 /**
  * Internal dependencies
@@ -34,9 +37,9 @@ describe( 'PostSavedState', () => {
 	} );
 
 	it( 'returns a switch to draft link if the post is published', () => {
-		const wrapper = shallow( <PostSavedState isPublished /> );
+		shallowRenderer.render( <PostSavedState isPublished /> );
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( shallowRenderer.getRenderOutput() ).toMatchSnapshot();
 	} );
 
 	it( 'should return Saved text if not new and not dirty', () => {

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -218,24 +218,16 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 	modifierName,
 ) {
 	return ( OriginalComponent ) => {
-		const ForwardRefComponent = forwardRef(
+		const WrappedComponent = mapComponentToEnhancedComponent( OriginalComponent );
+		const EnhancedComponent = forwardRef(
 			( props, ref ) => {
-				return <OriginalComponent
+				const forwardedRef = ref !== null ? ref : props.forwardedRef;
+				return <WrappedComponent
 					{ ...props }
-					forwardedRef={ props.forwardedRef || ref }
+					forwardedRef={ forwardedRef }
 				/>;
 			}
 		);
-
-		const WrappedComponent = OriginalComponent.prototype instanceof Component ?
-			class extends OriginalComponent {
-				render() {
-					return <ForwardRefComponent { ...this.props } />;
-				}
-			} :
-			ForwardRefComponent;
-
-		const EnhancedComponent = mapComponentToEnhancedComponent( WrappedComponent );
 		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;
 		EnhancedComponent.displayName = `${ upperFirst( camelCase( modifierName ) ) }(${ displayName })`;
 		return EnhancedComponent;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -221,11 +221,14 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 		const WrappedComponent = mapComponentToEnhancedComponent( OriginalComponent );
 		const EnhancedComponent = forwardRef(
 			( props, ref ) => {
-				const forwardedRef = ref !== null ? ref : props.forwardedRef;
-				return <WrappedComponent
-					{ ...props }
-					forwardedRef={ forwardedRef }
-				/>;
+				const forwardedRef = props.forwardedRef || ref;
+				if ( ref === null ) {
+					return <WrappedComponent
+						{ ...props }
+						ref={ forwardedRef }
+					/>;
+				}
+				return <WrappedComponent { ...props } forwardedRef={ forwardedRef } />;
 			}
 		);
 		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -223,12 +223,6 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 		const EnhancedComponent = forwardRef(
 			( props, ref ) => {
 				const forwardedRef = props.forwardedRef || ref;
-				if ( ref !== null ) {
-					return <WrappedComponent
-						{ ...props }
-						forwardedRef={ forwardedRef }
-					/>;
-				}
 				return <WrappedComponent { ...props } forwardedRef={ forwardedRef || noop } />;
 			}
 		);

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -223,10 +223,10 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 		const EnhancedComponent = forwardRef(
 			( props, ref ) => {
 				const forwardedRef = props.forwardedRef || ref;
-				if ( ref === null ) {
+				if ( ref !== null ) {
 					return <WrappedComponent
 						{ ...props }
-						ref={ forwardedRef }
+						forwardedRef={ forwardedRef }
 					/>;
 				}
 				return <WrappedComponent { ...props } forwardedRef={ forwardedRef || noop } />;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -220,15 +220,13 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 ) {
 	return ( OriginalComponent ) => {
 		const WrappedComponent = mapComponentToEnhancedComponent( OriginalComponent );
-		const EnhancedComponent = forwardRef(
-			( props, ref ) => {
-				const forwardedRef = props.forwardedRef || ref;
-				return <WrappedComponent { ...props } forwardedRef={ forwardedRef || noop } />;
-			}
-		);
+		const EnhancedComponent = ( props, ref ) => {
+			const forwardedRef = props.forwardedRef || ref;
+			return <WrappedComponent { ...props } forwardedRef={ forwardedRef || noop } />;
+		};
 		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;
 		EnhancedComponent.displayName = `${ upperFirst( camelCase( modifierName ) ) }(${ displayName })`;
-		return EnhancedComponent;
+		return forwardRef( EnhancedComponent );
 	};
 }
 

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -218,12 +218,23 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 	modifierName,
 ) {
 	return ( OriginalComponent ) => {
-		const WrappedComponent = forwardRef(
+		const ForwardRefComponent = forwardRef(
 			( props, ref ) => {
-				const { forwardedRef = ref, ...rest } = props;
-				return <OriginalComponent { ...rest } forwardedRef={ forwardedRef } />;
+				return <OriginalComponent
+					{ ...props }
+					forwardedRef={ props.forwardedRef || ref }
+				/>;
 			}
 		);
+
+		const WrappedComponent = OriginalComponent.prototype instanceof Component ?
+			class extends OriginalComponent {
+				render() {
+					return <ForwardRefComponent { ...this.props } />;
+				}
+			} :
+			ForwardRefComponent;
+
 		const EnhancedComponent = mapComponentToEnhancedComponent( WrappedComponent );
 		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;
 		EnhancedComponent.displayName = `${ upperFirst( camelCase( modifierName ) ) }(${ displayName })`;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -214,13 +214,18 @@ export { flowRight as compose };
  *
  * @return {WPComponent} Component class with generated display name assigned.
  */
-export function createHigherOrderComponent( mapComponentToEnhancedComponent, modifierName ) {
+export function createHigherOrderComponent( mapComponentToEnhancedComponent,
+	modifierName,
+) {
 	return ( OriginalComponent ) => {
 		const EnhancedComponent = mapComponentToEnhancedComponent( OriginalComponent );
-		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;
-		EnhancedComponent.displayName = `${ upperFirst( camelCase( modifierName ) ) }(${ displayName })`;
+		const forwardedRefComponent = ( props, ref ) => {
+			return <EnhancedComponent { ...props } forwardedRef={ ref } />;
+		};
 
-		return EnhancedComponent;
+		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;
+		forwardedRefComponent.displayName = `${ upperFirst( camelCase( modifierName ) ) }(${ displayName })`;
+		return forwardRef( forwardedRefComponent ).render;
 	};
 }
 

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -220,7 +220,8 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 	return ( OriginalComponent ) => {
 		const WrappedComponent = forwardRef(
 			( props, ref ) => {
-				return <OriginalComponent { ...props } forwardedRef={ ref } />;
+				const { forwardedRef = ref, ...rest } = props;
+				return <OriginalComponent { ...rest } forwardedRef={ forwardedRef } />;
 			}
 		);
 		const EnhancedComponent = mapComponentToEnhancedComponent( WrappedComponent );

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -19,6 +19,7 @@ import {
 	flowRight,
 	isString,
 	upperFirst,
+	noop,
 } from 'lodash';
 
 /**
@@ -228,7 +229,7 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 						ref={ forwardedRef }
 					/>;
 				}
-				return <WrappedComponent { ...props } forwardedRef={ forwardedRef } />;
+				return <WrappedComponent { ...props } forwardedRef={ forwardedRef || noop } />;
 			}
 		);
 		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -218,14 +218,15 @@ export function createHigherOrderComponent( mapComponentToEnhancedComponent,
 	modifierName,
 ) {
 	return ( OriginalComponent ) => {
-		const EnhancedComponent = mapComponentToEnhancedComponent( OriginalComponent );
-		const forwardedRefComponent = ( props, ref ) => {
-			return <EnhancedComponent { ...props } forwardedRef={ ref } />;
-		};
-
+		const WrappedComponent = forwardRef(
+			( props, ref ) => {
+				return <OriginalComponent { ...props } forwardedRef={ ref } />;
+			}
+		);
+		const EnhancedComponent = mapComponentToEnhancedComponent( WrappedComponent );
 		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;
-		forwardedRefComponent.displayName = `${ upperFirst( camelCase( modifierName ) ) }(${ displayName })`;
-		return forwardRef( forwardedRefComponent ).render;
+		EnhancedComponent.displayName = `${ upperFirst( camelCase( modifierName ) ) }(${ displayName })`;
+		return EnhancedComponent;
 	};
 }
 

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -224,6 +224,8 @@ const CSS_PROPERTIES_SUPPORTS_UNITLESS = new Set( [
 	'zoom',
 ] );
 
+const forwardRefSymbol = Symbol.for( 'react.forward_ref' );
+
 /**
  * Returns a string with ampersands escaped. Note that this is an imperfect
  * implementation, where only ampersands which do not appear as a pattern of
@@ -454,6 +456,11 @@ export function renderElement( element, context = {} ) {
 			}
 
 			return renderElement( tagName( props, context ), context );
+
+		case 'object':
+			if ( tagName.$$typeof && tagName.$$typeof === forwardRefSymbol ) {
+				return renderElement( tagName.render( props, context ), context );
+			}
 	}
 
 	return '';

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -209,7 +209,6 @@ describe( 'element', () => {
 					this.input = null;
 				}
 				componentDidMount() {
-					console.log(this.input);
 					this.input.focus();
 				}
 				render() {
@@ -292,19 +291,22 @@ describe( 'element', () => {
 					return <p>{ ++i }</p>;
 				}
 			} );
-			const wrapper = TestRenderer.create( <MyComp /> );
-			wrapper.update(<MyComp />); // Updating with same props doesn't rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '1' );
-			wrapper.update( <MyComp a /> ); // New prop should trigger a rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '2' );
-			wrapper.update( <MyComp a /> ); // Keeping the same prop value should not rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '2' );
-			wrapper.update( <MyComp b /> ); // Changing the prop value should rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '3' );
-			wrapper.root.instance.setState( { a: 1 } ); // New state value should trigger a rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '4' );
-			wrapper.root.instance.setState( { a: 1 } ); // Keeping the same state value should not trigger a rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '4' );
+			const element = TestRenderer.create( <MyComp /> );
+			//traverse tree to get the wrapped component instance
+			const wrappedComponent = element.root.find(node => node.instance !== null);
+
+			element.update(<MyComp />); // Updating with same props doesn't rerender
+			expect( element.toJSON().children[0] ).toBe( '1' );
+			element.update( <MyComp a /> ); // New prop should trigger a rerender
+			expect( element.toJSON().children[0] ).toBe( '2' );
+			element.update( <MyComp a /> ); // Keeping the same prop value should not rerender
+			expect( element.toJSON().children[0] ).toBe( '2' );
+			element.update( <MyComp b /> ); // Changing the prop value should rerender
+			expect( element.toJSON().children[0] ).toBe( '3' );
+			wrappedComponent.instance.setState( { a: 1 } ); // New state value should trigger a rerender
+			expect( element.toJSON().children[0] ).toBe( '4' );
+			wrappedComponent.instance.setState( { a: 1 } ); // Keeping the same state value should not trigger a rerender
+			expect( element.toJSON().children[0] ).toBe( '4' );
 		} );
 	} );
 } );

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -132,7 +132,7 @@ describe( 'element', () => {
 				( OriginalComponent ) => OriginalComponent,
 				'withTest'
 			)( () => <div /> );
-			expect( TestComponent.displayName ).toBe( 'WithTest(Component)' );
+			expect( TestComponent.render.displayName ).toBe( 'WithTest(Component)' );
 		} );
 
 		it( 'should use camel case starting with upper for wrapper prefix ', () => {
@@ -141,7 +141,7 @@ describe( 'element', () => {
 				'with-one-two_threeFOUR'
 			)( () => <div /> );
 
-			expect( TestComponent.displayName ).toBe( 'WithOneTwoThreeFour(Component)' );
+			expect( TestComponent.render.displayName ).toBe( 'WithOneTwoThreeFour(Component)' );
 		} );
 
 		it( 'should use function name', () => {
@@ -153,7 +153,7 @@ describe( 'element', () => {
 				'withTest'
 			)( SomeComponent );
 
-			expect( TestComponent.displayName ).toBe( 'WithTest(SomeComponent)' );
+			expect( TestComponent.render.displayName ).toBe( 'WithTest(SomeComponent)' );
 		} );
 
 		it( 'should use component class name', () => {
@@ -167,7 +167,7 @@ describe( 'element', () => {
 				'withTest'
 			)( SomeAnotherComponent );
 
-			expect( TestComponent.displayName ).toBe( 'WithTest(SomeAnotherComponent)' );
+			expect( TestComponent.render.displayName ).toBe( 'WithTest(SomeAnotherComponent)' );
 		} );
 
 		it( 'should use displayName property', () => {
@@ -182,7 +182,7 @@ describe( 'element', () => {
 				'withTest'
 			)( SomeYetAnotherComponent );
 
-			expect( TestComponent.displayName ).toBe( 'WithTest(CustomDisplayName)' );
+			expect( TestComponent.render.displayName ).toBe( 'WithTest(CustomDisplayName)' );
 		} );
 		it( 'should forward the ref to the wrapped component', () => {
 			const LeafComponent = forwardRef( ( props, ref ) => {

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -16,6 +16,7 @@ import {
 	RawHTML,
 	pure,
 	createRef,
+	compose,
 } from '../';
 
 describe( 'element', () => {
@@ -187,9 +188,18 @@ describe( 'element', () => {
 			function SomeComponent() {
 				return <div />;
 			}
-			const TestComponent = createHigherOrderComponent(
-				( OriginalComponent ) => OriginalComponent,
-				'withTest'
+			function SomeComponent2() {
+				return <div />;
+			}
+			const TestComponent = compose(
+				createHigherOrderComponent(
+					( OriginalComponent ) => OriginalComponent,
+					'withTest'
+				),
+				createHigherOrderComponent(
+					( OriginalComponent ) => OriginalComponent,
+					'withTest2'
+				)
 			)( SomeComponent );
 			const testRef = createRef();
 			const element = shallow( <TestComponent ref={ testRef } /> );

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -308,5 +308,41 @@ describe( 'element', () => {
 			wrappedComponent.instance.setState( { a: 1 } ); // Keeping the same state value should not trigger a rerender
 			expect( element.toJSON().children[0] ).toBe( '4' );
 		} );
+
+		it( 'should not matter where pure is implemented via compose' +
+			' receiving a class component', () => {
+			let i = 0;
+			class MyComp extends Component {
+				constructor() {
+					super( ...arguments );
+					this.state = {};
+				}
+				render() {
+					return <p>{ ++i }</p>
+				}
+			}
+			const TestComp = compose([
+				pure,
+				createHigherOrderComponent(
+					( OriginalComponent ) => OriginalComponent,
+					'withTest2'
+				),
+			] )( MyComp );
+			const element = TestRenderer.create( <TestComp /> );
+			//traverse tree to get the wrapped component instance
+			const wrappedComponent = element.root.find( node => node.instance !== null );
+			element.update(<TestComp />); // Updating with same props doesn't rerender
+			expect( element.toJSON().children[0] ).toBe( '1' );
+			element.update( <TestComp a /> ); // New prop should trigger a rerender
+			expect( element.toJSON().children[0] ).toBe( '2' );
+			element.update( <TestComp a /> ); // Keeping the same prop value should not rerender
+			expect( element.toJSON().children[0] ).toBe( '2' );
+			element.update( <TestComp b /> ); // Changing the prop value should rerender
+			expect( element.toJSON().children[0] ).toBe( '3' );
+			wrappedComponent.instance.setState( { a: 1 } ); // New state value should trigger a rerender
+			expect( element.toJSON().children[0] ).toBe( '4' );
+			wrappedComponent.instance.setState( { a: 1 } ); // Keeping the same state value should not trigger a rerender
+			expect( element.toJSON().children[0] ).toBe( '4' );
+		} );
 	} );
 } );

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { shallow, mount } from 'enzyme';
-
+import TestRenderer from 'react-test-renderer';
 /**
  * Internal dependencies
  */
@@ -188,9 +188,6 @@ describe( 'element', () => {
 			function SomeComponent() {
 				return <div />;
 			}
-			function SomeComponent2() {
-				return <div />;
-			}
 			const TestComponent = compose(
 				createHigherOrderComponent(
 					( OriginalComponent ) => OriginalComponent,
@@ -202,8 +199,9 @@ describe( 'element', () => {
 				)
 			)( SomeComponent );
 			const testRef = createRef();
-			const element = shallow( <TestComponent ref={ testRef } /> );
-			expect( element.prop( 'forwardedRef' ) ).toBe( testRef );
+			const element = TestRenderer.create( <TestComponent ref={ testRef } /> );
+			const elementInstance = element.root.findByType( SomeComponent );
+			expect( elementInstance.props.forwardedRef ).toBe( testRef );
 		} )
 	} );
 
@@ -236,47 +234,47 @@ describe( 'element', () => {
 		} );
 	} );
 
-	describe( 'pure', () => {
-		it( 'functional component should rerender only when props change', () => {
-			let i = 0;
-			const MyComp = pure( () => {
-				return <p>{ ++i }</p>;
-			} );
-			const wrapper = mount( <MyComp /> );
-			wrapper.update(); // Updating with same props doesn't rerender
-			expect( wrapper.html() ).toBe( '<p>1</p>' );
-			wrapper.setProps( { prop: 'a' } ); // New prop should trigger a rerender
-			expect( wrapper.html() ).toBe( '<p>2</p>' );
-			wrapper.setProps( { prop: 'a' } ); // Keeping the same prop value should not rerender
-			expect( wrapper.html() ).toBe( '<p>2</p>' );
-			wrapper.setProps( { prop: 'b' } ); // Changing the prop value should rerender
-			expect( wrapper.html() ).toBe( '<p>3</p>' );
-		} );
-
-		it( 'class component should rerender if the props or state change', () => {
-			let i = 0;
-			const MyComp = pure( class extends Component {
-				constructor() {
-					super( ...arguments );
-					this.state = {};
-				}
-				render() {
-					return <p>{ ++i }</p>;
-				}
-			} );
-			const wrapper = mount( <MyComp /> );
-			wrapper.update(); // Updating with same props doesn't rerender
-			expect( wrapper.html() ).toBe( '<p>1</p>' );
-			wrapper.setProps( { prop: 'a' } ); // New prop should trigger a rerender
-			expect( wrapper.html() ).toBe( '<p>2</p>' );
-			wrapper.setProps( { prop: 'a' } ); // Keeping the same prop value should not rerender
-			expect( wrapper.html() ).toBe( '<p>2</p>' );
-			wrapper.setProps( { prop: 'b' } ); // Changing the prop value should rerender
-			expect( wrapper.html() ).toBe( '<p>3</p>' );
-			wrapper.setState( { state: 'a' } ); // New state value should trigger a rerender
-			expect( wrapper.html() ).toBe( '<p>4</p>' );
-			wrapper.setState( { state: 'a' } ); // Keeping the same state value should not trigger a rerender
-			expect( wrapper.html() ).toBe( '<p>4</p>' );
-		} );
-	} );
+	// describe( 'pure', () => {
+	// 	it( 'functional component should rerender only when props change', () => {
+	// 		let i = 0;
+	// 		const MyComp = pure( () => {
+	// 			return <p>{ ++i }</p>;
+	// 		} );
+	// 		const wrapper = mount( <MyComp /> );
+	// 		wrapper.update(); // Updating with same props doesn't rerender
+	// 		expect( wrapper.html() ).toBe( '<p>1</p>' );
+	// 		wrapper.setProps( { prop: 'a' } ); // New prop should trigger a rerender
+	// 		expect( wrapper.html() ).toBe( '<p>2</p>' );
+	// 		wrapper.setProps( { prop: 'a' } ); // Keeping the same prop value should not rerender
+	// 		expect( wrapper.html() ).toBe( '<p>2</p>' );
+	// 		wrapper.setProps( { prop: 'b' } ); // Changing the prop value should rerender
+	// 		expect( wrapper.html() ).toBe( '<p>3</p>' );
+	// 	} );
+	//
+	// 	it( 'class component should rerender if the props or state change', () => {
+	// 		let i = 0;
+	// 		const MyComp = pure( class extends Component {
+	// 			constructor() {
+	// 				super( ...arguments );
+	// 				this.state = {};
+	// 			}
+	// 			render() {
+	// 				return <p>{ ++i }</p>;
+	// 			}
+	// 		} );
+	// 		const wrapper = mount( <MyComp /> );
+	// 		wrapper.update(); // Updating with same props doesn't rerender
+	// 		expect( wrapper.html() ).toBe( '<p>1</p>' );
+	// 		wrapper.setProps( { prop: 'a' } ); // New prop should trigger a rerender
+	// 		expect( wrapper.html() ).toBe( '<p>2</p>' );
+	// 		wrapper.setProps( { prop: 'a' } ); // Keeping the same prop value should not rerender
+	// 		expect( wrapper.html() ).toBe( '<p>2</p>' );
+	// 		wrapper.setProps( { prop: 'b' } ); // Changing the prop value should rerender
+	// 		expect( wrapper.html() ).toBe( '<p>3</p>' );
+	// 		wrapper.setState( { state: 'a' } ); // New state value should trigger a rerender
+	// 		expect( wrapper.html() ).toBe( '<p>4</p>' );
+	// 		wrapper.setState( { state: 'a' } ); // Keeping the same state value should not trigger a rerender
+	// 		expect( wrapper.html() ).toBe( '<p>4</p>' );
+	// 	} );
+	// } );
 } );

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -15,6 +15,7 @@ import {
 	switchChildrenNodeName,
 	RawHTML,
 	pure,
+	createRef,
 } from '../';
 
 describe( 'element', () => {
@@ -130,7 +131,6 @@ describe( 'element', () => {
 				( OriginalComponent ) => OriginalComponent,
 				'withTest'
 			)( () => <div /> );
-
 			expect( TestComponent.displayName ).toBe( 'WithTest(Component)' );
 		} );
 
@@ -183,6 +183,18 @@ describe( 'element', () => {
 
 			expect( TestComponent.displayName ).toBe( 'WithTest(CustomDisplayName)' );
 		} );
+		it( 'should forward the ref to the wrapped component', () => {
+			function SomeComponent() {
+				return <div />;
+			}
+			const TestComponent = createHigherOrderComponent(
+				( OriginalComponent ) => OriginalComponent,
+				'withTest'
+			)( SomeComponent );
+			const testRef = createRef();
+			const element = shallow( <TestComponent ref={ testRef } /> );
+			expect( element.prop( 'forwardedRef' ) ).toBe( testRef );
+		} )
 	} );
 
 	describe( 'RawHTML', () => {

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import TestRenderer from 'react-test-renderer';
 /**
  * Internal dependencies
@@ -187,7 +187,7 @@ describe( 'element', () => {
 		it( 'should forward the ref to the wrapped component', () => {
 			const LeafComponent = forwardRef( ( props, ref ) => {
 				const forwardedRef = props.forwardedRef || null;
-				return <input type="text" ref={ ref || forwardedRef }/>;
+				return <input type="text" ref={ ref || forwardedRef } />;
 			} );
 			LeafComponent.displayName = 'LeafComponent';
 			const TestComponent = compose(
@@ -202,7 +202,7 @@ describe( 'element', () => {
 					'withTest'
 				),
 				createHigherOrderComponent(
-					( OriginalComponent ) => props => <OriginalComponent { ...props } />,
+					( OriginalComponent ) => ( props ) => <OriginalComponent { ...props } />,
 					'withTest2'
 				),
 			)( LeafComponent );
@@ -210,7 +210,7 @@ describe( 'element', () => {
 			// things still work.
 			const TestComponentReversed = compose(
 				createHigherOrderComponent(
-					( OriginalComponent ) => props => {
+					( OriginalComponent ) => ( props ) => {
 						return <OriginalComponent { ...props } />;
 					},
 					'withTest2'
@@ -253,22 +253,21 @@ describe( 'element', () => {
 			}
 			let focused = false;
 			const NODE_MOCK = {
-				createNodeMock: ( element ) =>
-				{
+				createNodeMock: ( element ) => {
 					if ( element.type === 'input' ) {
 						//mock focus function
 						return {
 							focus: () => {
 								focused = true;
-							}
-						}
+							},
+						};
 					}
-				}
+				},
 			};
 			TestRenderer.create( <MainComponent />, NODE_MOCK );
 			expect( focused ).toBe( true );
 			focused = false;
-			TestRenderer.create( <MainComponentReversed/>, NODE_MOCK );
+			TestRenderer.create( <MainComponentReversed />, NODE_MOCK );
 			expect( focused ).toBe( true );
 		} );
 	} );
@@ -309,14 +308,14 @@ describe( 'element', () => {
 				return <p>{ ++i }</p>;
 			} );
 			const wrapper = TestRenderer.create( <MyComp /> );
-			wrapper.update(<MyComp />); // Updating with same props doesn't rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '1' );
+			wrapper.update( <MyComp /> ); // Updating with same props doesn't rerender
+			expect( wrapper.toJSON().children[ 0 ] ).toBe( '1' );
 			wrapper.update( <MyComp a /> ); // New prop should trigger a rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '2' );
+			expect( wrapper.toJSON().children[ 0 ] ).toBe( '2' );
 			wrapper.update( <MyComp a /> ); // Keeping the same prop value should not rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '2' );
+			expect( wrapper.toJSON().children[ 0 ] ).toBe( '2' );
 			wrapper.update( <MyComp b /> ); // Changing the prop value should rerender
-			expect( wrapper.toJSON().children[0] ).toBe( '3' );
+			expect( wrapper.toJSON().children[ 0 ] ).toBe( '3' );
 		} );
 
 		it( 'class component should rerender if the props or state change', () => {
@@ -332,20 +331,20 @@ describe( 'element', () => {
 			} );
 			const element = TestRenderer.create( <MyComp /> );
 			//traverse tree to get the wrapped component instance
-			const wrappedComponent = element.root.find(node => node.instance !== null);
+			const wrappedComponent = element.root.find( ( node ) => node.instance !== null );
 
-			element.update(<MyComp />); // Updating with same props doesn't rerender
-			expect( element.toJSON().children[0] ).toBe( '1' );
+			element.update( <MyComp /> ); // Updating with same props doesn't rerender
+			expect( element.toJSON().children[ 0 ] ).toBe( '1' );
 			element.update( <MyComp a /> ); // New prop should trigger a rerender
-			expect( element.toJSON().children[0] ).toBe( '2' );
+			expect( element.toJSON().children[ 0 ] ).toBe( '2' );
 			element.update( <MyComp a /> ); // Keeping the same prop value should not rerender
-			expect( element.toJSON().children[0] ).toBe( '2' );
+			expect( element.toJSON().children[ 0 ] ).toBe( '2' );
 			element.update( <MyComp b /> ); // Changing the prop value should rerender
-			expect( element.toJSON().children[0] ).toBe( '3' );
+			expect( element.toJSON().children[ 0 ] ).toBe( '3' );
 			wrappedComponent.instance.setState( { a: 1 } ); // New state value should trigger a rerender
-			expect( element.toJSON().children[0] ).toBe( '4' );
+			expect( element.toJSON().children[ 0 ] ).toBe( '4' );
 			wrappedComponent.instance.setState( { a: 1 } ); // Keeping the same state value should not trigger a rerender
-			expect( element.toJSON().children[0] ).toBe( '4' );
+			expect( element.toJSON().children[ 0 ] ).toBe( '4' );
 		} );
 	} );
 } );

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -234,47 +234,47 @@ describe( 'element', () => {
 		} );
 	} );
 
-	// describe( 'pure', () => {
-	// 	it( 'functional component should rerender only when props change', () => {
-	// 		let i = 0;
-	// 		const MyComp = pure( () => {
-	// 			return <p>{ ++i }</p>;
-	// 		} );
-	// 		const wrapper = mount( <MyComp /> );
-	// 		wrapper.update(); // Updating with same props doesn't rerender
-	// 		expect( wrapper.html() ).toBe( '<p>1</p>' );
-	// 		wrapper.setProps( { prop: 'a' } ); // New prop should trigger a rerender
-	// 		expect( wrapper.html() ).toBe( '<p>2</p>' );
-	// 		wrapper.setProps( { prop: 'a' } ); // Keeping the same prop value should not rerender
-	// 		expect( wrapper.html() ).toBe( '<p>2</p>' );
-	// 		wrapper.setProps( { prop: 'b' } ); // Changing the prop value should rerender
-	// 		expect( wrapper.html() ).toBe( '<p>3</p>' );
-	// 	} );
-	//
-	// 	it( 'class component should rerender if the props or state change', () => {
-	// 		let i = 0;
-	// 		const MyComp = pure( class extends Component {
-	// 			constructor() {
-	// 				super( ...arguments );
-	// 				this.state = {};
-	// 			}
-	// 			render() {
-	// 				return <p>{ ++i }</p>;
-	// 			}
-	// 		} );
-	// 		const wrapper = mount( <MyComp /> );
-	// 		wrapper.update(); // Updating with same props doesn't rerender
-	// 		expect( wrapper.html() ).toBe( '<p>1</p>' );
-	// 		wrapper.setProps( { prop: 'a' } ); // New prop should trigger a rerender
-	// 		expect( wrapper.html() ).toBe( '<p>2</p>' );
-	// 		wrapper.setProps( { prop: 'a' } ); // Keeping the same prop value should not rerender
-	// 		expect( wrapper.html() ).toBe( '<p>2</p>' );
-	// 		wrapper.setProps( { prop: 'b' } ); // Changing the prop value should rerender
-	// 		expect( wrapper.html() ).toBe( '<p>3</p>' );
-	// 		wrapper.setState( { state: 'a' } ); // New state value should trigger a rerender
-	// 		expect( wrapper.html() ).toBe( '<p>4</p>' );
-	// 		wrapper.setState( { state: 'a' } ); // Keeping the same state value should not trigger a rerender
-	// 		expect( wrapper.html() ).toBe( '<p>4</p>' );
-	// 	} );
-	// } );
+	describe( 'pure', () => {
+		it( 'functional component should rerender only when props change', () => {
+			let i = 0;
+			const MyComp = pure( () => {
+				return <p>{ ++i }</p>;
+			} );
+			const wrapper = TestRenderer.create( <MyComp /> );
+			wrapper.update(<MyComp />); // Updating with same props doesn't rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '1' );
+			wrapper.update( <MyComp a /> ); // New prop should trigger a rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '2' );
+			wrapper.update( <MyComp a /> ); // Keeping the same prop value should not rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '2' );
+			wrapper.update( <MyComp b /> ); // Changing the prop value should rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '3' );
+		} );
+
+		it( 'class component should rerender if the props or state change', () => {
+			let i = 0;
+			const MyComp = pure( class extends Component {
+				constructor() {
+					super( ...arguments );
+					this.state = {};
+				}
+				render() {
+					return <p>{ ++i }</p>;
+				}
+			} );
+			const wrapper = TestRenderer.create( <MyComp /> );
+			wrapper.update(<MyComp />); // Updating with same props doesn't rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '1' );
+			wrapper.update( <MyComp a /> ); // New prop should trigger a rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '2' );
+			wrapper.update( <MyComp a /> ); // Keeping the same prop value should not rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '2' );
+			wrapper.update( <MyComp b /> ); // Changing the prop value should rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '3' );
+			wrapper.root.instance.setState( { a: 1 } ); // New state value should trigger a rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '4' );
+			wrapper.root.instance.setState( { a: 1 } ); // Keeping the same state value should not trigger a rerender
+			expect( wrapper.toJSON().children[0] ).toBe( '4' );
+		} );
+	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Using [React.forwardRef](https://reactjs.org/docs/forwarding-refs.html) it's possible to forward refs to children components from their parents.  This pull seeks to implement this with `createHigherOrderComponent` so any components wrapped by a HOC created through that will automatically have the ref passed through the HOC to them.

Currently this is a work in progress and it's not working as expected:

- I _expected_ that I'd be able to just return the result from `forwardRef(forwardedRefComponent)` but doing a build with that results in errors in the console when executing the GB editor.  Doing `forwardRef(forwardedRefComponent).render` appears to work well for the built files but there are failing tests so I suspect there's some issues not seen in basic user testing of the editor.
- The test I added for verifying the ref is actually forwarded isn't passing so it appears that the isn't actually getting forwarded.

I'm putting this pull up just so others can see the work so far and it might be quickly apparent what needs fixed or whether this is only feasible with some refactoring of other things.

Related issues/comments:

- https://github.com/WordPress/gutenberg/pull/6261#discussion_r191755736
- https://github.com/WordPress/gutenberg/pull/6480#issuecomment-392805451

See [summary comment](https://github.com/WordPress/gutenberg/pull/7557#issuecomment-401794634) regarding findings.  Basically we need a decision on whether to proceed (and how to proceed) with finishing off this pull considering the findings or whether individual HOCs should be responsible for implementing `forwardRef`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* [ ] Trying various blocks in the editor
* [x] Added unit tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

## Rollout

Here's some things needing done in this branch before its ready for merge.

* [x] All tests that fail in this branch (because of lack of enzyme support) switched to use alternative test utilities in pulls off master (see pulls linked through this issue).
* [ ] Master merged in and unit-tests passing.
* [ ] Jest updated so that snapshots can be updated (currently they don't print the pretty display name because the current Jest version doesn't detect forwardRef wrapped components properly).
* [ ] Making any necessary changes to existing HOCS implementing forwardRef manually.
