### PR TITLE
Convert enzyme tests to use React.TestUtilities (components/dropdown/test/index.js)

### DIFF
--- a/components/dropdown/test/index.js
+++ b/components/dropdown/test/index.js
@@ -1,22 +1,37 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
  */
 import Dropdown from '../';
+import Popover from '../../popover';
 
 describe( 'Dropdown', () => {
-	const expectPopoverVisible = ( wrapper, visible ) => expect( wrapper.find( 'Popover' ) ).toHaveLength( visible ? 1 : 0 );
+	const expectPopoverVisible = ( wrapper, visible ) => {
+		expect(
+			TestUtils.scryRenderedComponentsWithType( wrapper, Popover ) )
+			.toHaveLength( visible ? 1 : 0 );
+	};
+	const buttonElement = ( wrapper ) => TestUtils.findRenderedDOMComponentWithTag(
+		wrapper,
+		'button'
+	);
+	const openCloseElement = ( wrapper, className ) => TestUtils
+		.findRenderedDOMComponentWithClass( wrapper, className );
 
 	it( 'should toggle the dropdown properly', () => {
 		const expectButtonExpanded = ( wrapper, expanded ) => {
-			expect( wrapper.find( 'button' ) ).toHaveLength( 1 );
-			expect( wrapper.find( 'button' ) ).toHaveProp( 'aria-expanded', expanded );
+			expect(
+				TestUtils.scryRenderedDOMComponentsWithTag( wrapper, 'button' ) )
+				.toHaveLength( 1 );
+			expect(
+				buttonElement( wrapper ).getAttribute( 'aria-expanded' )
+			).toBe( expanded.toString() );
 		};
-		const wrapper = mount( <Dropdown
+		const wrapper = TestUtils.renderIntoDocument( <Dropdown
 			className="container"
 			contentClassName="content"
 			renderToggle={ ( { isOpen, onToggle } ) => (
@@ -28,15 +43,14 @@ describe( 'Dropdown', () => {
 		expectButtonExpanded( wrapper, false );
 		expectPopoverVisible( wrapper, false );
 
-		wrapper.find( 'button' ).simulate( 'click' );
-		wrapper.update();
+		TestUtils.Simulate.click( buttonElement( wrapper ) );
 
 		expectButtonExpanded( wrapper, true );
 		expectPopoverVisible( wrapper, true );
 	} );
 
 	it( 'should close the dropdown when calling onClose', () => {
-		const wrapper = mount( <Dropdown
+		const wrapper = TestUtils.renderIntoDocument( <Dropdown
 			className="container"
 			contentClassName="content"
 			renderToggle={ ( { isOpen, onToggle, onClose } ) => [
@@ -48,13 +62,11 @@ describe( 'Dropdown', () => {
 
 		expectPopoverVisible( wrapper, false );
 
-		wrapper.find( '.open' ).simulate( 'click' );
-		wrapper.update();
+		TestUtils.Simulate.click( openCloseElement( wrapper, 'open' ) );
 
 		expectPopoverVisible( wrapper, true );
 
-		wrapper.find( '.close' ).simulate( 'click' );
-		wrapper.update();
+		TestUtils.Simulate.click( openCloseElement( wrapper, 'close' ) );
 
 		expectPopoverVisible( wrapper, false );
 	} );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This pull converts all usage of enzyme for tests in `components/dropdown/test/index.js` to use `React.TestUtilities` instead. This is because enzyme does not support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as forwardRef usage in #7557)

I converted to use `React.TestUtilities` because of the need to do simulated clicks in the dom.  It’s a bit easier to do using TestUtilities as opposed to react-test-renderer.

There is also a bit of a speed improvement over using `enzyme.mount`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
