### PR TITLE
Rich Text: Remove updateContent function

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -697,8 +697,20 @@ export class RichText extends Component {
 
 	setContent( content ) {
 		const { format } = this.props;
+
+		// If editor has focus while content is being set, save the selection
+		// and restore caret position after content is set.
+		let bookmark;
+		if ( this.editor.hasFocus() ) {
+			bookmark = this.editor.selection.getBookmark( 2, true );
+		}
+
 		this.savedContent = content;
 		this.editor.setContent( valueToString( content, format ) );
+
+		if ( bookmark ) {
+			this.editor.selection.moveToBookmark( bookmark );
+		}
 	}
 
 	getContent() {

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -695,20 +695,9 @@ export class RichText extends Component {
 		}
 	}
 
-	updateContent() {
-		// Do not trigger a change event coming from the TinyMCE undo manager.
-		// Our global state is already up-to-date.
-		this.editor.undoManager.ignore( () => {
-			const bookmark = this.editor.selection.getBookmark( 2, true );
-
-			this.savedContent = this.props.value;
-			this.setContent( this.savedContent );
-			this.editor.selection.moveToBookmark( bookmark );
-		} );
-	}
-
 	setContent( content ) {
 		const { format } = this.props;
+		this.savedContent = content;
 		this.editor.setContent( valueToString( content, format ) );
 	}
 
@@ -739,7 +728,7 @@ export class RichText extends Component {
 			! isEqual( this.props.value, prevProps.value ) &&
 			! isEqual( this.props.value, this.savedContent )
 		) {
-			this.updateContent();
+			this.setContent( this.props.value );
 		}
 
 		if ( 'development' === process.env.NODE_ENV ) {
@@ -829,7 +818,7 @@ export class RichText extends Component {
 	 * @param {?Array} blocks blocks to insert at the split position
 	 */
 	restoreContentAndSplit( before, after, blocks = [] ) {
-		this.updateContent();
+		this.setContent( this.props.value );
 		this.props.onSplit( before, after, ...blocks );
 	}
 

--- a/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
@@ -15,3 +15,13 @@ exports[`splitting and merging blocks Should split and merge paragraph blocks us
 <p>FirstBetweenSecond</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`splitting and merging blocks Should split and merge paragraph blocks using Enter and Backspace 3`] = `
+"<!-- wp:paragraph -->
+<p><strong>First</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BeforeSecond:Second</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
@@ -12,6 +12,6 @@ exports[`splitting and merging blocks Should split and merge paragraph blocks us
 
 exports[`splitting and merging blocks Should split and merge paragraph blocks using Enter and Backspace 2`] = `
 "<!-- wp:paragraph -->
-<p>FirstSecond</p>
+<p>FirstBetweenSecond</p>
 <!-- /wp:paragraph -->"
 `;

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -2,7 +2,13 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage, insertBlock } from '../support/utils';
+import {
+	newPost,
+	newDesktopBrowserPage,
+	insertBlock,
+	getHTMLFromCodeEditor,
+	switchToEditor,
+} from '../support/utils';
 
 describe( 'splitting and merging blocks', () => {
 	beforeAll( async () => {
@@ -11,7 +17,7 @@ describe( 'splitting and merging blocks', () => {
 	} );
 
 	it( 'Should split and merge paragraph blocks using Enter and Backspace', async () => {
-		//Use regular inserter to add paragraph block and text
+		// Use regular inserter to add paragraph block and text
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'FirstSecond' );
 
@@ -21,32 +27,23 @@ describe( 'splitting and merging blocks', () => {
 		}
 		await page.keyboard.press( 'Enter' );
 
-		//Switch to Code Editor to check HTML output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		let codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
-
-		//Assert that there are now two paragraph blocks with correct content
-		let textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		// Assert that there are now two paragraph blocks with correct content
+		let textEditorContent = await getHTMLFromCodeEditor();
 		expect( textEditorContent ).toMatchSnapshot();
 
-		//Switch to Visual Editor to continue testing
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		const visualEditorButton = ( await page.$x( '//button[contains(text(), \'Visual Editor\')]' ) )[ 0 ];
-		await visualEditorButton.click( 'button' );
+		// Switch to Visual Editor to continue testing
+		await switchToEditor( 'Visual' );
 
-		//Press Backspace to merge paragraph blocks
+		// Press Backspace to merge paragraph blocks
 		await page.click( '.is-selected' );
 		await page.keyboard.press( 'Home' );
 		await page.keyboard.press( 'Backspace' );
 
-		//Switch to Code Editor to check HTML output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
+		// Ensure that caret position is correctly placed at the between point.
+		await page.keyboard.type( 'Between' );
 
-		//Assert that there is now one paragraph with correct content
-		textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
+		// Assert that there is now one paragraph with correct content
+		textEditorContent = await getHTMLFromCodeEditor();
 		expect( textEditorContent ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -4,6 +4,11 @@
 import { join } from 'path';
 import { URL } from 'url';
 
+/**
+ * External dependencies
+ */
+import { times } from 'lodash';
+
 const {
 	WP_BASE_URL = 'http://localhost:8888',
 	WP_USERNAME = 'admin',
@@ -25,6 +30,21 @@ const MOD_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
  * @type {RegExp}
  */
 const REGEXP_ZWSP = /[\u200B\u200C\u200D\uFEFF]/;
+
+/**
+ * Given an array of functions, each returning a promise, performs all
+ * promises in sequence (waterfall) order.
+ *
+ * @param {Function[]} sequence Array of promise creators.
+ *
+ * @return {Promise} Promise resolving once all in the sequence complete.
+ */
+async function promiseSequence( sequence ) {
+	return sequence.reduce(
+		( current, next ) => current.then( next ),
+		Promise.resolve()
+	);
+}
 
 export function getUrl( WPPath, query = '' ) {
 	const url = new URL( WP_BASE_URL );
@@ -230,6 +250,18 @@ export async function openDocumentSettingsSidebar() {
 	if ( openButton ) {
 		await page.click( openButton );
 	}
+}
+
+/**
+ * Presses the given keyboard key a number of times in sequence.
+ *
+ * @param {string} key   Key to press.
+ * @param {number} count Number of times to press.
+ *
+ * @return {Promise} Promise resolving when key presses complete.
+ */
+export async function pressTimes( key, count ) {
+	return promiseSequence( times( count, () => () => page.keyboard.press( key ) ) );
 }
 
 export async function clearLocalStorage() {


### PR DESCRIPTION
This pull request seeks to simplify `RichText` to have a single function for setting content, vs. the current `updateContent` and `setContent`, by removing `updateContent`.

It's current implementation includes three notable differences from just calling `setContent` directly, addressed below:

- Prevent the editor from adding an undo level. As I remarked at https://github.com/WordPress/gutenberg/pull/4956#discussion_r198970979, from what I can tell, there does not appear to be an undo level being added if this were not present.
- Restoring bookmark selection position. This seems to trace back to its very first implementation from #330. It's not clear to me however what we're trying to achieve here (preserving caret location? when does this matter?). It's also the cause of bugs like the one described in https://github.com/WordPress/gutenberg/issues/5095#issuecomment-400341216 , where focus jumps unpredictably when `updateContent` is called on a block split.
- Setting `this.savedContent` to the current value. This should take place in `setContent` if we're assuming that this value is always to be kept in sync with the current content of the editor instance.

**Testing instructions:**

Verify that there are no regressions in the behavior of the editor, particularly when splitting content, which until the merge of #7482 causes `updateContent` to be called.