### PR TITLE
Rich Text: Remove restoreContentAndSplit

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -633,8 +633,8 @@ export class RichText extends Component {
 			afterRange.setStart( selectionRange.endContainer, selectionRange.endOffset );
 			afterRange.setEnd( rootNode, dom.nodeIndex( rootNode.lastChild ) + 1 );
 
-			const beforeFragment = beforeRange.extractContents();
-			const afterFragment = afterRange.extractContents();
+			const beforeFragment = beforeRange.cloneContents();
+			const afterFragment = afterRange.cloneContents();
 
 			const { format } = this.props;
 			before = domToFormat( filterEmptyNodes( beforeFragment.childNodes ), format, this.editor );

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -542,7 +542,7 @@ export class RichText extends Component {
 				const before = domToFormat( beforeNodes, format, this.editor );
 				const after = domToFormat( afterNodes, format, this.editor );
 
-				this.restoreContentAndSplit( before, after );
+				this.props.onSplit( before, after );
 			} else {
 				event.preventDefault();
 
@@ -662,7 +662,7 @@ export class RichText extends Component {
 			after = this.isEmpty( after ) ? null : after;
 		}
 
-		this.restoreContentAndSplit( before, after, blocks );
+		onSplit( before, after, ...blocks );
 	}
 
 	onNodeChange( { parents } ) {
@@ -822,19 +822,6 @@ export class RichText extends Component {
 		this.setState( ( state ) => ( {
 			formats: merge( {}, state.formats, formats ),
 		} ) );
-	}
-
-	/**
-	 * Calling onSplit means we need to abort the change done by TinyMCE.
-	 * we need to call updateContent to restore the initial content before calling onSplit.
-	 *
-	 * @param {Array}  before content before the split position
-	 * @param {Array}  after  content after the split position
-	 * @param {?Array} blocks blocks to insert at the split position
-	 */
-	restoreContentAndSplit( before, after, blocks = [] ) {
-		this.setContent( this.props.value );
-		this.props.onSplit( before, after, ...blocks );
 	}
 
 	render() {


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/5100/files#r198953121

This pull request seeks to simplify the `RichText` component, removing its `restoreContentAndSplit` function which had been used to preserve content through a block split. In my testing, I had found that this was not a behavior caused by TinyMCE, as indicated by the function's comment, but rather in our use of [`Range#extractContents`](https://developer.mozilla.org/en-US/docs/Web/API/Range/extractContents) which _moves_ (i.e. destroys) contents of a range. Updating this code to use [`Range#cloneContents`](https://developer.mozilla.org/en-US/docs/Web/API/Range/cloneContents) instead avoids the need to re-set the `RichText` content which, in turn, should be a boon to performance and avoid the need for this pass-through function.

**Testing instructions:**

Verify that there are no regressions in block splitting. Particularly, ensure that a paragraphs contents are not destroyed after pressing Enter within.