### PR TITLE
Add shortcode package

### DIFF
--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -4,16 +4,16 @@
 import { some, castArray, first, mapValues, pickBy, includes } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { regexp, next } from '@wordpress/shortcode';
+
+/**
  * Internal dependencies
  */
 import { createBlock, getBlockTransforms, findTransform } from '../factory';
 import { getBlockType } from '../registration';
 import { getBlockAttributes } from '../parser';
-
-/**
- * Browser dependencies
- */
-const { shortcode } = window.wp;
 
 function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 	// Get all matches.
@@ -21,7 +21,7 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 
 	const transformation = findTransform( transformsFrom, ( transform ) => (
 		transform.type === 'shortcode' &&
-		some( castArray( transform.tag ), ( tag ) => shortcode.regexp( tag ).test( HTML ) )
+		some( castArray( transform.tag ), ( tag ) => regexp( tag ).test( HTML ) )
 	) );
 
 	if ( ! transformation ) {
@@ -33,7 +33,7 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 
 	let match;
 
-	if ( ( match = shortcode.next( transformTag, HTML, lastIndex ) ) ) {
+	if ( ( match = next( transformTag, HTML, lastIndex ) ) ) {
 		const beforeHTML = HTML.substr( 0, match.index );
 
 		lastIndex = match.index + match.content.length;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -196,6 +196,13 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/utils/index.js' ),
 		true
 	);
+	wp_register_script(
+		'wp-shortcode',
+		gutenberg_url( 'build/shortcode/index.js' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/shortcode/index.js' ),
+		true
+	);
 	wp_add_inline_script( 'wp-utils', 'var originalUtils = window.wp && window.wp.utils ? window.wp.utils : {};', 'before' );
 	wp_add_inline_script( 'wp-utils', 'for ( var key in originalUtils ) wp.utils[ key ] = originalUtils[ key ];' );
 	wp_register_script(
@@ -260,7 +267,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'build/blocks/index.js' ),
-		array( 'wp-blob', 'wp-deprecated', 'wp-dom', 'wp-element', 'wp-hooks', 'wp-i18n', 'shortcode', 'wp-data', 'lodash' ),
+		array( 'wp-blob', 'wp-deprecated', 'wp-dom', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-shortcode', 'wp-data', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/blocks/index.js' ),
 		true
 	);

--- a/packages/shortcode/README.md
+++ b/packages/shortcode/README.md
@@ -1,0 +1,13 @@
+# @wordpress/shortcode
+
+Shortcode utils for WordPress.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/shortcode --save
+```
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@wordpress/shortcode",
+	"version": "1.0.0-alpha.1",
+	"description": "Shortcode module for WordPress",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"shortcode"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/shortcode/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"dependencies": {
+		"lodash": "4.17.5"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -1,0 +1,350 @@
+/**
+ * Internal dependencies
+ */
+import { extend, pick, isString, isEqual, forEach, isNumber } from 'lodash';
+import memize from 'memize';
+
+/**
+ * Find the next matching shortcode.
+ *
+ * Given a shortcode `tag`, a block of `text`, and an optional starting
+ * `index`, returns the next matching shortcode or `undefined`.
+ *
+ * Shortcodes are formatted as an object that contains the match
+ * `content`, the matching `index`, and the parsed `shortcode` object.
+ *
+ * @param {[type]} tag   [description]
+ * @param {[type]} text  [description]
+ * @param {[type]} index [description]
+ *
+ * @return {Object} [description]
+ */
+export function next( tag, text, index ) {
+	const re = regexp( tag );
+
+	re.lastIndex = index || 0;
+
+	const match = re.exec( text );
+
+	if ( ! match ) {
+		return;
+	}
+
+	// If we matched an escaped shortcode, try again.
+	if ( '[' === match[ 1 ] && ']' === match[ 7 ] ) {
+		return next( tag, text, re.lastIndex );
+	}
+
+	const result = {
+		index: match.index,
+		content: match[ 0 ],
+		shortcode: fromMatch( match ),
+	};
+
+	// If we matched a leading `[`, strip it from the match
+	// and increment the index accordingly.
+	if ( match[ 1 ] ) {
+		result.content = result.content.slice( 1 );
+		result.index++;
+	}
+
+	// If we matched a trailing `]`, strip it from the match.
+	if ( match[ 7 ] ) {
+		result.content = result.content.slice( 0, -1 );
+	}
+
+	return result;
+}
+
+/**
+ * Replace matching shortcodes in a block of text.
+ *
+ * Accepts a shortcode `tag`, content `text` to scan, and a `callback`
+ * to process the shortcode matches and return a replacement string.
+ * Returns the `text` with all shortcodes replaced.
+ *
+ * Shortcode matches are objects that contain the shortcode `tag`,
+ * a shortcode `attrs` object, the `content` between shortcode tags,
+ * and a boolean flag to indicate if the match was a `single` tag.
+ *
+ * @param {[type]}   tag      [description]
+ * @param {[type]}   text     [description]
+ * @param {Function} callback [description]
+ *
+ * @return {[type]}   [description]
+ */
+export function replace( tag, text, callback ) {
+	return text.replace( regexp( tag ), ( match, left, $3, attrs, slash, content, closing, right ) => {
+		// If both extra brackets exist, the shortcode has been
+		// properly escaped.
+		if ( left === '[' && right === ']' ) {
+			return match;
+		}
+
+		// Create the match object and pass it through the callback.
+		const result = callback( fromMatch( arguments ) );
+
+		// Make sure to return any of the extra brackets if they
+		// weren't used to escape the shortcode.
+		return result ? left + result + right : match;
+	} );
+}
+
+/**
+ * Generate a string from shortcode parameters,
+ *
+ * Creates a `wp.shortcode` instance and returns a string.
+ *
+ * Accepts the same `options` as the `wp.shortcode()` constructor,
+ * containing a `tag` string, a string or object of `attrs`, a boolean
+ * indicating whether to format the shortcode using a `single` tag, and a
+ * `content` string.
+ *
+ * @param {[type]} options [description]
+ *
+ * @return {[type]} [description]
+ */
+export function string( options ) {
+	return new shortcode( options ).string();
+}
+
+/**
+ * Generate a RegExp to identify a shortcode.
+ *
+ * The base regex is functionally equivalent to the one found in
+ * `get_shortcode_regex()` in `wp-includes/shortcodes.php`.
+ *
+ * Capture groups:
+ *
+ * 1. An extra `[` to allow for escaping shortcodes with double `[[]]`
+ * 2. The shortcode name
+ * 3. The shortcode argument list
+ * 4. The self closing `/`
+ * 5. The content of a shortcode when it wraps some content.
+ * 6. The closing tag.
+ * 7. An extra `]` to allow for escaping shortcodes with double `[[]]`
+ *
+ * @param {[type]} tag [description]
+ *
+ * @return {[type]} [description]
+ */
+export const regexp = memize( ( tag ) => {
+	return new RegExp( '\\[(\\[?)(' + tag + ')(?![\\w-])([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*(?:\\[(?!\\/\\2\\])[^\\[]*)*)(\\[\\/\\2\\]))?)(\\]?)', 'g' );
+} );
+
+/**
+ * Parse shortcode attributes.
+ *
+ * Shortcodes accept many types of attributes. These can chiefly be
+ * divided into named and numeric attributes:
+ *
+ * Named attributes are assigned on a key/value basis, while numeric
+ * attributes are treated as an array.
+ *
+ * Named attributes can be formatted as either `name="value"`,
+ * `name='value'`, or `name=value`. Numeric attributes can be formatted
+ * as `"value"` or just `value`.
+ *
+ * @param {Object} text                         )             {	var named [description]
+ * @param {Array}  numeric                      [description]
+ * @param {[type]} pattern                      [description]
+ * @param {RegExp} match;															pattern [description]
+ *
+ * @return {[type]} [description]
+ */
+export const attrs = memize( ( text ) => {
+	const named = {};
+	const numeric = [];
+
+	// This regular expression is reused from `shortcode_parse_atts()`
+	// in `wp-includes/shortcodes.php`.
+	//
+	// Capture groups:
+	//
+	// 1. An attribute name, that corresponds to...
+	// 2. a value in double quotes.
+	// 3. An attribute name, that corresponds to...
+	// 4. a value in single quotes.
+	// 5. An attribute name, that corresponds to...
+	// 6. an unquoted value.
+	// 7. A numeric attribute in double quotes.
+	// 8. A numeric attribute in single quotes.
+	// 9. An unquoted numeric attribute.
+	const pattern = /([\w-]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w-]+)\s*=\s*'([^']*)'(?:\s|$)|([\w-]+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|'([^']*)'(?:\s|$)|(\S+)(?:\s|$)/g;
+
+	// Map zero-width spaces to actual spaces.
+	text = text.replace( /[\u00a0\u200b]/g, ' ' );
+
+	let match;
+
+	// Match and normalize attributes.
+	while ( ( match = pattern.exec( text ) ) ) {
+		if ( match[ 1 ] ) {
+			named[ match[ 1 ].toLowerCase() ] = match[ 2 ];
+		} else if ( match[ 3 ] ) {
+			named[ match[ 3 ].toLowerCase() ] = match[ 4 ];
+		} else if ( match[ 5 ] ) {
+			named[ match[ 5 ].toLowerCase() ] = match[ 6 ];
+		} else if ( match[ 7 ] ) {
+			numeric.push( match[ 7 ] );
+		} else if ( match[ 8 ] ) {
+			numeric.push( match[ 8 ] );
+		} else if ( match[ 9 ] ) {
+			numeric.push( match[ 9 ] );
+		}
+	}
+
+	return { named, numeric };
+} );
+
+/**
+ * Generate a Shortcode Object from a RegExp match.
+ *
+ * Accepts a `match` object from calling `regexp.exec()` on a `RegExp`
+ * generated by `wp.shortcode.regexp()`. `match` can also be set to the
+ * `arguments` from a callback passed to `regexp.replace()`.
+ *
+ * @param {[type]} match [description]
+ *
+ * @return {[type]} [description]
+ */
+export function fromMatch( match ) {
+	let type;
+
+	if ( match[ 4 ] ) {
+		type = 'self-closing';
+	} else if ( match[ 6 ] ) {
+		type = 'closed';
+	} else {
+		type = 'single';
+	}
+
+	return new shortcode( {
+		tag: match[ 2 ],
+		attrs: match[ 3 ],
+		type,
+		content: match[ 5 ],
+	} );
+}
+
+/**
+ * Shortcode Objects.
+ *
+ * Shortcode objects are generated automatically when using the main
+ * `wp.shortcode` methods: `next()`, `replace()`, and `string()`.
+ *
+ * To access a raw representation of a shortcode, pass an `options` object,
+ * containing a `tag` string, a string or object of `attrs`, a string
+ * indicating the `type` of the shortcode ('single', 'self-closing', or
+ * 'closed'), and a `content` string.
+ */
+const shortcode = extend( function( options ) {
+	extend( this, pick( options || {}, 'tag', 'attrs', 'type', 'content' ) );
+
+	const attributes = this.attrs;
+
+	// Ensure we have a correctly formatted `attrs` object.
+	this.attrs = {
+		named: {},
+		numeric: [],
+	};
+
+	if ( ! attributes ) {
+		return;
+	}
+
+	// Parse a string of attributes.
+	if ( isString( attributes ) ) {
+		this.attrs = attrs( attributes );
+	// Identify a correctly formatted `attrs` object.
+	} else if ( isEqual( Object.keys( attributes ), [ 'named', 'numeric' ] ) ) {
+		this.attrs = attributes;
+	// Handle a flat object of attributes.
+	} else {
+		forEach( attributes, ( value, key ) => {
+			this.set( key, value );
+		} );
+	}
+}, {
+	next,
+	replace,
+	string,
+	regexp,
+	attrs,
+	fromMatch,
+} );
+
+extend( shortcode.prototype, {
+
+	/**
+	 * Get a shortcode attribute.
+	 *
+	 * Automatically detects whether `attr` is named or numeric and routes
+	 * it accordingly.
+	 *
+	 * @param {[type]} attr [description]
+	 *
+	 * @return {[type]} [description]
+	 */
+	get( attr ) {
+		return this.attrs[ isNumber( attr ) ? 'numeric' : 'named' ][ attr ];
+	},
+
+	/**
+	 * Set a shortcode attribute.
+	 *
+	 * Automatically detects whether `attr` is named or numeric and routes
+	 * it accordingly.
+	 *
+	 * @param {[type]} attr  [description]
+	 * @param {[type]} value [description]
+	 *
+	 * @return {[type]} [description]
+	 */
+	set( attr, value ) {
+		this.attrs[ isNumber( attr ) ? 'numeric' : 'named' ][ attr ] = value;
+		return this;
+	},
+
+	/**
+	 * Transform the shortcode match into a string.
+	 *
+	 * @return {[type]} [description]
+	 */
+	string() {
+		let text = '[' + this.tag;
+
+		forEach( this.attrs.numeric, ( value ) => {
+			if ( /\s/.test( value ) ) {
+				text += ' "' + value + '"';
+			} else {
+				text += ' ' + value;
+			}
+		} );
+
+		forEach( this.attrs.named, ( value, name ) => {
+			text += ' ' + name + '="' + value + '"';
+		} );
+
+		// If the tag is marked as `single` or `self-closing`, close the
+		// tag and ignore any additional content.
+		if ( 'single' === this.type ) {
+			return text + ']';
+		} else if ( 'self-closing' === this.type ) {
+			return text + ' /]';
+		}
+
+		// Complete the opening tag.
+		text += ']';
+
+		if ( this.content ) {
+			text += this.content;
+		}
+
+		// Add the closing tag.
+		return text + '[/' + this.tag + ']';
+	},
+
+} );
+
+export default shortcode;

--- a/packages/shortcode/src/test/index.js
+++ b/packages/shortcode/src/test/index.js
@@ -1,0 +1,198 @@
+/**
+ * Internal dependencies
+ */
+import { next, replace, attrs } from '../';
+
+describe( 'shortcode', () => {
+	describe( 'next', () => {
+		it( 'should find the shortcode', () => {
+			const result = next( 'foo', 'this has the [foo] shortcode' );
+			expect( result.index ).toBe( 13 );
+		} );
+
+		it( 'should find the shortcode with attributes', () => {
+			const result = next( 'foo', 'this has the [foo param="foo"] shortcode' );
+			expect( result.index ).toBe( 13 );
+		} );
+
+		it( 'should not find shortcodes that are not there', () => {
+			const result = next( 'bar', 'this has the [foo] shortcode' );
+			expect( result ).toBe( undefined );
+		} );
+
+		it( 'should not find shortcodes with attributes that are not there', () => {
+			const result = next( 'bar', 'this has the [foo param="bar"] shortcode' );
+			expect( result ).toBe( undefined );
+		} );
+
+		it( 'should find the shortcode when told to start looking beyond the start of the string', () => {
+			const result1 = next( 'foo', 'this has the [foo] shortcode', 12 );
+			expect( result1.index ).toBe( 13 );
+
+			const result2 = next( 'foo', 'this has the [foo] shortcode', 13 );
+			expect( result2.index ).toBe( 13 );
+
+			const result3 = next( 'foo', 'this has the [foo] shortcode', 14 );
+			expect( result3 ).toBe( undefined );
+		} );
+
+		it( 'should find the second instances of the shortcode when the starting indice is after the start of the first one', () => {
+			const result = next( 'foo', 'this has the [foo] shortcode [foo] twice', 14 );
+			expect( result.index ).toBe( 29 );
+		} );
+
+		it( 'should not find escaped shortcodes', () => {
+			const result = next( 'foo', 'this has the [[foo]] shortcode' );
+			expect( result ).toBe( undefined );
+		} );
+
+		it( 'should not find escaped shortcodes with attributes', () => {
+			const result = next( 'foo', 'this has the [[foo param="foo"]] shortcode' );
+			expect( result ).toBe( undefined );
+		} );
+
+		it( 'should find shortcodes that are incorrectly escaped by newlines', () => {
+			const result1 = next( 'foo', 'this has the [\n[foo]] shortcode' );
+			expect( result1.index ).toBe( 15 );
+
+			const result2 = next( 'foo', 'this has the [[foo]\n] shortcode' );
+			expect( result2.index ).toBe( 14 );
+		} );
+
+		it( 'should still work when there are not equal ammounts of square brackets', () => {
+			const result1 = next( 'foo', 'this has the [[foo] shortcode' );
+			expect( result1.index ).toBe( 14 );
+
+			const result2 = next( 'foo', 'this has the [foo]] shortcode' );
+			expect( result2.index ).toBe( 13 );
+		} );
+
+		it( 'should find the second instances of the shortcode when the first one is escaped', () => {
+			const result = next( 'foo', 'this has the [[foo]] shortcode [foo] twice' );
+			expect( result.index ).toBe( 31 );
+		} );
+
+		it( 'should not find shortcodes that are not full matches', () => {
+			const result1 = next( 'foo', 'this has the [foobar] shortcode' );
+			expect( result1 ).toBe( undefined );
+
+			const result2 = next( 'foobar', 'this has the [foo] shortcode' );
+			expect( result2 ).toBe( undefined );
+		} );
+	} );
+
+	describe( 'replace', () => {
+		it( 'should replace the shortcode', () => {
+			const result1 = replace( 'foo', 'this has the [foo] shortcode', () => 'bar' );
+			expect( result1 ).toBe( 'this has the bar shortcode' );
+
+			const result2 = replace( 'foo', 'this has the [foo param="foo"] shortcode', () => 'bar' );
+			expect( result2 ).toBe( 'this has the bar shortcode' );
+		} );
+
+		it( 'should not replace the shortcode when it does not match', () => {
+			const result1 = replace( 'bar', 'this has the [foo] shortcode', () => 'bar' );
+			expect( result1 ).toBe( 'this has the [foo] shortcode' );
+
+			const result2 = replace( 'bar', 'this has the [foo param="bar"] shortcode', () => 'bar' );
+			expect( result2 ).toBe( 'this has the [foo param="bar"] shortcode' );
+		} );
+
+		it( 'should replace the shortcode in all instances of its use', () => {
+			const result1 = replace( 'foo', 'this has the [foo] shortcode [foo] twice', () => 'bar' );
+			expect( result1 ).toBe( 'this has the bar shortcode bar twice' );
+
+			const result2 = replace( 'foo', 'this has the [foo param="foo"] shortcode [foo] twice', () => 'bar' );
+			expect( result2 ).toBe( 'this has the bar shortcode bar twice' );
+		} );
+
+		it( 'should not replace the escaped shortcodes', () => {
+			const result1 = replace( 'foo', 'this has the [[foo]] shortcode', () => 'bar' );
+			expect( result1 ).toBe( 'this has the [[foo]] shortcode' );
+
+			const result2 = replace( 'foo', 'this has the [[foo param="bar"]] shortcode', () => 'bar' );
+			expect( result2 ).toBe( 'this has the [[foo param="bar"]] shortcode' );
+
+			const result3 = replace( 'foo', 'this [foo] has the [[foo param="bar"]] shortcode escaped', () => 'bar' );
+			expect( result3 ).toBe( 'this bar has the [[foo param="bar"]] shortcode escaped' );
+		} );
+
+		it( 'should replace improperly escaped shortcodes that include newlines', () => {
+			const result1 = replace( 'foo', 'this [foo] has the [[foo param="bar"]\n] shortcode ', () => 'bar' );
+			expect( result1 ).toBe( 'this bar has the [bar\n] shortcode ' );
+
+			const result2 = replace( 'foo', 'this [foo] has the [\n[foo param="bar"]] shortcode ', () => 'bar' );
+			expect( result2 ).toBe( 'this bar has the [\nbar] shortcode ' );
+		} );
+
+		it( 'should not replace the shortcode when it is an incomplete match', () => {
+			const result1 = replace( 'foo', 'this has the [foobar] shortcode', () => 'bar' );
+			expect( result1 ).toBe( 'this has the [foobar] shortcode' );
+
+			const result2 = replace( 'foobar', 'this has the [foo] shortcode', () => 'bar' );
+			expect( result2 ).toBe( 'this has the [foo] shortcode' );
+		} );
+	} );
+
+	describe( 'attrs', () => {
+		it( 'should return named attributes created with single, double, and no quotes', () => {
+			const result = attrs( 'param="foo" another=\'bar\' andagain=baz' );
+			const expected = {
+				named: {
+					param: 'foo',
+					another: 'bar',
+					andagain: 'baz',
+				},
+				numeric: [],
+			};
+
+			expect( result ).toEqual( expected );
+		} );
+
+		it( 'should return numeric attributes in the order they are used', () => {
+			const result = attrs( 'foo bar baz' );
+			const expected = {
+				named: {},
+				numeric: [ 'foo', 'bar', 'baz' ],
+			};
+
+			expect( result ).toEqual( expected );
+		} );
+
+		it( 'should return numeric attributes in the order they are used when they have named attributes in between', () => {
+			const result = attrs( 'foo not="a blocker" bar baz' );
+			const expected = {
+				named: {
+					not: 'a blocker',
+				},
+				numeric: [ 'foo', 'bar', 'baz' ],
+			};
+
+			expect( result ).toEqual( expected );
+		} );
+
+		it( 'should return numeric attributes created with single, double, and no quotes', () => {
+			const result = attrs( 'foo "bar" \'baz\'' );
+			const expected = {
+				named: {},
+				numeric: [ 'foo', 'bar', 'baz' ],
+			};
+
+			expect( result ).toEqual( expected );
+		} );
+
+		it( 'should return mixed attributes created with single, double, and no quotes', () => {
+			const result = attrs( 'a="foo" b=\'bar\' c=baz foo "bar" \'baz\'' );
+			const expected = {
+				named: {
+					a: 'foo',
+					b: 'bar',
+					c: 'baz',
+				},
+				numeric: [ 'foo', 'bar', 'baz' ],
+			};
+
+			expect( result ).toEqual( expected );
+		} );
+	} );
+} );

--- a/test/integration/fixtures/wordpress-in.html
+++ b/test/integration/fixtures/wordpress-in.html
@@ -2,3 +2,5 @@
 <p>This is a paragraph.</p>
 <h3>More tag</h3>
 <p><!--more--></p>
+<h3>Shortcode</h3>
+<p>[gallery ids="1"]</p>

--- a/test/integration/fixtures/wordpress-out.html
+++ b/test/integration/fixtures/wordpress-out.html
@@ -13,3 +13,15 @@
 <!-- wp:more -->
 <!--more-->
 <!-- /wp:more -->
+
+<!-- wp:heading -->
+<h3>Shortcode</h3>
+<!-- /wp:heading -->
+
+<!-- wp:gallery {"columns":3,"linkTo":"attachment"} -->
+<ul class="wp-block-gallery alignnone columns-3 is-cropped">
+	<li class="blocks-gallery-item">
+		<figure><img data-id="1" /></figure>
+	</li>
+</ul>
+<!-- /wp:gallery -->

--- a/test/unit/jest.config.json
+++ b/test/unit/jest.config.json
@@ -6,7 +6,7 @@
 	],
 	"moduleNameMapper": {
 		"@wordpress\\/(blocks|components|editor|utils|edit-post|viewport|core-data|core-blocks|nux)$": "$1",
-		"@wordpress\\/(api-request|blob|core-data|data|date|dom|deprecated|element|keycodes|plugins|postcss-themes)$": "packages/$1/src"
+		"@wordpress\\/(api-request|blob|core-data|data|date|dom|deprecated|element|keycodes|plugins|shortcode|postcss-themes)$": "packages/$1/src"
 	},
 	"preset": "@wordpress/jest-preset-default",
 	"setupFiles": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -158,6 +158,7 @@ const gutenbergPackages = [
 	'element',
 	'keycodes',
 	'plugins',
+	'shortcode',
 ];
 
 const wordPressPackages = [


### PR DESCRIPTION
## Description
This branch adds a shortcode package to Gutenberg, instead of relying on the core global. This is needed for us to add tests for the shortcode converter (and future tweaks).

See https://github.com/WordPress/wordpress-develop/blob/master/src/js/_enqueues/wp/shortcode.js and https://github.com/WordPress/wordpress-develop/blob/master/tests/qunit/wp-includes/js/shortcode.js.

## How has this been tested?
Ensure shortcode converting still works.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->