### PR TITLE
Add Woo color theme

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,6 +100,13 @@ const extractConfig = {
 								button: '#d1864a',
 								outlines: '#837425',
 							},
+							'admin-color-woo': {
+								primary: '#95588a',
+								secondary: '#95588a',
+								toggle: '#95588a',
+								button: '#95588a',
+								outlines: '#95588a',
+							},
 						},
 					} ),
 					require( 'autoprefixer' ),


### PR DESCRIPTION
## Description
Add a WooCommerce color theme to be created at build time. The goal is to use components such as `Button` without having to overwrite styles, including all the various states.

I understand the coupling of a consuming extension's styles into Gutenberg is less than ideal. Is there a better way to reuse these components? I'd like to avoid writing our own. Additionally, overwritting all the styles seems to introduce just as much code as writing our own. Thanks!

## Screenshots <!-- if applicable -->
![screen shot 2018-07-05 at 1 00 51 pm](https://user-images.githubusercontent.com/1922453/42297503-f5667c14-8053-11e8-87b9-97cc1fafb604.png)

cc @youknowriad @LevinMedia 
