### PR TITLE
Docs: Change closing </div> to </p>

### DIFF
--- a/docs/block-api/deprecated-blocks.md
+++ b/docs/block-api/deprecated-blocks.md
@@ -230,7 +230,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	// ... block properties go here
 
 	save( props ) {
-		return <p>{ props.attributes.title }</div>;
+		return <p>{ props.attributes.title }</p>;
 	},
 
 	deprecated: [


### PR DESCRIPTION
## Description
Changed the closing `</div>` to `</p>` in the code example to match the opening tag.