### PR TITLE
[Enhancement] Allow transformation of image block to file block and vice-versa

### DIFF
--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -168,6 +168,14 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/image' ],
+				isMatch: ( { id } ) => {
+					if ( ! id ) {
+						return false;
+					}
+					const { getMedia } = select( 'core' );
+					const media = getMedia( id );
+					return !! media && includes( media.mime_type, 'image' );
+				},
 				transform: ( attributes ) => {
 					return createBlock( 'core/image', {
 						url: attributes.href,

--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -113,6 +113,18 @@ export const settings = {
 					} );
 				},
 			},
+			{
+				type: 'block',
+				blocks: [ 'core/image' ],
+				transform: ( attributes ) => {
+					return createBlock( 'core/file', {
+						href: attributes.url,
+						fileName: attributes.caption && attributes.caption.join(),
+						textLinkHref: attributes.url,
+						id: attributes.id,
+					} );
+				},
+			},
 		],
 		to: [
 			{
@@ -148,6 +160,17 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/video', {
 						src: attributes.href,
+						caption: [ attributes.fileName ],
+						id: attributes.id,
+					} );
+				},
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/image' ],
+				transform: ( attributes ) => {
+					return createBlock( 'core/image', {
+						url: attributes.href,
 						caption: [ attributes.fileName ],
 						id: attributes.id,
 					} );


### PR DESCRIPTION
## Description
This PR addresses #7774 which requests the inclusion of the transformation feature of the image block to the file block and vice-versa.

## How has this been tested?
This has been tested by making sure the image to file transformation and vice-versa options show up in the respective blocks and the transformation works as expected, including file URLs and caption.

This was tested in WP 4.9.7, Gutenberg 3.2.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-7774-min](https://user-images.githubusercontent.com/20284937/42419974-8bd892a2-82e0-11e8-83bc-2377391f7bd9.gif)

## Types of changes
This PR adapts the block transformation code regarding audio and video blocks inside the file block and copies over the correct attributes in the transformation from the image block. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
