### PR TITLE
Update HOCs to use createHigherOrderComponent

### DIFF
--- a/components/higher-order/navigate-regions/index.js
+++ b/components/higher-order/navigate-regions/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress Dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createHigherOrderComponent } from '@wordpress/element';
 
 /**
  * Internal Dependencies
@@ -14,67 +14,67 @@ import { Component } from '@wordpress/element';
 import './style.scss';
 import KeyboardShortcuts from '../../keyboard-shortcuts';
 
-function navigateRegions( WrappedComponent ) {
-	return class extends Component {
-		constructor() {
-			super( ...arguments );
-			this.bindContainer = this.bindContainer.bind( this );
-			this.focusNextRegion = this.focusRegion.bind( this, 1 );
-			this.focusPreviousRegion = this.focusRegion.bind( this, -1 );
-			this.onClick = this.onClick.bind( this );
-			this.state = {
-				isFocusingRegions: false,
-			};
-		}
-
-		bindContainer( ref ) {
-			this.container = ref;
-		}
-
-		focusRegion( offset ) {
-			const regions = [ ...this.container.querySelectorAll( '[role="region"]' ) ];
-			if ( ! regions.length ) {
-				return;
-			}
-			let nextRegion = regions[ 0 ];
-			const selectedIndex = regions.indexOf( document.activeElement );
-			if ( selectedIndex !== -1 ) {
-				let nextIndex = selectedIndex + offset;
-				nextIndex = nextIndex === -1 ? regions.length - 1 : nextIndex;
-				nextIndex = nextIndex === regions.length ? 0 : nextIndex;
-				nextRegion = regions[ nextIndex ];
+export default createHigherOrderComponent(
+	( WrappedComponent ) => {
+		return class extends Component {
+			constructor() {
+				super( ...arguments );
+				this.bindContainer = this.bindContainer.bind( this );
+				this.focusNextRegion = this.focusRegion.bind( this, 1 );
+				this.focusPreviousRegion = this.focusRegion.bind( this, -1 );
+				this.onClick = this.onClick.bind( this );
+				this.state = {
+					isFocusingRegions: false,
+				};
 			}
 
-			nextRegion.focus();
-			this.setState( { isFocusingRegions: true } );
-		}
+			bindContainer( ref ) {
+				this.container = ref;
+			}
 
-		onClick() {
-			this.setState( { isFocusingRegions: false } );
-		}
+			focusRegion( offset ) {
+				const regions = [ ...this.container.querySelectorAll( '[role="region"]' ) ];
+				if ( ! regions.length ) {
+					return;
+				}
+				let nextRegion = regions[ 0 ];
+				const selectedIndex = regions.indexOf( document.activeElement );
+				if ( selectedIndex !== -1 ) {
+					let nextIndex = selectedIndex + offset;
+					nextIndex = nextIndex === -1 ? regions.length - 1 : nextIndex;
+					nextIndex = nextIndex === regions.length ? 0 : nextIndex;
+					nextRegion = regions[ nextIndex ];
+				}
 
-		render() {
-			const className = classnames( 'components-navigate-regions', {
-				'is-focusing-regions': this.state.isFocusingRegions,
-			} );
+				nextRegion.focus();
+				this.setState( { isFocusingRegions: true } );
+			}
 
-			// Disable reason: Clicking the editor should dismiss the regions focus style
-			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-			return (
-				<div ref={ this.bindContainer } className={ className } onClick={ this.onClick }>
-					<KeyboardShortcuts
-						bindGlobal
-						shortcuts={ {
-							'ctrl+`': this.focusNextRegion,
-							'ctrl+shift+`': this.focusPreviousRegion,
-						} }
-					/>
-					<WrappedComponent { ...this.props } />
-				</div>
-			);
-			/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-		}
-	};
-}
+			onClick() {
+				this.setState( { isFocusingRegions: false } );
+			}
 
-export default navigateRegions;
+			render() {
+				const className = classnames( 'components-navigate-regions', {
+					'is-focusing-regions': this.state.isFocusingRegions,
+				} );
+
+				// Disable reason: Clicking the editor should dismiss the regions focus style
+				/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+				return (
+					<div ref={ this.bindContainer } className={ className } onClick={ this.onClick }>
+						<KeyboardShortcuts
+							bindGlobal
+							shortcuts={ {
+								'ctrl+`': this.focusNextRegion,
+								'ctrl+shift+`': this.focusPreviousRegion,
+							} }
+						/>
+						<WrappedComponent { ...this.props } />
+					</div>
+				);
+				/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+			}
+		};
+	}, 'navigateRegions'
+);

--- a/components/higher-order/with-context/index.js
+++ b/components/higher-order/with-context/index.js
@@ -6,29 +6,30 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createHigherOrderComponent } from '@wordpress/element';
 
-const withContext = ( contextName ) => ( mapSettingsToProps ) => ( OriginalComponent ) => {
-	class WrappedComponent extends Component {
-		render() {
-			const extraProps = mapSettingsToProps ?
-				mapSettingsToProps( this.context[ contextName ], this.props ) :
-				{ [ contextName ]: this.context[ contextName ] };
+export default ( contextName ) => ( mapSettingsToProps ) => createHigherOrderComponent(
+	( OriginalComponent ) => {
+		class WrappedComponent extends Component {
+			render() {
+				const extraProps = mapSettingsToProps ?
+					mapSettingsToProps( this.context[ contextName ], this.props ) :
+					{ [ contextName ]: this.context[ contextName ] };
 
-			return (
-				<OriginalComponent
-					{ ...this.props }
-					{ ...extraProps }
-				/>
-			);
+				return (
+					<OriginalComponent
+						{ ...this.props }
+						{ ...extraProps }
+					/>
+				);
+			}
 		}
-	}
 
-	WrappedComponent.contextTypes = {
-		[ contextName ]: noop,
-	};
+		WrappedComponent.contextTypes = {
+			[ contextName ]: noop,
+		};
 
-	return WrappedComponent;
-};
-
-export default withContext;
+		return WrappedComponent;
+	},
+	'withContext'
+);

--- a/components/higher-order/with-fallback-styles/index.js
+++ b/components/higher-order/with-fallback-styles/index.js
@@ -54,7 +54,7 @@ export default ( mapNodeToProps ) => createHigherOrderComponent(
 				const wrappedComponent = <WrappedComponent { ...this.props } { ...this.state.fallbackStyles } />;
 				return this.props.node ? wrappedComponent : <div ref={ this.bindRef }> { wrappedComponent } </div>;
 			}
-		}
+		};
 	},
 	'withFallbackStyles'
 );

--- a/components/higher-order/with-fallback-styles/index.js
+++ b/components/higher-order/with-fallback-styles/index.js
@@ -6,52 +6,55 @@ import { every, isEqual } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createHigherOrderComponent } from '@wordpress/element';
 
-export default ( mapNodeToProps ) => ( WrappedComponent ) => {
-	return class extends Component {
-		constructor() {
-			super( ...arguments );
-			this.nodeRef = this.props.node;
-			this.state = {
-				fallbackStyles: undefined,
-				grabStylesCompleted: false,
-			};
+export default ( mapNodeToProps ) => createHigherOrderComponent(
+	( WrappedComponent ) => {
+		return class extends Component {
+			constructor() {
+				super( ...arguments );
+				this.nodeRef = this.props.node;
+				this.state = {
+					fallbackStyles: undefined,
+					grabStylesCompleted: false,
+				};
 
-			this.bindRef = this.bindRef.bind( this );
-		}
-
-		bindRef( node ) {
-			if ( ! node ) {
-				return;
+				this.bindRef = this.bindRef.bind( this );
 			}
-			this.nodeRef = node;
-		}
 
-		componentDidMount() {
-			this.grabFallbackStyles();
-		}
+			bindRef( node ) {
+				if ( ! node ) {
+					return;
+				}
+				this.nodeRef = node;
+			}
 
-		componentDidUpdate() {
-			this.grabFallbackStyles();
-		}
+			componentDidMount() {
+				this.grabFallbackStyles();
+			}
 
-		grabFallbackStyles() {
-			const { grabStylesCompleted, fallbackStyles } = this.state;
-			if ( this.nodeRef && ! grabStylesCompleted ) {
-				const newFallbackStyles = mapNodeToProps( this.nodeRef, this.props );
-				if ( ! isEqual( newFallbackStyles, fallbackStyles ) ) {
-					this.setState( {
-						fallbackStyles: newFallbackStyles,
-						grabStylesCompleted: !! every( newFallbackStyles ),
-					} );
+			componentDidUpdate() {
+				this.grabFallbackStyles();
+			}
+
+			grabFallbackStyles() {
+				const { grabStylesCompleted, fallbackStyles } = this.state;
+				if ( this.nodeRef && ! grabStylesCompleted ) {
+					const newFallbackStyles = mapNodeToProps( this.nodeRef, this.props );
+					if ( ! isEqual( newFallbackStyles, fallbackStyles ) ) {
+						this.setState( {
+							fallbackStyles: newFallbackStyles,
+							grabStylesCompleted: !! every( newFallbackStyles ),
+						} );
+					}
 				}
 			}
-		}
 
-		render() {
-			const wrappedComponent = <WrappedComponent { ...this.props } { ...this.state.fallbackStyles } />;
-			return this.props.node ? wrappedComponent : <div ref={ this.bindRef }> { wrappedComponent } </div>;
+			render() {
+				const wrappedComponent = <WrappedComponent { ...this.props } { ...this.state.fallbackStyles } />;
+				return this.props.node ? wrappedComponent : <div ref={ this.bindRef }> { wrappedComponent } </div>;
+			}
 		}
-	};
-};
+	},
+	'withFallbackStyles'
+);

--- a/components/higher-order/with-focus-outside/index.js
+++ b/components/higher-order/with-focus-outside/index.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createHigherOrderComponent } from '@wordpress/element';
 
 /**
  * Input types which are classified as button types, for use in considering
@@ -42,96 +42,96 @@ function isFocusNormalizedButton( element ) {
 	return false;
 }
 
-function withFocusOutside( WrappedComponent ) {
-	return class extends Component {
-		constructor() {
-			super( ...arguments );
+export default createHigherOrderComponent(
+	( WrappedComponent ) => {
+		return class extends Component {
+			constructor() {
+				super( ...arguments );
 
-			this.bindNode = this.bindNode.bind( this );
-			this.cancelBlurCheck = this.cancelBlurCheck.bind( this );
-			this.queueBlurCheck = this.queueBlurCheck.bind( this );
-			this.normalizeButtonFocus = this.normalizeButtonFocus.bind( this );
-		}
+				this.bindNode = this.bindNode.bind( this );
+				this.cancelBlurCheck = this.cancelBlurCheck.bind( this );
+				this.queueBlurCheck = this.queueBlurCheck.bind( this );
+				this.normalizeButtonFocus = this.normalizeButtonFocus.bind( this );
+			}
 
-		componentWillUnmount() {
-			this.cancelBlurCheck();
-		}
-
-		bindNode( node ) {
-			if ( node ) {
-				this.node = node;
-			} else {
-				delete this.node;
+			componentWillUnmount() {
 				this.cancelBlurCheck();
 			}
-		}
 
-		queueBlurCheck( event ) {
-			// React does not allow using an event reference asynchronously
-			// due to recycling behavior, except when explicitly persisted.
-			event.persist();
-
-			// Skip blur check if clicking button. See `normalizeButtonFocus`.
-			if ( this.preventBlurCheck ) {
-				return;
-			}
-
-			this.blurCheckTimeout = setTimeout( () => {
-				if ( 'function' === typeof this.node.handleFocusOutside ) {
-					this.node.handleFocusOutside( event );
+			bindNode( node ) {
+				if ( node ) {
+					this.node = node;
+				} else {
+					delete this.node;
+					this.cancelBlurCheck();
 				}
-			}, 0 );
-		}
+			}
 
-		cancelBlurCheck() {
-			clearTimeout( this.blurCheckTimeout );
-		}
+			queueBlurCheck( event ) {
+				// React does not allow using an event reference asynchronously
+				// due to recycling behavior, except when explicitly persisted.
+				event.persist();
 
-		/**
-		 * Handles a mousedown or mouseup event to respectively assign and
-		 * unassign a flag for preventing blur check on button elements. Some
-		 * browsers, namely Firefox and Safari, do not emit a focus event on
-		 * button elements when clicked, while others do. The logic here
-		 * intends to normalize this as treating click on buttons as focus.
-		 *
-		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-		 *
-		 * @param {MouseEvent} event Event for mousedown or mouseup.
-		 */
-		normalizeButtonFocus( event ) {
-			const { type, target } = event;
+				// Skip blur check if clicking button. See `normalizeButtonFocus`.
+				if ( this.preventBlurCheck ) {
+					return;
+				}
 
-			const isInteractionEnd = includes( [ 'mouseup', 'touchend' ], type );
+				this.blurCheckTimeout = setTimeout( () => {
+					if ( 'function' === typeof this.node.handleFocusOutside ) {
+						this.node.handleFocusOutside( event );
+					}
+				}, 0 );
+			}
 
