### PR TITLE
Inner Blocks: Respecting locking in display of default block appender

### DIFF
--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -18,6 +18,7 @@ import 'element-closest';
  */
 import { Component, compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { getDefaultBlockName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -193,6 +194,7 @@ class BlockListLayout extends Component {
 			layout,
 			isGroupedByLayout,
 			rootUID,
+			canInsertDefaultBlock,
 		} = this.props;
 
 		let defaultLayout;
@@ -220,27 +222,31 @@ class BlockListLayout extends Component {
 						isLast={ blockIndex === blockUIDs.length - 1 }
 					/>
 				) ) }
-				<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
-					<DefaultBlockAppender
-						rootUID={ rootUID }
-						lastBlockUID={ last( blockUIDs ) }
-						layout={ defaultLayout }
-					/>
-				</IgnoreNestedEvents>
+				{ canInsertDefaultBlock && (
+					<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
+						<DefaultBlockAppender
+							rootUID={ rootUID }
+							lastBlockUID={ last( blockUIDs ) }
+							layout={ defaultLayout }
+						/>
+					</IgnoreNestedEvents>
+				) }
 			</div>
 		);
 	}
 }
 
 export default compose( [
-	withSelect( ( select ) => {
+	withSelect( ( select, ownProps ) => {
 		const {
 			isSelectionEnabled,
 			isMultiSelecting,
 			getMultiSelectedBlocksStartUid,
 			getMultiSelectedBlocksEndUid,
 			getBlockSelectionStart,
+			canInsertBlockType,
 		} = select( 'core/editor' );
+		const { rootUID } = ownProps;
 
 		return {
 			selectionStart: getMultiSelectedBlocksStartUid(),
@@ -248,6 +254,7 @@ export default compose( [
 			selectionStartUID: getBlockSelectionStart(),
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
+			canInsertDefaultBlock: canInsertBlockType( getDefaultBlockName(), rootUID ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/editor/components/inner-blocks/index.js
+++ b/editor/components/inner-blocks/index.js
@@ -22,8 +22,13 @@ import BlockList from '../block-list';
 import { withBlockEditContext } from '../block-edit/context';
 
 class InnerBlocks extends Component {
-	componentDidMount() {
+	constructor() {
+		super( ...arguments );
+
 		this.updateNestedSettings();
+	}
+
+	componentDidMount() {
 		this.synchronizeBlocksWithTemplate();
 	}
 

--- a/editor/components/inner-blocks/index.js
+++ b/editor/components/inner-blocks/index.js
@@ -33,17 +33,12 @@ class InnerBlocks extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { template, block } = this.props;
+		const { template } = this.props;
 
 		this.updateNestedSettings();
 
 		const hasTemplateChanged = ! isEqual( template, prevProps.template );
-		const isTemplateInnerBlockMismatch = (
-			template &&
-			block.innerBlocks.length !== template.length
-		);
-
-		if ( hasTemplateChanged || isTemplateInnerBlockMismatch ) {
+		if ( hasTemplateChanged ) {
 			this.synchronizeBlocksWithTemplate();
 		}
 	}


### PR DESCRIPTION
Alternative to #7723

This pull request seeks to resolve an issue where inserting a block which had full locking on its template would cause a default block to be appended because the DefaultBlockAppender's rendering was not conditional based on the locking settings of its layout context. This was only not obvious previously because we had a condition in the InnerBlocks to allow the template to synchronize itself on the basis of block count mismatch, so the templated blocks would be reset to its intended form after the default block was appended.

Example:

Insert Columns
Template has 2 "Column" blocks.
Default appender would be focused by BlockListBlock's focusTabbable and a new paragraph wrongly inserted into "Columns" block.
Previously: InnerBlocks would re-sync its template to delete the paragraph block.
Now: The paragraph block is never inserted to begin with. 

**Testing instructions:**

Repeat testing instructions from #7723 
Verify that template is respected when inserting Columns block.
Ensure end-to-end tests pass:

```
npm run test-e2e
```