### PR TITLE
Add video block attributes: Autoplay, Controls, Loop, Muted

### DIFF
--- a/core-blocks/test/fixtures/core__video.html
+++ b/core-blocks/test/fixtures/core__video.html
@@ -1,3 +1,3 @@
 <!-- wp:core/video -->
-<figure class="wp-block-video"><video src="https://awesome-fake.video/file.mp4" controls=""></video></figure>
+<figure class="wp-block-video"><video controls src="https://awesome-fake.video/file.mp4"></video></figure>
 <!-- /wp:core/video -->

--- a/core-blocks/test/fixtures/core__video.json
+++ b/core-blocks/test/fixtures/core__video.json
@@ -12,6 +12,6 @@
             "src": "https://awesome-fake.video/file.mp4"
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"\"></video></figure>"
+        "originalContent": "<figure class=\"wp-block-video\"><video controls src=\"https://awesome-fake.video/file.mp4\"></video></figure>"
     }
 ]

--- a/core-blocks/test/fixtures/core__video.json
+++ b/core-blocks/test/fixtures/core__video.json
@@ -4,8 +4,12 @@
         "name": "core/video",
         "isValid": true,
         "attributes": {
-            "src": "https://awesome-fake.video/file.mp4",
-            "caption": []
+            "autoplay": false,
+            "caption": [],
+            "controls": true,
+            "loop": false,
+            "muted": false,
+            "src": "https://awesome-fake.video/file.mp4"
         },
         "innerBlocks": [],
         "originalContent": "<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"\"></video></figure>"

