### PR TITLE
Switch test away from enzyme.mount usage (components/dropdown-menu/test/index.js )

### DIFF
--- a/components/dropdown-menu/test/index.js
+++ b/components/dropdown-menu/test/index.js
@@ -1,17 +1,20 @@
 /**
  * External dependencies
  */
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
 
 /**
  * WordPress dependencies
  */
 import { DOWN } from '@wordpress/keycodes';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import DropdownMenu from '../';
+import Popover from '../../popover';
 
 describe( 'DropdownMenu', () => {
 	let controls;
@@ -54,16 +57,29 @@ describe( 'DropdownMenu', () => {
 		} );
 
 		it( 'should open menu on arrow down', () => {
-			const wrapper = mount( <DropdownMenu controls={ controls } /> );
-
+			// needed because TestUtils.renderIntoDocument returns null for stateless
+			// components
+			class Menu extends Component {
+				render() {
+					return <DropdownMenu { ...this.props } />;
+				}
+			}
+			const wrapper = TestUtils.renderIntoDocument( <Menu controls={ controls } /> );
+			const buttonElement = TestUtils.findRenderedDOMComponentWithClass(
+				wrapper,
+				'components-dropdown-menu__toggle'
+			);
 			// Close menu by keyup
-			wrapper.find( 'button.components-dropdown-menu__toggle' ).simulate( 'keydown', {
-				stopPropagation: () => {},
-				preventDefault: () => {},
-				keyCode: DOWN,
-			} );
+			TestUtils.Simulate.keyDown(
+				buttonElement,
+				{
+					stopPropagation: () => {},
+					preventDefault: () => {},
+					keyCode: DOWN,
+				}
+			);
 
-			expect( wrapper.find( 'Popover' ) ).toHaveLength( 1 );
+			expect( TestUtils.scryRenderedComponentsWithType( wrapper, Popover ) ).toHaveLength( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Switches `should open menu on arrow down` test from rendering using `enzyme.mount` to rendering using `React.TestUtils`.  This is needed because enzyme does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as forwardRef usage in #7557).  This specific test was the only one to fail in #7557.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
