### PR TITLE
Rich Text: Remove createUndoLevel for split, merge

### DIFF
--- a/editor/components/editor-history/redo.js
+++ b/editor/components/editor-history/redo.js
@@ -15,7 +15,7 @@ function EditorHistoryRedo( { hasRedo, redo } ) {
 			shortcut={ displayShortcut.primaryShift( 'z' ) }
 			disabled={ ! hasRedo }
 			onClick={ redo }
-			className="editor-history__undo"
+			className="editor-history__redo"
 		/>
 	);
 }

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -535,8 +535,6 @@ export class RichText extends Component {
 				return;
 			}
 
-			this.onCreateUndoLevel();
-
 			const forward = keyCode === DELETE;
 
 			if ( this.props.onMerge ) {
@@ -574,7 +572,6 @@ export class RichText extends Component {
 				}
 
 				event.preventDefault();
-				this.onCreateUndoLevel();
 
 				const childNodes = Array.from( rootNode.childNodes );
 				const index = dom.nodeIndex( selectedNode );
@@ -588,7 +585,6 @@ export class RichText extends Component {
 				this.restoreContentAndSplit( before, after );
 			} else {
 				event.preventDefault();
-				this.onCreateUndoLevel();
 
 				if ( event.shiftKey || ! this.props.onSplit ) {
 					this.editor.execCommand( 'InsertLineBreak', false, event );

--- a/test/e2e/specs/undo.test.js
+++ b/test/e2e/specs/undo.test.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import {
+	newPost,
+	newDesktopBrowserPage,
+	pressWithModifier,
+	getHTMLFromCodeEditor,
+} from '../support/utils';
+
+describe( 'undo', () => {
+	beforeAll( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+	} );
+
+	it( 'Should undo to expected level intervals', async () => {
+		await page.click( '.editor-default-block-appender' );
+
+		await page.keyboard.type( 'This' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'is' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'test' );
+
+		await pressWithModifier( 'mod', 'z' ); // Strip 3rd paragraph text
+		await pressWithModifier( 'mod', 'z' ); // Strip 3rd paragraph block
+		await pressWithModifier( 'mod', 'z' ); // Strip 2nd paragraph text
+		await pressWithModifier( 'mod', 'z' ); // Strip 2nd paragraph block
+		await pressWithModifier( 'mod', 'z' ); // Strip 1st paragraph text
+		await pressWithModifier( 'mod', 'z' ); // Strip 1st paragraph block
+
+		expect( await getHTMLFromCodeEditor() ).toBe( '' );
+
+		// Should have no more history.
+		const undoButton = await page.$( '.editor-history__undo:not( :disabled )' );
+		expect( undoButton ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/4956#discussion_r197473908

This pull request seeks to optimize `RichText` by removing the creation of undo levels at split and merge steps. These have the adverse effect of causing the field's `onChange` callback to be called needlessly.

These changes introduce new, very basic end-to-end tests to verify against regression in undo behaviors on splitting.

**Testing instructions:**

Verify there are no regressions in splitting or merging blocks (e.g. paragraph), and that undo-ing still has the desired effect.

Ensure end-to-end tests pass:

```
npm run test-e2e
```