### PR TITLE
Fix CSS vendor-prefixed property serialization

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -360,17 +360,23 @@ function getNormalAttributeName( attribute ) {
 }
 
 /**
- * Returns the normal form of the style property name for HTML. Converts
- * property names to kebab-case (e.g. 'backgroundColor' → 'background-color'),
- * unless the property name begins with a '-' (e.g. '-webkit-overflow-scroll').
+ * Returns the normal form of the style property name for HTML.
+ *
+ * - Converts property names to kebab-case, e.g. 'backgroundColor' → 'background-color'
+ * - Leaves custom attributes alone, e.g. '--myBackgroundColor' → '--myBackgroundColor'
+ * - Converts vendor-prefixed property names to -kebab-case, e.g. 'MozTransform' → '-moz-transform'
  *
  * @param {string} property Property name.
  *
  * @return {string} Normalized property name.
  */
 function getNormalStylePropertyName( property ) {
-	if ( startsWith( property, '-' ) ) {
+	if ( startsWith( property, '--' ) ) {
 		return property;
+	}
+
+	if ( hasPrefix( property, [ 'ms', 'O', 'Moz', 'Webkit' ] ) ) {
+		return '-' + kebabCase( property );
 	}
 
 	return kebabCase( property );

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -566,12 +566,15 @@ describe( 'renderStyle()', () => {
 		expect( result ).toBe( '--myBackgroundColor:palegoldenrod' );
 	} );
 
-	it( 'should not kebab-case properties with a vendor prefix', () => {
+	it( 'should -kebab-case style properties with a vendor prefix', () => {
 		const result = renderStyle( {
-			'-webkit-overflow-scrolling': 'touch',
+			msTransform: 'none',
+			OTransform: 'none',
+			MozTransform: 'none',
+			WebkitTransform: 'none',
 		} );
 
-		expect( result ).toBe( '-webkit-overflow-scrolling:touch' );
+		expect( result ).toBe( '-ms-transform:none;-o-transform:none;-moz-transform:none;-webkit-transform:none' );
 	} );
 
 	describe( 'value unit', () => {


### PR DESCRIPTION
## Description

I recently merged https://github.com/WordPress/gutenberg/pull/7676 which attempted to improve how we handle serialising CSS properties. This PR made `wp.element.renderToString()` correctly serialise custom attribute properties, but was naive in its handling of elements that contain vendor-prefixed properties.

My confusion was that I didn't realise that, in React, you're supposed to write `<div style={ { WebkitTransform: 'none' } }>` and not `<div style={ { '-webkit-transform': 'none' } }>`.

The complete rules, inspired by [these relevant React unit tests](https://github.com/facebook/react/blob/master/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js) are:

- Convert regular property names to kebab-case, e.g. `backgroundColor` → `background-color`
- Leave custom attributes alone, e.g. `--myBackgroundColor` → `--myBackgroundColor`
- Convert vendor-prefixed property names to -kebab-case, e.g. `MozTransform` → `-moz-transform`

## How has this been tested?

Unit tests have been updated.

You could also create a block that has returns a `<div style={ { WebkitTransform: 'none' } }>` in its `save()` function. Gutenberg should correctly save `<div style="-webkit-transform:none">` to the post.