### PR TITLE
Block API: Deprecate `id` prop in favor of `clientId`

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -4,6 +4,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 
  - `focusOnMount` prop in the `Popover` component has been changed from `Boolean`-only to an enum-style property that accepts `"firstElement"`, `"container"`, or `false`. Please convert any `<Popover focusOnMount />` usage to `<Popover focusOnMount="firstElement" />`.
  - `wp.utils.keycodes` utilities are removed. Please use `wp.keycodes` instead.
+ - Block `id` prop in `edit` function removed. Please use block `clientId` prop instead.
 
 ## 3.3.0
 

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -4,6 +4,7 @@
 import { registerCoreBlocks } from '@wordpress/core-blocks';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -52,6 +53,14 @@ export function reinitializeEditor( postType, postId, target, settings, override
 export function initializeEditor( id, postType, postId, settings, overridePost ) {
 	const target = document.getElementById( id );
 	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, overridePost );
+
+	// Global deprecations which cannot otherwise be injected into known usage.
+	deprecated( 'block `id` prop in `edit` function', {
+		version: '3.4',
+		alternative: 'block `clientId` prop',
+		plugin: 'Gutenberg',
+		hint: 'This is a global warning, shown regardless of whether blocks exist using the deprecated prop.',
+	} );
 
 	registerCoreBlocks();
 

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -534,6 +534,7 @@ export class BlockListBlock extends Component {
 								insertBlocksAfter={ isLocked ? undefined : this.insertBlocksAfter }
 								onReplace={ isLocked ? undefined : onReplace }
 								mergeBlocks={ isLocked ? undefined : this.mergeBlocks }
+								clientId={ uid }
 								id={ uid }
 								isSelectionEnabled={ this.props.isSelectionEnabled }
 								toggleSelection={ this.props.toggleSelection }


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/6741#issuecomment-401847523

This pull request seeks to propose deprecating the block `id` prop, which was never consistent, with a new standardization toward referencing a block's `uid` as its `clientId`. This is also intended as part of a capitalization normalization effort, where equivalent selectors and internal props are planned to be updated as well. The idea with the changes here are to deprecate early for the public-facing API, ahead of the upcoming 3.2 release.

**Testing instructions:**

Verify there are no regressions in the behavior of blocks.

To my knowledge, no core blocks use the `id` prop. You can add this to an existing block to test that the deprecated warning is shown, but the behavior of `id` is otherwise unaffected.

Related: Confirmation that destructuring of objects triggers getters (and therein the `deprecated`), thus not requiring a warning to be shown except in the case of blocks making use of this prop:

https://codepen.io/aduth/pen/VdRmav?editors=1111