### PR TITLE
[Image Block] Set default values of the width and height input fields according to the actual image dimensions

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -474,8 +474,7 @@ class ImageEdit extends Component {
 									type="number"
 									className="block-library-image__dimensions__width"
 									label={ __( 'Width' ) }
-									value={ width !== undefined ? width : '' }
-									placeholder={ imageWidth }
+									value={ width !== undefined ? width : imageWidth }
 									min={ 1 }
 									onChange={ this.updateWidth }
 								/>
@@ -483,8 +482,7 @@ class ImageEdit extends Component {
 									type="number"
 									className="block-library-image__dimensions__height"
 									label={ __( 'Height' ) }
-									value={ height !== undefined ? height : '' }
-									placeholder={ imageHeight }
+									value={ height !== undefined ? height : imageHeight }
 									min={ 1 }
 									onChange={ this.updateHeight }
 								/>


### PR DESCRIPTION
## Description
Fixes #7638.

This PR addresses #7638 which reports the unexpected behavior of changing the input values, as the placeholder shows the actual image dimensions but pressing the up/down arrows of the number input fields start their values from `0`.

This PR strips out the placeholder from the mentioned fields and sets the actual dimensions as the default field values. The default values don't take effect until they are changed and when they are changed, values start changing from the displayed width or height values, which is described as the expected behavior in #7638.

## How has this been tested?
This has been tested by going through the following steps:

1. Add an image block into Gutenberg editor.
2. Try changing the image's width/height using the number input field's up/down arrows provided by the browser.

The values should start changing from the actual image dimensions, as opposed to the previous behavior which started the change from `0`. It has also been made sure that the default values do not take effect on the image until the field values are actually changed.

This was tested in WP 4.9.6, Gutenberg 3.1.1, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Types of changes
This PR removes the `placeholder` attribute from the width and height number `input` fields. Then it sets the `imageWidth` and `imageHeight` variables in place of the blank `value` attribute when the dimensions are `undefined`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
