### PR TITLE
Rich Text: Remove componentDidUpdate deep equality conditions

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -681,21 +681,34 @@ export class RichText extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		const { tagName, value } = this.props;
+
 		// The `savedContent` var allows us to avoid updating the content right after an `onChange` call
 		if (
 			!! this.editor &&
-			this.props.tagName === prevProps.tagName &&
-			this.props.value !== prevProps.value &&
-			this.props.value !== this.savedContent
+			tagName === prevProps.tagName &&
+			value !== prevProps.value &&
+			value !== this.savedContent
 		) {
 			this.setContent( this.props.value );
 		}
 
+		// Note: Environment condition must be independent for it to be dropped
+		// in dead code elimination with webpack.DefinePlugin.
 		if ( 'development' === process.env.NODE_ENV ) {
+			/* eslint-disable no-console */
+			if ( value !== prevProps.value && isEqual( value, prevProps.value ) ) {
+				console.error( 'RichText value reference changed while being deeply equal to `prevProps.value`. This will incur wasted effort to update the RichText field.' );
+			}
+
+			if ( value !== this.savedContent && isEqual( value, this.savedContent ) ) {
+				console.error( 'RichText value reference changed while being deeply equal to `this.savedContent`. This will incur wasted effort to update the RichText field.' );
+			}
+
 			if ( ! isEqual( this.props.formatters, prevProps.formatters ) ) {
-				// eslint-disable-next-line no-console
 				console.error( 'Formatters passed via `formatters` prop will only be registered once. Formatters can be enabled/disabled via the `formattingControls` prop.' );
 			}
+			/* eslint-enable no-console */
 		}
 	}
 

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -686,13 +686,7 @@ export class RichText extends Component {
 			!! this.editor &&
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
-			this.props.value !== this.savedContent &&
-
-			// Comparing using isEqual is necessary especially to avoid unnecessary updateContent calls
-			// This fixes issues in multi richText blocks like quotes when moving the focus between
-			// the different editables.
-			! isEqual( this.props.value, prevProps.value ) &&
-			! isEqual( this.props.value, this.savedContent )
+			this.props.value !== this.savedContent
 		) {
 			this.setContent( this.props.value );
 		}

--- a/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
@@ -6,7 +6,7 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 <!-- /wp:paragraph -->
 
 <!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><p>Quote block</p></blockquote>
+<blockquote class=\\"wp-block-quote\\"><p>Quote block</p><cite>Quote citation</cite></blockquote>
 <!-- /wp:quote -->
 
 <!-- wp:image -->
@@ -24,7 +24,7 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 <!-- /wp:paragraph -->
 
 <!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><p>Quote block</p></blockquote>
+<blockquote class=\\"wp-block-quote\\"><p>Quote block</p><cite>Quote citation</cite></blockquote>
 <!-- /wp:quote -->"
 `;
 
@@ -38,7 +38,7 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 <!-- /wp:paragraph -->
 
 <!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><p>Quote block</p></blockquote>
+<blockquote class=\\"wp-block-quote\\"><p>Quote block</p><cite>Quote citation</cite></blockquote>
 <!-- /wp:quote -->
 
 <!-- wp:preformatted -->

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -39,9 +39,10 @@ describe( 'adding blocks', () => {
 		await page.keyboard.type( '/quote' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Quote block' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.type( 'Quote citation' );
 
 		// Arrow down into default appender.
-		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );
 
 		// Focus should be moved to block focus boundary on a block which does
@@ -87,11 +88,6 @@ describe( 'adding blocks', () => {
 		await page.mouse.move( rect.x + ( rect.width / 2 ), rect.y + ( rect.height / 2 ) );
 		await page.click( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
 		await page.keyboard.type( 'Second paragraph' );
-
-		// Switch to Text Mode to check HTML Output
-		await page.click( '.edit-post-more-menu [aria-label="More"]' );
-		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
This pull request seeks to simplify the RichText component, removing two deep equality conditions performed on each component update. These were introduced in #5100 to resolve an issue described in #5081. The issue is in-fact related to forceful focusing caused by `updateContent`, which is slated to be separately resolved by #7620 in checking that the editor has focus when restoring the stored bookmark when setting content.

~**_Thus, this pull request is considered blocked by #7620._** There is an added end-to-end test here which fails as expected from the steps described in #5081, and are expected to pass once #7620 is merged and this pull request rebased.~

Speaking more broadly, it is an issue that we cannot trust that content has changed unexpectedly without a deep equality check. We should not need to rely on these conditions. Strict equality should be sufficient.

**Testing instructions:**

Repeat testing instructions from #5100.

Ensure end-to-end tests pass:

```
npm run test-e2e
```