### PR TITLE
chore(release): publish

### DIFF
--- a/packages/api-request/package.json
+++ b/packages/api-request/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/api-request",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Utility to call WordPress REST APIs",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/babel-plugin-import-jsx-pragma",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Babel transform plugin for automatically injecting an import to be used as the pragma for the React JSX Transform plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/blob",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Blob utils for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-data",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Access to and manipulation of core WordPress entities",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -20,8 +20,8 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@wordpress/api-request": "^1.0.0-alpha.1",
-		"@wordpress/data": "^1.0.0-alpha.1",
+		"@wordpress/api-request": "^1.0.0-alpha.2",
+		"@wordpress/data": "^1.0.0-alpha.2",
 		"lodash": "4.17.5",
 		"rememo": "3.0.0"
 	},

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/data",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Data module for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -20,8 +20,8 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@wordpress/deprecated": "^1.0.0-alpha.1",
-		"@wordpress/element": "^1.0.0-alpha.1",
+		"@wordpress/deprecated": "^1.0.0-alpha.2",
+		"@wordpress/element": "^1.0.0-alpha.2",
 		"@wordpress/is-shallow-equal": "1.0.2",
 		"equivalent-key-map": "0.2.0",
 		"lodash": "4.17.5",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/date",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Date module for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/deprecated",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Deprecation utility for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dom",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "DOM utils module for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/element",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Element React module for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@wordpress/deprecated": "^1.0.0-alpha.1",
+		"@wordpress/deprecated": "^1.0.0-alpha.2",
 		"@wordpress/is-shallow-equal": "1.0.2",
 		"lodash": "4.17.5",
 		"react": "16.4.1",

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/keycodes",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "KeyCodes utilities for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/library-export-default-webpack-plugin",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Webpack plugin for exporting default property for selected libraries",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/plugins",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Plugins module for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@wordpress/element": "^1.0.0-alpha.1",
+		"@wordpress/element": "^1.0.0-alpha.2",
 		"@wordpress/hooks": "1.1.6",
 		"lodash": "4.17.5"
 	},

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/postcss-themes",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "PostCSS plugin to generate theme colors",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/shortcode",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Shortcode module for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
 - @wordpress/api-request@1.0.0-alpha.2
 - @wordpress/babel-plugin-import-jsx-pragma@1.0.0-alpha.2
 - @wordpress/blob@1.0.0-alpha.2
 - @wordpress/core-data@1.0.0-alpha.2
 - @wordpress/data@1.0.0-alpha.2
 - @wordpress/date@1.0.0-alpha.2
 - @wordpress/deprecated@1.0.0-alpha.2
 - @wordpress/dom@1.0.0-alpha.2
 - @wordpress/element@1.0.0-alpha.2
 - @wordpress/keycodes@1.0.0-alpha.2
 - @wordpress/library-export-default-webpack-plugin@1.0.0-alpha.2
 - @wordpress/plugins@1.0.0-alpha.2
 - @wordpress/postcss-themes@1.0.0-alpha.2
 - @wordpress/shortcode@1.0.0-alpha.2