### PR TITLE
Update plugin version to 3.1.1

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 3.1.0
+ * Version: 3.1.1
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"private": true,
 	"description": "A new WordPress editor experience",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
## Description
This PR just updates the plugin version from 3.1.0 to 3.1.1

## How has this been tested?
This has been tested by making sure that the plugin at Github repository is at the same version with the released version which is currently [3.1.1](https://github.com/WordPress/gutenberg/releases/tag/v3.1.1).

This was tested in WP 4.9.6, Gutenberg 3.1.1, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Types of changes
This PR just changes the version number in the core plugin file and npm package files.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
