### PR TITLE
Update import from @wordpress/deprecated

### DIFF
--- a/editor/components/colors/with-colors.js
+++ b/editor/components/colors/with-colors.js
@@ -8,7 +8,7 @@ import { find, get, isFunction, isString, kebabCase, reduce, upperFirst } from '
  */
 import { createHigherOrderComponent, Component, compose } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
-import { deprecated } from '@wordpress/utils';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## Description
`deprecated` was moved into its own package `@wordpress/deprecated` in #6914.
This one was missing.