### PR TITLE
Rich Text: Detect handled horizontal navigation by preventDefault

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -188,13 +188,9 @@ class WritingFlow extends Component {
 	onKeyDown( event ) {
 		const { hasMultiSelection, onMultiSelect, blocks } = this.props;
 
-		// If navigation has already been handled (e.g. TinyMCE inline
-		// boundaries), abort. Ideally this uses Event#defaultPrevented. This
-		// is currently not possible because TinyMCE will misreport an event
-		// default as prevented on outside edges of inline boundaries.
-		//
-		// See: https://github.com/tinymce/tinymce/issues/4476
-		if ( event.nativeEvent._navigationHandled ) {
+		// Aobrt if navigation has already been handled (e.g. TinyMCE inline
+		// boundaries).
+		if ( event.nativeEvent.defaultPrevented ) {
 			return;
 		}
 

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -82,7 +82,20 @@ describe( 'adding blocks', () => {
 		await page.keyboard.up( 'Shift' );
 		await pressWithModifier( 'mod', 'b' );
 
-		// Arrow left from selected bold should traverse into first.
+		// Arrow left from selected bold should collapse to before the inline
+		// boundary. Arrow once more to traverse into first paragraph.
+		//
+		// See native behavior example: http://fiddle.tinymce.com/kvgaab
+		//
+		//  1. Select all of second paragraph, end to beginning
+		//  2. Press ArrowLeft
+		//  3. Type
+		//  4. Note that text is not bolded
+		//
+		// This is technically different than how other word processors treat
+		// the collapse while a bolded segment is selected, but our behavior
+		// is consistent with TinyMCE.
+		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.type( 'After' );
 


### PR DESCRIPTION
Related: #6712

This pull request seeks to improve upon the implementation of horizontal navigation in RichText from #6712. Per observation in https://github.com/WordPress/gutenberg/pull/6712#issuecomment-401383762 , it finds a workaround to TinyMCE's calling of `preventDefault` on an unhandled caret movement by reassigning its internal event's `preventDefault` to a `noop` when the arrow key is moving _away_ from the inline boundary (not within it). This allows `WritingFlow` to detect the key press as being handled via the standard `Event#defaultPrevented`, rather than knowledge of an internal `_navigationHandled` property.

Further, it avoids binding a `keydown` event to the entire document, which as noted in https://github.com/WordPress/gutenberg/pull/6712#issuecomment-401446040 could be problematic.

The revised implementation also seems to correct a potentially wrong behavior where collapsing a selection was wrongly causing the selection to be moved to a previous / next paragraph. This is reflected in updated end-to-end test with explaining comment.

**Testing instructions:**

Verify that you can traverse into and out of inline boundaries, including those which occur at the beginning or end of a paragraph.

Ensure end-to-end tests pass:

```
./bin/run-e2e-tests.sh
```