### PR TITLE
Experiment: RichText: Format content from tree value

### DIFF
--- a/editor/components/rich-text/style.scss
+++ b/editor/components/rich-text/style.scss
@@ -5,15 +5,15 @@
 }
 
 .editor-rich-text__tinymce {
-	margin: 0;
 	position: relative;
+
+	&,
+	p {
+		margin: 0;
+	}
 
 	> p:empty {
 		min-height: $editor-font-size * $editor-line-height;
-	}
-
-	> p:first-child {
-		margin-top: 0;
 	}
 
 	&:focus {
@@ -66,10 +66,6 @@
 		top: 0;
 		width: 100%;
 		margin-top: 0;
-
-		& > p {
-			margin-top: 0;
-		}
 	}
 
 	& + .editor-rich-text__tinymce {

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -161,7 +161,17 @@ export { serialize as renderToString };
 export function concatChildren( ...childrenArguments ) {
 	return childrenArguments.reduce( ( memo, children, i ) => {
 		Children.forEach( children, ( child, j ) => {
-			if ( child && 'string' !== typeof child ) {
+			if ( ! child ) {
+				return;
+			}
+
+			if ( typeof child === 'string' ) {
+				const lastChild = memo[ memo.length - 1 ];
+				if ( typeof lastChild === 'string' ) {
+					memo[ memo.length - 1 ] = lastChild + child;
+					return;
+				}
+			} else {
 				child = cloneElement( child, {
 					key: [ i, j ].join(),
 				} );

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -81,8 +81,12 @@ describe( 'element', () => {
 			expect( concatChildren() ).toEqual( [] );
 		} );
 
+		it( 'should disregard falsey children', () => {
+			expect( concatChildren( [ 'a' ], [ null ], [ 'b' ] ) ).toEqual( [ 'ab' ] );
+		} );
+
 		it( 'should concat the string arrays', () => {
-			expect( concatChildren( [ 'a' ], 'b' ) ).toEqual( [ 'a', 'b' ] );
+			expect( concatChildren( [ 'a' ], 'b' ) ).toEqual( [ 'ab' ] );
 		} );
 
 		it( 'should concat the object arrays and rewrite keys', () => {


### PR DESCRIPTION
Related: #3713

_Note: This pull request is considered to be a failed experiment and will be closed immediately upon open, serving only as reference for future effort / discussion._

This pull request seeks to explore using TinyMCE's `tree` format as the base source from which to generate content, leveraging its own empty content filtering rather than trying to recreate it in Gutenberg. It's tangentially related to #7482 in trying to be more aware of block splitting to reuse the existing value on an empty new block. Further, it tries to consolidate splitting behaviors into relying on only TinyMCE's `NewBlock` event, treating paragraphs as top-level nodes from which new blocks are to be generated (see also https://github.com/WordPress/gutenberg/pull/3713#issuecomment-400709789).

Unfortunately, this seems to have a noticeable performance degradation on simple typing within a paragraph. Exploring further, it appears that `getContent( { format: 'tree' } )` [incurs a fresh parse on the `innerHTML` of the editor node](https://github.com/tinymce/tinymce/blob/7dfd8102cadfb35e7304cacec7f122aa9e81b1ad/src/core/main/ts/dom/DomSerializer.ts#L88) to generate the node tree. This is in contrast to our existing implementation which simply walks the DOM and tries to filter empty nodes, which is trivial in comparison.

**Useful notes for future consideration:**

- Unlike #3713, I didn't try to pull in `dom-react` to do back-mapping of attributes, because I was left wondering: Should we expect any attributes to be assigned to elements in rich-text? If not, we could consider simplifying our `domToElement` implementation, avoiding `nodeListToReact` and simply creating elements directly via `createElement` on the `nodeName.toLowerCase()` and its `childNodes` (perhaps helpful for #7476).
- The included changes to unset `paddEmpty` from the editor elements schema can prevent new blocks from including being empty yet assigned as technically a value of `[ ' ' ]`
- I'm still not convinced we're ever hitting the `NewBlock` event in current master (commented as such at https://github.com/WordPress/gutenberg/pull/409#discussion_r197460877)
- We can optimize `concatChildren` to consider two sets of children which are both strings to be a single set of one concatenated string child (helps when comparing the `RichText` value as having been changed if value changes from e.g. `[ 'Foo' ]` to `[ 'Foo', '' ]` (merging two paragraphs into one when the second paragraph has no text of its own).