### PR TITLE
Correctly handle case where 'post-thumbnails' is array of post types

### DIFF
--- a/editor/components/post-featured-image/check.js
+++ b/editor/components/post-featured-image/check.js
@@ -1,4 +1,10 @@
 /**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
@@ -13,4 +19,12 @@ function PostFeaturedImageCheck( props ) {
 	);
 }
 
-export default PostFeaturedImageCheck;
+const applyWithSelect = withSelect( ( select ) => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	return {
+		postType: getEditedPostAttribute( 'type' ),
+	};
+} );
+export default compose(
+	applyWithSelect,
+)( PostFeaturedImageCheck );

--- a/editor/components/post-featured-image/check.js
+++ b/editor/components/post-featured-image/check.js
@@ -5,8 +5,9 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import ThemeSupportCheck from '../theme-support-check';
 
 function PostFeaturedImageCheck( props ) {
+	const { postType } = props;
 	return (
-		<ThemeSupportCheck supportKeys="post-thumbnails">
+		<ThemeSupportCheck supportKeys="post-thumbnails" postType={ postType } >
 			<PostTypeSupportCheck { ...props } supportKeys="thumbnail" />
 		</ThemeSupportCheck>
 	);

--- a/editor/components/post-featured-image/check.js
+++ b/editor/components/post-featured-image/check.js
@@ -1,30 +1,15 @@
 /**
- * WordPress dependencies
- */
-import { compose } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
 import ThemeSupportCheck from '../theme-support-check';
 
 function PostFeaturedImageCheck( props ) {
-	const { postType } = props;
 	return (
-		<ThemeSupportCheck supportKeys="post-thumbnails" postType={ postType } >
+		<ThemeSupportCheck supportKeys="post-thumbnails">
 			<PostTypeSupportCheck { ...props } supportKeys="thumbnail" />
 		</ThemeSupportCheck>
 	);
 }
 
-const applyWithSelect = withSelect( ( select ) => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	return {
-		postType: getEditedPostAttribute( 'type' ),
-	};
-} );
-export default compose(
-	applyWithSelect,
-)( PostFeaturedImageCheck );
+export default PostFeaturedImageCheck;

--- a/editor/components/theme-support-check/index.js
+++ b/editor/components/theme-support-check/index.js
@@ -1,16 +1,35 @@
 /**
  * External dependencies
  */
-import { get, some, castArray } from 'lodash';
+import {
+	castArray,
+	includes,
+	isArray,
+	get,
+	some,
+} from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
 
