### PR TITLE
chore: Use 4 columns for tab indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,8 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
+indent_size = tab
+tab_width = 4
 
 [*.yml]
 indent_style = space


### PR DESCRIPTION
In the interest of [receiving less shame images](https://github.com/WordPress/gutenberg/pull/7746#issuecomment-403033120) and more consistency in our newlines for comments/bode, I propose we set a consistent column width for tabs in our code.

I've been running tabs in Gutenberg and other WordPress projects, but I kept my tab column width at 2 spaces because that's what other JS projects tend to use and I'm used to it. It seems 4-column-width, hard tabs are the WordPress norm, so we should have people's editors respect that.