### PR TITLE
[Fix] Show required image settings in wide and full-width alignments of the image block

### DIFF
--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -276,7 +276,7 @@ class ImageEdit extends Component {
 						onChange={ this.updateAlt }
 						help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) }
 					/>
-					{ ! isEmpty( availableSizes ) && (
+					{ ! isEmpty( availableSizes ) && isResizable && (
 						<SelectControl
 							label={ __( 'Source Type' ) }
 							value={ url }
@@ -287,59 +287,61 @@ class ImageEdit extends Component {
 							onChange={ this.updateImageURL }
 						/>
 					) }
-					<div className="core-blocks-image__dimensions">
-						<p className="core-blocks-image__dimensions__row">
-							{ __( 'Image Dimensions' ) }
-						</p>
-						<div className="core-blocks-image__dimensions__row">
-							<TextControl
-								type="number"
-								className="core-blocks-image__dimensions__width"
-								label={ __( 'Width' ) }
-								value={ width !== undefined ? width : '' }
-								placeholder={ imageWidth }
-								min={ 1 }
-								onChange={ this.updateWidth }
-							/>
-							<TextControl
-								type="number"
-								className="core-blocks-image__dimensions__height"
-								label={ __( 'Height' ) }
-								value={ height !== undefined ? height : '' }
-								placeholder={ imageHeight }
-								min={ 1 }
-								onChange={ this.updateHeight }
-							/>
-						</div>
-						<div className="core-blocks-image__dimensions__row">
-							<ButtonGroup aria-label={ __( 'Image Size' ) }>
-								{ [ 25, 50, 75, 100 ].map( ( scale ) => {
-									const scaledWidth = Math.round( imageWidth * ( scale / 100 ) );
-									const scaledHeight = Math.round( imageHeight * ( scale / 100 ) );
+					{ isResizable &&
+						<div className="core-blocks-image__dimensions">
+							<p className="core-blocks-image__dimensions__row">
+								{ __( 'Image Dimensions' ) }
+							</p>
+							<div className="core-blocks-image__dimensions__row">
+								<TextControl
+									type="number"
+									className="core-blocks-image__dimensions__width"
+									label={ __( 'Width' ) }
+									value={ width !== undefined ? width : '' }
+									placeholder={ imageWidth }
+									min={ 1 }
+									onChange={ this.updateWidth }
+								/>
+								<TextControl
+									type="number"
+									className="core-blocks-image__dimensions__height"
+									label={ __( 'Height' ) }
+									value={ height !== undefined ? height : '' }
+									placeholder={ imageHeight }
+									min={ 1 }
+									onChange={ this.updateHeight }
+								/>
+							</div>
+							<div className="core-blocks-image__dimensions__row">
+								<ButtonGroup aria-label={ __( 'Image Size' ) }>
+									{ [ 25, 50, 75, 100 ].map( ( scale ) => {
+										const scaledWidth = Math.round( imageWidth * ( scale / 100 ) );
+										const scaledHeight = Math.round( imageHeight * ( scale / 100 ) );
 
-									const isCurrent = width === scaledWidth && height === scaledHeight;
+										const isCurrent = width === scaledWidth && height === scaledHeight;
 
-									return (
-										<Button
-											key={ scale }
-											isSmall
-											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
-											onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
-										>
-											{ scale }%
-										</Button>
-									);
-								} ) }
-							</ButtonGroup>
-							<Button
-								isSmall
-								onClick={ this.updateDimensions() }
-							>
-								{ __( 'Reset' ) }
-							</Button>
+										return (
+											<Button
+												key={ scale }
+												isSmall
+												isPrimary={ isCurrent }
+												aria-pressed={ isCurrent }
+												onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
+											>
+												{ scale }%
+											</Button>
+										);
+									} ) }
+								</ButtonGroup>
+								<Button
+									isSmall
+									onClick={ this.updateDimensions() }
+								>
+									{ __( 'Reset' ) }
+								</Button>
+							</div>
 						</div>
-					</div>
+					}
 				</PanelBody>
 				<PanelBody title={ __( 'Link Settings' ) }>
 					<SelectControl
@@ -381,9 +383,12 @@ class ImageEdit extends Component {
 
 							if ( ! isResizable || ! imageWidthWithinContainer ) {
 								return (
-									<div style={ { width, height } }>
-										{ img }
-									</div>
+									<Fragment>
+										{ getInspectorControls( imageWidth, imageHeight ) }
+										<div style={ { width, height } }>
+											{ img }
+										</div>
+									</Fragment>
 								);
 							}
 


### PR DESCRIPTION
## Description
This PR addresses #7750 which reports the disappearance of the required image settings in the inspector controls of the image block for wide and full-width alignments. These changes bring back the "Textual Alternative" and "Link Settings" in the mentioned alignments.

## How has this been tested?
This has been tested by following these steps:
1. `align-wide` [theme support](https://wordpress.org/gutenberg/handbook/extensibility/theme-support/) was enabled.
2. An image block was inserted in the Gutenberg editor.
3. The wide/full-width alignment was selected.
4. It was made sure that the "Textual Alternative" and "Link Settings" panel bodies showed up in the inspector controls.

This was tested in WP 4.9.7, Gutenberg 3.2.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-7750](https://user-images.githubusercontent.com/20284937/42420948-4e1e0be0-82ef-11e8-8a8f-584924b3d371.png)

## Types of changes
This PR makes the inspector controls display in the wide and full-width alignments. The "Source Type" and "Image Dimensions" settings were made unavailable from showing up in case of the mentioned blocks by making them conditionally display with the `isResizable` condition.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
