### PR TITLE
Add jquery dependency to wp-api-request

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -119,7 +119,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-api-request',
 		gutenberg_url( 'build/api-request/index.js' ),
-		array(),
+		array( 'jquery' ),
 		filemtime( gutenberg_dir_path() . 'build/api-request/index.js' ),
 		true
 	);


### PR DESCRIPTION
## Description
Make sure that `wp-api-request` requires `jquery`

## How has this been tested?

You can replicate the issue in master by adding this to a plugin:
```php
wp_enqueue_script( 'fix-api-request-script', '/path/to/some/script', [ 'wp-api-request' ] );
```

You should get an error like
```
TypeError: o(...) is not a function at api-request/index.js
```
which is coming from this minified code in the nonce middleware:
```javascript
o()(document).on("heartbeat-tick",
```

## Types of changes
Bug fix: packages/api-request/src/middlewares/nonce.js requires jquery, but wp-api-request doesn't explicitly depend on that.

This can be an issue if you are trying to extend Gutenberg with `wp-api-request` in a script with few other dependencies. The jQuery usage in `nonce.js` will be loaded but it will be undefined.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
