### PR TITLE
Fix CSS property serialization

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -28,7 +28,7 @@
 /**
  * External dependencies
  */
-import { flowRight, isEmpty, castArray, omit, kebabCase } from 'lodash';
+import { flowRight, isEmpty, castArray, omit, startsWith, kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -360,6 +360,23 @@ function getNormalAttributeName( attribute ) {
 }
 
 /**
+ * Returns the normal form of the style property name for HTML. Converts
+ * property names to kebab-case (e.g. 'backgroundColor' → 'background-color'),
+ * unless the property name begins with a '-' (e.g. '-webkit-overflow-scroll').
+ *
+ * @param {string} property Property name.
+ *
+ * @return {string} Normalized property name.
+ */
+function getNormalStylePropertyName( property ) {
+	if ( startsWith( property, '-' ) ) {
+		return property;
+	}
+
+	return kebabCase( property );
+}
+
+/**
  * Returns the normal form of the style property value for HTML. Appends a
  * default pixel unit if numeric, not a unitless property, and not zero.
  *
@@ -368,7 +385,7 @@ function getNormalAttributeName( attribute ) {
  *
  * @return {*} Normalized property value.
  */
-function getNormalStyleValue( property, value ) {
+function getNormalStylePropertyValue( property, value ) {
 	if ( typeof value === 'number' && 0 !== value &&
 			! CSS_PROPERTIES_SUPPORTS_UNITLESS.has( property ) ) {
 		return value + 'px';
@@ -609,7 +626,9 @@ export function renderStyle( style ) {
 			result = '';
 		}
 
-		result += kebabCase( property ) + ':' + getNormalStyleValue( property, value );
+		const normalName = getNormalStylePropertyName( property );
+		const normalValue = getNormalStylePropertyValue( property, value );
+		result += normalName + ':' + normalValue;
 	}
 
 	return result;

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -558,6 +558,22 @@ describe( 'renderStyle()', () => {
 		expect( result ).toBe( 'color:red;background-color:green' );
 	} );
 
+	it( 'should not kebab-case custom properties', () => {
+		const result = renderStyle( {
+			'--myBackgroundColor': 'palegoldenrod',
+		} );
+
+		expect( result ).toBe( '--myBackgroundColor:palegoldenrod' );
+	} );
+
+	it( 'should not kebab-case properties with a vendor prefix', () => {
+		const result = renderStyle( {
+			'-webkit-overflow-scrolling': 'touch',
+		} );
+
+		expect( result ).toBe( '-webkit-overflow-scrolling:touch' );
+	} );
+
 	describe( 'value unit', () => {
 		it( 'should not render zero unit', () => {
 			const result = renderStyle( {


### PR DESCRIPTION
## Description

Fixes #7326.

Prevents `wp.element.renderToString()` from converting CSS properties that begin with a `-` to kebab-case. This fixes a bug where Gutenberg breaks styles defined in a block's `save()` function such as `--myBackgroundColor: palegoldenrod` when saving a post.

## How has this been tested?
Unit tests are included. I also confirmed that https://github.com/WordPress/gutenberg/issues/7326 can no longer be reproduced. 