### PR TITLE
Fix typo in video block description - "an video" -> "a video"

### DIFF
--- a/core-blocks/video/index.js
+++ b/core-blocks/video/index.js
@@ -19,7 +19,7 @@ export const name = 'core/video';
 export const settings = {
 	title: __( 'Video' ),
 
-	description: __( 'Embed an video file and a simple video player.' ),
+	description: __( 'Embed a video file and a simple video player.' ),
 
 	icon: 'format-video',
 


### PR DESCRIPTION
## Description
Single character change to fix a typo in the video block description. Copy was previously:
"Embed an video file and a simple video player."

this changes it to:
"Embed a video file and a simple video player."

## Screenshots
![screen shot 2018-07-02 at 3 48 34 pm](https://user-images.githubusercontent.com/677833/42151394-73827c84-7e0f-11e8-8f8d-f3152b44c0d0.png)

## Types of changes
Copy fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
