### PR TITLE
Own package for keycodes

### DIFF
--- a/components/code-editor/editor.js
+++ b/components/code-editor/editor.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { UP, DOWN } from '@wordpress/utils';
+import { UP, DOWN } from '@wordpress/keycodes';
 
 class CodeEditor extends Component {
 	constructor() {


### PR DESCRIPTION
## Description
Keycodes was extracted to its own package. So `@wordpress/utils` should have changed to `@wordpress/keycodes`. This one was missing.
