### PR TITLE
Ensure ellipsis icon button is visible when block settings menu is open

### DIFF
--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -60,17 +60,14 @@ export class BlockSettingsMenu extends Component {
 		const firstBlockUID = blockUIDs[ 0 ];
 
 		return (
-			<div
-				className={ classnames( 'editor-block-settings-menu', {
-					'is-visible': isFocused || ! isHidden,
-				} ) }
-			>
+			<div className="editor-block-settings-menu">
 				<Dropdown
 					contentClassName="editor-block-settings-menu__popover"
 					position="bottom left"
 					renderToggle={ ( { onToggle, isOpen } ) => {
 						const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
 							'is-opened': isOpen,
+							'is-visible': isFocused || isOpen || ! isHidden,
 						} );
 						const label = isOpen ? __( 'Hide Options' ) : __( 'More Options' );
 

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -1,10 +1,5 @@
 .editor-block-settings-menu {
 	line-height: 1;
-	opacity: 0;
-
-	&.is-visible {
-		@include fade_in;
-	}
 }
 
 // The Blocks "More" Menu ellipsis icon button, and trash button
@@ -15,9 +10,14 @@
 	width: $block-side-ui-width;
 	height: $block-side-ui-width;
 	border-radius: $button-style__radius-roundrect;
+	opacity: 0;
 
 	// use opacity to work in various editor styles
 	color: $dark-opacity-500;
+
+	&.is-visible {
+		@include fade_in;
+	}
 
 	.is-dark-theme & {
 		color: $light-opacity-500;
@@ -29,10 +29,10 @@
 			background: $white;
 			box-shadow: inset 0 0 0 1px $light-gray-500;
 			color: $dark-gray-500; // always show dark gray in nested contexts
-	
+
 			&:first-child {
 				margin-bottom: -1px;
-			}	
+			}
 
 			&:hover,
 			&:active,


### PR DESCRIPTION
## Description

Fixes #7596 - previously, while the block settings menu was open the ellipsis icon button could become hidden if it lost its hover state.

This change ensures the icon button remains visible while the menu is open. 

When the block settings menu is not open, the icon button has the same behaviour as it did previously.

## How has this been tested?
- Manual UI testing
- Ensured unit and e2e tests pass

## Screenshots
![ellipsis-fix](https://user-images.githubusercontent.com/677833/42026897-dcc768de-7afa-11e8-9ff3-2ddf5099d6d2.gif)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
