### PR TITLE
Inserter: Prevent unnecessary re-renders when selecting a different block

### DIFF
--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -36,7 +36,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     value="Write your story"
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(Inserter)
     position="top right"
   >
     <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
@@ -44,7 +44,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     >
       Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
     </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  </WithSelect(Inserter)>
 </div>
 `;
 
@@ -66,7 +66,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     value="Write your story"
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(Inserter)
     position="top right"
   >
     <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
@@ -74,7 +74,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     >
       Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
     </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  </WithSelect(Inserter)>
 </div>
 `;
 
@@ -96,7 +96,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     value=""
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(Inserter)
     position="top right"
   >
     <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
@@ -104,6 +104,6 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     >
       Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
     </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  </WithSelect(Inserter)>
 </div>
 `;

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -3,16 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton } from '@wordpress/components';
-import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import InserterMenu from './menu';
-
-export { default as InserterResultsPortal } from './results-portal';
 
 class Inserter extends Component {
 	constructor() {
@@ -32,15 +29,13 @@ class Inserter extends Component {
 
 	render() {
 		const {
-			items,
+			hasBlockTypes,
 			position,
 			title,
 			children,
-			onInsertBlock,
-			rootUID,
 		} = this.props;
 
-		if ( items.length === 0 ) {
+		if ( ! hasBlockTypes ) {
 			return null;
 		}
 
@@ -65,13 +60,7 @@ class Inserter extends Component {
 					</IconButton>
 				) }
 				renderContent={ ( { onClose } ) => {
-					const onSelect = ( item ) => {
-						onInsertBlock( item );
-
-						onClose();
-					};
-
-					return <InserterMenu items={ items } onSelect={ onSelect } rootUID={ rootUID } />;
+					return <InserterMenu onClose={ onClose } />;
 				} }
 			/>
 		);
@@ -81,31 +70,14 @@ class Inserter extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const {
+			getBlockTypes,
+		} = select( 'core/blocks' );
+		const {
 			getEditedPostAttribute,
-			getBlockInsertionPoint,
-			getSelectedBlock,
-			getInserterItems,
 		} = select( 'core/editor' );
-		const insertionPoint = getBlockInsertionPoint();
-		const { rootUID } = insertionPoint;
 		return {
+			hasBlockTypes: getBlockTypes().length > 0,
 			title: getEditedPostAttribute( 'title' ),
-			insertionPoint,
-			selectedBlock: getSelectedBlock(),
-			items: getInserterItems( rootUID ),
-			rootUID,
 		};
 	} ),
-	withDispatch( ( dispatch, ownProps ) => ( {
-		onInsertBlock: ( item ) => {
-			const { insertionPoint, selectedBlock } = ownProps;
-			const { index, rootUID, layout } = insertionPoint;
-			const { name, initialAttributes } = item;
-			const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
-			if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
-				return dispatch( 'core/editor' ).replaceBlocks( selectedBlock.uid, insertedBlock );
-			}
-			return dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootUID );
-		},
-	} ) ),
 ] )( Inserter );

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -310,12 +310,15 @@ export default compose(
 			const { insertionPoint, onClose, selectedBlock } = ownProps;
 			const { index, rootUID, layout } = insertionPoint;
 			const { name, initialAttributes } = item;
+
 			const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
+
 			if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
 				dispatch( 'core/editor' ).replaceBlocks( selectedBlock.uid, insertedBlock );
 			} else {
 				dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootUID );
 			}
+
 			if ( onClose ) {
 				onClose();
 			}

--- a/editor/components/rich-text/tokens/ui/index.js
+++ b/editor/components/rich-text/tokens/ui/index.js
@@ -10,7 +10,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import './style.scss';
-import { InserterResultsPortal } from '../../../inserter';
+import InserterResultsPortal from '../../../inserter/results-portal';
 
 class TokenUI extends Component {
 	constructor() {


### PR DESCRIPTION
## Description
When testing one of the performance improvements I noticed that `Inserter` component re-renders each time something changes in the editor. This is very unexpected because it is just a button.

The improvement I propose is to move all store operations to the child component which is the one that needs those data to be fetched. The only check that is left is whether there is any block registered to make sure we don't display the inserter when there no blocks available. 

It still needs to be verified how it interacts with the template lock.

## How has this been tested?

Manually with Highlight Updates enabled in React devTools.

## Screenshots 

### Before

![inserter-blink-when-using-keyboard](https://user-images.githubusercontent.com/699132/42324962-1971a316-8065-11e8-8d05-1ed8e1c0e484.gif)

### After

![inserter-blink-when-using-keyboard-after](https://user-images.githubusercontent.com/699132/42324970-1f7cb3d6-8065-11e8-88ab-a8ddeae05b3b.gif)

## Types of changes
Performance optimization.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
