### PR TITLE
Polish/relative font sizes

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -179,7 +179,7 @@
 		height: 24px;
 		line-height: 22px;
 		padding: 0 8px 1px;
-		font-size: 11px;
+		font-size: 0.6875em;
 	}
 }
 

--- a/core-blocks/paragraph/style.scss
+++ b/core-blocks/paragraph/style.scss
@@ -1,18 +1,18 @@
 p {
 	&.is-small-text {
-		font-size: 14px;
+		font-size: 0.875em;
 	}
 
 	&.is-regular-text {
-		font-size: 16px;
+		font-size: 1em;
 	}
 
 	&.is-large-text {
-		font-size: 36px;
+		font-size: 2.25em;
 	}
 
 	&.is-larger-text {
-		font-size: 48px;
+		font-size: 3em;
 	}
 
 	// Don't show the drop cap when editing the paragraph's content. It causes a


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
In the paragraph and button blocks this replaces the font-size utility classes to use relative font-sizes, `em`s. I've based the sizes of a `16px` base as that matches the editor default styles.

In the editor the changes have no visual affect, on the front end they do if the theme has a different base font-size such as twenty-seventeen.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Visually tested master against this branch.

## Screenshots <!-- if applicable -->

<img width="1012" alt="opinionated_paragraphs___ _wordpress_site_ _wordpress_and_unopinionated_paragraphs___ _wordpress_site_ _wordpress_and_gutenberg_ _master__upstream_master__6689_commits_" src="https://user-images.githubusercontent.com/519727/42407166-962f09de-81fa-11e8-9796-38e57b2d63b0.png">



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
