### PR TITLE
Implement File block

### DIFF
--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -88,8 +88,8 @@ class ClipboardButton extends Component {
 		// This causes documentHasSelection() in the copy-handler component to
 		// mistakenly override the ClipboardButton, and copy a serialized string
 		// of the current block instead.
-		const focusOnCopyEventTarget = ( e ) => {
-			e.target.focus();
+		const focusOnCopyEventTarget = ( event ) => {
+			event.target.focus();
 		};
 
 		return (

--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -83,8 +83,17 @@ class ClipboardButton extends Component {
 		const classes = classnames( 'components-clipboard-button', className );
 		const ComponentToUse = icon ? IconButton : Button;
 
+		// Workaround for inconsistent behavior in Safari, where <textarea> is not
+		// the document.activeElement at the moment when the copy event fires.
+		// This causes documentHasSelection() in the copy-handler component to
+		// mistakenly override the ClipboardButton, and copy a serialized string
+		// of the current block instead.
+		const focusOnCopyEventTarget = ( e ) => {
+			e.target.focus();
+		};
+
 		return (
-			<span ref={ this.bindContainer }>
+			<span ref={ this.bindContainer } onCopy={ focusOnCopyEventTarget }>
 				<ComponentToUse { ...buttonProps } className={ classes }>
 					{ children }
 				</ComponentToUse>

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -78,6 +78,15 @@ class FileEdit extends Component {
 
 	render() {
 		const {
+			className,
+			isSelected,
+			attributes,
+			setAttributes,
+			noticeUI,
+			noticeOperations,
+			media,
+		} = this.props;
+		const {
 			fileName,
 			href,
 			textLinkHref,
@@ -85,15 +94,7 @@ class FileEdit extends Component {
 			showDownloadButton,
 			buttonText,
 			id,
-		} = this.props.attributes;
-		const {
-			className,
-			isSelected,
-			setAttributes,
-			noticeUI,
-			noticeOperations,
-			media,
-		} = this.props;
+		} = attributes;
 		const { showCopyConfirmation } = this.state;
 		const attachmentPage = media && media.link;
 

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -1,0 +1,232 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { getBlobByURL, revokeBlobURL } from '@wordpress/utils';
+import {
+	ClipboardButton,
+	IconButton,
+	Toolbar,
+	withNotices,
+} from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
+import { Component, compose, Fragment } from '@wordpress/element';
+import {
+	MediaUpload,
+	MediaPlaceholder,
+	BlockControls,
+	RichText,
+	editorMediaUpload,
+} from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import FileBlockInspector from './inspector';
+import FileBlockEditableLink from './editable-link';
+
+class FileEdit extends Component {
+	constructor() {
+		super( ...arguments );
+
+		const {
+			showDownloadButton = true,
+			buttonText = __( 'Download' ),
+		} = this.props.attributes;
+
+		this.onSelectFile = this.onSelectFile.bind( this );
+
+		// Initialize default values if undefined
+		this.props.setAttributes( {
+			showDownloadButton,
+			buttonText,
+		} );
+
+		this.state = {
+			showCopyConfirmation: false,
+		};
+	}
+
+	componentDidMount() {
+		const { href } = this.props.attributes;
+
+		// Upload a file drag-and-dropped into the editor
+		if ( this.isBlobURL( href ) ) {
+			getBlobByURL( href )
+				.then( ( file ) => {
+					editorMediaUpload( {
+						allowedType: '*',
+						filesList: [ file ],
+						onFileChange: ( [ media ] ) => this.onSelectFile( media ),
+					} );
+					revokeBlobURL( href );
+				} );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		// Reset copy confirmation state when block is deselected
+		if ( prevProps.isSelected && ! this.props.isSelected ) {
+			this.setState( { showCopyConfirmation: false } );
+		}
+	}
+
+	onSelectFile( media ) {
+		if ( media && media.url ) {
+			this.props.setAttributes( {
+				href: media.url,
+				fileName: media.title,
+				textLinkHref: media.url,
+				id: media.id,
+			} );
+		}
+	}
+
+	isBlobURL( url = '' ) {
+		return url.indexOf( 'blob:' ) === 0;
+	}
+
+	render() {
+		const {
+			fileName,
+			href,
+			textLinkHref,
+			openInNewWindow,
+			showDownloadButton,
+			buttonText,
+			id,
+		} = this.props.attributes;
+		const {
+			className,
+			isSelected,
+			setAttributes,
+			noticeUI,
+			noticeOperations,
+			media,
+		} = this.props;
+		const { showCopyConfirmation } = this.state;
+		const attachmentPage = media && media.link;
+
+		const classNames = [
+			className,
+			this.isBlobURL( href ) ? 'is-transient' : '',
+		].join( ' ' );
+
+		const confirmCopyURL = () => {
+			this.setState( { showCopyConfirmation: true } );
+		};
+		const resetCopyConfirmation = () => {
+			this.setState( { showCopyConfirmation: false } );
+		};
+
+		// Choose Media File or Attachment Page (when file is in Media Library)
+		const changeLinkDestinationOption = ( newHref ) => {
+			setAttributes( { textLinkHref: newHref } );
+		};
+		const changeOpenInNewWindow = ( newValue ) => {
+			setAttributes( {
+				openInNewWindow: newValue ? '_blank' : false,
+			} );
+		};
+		const changeShowDownloadButton = ( newValue ) => {
+			setAttributes( { showDownloadButton: newValue } );
+		};
+
+		if ( ! href ) {
+			return (
+				<MediaPlaceholder
+					icon="media-default"
+					labels={ {
+						title: __( 'File' ),
+						name: __( 'a file' ),
+					} }
+					onSelect={ this.onSelectFile }
+					notices={ noticeUI }
+					onError={ noticeOperations.createErrorNotice }
+					accept="*"
+					type="*"
+				/>
+			);
+		}
+
+		return (
+			<Fragment>
+				<FileBlockInspector
+					hrefs={ { href, textLinkHref, attachmentPage } }
+					{ ...{
+						openInNewWindow,
+						showDownloadButton,
+						changeLinkDestinationOption,
+						changeOpenInNewWindow,
+						changeShowDownloadButton,
+					} }
+				/>
+				<BlockControls>
+					<Toolbar>
+						<MediaUpload
+							onSelect={ this.onSelectFile }
+							type="*"
+							value={ id }
+							render={ ( { open } ) => (
+								<IconButton
+									className="components-toolbar__control"
+									label={ __( 'Edit file' ) }
+									onClick={ open }
+									icon="edit"
+								/>
+							) }
+						/>
+					</Toolbar>
+				</BlockControls>
+				<div className={ classNames }>
+					<div>
+						<FileBlockEditableLink
+							className={ className }
+							placeholder={ __( 'Write file name…' ) }
+							text={ fileName }
+							href={ textLinkHref }
+							updateFileName={ ( text ) => setAttributes( { fileName: text } ) }
+						/>
+						{ showDownloadButton &&
+							<div className={ `${ className }__button-richtext-wrapper` }>
+								<RichText
+									tagName="div" // must be block-level or else cursor disappears
+									className={ `${ className }__button` }
+									value={ buttonText }
+									formattingControls={ [] } // disable controls
+									placeholder={ __( 'Add text…' ) }
+									keepPlaceholderOnFocus
+									multiline="false"
+									onChange={ ( text ) => setAttributes( { buttonText: text } ) }
+								/>
+							</div>
+						}
+					</div>
+					{ isSelected &&
+						<ClipboardButton
+							isDefault
+							text={ href }
+							className={ `${ className }__copy-url-button` }
+							onCopy={ confirmCopyURL }
+							onFinishCopy={ resetCopyConfirmation }
+						>
+							{ showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy URL' ) }
+						</ClipboardButton>
+					}
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( ( select, props ) => {
+		const { getMedia } = select( 'core' );
+		const { id } = props.attributes;
+		return {
+			media: id === undefined ? undefined : getMedia( id ),
+		};
+	} ),
+	withNotices,
+] )( FileEdit );

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -52,15 +52,15 @@ class FileEdit extends Component {
 
 		// Upload a file drag-and-dropped into the editor
 		if ( this.isBlobURL( href ) ) {
-			getBlobByURL( href )
-				.then( ( file ) => {
-					editorMediaUpload( {
-						allowedType: '*',
-						filesList: [ file ],
-						onFileChange: ( [ media ] ) => this.onSelectFile( media ),
-					} );
-					revokeBlobURL( href );
-				} );
+			const file = getBlobByURL( href );
+
+			editorMediaUpload( {
+				allowedType: '*',
+				filesList: [ file ],
+				onFileChange: ( [ media ] ) => this.onSelectFile( media ),
+			} );
+
+			revokeBlobURL( href );
 		}
 	}
 

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -36,6 +36,11 @@ class FileEdit extends Component {
 		super( ...arguments );
 
 		this.onSelectFile = this.onSelectFile.bind( this );
+		this.confirmCopyURL = this.confirmCopyURL.bind( this );
+		this.resetCopyConfirmation = this.resetCopyConfirmation.bind( this );
+		this.changeLinkDestinationOption = this.changeLinkDestinationOption.bind( this );
+		this.changeOpenInNewWindow = this.changeOpenInNewWindow.bind( this );
+		this.changeShowDownloadButton = this.changeShowDownloadButton.bind( this );
 
 		this.state = {
 			showCopyConfirmation: false,
@@ -81,6 +86,29 @@ class FileEdit extends Component {
 		return url.indexOf( 'blob:' ) === 0;
 	}
 
+	confirmCopyURL() {
+		this.setState( { showCopyConfirmation: true } );
+	}
+
+	resetCopyConfirmation() {
+		this.setState( { showCopyConfirmation: false } );
+	}
+
+	changeLinkDestinationOption( newHref ) {
+		// Choose Media File or Attachment Page (when file is in Media Library)
+		this.props.setAttributes( { textLinkHref: newHref } );
+	}
+
+	changeOpenInNewWindow( newValue ) {
+		this.props.setAttributes( {
+			openInNewWindow: newValue ? '_blank' : false,
+		} );
+	}
+
+	changeShowDownloadButton( newValue ) {
+		this.props.setAttributes( { showDownloadButton: newValue } );
+	}
+
 	render() {
 		const {
 			className,
@@ -107,26 +135,6 @@ class FileEdit extends Component {
 			'is-transient': this.isBlobURL( href ),
 		} );
 
-		const confirmCopyURL = () => {
-			this.setState( { showCopyConfirmation: true } );
-		};
-		const resetCopyConfirmation = () => {
-			this.setState( { showCopyConfirmation: false } );
-		};
-
-		// Choose Media File or Attachment Page (when file is in Media Library)
-		const changeLinkDestinationOption = ( newHref ) => {
-			setAttributes( { textLinkHref: newHref } );
-		};
-		const changeOpenInNewWindow = ( newValue ) => {
-			setAttributes( {
-				openInNewWindow: newValue ? '_blank' : false,
-			} );
-		};
-		const changeShowDownloadButton = ( newValue ) => {
-			setAttributes( { showDownloadButton: newValue } );
-		};
-
 		if ( ! href ) {
 			return (
 				<MediaPlaceholder
@@ -151,9 +159,9 @@ class FileEdit extends Component {
 					{ ...{
 						openInNewWindow,
 						showDownloadButton,
-						changeLinkDestinationOption,
-						changeOpenInNewWindow,
-						changeShowDownloadButton,
+						changeLinkDestinationOption: this.changeLinkDestinationOption,
+						changeOpenInNewWindow: this.changeOpenInNewWindow,
+						changeShowDownloadButton: this.changeShowDownloadButton,
 					} }
 				/>
 				<BlockControls>
@@ -202,8 +210,8 @@ class FileEdit extends Component {
 							isDefault
 							text={ href }
 							className={ `${ className }__copy-url-button` }
-							onCopy={ confirmCopyURL }
-							onFinishCopy={ resetCopyConfirmation }
+							onCopy={ this.confirmCopyURL }
+							onFinishCopy={ this.resetCopyConfirmation }
 						>
 							{ showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy URL' ) }
 						</ClipboardButton>

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getBlobByURL, revokeBlobURL } from '@wordpress/utils';
+import { getBlobByURL, revokeBlobURL } from '@wordpress/blob';
 import {
 	ClipboardButton,
 	IconButton,

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -101,7 +101,7 @@ class FileEdit extends Component {
 
 	changeOpenInNewWindow( newValue ) {
 		this.props.setAttributes( {
-			openInNewWindow: newValue ? '_blank' : false,
+			textLinkTarget: newValue ? '_blank' : false,
 		} );
 	}
 
@@ -123,7 +123,7 @@ class FileEdit extends Component {
 			fileName,
 			href,
 			textLinkHref,
-			openInNewWindow,
+			textLinkTarget,
 			showDownloadButton,
 			downloadButtonText,
 			id,
@@ -157,7 +157,7 @@ class FileEdit extends Component {
 				<FileBlockInspector
 					hrefs={ { href, textLinkHref, attachmentPage } }
 					{ ...{
-						openInNewWindow,
+						openInNewWindow: !! textLinkTarget,
 						showDownloadButton,
 						changeLinkDestinationOption: this.changeLinkDestinationOption,
 						changeOpenInNewWindow: this.changeOpenInNewWindow,

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -192,6 +192,7 @@ class FileEdit extends Component {
 						/>
 						{ showDownloadButton &&
 							<div className={ `${ className }__button-richtext-wrapper` }>
+								{ /* Using RichText here instead of PlainText so that it can be styled like a button */ }
 								<RichText
 									tagName="div" // must be block-level or else cursor disappears
 									className={ `${ className }__button` }

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -30,18 +30,7 @@ class FileEdit extends Component {
 	constructor() {
 		super( ...arguments );
 
-		const {
-			showDownloadButton = true,
-			buttonText = __( 'Download' ),
-		} = this.props.attributes;
-
 		this.onSelectFile = this.onSelectFile.bind( this );
-
-		// Initialize default values if undefined
-		this.props.setAttributes( {
-			showDownloadButton,
-			buttonText,
-		} );
 
 		this.state = {
 			showCopyConfirmation: false,

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -125,7 +125,7 @@ class FileEdit extends Component {
 			textLinkHref,
 			openInNewWindow,
 			showDownloadButton,
-			buttonText,
+			downloadButtonText,
 			id,
 		} = attributes;
 		const { showCopyConfirmation } = this.state;
@@ -196,12 +196,12 @@ class FileEdit extends Component {
 								<RichText
 									tagName="div" // must be block-level or else cursor disappears
 									className={ `${ className }__button` }
-									value={ buttonText }
+									value={ downloadButtonText }
 									formattingControls={ [] } // disable controls
 									placeholder={ __( 'Add text…' ) }
 									keepPlaceholderOnFocus
 									multiline="false"
-									onChange={ ( text ) => setAttributes( { buttonText: text } ) }
+									onChange={ ( text ) => setAttributes( { downloadButtonText: text } ) }
 								/>
 							</div>
 						}

--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External depedencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -98,10 +103,9 @@ class FileEdit extends Component {
 		const { showCopyConfirmation } = this.state;
 		const attachmentPage = media && media.link;
 
-		const classNames = [
-			className,
-			this.isBlobURL( href ) ? 'is-transient' : '',
-		].join( ' ' );
+		const classes = classnames( className, {
+			'is-transient': this.isBlobURL( href ),
+		} );
 
 		const confirmCopyURL = () => {
 			this.setState( { showCopyConfirmation: true } );
@@ -169,7 +173,7 @@ class FileEdit extends Component {
 						/>
 					</Toolbar>
 				</BlockControls>
-				<div className={ classNames }>
+				<div className={ classes }>
 					<div>
 						<FileBlockEditableLink
 							className={ className }

--- a/core-blocks/file/editable-link.js
+++ b/core-blocks/file/editable-link.js
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+
+export default class FileBlockEditableLink extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			showPlaceholder: ! this.props.text,
+		};
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.text !== this.props.text ) {
+			this.setState( { showPlaceholder: ! this.props.text } );
+		}
+	}
+
+	render() {
+		const { className, placeholder, text, href, updateFileName } = this.props;
+		const { showPlaceholder } = this.state;
+
+		const copyLinkToClipboard = ( e ) => {
+			const selectedText = document.getSelection().toString();
+			const htmlLink = `<a href="${ href }">${ selectedText }</a>`;
+			e.clipboardData.setData( 'text/plain', selectedText );
+			e.clipboardData.setData( 'text/html', htmlLink );
+		};
+
+		const forcePlainTextPaste = ( e ) => {
+			e.preventDefault();
+
+			const selection = document.getSelection();
+			const clipboard =
+				e.clipboardData.getData( 'text/plain' ).replace( /[\n\r]/g, '' );
+			const textNode = document.createTextNode( clipboard );
+
+			selection.getRangeAt( 0 ).insertNode( textNode );
+			selection.collapseToEnd();
+		};
+
+		const showPlaceholderIfEmptyString = ( e ) => {
+			if ( e.target.innerText === '' ) {
+				this.setState( { showPlaceholder: true } );
+			} else {
+				this.setState( { showPlaceholder: false } );
+			}
+		};
+
+		return (
+			<Fragment>
+				<a
+					aria-label={ placeholder }
+					className={ `${ className }__textlink` }
+					contentEditable={ true }
+					href={ href }
+					onBlur={ ( e ) => updateFileName( e.target.innerText ) }
+					onInput={ showPlaceholderIfEmptyString }
+					onCopy={ copyLinkToClipboard }
+					onCut={ copyLinkToClipboard }
+					onPaste={ forcePlainTextPaste }
+				>
+					{ text }
+				</a>
+				{ showPlaceholder &&
+					// Disable reason: Only useful for mouse users
+					/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+					<span
+						className={ `${ className }__textlink-placeholder` }
+						onClick={ ( e ) => e.target.previousSibling.focus() }
+					>
+						{ placeholder }
+					</span>
+					/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+				}
+			</Fragment>
+		);
+	}
+}

--- a/core-blocks/file/editable-link.js
+++ b/core-blocks/file/editable-link.js
@@ -7,6 +7,9 @@ export default class FileBlockEditableLink extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.copyLinkToClipboard = this.copyLinkToClipboard.bind( this );
+		this.showPlaceholderIfEmptyString = this.showPlaceholderIfEmptyString.bind( this );
+
 		this.state = {
 			showPlaceholder: ! this.props.text,
 		};
@@ -18,49 +21,44 @@ export default class FileBlockEditableLink extends Component {
 		}
 	}
 
+	copyLinkToClipboard( event ) {
+		const selectedText = document.getSelection().toString();
+		const htmlLink = `<a href="${ this.props.href }">${ selectedText }</a>`;
+		event.clipboardData.setData( 'text/plain', selectedText );
+		event.clipboardData.setData( 'text/html', htmlLink );
+	}
+
+	forcePlainTextPaste( event ) {
+		event.preventDefault();
+
+		const selection = document.getSelection();
+		const clipboard = event.clipboardData.getData( 'text/plain' ).replace( /[\n\r]/g, '' );
+		const textNode = document.createTextNode( clipboard );
+
+		selection.getRangeAt( 0 ).insertNode( textNode );
+		selection.collapseToEnd();
+	}
+
+	showPlaceholderIfEmptyString( event ) {
+		this.setState( { showPlaceholder: event.target.innerText === '' } );
+	}
+
 	render() {
 		const { className, placeholder, text, href, updateFileName } = this.props;
 		const { showPlaceholder } = this.state;
-
-		const copyLinkToClipboard = ( e ) => {
-			const selectedText = document.getSelection().toString();
-			const htmlLink = `<a href="${ href }">${ selectedText }</a>`;
-			e.clipboardData.setData( 'text/plain', selectedText );
-			e.clipboardData.setData( 'text/html', htmlLink );
-		};
-
-		const forcePlainTextPaste = ( e ) => {
-			e.preventDefault();
-
-			const selection = document.getSelection();
-			const clipboard =
-				e.clipboardData.getData( 'text/plain' ).replace( /[\n\r]/g, '' );
-			const textNode = document.createTextNode( clipboard );
-
-			selection.getRangeAt( 0 ).insertNode( textNode );
-			selection.collapseToEnd();
-		};
-
-		const showPlaceholderIfEmptyString = ( e ) => {
-			if ( e.target.innerText === '' ) {
-				this.setState( { showPlaceholder: true } );
-			} else {
-				this.setState( { showPlaceholder: false } );
-			}
-		};
 
 		return (
 			<Fragment>
 				<a
 					aria-label={ placeholder }
 					className={ `${ className }__textlink` }
-					contentEditable={ true }
 					href={ href }
-					onBlur={ ( e ) => updateFileName( e.target.innerText ) }
-					onInput={ showPlaceholderIfEmptyString }
-					onCopy={ copyLinkToClipboard }
-					onCut={ copyLinkToClipboard }
-					onPaste={ forcePlainTextPaste }
+					onBlur={ ( event ) => updateFileName( event.target.innerText ) }
+					onInput={ this.showPlaceholderIfEmptyString }
+					onCopy={ this.copyLinkToClipboard }
+					onCut={ this.copyLinkToClipboard }
+					onPaste={ this.forcePlainTextPaste }
+					contentEditable
 				>
 					{ text }
 				</a>
@@ -69,7 +67,7 @@ export default class FileBlockEditableLink extends Component {
 					/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 					<span
 						className={ `${ className }__textlink-placeholder` }
-						onClick={ ( e ) => e.target.previousSibling.focus() }
+						onClick={ ( event ) => event.target.previousSibling.focus() }
 					>
 						{ placeholder }
 					</span>

--- a/core-blocks/file/editor.scss
+++ b/core-blocks/file/editor.scss
@@ -1,0 +1,35 @@
+.wp-block-file {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 0;
+
+	&.is-transient {
+		@include loading_fade;
+	}
+
+	&__textlink {
+		color: $blue-medium-700;
+		min-width: 1em;
+		text-decoration: underline;
+
+		&:focus {
+			box-shadow: none;
+			color: $blue-medium-700;
+		}
+	}
+
+	&__textlink-placeholder {
+		opacity: .5;
+		text-decoration: underline;
+	}
+
+	&__button-richtext-wrapper {
+		display: inline-block;
+		margin-left: 0.75em;
+	}
+
+	&__copy-url-button {
+		margin-left: 1em;
+	}
+}

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -16,7 +16,7 @@ export const name = 'core/file';
 export const settings = {
 	title: __( 'File' ),
 
-	description: __( 'Link to a file.' ),
+	description: __( 'Add a link to a file that visitors can download.' ),
 
 	icon: 'media-default',
 

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -47,11 +47,13 @@ export const settings = {
 		},
 		showDownloadButton: {
 			type: 'boolean',
+			default: true,
 		},
 		buttonText: {
 			type: 'string',
 			source: 'text',
 			selector: 'a[download]',
+			default: __( 'Download' ),
 		},
 		id: {
 			type: 'number',

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -25,6 +25,9 @@ export const settings = {
 	keywords: [ __( 'document' ), __( 'pdf' ) ],
 
 	attributes: {
+		id: {
+			type: 'number',
+		},
 		href: {
 			type: 'string',
 		},
@@ -33,12 +36,14 @@ export const settings = {
 			source: 'text',
 			selector: 'a:not([download])',
 		},
+		// Differs to the href when the block is configured to link to the attachment page
 		textLinkHref: {
 			type: 'string',
 			source: 'attribute',
 			selector: 'a:not([download])',
 			attribute: 'href',
 		},
+		// e.g. `_blank` when the block is configured to open in a new window
 		openInNewWindow: {
 			type: 'string',
 			source: 'attribute',
@@ -49,14 +54,11 @@ export const settings = {
 			type: 'boolean',
 			default: true,
 		},
-		buttonText: {
+		downloadButtonText: {
 			type: 'string',
 			source: 'text',
 			selector: 'a[download]',
 			default: __( 'Download' ),
-		},
-		id: {
-			type: 'number',
 		},
 	},
 
@@ -141,7 +143,7 @@ export const settings = {
 			textLinkHref,
 			openInNewWindow,
 			showDownloadButton,
-			buttonText,
+			downloadButtonText,
 		} = attributes;
 
 		return ( href &&
@@ -160,7 +162,7 @@ export const settings = {
 						href={ href }
 						className="wp-block-file__button"
 						download={ fileName }>
-						{ buttonText }
+						{ downloadButtonText }
 					</a>
 				}
 			</div>

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -29,15 +29,18 @@ export const settings = {
 			type: 'string',
 		},
 		fileName: {
+			type: 'string',
 			source: 'text',
 			selector: 'a:not([download])',
 		},
 		textLinkHref: {
+			type: 'string',
 			source: 'attribute',
 			selector: 'a:not([download])',
 			attribute: 'href',
 		},
 		openInNewWindow: {
+			type: 'string',
 			source: 'attribute',
 			selector: 'a:not([download])',
 			attribute: 'target',
@@ -46,6 +49,7 @@ export const settings = {
 			type: 'boolean',
 		},
 		buttonText: {
+			type: 'string',
 			source: 'text',
 			selector: 'a[download]',
 		},

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -44,7 +44,7 @@ export const settings = {
 			attribute: 'href',
 		},
 		// e.g. `_blank` when the block is configured to open in a new window
-		openInNewWindow: {
+		textLinkTarget: {
 			type: 'string',
 			source: 'attribute',
 			selector: 'a:not([download])',
@@ -141,7 +141,7 @@ export const settings = {
 			href,
 			fileName,
 			textLinkHref,
-			openInNewWindow,
+			textLinkTarget,
 			showDownloadButton,
 			downloadButtonText,
 		} = attributes;
@@ -151,8 +151,8 @@ export const settings = {
 				{ fileName &&
 					<a
 						href={ textLinkHref }
-						target={ openInNewWindow }
-						rel={ openInNewWindow ? 'noreferrer noopener' : false }
+						target={ textLinkTarget }
+						rel={ textLinkTarget ? 'noreferrer noopener' : false }
 					>
 						{ fileName }
 					</a>

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -1,0 +1,164 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createBlobURL } from '@wordpress/utils';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import edit from './edit';
+
+export const name = 'core/file';
+
+export const settings = {
+	title: __( 'File' ),
+
+	description: __( 'Link to a file.' ),
+
+	icon: 'media-default',
+
+	category: 'common',
+
+	keywords: [ __( 'document' ), __( 'pdf' ) ],
+
+	attributes: {
+		href: {
+			type: 'string',
+		},
+		fileName: {
+			source: 'text',
+			selector: 'a:not([download])',
+		},
+		textLinkHref: {
+			source: 'attribute',
+			selector: 'a:not([download])',
+			attribute: 'href',
+		},
+		openInNewWindow: {
+			source: 'attribute',
+			selector: 'a:not([download])',
+			attribute: 'target',
+		},
+		showDownloadButton: {
+			type: 'boolean',
+		},
+		buttonText: {
+			source: 'text',
+			selector: 'a[download]',
+		},
+		id: {
+			type: 'number',
+		},
+	},
+
+	supports: {
+		align: true,
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'files',
+				isMatch: ( files ) => files.length === 1,
+				transform: ( files ) => {
+					const file = files[ 0 ];
+					const blobURL = createBlobURL( file );
+
+					// File will be uploaded in componentDidMount()
+					return createBlock( 'core/file', {
+						href: blobURL,
+						fileName: file.name,
+						textLinkHref: blobURL,
+					} );
+				},
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/audio' ],
+				transform: ( attributes ) => {
+					return createBlock( 'core/file', {
+						href: attributes.src,
+						fileName: attributes.caption && attributes.caption.join(),
+						textLinkHref: attributes.src,
+						id: attributes.id,
+					} );
+				},
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/video' ],
+				transform: ( attributes ) => {
+					return createBlock( 'core/file', {
+						href: attributes.src,
+						fileName: attributes.caption && attributes.caption.join(),
+						textLinkHref: attributes.src,
+						id: attributes.id,
+					} );
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/audio' ],
+				transform: ( attributes ) => {
+					return createBlock( 'core/audio', {
+						src: attributes.href,
+						caption: [ attributes.fileName ],
+						id: attributes.id,
+					} );
+				},
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/video' ],
+				transform: ( attributes ) => {
+					return createBlock( 'core/video', {
+						src: attributes.href,
+						caption: [ attributes.fileName ],
+						id: attributes.id,
+					} );
+				},
+			},
+		],
+	},
+
+	edit,
+
+	save( { attributes } ) {
+		const {
+			href,
+			fileName,
+			textLinkHref,
+			openInNewWindow,
+			showDownloadButton,
+			buttonText,
+		} = attributes;
+
+		return ( href &&
+			<div>
+				{ fileName &&
+					<a
+						href={ textLinkHref }
+						target={ openInNewWindow }
+						rel={ openInNewWindow ? 'noreferrer noopener' : false }
+					>
+						{ fileName }
+					</a>
+				}
+				{ showDownloadButton &&
+					<a
+						href={ href }
+						className="wp-block-file__button"
+						download={ fileName }>
+						{ buttonText }
+					</a>
+				}
+			</div>
+		);
+	},
+
+};

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createBlobURL } from '@wordpress/utils';
+import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 
 /**

--- a/core-blocks/file/inspector.js
+++ b/core-blocks/file/inspector.js
@@ -15,13 +15,14 @@ import {
 export default class FileBlockInspector extends Component {
 	render() {
 		const {
+			hrefs,
 			openInNewWindow,
 			showDownloadButton,
 			changeLinkDestinationOption,
 			changeOpenInNewWindow,
 			changeShowDownloadButton,
 		} = this.props;
-		const { href, textLinkHref, attachmentPage } = this.props.hrefs;
+		const { href, textLinkHref, attachmentPage } = hrefs;
 
 		const linkDestinationOptions = ( () => {
 			if ( attachmentPage ) {

--- a/core-blocks/file/inspector.js
+++ b/core-blocks/file/inspector.js
@@ -12,6 +12,10 @@ import {
 	InspectorControls,
 } from '@wordpress/editor';
 
+function getDownloadButtonHelp( checked ) {
+	return checked ? __( 'The download button is shown.' ) : __( 'The download button is hidden.' );
+}
+
 export default class FileBlockInspector extends Component {
 	render() {
 		const {
@@ -43,16 +47,15 @@ export default class FileBlockInspector extends Component {
 							onChange={ changeLinkDestinationOption }
 						/>
 						<ToggleControl
-							label={ __( 'Open in new window' ) }
+							label={ __( 'Open in New Window' ) }
 							checked={ openInNewWindow }
 							onChange={ changeOpenInNewWindow }
 						/>
 					</PanelBody>
-				</InspectorControls>
-				<InspectorControls>
-					<PanelBody title={ __( 'Download Button' ) }>
+					<PanelBody title={ __( 'Download Button Settings' ) }>
 						<ToggleControl
-							label={ __( 'Show button' ) }
+							label={ __( 'Show Download Button' ) }
+							help={ getDownloadButtonHelp }
 							checked={ showDownloadButton }
 							onChange={ changeShowDownloadButton }
 						/>

--- a/core-blocks/file/inspector.js
+++ b/core-blocks/file/inspector.js
@@ -24,15 +24,13 @@ export default class FileBlockInspector extends Component {
 		} = this.props;
 		const { href, textLinkHref, attachmentPage } = hrefs;
 
-		const linkDestinationOptions = ( () => {
-			if ( attachmentPage ) {
-				return [
-					{ value: href, label: __( 'Media File' ) },
-					{ value: attachmentPage, label: __( 'Attachment Page' ) },
-				];
-			}
-			return [ { value: href, label: __( 'URL' ) } ];
-		} )();
+		let linkDestinationOptions = [ { value: href, label: __( 'URL' ) } ];
+		if ( attachmentPage ) {
+			linkDestinationOptions = [
+				{ value: href, label: __( 'Media File' ) },
+				{ value: attachmentPage, label: __( 'Attachment Page' ) },
+			];
+		}
 
 		return (
 			<Fragment>

--- a/core-blocks/file/inspector.js
+++ b/core-blocks/file/inspector.js
@@ -7,61 +7,56 @@ import {
 	SelectControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
-import {
-	InspectorControls,
-} from '@wordpress/editor';
+import { Fragment } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/editor';
 
 function getDownloadButtonHelp( checked ) {
 	return checked ? __( 'The download button is shown.' ) : __( 'The download button is hidden.' );
 }
 
-export default class FileBlockInspector extends Component {
-	render() {
-		const {
-			hrefs,
-			openInNewWindow,
-			showDownloadButton,
-			changeLinkDestinationOption,
-			changeOpenInNewWindow,
-			changeShowDownloadButton,
-		} = this.props;
-		const { href, textLinkHref, attachmentPage } = hrefs;
+export default function FileBlockInspector( {
+	hrefs,
+	openInNewWindow,
+	showDownloadButton,
+	changeLinkDestinationOption,
+	changeOpenInNewWindow,
+	changeShowDownloadButton,
+} ) {
+	const { href, textLinkHref, attachmentPage } = hrefs;
 
-		let linkDestinationOptions = [ { value: href, label: __( 'URL' ) } ];
-		if ( attachmentPage ) {
-			linkDestinationOptions = [
-				{ value: href, label: __( 'Media File' ) },
-				{ value: attachmentPage, label: __( 'Attachment Page' ) },
-			];
-		}
-
-		return (
-			<Fragment>
-				<InspectorControls>
-					<PanelBody title={ __( 'Text Link Settings' ) }>
-						<SelectControl
-							label={ __( 'Link To' ) }
-							value={ textLinkHref }
-							options={ linkDestinationOptions }
-							onChange={ changeLinkDestinationOption }
-						/>
-						<ToggleControl
-							label={ __( 'Open in New Window' ) }
-							checked={ openInNewWindow }
-							onChange={ changeOpenInNewWindow }
-						/>
-					</PanelBody>
-					<PanelBody title={ __( 'Download Button Settings' ) }>
-						<ToggleControl
-							label={ __( 'Show Download Button' ) }
-							help={ getDownloadButtonHelp }
-							checked={ showDownloadButton }
-							onChange={ changeShowDownloadButton }
-						/>
-					</PanelBody>
-				</InspectorControls>
-			</Fragment>
-		);
+	let linkDestinationOptions = [ { value: href, label: __( 'URL' ) } ];
+	if ( attachmentPage ) {
+		linkDestinationOptions = [
+			{ value: href, label: __( 'Media File' ) },
+			{ value: attachmentPage, label: __( 'Attachment Page' ) },
+		];
 	}
+
+	return (
+		<Fragment>
+			<InspectorControls>
+				<PanelBody title={ __( 'Text Link Settings' ) }>
+					<SelectControl
+						label={ __( 'Link To' ) }
+						value={ textLinkHref }
+						options={ linkDestinationOptions }
+						onChange={ changeLinkDestinationOption }
+					/>
+					<ToggleControl
+						label={ __( 'Open in New Window' ) }
+						checked={ openInNewWindow }
+						onChange={ changeOpenInNewWindow }
+					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Download Button Settings' ) }>
+					<ToggleControl
+						label={ __( 'Show Download Button' ) }
+						help={ getDownloadButtonHelp }
+						checked={ showDownloadButton }
+						onChange={ changeShowDownloadButton }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</Fragment>
+	);
 }

--- a/core-blocks/file/inspector.js
+++ b/core-blocks/file/inspector.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	PanelBody,
+	SelectControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import {
+	InspectorControls,
+} from '@wordpress/editor';
+
+export default class FileBlockInspector extends Component {
+	render() {
+		const {
+			openInNewWindow,
+			showDownloadButton,
+			changeLinkDestinationOption,
+			changeOpenInNewWindow,
+			changeShowDownloadButton,
+		} = this.props;
+		const { href, textLinkHref, attachmentPage } = this.props.hrefs;
+
+		const linkDestinationOptions = ( () => {
+			if ( attachmentPage ) {
+				return [
+					{ value: href, label: __( 'Media File' ) },
+					{ value: attachmentPage, label: __( 'Attachment Page' ) },
+				];
+			}
+			return [ { value: href, label: __( 'URL' ) } ];
+		} )();
+
+		return (
+			<Fragment>
+				<InspectorControls>
+					<PanelBody title={ __( 'Text Link Settings' ) }>
+						<SelectControl
+							label={ __( 'Link To' ) }
+							value={ textLinkHref }
+							options={ linkDestinationOptions }
+							onChange={ changeLinkDestinationOption }
+						/>
+						<ToggleControl
+							label={ __( 'Open in new window' ) }
+							checked={ openInNewWindow }
+							onChange={ changeOpenInNewWindow }
+						/>
+					</PanelBody>
+				</InspectorControls>
+				<InspectorControls>
+					<PanelBody title={ __( 'Download Button' ) }>
+						<ToggleControl
+							label={ __( 'Show button' ) }
+							checked={ showDownloadButton }
+							onChange={ changeShowDownloadButton }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	}
+}

--- a/core-blocks/file/style.scss
+++ b/core-blocks/file/style.scss
@@ -1,0 +1,36 @@
+.wp-block-file {
+	margin-bottom: 1.5em;
+
+	&.aligncenter {
+		text-align: center;
+	}
+
+	&.alignright {
+		text-align: right;
+	}
+
+	&__button {
+		background: $dark-gray-700;
+		border-radius: 2em;
+		color: $white;
+		font-size: $default-font-size;
+		padding: 0.5em 1em;
+	}
+
+	a#{&}__button {
+		text-decoration: none;
+
+		&:hover,
+		&:focus,
+		&:active {
+			box-shadow: none;
+			color: $white;
+			opacity: .85;
+			text-decoration: none;
+		}
+	}
+
+	* + &__button {
+		margin-left: 0.75em;
+	}
+}

--- a/core-blocks/file/style.scss
+++ b/core-blocks/file/style.scss
@@ -21,6 +21,7 @@
 		text-decoration: none;
 
 		&:hover,
+		&:visited,
 		&:focus,
 		&:active {
 			box-shadow: none;

--- a/core-blocks/index.js
+++ b/core-blocks/index.js
@@ -23,6 +23,7 @@ import * as code from './code';
 import * as columns from './columns';
 import * as coverImage from './cover-image';
 import * as embed from './embed';
+import * as file from './file';
 import * as freeform from './freeform';
 import * as html from './html';
 import * as latestPosts from './latest-posts';
@@ -63,6 +64,7 @@ export const registerCoreBlocks = () => {
 		embed,
 		...embed.common,
 		...embed.others,
+		file,
 		freeform,
 		html,
 		latestPosts,

--- a/core-blocks/test/fixtures/core__file__new-window.html
+++ b/core-blocks/test/fixtures/core__file__new-window.html
@@ -1,0 +1,3 @@
+<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="6546">Download</a></div>
+<!-- /wp:file -->

--- a/core-blocks/test/fixtures/core__file__new-window.json
+++ b/core-blocks/test/fixtures/core__file__new-window.json
@@ -7,9 +7,9 @@
             "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
             "fileName": "6546",
             "textLinkHref": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
-            "openInNewWindow": "_blank",
+            "textLinkTarget": "_blank",
             "showDownloadButton": true,
-            "buttonText": "Download",
+            "downloadButtonText": "Download",
             "id": 176
         },
         "innerBlocks": [],

--- a/core-blocks/test/fixtures/core__file__new-window.json
+++ b/core-blocks/test/fixtures/core__file__new-window.json
@@ -1,0 +1,18 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/file",
+        "isValid": true,
+        "attributes": {
+            "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
+            "fileName": "6546",
+            "textLinkHref": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
+            "openInNewWindow": "_blank",
+            "showDownloadButton": true,
+            "buttonText": "Download",
+            "id": 176
+        },
+        "innerBlocks": [],
+        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"6546\">Download</a></div>"
+    }
+]

--- a/core-blocks/test/fixtures/core__file__new-window.parsed.json
+++ b/core-blocks/test/fixtures/core__file__new-window.parsed.json
@@ -1,0 +1,16 @@
+[
+    {
+        "blockName": "core/file",
+        "attrs": {
+            "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
+            "showDownloadButton": true,
+            "id": 176
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"6546\">Download</a></div>\n"
+    },
+    {
+        "attrs": {},
+        "innerHTML": "\n"
+    }
+]

--- a/core-blocks/test/fixtures/core__file__new-window.serialized.html
+++ b/core-blocks/test/fixtures/core__file__new-window.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="6546">Download</a></div>
+<!-- /wp:file -->

--- a/core-blocks/test/fixtures/core__file__new-window.serialized.html
+++ b/core-blocks/test/fixtures/core__file__new-window.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
+<!-- wp:file {"id":176,"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js"} -->
 <div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="6546">Download</a></div>
 <!-- /wp:file -->

--- a/core-blocks/test/fixtures/core__file__no-download-button.html
+++ b/core-blocks/test/fixtures/core__file__no-download-button.html
@@ -1,0 +1,3 @@
+<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":false,"id":176} -->
+<div class="wp-block-file"><a href="http://localhost:8888/?attachment_id=176">lkjfijwef</a></div>
+<!-- /wp:file -->

--- a/core-blocks/test/fixtures/core__file__no-download-button.json
+++ b/core-blocks/test/fixtures/core__file__no-download-button.json
@@ -8,6 +8,7 @@
             "fileName": "lkjfijwef",
             "textLinkHref": "http://localhost:8888/?attachment_id=176",
             "showDownloadButton": false,
+            "downloadButtonText": "Download",
             "id": 176
         },
         "innerBlocks": [],

--- a/core-blocks/test/fixtures/core__file__no-download-button.json
+++ b/core-blocks/test/fixtures/core__file__no-download-button.json
@@ -1,0 +1,16 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/file",
+        "isValid": true,
+        "attributes": {
+            "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
+            "fileName": "lkjfijwef",
+            "textLinkHref": "http://localhost:8888/?attachment_id=176",
+            "showDownloadButton": false,
+            "id": 176
+        },
+        "innerBlocks": [],
+        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/?attachment_id=176\">lkjfijwef</a></div>"
+    }
+]

--- a/core-blocks/test/fixtures/core__file__no-download-button.parsed.json
+++ b/core-blocks/test/fixtures/core__file__no-download-button.parsed.json
@@ -1,0 +1,16 @@
+[
+    {
+        "blockName": "core/file",
+        "attrs": {
+            "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
+            "showDownloadButton": false,
+            "id": 176
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/?attachment_id=176\">lkjfijwef</a></div>\n"
+    },
+    {
+        "attrs": {},
+        "innerHTML": "\n"
+    }
+]

--- a/core-blocks/test/fixtures/core__file__no-download-button.serialized.html
+++ b/core-blocks/test/fixtures/core__file__no-download-button.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":false,"id":176} -->
+<div class="wp-block-file"><a href="http://localhost:8888/?attachment_id=176">lkjfijwef</a></div>
+<!-- /wp:file -->

--- a/core-blocks/test/fixtures/core__file__no-download-button.serialized.html
+++ b/core-blocks/test/fixtures/core__file__no-download-button.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":false,"id":176} -->
+<!-- wp:file {"id":176,"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":false} -->
 <div class="wp-block-file"><a href="http://localhost:8888/?attachment_id=176">lkjfijwef</a></div>
 <!-- /wp:file -->

--- a/core-blocks/test/fixtures/core__file__no-text-link.html
+++ b/core-blocks/test/fixtures/core__file__no-text-link.html
@@ -1,0 +1,3 @@
+<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="">Download</a></div>
+<!-- /wp:file -->

--- a/core-blocks/test/fixtures/core__file__no-text-link.json
+++ b/core-blocks/test/fixtures/core__file__no-text-link.json
@@ -1,0 +1,15 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/file",
+        "isValid": true,
+        "attributes": {
+            "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
+            "showDownloadButton": true,
+            "buttonText": "Download",
+            "id": 176
+        },
+        "innerBlocks": [],
+        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>"
+    }
+]

--- a/core-blocks/test/fixtures/core__file__no-text-link.json
+++ b/core-blocks/test/fixtures/core__file__no-text-link.json
@@ -6,7 +6,7 @@
         "attributes": {
             "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
             "showDownloadButton": true,
-            "buttonText": "Download",
+            "downloadButtonText": "Download",
             "id": 176
         },
         "innerBlocks": [],

--- a/core-blocks/test/fixtures/core__file__no-text-link.parsed.json
+++ b/core-blocks/test/fixtures/core__file__no-text-link.parsed.json
@@ -1,0 +1,16 @@
+[
+    {
+        "blockName": "core/file",
+        "attrs": {
+            "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
+            "showDownloadButton": true,
+            "id": 176
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>\n"
+    },
+    {
+        "attrs": {},
+        "innerHTML": "\n"
+    }
+]

--- a/core-blocks/test/fixtures/core__file__no-text-link.serialized.html
+++ b/core-blocks/test/fixtures/core__file__no-text-link.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button">Download</a></div>
+<!-- /wp:file -->

--- a/core-blocks/test/fixtures/core__file__no-text-link.serialized.html
+++ b/core-blocks/test/fixtures/core__file__no-text-link.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
+<!-- wp:file {"id":176,"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js"} -->
 <div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button">Download</a></div>
 <!-- /wp:file -->

--- a/editor/utils/editor-media-upload/index.js
+++ b/editor/utils/editor-media-upload/index.js
@@ -14,7 +14,7 @@ import { mediaUpload } from '@wordpress/utils';
  * Wrapper around mediaUpload() that injects the current post ID.
  *
  * @param   {Object}   $0                   Parameters object passed to the function.
- * @param   {string}   $0.allowedType       The type of media that can be uploaded.
+ * @param   {string}   $0.allowedType       The type of media that can be uploaded, or '*' to allow all.
  * @param   {?Object}  $0.additionalData    Additional data to include in the request.
  * @param   {Array}    $0.filesList         List of files.
  * @param   {?number}  $0.maxUploadFileSize Maximum upload size in bytes allowed for the site.

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -38,13 +38,13 @@ export function getMimeTypesArray( wpMimeTypesObject ) {
 }
 
 /**
- *	Media Upload is used by audio, image, gallery and video blocks to handle uploading a media file
- *	when a file upload button is activated.
+ *	Media Upload is used by audio, image, gallery, video, and file blocks to
+ *	handle uploading a media file when a file upload button is activated.
  *
  *	TODO: future enhancement to add an upload indicator.
  *
  * @param   {Object}   $0                   Parameters object passed to the function.
- * @param   {string}   $0.allowedType       The type of media that can be uploaded.
+ * @param   {string}   $0.allowedType       The type of media that can be uploaded, or '*' to allow all.
  * @param   {?Object}  $0.additionalData    Additional data to include in the request.
  * @param   {Array}    $0.filesList         List of files.
  * @param   {?number}  $0.maxUploadFileSize Maximum upload size in bytes allowed for the site.
@@ -69,7 +69,9 @@ export function mediaUpload( {
 	};
 
 	// Allowed type specified by consumer
-	const isAllowedType = ( fileType ) => startsWith( fileType, `${ allowedType }/` );
+	const isAllowedType = ( fileType ) => {
+		return ( allowedType === '*' ) || startsWith( fileType, `${ allowedType }/` );
+	};
 
 	// Allowed types for the current WP_User
 	const allowedMimeTypesForUser = getMimeTypesArray( get( window, [ '_wpMediaSettings', 'allowedMimeTypes' ] ) );
@@ -118,6 +120,7 @@ export function mediaUpload( {
 					caption: get( savedMedia, [ 'caption', 'raw' ], '' ),
 					id: savedMedia.id,
 					link: savedMedia.link,
+					title: savedMedia.title.raw,
 					url: savedMedia.source_url,
 				};
 				setAndUpdateFiles( idx, mediaObject );


### PR DESCRIPTION
Based off of @mirka's work in https://github.com/WordPress/gutenberg/pull/6805.

Closes #5462.

Implements a File block with the following features:

- Editable text link
- Text link can be copy and pasted to create a normal link
- HTML5 download link
- Copy URL button to copy the media file URL to clipboard
- Accepts both Media Library files and external URLs only Media Library files
- Text link can be changed to point to the Attachment Page
- Text link can be changed to open in a new window
- Accepts and uploads a file drag-and-dropped into the editor (or placeholder)
- Transforms to/from Audio and Video blocks
- Download button text is editable
- Download button is optional