### PR TITLE
Convert ‘it closes by blur’ test to use React.TestUtils ( editor/components/autocomplete/test/index.js)

### DIFF
--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -39,32 +39,11 @@ class FakeEditor extends Component {
 
 function makeAutocompleter( completers, {
 	AutocompleteComponent = Autocomplete,
+	mountImplementation = mount,
 	onReplace = noop,
 } = {} ) {
-	return mount(
+	return mountImplementation(
 		<AutocompleteComponent instanceId="1"
-			completers={ completers }
-			onReplace={ onReplace }
-		>
-			{ ( { isExpanded, listBoxId, activeId } ) => (
-				<FakeEditor
-					aria-autocomplete="list"
-					aria-expanded={ isExpanded }
-					aria-owns={ listBoxId }
-					aria-activedescendant={ activeId }
-				/>
-			) }
-		</AutocompleteComponent>
-	);
-}
-
-function makeAutocompleterWithUtils( completers, {
-	AutocompleteComponent = Autocomplete,
-	onReplace = noop,
-} = {} ) {
-	return TestUtils.renderIntoDocument(
-		<AutocompleteComponent
-			instanceId="1"
 			completers={ completers }
 			onReplace={ onReplace }
 		>
@@ -633,8 +612,9 @@ describe( 'Autocomplete', () => {
 				}
 			}
 
-			const wrapper = makeAutocompleterWithUtils( [], {
+			const wrapper = makeAutocompleter( [], {
 				AutocompleteComponent: Enhanced,
+				mountImplementation: TestUtils.renderIntoDocument,
 			} );
 			simulateInputForUtils( wrapper, [ par( tx( '/' ) ) ] );
 			TestUtils.Simulate.blur(

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -62,10 +62,11 @@ function makeAutocompleterWithUtils( completers, {
 	AutocompleteComponent = Autocomplete,
 	onReplace = noop,
 } = {} ) {
-	const wrapper = TestUtils.renderIntoDocument(
-		<AutocompleteComponent instanceId="1"
-													 completers={ completers }
-													 onReplace={ onReplace }
+	return TestUtils.renderIntoDocument(
+		<AutocompleteComponent
+			instanceId="1"
+			completers={ completers }
+			onReplace={ onReplace }
 		>
 			{ ( { isExpanded, listBoxId, activeId } ) => (
 				<FakeEditor
@@ -77,7 +78,6 @@ function makeAutocompleterWithUtils( completers, {
 			) }
 		</AutocompleteComponent>
 	);
-	return wrapper;
 }
 
 /**
@@ -154,7 +154,7 @@ function simulateInputForUtils( wrapper, nodeList, cursorPosition ) {
 	TestUtils.Simulate.input(
 		fakeEditor,
 		{
-			target: fakeEditor
+			target: fakeEditor,
 		}
 	);
 }
@@ -629,7 +629,7 @@ describe( 'Autocomplete', () => {
 			// reason.  Without this, wrapper would end up with the value of null.
 			class Enhanced extends Component {
 				render() {
-					return <EnhancedAutocomplete { ...this.props } />
+					return <EnhancedAutocomplete { ...this.props } />;
 				}
 			}
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This pull converts the usage of `enzyme.mount` for the `it closes by blur` test in `editor/components/autocomplete/test/index.js` to use `React.TestUtilities` instead. This is because enzyme does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as forwardRef usage in #7557).  This specific test was the only one to fail in #7557 due to the test involving the `EnhancedAutocomplete` component that has forwardRef applied on it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
