### PR TITLE
Documentation: Adding the packages READMEs to the handbook

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -210,6 +210,144 @@
 		"parent": "outreach"
 	},
 	{
+		"title": "Packages",
+		"slug": "packages",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/packages.md",
+		"parent": null
+	},
+	{
+		"title": "@wordpress/api-request",
+		"slug": "packages-api-request",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/api-request/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/babel-plugin-import-jsx-pragam",
+		"slug": "packages-babel-plugin-import-jsx-pragam",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/babel-plugin-import-jsx-pragam/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/blob",
+		"slug": "packages-blob",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/blob/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/core-data",
+		"slug": "packages-core-data",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/core-data/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/data",
+		"slug": "packages-data",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/data/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/date",
+		"slug": "packages-date",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/date/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/deprecated",
+		"slug": "packages-deprecated",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/deprecated/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/dom",
+		"slug": "packages-dom",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/dom/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/element",
+		"slug": "packages-element",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/element/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/keycodes",
+		"slug": "packages-keycodes",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/keycodes/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/library-export-default-webpack-plugin",
+		"slug": "packages-library-export-default-webpack-plugin",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/library-export-default-webpack-plugin/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/plugins",
+		"slug": "packages-plugins",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/plugins/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/postcss-themes",
+		"slug": "packages-postcss-themes",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/postcss-themes/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/shortcode",
+		"slug": "packages-shortcode",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/shortcode/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/blocks",
+		"slug": "packages-blocks",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/blocks/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/components",
+		"slug": "packages-components",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/components/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/core-blocks",
+		"slug": "packages-core-blocks",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/core-blocks/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/edit-post",
+		"slug": "packages-edit-post",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/edit-post/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/editor",
+		"slug": "packages-editor",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/editor/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/nux",
+		"slug": "packages-nux",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/nux/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/utils",
+		"slug": "packages-utils",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/utils/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/viewport",
+		"slug": "packages-viewport",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/viewport/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "Data Package Reference",
 		"slug": "data",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/README.md",

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,11 @@
+# packages
+
+Gutenberg exposes a list of JavaScript packages and tools for WordPress development.
+
+## Using the packages
+
+JavaScript packages are available as a registered script in WordPress and can be accessed using the `wp` global variable.
+
+All the packages are also available on [npm](https://www.npmjs.com/org/wordpress) if you want to bundle them in your code.
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/docs/root-manifest.json
+++ b/docs/root-manifest.json
@@ -208,5 +208,11 @@
 		"slug": "resources",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/outreach\/resources.md",
 		"parent": "outreach"
+	},
+	{
+		"title": "Packages",
+		"slug": "packages",
+		"markdown_source":  "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/packages.md",
+		"parent": null
 	}
 ]

--- a/docs/tool/config.js
+++ b/docs/tool/config.js
@@ -5,6 +5,7 @@ const path = require( 'path' );
 
 const root = path.resolve( __dirname, '../../' );
 
