### PR TITLE
Blocks: Add a way to manage block categories

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -1,13 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { select } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 
 /**
  * Returns all the block categories.
  *
- * @return {Array} Block categories.
+ * @return {Object[]} Block categories.
  */
 export function getCategories() {
 	return select( 'core/blocks' ).getCategories();
+}
+
+/**
+ * Sets the block categories.
+ *
+ * @param {Object[]} categories Block categories.
+ */
+export function setCategories( categories ) {
+	dispatch( 'core/blocks' ).setCategories( categories );
 }

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -20,7 +20,10 @@ export {
 	getSaveElement,
 } from './serializer';
 export { isValidBlock } from './validation';
-export { getCategories } from './categories';
+export {
+	getCategories,
+	setCategories,
+} from './categories';
 export {
 	registerBlockType,
 	unregisterBlockType,

--- a/blocks/store/actions.js
+++ b/blocks/store/actions.js
@@ -58,3 +58,17 @@ export function setFallbackBlockName( name ) {
 		name,
 	};
 }
+
+/**
+ * Returns an action object used to set block categories.
+ *
+ * @param {Object[]} categories Block categories.
+ *
+ * @return {Object} Action object.
+ */
+export function setCategories( categories ) {
+	return {
+		type: 'SET_CATEGORIES',
+		categories,
+	};
+}

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -80,10 +80,8 @@ export const fallbackBlockName = createBlockNameSetterReducer( 'SET_FALLBACK_BLO
  * @return {Object} Updated state.
  */
 export function categories( state = DEFAULT_CATEGORIES, action ) {
-	if ( action.type === 'ADD_CATEGORIES' ) {
-		const addedSlugs = map( action.categories, ( category ) => category.slug );
-		const previousState = filter( state, ( category ) => addedSlugs.indexOf( category.slug ) === -1 );
-		return [ ...previousState, ...action.categories ];
+	if ( action.type === 'SET_CATEGORIES' ) {
+		return action.categories || [];
 	}
 
 	return state;

--- a/blocks/store/reducer.js
+++ b/blocks/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, map, keyBy, omit } from 'lodash';
+import { keyBy, omit } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/blocks/store/test/reducer.js
+++ b/blocks/store/test/reducer.js
@@ -99,18 +99,17 @@ describe( 'categories', () => {
 		expect( categories( undefined, {} ) ).toEqual( DEFAULT_CATEGORIES );
 	} );
 
-	it( 'should add add a new category', () => {
+	it( 'should override categories', () => {
 		const original = deepFreeze( [
 			{ slug: 'chicken', title: 'Chicken' },
 		] );
 
 		const state = categories( original, {
-			type: 'ADD_CATEGORIES',
+			type: 'SET_CATEGORIES',
 			categories: [ { slug: 'wings', title: 'Wings' } ],
 		} );
 
 		expect( state ).toEqual( [
-			{ slug: 'chicken', title: 'Chicken' },
 			{ slug: 'wings', title: 'Wings' },
 		] );
 	} );

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -189,9 +189,30 @@ On the server, you can filter the list of blocks shown in the inserter using the
 
 ```php
 add_filter( 'allowed_block_types', function( $allowed_block_types, $post ) {
-	if ( $post->post_type === 'post' ) {
+	if ( $post->post_type !== 'post' ) {
 	    return $allowed_block_types;
 	}
-	return [ 'core/paragraph' ];
+	return array( 'core/paragraph' );
+}, 10, 2 );
+```
+
+## Managing block categories
+
+It is possible to filter the list of default block categories using the `block_categories` filter. You can do it on the server by implementing a function which returns a list of categories. It is going to be used during blocks registration and to group blocks in the inserter. You can also use the second provided param `$post` to generate a different list depending on the post's content.
+
+```php
+add_filter( 'block_categories', function( $categories, $post ) {
+	if ( $post->post_type !== 'post' ) {
+		return $categories;
+	}
+	return array_merge(
+		$categories,
+		array(
+			array(
+				'slug' => 'my-category',
+				'title' => __( 'My category', 'my-plugin' ),
+			),
+		)
+	);
 }, 10, 2 );
 ```

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -142,7 +142,7 @@ wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-data-align', withDa
 Adding blocks is easy enough, removing them is as easy. Plugin or theme authors have the possibility to "unregister" blocks.
 
 ```js
-// myplugin.js
+// myp-lugin.js
 
 wp.blocks.unregisterBlockType( 'core/verse' );
 ```
@@ -151,16 +151,16 @@ and load this script in the Editor
 
 ```php
 <?php
-// myplugin.php
+// my-plugin.php
 
-function myplugin_blacklist_blocks() {
+function my_plugin_blacklist_blocks() {
 	wp_enqueue_script(
-		'myplugin-blacklist-blocks',
-		plugins_url( 'myplugin.js', __FILE__ ),
+		'my-plugin-blacklist-blocks',
+		plugins_url( 'my-plugin.js', __FILE__ ),
 		array( 'wp-blocks' )
 	);
 }
-add_action( 'enqueue_block_editor_assets', 'myplugin_blacklist_blocks' );
+add_action( 'enqueue_block_editor_assets', 'my_plugin_blacklist_blocks' );
 ```
 
 ### Using a whitelist
@@ -168,7 +168,8 @@ add_action( 'enqueue_block_editor_assets', 'myplugin_blacklist_blocks' );
 If you want to disable all blocks except a whitelisted list, you can adapt the script above like so:
 
 ```js
-// myplugin.js
+// my-plugin.js
+
 var allowedBlocks = [
 	'core/paragraph',
 	'core/image',
@@ -188,12 +189,17 @@ wp.blocks.getBlockTypes().forEach( function( blockType ) {
 On the server, you can filter the list of blocks shown in the inserter using the `allowed_block_types` filter. You can return either true (all block types supported), false (no block types supported), or an array of block type names to allow. You can also use the second provided param `$post` to filter block types based on its content.
 
 ```php
-add_filter( 'allowed_block_types', function( $allowed_block_types, $post ) {
+<?php
+// my-plugin.php
+
+function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
 	if ( $post->post_type !== 'post' ) {
 	    return $allowed_block_types;
 	}
 	return array( 'core/paragraph' );
-}, 10, 2 );
+}
+
+add_filter( 'allowed_block_types', 'my_plugin_allowed_block_types', 10, 2 );
 ```
 
 ## Managing block categories
@@ -201,7 +207,10 @@ add_filter( 'allowed_block_types', function( $allowed_block_types, $post ) {
 It is possible to filter the list of default block categories using the `block_categories` filter. You can do it on the server by implementing a function which returns a list of categories. It is going to be used during blocks registration and to group blocks in the inserter. You can also use the second provided param `$post` to generate a different list depending on the post's content.
 
 ```php
-add_filter( 'block_categories', function( $categories, $post ) {
+<?php
+// my-plugin.php
+
+function my_plugin_block_categories( $categories, $post ) {
 	if ( $post->post_type !== 'post' ) {
 		return $categories;
 	}
@@ -214,5 +223,6 @@ add_filter( 'block_categories', function( $categories, $post ) {
 			),
 		)
 	);
-}, 10, 2 );
+}
+add_filter( 'block_categories', 'my_plugin_block_categories', 10, 2 );
 ```

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -983,6 +983,45 @@ function get_autosave_newer_than_post_save( $post ) {
 }
 
 /**
+ * Returns all the block categories.
+ *
+ * @since 2.2.0
+ *
+ * @param  WP_Post $post Post object.
+ * @return Object[] Block categories.
+ */
+function get_block_categories( $post ) {
+	$default_categories = array(
+		array(
+			'slug'  => 'common',
+			'title' => __( 'Common Blocks', 'gutenberg' ),
+		),
+		array(
+			'slug'  => 'formatting',
+			'title' => __( 'Formatting', 'gutenberg' ),
+		),
+		array(
+			'slug'  => 'layout',
+			'title' => __( 'Layout Elements', 'gutenberg' ),
+		),
+		array(
+			'slug'  => 'widgets',
+			'title' => __( 'Widgets', 'gutenberg' ),
+		),
+		array(
+			'slug'  => 'embed',
+			'title' => __( 'Embeds', 'gutenberg' ),
+		),
+		array(
+			'slug'  => 'shared',
+			'title' => __( 'Shared Blocks', 'gutenberg' ),
+		),
+	);
+
+	return apply_filters( 'block_categories', $default_categories, $post );
+}
+
+/**
  * Scripts & Styles.
  *
  * Enqueues the needed scripts and styles when visiting the top-level page of
@@ -1040,6 +1079,12 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	wp_add_inline_script(
 		'wp-api-request',
 		sprintf( 'wp.apiRequest.use( wp.apiRequest.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),
+		'after'
+	);
+
+	wp_add_inline_script(
+		'wp-blocks',
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $post ) ) ),
 		'after'
 	);
 


### PR DESCRIPTION
## Description
Supersedes #1732.

With this PR, It is possible to filter the list of default block categories using the `block_categories` filter. You can do it on the server by implementing a function which returns a list of categories. It is going to be used during blocks registration and to group blocks in the inserter. You can also use the second provided param `$post` to generate a different list depending on the post's content.

```php
add_filter( 'block_categories', function( $categories, $post ) {
	if ( $post->post_type !== 'post' ) {
		return $categories;
	}
	return array_merge(
		$categories,
		array(
			array(
				'slug' => 'my-category',
				'title' => __( 'My category', 'my-plugin' ),
			),
		)
	);
}, 10, 2 );
```

## How has this been tested?

Renamed the category of one of the blocks to `my-category` and included the code shared above to activate this category.

I also tried what happens when some existing categories get removed. You see warnings (expected non-destructive errors triggered by our code) on the console informing that blocks couldn't be registered because a given category doesn't exist. **Which is more than expected.**

## Screenshots <!-- if applicable -->

![screen shot 2018-06-28 at 15 34 33](https://user-images.githubusercontent.com/699132/42039322-64465f30-7aed-11e8-91f8-eee88172b6d3.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
