### PR TITLE
Build: Invert JSX pragma application condition

### DIFF
--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -19,7 +19,7 @@ const plugins = map( babelDefaultConfig.plugins, ( plugin ) => {
 	return plugin;
 } );
 
-if ( process.env.TRANSFORM_JSX_PRAGMA ) {
+if ( ! process.env.SKIP_JSX_PRAGMA_TRANSFORM ) {
 	plugins.push( [ require( '../../packages/babel-plugin-import-jsx-pragma' ).default, {
 		scopeVariable: 'createElement',
 		source: '@wordpress/element',

--- a/package.json
+++ b/package.json
@@ -160,8 +160,8 @@
 	"scripts": {
 		"prebuild": "npm run check-engines",
 		"clean:packages": "rimraf ./packages/*/build ./packages/*/build-module",
-		"prebuild:packages": "npm run clean:packages && cross-env INCLUDE_PACKAGES=babel-plugin-import-jsx-pragma node ./bin/packages/build.js",
-		"build:packages": "cross-env TRANSFORM_JSX_PRAGMA=1 EXCLUDE_PACKAGES=babel-plugin-import-jsx-pragma node ./bin/packages/build.js",
+		"prebuild:packages": "npm run clean:packages && cross-env INCLUDE_PACKAGES=babel-plugin-import-jsx-pragma SKIP_JSX_PRAGMA_TRANSFORM=1 node ./bin/packages/build.js",
+		"build:packages": "cross-env EXCLUDE_PACKAGES=babel-plugin-import-jsx-pragma node ./bin/packages/build.js",
 		"build": "npm run build:packages && cross-env NODE_ENV=production webpack",
 		"check-engines": "check-node-version --package",
 		"ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",


### PR DESCRIPTION
Related: #7493

This pull request seeks to resolve an issue where making changes to a packages file which includes JSX will cause the JSX pragma to not be injected correctly, resulting in errors when reloading the editor after the rebuild completes. This is because the watch task for plugin build runs a rebuild in a subprocess which does not inherit the `TRANSFORM_JSX_PRAGMA` environment variable used to include the plugin necessary for pragma injection.

The changes in this pull request invert the condition to a "skip" environment variable, used exclusively in the prebuild step for transpiling the `babel-plugin-import-jsx-pragma` package.

**Testing instructions:**

1. Run `npm run dev`
2. Make a change to `packages/data/src/index.js` and save the file
3. Reload the editor once the rebuild has completed
4. Observe there are no errors