### PR TITLE
Convert tests using enzyme to use react-test-renderer instead (components/inserter/test/menu.js)

### DIFF
--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -91,7 +91,7 @@ const items = [
 	sharedItem,
 ];
 
-const defaultProps = {
+const DEFAULT_PROPS = {
 	position: 'top center',
 	instanceID: 1,
 	items: items,
@@ -100,16 +100,14 @@ const defaultProps = {
 	setTimeout: noop,
 };
 
-let wrapper;
-
-const setWrapperForProps = ( propOverrides ) => {
-	wrapper = TestUtils.renderIntoDocument(
-		<InserterMenu { ...defaultProps } { ...propOverrides } />
+const getWrapperForProps = ( propOverrides ) => {
+	return TestUtils.renderIntoDocument(
+		<InserterMenu { ...DEFAULT_PROPS } { ...propOverrides } />
 	);
 };
 
 const initializeMenuDefaultStateAndReturnElement = ( propOverrides ) => {
-	setWrapperForProps( propOverrides );
+	const wrapper = getWrapperForProps( propOverrides );
 	/* eslint-disable react/no-find-dom-node */
 	return ReactDOM.findDOMNode( wrapper );
 	/* eslint-enable react/no-find-dom-node */

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -141,7 +141,8 @@ describe( 'InserterMenu', () => {
 
 		const activeCategory = wrapper.root.find( ( node ) => {
 			return node.props.className &&
-				node.props.className.includes( 'components-panel__body is-opened' );
+				node.props.className.includes( 'components-panel__body' ) &&
+				node.props.className.includes( 'is-opened' );
 		} ).find( ( node ) => {
 			return node.props.className &&
 				node.props.className.includes( 'components-panel__body-title' );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This pull converts all usage of enzyme for tests in `components/inserter/test/menu.js` to use `react-test-renderer` instead.  This is because enzyme does not support React 16.3+ (and movement to do so is really slow).  This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
