### PR TITLE
Replace "Fix toolbar" with "Stick toolbar"

### DIFF
--- a/edit-post/components/header/fixed-toolbar-toggle/index.js
+++ b/edit-post/components/header/fixed-toolbar-toggle/index.js
@@ -18,7 +18,7 @@ function FixedToolbarToggle( { onToggle, isActive } ) {
 			isSelected={ isActive }
 			onClick={ onToggle }
 		>
-			{ __( 'Fix Toolbar to Top' ) }
+			{ __( 'Stick Toolbar to Top' ) }
 		</MenuItem>
 	);
 }

--- a/test/e2e/specs/managing-links.test.js
+++ b/test/e2e/specs/managing-links.test.js
@@ -12,7 +12,7 @@ describe( 'Managing links', () => {
 
 	const setFixedToolbar = async ( b ) => {
 		await page.click( '.edit-post-more-menu button' );
-		const button = ( await page.$x( '//button[contains(text(), \'Fix Toolbar to Top\')]' ) )[ 0 ];
+		const button = ( await page.$x( '//button[contains(text(), \'Stick Toolbar to Top\')]' ) )[ 0 ];
 		const buttonClassNameProperty = await button.getProperty( 'className' );
 		const buttonClassName = await buttonClassNameProperty.jsonValue();
 		const isSelected = buttonClassName.indexOf( 'is-selected' ) !== -1;


### PR DESCRIPTION
## Description
Fix #7709 
I feel like "Stick toolbar" is the most appropriate word in this situation rather than "Fix" or "Dock".

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
