### PR TITLE
update documentation for generating blocks (change url and repo for ahmads gutenberg repo)

### DIFF
--- a/docs/blocks/generate-blocks-with-wp-cli.md
+++ b/docs/blocks/generate-blocks-with-wp-cli.md
@@ -3,7 +3,7 @@
 It turns out that writing the simplest possible block which contains only static content might not be the easiest task. It requires to follow closely the steps described in the documentation. It stems from the fact that you need to create at least 2 files and integrate your code with the existing APIs. One way to mitigate this inconvenience is to copy the source code of the existing block from one of the repositories that share working examples:
 - [WordPress/gutenberg-examples](https://github.com/WordPress/gutenberg-examples) - the official examples for extending Gutenberg with plugins which create blocks
 - [zgordon/gutenberg-course](https://github.com/zgordon/gutenberg-course) - a repository for Zac Gordon's Gutenberg Development Course
-- [ahmadawais/Gutenberg-Boilerplate](https://github.com/ahmadawais/Gutenberg-Boilerplate) - an inline documented starter WordPress plugin for the new Gutenberg editor
+- [ahmadawais/create-guten-block](https://github.com/ahmadawais/create-guten-block) - A zero-configuration developer toolkit for building WordPress Gutenberg block plugins
 
 It might be also a good idea to browse the folder with [all core blocks](https://github.com/WordPress/gutenberg/tree/master/core-blocks) to see how they are implemented.
 


### PR DESCRIPTION
## Description

https://wordpress.org/gutenberg/handbook/blocks/generate-blocks-with-wp-cli/ links 
[@ahmadawais ' Gutenberg-Boilerplate ](https://github.com/ahmadawais/Gutenberg-Boilerplate) as a recommended resource for building blocks. It is no longer maintained. Author now recommends his other repository https://github.com/ahmadawais/create-guten-block

Documentation is updated to reflect this. 

## Has it been tested? 
No, it's a markdown file?
