### PR TITLE
Improving color palette backcompat

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1147,16 +1147,17 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
 	$align_wide              = get_theme_support( 'align-wide' );
-	$color_palette           = current( (array) get_theme_support( 'editor-color-palette' ) );
+	$color_palette           = (array) get_theme_support( 'editor-color-palette' );
 
 	// Backcompat for Color Palette set as multiple parameters.
-	if ( is_string( $color_palette ) || isset( $color_palette['color'] ) ) {
-		$color_palette = get_theme_support( 'editor-color-palette' );
+	if ( isset( $color_palette[0] ) && ( is_string( $color_palette[0] ) || isset( $color_palette[0]['color'] ) ) ) {
 		_doing_it_wrong(
 			'add_theme_support()',
 			__( 'Setting colors using multiple parameters is deprecated. Please pass a single parameter with an array of colors. See https://wordpress.org/gutenberg/handbook/extensibility/theme-support/ for details.', 'gutenberg' ),
 			'3.4.0'
 		);
+	} else {
+		$color_palette = current( $color_palette );
 	}
 
 	// Backcompat for Color Palette set through `gutenberg` array.


### PR DESCRIPTION
Improving color palette theme support backwards compatibility as of @felixarntz [comment](https://github.com/WordPress/gutenberg/pull/7619#discussion_r199831505).