### PR TITLE
Changed createObjectUrl to createBlobURL

### DIFF
--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -12,6 +12,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { createBlobURL } from '@wordpress/blob';
 
 /**
  * Browsers may use unexpected mime types, and they differ from browser to browser.
@@ -110,7 +111,7 @@ export function mediaUpload( {
 
 		// Set temporary URL to create placeholder media file, this is replaced
 		// with final file from media gallery when upload is `done` below
-		filesSet.push( { url: window.URL.createObjectURL( mediaFile ) } );
+		filesSet.push( { url: createBlobURL( mediaFile ) } );
 		onFileChange( filesSet );
 
 		return createMediaFromFile( mediaFile, additionalData )


### PR DESCRIPTION
## Description
Changed createObjectUrl to createBlobURL from the @wordpress package.

## How has this been tested?
Included tests and manually


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