-			if ( isInteractionEnd ) {
-				this.preventBlurCheck = false;
-			} else if ( isFocusNormalizedButton( target ) ) {
-				this.preventBlurCheck = true;
+			cancelBlurCheck() {
+				clearTimeout( this.blurCheckTimeout );
+			}
+
+			/**
+			 * Handles a mousedown or mouseup event to respectively assign and
+			 * unassign a flag for preventing blur check on button elements. Some
+			 * browsers, namely Firefox and Safari, do not emit a focus event on
+			 * button elements when clicked, while others do. The logic here
+			 * intends to normalize this as treating click on buttons as focus.
+			 *
+			 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+			 *
+			 * @param {MouseEvent} event Event for mousedown or mouseup.
+			 */
+			normalizeButtonFocus( event ) {
+				const { type, target } = event;
+
+				const isInteractionEnd = includes( [ 'mouseup', 'touchend' ], type );
+
+				if ( isInteractionEnd ) {
+					this.preventBlurCheck = false;
+				} else if ( isFocusNormalizedButton( target ) ) {
+					this.preventBlurCheck = true;
+				}
+			}
+
+			render() {
+				// Disable reason: See `normalizeButtonFocus` for browser-specific
+				// focus event normalization.
+
+				/* eslint-disable jsx-a11y/no-static-element-interactions */
+				return (
+					<div
+						onFocus={ this.cancelBlurCheck }
+						onMouseDown={ this.normalizeButtonFocus }
+						onMouseUp={ this.normalizeButtonFocus }
+						onTouchStart={ this.normalizeButtonFocus }
+						onTouchEnd={ this.normalizeButtonFocus }
+						onBlur={ this.queueBlurCheck }
+					>
+						<WrappedComponent
+							ref={ this.bindNode }
+							{ ...this.props } />
+					</div>
+				);
+				/* eslint-enable jsx-a11y/no-static-element-interactions */
 			}
 		}
