### PR TITLE
InnerBlocks: Fix regression where setting a template also locked it

### DIFF
--- a/editor/components/inner-blocks/index.js
+++ b/editor/components/inner-blocks/index.js
@@ -28,9 +28,12 @@ class InnerBlocks extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { template, block } = this.props;
+		const { template, templateLock, block } = this.props;
 
 		this.updateNestedSettings();
+		if ( templateLock !== 'all' && block.innerBlocks && block.innerBlocks.length > 0 ) {
+			return;
+		}
 
 		const hasTemplateChanged = ! isEqual( template, prevProps.template );
 		const isTemplateInnerBlockMismatch = (


### PR DESCRIPTION
Regressed in: https://github.com/WordPress/gutenberg/pull/7234

InnerBlocks applied template sync on each update. This created a bug where if locking was not set when inserting or removing a block the template mechanism reverted the action.
This commit makes sure we only sync with the template if templateLock equals "all" or if the template contains inner blocks and the block does not contain any inner block.

## How has this been tested?
I checked columns block continues to work as before.
I added the test blocks available in https://gist.github.com/jorgefilipecosta/2bac096fe3be7f6ff0de7452292161cb.
I added the locking all and checked we cannot insert blocks on the locking all. But we can insert on the no locking block inside (on master we can't).
I added the "no locking" and "locking unset" blocks and verified in both of them I can insert an image.