### PR TITLE
Do not allow negative values in image dimensions

### DIFF
--- a/components/text-control/index.js
+++ b/components/text-control/index.js
@@ -5,7 +5,7 @@ import BaseControl from '../base-control';
 import withInstanceId from '../higher-order/with-instance-id';
 import './style.scss';
 
-function TextControl( { label, value, help, className, instanceId, onChange, type = 'text', ...props } ) {
+function TextControl( { label, value, help, className, instanceId, min, onChange, type = 'text', ...props } ) {
 	const id = `inspector-text-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
@@ -15,6 +15,7 @@ function TextControl( { label, value, help, className, instanceId, onChange, typ
 				type={ type }
 				id={ id }
 				value={ value }
+				min={ min }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props }

--- a/components/text-control/index.js
+++ b/components/text-control/index.js
@@ -5,7 +5,7 @@ import BaseControl from '../base-control';
 import withInstanceId from '../higher-order/with-instance-id';
 import './style.scss';
 
-function TextControl( { label, value, help, className, instanceId, min, onChange, type = 'text', ...props } ) {
+function TextControl( { label, value, help, className, instanceId, onChange, type = 'text', ...props } ) {
 	const id = `inspector-text-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
@@ -15,7 +15,6 @@ function TextControl( { label, value, help, className, instanceId, min, onChange
 				type={ type }
 				id={ id }
 				value={ value }
-				min={ min }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props }

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -267,6 +267,7 @@ class ImageEdit extends Component {
 								label={ __( 'Width' ) }
 								value={ width !== undefined ? width : '' }
 								placeholder={ imageWidth }
+								min={ 1 }
 								onChange={ this.updateWidth }
 							/>
 							<TextControl
@@ -275,6 +276,7 @@ class ImageEdit extends Component {
 								label={ __( 'Height' ) }
 								value={ height !== undefined ? height : '' }
 								placeholder={ imageHeight }
+								min={ 1 }
 								onChange={ this.updateHeight }
 							/>
 						</div>


### PR DESCRIPTION
## Description
This PR addresses #7637 which reports the allowance of negative values in width and height input fields belonging to the block inspector settings of the image block.

## How has this been tested?
This has been tested by making sure a minimum value of `1` is enforced in the mentioned input fields so that no negative values are allowed.

This was tested in WP 4.9.6, Gutenberg 3.1.1, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-7637-min](https://user-images.githubusercontent.com/20284937/42137095-3ffb3d06-7d88-11e8-8ccd-6af805edfe00.gif)

## Types of changes
This PR introduces a new attribute named `min` in the `TextControl` element, which is used in the image block's width and height `TextControl` fields. A minimum value of `1` set in the fields so that negative values are not allowed. This uses HTML `input` field's `min` attribute, more details on that [here](https://www.w3schools.com/tags/att_input_min.asp).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