-
-		render() {
-			// Disable reason: See `normalizeButtonFocus` for browser-specific
-			// focus event normalization.
-
-			/* eslint-disable jsx-a11y/no-static-element-interactions */
-			return (
-				<div
-					onFocus={ this.cancelBlurCheck }
-					onMouseDown={ this.normalizeButtonFocus }
-					onMouseUp={ this.normalizeButtonFocus }
-					onTouchStart={ this.normalizeButtonFocus }
-					onTouchEnd={ this.normalizeButtonFocus }
-					onBlur={ this.queueBlurCheck }
-				>
-					<WrappedComponent
-						ref={ this.bindNode }
-						{ ...this.props } />
-				</div>
-			);
-			/* eslint-enable jsx-a11y/no-static-element-interactions */
-		}
-	};
-}
-
-export default withFocusOutside;
+	}, 'withFocusOutside'
+);

--- a/components/higher-order/with-focus-outside/index.js
+++ b/components/higher-order/with-focus-outside/index.js
@@ -132,6 +132,6 @@ export default createHigherOrderComponent(
 				);
 				/* eslint-enable jsx-a11y/no-static-element-interactions */
 			}
-		}
+		};
 	}, 'withFocusOutside'
 );

--- a/components/higher-order/with-focus-return/index.js
+++ b/components/higher-order/with-focus-return/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createHigherOrderComponent } from '@wordpress/element';
 
 /**
  * Higher Order Component used to be used to wrap disposable elements like
@@ -13,39 +13,39 @@ import { Component } from '@wordpress/element';
  *
  * @return {Component} Component with the focus restauration behaviour.
  */
