### PR TITLE
Columns: Avoid re-render and subsequent action dispatch by adopting module constant

### DIFF
--- a/core-blocks/columns/index.js
+++ b/core-blocks/columns/index.js
@@ -23,6 +23,8 @@ import {
 import './style.scss';
 import './editor.scss';
 
+const ALLOWED_BLOCKS = [ 'core/column' ];
+
 /**
  * Returns the layouts configuration for a given number of columns.
  *
@@ -145,7 +147,7 @@ export const settings = {
 					<InnerBlocks
 						template={ getColumnsTemplate( columns ) }
 						templateLock="all"
-						allowedBlocks={ [ 'core/column' ] } />
+						allowedBlocks={ ALLOWED_BLOCKS } />
 				</div>
 			</Fragment>
 		);


### PR DESCRIPTION
We were passing a new allowedBlocks reference on each column render. This dispatch additional unnecessary further actions to update inner block settings.
allowedBlocks reference should only be changed if, in fact, we are changing the allowedBlocks.
In the columns block, we can make allowed block a constant given that it never changes.

This problem may cause noticeable lag when writing/using columns because updating the InnerBlock setting may cause another rerender and another rerender updates the settings again. So this change prevents cascade re-renders.

The alternative is comparing each element of the array to verify if it changed or not. But this has a performance impact and we should not pass new props during rerenders if the props did not change so I feel this is the correct approach.

## How has this been tested?
I verified the columns block works as before and no unnecessary UPDATE_BLOCK_LIST_SETTINGS are being dispatched.
