### PR TITLE
Convert snapshots to use react-test-renderer/shallow (core-blocks/more/test/edit.js)

### DIFF
--- a/core-blocks/more/test/edit.js
+++ b/core-blocks/more/test/edit.js
@@ -18,12 +18,12 @@ describe( 'core/more/edit', () => {
 		attributes.noTeaser = false;
 	} );
 	test( 'should match snapshot when noTeaser is false', () => {
-		const wrapper = ShallowRenderer.render( <MoreEdit attributes={ attributes } /> );
+		ShallowRenderer.render( <MoreEdit attributes={ attributes } /> );
 		expect( ShallowRenderer.getRenderOutput() ).toMatchSnapshot();
 	} );
 	test( 'should match snapshot when noTeaser is true', () => {
 		attributes.noTeaser = true;
-		const wrapper = ShallowRenderer.render( <MoreEdit attributes={ attributes } /> );
+		ShallowRenderer.render( <MoreEdit attributes={ attributes } /> );
 		expect( ShallowRenderer.getRenderOutput() ).toMatchSnapshot();
 	} );
 } );

--- a/core-blocks/more/test/edit.js
+++ b/core-blocks/more/test/edit.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import Shallow from 'react-test-renderer/shallow';
+const ShallowRenderer = new Shallow();
 /**
  * Internal dependencies
  */
@@ -17,12 +18,12 @@ describe( 'core/more/edit', () => {
 		attributes.noTeaser = false;
 	} );
 	test( 'should match snapshot when noTeaser is false', () => {
-		const wrapper = shallow( <MoreEdit attributes={ attributes } /> );
-		expect( wrapper ).toMatchSnapshot();
+		const wrapper = ShallowRenderer.render( <MoreEdit attributes={ attributes } /> );
+		expect( ShallowRenderer.getRenderOutput() ).toMatchSnapshot();
 	} );
 	test( 'should match snapshot when noTeaser is true', () => {
 		attributes.noTeaser = true;
-		const wrapper = shallow( <MoreEdit attributes={ attributes } /> );
-		expect( wrapper ).toMatchSnapshot();
+		const wrapper = ShallowRenderer.render( <MoreEdit attributes={ attributes } /> );
+		expect( ShallowRenderer.getRenderOutput() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
Note: with react-test-renderer, the current version of the jest pretty-format module does not handle pretty names for `React.Fragment` and `React.forwardRef`.  Thus the snapshot results in `<Undefined>` for related components in the rendered tree for the formats.  

I've confirmed that updating the react element serializer in the pretty-format package (via manually editing it in `node_modules`) to the latest as it is [here](https://github.com/facebook/jest/blob/master/packages/pretty-format/src/plugins/react_element.js) fixes it.  I'm not quite sure what is setting up this dependency so some assistance will be needed to get the related modules updated so the new pretty-format serializer is being used.

I did not update the snapshot in this pull yet until that is resolved.

## Tests with snapshots to update when Jest has been updated:

* [x] `core-blocks/more/test/edit.js`
* [ ] `editor/components/block-switcher/test/multi-blocks-switcher.js`
* [ ] `editor/components/default-block-appender/test/index.js`
* [ ] `editor/components/post-saved-state/test/index.js`