-function withFocusReturn( WrappedComponent ) {
-	return class extends Component {
-		constructor() {
-			super( ...arguments );
+export default createHigherOrderComponent(
+	( WrappedComponent ) => {
+		return class extends Component {
+			constructor() {
+				super( ...arguments );
 
-			this.setIsFocusedTrue = () => this.isFocused = true;
-			this.setIsFocusedFalse = () => this.isFocused = false;
-			this.activeElementOnMount = document.activeElement;
-		}
-
-		componentWillUnmount() {
-			const { activeElementOnMount, isFocused } = this;
-			if ( ! activeElementOnMount ) {
-				return;
+				this.setIsFocusedTrue = () => this.isFocused = true;
+				this.setIsFocusedFalse = () => this.isFocused = false;
+				this.activeElementOnMount = document.activeElement;
 			}
 
-			const { body, activeElement } = document;
-			if ( isFocused || null === activeElement || body === activeElement ) {
-				activeElementOnMount.focus();
+			componentWillUnmount() {
+				const { activeElementOnMount, isFocused } = this;
+				if ( ! activeElementOnMount ) {
+					return;
+				}
+
+				const { body, activeElement } = document;
+				if ( isFocused || null === activeElement || body === activeElement ) {
+					activeElementOnMount.focus();
+				}
 			}
-		}
 
-		render() {
-			return (
-				<div
-					onFocus={ this.setIsFocusedTrue }
-					onBlur={ this.setIsFocusedFalse }
-				>
-					<WrappedComponent { ...this.props } />
-				</div>
-			);
-		}
-	};
-}
-
-export default withFocusReturn;
+			render() {
+				return (
+					<div
+						onFocus={ this.setIsFocusedTrue }
+						onBlur={ this.setIsFocusedFalse }
+					>
+						<WrappedComponent { ...this.props } />
+					</div>
+				);
+			}
+		};
+	}, 'withFocusReturn'
+);

--- a/components/higher-order/with-instance-id/index.js
+++ b/components/higher-order/with-instance-id/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createHigherOrderComponent } from '@wordpress/element';
 
 /**
  * A Higher Order Component used to be provide a unique instance ID by
@@ -11,7 +11,7 @@ import { Component } from '@wordpress/element';
  *
  * @return {Component} Component with an instanceId prop.
  */
-function withInstanceId( WrappedComponent ) {
+export default createHigherOrderComponent( ( WrappedComponent ) => {
 	let instances = 0;
 
 	return class extends Component {
@@ -26,6 +26,4 @@ function withInstanceId( WrappedComponent ) {
 			);
 		}
 	};
-}
-
-export default withInstanceId;
+}, 'withInstanceId' );

