### PR TITLE
Rich Text: Remove NewBlock event handling

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -3,7 +3,6 @@
  */
 import classnames from 'classnames';
 import {
-	last,
 	isEqual,
 	forEach,
 	merge,
@@ -110,7 +109,6 @@ export class RichText extends Component {
 		this.onSetup = this.onSetup.bind( this );
 		this.onFocus = this.onFocus.bind( this );
 		this.onChange = this.onChange.bind( this );
-		this.onNewBlock = this.onNewBlock.bind( this );
 		this.onNodeChange = this.onNodeChange.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onKeyUp = this.onKeyUp.bind( this );
@@ -159,7 +157,6 @@ export class RichText extends Component {
 		this.editor = editor;
 
 		editor.on( 'init', this.onInit );
-		editor.on( 'NewBlock', this.onNewBlock );
 		editor.on( 'nodechange', this.onNodeChange );
 		editor.on( 'keydown', this.onKeyDown );
 		editor.on( 'keyup', this.onKeyUp );
@@ -608,55 +605,6 @@ export class RichText extends Component {
 		} else {
 			this.restoreContentAndSplit( [], [], blocks );
 		}
-	}
-
-	onNewBlock() {
-		if ( this.props.multiline !== 'p' || ! this.props.onSplit ) {
-			return;
-		}
-
-		// Getting the content before and after the cursor
-		const childNodes = Array.from( this.editor.getBody().childNodes );
-		let selectedChild = this.editor.selection.getStart();
-		while ( childNodes.indexOf( selectedChild ) === -1 && selectedChild.parentNode ) {
-			selectedChild = selectedChild.parentNode;
-		}
-		const splitIndex = childNodes.indexOf( selectedChild );
-		if ( splitIndex === -1 ) {
-			return;
-		}
-		const beforeNodes = childNodes.slice( 0, splitIndex );
-		const lastNodeBeforeCursor = last( beforeNodes );
-		// Avoid splitting on single enter
-		if (
-			! lastNodeBeforeCursor ||
-			beforeNodes.length < 2 ||
-			!! lastNodeBeforeCursor.textContent
-		) {
-			return;
-		}
-
-		const before = beforeNodes.slice( 0, beforeNodes.length - 1 );
-
-		// Removing empty nodes from the beginning of the "after"
-		// avoids empty paragraphs at the beginning of newly created blocks.
-		const after = childNodes.slice( splitIndex ).reduce( ( memo, node ) => {
-			if ( ! memo.length && ! node.textContent ) {
-				return memo;
-			}
-
-			memo.push( node );
-			return memo;
-		}, [] );
-
-		// Splitting into two blocks
-		this.setContent( this.props.value );
-
-		const { format } = this.props;
-		this.restoreContentAndSplit(
-			domToFormat( before, format, this.editor ),
-			domToFormat( after, format, this.editor )
-		);
 	}
 
 	onNodeChange( { parents } ) {


### PR DESCRIPTION
This pull request seeks to remove the `NewBlock` event handling from the `RichText` component. The function neither has DocBlock nor is publicly documented in the RichText documentation, so I was unable to determine its reason for being. Prompting justification on its introduction in https://github.com/WordPress/gutenberg/pull/409#discussion_r197460877 was further unsuccessful in determining that it needs to exist. We currently have no core components which are both `multiline="p"` and have an `onSplit` function passed to its `RichText`, so it appears to be unreachable. Per its introduction in #409, it may have been useful for when the text block could allow enter presses and a second press responsible for creating the split block.

Based on explorations in #7583, we may want to leverage TinyMCE's `NewBlock` event, but I believe we should do so consistent for _all_ splitting behavior. In the meantime, it should be removed.

**Testing instructions:**

Verify there are no regressions for block splitting, namely:

- Non-multiline blocks (paragraph)
   - Pressing enter once should split to a new paragraph
- Multiline blocks (list)
   - Pressing enter once should add new list item
   - Pressing enter twice should escape out into a new paragraph block

There should be end-to-end tests for this. See also #6467.