### PR TITLE
Block warning: add ellipsis menu and convert to classic block

### DIFF
--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -20,7 +20,7 @@ function BlockInvalidWarning( { convertToHTML, convertToBlocks } ) {
 
 	return (
 		<Warning
-			actions={ [
+			primaryActions={ [
 				<Button key="convert" onClick={ convertToBlocks } isLarge isPrimary={ ! hasHTMLBlock }>
 					{ __( 'Convert to Blocks' ) }
 				</Button>,

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -15,7 +15,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import Warning from '../warning';
 
-function BlockInvalidWarning( { convertToHTML, convertToBlocks } ) {
+function BlockInvalidWarning( { convertToHTML, convertToBlocks, convertToClassic } ) {
 	const hasHTMLBlock = !! getBlockType( 'core/html' );
 
 	return (
@@ -30,6 +30,10 @@ function BlockInvalidWarning( { convertToHTML, convertToBlocks } ) {
 					</Button>
 				),
 			] }
+			hiddenActions={ [
+				{ title: __( 'Convert to Blocks' ), onClick: convertToBlocks },
+				{ title: __( 'Convert to Classic Block' ), onClick: convertToClassic },
+			] }
 		>
 			{ __( 'This block has been modified externally.' ) }
 		</Warning>
@@ -39,6 +43,11 @@ function BlockInvalidWarning( { convertToHTML, convertToBlocks } ) {
 export default withDispatch( ( dispatch, { block } ) => {
 	const { replaceBlock } = dispatch( 'core/editor' );
 	return {
+		convertToClassic() {
+			replaceBlock( block.uid, createBlock( 'core/freeform', {
+				content: block.originalContent,
+			} ) );
+		},
 		convertToHTML() {
 			replaceBlock( block.clientId, createBlock( 'core/html', {
 				content: block.originalContent,

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -30,7 +30,7 @@ function BlockInvalidWarning( { convertToHTML, convertToBlocks, convertToClassic
 					</Button>
 				),
 			] }
-			hiddenActions={ [
+			secondaryActions={ [
 				{ title: __( 'Convert to Blocks' ), onClick: convertToBlocks },
 				{ title: __( 'Convert to Classic Block' ), onClick: convertToClassic },
 			] }

--- a/packages/editor/src/components/warning/index.js
+++ b/packages/editor/src/components/warning/index.js
@@ -7,16 +7,18 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Children } from '@wordpress/element';
+import { Dropdown, IconButton, MenuGroup, MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
-function Warning( { className, actions, children } ) {
+function Warning( { className, primaryActions, children, hiddenActions } ) {
 	return (
 		<div className={ classnames( className, 'editor-warning' ) }>
 			<div className="editor-warning__contents">
 				<p className="editor-warning__message">{ children }</p>
 
-				{ Children.count( actions ) > 0 && (
+				{ Children.count( primaryActions ) > 0 && (
 					<div className="editor-warning__actions">
-						{ Children.map( actions, ( action, i ) => (
+						{ Children.map( primaryActions, ( action, i ) => (
 							<span key={ i } className="editor-warning__action">
 								{ action }
 							</span>
@@ -24,6 +26,34 @@ function Warning( { className, actions, children } ) {
 					</div>
 				) }
 			</div>
+
+			{ hiddenActions && (
+				<div className="editor-warning__hidden">
+					<Dropdown
+						className="edit-post-more-menu"
+						position="bottom left"
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<IconButton
+								icon="ellipsis"
+								label={ __( 'More options' ) }
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+							/>
+						) }
+						renderContent={ () => (
+							<div className="edit-post-more-menu__content">
+								<MenuGroup label={ __( 'More options' ) }>
+									{ hiddenActions.map( ( item, pos ) =>
+										<MenuItem onClick={ item.onClick } key={ pos }>
+											{ item.title }
+										</MenuItem>
+									) }
+								</MenuGroup>
+							</div>
+						) }
+					/>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/packages/editor/src/components/warning/index.js
+++ b/packages/editor/src/components/warning/index.js
@@ -28,31 +28,27 @@ function Warning( { className, primaryActions, children, secondaryActions } ) {
 			</div>
 
 			{ secondaryActions && (
-				<div className="editor-warning__hidden">
-					<Dropdown
-						className="edit-post-more-menu"
-						position="bottom left"
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<IconButton
-								icon="ellipsis"
-								label={ __( 'More options' ) }
-								onClick={ onToggle }
-								aria-expanded={ isOpen }
-							/>
-						) }
-						renderContent={ () => (
-							<div className="edit-post-more-menu__content">
-								<MenuGroup label={ __( 'More options' ) }>
-									{ secondaryActions.map( ( item, pos ) =>
-										<MenuItem onClick={ item.onClick } key={ pos }>
-											{ item.title }
-										</MenuItem>
-									) }
-								</MenuGroup>
-							</div>
-						) }
-					/>
-				</div>
+				<Dropdown
+					className="editor-warning__secondary"
+					position="bottom left"
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<IconButton
+							icon="ellipsis"
+							label={ __( 'More options' ) }
+							onClick={ onToggle }
+							aria-expanded={ isOpen }
+						/>
+					) }
+					renderContent={ () => (
+						<MenuGroup label={ __( 'More options' ) }>
+							{ secondaryActions.map( ( item, pos ) =>
+								<MenuItem onClick={ item.onClick } key={ pos }>
+									{ item.title }
+								</MenuItem>
+							) }
+						</MenuGroup>
+					) }
+				/>
 			) }
 		</div>
 	);

--- a/packages/editor/src/components/warning/index.js
+++ b/packages/editor/src/components/warning/index.js
@@ -10,7 +10,7 @@ import { Children } from '@wordpress/element';
 import { Dropdown, IconButton, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function Warning( { className, primaryActions, children, hiddenActions } ) {
+function Warning( { className, primaryActions, children, secondaryActions } ) {
 	return (
 		<div className={ classnames( className, 'editor-warning' ) }>
 			<div className="editor-warning__contents">
@@ -27,7 +27,7 @@ function Warning( { className, primaryActions, children, hiddenActions } ) {
 				) }
 			</div>
 
-			{ hiddenActions && (
+			{ secondaryActions && (
 				<div className="editor-warning__hidden">
 					<Dropdown
 						className="edit-post-more-menu"
@@ -43,7 +43,7 @@ function Warning( { className, primaryActions, children, hiddenActions } ) {
 						renderContent={ () => (
 							<div className="edit-post-more-menu__content">
 								<MenuGroup label={ __( 'More options' ) }>
-									{ hiddenActions.map( ( item, pos ) =>
+									{ secondaryActions.map( ( item, pos ) =>
 										<MenuItem onClick={ item.onClick } key={ pos }>
 											{ item.title }
 										</MenuItem>

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -31,4 +31,8 @@
 		margin: 0 6px 0 0;
 		margin-left: 0;
 	}
+
+	.editor-warning__hidden {
+		margin-top: 3px;
+	}
 }

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -31,8 +31,26 @@
 		margin: 0 6px 0 0;
 		margin-left: 0;
 	}
+}
 
-	.editor-warning__hidden {
-		margin-top: 3px;
+.editor-warning__secondary {
+	margin: 3px 0 0 -4px;
+
+	// the padding and margin of the more menu is intentionally non-standard
+	.components-icon-button {
+		width: auto;
+		padding: 8px 2px;
+	}
+
+	@include break-small() {
+		margin-left: 4px;
+
+		.components-icon-button {
+			padding: 8px 4px;
+		}
+	}
+
+	.components-button svg {
+		transform: rotate(90deg);
 	}
 }

--- a/packages/editor/src/components/warning/test/index.js
+++ b/packages/editor/src/components/warning/test/index.js
@@ -15,15 +15,16 @@ describe( 'Warning', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'should has valid class', () => {
+	it( 'should have valid class', () => {
 		const wrapper = shallow( <Warning /> );
 
 		expect( wrapper.hasClass( 'editor-warning' ) ).toBe( true );
 		expect( wrapper.find( '.editor-warning__actions' ) ).toHaveLength( 0 );
+		expect( wrapper.find( '.editor-warning__hidden' ) ).toHaveLength( 0 );
 	} );
 
 	it( 'should show child error message element', () => {
-		const wrapper = shallow( <Warning actions={ <button /> }>Message</Warning> );
+		const wrapper = shallow( <Warning primaryActions={ <button /> }>Message</Warning> );
 
 		const actions = wrapper.find( '.editor-warning__actions' );
 		const action = actions.childAt( 0 );
@@ -31,5 +32,13 @@ describe( 'Warning', () => {
 		expect( actions ).toHaveLength( 1 );
 		expect( action.hasClass( 'editor-warning__action' ) ).toBe( true );
 		expect( action.childAt( 0 ).type() ).toBe( 'button' );
+	} );
+
+	it( 'should show hidden actions', () => {
+		const wrapper = shallow( <Warning hiddenActions={ [ { title: 'test', onClick: null } ] }>Message</Warning> );
+
+		const actions = wrapper.find( '.editor-warning__hidden' );
+
+		expect( actions ).toHaveLength( 1 );
 	} );
 } );

--- a/packages/editor/src/components/warning/test/index.js
+++ b/packages/editor/src/components/warning/test/index.js
@@ -35,7 +35,7 @@ describe( 'Warning', () => {
 	} );
 
 	it( 'should show hidden actions', () => {
-		const wrapper = shallow( <Warning hiddenActions={ [ { title: 'test', onClick: null } ] }>Message</Warning> );
+		const wrapper = shallow( <Warning secondaryActions={ [ { title: 'test', onClick: null } ] }>Message</Warning> );
 
 		const actions = wrapper.find( '.editor-warning__hidden' );
 

--- a/packages/editor/src/components/warning/test/index.js
+++ b/packages/editor/src/components/warning/test/index.js
@@ -37,7 +37,7 @@ describe( 'Warning', () => {
 	it( 'should show hidden actions', () => {
 		const wrapper = shallow( <Warning secondaryActions={ [ { title: 'test', onClick: null } ] }>Message</Warning> );
 
-		const actions = wrapper.find( '.editor-warning__hidden' );
+		const actions = wrapper.find( '.editor-warning__secondary' );
 
 		expect( actions ).toHaveLength( 1 );
 	} );


### PR DESCRIPTION
## Description
Add the ability for a block warning message to show a list of additional actions that are hidden behind a dropdown ellipsis menu. This will be used to expand the options available to a user when an invalid block is detected.

The '_convert to blocks_' option is copied into this menu, along with a new '_convert to classic block_' option. This matches the mockup in #7604. More options will be added in future PRs

![another_post___ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/43129377-2d237a76-8f2c-11e8-865a-74ce0525162b.jpg)

## How has this been tested?

Extra unit tests have been added to verify when the ellipsis menu appears.

`npm run test warning`

## Types of changes

A non-breaking new feature is added to an existing component. The `Warning` component is used by:

- `BlockInvalidWarning`
- `BlockCrashWarning`

To test `BlockInvalidWarning`:
- Create a paragraph
- Edit as HTML and remove the trailing `</p>` to trigger the block validation message
- Verify that the invalid block message is displayed with a new ellipsis menu:
![another_post___ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/42573058-fbded00a-8512-11e8-9cf8-e09fa7ef20d4.jpg)
- Verify that reducing the page width causes the primary buttons to move onto the next line, but the ellipsis menu remains on the right:
![another_post___ _wordpress_latest_ _wordpress_and_gutenberg_ _update_block-warning-options__origin_update_block-warning-options__7169_commits_](https://user-images.githubusercontent.com/1277682/42573270-86a6348a-8513-11e8-945f-837c24ab975a.jpg)
- Verify that clicking 'convert to block' from the ellipsis menu performs the same action as the 'convert to block' button
- Verify that clicking 'convert to classic block' converts it to a classic block

To test `BlockCrashWarning`:
- From a developer console type `wp.blocks.registerBlockType( 'myplugin/mr-crashy', { title: 'Mr. Crashy', category: 'common', icon: 'warning', edit() { throw new Error(); }, save() { return ''; } } );`
- Add `Mr Crashy` block to a post
- Verify that the crash message is displayed without changes:
![another_post___ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/42457439-6470a68c-838f-11e8-9cf8-3b6a4f49f695.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
