### PR TITLE
Restore captions for image and embed

### DIFF
--- a/core-blocks/embed/index.js
+++ b/core-blocks/embed/index.js
@@ -26,7 +26,6 @@ import apiRequest from '@wordpress/api-request';
  */
 import './style.scss';
 import './editor.scss';
-import './theme.scss';
 
 // These embeds do not work in sandboxes
 const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];

--- a/core-blocks/embed/style.scss
+++ b/core-blocks/embed/style.scss
@@ -6,3 +6,12 @@
 	max-width: $content-width / 2;
 	width: 100%;
 }
+
+.wp-block-embed {
+	// Supply caption styles to images, even if the theme hasn't opted in.
+	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those.
+	figcaption {
+		@include caption-style();
+	}
+}

--- a/core-blocks/embed/theme.scss
+++ b/core-blocks/embed/theme.scss
@@ -1,3 +1,0 @@
-.wp-block-embed figcaption {
-	@include caption-style();
-}

--- a/core-blocks/image/index.js
+++ b/core-blocks/image/index.js
@@ -20,7 +20,6 @@ import { createBlobURL } from '@wordpress/blob';
  * Internal dependencies
  */
 import './style.scss';
-import './theme.scss';
 import edit from './edit';
 
 export const name = 'core/image';

--- a/core-blocks/image/style.scss
+++ b/core-blocks/image/style.scss
@@ -23,4 +23,11 @@
 			max-width: none;
 		}
 	}
+
+	// Supply caption styles to images, even if the theme hasn't opted in.
+	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those.
+	figcaption {
+		@include caption-style();
+	}
 }

--- a/core-blocks/image/theme.scss
+++ b/core-blocks/image/theme.scss
@@ -1,5 +1,0 @@
-.wp-block-image {
-	figcaption {
-		@include caption-style();
-	}
-}


### PR DESCRIPTION
This PR is a followup to #7624.

It adds back the caption styles for images and embeds. This is because the majority of existing themes won't have styles to accommodate the new `figcaption` markup, and are likely to be styling the WP Captions instead. For those themes, if the caption styles live in the `theme.scss` file, the captions will appear unstyled or broken.

Some time in the future, this can possibly be revisited and shuffled around.

![screen shot 2018-07-06 at 17 13 57](https://user-images.githubusercontent.com/1204802/42386640-57b2cc82-8140-11e8-8f7e-14beeea81218.png)
