### PR TITLE
chore: Move "Remove" block button to ellipsis menu

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -27,7 +27,6 @@ $z-layers: (
 	'.wp-block-image__resize-handlers': 1, // Resize handlers above sibling inserter
 
 	// Side UI active buttons
-	'.editor-block-settings-remove': 1,
 	'.editor-block-mover__control': 1,
 
 	// Should have lower index than anything else positioned inside the block containers

--- a/editor/components/block-settings-menu/block-remove-button.js
+++ b/editor/components/block-settings-menu/block-remove-button.js
@@ -11,22 +11,24 @@ import { IconButton } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 
-export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, role, ...props } ) {
+export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, role, small = false, ...props } ) {
 	if ( isLocked ) {
 		return null;
 	}
 
-	const label = __( 'Remove' );
+	const label = __( 'Remove this block' );
 
 	return (
 		<IconButton
-			className="editor-block-settings-remove"
+			className="editor-block-settings-menu__control"
 			onClick={ flow( onRemove, onClick ) }
 			icon="trash"
-			label={ label }
+			label={ small ? label : undefined }
 			role={ role }
 			{ ...props }
-		/>
+		>
+			{ ! small && label }
+		</IconButton>
 	);
 }
 

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -99,13 +99,13 @@ export class BlockSettingsMenu extends Component {
 							{ count === 1 && <UnknownConverter uid={ firstBlockUID } role="menuitem" /> }
 							<BlockDuplicateButton uids={ uids } rootUID={ rootUID } role="menuitem" />
 							{ count === 1 && <SharedBlockSettings uid={ firstBlockUID } onToggle={ onClose } itemsRole="menuitem" /> }
+							<BlockRemoveButton
+								uids={ uids }
+								onFocus={ this.onFocus }
+								onBlur={ this.onBlur }
+							/>
 						</NavigableMenu>
 					) }
-				/>
-				<BlockRemoveButton
-					uids={ uids }
-					onFocus={ this.onFocus }
-					onBlur={ this.onBlur }
 				/>
 			</div>
 		);

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -71,7 +71,7 @@ export class BlockSettingsMenu extends Component {
 						const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
 							'is-opened': isOpen,
 						} );
-						const label = isOpen ? __( 'Hide Options' ) : __( 'More Options' );
+						const label = isOpen ? __( 'Hide Options' ) : __( 'Show Options' );
 
 						return (
 							<IconButton

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -8,7 +8,6 @@
 }
 
 // The Blocks "More" Menu ellipsis icon button, and trash button
-.editor-block-settings-remove,
 .editor-block-settings-menu__toggle {
 	justify-content: center;
 	padding: 0;
@@ -29,15 +28,9 @@
 			background: $white;
 			box-shadow: inset 0 0 0 1px $light-gray-500;
 			color: $dark-gray-500; // always show dark gray in nested contexts
-	
+
 			&:first-child {
 				margin-bottom: -1px;
-			}	
-
-			&:hover,
-			&:active,
-			&:focus {
-				z-index: z-index( '.editor-block-settings-remove' );
 			}
 		}
 	}


### PR DESCRIPTION
Close #7216

## Description
Move the remove button from the side of each block to the "options"/ellipsis menu for each block.

This also changes the label for the ellipsis menu from "More options" to "Show options" because now it's the only button… but maybe just "Options" or "Manage Block" or something would be better. 🤷‍♂️

## How has this been tested?
Ran locally on mobile device and in Firefox, removal still worked fine.

## Screenshots

### Mobile
![2018-06-27 20 14 30](https://user-images.githubusercontent.com/90871/41994570-c73109d0-7a46-11e8-95a2-0c8d2864d81f.gif)

### Desktop
![2018-06-27 20 11 13](https://user-images.githubusercontent.com/90871/41994576-cc40abec-7a46-11e8-9d7e-3babf6f4b8ec.gif)

## Types of changes
This changes the location of the remove block button and modifies a few i18n strings to accommodate the new layout.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->