### PR TITLE
Switch test away from using `enzyme.mount` (editor/components/url-input/test/button.js)

### DIFF
--- a/editor/components/url-input/test/button.js
+++ b/editor/components/url-input/test/button.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
+import ReactDOM from 'react-dom';
 
 /**
  * Internal dependencies
@@ -57,11 +59,21 @@ describe( 'UrlInputButton', () => {
 		expect( wrapper.state().expanded ).toBe( false );
 	} );
 	it( 'should close the form when user submits it', () => {
-		const wrapper = mount( <UrlInputButton /> );
-		clickEditLink( wrapper );
-		expect( wrapper.state().expanded ).toBe( true );
-		wrapper.find( 'form' ).simulate( 'submit' );
-		expect( wrapper.state().expanded ).toBe( false );
-		wrapper.unmount();
+		const wrapper = TestUtils.renderIntoDocument( <UrlInputButton /> );
+		const buttonElement = () => TestUtils.findRenderedDOMComponentWithClass(
+			wrapper,
+			'components-toolbar__control'
+		);
+		const formElement = () => TestUtils.findRenderedDOMComponentWithTag(
+			wrapper,
+			'form'
+		);
+		TestUtils.Simulate.click( buttonElement() );
+		expect( wrapper.state.expanded ).toBe( true );
+		TestUtils.Simulate.submit( formElement() );
+		expect( wrapper.state.expanded ).toBe( false );
+		/* eslint-disable react/no-find-dom-node */
+		ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( wrapper ).parentNode );
+		/* eslint-enable react/no-find-dom-node */
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This switched the `should close the form when user submits it` test in `editor/components/url-input/test/button.js` from using enzyme.mount to `React.TestUtilities`.  This is because `enzyme` does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
