### PR TITLE
Show images inside recently created gallery by dropping on insertion point

### DIFF
--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -130,7 +130,9 @@ export const settings = {
 					return files.length !== 1 && every( files, ( file ) => file.type.indexOf( 'image/' ) === 0 );
 				},
 				transform( files, onChange ) {
-					const block = createBlock( 'core/gallery' );
+					const block = createBlock( 'core/gallery', {
+						images: files.map( ( file ) => ( { url: window.URL.createObjectURL( file ) } ) ),
+					} );
 					editorMediaUpload( {
 						filesList: files,
 						onFileChange: ( images ) => onChange( block.uid, { images } ),

--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -9,6 +9,7 @@ import { filter, every } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { RichText, editorMediaUpload } from '@wordpress/editor';
+import { createBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -132,7 +133,7 @@ export const settings = {
 				},
 				transform( files, onChange ) {
 					const block = createBlock( 'core/gallery', {
-						images: files.map( ( file ) => ( { url: window.URL.createObjectURL( file ) } ) ),
+						images: files.map( ( file ) => ( { url: createBlobURL( file ) } ) ),
 					} );
 					editorMediaUpload( {
 						filesList: files,

--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -125,6 +125,7 @@ export const settings = {
 				},
 			},
 			{
+				// When created by drag and dropping multiple files on an insertion point
 				type: 'files',
 				isMatch( files ) {
 					return files.length !== 1 && every( files, ( file ) => file.type.indexOf( 'image/' ) === 0 );


### PR DESCRIPTION
Fixes issue #7368 

## Description
This change makes fixes the gallery not showing anything when being created by drag and dropping multiple image files into an insertion point. 

## How has this been tested?
Manually and ran the existing tests

## Screenshots
Before fix:
![before1](https://user-images.githubusercontent.com/3190666/42138823-2abcc8a4-7d49-11e8-9508-4ceeb6e7a2e3.gif)


After fix:
![after1](https://user-images.githubusercontent.com/3190666/42138825-3415860c-7d49-11e8-9afd-7fe498a69ac9.gif)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards. 
- [x] My code has proper inline documentation. 