### PR TITLE
Make the inserter results panel focusable and improve accessibility.

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -207,7 +207,13 @@ export class InserterMenu extends Component {
 					onChange={ this.onChangeSearchInput }
 				/>
 
-				<div className="editor-inserter__results" ref={ this.inserterResults }>
+				<div
+					className="editor-inserter__results"
+					ref={ this.inserterResults }
+					tabIndex="0"
+					role="region"
+					aria-label={ __( 'Available block types' ) }
+				>
 					<InserterResultsPortal.Slot fillProps={ { filterValue } } />
 
 					<ChildBlocks

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -82,6 +82,10 @@ $block-inserter-search-height: 38px;
 	position: relative;
 	z-index: 1; // Necessary for the stacked card below parent blocks to show up.
 
+	&:focus {
+		outline: 1px dotted $dark-gray-500;
+	}
+
 	@include break-medium {
 		height: $block-inserter-content-height + $block-inserter-tabs-height;
 	}


### PR DESCRIPTION
This PR seeks to improve the interaction and accessibility of the main inserter results panel. Scrollable div elements are natively focusable in Firefox, but not in other browsers. For keyboard users and assistive technology users, this adds inconsistency across browsers.

The Firefox behavior is for accessibility reasons: by making the div focusable, it allows to scroll using the arrow keys. Using a simple technique, it's possible to make it always focusable across all browsers. For more details see this post by Mr. Steve Faulkner: https://developer.paciellogroup.com/blog/2016/02/short-note-on-improving-usability-of-scrollable-regions/

For better accessiblity, the div now uses also an ARIA role and is labelled with an aria-label "Available block types".

Worth noting this is not completely new, as in Gutenberg 2.4 the inserter was a bit different because it used a tab interface, but the scrollable panel was focusable and properly labeled.

As per the focus style, I've opted to use the same style already used for the inserter expandable panel: a dotted outline:

The focused panel in Gutenberg 2.4:

<img width="473" alt="screen shot 2018-07-02 at 14 24 36" src="https://user-images.githubusercontent.com/1682452/42165910-bb40e2d2-7e09-11e8-883b-4932f4360f9e.png">

In this PR:

<img width="665" alt="screen shot 2018-07-02 at 14 55 04" src="https://user-images.githubusercontent.com/1682452/42165917-c1506b02-7e09-11e8-9172-588f76a3adcc.png">

In this PR, announced by a screen reader:

<img width="682" alt="screen shot 2018-07-02 at 14 55 27" src="https://user-images.githubusercontent.com/1682452/42165930-c6bae482-7e09-11e8-9885-b0575f0eab6b.png">



## How has this been tested?
npm test


fixes #7576