--- a/components/higher-order/with-spoken-messages/index.js
+++ b/components/higher-order/with-spoken-messages/index.js
@@ -6,7 +6,7 @@ import { debounce } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createHigherOrderComponent } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
 
 /**
@@ -17,7 +17,7 @@ import { speak } from '@wordpress/a11y';
  *
  * @return {Component} Component with an instanceId prop.
  */
-function withSpokenMessages( WrappedComponent ) {
+export default createHigherOrderComponent( ( WrappedComponent ) => {
 	return class extends Component {
 		constructor() {
 			super( ...arguments );
@@ -41,6 +41,4 @@ function withSpokenMessages( WrappedComponent ) {
 			);
 		}
 	};
-}
-
-export default withSpokenMessages;
+}, 'withSpokenMessages' );

--- a/core-blocks/more/test/__snapshots__/edit.js.snap
+++ b/core-blocks/more/test/__snapshots__/edit.js.snap
@@ -4,7 +4,7 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
 <React.Fragment>
   <IfBlockEditSelected(InspectorControlsFill)>
     <PanelBody>
-      <_class
+      <WithInstanceId(ToggleControl)
         checked={false}
         label="Hide the teaser before the \\"More\\" tag"
         onChange={[Function]}
@@ -28,7 +28,7 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
 <React.Fragment>
   <IfBlockEditSelected(InspectorControlsFill)>
     <PanelBody>
-      <_class
+      <WithInstanceId(ToggleControl)
         checked={true}
         label="Hide the teaser before the \\"More\\" tag"
         onChange={[Function]}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This pull ensures that all HOCs are consistently using `createHigherOrderComponent`.  This is prep work for doing global HOC behaviour changes for all HOCs (such as implementing [forwardRef](https://github.com/WordPress/gutenberg/pull/7557))

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* [ ] This should be covered by all existing tests, so testing just involves ensuring that existing unit and e2e tests pass.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
