### PR TITLE
Build: Packages: Ignore non-JS file events

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -21,6 +21,12 @@ const exists = ( filename ) => {
 	} catch ( e ) {}
 	return false;
 };
+
+// Exclude deceitful source-like files, such as editor swap files.
+const isSourceFile = ( filename ) => {
+	return /.\.js$/.test( filename );
+};
+
 const rebuild = ( filename ) => filesToBuild.set( filename, true );
 
 getPackages().forEach( ( p ) => {
@@ -29,6 +35,10 @@ getPackages().forEach( ( p ) => {
 		fs.accessSync( srcDir, fs.F_OK );
 		fs.watch( path.resolve( p, 'src' ), { recursive: true }, ( event, filename ) => {
 			const filePath = path.resolve( srcDir, filename );
+
+			if ( ! isSourceFile( filename ) ) {
+				return;
+			}
 
 			if ( ( event === 'change' || event === 'rename' ) && exists( filePath ) ) {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
## Description

Editors (e.g. Vim, gedit) typically rely on temporary swap files to manage a user's editing session. When editing a file, e.g.

```
packages/core-data/src/actions.js
```

a temporary file may be created:

```
packages/core-data/src/.actions.js.swp // or
packages/core-data/src/actions.js~
```

This PR checks for filename format to prevent most scenarios; essentially, files should end with `.js` ~and not start with `.` (an indicator, in Unix tradition, of hidden files).~

Without this guard, upon creation of a swap file, the watcher will attempt to build from the swap file, resulting in syntax errors.

## How has this been tested?

- Run `npm run dev` and wait for the initial build
- Use Vim with default `swapfile` settings (and related `swapsync`, etc.)
- Open a file in `packages/`, e.g. `packages/core-data/src/actions.js`
- Start editing it, without saving
- Confirm that a swapfile is being used in the file's directory: `:swapname`
- Confirm that **no** rebuild is triggered as you edit without saving
- Save the open file
- Confirm that a rebuild is triggered
- Close the saved file
- Confirm that **no** rebuild is triggered

## Screenshots

<img width="700" alt="screen shot 2018-06-28 at 15 38 05" src="https://user-images.githubusercontent.com/150562/42241627-244e8ece-7f03-11e8-8f4a-a25f9381c813.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
