### PR TITLE
Data Module: Move the data reference to the root level

### DIFF
--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -1,8 +1,8 @@
 # Data Module Reference
 
- - [**core**: WordPress Core Data](./core.md)
- - [**core/blocks**: Block Types Data](./core-blocks.md)
- - [**core/editor**: The Editor's Data](./core-editor.md)
- - [**core/edit-post**: The Editor's UI Data](./core-edit-post.md)
- - [**core/viewport**: The viewport module Data](./core-viewport.md)
- - [**core/nux**: The NUX (New User Experience) module Data](./core-nux.md)
+ - [**core**: WordPress Core Data](../../docs/data/core.md)
+ - [**core/blocks**: Block Types Data](../../docs/data/core-blocks.md)
+ - [**core/editor**: The Editor's Data](../../docs/data/core-editor.md)
+ - [**core/edit-post**: The Editor's UI Data](../../docs/data/core-edit-post.md)
+ - [**core/viewport**: The viewport module Data](../../docs/data/core-viewport.md)
+ - [**core/nux**: The NUX (New User Experience) module Data](../../docs/data/core-nux.md)

--- a/docs/data/core-blocks.md
+++ b/docs/data/core-blocks.md
@@ -80,3 +80,11 @@ Returns an action object used to set the fallback block name.
 *Parameters*
 
  * name: Block name.
+
+### setCategories
+
+Returns an action object used to set block categories.
+
+*Parameters*
+
+ * categories: Block categories.

--- a/docs/data/core-editor.md
+++ b/docs/data/core-editor.md
@@ -139,6 +139,19 @@ been saved.
 
 Object of key value pairs comprising unsaved edits.
 
+### getCurrentPostAttribute
+
+Returns an attribute value of the saved post.
+
+*Parameters*
+
+ * state: Global application state.
+ * attributeName: Post attribute name.
+
+*Returns*
+
+Post attribute value.
+
 ### getEditedPostAttribute
 
 Returns a single attribute of the post being edited, preferring the unsaved
@@ -153,6 +166,20 @@ saved state of the post.
 *Returns*
 
 Post attribute value.
+
+### getAutosaveAttribute
+
+Returns an attribute value of the current autosave revision for a post, or
+null if there is no autosave for the post.
+
+*Parameters*
+
+ * state: Global application state.
+ * attributeName: Autosave attribute name.
+
+*Returns*
+
+Autosave attribute value.
 
 ### getEditedPostVisibility
 
@@ -304,18 +331,6 @@ Gets the document title to be used.
 *Returns*
 
 Document title.
-
-### getEditedPostPreviewLink
-
-Returns a URL to preview the post being edited.
-
-*Parameters*
-
- * state: Global application state.
-
-*Returns*
-
-Preview URL.
 
 ### getBlockName
 
@@ -1028,6 +1043,18 @@ Returns the editor settings.
 
 The editor settings object
 
+### getTokenSettings
+
+Returns the editor settings.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+The editor settings object
+
 ## Actions
 
 ### setupEditor
@@ -1057,6 +1084,15 @@ post has been received, by initialization or autosave.
 *Parameters*
 
  * post: Autosave post object.
+
+### updatePost
+
+Returns an action object used in signalling that a patch of updates for the
+latest version of the post have been received.
+
+*Parameters*
+
+ * edits: Updated post fields.
 
 ### setupEditorState
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -213,7 +213,7 @@
 		"title": "Data Package Reference",
 		"slug": "packages-data",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/README.md",
-		"parent": "reference"
+		"parent": null
 	},
 	{
 		"title": "WordPress Core Data",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -211,44 +211,44 @@
 	},
 	{
 		"title": "Data Package Reference",
-		"slug": "packages-data",
+		"slug": "data",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/README.md",
 		"parent": null
 	},
 	{
 		"title": "WordPress Core Data",
-		"slug": "packages-data-core",
+		"slug": "data-core",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/core.md",
-		"parent": "packages-data"
+		"parent": "data"
 	},
 	{
 		"title": "Block Types Data",
-		"slug": "packages-data-core-blocks",
+		"slug": "data-core-blocks",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/core-blocks.md",
-		"parent": "packages-data"
+		"parent": "data"
 	},
 	{
 		"title": "The Editor's Data",
-		"slug": "packages-data-core-editor",
+		"slug": "data-core-editor",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/core-editor.md",
-		"parent": "packages-data"
+		"parent": "data"
 	},
 	{
 		"title": "The Editor's UI Data",
-		"slug": "packages-data-core-edit-post",
+		"slug": "data-core-edit-post",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/core-edit-post.md",
-		"parent": "packages-data"
+		"parent": "data"
 	},
 	{
 		"title": "The viewport module Data",
-		"slug": "packages-data-core-viewport",
+		"slug": "data-core-viewport",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/core-viewport.md",
-		"parent": "packages-data"
+		"parent": "data"
 	},
 	{
 		"title": "The NUX (New User Experience) module Data",
-		"slug": "packages-data-core-nux",
+		"slug": "data-core-nux",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/core-nux.md",
-		"parent": "packages-data"
+		"parent": "data"
 	}
 ]

--- a/docs/tool/generator.js
+++ b/docs/tool/generator.js
@@ -17,7 +17,7 @@ function generateTableOfContent( parsedNamespaces ) {
 		'# Data Module Reference',
 		'',
 		Object.values( parsedNamespaces ).map( ( parsedNamespace ) => {
-			return ` - [**${ parsedNamespace.name }**: ${ parsedNamespace.title }](./${ kebabCase( parsedNamespace.name ) }.md)`;
+			return ` - [**${ parsedNamespace.name }**: ${ parsedNamespace.title }](../../docs/data/${ kebabCase( parsedNamespace.name ) }.md)`;
 		} ).join( '\n' ),
 	].join( '\n' );
 }

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -15,7 +15,7 @@ module.exports = function( parsedNamespaces ) {
 		title: 'Data Package Reference',
 		slug: 'packages-data',
 		markdown_source: 'https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/README.md',
-		parent: 'reference',
+		parent: null,
 	} ].concat(
 		Object.values( parsedNamespaces ).map( ( parsedNamespace ) => {
 			const slug = kebabCase( parsedNamespace.name );

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -13,7 +13,7 @@ const { kebabCase } = require( 'lodash' );
 module.exports = function( parsedNamespaces ) {
 	return [ {
 		title: 'Data Package Reference',
-		slug: 'packages-data',
+		slug: 'data',
 		markdown_source: 'https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/README.md',
 		parent: null,
 	} ].concat(
@@ -21,9 +21,9 @@ module.exports = function( parsedNamespaces ) {
 			const slug = kebabCase( parsedNamespace.name );
 			return {
 				title: parsedNamespace.title,
-				slug: 'packages-data-' + slug,
+				slug: 'data-' + slug,
 				markdown_source: 'https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/' + slug + '.md',
-				parent: 'packages-data',
+				parent: 'data',
 			};
 		} )
 	);


### PR DESCRIPTION
This PR fixes the data module docs by moving them to the root level of the handbook. Even if the handbook supports nested levels, it doesn't look good.

Also tries to fix the links in the table of contents and use a "trick" to make them work in both github and the handbook.