-export function ThemeSupportCheck( { themeSupports, children, supportKeys } ) {
+export function ThemeSupportCheck( { themeSupports, children, postType = null, supportKeys } ) {
 	const isSupported = some(
-		castArray( supportKeys ), ( key ) => get( themeSupports, [ key ], false )
+		castArray( supportKeys ), ( key ) => {
+			const supported = get( themeSupports, [ key ], false );
+			// 'post-thumbnails' can be boolean or an array of post types.
+			// In the latter case, we need to verify `postType` exists
+			// within `supported`. If `postType` isn't passed, then the check
+			// should fail.
+			if ( 'post-thumbnails' === key && isArray( supported ) ) {
+				if ( null === postType ) {
+					return false;
+				}
+				return includes( supported, postType );
+			}
+			return supported;
+		}
 	);
 
 	if ( ! isSupported ) {

--- a/editor/components/theme-support-check/index.js
+++ b/editor/components/theme-support-check/index.js
@@ -23,9 +23,6 @@ export function ThemeSupportCheck( { themeSupports, children, postType, supportK
 			// within `supported`. If `postType` isn't passed, then the check
 			// should fail.
 			if ( 'post-thumbnails' === key && isArray( supported ) ) {
-				if ( ! postType ) {
-					return false;
-				}
 				return includes( supported, postType );
 			}
 			return supported;

--- a/editor/components/theme-support-check/index.js
+++ b/editor/components/theme-support-check/index.js
@@ -14,7 +14,7 @@ import {
  */
 import { withSelect } from '@wordpress/data';
 
-export function ThemeSupportCheck( { themeSupports, children, postType = null, supportKeys } ) {
+export function ThemeSupportCheck( { themeSupports, children, postType, supportKeys } ) {
 	const isSupported = some(
 		castArray( supportKeys ), ( key ) => {
 			const supported = get( themeSupports, [ key ], false );
@@ -23,7 +23,7 @@ export function ThemeSupportCheck( { themeSupports, children, postType = null, s
 			// within `supported`. If `postType` isn't passed, then the check
 			// should fail.
 			if ( 'post-thumbnails' === key && isArray( supported ) ) {
-				if ( null === postType ) {
+				if ( ! postType ) {
 					return false;
 				}
 				return includes( supported, postType );
@@ -41,7 +41,9 @@ export function ThemeSupportCheck( { themeSupports, children, postType = null, s
 
 export default withSelect( ( select ) => {
 	const { getThemeSupports } = select( 'core' );
+	const { getEditedPostAttribute } = select( 'core/editor' );
 	return {
+		postType: getEditedPostAttribute( 'type' ),
 		themeSupports: getThemeSupports(),
 	};
 } )( ThemeSupportCheck );

--- a/editor/components/theme-support-check/test/index.js
+++ b/editor/components/theme-support-check/test/index.js
@@ -49,6 +49,18 @@ describe( 'ThemeSupportCheck', () => {
 		expect( wrapper.type() ).toBe( null );
 	} );
 
+	it( 'should not render if post-thumbnails is limited and false is passed for postType', () => {
+		const themeSupports = {
+			'post-thumbnails': [ 'post' ],
+		};
+		const supportKeys = 'post-thumbnails';
+		const wrapper = shallow( <ThemeSupportCheck
+			supportKeys={ supportKeys }
+			postType={ false }
+			themeSupports={ themeSupports }>foobar</ThemeSupportCheck> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+
 	it( 'should not render if theme doesn\'t support post-thumbnails', () => {
 		const themeSupports = {
 			'post-thumbnails': false,

--- a/editor/components/theme-support-check/test/index.js
+++ b/editor/components/theme-support-check/test/index.js
@@ -25,6 +25,30 @@ describe( 'ThemeSupportCheck', () => {
 		expect( wrapper.type() ).not.toBe( null );
 	} );
 
+	it( 'should render if post-thumbnails are supported for the post type', () => {
+		const themeSupports = {
+			'post-thumbnails': [ 'post' ],
+		};
+		const supportKeys = 'post-thumbnails';
+		const wrapper = shallow( <ThemeSupportCheck
+			supportKeys={ supportKeys }
+			postType={ 'post' }
+			themeSupports={ themeSupports }>foobar</ThemeSupportCheck> );
+		expect( wrapper.type() ).not.toBe( null );
+	} );
+
+	it( 'should not render if post-thumbnails aren\'t supported for the post type', () => {
+		const themeSupports = {
+			'post-thumbnails': [ 'post' ],
+		};
+		const supportKeys = 'post-thumbnails';
+		const wrapper = shallow( <ThemeSupportCheck
+			supportKeys={ supportKeys }
+			postType={ 'page' }
+			themeSupports={ themeSupports }>foobar</ThemeSupportCheck> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+
 	it( 'should not render if theme doesn\'t support post-thumbnails', () => {
 		const themeSupports = {
 			'post-thumbnails': false,

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -428,8 +428,11 @@ function gutenberg_ensure_wp_json_has_theme_supports( $response ) {
 		$site_info['theme_supports']['formats'] = $formats;
 	}
 	if ( ! array_key_exists( 'post-thumbnails', $site_info['theme_supports'] ) ) {
-		if ( get_theme_support( 'post-thumbnails' ) ) {
-			$site_info['theme_supports']['post-thumbnails'] = true;
+		$post_thumbnails = get_theme_support( 'post-thumbnails' );
+		if ( $post_thumbnails ) {
+			// $post_thumbnails can contain a nested array of post types.
+			// e.g. array( array( 'post', 'page' ) ).
+			$site_info['theme_supports']['post-thumbnails'] = is_array( $post_thumbnails ) ? $post_thumbnails[0] : true;
 		}
 	}
 	$response->set_data( $site_info );

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -278,6 +278,35 @@ class Gutenberg_REST_API_Test extends WP_Test_REST_TestCase {
 		$this->assertTrue( in_array( 'standard', $result['theme_supports']['formats'] ) );
 	}
 
+	public function test_theme_supports_post_thumbnails_false() {
+		remove_theme_support( 'post-thumbnails' );
+		$request  = new WP_REST_Request( 'GET', '/' );
+		$response = rest_do_request( $request );
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result['theme_supports'] ) );
+		$this->assertFalse( isset( $result['theme_supports']['post-thumbnails'] ) );
+	}
+
+	public function test_theme_supports_post_thumbnails_true() {
+		remove_theme_support( 'post-thumbnails' );
+		add_theme_support( 'post-thumbnails' );
+		$request  = new WP_REST_Request( 'GET', '/' );
+		$response = rest_do_request( $request );
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result['theme_supports'] ) );
+		$this->assertEquals( true, $result['theme_supports']['post-thumbnails'] );
+	}
+
+	public function test_theme_supports_post_thumbnails_array() {
+		remove_theme_support( 'post-thumbnails' );
+		add_theme_support( 'post-thumbnails', array( 'post' ) );
+		$request  = new WP_REST_Request( 'GET', '/' );
+		$response = rest_do_request( $request );
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result['theme_supports'] ) );
+		$this->assertEquals( array( 'post' ), $result['theme_supports']['post-thumbnails'] );
+	}
+
 	public function test_get_taxonomies_context_edit() {
 		wp_set_current_user( $this->contributor );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );


### PR DESCRIPTION
## Description

Updates `ThemeSupportCheck` to support scenario where `'post-thumbnails'` is an array of post types instead of a straight boolean value.

If `'post-thumbnails'` is an array of post types, then `postType` becomes a required argument for `PostFeaturedImageCheck` (which is the only check referring to `'post-thumbnails'` support.

Fixes #7547

## How has this been tested?

1. Add the following code snippet to your `functions.php`:

```
add_action( 'after_setup_theme', function(){
	remove_theme_support( 'post-thumbnails' );
	add_theme_support( 'post-thumbnails', array( 'post' ) );
}, 11 );
```

2. Verify the "Featured Image" Post Setting is only present on the Post screen and not a Page screen.

Post:

![image](https://user-images.githubusercontent.com/36432/41989081-f7b90eda-79f2-11e8-9396-644fa1022ba8.png)

Page:

![image](https://user-images.githubusercontent.com/36432/41989055-e3546dd6-79f2-11e8-80e5-9db45d95a41a.png)

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->