### PR TITLE
Force the display of hidden meta boxes

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -41,6 +41,9 @@ function gutenberg_collect_meta_box_data() {
 
 	$screen = $current_screen;
 
+	// Disable hidden metaboxes because there's no UI to toggle visibility.
+	add_filter( 'hidden_meta_boxes', '__return_empty_array' );
+
 	// If we are working with an already predetermined post.
 	if ( isset( $_REQUEST['post'] ) ) {
 		$post    = get_post( absint( $_REQUEST['post'] ) );


### PR DESCRIPTION
## Description

Forces the display of hidden meta boxes in Gutenberg, because Gutenberg doesn't have UI for managing meta boxes.

It remains to be seen whether Gutenberg will have the concept of hidden meta boxes, so this is an interim solution to the problem that may become the permanent solution.

Fixes #6495
Fixes #5841
To be documented in #4186

## How has this been tested?

1. Register a custom meta box:

```
add_action( 'add_meta_boxes', function(){
	add_meta_box( 'gutenberg-test', 'Gutenberg Test', function(){
		echo 'Hello World';
	}, get_post_type(), 'side' );
});
```

2. View the meta box as present in the Classic Editor right column:

<img width="393" alt="image" src="https://user-images.githubusercontent.com/36432/41973920-5049922c-79cb-11e8-8330-45b9c715933b.png">

3. Hide the meta box using Screen Options:

<img width="1147" alt="image" src="https://user-images.githubusercontent.com/36432/41974003-8a0c1516-79cb-11e8-9add-1d3001bcf379.png">

4. Notice that the meta box displays correctly in Extended Settings:

<img width="324" alt="image" src="https://user-images.githubusercontent.com/36432/41974101-cdfa01ca-79cb-11e8-8c67-b4b5fb75591d.png">

## Types of changes

Bug fix.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
