### PR TITLE
fix: Check for forwardedRef in withGlobalEvents

### DIFF
--- a/components/higher-order/with-global-events/index.js
+++ b/components/higher-order/with-global-events/index.js
@@ -55,7 +55,12 @@ function withGlobalEvents( eventTypesToHandlers ) {
 
 			handleRef( el ) {
 				this.wrappedRef = el;
-				this.props.forwardedRef( el );
+				// Any component using `withGlobalEvents` that is not setting a `ref`
+				// will cause `this.props.forwardedRef` to be `null`, so we need this
+				// check.
+				if ( this.props.forwardedRef ) {
+					this.props.forwardedRef( el );
+				}
 			}
 
 			render() {


### PR DESCRIPTION
Fix #7707

## Description
If a component isn't setting a `ref` then `forwardedRef` will be `null` and the block will crash. This checks for the ref first.

## How has this been tested?
Ran it locally and things seem fine, and it fixes the problem in the issue.