--- a/core-blocks/test/fixtures/core__video.parsed.json
+++ b/core-blocks/test/fixtures/core__video.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/video",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"\"></video></figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-video\"><video controls src=\"https://awesome-fake.video/file.mp4\"></video></figure>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -2,12 +2,19 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, Toolbar, withNotices } from '@wordpress/components';
+import {
+	IconButton,
+	PanelBody,
+	Toolbar,
+	ToggleControl,
+	withNotices,
+} from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import {
+	BlockControls,
+	InspectorControls,
 	MediaPlaceholder,
 	RichText,
-	BlockControls,
 } from '@wordpress/editor';
 
 /**
@@ -23,10 +30,18 @@ class VideoEdit extends Component {
 		this.state = {
 			editing: ! this.props.attributes.src,
 		};
+
+		this.toggleAttribute = this.toggleAttribute.bind( this );
+	}
+
+	toggleAttribute( attribute ) {
+		return ( newValue ) => {
+			this.props.setAttributes( { [ attribute ]: newValue } );
+		};
 	}
 
 	render() {
-		const { caption, src } = this.props.attributes;
+		const { autoplay, caption, controls, loop, muted, src } = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
 		const switchToEditing = () => {
@@ -86,8 +101,37 @@ class VideoEdit extends Component {
 						/>
 					</Toolbar>
 				</BlockControls>
+				<InspectorControls>
+					<PanelBody title={ __( 'Video Settings' ) }>
+						<ToggleControl
+							label={ __( 'Autoplay' ) }
+							onChange={ this.toggleAttribute( 'autoplay' ) }
+							checked={ autoplay }
+						/>
+						<ToggleControl
+							label={ __( 'Controls' ) }
+							onChange={ this.toggleAttribute( 'controls' ) }
+							checked={ controls }
+						/>
+						<ToggleControl
+							label={ __( 'Loop' ) }
+							onChange={ this.toggleAttribute( 'loop' ) }
+							checked={ loop }
+						/>
+						<ToggleControl
+							label={ __( 'Muted' ) }
+							onChange={ this.toggleAttribute( 'muted' ) }
+							checked={ muted }
+						/>
+					</PanelBody>
+				</InspectorControls>
 				<figure className={ className }>
-					<video controls src={ src } />
+					<video
+						controls={ controls }
+						src={ src }
+						loop={ loop }
+						muted={ muted }
+					/>
 					{ ( ( caption && caption.length ) || !! isSelected ) && (
 						<RichText
 							tagName="figcaption"

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -102,16 +102,11 @@ class VideoEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody title={ __( 'Playback Controls' ) }>
+					<PanelBody title={ __( 'Video Options' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }
 							onChange={ this.toggleAttribute( 'autoplay' ) }
 							checked={ autoplay }
-						/>
-						<ToggleControl
-							label={ __( 'Controls' ) }
-							onChange={ this.toggleAttribute( 'controls' ) }
-							checked={ controls }
 						/>
 						<ToggleControl
 							label={ __( 'Loop' ) }
@@ -122,6 +117,11 @@ class VideoEdit extends Component {
 							label={ __( 'Muted' ) }
 							onChange={ this.toggleAttribute( 'muted' ) }
 							checked={ muted }
+						/>
+						<ToggleControl
+							label={ __( 'Playback Controls' ) }
+							onChange={ this.toggleAttribute( 'controls' ) }
+							checked={ controls }
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -102,7 +102,7 @@ class VideoEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody title={ __( 'Video Settings' ) }>
+					<PanelBody title={ __( 'Playback Controls' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }
 							onChange={ this.toggleAttribute( 'autoplay' ) }

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -126,12 +126,7 @@ class VideoEdit extends Component {
 					</PanelBody>
 				</InspectorControls>
 				<figure className={ className }>
-					<video
-						controls={ controls }
-						src={ src }
-						loop={ loop }
-						muted={ muted }
-					/>
+					<video controls src={ src } />
 					{ ( ( caption && caption.length ) || !! isSelected ) && (
 						<RichText
 							tagName="figcaption"

--- a/core-blocks/video/index.js
+++ b/core-blocks/video/index.js
@@ -26,19 +26,44 @@ export const settings = {
 	category: 'common',
 
 	attributes: {
+		autoplay: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'video',
+			attribute: 'autoplay',
+		},
+		caption: {
+			type: 'array',
+			source: 'children',
+			selector: 'figcaption',
+		},
+		controls: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'video',
+			attribute: 'controls',
+			default: true,
+		},
 		id: {
 			type: 'number',
+		},
+		loop: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'video',
+			attribute: 'loop',
+		},
+		muted: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'video',
+			attribute: 'muted',
 		},
 		src: {
 			type: 'string',
 			source: 'attribute',
 			selector: 'video',
 			attribute: 'src',
-		},
-		caption: {
-			type: 'array',
-			source: 'children',
-			selector: 'figcaption',
 		},
 	},
 
@@ -49,12 +74,22 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { src, caption } = attributes;
+		const { autoplay, caption, controls, loop, muted, src } = attributes;
 		return (
 
 			<figure>
-				{ src && <video controls src={ src } /> }
-				{ caption && caption.length > 0 && <RichText.Content tagName="figcaption" value={ caption } /> }
+				{ src && (
+					<video
+						autoPlay={ autoplay }
+						controls={ controls }
+						src={ src }
+						loop={ loop }
+						muted={ muted }
+					/>
+				) }
+				{ caption && caption.length > 0 && (
+					<RichText.Content tagName="figcaption" value={ caption } />
+				) }
 			</figure>
 		);
 	},

--- a/core-blocks/video/index.js
+++ b/core-blocks/video/index.js
@@ -76,7 +76,6 @@ export const settings = {
 	save( { attributes } ) {
 		const { autoplay, caption, controls, loop, muted, src } = attributes;
 		return (
-
 			<figure>
 				{ src && (
 					<video
@@ -87,7 +86,7 @@ export const settings = {
 						muted={ muted }
 					/>
 				) }
-				{ caption && caption.length && (
+				{ caption && caption.length > 0 && (
 					<RichText.Content tagName="figcaption" value={ caption } />
 				) }
 			</figure>

--- a/core-blocks/video/index.js
+++ b/core-blocks/video/index.js
@@ -87,7 +87,7 @@ export const settings = {
 						muted={ muted }
 					/>
 				) }
-				{ caption && caption.length > 0 && (
+				{ caption && caption.length && (
 					<RichText.Content tagName="figcaption" value={ caption } />
 				) }
 			</figure>


### PR DESCRIPTION
## Description
This PR adds 4 additional attributes to the video block.
- Autoplay
- Controls
- Loop
- Muted

See: https://developer.mozilla.org/de/docs/Web/HTML/Element/video

## Types of changes
- `Autoplay` and `Loop` are just added in `save` not in `edit`.
- `Autoplay` and `Loop` are already in the Classic Editor, `Controls` and `Muted` are new in WordPress.
- `Controls` is default `true`

Related: #7501

## Screenshots <!-- if applicable -->
![bildschirmfoto 2018-07-03 um 09 26 34](https://user-images.githubusercontent.com/695201/42204942-5e76ac68-7ea3-11e8-86da-4c397dd23c8b.png)