+// These are packages published to NPM as their own node modules.
 const npmReadyPackages = [
 	'api-request',
 	'babel-plugin-import-jsx-pragam',
@@ -22,6 +23,8 @@ const npmReadyPackages = [
 	'shortcode',
 ];
 
+// These are internal-only packages (for now), not yet published as standalone
+// node modules.
 const gutenbergPackages = [
 	'blocks',
 	'components',

--- a/docs/tool/config.js
+++ b/docs/tool/config.js
@@ -5,6 +5,34 @@ const path = require( 'path' );
 
 const root = path.resolve( __dirname, '../../' );
 
+const npmReadyPackages = [
+	'api-request',
+	'babel-plugin-import-jsx-pragam',
+	'blob',
+	'core-data',
+	'data',
+	'date',
+	'deprecated',
+	'dom',
+	'element',
+	'keycodes',
+	'library-export-default-webpack-plugin',
+	'plugins',
+	'postcss-themes',
+	'shortcode',
+];
+
+const gutenbergPackages = [
+	'blocks',
+	'components',
+	'core-blocks',
+	'edit-post',
+	'editor',
+	'nux',
+	'utils',
+	'viewport',
+];
+
 module.exports = {
 	dataNamespaces: {
 		core: {
@@ -39,10 +67,19 @@ module.exports = {
 			actions: [ path.resolve( root, 'nux/store/actions.js' ) ],
 		},
 	},
-
 	dataDocsOutput: path.resolve( __dirname, '../data' ),
 
-	rootManifest: path.resolve( __dirname, '../root-manifest.json' ),
+	packages: {
+		...npmReadyPackages.reduce( ( memo, pkg ) => {
+			memo[ pkg ] = { isNpmReady: true };
+			return memo;
+		}, {} ),
+		...gutenbergPackages.reduce( ( memo, pkg ) => {
+			memo[ pkg ] = { isNpmReady: false };
+			return memo;
+		}, {} ),
+	},
 
+	rootManifest: path.resolve( __dirname, '../root-manifest.json' ),
 	manifestOutput: path.resolve( __dirname, '../manifest.json' ),
 };

--- a/docs/tool/config.js
+++ b/docs/tool/config.js
@@ -70,12 +70,12 @@ module.exports = {
 	dataDocsOutput: path.resolve( __dirname, '../data' ),
 
 	packages: {
-		...npmReadyPackages.reduce( ( memo, pkg ) => {
-			memo[ pkg ] = { isNpmReady: true };
+		...npmReadyPackages.reduce( ( memo, packageName ) => {
+			memo[ packageName ] = { isNpmReady: true };
 			return memo;
 		}, {} ),
-		...gutenbergPackages.reduce( ( memo, pkg ) => {
-			memo[ pkg ] = { isNpmReady: false };
+		...gutenbergPackages.reduce( ( memo, packageName ) => {
+			memo[ packageName ] = { isNpmReady: false };
 			return memo;
 		}, {} ),
 	},

--- a/docs/tool/index.js
+++ b/docs/tool/index.js
@@ -14,7 +14,7 @@ const getManifest = require( './manifest' );
 const parsedModules = parser( config.dataNamespaces );
 generator( parsedModules, config.dataDocsOutput );
 const rootManifest = require( config.rootManifest );
-const dataModuleManifest = getManifest( parsedModules );
+const dataModuleManifest = getManifest( parsedModules, config.packages );
 
 fs.writeFileSync(
 	config.manifestOutput,

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -22,8 +22,8 @@ module.exports = function( parsedNamespaces, packagesConfig ) {
 			const slug = kebabCase( parsedNamespace.name );
 			return {
 				title: parsedNamespace.title,
-				slug: 'data-' + slug,
-				markdown_source: 'https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/' + slug + '.md',
+				slug: `data-${ slug }`,
+				markdown_source: `https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/${ slug }.md`,
 				parent: 'data',
 			};
 		} )
@@ -31,11 +31,11 @@ module.exports = function( parsedNamespaces, packagesConfig ) {
 
 	const packagesManifest = Object.entries( packagesConfig ).map( ( [ packageSlug, config ] ) => {
 		const path = config.isNpmReady === false ?
-			'https://raw.githubusercontent.com/WordPress/gutenberg/master/' + packageSlug + '/README.md' :
-			'https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/' + packageSlug + '/README.md';
+			`https://raw.githubusercontent.com/WordPress/gutenberg/master/${ packageSlug }/README.md` :
+			`https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/${ packageSlug }/README.md`;
 		return {
-			title: '@wordpress/' + packageSlug,
-			slug: 'packages-' + packageSlug,
+			title: `@wordpress/${ packageSlug }`,
+			slug: `packages-${ packageSlug }`,
 			markdown_source: path,
 			parent: 'packages',
 		};

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -7,11 +7,12 @@ const { kebabCase } = require( 'lodash' );
  * Generates the manifest for the given namespaces.
  *
  * @param {Object} parsedNamespaces Parsed Namespace Object.
+ * @param {Object} packagesConfig   Packages Docs Config.
  *
  * @return {Array} manifest.
  */
-module.exports = function( parsedNamespaces ) {
-	return [ {
+module.exports = function( parsedNamespaces, packagesConfig ) {
+	const dataManifest = [ {
 		title: 'Data Package Reference',
 		slug: 'data',
 		markdown_source: 'https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/README.md',
@@ -27,4 +28,18 @@ module.exports = function( parsedNamespaces ) {
 			};
 		} )
 	);
+
+	const packagesManifest = Object.entries( packagesConfig ).map( ( [ packageSlug, config ] ) => {
+		const path = config.isNpmReady === false ?
+			'https://raw.githubusercontent.com/WordPress/gutenberg/master/' + packageSlug + '/README.md' :
+			'https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/' + packageSlug + '/README.md';
+		return {
+			title: '@wordpress/' + packageSlug,
+			slug: 'packages-' + packageSlug,
+			markdown_source: path,
+			parent: 'packages',
+		};
+	} );
+
+	return packagesManifest.concat( dataManifest );
 };


### PR DESCRIPTION
This PR adds the packages READMEs to the handbook grouped under a "packages" section. This makes it easier to navigate between the docs of the different packages.

For now, I'm just using the README but we could imagine adding support for a `docs` folder per package if the package is important enough to require multiple pages of docs.