### PR TITLE
Parser: Fix boolean attribute explicit string value result

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -24,14 +24,27 @@ import { attr, prop, html, text, query, node, children } from './matchers';
  * or false depending on whether the original matcher returns undefined. This
  * is useful for boolean attributes (e.g. disabled) whose attribute values may
  * be technically falsey (empty string), though their mere presence should be
- * enough to infer as a truthy value.
+ * enough to infer as true.
  *
  * @param {Function} matcher Original hpq matcher.
  *
- * @return {Function} Enhanced hpq matcher.``
+ * @return {Function} Enhanced hpq matcher.
  */
 export const toBooleanAttributeMatcher = ( matcher ) => flow( [
 	matcher,
+	// Expected values from `attr( 'disabled' )`:
+	//
+	// <input>
+	// - Value:       `undefined`
+	// - Transformed: `false`
+	//
+	// <input disabled>
+	// - Value:       `''`
+	// - Transformed: `true`
+	//
+	// <input disabled="disabled">
+	// - Value:       `'disabled'`
+	// - Transformed: `true`
 	( value ) => value !== undefined,
 ] );
 

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { parse as hpqParse } from 'hpq';
-import { castArray, mapValues, omit } from 'lodash';
+import { flow, castArray, mapValues, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,6 +18,22 @@ import { createBlock } from './factory';
 import { isValidBlock } from './validation';
 import { getCommentDelimitedContent } from './serializer';
 import { attr, prop, html, text, query, node, children } from './matchers';
+
+/**
+ * Higher-order hpq matcher which enhances an attribute matcher to return true
+ * or false depending on whether the original matcher returns undefined. This
+ * is useful for boolean attributes (e.g. disabled) whose attribute values may
+ * be technically falsey (empty string), though their mere presence should be
+ * enough to infer as a truthy value.
+ *
+ * @param {Function} matcher Original hpq matcher.
+ *
+ * @return {Function} Enhanced hpq matcher.``
+ */
+export const toBooleanAttributeMatcher = ( matcher ) => flow( [
+	matcher,
+	( value ) => value !== undefined,
+] );
 
 /**
  * Returns value coerced to the specified JSON schema type string.
@@ -68,7 +84,12 @@ export function asType( value, type ) {
 export function matcherFromSource( sourceConfig ) {
 	switch ( sourceConfig.source ) {
 		case 'attribute':
-			return attr( sourceConfig.selector, sourceConfig.attribute );
+			let matcher = attr( sourceConfig.selector, sourceConfig.attribute );
+			if ( sourceConfig.type === 'boolean' ) {
+				matcher = toBooleanAttributeMatcher( matcher );
+			}
+
+			return matcher;
 		case 'property':
 			return prop( sourceConfig.selector, sourceConfig.property );
 		case 'html':
@@ -98,14 +119,7 @@ export function matcherFromSource( sourceConfig ) {
  * @return {*} Attribute value.
  */
 export function parseWithAttributeSchema( innerHTML, attributeSchema ) {
-	const attributeValue = hpqParse( innerHTML, matcherFromSource( attributeSchema ) );
-	// HTML attributes without a defined value (e.g. <audio loop>) are parsed
-	// to a value of '' (empty string), so return `true` if we know this should
-	// be boolean.
-	if ( 'attribute' === attributeSchema.source && 'boolean' === attributeSchema.type ) {
-		return '' === attributeValue;
-	}
-	return attributeValue;
+	return hpqParse( innerHTML, matcherFromSource( attributeSchema ) );
 }
 
 /**


### PR DESCRIPTION
Related: #7322

This pull request seeks to fix an issue in the implementation of #7322 where an explicit string value assigned as an attribute would be wrongly interpreted as `false` when assigned as a `boolean` attribute type. Both `<input disabled>` and `<input disabled="disabled">` should return `true` for a boolean attribute source type.

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit blocks/api/parser.js
```

Repeat testing instructions from #7322.