### PR TITLE
Data: Schedule render by store update via setState

### DIFF
--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -307,25 +307,26 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			this.unsubscribe();
 		}
 
-		shouldComponentUpdate( nextProps ) {
-			// This implementation of shouldComponentUpdate is only intended
-			// to handle incoming props changes. Changes effected via state
-			// changes are reflected by the subscribe handler's forceUpdate.
-			if ( isShallowEqual( this.props, nextProps ) ) {
+		shouldComponentUpdate( nextProps, nextState ) {
+			const hasPropsChanged = ! isShallowEqual( this.props, nextProps );
+
+			// Only render if result of props change or merge props update
+			// from store subscriber.
+			if ( this.state === nextState && ! hasPropsChanged ) {
 				return false;
 			}
 
-			// Regardless of whether merge props are changing, the component
-			// will need to render if props are different. But if the merge
-			// props change as a result of the incoming props, they should be
-			// reflected as such in the next render.
-			const nextMergeProps = getNextMergeProps( nextProps );
-			if ( ! isShallowEqual( this.mergeProps, nextMergeProps ) ) {
-				// Yes, this is a side effect. Yes, side effects don't belong
-				// in shouldComponentUpdate. This is not a typical component in
-				// that it is very much a hot code path, and will employ any
-				// and all gymnastics necessary for optimal performance.
-				this.mergeProps = nextMergeProps;
+			// If merge props change as a result of the incoming props, they
+			// should be reflected as such in the upcoming render.
+			if ( hasPropsChanged ) {
+				const nextMergeProps = getNextMergeProps( nextProps );
+				if ( ! isShallowEqual( this.mergeProps, nextMergeProps ) ) {
+					// While side effects are typically discouraged in this
+					// lifecycle methods, this component is very much on a hot
+					// code path. Prior efforts to use getDerivedStateFromProps
+					// have demonstrated miserable performance.
+					this.mergeProps = nextMergeProps;
+				}
 			}
 
 			return true;
@@ -344,10 +345,15 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 
 				this.mergeProps = nextMergeProps;
 
-				// forceUpdate is used to intentionally bypass the default
-				// behavior of shouldComponentUpdate, which in this component
-				// is specifically designed to handle only props changes.
-				this.forceUpdate();
+				// Schedule an update. Merge props are not assigned to state
+				// because derivation of merge props from incoming props occurs
+				// within shouldComponentUpdate, where setState is not allowed.
+				// setState is used here instead of forceUpdate because via the
+				// latter, shouldComponentUpdate will be bypassed altogether.
+				// This isn't desireable if both state and props change within
+				// within the same render. Unfortunately this will also require
+				// that next merge props are generated twice.
+				this.setState( {} );
 			} );
 		}
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -310,8 +310,8 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 		shouldComponentUpdate( nextProps, nextState ) {
 			const hasPropsChanged = ! isShallowEqual( this.props, nextProps );
 
-			// Only render if result of props change or merge props update
-			// from store subscriber.
+			// Only render if props have changed or merge props have been updated
+			// from the store subscriber.
 			if ( this.state === nextState && ! hasPropsChanged ) {
 				return false;
 			}
@@ -321,10 +321,11 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 			if ( hasPropsChanged ) {
 				const nextMergeProps = getNextMergeProps( nextProps );
 				if ( ! isShallowEqual( this.mergeProps, nextMergeProps ) ) {
-					// While side effects are typically discouraged in this
-					// lifecycle methods, this component is very much on a hot
-					// code path. Prior efforts to use getDerivedStateFromProps
-					// have demonstrated miserable performance.
+					// Side effects are typically discouraged in lifecycle methods, but
+					// this component is heavily used and this is the most performant
+					// code we've found thus far.
+					// Prior efforts to use `getDerivedStateFromProps` have demonstrated
+					// miserable performance.
 					this.mergeProps = nextMergeProps;
 				}
 			}
@@ -348,11 +349,11 @@ export const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( W
 				// Schedule an update. Merge props are not assigned to state
 				// because derivation of merge props from incoming props occurs
 				// within shouldComponentUpdate, where setState is not allowed.
-				// setState is used here instead of forceUpdate because via the
-				// latter, shouldComponentUpdate will be bypassed altogether.
-				// This isn't desireable if both state and props change within
-				// within the same render. Unfortunately this will also require
-				// that next merge props are generated twice.
+				// setState is used here instead of forceUpdate because forceUpdate
+				// bypasses shouldComponentUpdate altogether, which isn't desireable
+				// if both state and props change within the same render.
+				// Unfortunately this requires that next merge props are generated
+				// twice.
 				this.setState( {} );
 			} );
 		}


### PR DESCRIPTION
Fixes #7722

This pull request seeks to resolve an issue with `withSelect` state derivations where a subscribe update could be called with old versions of `this.props` during a scheduled update. Its subsequent `forceUpdate` would thereby prevent the default `shouldComponentUpdate` from taking place, where new props would be expected to be accounted for. The revised implementation here uses `setState` with awareness of the state change by referential equality condition to allow a props change to be accounted for after the subscribe.

**Implementation notes:**

I have thus far been unsuccessful in recreating this via a failing unit test. It's unclear if the render reconciliation flow is different in Enzyme / `react-test-renderer`. Neither have shown promise. The general idea would be that a prop update from a parent would be applied _after_ a child had already triggered `forceUpdate`, and this prop update should but does not have an impact on the `getDerivedStateFromProps`. In the case of #7722, this prop is `lastBlockUID`, where the presence of a previous default block should be preventing the appender from being shown.

The specific handling in React where `shouldComponentUpdate` is being skipped occurs here:

https://github.com/facebook/react/blob/4fe6eec15bc69737910e5c6c749ebc6187d67be0/packages/react-reconciler/src/ReactFiberClassComponent.js#L816-L825

I had explored a number of alternative approaches here, none of which proved to provide stability in ensuring (a) synchronous application of state changes (otherwise resulting in strange behaviors like caret positioning shifting) or (b) major performance regressions.

See: https://gist.github.com/aduth/0b5b6ed26acbbf2f6387cb46d42059fe

**Testing instructions:**

Repeat Steps to Reproduce from #7722, verifying that no ghost appender appears.

Ensure unit tests pass:

```
npm run test-unit
```

Verify there are no performance regressions by typing within the Demo post.