### PR TITLE
Rich Text: Remove isEmpty condition from getContent

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -818,9 +818,7 @@ export class RichText extends Component {
 			case 'string':
 				return this.editor.getContent();
 			default:
-				return this.editor.dom.isEmpty( this.editor.getBody() ) ?
-					[] :
-					domToFormat( this.editor.getBody().childNodes || [], 'element', this.editor );
+				return domToFormat( this.editor.getBody().childNodes || [], 'element', this.editor );
 		}
 	}
 


### PR DESCRIPTION
This pull request seeks to simplify the RichText component's `getContent` function to remove a call to TinyMCE's `isEmpty` function, which incurs a DOM walk to determine emptiness. This should not be needed because our own `domToFormat` should be responsible for stripping empty / bogus nodes, regardless of whether TinyMCE reports its own content as empty. Otherwise we risk bugs where empty / bogus nodes should be disregarded but are not because the editor is not otherwise empty. This can also be considered an optimization since `getContent` is called frequently while typing (each key press).

**Testing instructions:**

Verify that there are no regressions in updating content in the editor.

Ensure end-to-end tests pass.

```
npm run test-e2e
```