### PR TITLE
De-emphasize inline images

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -42,6 +42,7 @@ export {
 	hasChildBlocks,
 } from './registration';
 export {
+	isUnmodifiedBlock,
 	isUnmodifiedDefaultBlock,
 	normalizeIconObject,
 	isValidIcon,

--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -25,22 +25,15 @@ import { createBlock } from './factory';
 const ICON_COLORS = [ '#191e23', '#f8f9f9' ];
 
 /**
- * Determines whether the block is a default block
- * and its attributes are equal to the default attributes
+ * Determines whether the block's attributes are equal to the default attributes
  * which means the block is unmodified.
  *
- * @param  {WPBlock} block Block Object
+ * @param {WPBlock} block Block Object.
  *
- * @return {boolean}       Whether the block is an unmodified default block
+ * @return {boolean} Whether the block is an unmodified block.
  */
-export function isUnmodifiedDefaultBlock( block ) {
-	const defaultBlockName = getDefaultBlockName();
-	if ( block.name !== defaultBlockName ) {
-		return false;
-	}
-
-	const newDefaultBlock = createBlock( defaultBlockName );
-
+export function isUnmodifiedBlock( block ) {
+	const newDefaultBlock = createBlock( block.name );
 	const attributeKeys = applyFilters( 'blocks.isUnmodifiedDefaultBlock.attributes', [
 		...keys( newDefaultBlock.attributes ),
 		...keys( block.attributes ),
@@ -49,6 +42,23 @@ export function isUnmodifiedDefaultBlock( block ) {
 	return every( attributeKeys, ( key ) =>
 		isEqual( newDefaultBlock.attributes[ key ], block.attributes[ key ] )
 	);
+}
+
+/**
+ * Determines whether the block is a default block and its attributes are equal
+ * to the default attributes which means the block is unmodified.
+ *
+ * @param {WPBlock} block Block Object.
+ *
+ * @return {boolean} Whether the block is an unmodified default block.
+ */
+export function isUnmodifiedDefaultBlock( block ) {
+	const defaultBlockName = getDefaultBlockName();
+	if ( block.name !== defaultBlockName ) {
+		return false;
+	}
+
+	return isUnmodifiedBlock( block );
 }
 
 /**

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -38,6 +38,7 @@ class Inserter extends Component {
 			children,
 			onInsertBlock,
 			rootUID,
+			selectedBlock,
 		} = this.props;
 
 		if ( items.length === 0 ) {
@@ -71,7 +72,14 @@ class Inserter extends Component {
 						onClose();
 					};
 
-					return <InserterMenu items={ items } onSelect={ onSelect } rootUID={ rootUID } />;
+					return (
+						<InserterMenu
+							items={ items }
+							onSelect={ onSelect }
+							rootUID={ rootUID }
+							selectedBlock={ selectedBlock }
+						/>
+					);
 				} }
 			/>
 		);

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -27,7 +27,7 @@ import {
 	PanelBody,
 	withSafeTimeout,
 } from '@wordpress/components';
-import { getCategories, isSharedBlock } from '@wordpress/blocks';
+import { getCategories, isSharedBlock, isUnmodifiedBlock } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
@@ -183,10 +183,11 @@ export class InserterMenu extends Component {
 	}
 
 	render() {
-		const { instanceId, onSelect, rootUID } = this.props;
+		const { instanceId, onSelect, rootUID, selectedBlock } = this.props;
 		const { childItems, filterValue, hoveredItem, suggestedItems, sharedItems, itemsPerCategory, openPanels } = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
 		const isSearching = !! filterValue;
+		const isSelectedBlockModified = selectedBlock && ! isUnmodifiedBlock( selectedBlock );
 
 		// Disable reason: The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of
@@ -214,7 +215,7 @@ export class InserterMenu extends Component {
 					role="region"
 					aria-label={ __( 'Available block types' ) }
 				>
-					<InserterResultsPortal.Slot fillProps={ { filterValue } } />
+					{ isSelectedBlockModified && <InserterResultsPortal.Slot fillProps={ { filterValue } } /> }
 
 					<ChildBlocks
 						rootUID={ rootUID }
@@ -261,6 +262,7 @@ export class InserterMenu extends Component {
 							<BlockTypesList items={ sharedItems } onSelect={ onSelect } onHover={ this.onHover } />
 						</PanelBody>
 					) }
+					{ ! isSelectedBlockModified && <InserterResultsPortal.Slot fillProps={ { filterValue } } /> }
 					{ isEmpty( suggestedItems ) && isEmpty( sharedItems ) && isEmpty( itemsPerCategory ) && (
 						<p className="editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
 					) }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes #7661. Moves the inline token section down if the (any) block has not been modified. Unsure if it should move down for any unmodified block or only an empty default block.

## How has this been tested?
Open the inserter with an empty paragraph selected. Inline image should not be the first item.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->