### PR TITLE
Leave out .js so Metro can resolve native variant

### DIFF
--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -17,8 +17,8 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"main": "build/index",
-	"module": "build-module/index",
+	"main": "build/index.js",
+	"module": "build-module/index.js",
 	"dependencies": {
 		"@wordpress/deprecated": "^1.0.0-alpha.2",
 		"@wordpress/is-shallow-equal": "1.0.2",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -19,6 +19,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "build/index",
 	"dependencies": {
 		"@wordpress/deprecated": "^1.0.0-alpha.2",
 		"@wordpress/is-shallow-equal": "1.0.2",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -17,8 +17,8 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"main": "build/index.js",
-	"module": "build-module/index.js",
+	"main": "build/index",
+	"module": "build-module/index",
 	"dependencies": {
 		"@wordpress/deprecated": "^1.0.0-alpha.2",
 		"@wordpress/is-shallow-equal": "1.0.2",


### PR DESCRIPTION
## Description
This PR drops the `.js` extension from `@wordpress/element`'s `package.json` entrypoint definitions so when used in the mobile RN app the correct module (`index.native.js`) can be resolved by Metro.

The same treatment should probably be performed in all packages, or at least the ones that have native mobile specializations but, let's do that step by step starting with the `element` package that currently is breaking the RN app (at the time of writing, [commit hash](d73c4431f44430b345ab18c4622d916ad5d78dd4)).

## How has this been tested?
Ran `npm run dev` successfully.

## Types of changes
Bug fix: Modify the `@wordpress/element` package entrypoint definitions (`main`, `module`).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
