### PR TITLE
Theme support: Allow editor color palette to be empty

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1210,7 +1210,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		);
 	}
 
-	if ( ! empty( $color_palette ) ) {
+	if ( false !== $color_palette ) {
 		$editor_settings['colors'] = editor_color_palette_slugs( $color_palette );
 	}
 


### PR DESCRIPTION
## Description
With the merge of https://github.com/WordPress/gutenberg/pull/7619 setting an empty array should set an empty color palette. I did some additional tests and I checked that it was not the case. This PR's fixes that.

## How has this been tested?
I checked that adding `add_theme_support( 'editor-color-palette' )` sets an empty color palette (same as in master).
I checked that adding `add_theme_support( 'editor-color-palette', array() );` sets an empty color palette (in master it sets the default color palette)
I checked that for the previous cases If we add `add_theme_support( 'disable-custom-colors' );` no color UI is available.
I checked that if 'editor-color-palette' is not specified, we use the default color palette.
