### PR TITLE
Fix don't show hover effect if the ancestor of a block is multi-selected

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -206,10 +206,10 @@ export class BlockListBlock extends Component {
 	 * @see https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
 	 */
 	maybeHover() {
-		const { isMultiSelected, isSelected } = this.props;
+		const { isPartOfMultiSelection, isSelected } = this.props;
 		const { isHovered } = this.state;
 
-		if ( isHovered || isMultiSelected || isSelected ||
+		if ( isHovered || isPartOfMultiSelection || isSelected ||
 				this.props.isMultiSelecting || this.hadTouchStart ) {
 			return;
 		}
@@ -258,7 +258,7 @@ export class BlockListBlock extends Component {
 	 * @return {void}
 	 */
 	onFocus() {
-		if ( ! this.props.isSelected && ! this.props.isMultiSelected ) {
+		if ( ! this.props.isSelected && ! this.props.isPartOfMultiSelection ) {
 			this.props.onSelect();
 		}
 	}
@@ -302,7 +302,7 @@ export class BlockListBlock extends Component {
 			// onFocus excludes blocks involved in a multiselection, as
 			// focus can be incurred by starting a multiselection (focus
 			// moved to first block's multi-controls).
-			if ( this.props.isMultiSelected ) {
+			if ( this.props.isPartOfMultiSelection ) {
 				this.props.onSelect();
 			}
 		}
@@ -378,7 +378,7 @@ export class BlockListBlock extends Component {
 			rootUID,
 			layout,
 			isSelected,
-			isMultiSelected,
+			isPartOfMultiSelection,
 			isFirstMultiSelected,
 			isTypingWithinBlock,
 			isMultiSelecting,
@@ -403,8 +403,8 @@ export class BlockListBlock extends Component {
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showSideInserter && ( isSelected || hasSelectedInnerBlock ) && ! isTypingWithinBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
-		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isMultiSelected && ! isTypingWithinBlock;
-		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isMultiSelected && ! isTypingWithinBlock;
+		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
+		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldShowBreadcrumb = isHovered && ! isEmptyDefaultBlock;
 		const shouldShowContextualToolbar = ! showSideInserter && isSelected && ! isTypingWithinBlock && isValid && ( ! hasFixedToolbar || ! isLargeViewport );
 		const shouldShowMobileToolbar = shouldAppearSelected;
@@ -413,14 +413,14 @@ export class BlockListBlock extends Component {
 		// Insertion point can only be made visible when the side inserter is
 		// not present, and either the block is at the extent of a selection or
 		// is the first block in the top-level list rendering.
-		const shouldShowInsertionPoint = ( isMultiSelected && isFirst ) || ! isMultiSelected;
+		const shouldShowInsertionPoint = ( isPartOfMultiSelection && isFirst ) || ! isPartOfMultiSelection;
 		const canShowInBetweenInserter = ! isEmptyDefaultBlock && ! isPreviousBlockADefaultEmptyBlock;
 
 		// Generate the wrapper class names handling the different states of the block.
 		const wrapperClassName = classnames( 'editor-block-list__block', {
 			'has-warning': ! isValid || !! error,
 			'is-selected': shouldAppearSelected,
-			'is-multi-selected': isMultiSelected,
+			'is-multi-selected': isPartOfMultiSelection,
 			'is-hovered': isHovered && ! isEmptyDefaultBlock,
 			'is-shared': isSharedBlock( blockType ),
 			'is-hidden': dragging,
@@ -469,7 +469,7 @@ export class BlockListBlock extends Component {
 				] }
 				{ ...wrapperProps }
 			>
-				{ ! isMultiSelected && isMovable && (
+				{ ! isPartOfMultiSelection && isMovable && (
 					<BlockDraggable
 						rootUID={ rootUID }
 						index={ order }
@@ -584,6 +584,7 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		getPreviousBlockUid,
 		getNextBlockUid,
 		getBlock,
+		isAncestorMultiSelected,
 		isBlockMultiSelected,
 		isFirstMultiSelectedBlock,
 		isMultiSelecting,
@@ -602,10 +603,9 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 	const block = getBlock( uid );
 	const previousBlockUid = getPreviousBlockUid( uid );
 	const previousBlock = getBlock( previousBlockUid );
-
 	return {
 		nextBlockUid: getNextBlockUid( uid ),
-		isMultiSelected: isBlockMultiSelected( uid ),
+		isPartOfMultiSelection: isBlockMultiSelected( uid ) || isAncestorMultiSelected( uid ),
 		isFirstMultiSelected: isFirstMultiSelectedBlock( uid ),
 		isMultiSelecting: isMultiSelecting(),
 		hasSelectedInnerBlock: isParentOfSelectedBlock,

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -931,6 +931,30 @@ export function isBlockMultiSelected( state, uid ) {
 }
 
 /**
+ * Returns true if an ancestor of the block is multi-selected and false otherwise.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} uid   Block unique ID.
+ *
+ * @return {boolean} Whether an ancestor of the block is in multi-selection set.
+ */
+export const isAncestorMultiSelected = createSelector(
+	( state, uid ) => {
+		let ancestorUid = uid;
+		let isMultiSelected = false;
+		while ( ancestorUid && ! isMultiSelected ) {
+			ancestorUid = getBlockRootUID( state, ancestorUid );
+			isMultiSelected = isBlockMultiSelected( state, ancestorUid );
+		}
+		return isMultiSelected;
+	},
+	( state ) => [
+		state.editor.present.blockOrder,
+		state.blockSelection.start,
+		state.blockSelection.end,
+	],
+);
+/**
  * Returns the unique ID of the block which begins the multi-selection set, or
  * null if there is no multi-selection.
  *


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/7361

Before even if a parent block was multi-selected we still showed the hover effect on the children. This PR's corrects that.

## How has this been tested?
I added some paragraphs and images and columns block. Added some blocks inside the columns. I multi-selected the columns and some blocks. I verified the hover effect does not appear on the children of the columns. But still appears in other blocks.

