### PR TITLE
Block List: Reenable pointer events on insertion point hover

### DIFF
--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -27,7 +27,6 @@ class BlockInsertionPoint extends Component {
 	onFocusInserter( event ) {
 		// We stop propagation of the focus event to avoid selecting the current block
 		// While we're trying to insert a new block
-		// We also attach this to onMouseDown, due to a difference in behavior in Firefox and Safari, where buttons don't receive focus: https://gist.github.com/cvrebert/68659d0333a578d75372
 		event.stopPropagation();
 
 		this.setState( {
@@ -66,7 +65,6 @@ class BlockInsertionPoint extends Component {
 							onClick={ this.onClick }
 							label={ __( 'Insert block' ) }
 							onFocus={ this.onFocusInserter }
-							onMouseDown={ this.onFocusInserter }
 							onBlur={ this.onBlurInserter }
 						/>
 					</div>

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -744,6 +744,7 @@
 		opacity: 0;
 		pointer-events: none;
 
+		&:hover,
 		&.is-visible {
 			opacity: 1;
 			pointer-events: auto;


### PR DESCRIPTION
Alternative to #7530

This pull request seeks to resolve the issue with sibling inserter on FIrefox / Safari. The issue was that we make reenable visibility (`opacity`) of the insertion point on hover, but there are also `pointer-events: none` which were not also being reset on `:hover`. Not sure why the `pointer-events` are being reset in the first place.

**Testing instructions:**

Repeat testing instructions from #7530 
