### PR TITLE
Add an isMatch method to the block transform api, and use it to prevent file blocks from transforming unless the uploaded file type matches

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -97,10 +97,11 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
  *
  * @return {boolean} Is the transform possible?
  */
-const isPossibleTransformForSource = ( transform, direction, blocks, isMultiBlock ) => {
+const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 	if ( isEmpty( blocks ) ) {
 		return false;
 	}
+	const isMultiBlock = blocks.length > 1;
 	const sourceBlock = first( blocks );
 
 	// If multiple blocks are selected, only multi block transforms are allowed
@@ -141,7 +142,7 @@ const isPossibleTransformForSource = ( transform, direction, blocks, isMultiBloc
  *
  * @return {Array} Block types that the blocks can be transformed into.
  */
-const getBlockTypesForPossibleFromTransforms = ( blocks, isMultiBlock = false ) => {
+const getBlockTypesForPossibleFromTransforms = ( blocks ) => {
 	if ( isEmpty( blocks ) ) {
 		return [];
 	}
@@ -156,7 +157,7 @@ const getBlockTypesForPossibleFromTransforms = ( blocks, isMultiBlock = false ) 
 
 			return !! findTransform(
 				fromTransforms,
-				( transform ) => isPossibleTransformForSource( transform, 'from', blocks, isMultiBlock )
+				( transform ) => isPossibleTransformForSource( transform, 'from', blocks )
 			);
 		},
 	);
@@ -173,7 +174,7 @@ const getBlockTypesForPossibleFromTransforms = ( blocks, isMultiBlock = false ) 
  *
  * @return {Array} Block types that the source can be transformed into.
  */
-const getBlockTypesForPossibleToTransforms = ( blocks, isMultiBlock = false ) => {
+const getBlockTypesForPossibleToTransforms = ( blocks ) => {
 	if ( isEmpty( blocks ) ) {
 		return [];
 	}
@@ -185,7 +186,7 @@ const getBlockTypesForPossibleToTransforms = ( blocks, isMultiBlock = false ) =>
 	// filter all 'to' transforms to find those that are possible.
 	const possibleTransforms = filter(
 		transformsTo,
-		( transform ) => isPossibleTransformForSource( transform, 'to', blocks, isMultiBlock )
+		( transform ) => isPossibleTransformForSource( transform, 'to', blocks )
 	);
 
 	// Build a list of block names using the possible 'to' transforms.
@@ -217,8 +218,8 @@ export function getPossibleBlockTransformations( blocks ) {
 		return [];
 	}
 
-	const blockTypesForFromTransforms = getBlockTypesForPossibleFromTransforms( blocks, isMultiBlock );
-	const blockTypesForToTransforms = getBlockTypesForPossibleToTransforms( blocks, isMultiBlock );
+	const blockTypesForFromTransforms = getBlockTypesForPossibleFromTransforms( blocks );
+	const blockTypesForToTransforms = getBlockTypesForPossibleToTransforms( blocks );
 
 	return uniq( [
 		...blockTypesForFromTransforms,

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -123,22 +123,31 @@ const isValidTransformForSource = ( transform, direction, sourceBlock, isMultiBl
 };
 
 /**
- * Returns a predicate that receives a transformation and returns true if the
- * given transformation is able to execute in the situation specified in the
- * params.
+ * Returns the names of the blocks that the source block can be transformed
+ * into, based on 'from' transforms on other blocks.
  *
  * @param {Object}  sourceBlock  Source block.
  * @param {boolean} isMultiBlock Array of possible block transformations.
  *
- * @return {Function} Predicate that receives a block type.
+ * @return {Array} An array of block names
  */
-const blockContainsValidFromTransform = ( sourceBlock, isMultiBlock = false ) => ( blockType ) => {
-	const fromTransforms = getBlockTransforms( 'from', blockType.name );
+const getValidFromTransformsForSource = ( sourceBlock, isMultiBlock = false ) => {
+	const allBlockTypes = getBlockTypes();
 
-	return !! findTransform(
-		fromTransforms,
-		( transform ) => isValidTransformForSource( transform, 'from', sourceBlock, isMultiBlock )
+	// filter all blocks to find those with a valid 'from' transform
+	const blocksWithValidFromTransforms = filter(
+		allBlockTypes,
+		( blockType ) => {
+			const fromTransforms = getBlockTransforms( 'from', blockType.name );
+
+			return !! findTransform(
+				fromTransforms,
+				( transform ) => isValidTransformForSource( transform, 'from', sourceBlock, isMultiBlock )
+			);
+		},
 	);
+
+	return blocksWithValidFromTransforms.map( ( type ) => type.name );
 };
 
 /**
@@ -161,11 +170,7 @@ export function getPossibleBlockTransformations( blocks ) {
 		return [];
 	}
 
-	// Compute the block that have a from transformation able to transfer blocks passed as argument.
-	const blocksToBeTransformedFrom = filter(
-		getBlockTypes(),
-		blockContainsValidFromTransform( sourceBlock, isMultiBlock ),
-	).map( ( type ) => type.name );
+	const blocksToBeTransformedFrom = getValidFromTransformsForSource( sourceBlock, isMultiBlock );
 
 	const blockType = getBlockType( sourceBlockName );
 	const transformsTo = getBlockTransforms( 'to', blockType.name );

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -95,11 +95,13 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
  * @return {boolean} Is the transform valid?
  */
 const isValidTransformForSource = ( transform, direction, sourceBlock, isMultiBlock ) => {
+	// If multiple blocks are selected, only multi block transforms are valid
 	const isValidForMultiBlocks = ! isMultiBlock || transform.isMultiBlock;
 	if ( ! isValidForMultiBlocks ) {
 		return false;
 	}
 
+	// Only consider transforms from and to blocks as valid
 	const isValidType = transform.type === 'block';
 	if ( ! isValidType ) {
 		return false;
@@ -108,6 +110,12 @@ const isValidTransformForSource = ( transform, direction, sourceBlock, isMultiBl
 	// Check is the transform's block name matches the source block only if this is a transform 'from'
 	const isValidForSourceName = direction !== 'from' || transform.blocks.indexOf( sourceBlock.name ) !== -1;
 	if ( ! isValidForSourceName ) {
+		return false;
+	}
+
+	// If the transform has a `canTransform` function specified, check that it returns true
+	const canTransform = ! transform.canTransform || !! transform.canTransform( sourceBlock.attributes );
+	if ( ! canTransform ) {
 		return false;
 	}
 

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -131,12 +131,12 @@ const isPossibleTransformForSource = ( transform, direction, sourceBlock, isMult
  * @param {Object}  sourceBlock  The instance of the source block.
  * @param {boolean} isMultiBlock Have multiple blocks been selected?
  *
- * @return {Array} Block types that the source block can be transformed into
+ * @return {Array} Block types that the source block can be transformed into.
  */
 const getBlockTypesForPossibleFromTransforms = ( sourceBlock, isMultiBlock = false ) => {
 	const allBlockTypes = getBlockTypes();
 
-	// filter all blocks to find those with a 'from' transform
+	// filter all blocks to find those with a 'from' transform.
 	const blockTypesWithPossibleFromTransforms = filter(
 		allBlockTypes,
 		( blockType ) => {
@@ -154,39 +154,40 @@ const getBlockTypesForPossibleFromTransforms = ( sourceBlock, isMultiBlock = fal
 
 /**
  * Returns block types that the source block can be transformed into, based on
- * its own 'to' transforms
+ * its own 'to' transforms.
  *
- * @param {Object} sourceBlock The instance of the source block
+ * @param {Object} sourceBlock The instance of the source block.
  * @param {boolean} isMultiBlock Have multiple blocks been selected?
  *
- * @return {Array} Block types that the source can transform into
+ * @return {Array} Block types that the source can be transformed into.
  */
 const getBlockTypesForPossibleToTransforms = ( sourceBlock, isMultiBlock = false ) => {
 	const blockType = getBlockType( sourceBlock.name );
 	const transformsTo = getBlockTransforms( 'to', blockType.name );
 
-	// filter all 'to' transforms to find those that are possible
+	// filter all 'to' transforms to find those that are possible.
 	const possibleTransforms = filter(
 		transformsTo,
 		( transform ) => isPossibleTransformForSource( transform, 'to', sourceBlock, isMultiBlock )
 	);
 
-	// Build a list of block names using the possible 'to' transforms
+	// Build a list of block names using the possible 'to' transforms.
 	const blockNames = flatMap(
 		possibleTransforms,
 		( transformation ) => transformation.blocks
 	);
 
+	// Map block names to block types.
 	return blockNames.map( ( name ) => getBlockType( name ) );
 };
 
 /**
- * Returns an array of possible block transformations that could happen on the
- * set of blocks received as argument.
+ * Returns an array of block types that the set of blocks received as argument
+ * can be transformed into.
  *
  * @param {Array} blocks Blocks array.
  *
- * @return {Array} Array of possible block transformations.
+ * @return {Array} block types that the blocks argument can be transformed to.
  */
 export function getPossibleBlockTransformations( blocks ) {
 	const sourceBlock = first( blocks );

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -122,10 +122,10 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 		return false;
 	}
 
-	// If the transform has a `canTransform` function specified, check that it returns true.
-	if ( isFunction( transform.canTransform ) ) {
+	// If the transform has a `isMatch` function specified, check that it returns true.
+	if ( isFunction( transform.isMatch ) ) {
 		const attributes = transform.isMultiBlock ? blocks.map( ( block ) => block.attributes ) : sourceBlock.attributes;
-		if ( ! transform.canTransform( attributes ) ) {
+		if ( ! transform.isMatch( attributes ) ) {
 			return false;
 		}
 	}

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -88,11 +88,11 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 
 /**
  * Returns a boolean indicating whether a transform is possible based on
- * various bits of context
+ * various bits of context.
  *
- * @param {Object} transform The transform object to validate
- * @param {string} direction Is this a 'from' or 'to' transform
- * @param {Array} blocks The blocks to transform from
+ * @param {Object} transform The transform object to validate.
+ * @param {string} direction Is this a 'from' or 'to' transform.
+ * @param {Array} blocks The blocks to transform from.
  * @param {boolean} isMultiBlock Have multiple blocks been selected?
  *
  * @return {boolean} Is the transform possible?
@@ -104,25 +104,25 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 	const isMultiBlock = blocks.length > 1;
 	const sourceBlock = first( blocks );
 
-	// If multiple blocks are selected, only multi block transforms are allowed
+	// If multiple blocks are selected, only multi block transforms are allowed.
 	const isValidForMultiBlocks = ! isMultiBlock || transform.isMultiBlock;
 	if ( ! isValidForMultiBlocks ) {
 		return false;
 	}
 
-	// Only consider 'block' type transforms as valid
+	// Only consider 'block' type transforms as valid.
 	const isBlockType = transform.type === 'block';
 	if ( ! isBlockType ) {
 		return false;
 	}
 
-	// Check if the transform's block name matches the source block only if this is a transform 'from'
+	// Check if the transform's block name matches the source block only if this is a transform 'from'.
 	const hasMatchingName = direction !== 'from' || transform.blocks.indexOf( sourceBlock.name ) !== -1;
 	if ( ! hasMatchingName ) {
 		return false;
 	}
 
-	// If the transform has a `canTransform` function specified, check that it returns true
+	// If the transform has a `canTransform` function specified, check that it returns true.
 	if ( isFunction( transform.canTransform ) ) {
 		const attributes = transform.isMultiBlock ? blocks.map( ( block ) => block.attributes ) : sourceBlock.attributes;
 		if ( ! transform.canTransform( attributes ) ) {
@@ -137,7 +137,7 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
  * Returns block types that the 'blocks' can be transformed into, based on
  * 'from' transforms on other blocks.
  *
- * @param {Array}  blocks  The blocks to transform from
+ * @param {Array}  blocks  The blocks to transform from.
  * @param {boolean} isMultiBlock Have multiple blocks been selected?
  *
  * @return {Array} Block types that the blocks can be transformed into.
@@ -205,7 +205,7 @@ const getBlockTypesForPossibleToTransforms = ( blocks ) => {
  *
  * @param {Array} blocks Blocks array.
  *
- * @return {Array} block types that the blocks argument can be transformed to.
+ * @return {Array} Block types that the blocks argument can be transformed to.
  */
 export function getPossibleBlockTransformations( blocks ) {
 	if ( isEmpty( blocks ) ) {

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -101,21 +101,23 @@ const isTransformForBlockSource = ( sourceName, isMultiBlock = false ) => ( tran
 );
 
 /**
- * Returns a predicate that receives a block type and returns true if the given
- * block type contains a transformation able to execute in the situation
- * specified in the params.
+ * Returns a predicate that receives a transformation and returns true if the
+ * given transformation is able to execute in the situation specified in the
+ * params.
  *
  * @param {string}  sourceName   Block name.
  * @param {boolean} isMultiBlock Array of possible block transformations.
  *
  * @return {Function} Predicate that receives a block type.
  */
-const createIsTypeTransformableFrom = ( sourceName, isMultiBlock = false ) => ( blockType ) => (
-	!! findTransform(
-		getBlockTransforms( 'from', blockType.name ),
+const blockContainsValidFromTransform = ( sourceName, isMultiBlock = false ) => ( blockType ) => {
+	const fromTransforms = getBlockTransforms( 'from', blockType.name );
+
+	return !! findTransform(
+		fromTransforms,
 		isTransformForBlockSource( sourceName, isMultiBlock )
-	)
-);
+	);
+};
 
 /**
  * Returns an array of possible block transformations that could happen on the
@@ -140,7 +142,7 @@ export function getPossibleBlockTransformations( blocks ) {
 	// Compute the block that have a from transformation able to transfer blocks passed as argument.
 	const blocksToBeTransformedFrom = filter(
 		getBlockTypes(),
-		createIsTypeTransformableFrom( sourceBlockName, isMultiBlock ),
+		blockContainsValidFromTransform( sourceBlockName, isMultiBlock ),
 	).map( ( type ) => type.name );
 
 	const blockType = getBlockType( sourceBlockName );

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -7,7 +7,6 @@ import {
 	reduce,
 	castArray,
 	findIndex,
-	includes,
 	isObjectLike,
 	filter,
 	first,

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -151,6 +151,32 @@ const getValidFromTransformsForSource = ( sourceBlock, isMultiBlock = false ) =>
 };
 
 /**
+ * Returns the names of blocks that the source block can be transformed
+ * into, based on its own 'to' transforms
+ *
+ * @param {Object} sourceBlock The instance of the source block
+ * @param {boolean} isMultiBlock Have multiple blocks been selected?
+ *
+ * @return {Array} An array of block names
+ */
+const getValidToTransformsForSource = ( sourceBlock, isMultiBlock = false ) => {
+	const blockType = getBlockType( sourceBlock.name );
+	const transformsTo = getBlockTransforms( 'to', blockType.name );
+
+	// filter all 'to' transforms to find those that are valid
+	const validTransformsTo = filter(
+		transformsTo,
+		( transform ) => isValidTransformForSource( transform, 'to', sourceBlock, isMultiBlock )
+	);
+
+	// Build a list of block names using the valid 'to' transforms
+	return flatMap(
+		validTransformsTo,
+		( transformation ) => transformation.blocks
+	);
+};
+
+/**
  * Returns an array of possible block transformations that could happen on the
  * set of blocks received as argument.
  *
@@ -164,26 +190,12 @@ export function getPossibleBlockTransformations( blocks ) {
 		return [];
 	}
 	const isMultiBlock = blocks.length > 1;
-	const sourceBlockName = sourceBlock.name;
-
-	if ( isMultiBlock && ! every( blocks, { name: sourceBlockName } ) ) {
+	if ( isMultiBlock && ! every( blocks, { name: sourceBlock.name } ) ) {
 		return [];
 	}
 
 	const blocksToBeTransformedFrom = getValidFromTransformsForSource( sourceBlock, isMultiBlock );
-
-	const blockType = getBlockType( sourceBlockName );
-	const transformsTo = getBlockTransforms( 'to', blockType.name );
-	const validTransformsTo = filter(
-		transformsTo,
-		( transform ) => isValidTransformForSource( transform, 'to', sourceBlock, isMultiBlock )
-	);
-
-	// Generate list of block transformations using the supplied "transforms to".
-	const blocksToBeTransformedTo = flatMap(
-		validTransformsTo,
-		( transformation ) => transformation.blocks
-	);
+	const blocksToBeTransformedTo = getValidToTransformsForSource( sourceBlock, isMultiBlock );
 
 	// Returns a unique list of available block transformations.
 	return reduce( [

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -319,7 +319,7 @@ describe( 'block factory', () => {
 			expect( availableBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
 		} );
 
-		it( 'should show multiple possible transformations"', () => {
+		it( 'should show multiple possible transformations', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {
@@ -337,6 +337,88 @@ describe( 'block factory', () => {
 						blocks: [ 'core/another-text-block' ],
 						transform: noop,
 						isMultiBlock: true,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'core/another-text-block', defaultBlockSettings );
+
+			const block = createBlock( 'core/updated-text-block', {
+				value: 'chicken',
+			} );
+
+			const availableBlocks = getPossibleBlockTransformations( [ block ] );
+
+			expect( availableBlocks ).toHaveLength( 2 );
+			expect( availableBlocks[ 0 ].name ).toBe( 'core/text-block' );
+			expect( availableBlocks[ 1 ].name ).toBe( 'core/another-text-block' );
+		} );
+
+		it( 'should show multiple possible transformations when multiple blocks have a matching `from` transform', () => {
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					from: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						transform: noop,
+						isMultiBlock: false,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/another-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					from: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						transform: noop,
+						isMultiBlock: true,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'another text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const block = createBlock( 'core/text-block', {
+				value: 'chicken',
+			} );
+
+			const availableBlocks = getPossibleBlockTransformations( [ block ] );
+
+			expect( availableBlocks ).toHaveLength( 2 );
+			expect( availableBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
+			expect( availableBlocks[ 1 ].name ).toBe( 'core/another-text-block' );
+		} );
+
+		it( 'should show multiple possible transformations for a single `to` transform object with multiple blocks', () => {
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [ {
+						type: 'block',
+						blocks: [ 'core/text-block', 'core/another-text-block' ],
+						transform: noop,
 					} ],
 				},
 				save: noop,

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -475,7 +475,7 @@ describe( 'block factory', () => {
 			expect( availableBlocks[ 1 ].name ).toBe( 'core/another-text-block' );
 		} );
 
-		it( 'should show multiple possible transformations for a single `to` transform object with multiple blocks', () => {
+		it( 'should show multiple possible transformations for a single `to` transform object with multiple block names', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -628,6 +628,75 @@ describe( 'block factory', () => {
 
 			expect( availableBlocks ).toEqual( [] );
 		} );
+
+		it( 'for a non multiblock transform, the canTransform function receives the source block\'s attributes object as its first argument', () => {
+			const canTransform = jest.fn();
+
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						transform: noop,
+						canTransform,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const block = createBlock( 'core/updated-text-block', {
+				value: 'ribs',
+			} );
+
+			getPossibleBlockTransformations( [ block ] );
+
+			expect( canTransform ).toHaveBeenCalledWith( { value: 'ribs' } );
+		} );
+
+		it( 'for a multiblock transform, the canTransform function receives an array containing every source block\'s attributes as its first argument', () => {
+			const canTransform = jest.fn();
+
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						transform: noop,
+						isMultiBlock: true,
+						canTransform,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const meatBlock = createBlock( 'core/updated-text-block', {
+				value: 'ribs',
+			} );
+
+			const cheeseBlock = createBlock( 'core/updated-text-block', {
+				value: 'halloumi',
+			} );
+
+			getPossibleBlockTransformations( [ meatBlock, cheeseBlock ] );
+
+			expect( canTransform ).toHaveBeenCalledWith( [ { value: 'ribs' }, { value: 'halloumi' } ] );
+		} );
 	} );
 
 	describe( 'switchToBlockType()', () => {

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -506,6 +506,128 @@ describe( 'block factory', () => {
 			expect( availableBlocks[ 0 ].name ).toBe( 'core/text-block' );
 			expect( availableBlocks[ 1 ].name ).toBe( 'core/another-text-block' );
 		} );
+
+		it( 'returns a single transformation for a "from" transform that has a `canTransform` function returning `true`', () => {
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					from: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						transform: noop,
+						canTransform: () => true,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const block = createBlock( 'core/text-block', {
+				value: 'chicken',
+			} );
+
+			const availableBlocks = getPossibleBlockTransformations( [ block ] );
+
+			expect( availableBlocks ).toHaveLength( 1 );
+			expect( availableBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
+		} );
+
+		it( 'returns no transformations for a "from" transform with a `canTransform` function returning `false`', () => {
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					from: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						transform: noop,
+						canTransform: () => false,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const block = createBlock( 'core/text-block', {
+				value: 'chicken',
+			} );
+
+			const availableBlocks = getPossibleBlockTransformations( [ block ] );
+
+			expect( availableBlocks ).toEqual( [] );
+		} );
+
+		it( 'returns a single transformation for a "to" transform that has a `canTransform` function returning `true`', () => {
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						transform: noop,
+						canTransform: () => true,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const block = createBlock( 'core/updated-text-block', {
+				value: 'ribs',
+			} );
+
+			const availableBlocks = getPossibleBlockTransformations( [ block ] );
+
+			expect( availableBlocks ).toHaveLength( 1 );
+			expect( availableBlocks[ 0 ].name ).toBe( 'core/text-block' );
+		} );
+
+		it( 'returns no transformations for a "to" transform with a `canTransform` function returning `false`', () => {
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						transform: noop,
+						canTransform: () => false,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const block = createBlock( 'core/updated-text-block', {
+				value: 'ribs',
+			} );
+
+			const availableBlocks = getPossibleBlockTransformations( [ block ] );
+
+			expect( availableBlocks ).toEqual( [] );
+		} );
 	} );
 
 	describe( 'switchToBlockType()', () => {

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -251,7 +251,7 @@ describe( 'block factory', () => {
 			expect( availableBlocks[ 0 ].name ).toBe( 'core/text-block' );
 		} );
 
-		it( 'should not show a transformation if multiple blocks are passed and the transformation is not multi block', () => {
+		it( 'should not show a transformation if multiple blocks are passed and the transformation is not multi block (for a "from" transform)', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {
@@ -284,7 +284,40 @@ describe( 'block factory', () => {
 			expect( availableBlocks ).toEqual( [] );
 		} );
 
-		it( 'should show a transformation as available if multiple blocks are passed and the transformation accepts multiple blocks', () => {
+		it( 'should not show a transformation if multiple blocks are passed and the transformation is not multi block (for a "to" transform)', () => {
+			registerBlockType( 'core/text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [ {
+						type: 'block',
+						blocks: [ 'core/updated-text-block' ],
+						transform: noop,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
+
+			const block1 = createBlock( 'core/text-block', {
+				value: 'chicken',
+			} );
+
+			const block2 = createBlock( 'core/text-block', {
+				value: 'ribs',
+			} );
+
+			const availableBlocks = getPossibleBlockTransformations( [ block1, block2 ] );
+
+			expect( availableBlocks ).toEqual( [] );
+		} );
+
+		it( 'should show a transformation as available if multiple blocks are passed and the transformation accepts multiple blocks (for a "from" transform)', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {
@@ -304,6 +337,41 @@ describe( 'block factory', () => {
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const block1 = createBlock( 'core/text-block', {
+				value: 'chicken',
+			} );
+
+			const block2 = createBlock( 'core/text-block', {
+				value: 'ribs',
+			} );
+
+			const availableBlocks = getPossibleBlockTransformations( [ block1, block2 ] );
+
+			expect( availableBlocks ).toHaveLength( 1 );
+			expect( availableBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
+		} );
+
+		it( 'should show a transformation as available if multiple blocks are passed and the transformation accepts multiple blocks (for a "to" transform)', () => {
+			registerBlockType( 'core/text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [ {
+						type: 'block',
+						blocks: [ 'core/updated-text-block' ],
+						transform: noop,
+						isMultiBlock: true,
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 
 			const block1 = createBlock( 'core/text-block', {
 				value: 'chicken',

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -507,7 +507,7 @@ describe( 'block factory', () => {
 			expect( availableBlocks[ 1 ].name ).toBe( 'core/another-text-block' );
 		} );
 
-		it( 'returns a single transformation for a "from" transform that has a `canTransform` function returning `true`', () => {
+		it( 'returns a single transformation for a "from" transform that has a `isMatch` function returning `true`', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {
@@ -519,7 +519,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
 						transform: noop,
-						canTransform: () => true,
+						isMatch: () => true,
 					} ],
 				},
 				save: noop,
@@ -538,7 +538,7 @@ describe( 'block factory', () => {
 			expect( availableBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
 		} );
 
-		it( 'returns no transformations for a "from" transform with a `canTransform` function returning `false`', () => {
+		it( 'returns no transformations for a "from" transform with a `isMatch` function returning `false`', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {
@@ -550,7 +550,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
 						transform: noop,
-						canTransform: () => false,
+						isMatch: () => false,
 					} ],
 				},
 				save: noop,
@@ -568,7 +568,7 @@ describe( 'block factory', () => {
 			expect( availableBlocks ).toEqual( [] );
 		} );
 
-		it( 'returns a single transformation for a "to" transform that has a `canTransform` function returning `true`', () => {
+		it( 'returns a single transformation for a "to" transform that has a `isMatch` function returning `true`', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {
@@ -580,7 +580,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
 						transform: noop,
-						canTransform: () => true,
+						isMatch: () => true,
 					} ],
 				},
 				save: noop,
@@ -599,7 +599,7 @@ describe( 'block factory', () => {
 			expect( availableBlocks[ 0 ].name ).toBe( 'core/text-block' );
 		} );
 
-		it( 'returns no transformations for a "to" transform with a `canTransform` function returning `false`', () => {
+		it( 'returns no transformations for a "to" transform with a `isMatch` function returning `false`', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {
@@ -611,7 +611,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
 						transform: noop,
-						canTransform: () => false,
+						isMatch: () => false,
 					} ],
 				},
 				save: noop,
@@ -629,8 +629,8 @@ describe( 'block factory', () => {
 			expect( availableBlocks ).toEqual( [] );
 		} );
 
-		it( 'for a non multiblock transform, the canTransform function receives the source block\'s attributes object as its first argument', () => {
-			const canTransform = jest.fn();
+		it( 'for a non multiblock transform, the isMatch function receives the source block\'s attributes object as its first argument', () => {
+			const isMatch = jest.fn();
 
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
@@ -643,7 +643,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
 						transform: noop,
-						canTransform,
+						isMatch,
 					} ],
 				},
 				save: noop,
@@ -658,11 +658,11 @@ describe( 'block factory', () => {
 
 			getPossibleBlockTransformations( [ block ] );
 
-			expect( canTransform ).toHaveBeenCalledWith( { value: 'ribs' } );
+			expect( isMatch ).toHaveBeenCalledWith( { value: 'ribs' } );
 		} );
 
-		it( 'for a multiblock transform, the canTransform function receives an array containing every source block\'s attributes as its first argument', () => {
-			const canTransform = jest.fn();
+		it( 'for a multiblock transform, the isMatch function receives an array containing every source block\'s attributes as its first argument', () => {
+			const isMatch = jest.fn();
 
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
@@ -676,7 +676,7 @@ describe( 'block factory', () => {
 						blocks: [ 'core/text-block' ],
 						transform: noop,
 						isMultiBlock: true,
-						canTransform,
+						isMatch,
 					} ],
 				},
 				save: noop,
@@ -695,7 +695,7 @@ describe( 'block factory', () => {
 
 			getPossibleBlockTransformations( [ meatBlock, cheeseBlock ] );
 
-			expect( canTransform ).toHaveBeenCalledWith( [ { value: 'ribs' }, { value: 'halloumi' } ] );
+			expect( isMatch ).toHaveBeenCalledWith( [ { value: 'ribs' }, { value: 'halloumi' } ] );
 		} );
 	} );
 

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -119,7 +124,7 @@ export const settings = {
 					}
 					const { getMedia } = select( 'core' );
 					const media = getMedia( id );
-					return media && media.mime_type.indexOf( 'audio' ) > -1;
+					return !! media && includes( media.mime_type, 'audio' );
 				},
 				transform: ( attributes ) => {
 					return createBlock( 'core/audio', {
@@ -138,7 +143,7 @@ export const settings = {
 					}
 					const { getMedia } = select( 'core' );
 					const media = getMedia( id );
-					return media && media.mime_type.indexOf( 'video' ) > -1;
+					return !! media && includes( media.mime_type, 'video' );
 				},
 				transform: ( attributes ) => {
 					return createBlock( 'core/video', {

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -118,7 +118,7 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/audio' ],
-				canTransform: ( { id } ) => {
+				isMatch: ( { id } ) => {
 					if ( ! id ) {
 						return false;
 					}
@@ -137,7 +137,7 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/video' ],
-				canTransform: ( { id } ) => {
+				isMatch: ( { id } ) => {
 					if ( ! id ) {
 						return false;
 					}

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -112,6 +113,14 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/audio' ],
+				canTransform: ( { id } ) => {
+					if ( ! id ) {
+						return false;
+					}
+					const { getMedia } = select( 'core' );
+					const media = getMedia( id );
+					return media && media.mime_type.indexOf( 'audio' ) > -1;
+				},
 				transform: ( attributes ) => {
 					return createBlock( 'core/audio', {
 						src: attributes.href,
@@ -123,6 +132,14 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/video' ],
+				canTransform: ( { id } ) => {
+					if ( ! id ) {
+						return false;
+					}
+					const { getMedia } = select( 'core' );
+					const media = getMedia( id );
+					return media && media.mime_type.indexOf( 'video' ) > -1;
+				},
 				transform: ( attributes ) => {
 					return createBlock( 'core/video', {
 						src: attributes.href,

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -267,6 +267,47 @@ transforms: {
 ```
 {% end %}
 
+An optional `isMatch` function can be specified on a transform object. This provides an opportunity to perform additional checks on whether a transform should be possible. Returning `false` from this function will prevent the transform from being displayed as an option to the user.
+
+{% codetabs %}
+{% ES5 %}
+```js
+transforms: {
+    to: [
+        {
+            type: 'block',
+			blocks: [ 'core/paragraph' ],
+			isMatch: function( attribute ) {
+				return attributes.isText;
+			},
+            transform: function( content ) {
+                return createBlock( 'core/paragraph', {
+                    content,
+                } );
+            },
+        },
+    ],
+},
+```
+{% ESNext %}
+```js
+transforms: {
+    to: [
+        {
+            type: 'block',
+			blocks: [ 'core/paragraph' ],
+			isMatch: ( { isText } ) => isText,
+            transform: ( { content } ) => {
+                return createBlock( 'core/paragraph', {
+                    content,
+                } );
+            },
+        },
+    ],
+},
+```
+{% end %}
+
 To control the priority with which a transform is applied, define a `priority` numeric property on your transform object, where a lower value will take precedence over higher values. This behaves much like a [WordPress hook](https://codex.wordpress.org/Plugin_API#Hook_to_WordPress). Like hooks, the default priority is `10` when not otherwise set.
 
 


### PR DESCRIPTION
## Description
closes #7625

Presently, file blocks can be transformed into audio or video blocks even if the uploaded file type is not audio or video.

We need a mechanism to restrict a transform from being displayed based on the source block's current state (or attributes).

This PR allows for an `isMatch` property to be specified on the transform object for block type transforms. This property can be specified as a function which receives the source block's attributes and returns a boolean indicating whether the transform is possible.

Furthermore, `isMatch` functions are added to prevent transformations from file blocks to audio and video blocks unless the uploaded file types are audio and video blocks.

## Screenshot
![file-block-transforms](https://user-images.githubusercontent.com/677833/42369165-b8567098-813b-11e8-95fb-1d65345e861a.gif)

## How has this been tested?
- Used a TDD approach to ensure existing functionality isn't broken
- Manual testing

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
New feature - adds new functionality, but doesn't break existing functionality
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
