### PR TITLE
Support 'preload' attribute for Audio Block

### DIFF
--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -1,8 +1,15 @@
 /**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
+	Button,
+	ButtonGroup,
 	IconButton,
 	PanelBody,
 	Toolbar,
@@ -41,7 +48,7 @@ class AudioEdit extends Component {
 	}
 
 	render() {
-		const { autoplay, caption, loop, src } = this.props.attributes;
+		const { autoplay, caption, loop, preload, src } = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
 		const switchToEditing = () => {
@@ -102,6 +109,37 @@ class AudioEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<InspectorControls>
+					<PanelBody title={ __( 'Preload' ) }>
+						<ButtonGroup aria-label={ __( 'Preload' ) }>
+							{ map( [
+								{
+									name: __( 'Auto' ),
+									key: 'auto',
+									attributeValue: 'auto',
+								},
+								{
+									name: __( 'Metadata' ),
+									key: 'metadata',
+									attributeValue: 'metadata',
+								},
+								{
+									name: __( 'None' ),
+									key: 'none',
+									attributeValue: undefined,
+								},
+							], ( { name, key, attributeValue } ) => (
+								<Button
+									key={ key }
+									isLarge
+									isPrimary={ attributeValue === preload }
+									aria-pressed={ attributeValue === preload }
+									onClick={ () => setAttributes( { preload: attributeValue } ) }
+								>
+									{ name }
+								</Button>
+							) ) }
+						</ButtonGroup>
+					</PanelBody>
 					<PanelBody title={ __( 'Playback Controls' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -105,6 +105,7 @@ class AudioEdit extends Component {
 					<SelectControl
 						label={ __( 'Preload' ) }
 						value={ undefined !== preload ? preload : 'none' }
+						// `undefined` is required for the preload attribute to be unset.
 						onChange={ ( value ) => setAttributes( { preload: 'none' !== value ? value : undefined } ) }
 						options={ [
 							{ value: 'auto', label: __( 'Auto' ) },

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -118,7 +118,7 @@ class AudioEdit extends Component {
 							label={ __( 'Preload' ) }
 							value={ undefined !== preload ? preload : 'none' }
 							// `undefined` is required for the preload attribute to be unset.
-							onChange={ ( value ) => setAttributes( { preload: 'none' !== value ? value : undefined } ) }
+							onChange={ ( value ) => setAttributes( { preload: ( 'none' !== value ) ? value : undefined } ) }
 							options={ [
 								{ value: 'auto', label: __( 'Auto' ) },
 								{ value: 'metadata', label: __( 'Metadata' ) },

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	IconButton,
+	PanelBody,
 	SelectControl,
 	Toolbar,
 	ToggleControl,
@@ -102,27 +103,29 @@ class AudioEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<InspectorControls>
-					<SelectControl
-						label={ __( 'Preload' ) }
-						value={ undefined !== preload ? preload : 'none' }
-						// `undefined` is required for the preload attribute to be unset.
-						onChange={ ( value ) => setAttributes( { preload: 'none' !== value ? value : undefined } ) }
-						options={ [
-							{ value: 'auto', label: __( 'Auto' ) },
-							{ value: 'metadata', label: __( 'Metadata' ) },
-							{ value: 'none', label: __( 'None' ) },
-						] }
-					/>
-					<ToggleControl
-						label={ __( 'Autoplay' ) }
-						onChange={ this.toggleAttribute( 'autoplay' ) }
-						checked={ autoplay }
-					/>
-					<ToggleControl
-						label={ __( 'Loop' ) }
-						onChange={ this.toggleAttribute( 'loop' ) }
-						checked={ loop }
-					/>
+					<PanelBody>
+						<ToggleControl
+							label={ __( 'Autoplay' ) }
+							onChange={ this.toggleAttribute( 'autoplay' ) }
+							checked={ autoplay }
+						/>
+						<ToggleControl
+							label={ __( 'Loop' ) }
+							onChange={ this.toggleAttribute( 'loop' ) }
+							checked={ loop }
+						/>
+						<SelectControl
+							label={ __( 'Preload' ) }
+							value={ undefined !== preload ? preload : 'none' }
+							// `undefined` is required for the preload attribute to be unset.
+							onChange={ ( value ) => setAttributes( { preload: 'none' !== value ? value : undefined } ) }
+							options={ [
+								{ value: 'auto', label: __( 'Auto' ) },
+								{ value: 'metadata', label: __( 'Metadata' ) },
+								{ value: 'none', label: __( 'None' ) },
+							] }
+						/>
+					</PanelBody>
 				</InspectorControls>
 				<figure className={ className }>
 					<audio controls="controls" src={ src } />

--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -1,17 +1,10 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
-	Button,
-	ButtonGroup,
 	IconButton,
-	PanelBody,
+	SelectControl,
 	Toolbar,
 	ToggleControl,
 	withNotices,
@@ -109,49 +102,26 @@ class AudioEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody title={ __( 'Preload' ) }>
-						<ButtonGroup aria-label={ __( 'Preload' ) }>
-							{ map( [
-								{
-									name: __( 'Auto' ),
-									key: 'auto',
-									attributeValue: 'auto',
-								},
-								{
-									name: __( 'Metadata' ),
-									key: 'metadata',
-									attributeValue: 'metadata',
-								},
-								{
-									name: __( 'None' ),
-									key: 'none',
-									attributeValue: undefined,
-								},
-							], ( { name, key, attributeValue } ) => (
-								<Button
-									key={ key }
-									isLarge
-									isPrimary={ attributeValue === preload }
-									aria-pressed={ attributeValue === preload }
-									onClick={ () => setAttributes( { preload: attributeValue } ) }
-								>
-									{ name }
-								</Button>
-							) ) }
-						</ButtonGroup>
-					</PanelBody>
-					<PanelBody title={ __( 'Playback Controls' ) }>
-						<ToggleControl
-							label={ __( 'Autoplay' ) }
-							onChange={ this.toggleAttribute( 'autoplay' ) }
-							checked={ autoplay }
-						/>
-						<ToggleControl
-							label={ __( 'Loop' ) }
-							onChange={ this.toggleAttribute( 'loop' ) }
-							checked={ loop }
-						/>
-					</PanelBody>
+					<SelectControl
+						label={ __( 'Preload' ) }
+						value={ undefined !== preload ? preload : 'none' }
+						onChange={ ( value ) => setAttributes( { preload: 'none' !== value ? value : undefined } ) }
+						options={ [
+							{ value: 'auto', label: __( 'Auto' ) },
+							{ value: 'metadata', label: __( 'Metadata' ) },
+							{ value: 'none', label: __( 'None' ) },
+						] }
+					/>
+					<ToggleControl
+						label={ __( 'Autoplay' ) }
+						onChange={ this.toggleAttribute( 'autoplay' ) }
+						checked={ autoplay }
+					/>
+					<ToggleControl
+						label={ __( 'Loop' ) }
+						onChange={ this.toggleAttribute( 'loop' ) }
+						checked={ loop }
+					/>
 				</InspectorControls>
 				<figure className={ className }>
 					<audio controls="controls" src={ src } />

--- a/core-blocks/audio/index.js
+++ b/core-blocks/audio/index.js
@@ -48,6 +48,12 @@ export const settings = {
 			selector: 'audio',
 			attribute: 'loop',
 		},
+		preload: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'audio',
+			attribute: 'preload',
+		},
 	},
 
 	supports: {
@@ -57,10 +63,10 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { autoplay, caption, loop, src } = attributes;
+		const { autoplay, caption, loop, preload, src } = attributes;
 		return (
 			<figure>
-				<audio controls="controls" src={ src } autoPlay={ autoplay } loop={ loop } />
+				<audio controls="controls" src={ src } autoPlay={ autoplay } loop={ loop } preload={ preload } />
 				{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
 			</figure>
 		);


### PR DESCRIPTION
## Description

Adds UI for managing `preload` attribute of the Audio Block:

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/36432/41996599-3d9f09c4-7a0a-11e8-9bf3-d41d5f55c516.png">

This is for feature parity with the `[audio]` shortcode:

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/36432/41996628-5add3b1e-7a0a-11e8-9ecd-0013a250da34.png">

The default value is 'None'. Selecting 'Auto' or 'Metadata' will add `preload="auto"` or `preload="meta"` to the `<audio>` element, respectively.

Fixes #6581
Previously #7322

## How has this been tested?

1. Add an Audio Block to the editor. View that it has no `preload` attribute set by default:

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/36432/41996865-14ba2a6a-7a0b-11e8-8335-3b7f657605ce.png">

<img width="751" alt="image" src="https://user-images.githubusercontent.com/36432/41996815-e591296e-7a0a-11e8-93d7-57c5ae79872a.png">

2. Switch back to Visual mode, select "Auto", and then view that `preload='auto'` is set:

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/36432/41996847-080047be-7a0b-11e8-9b65-545edb53910c.png">

<img width="726" alt="image" src="https://user-images.githubusercontent.com/36432/41996838-00a64c8e-7a0b-11e8-94f0-a2b6c7654a2f.png">

3. Save the post and verify the `<audio>` element includes `preload="auto"`:

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/36432/41996966-63393a46-7a0b-11e8-8ee2-835cee058bd4.png">

## Types of changes

Enhancement to existing feature.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
