### PR TITLE
convert all tests to use React.TestRenderer (viewport/test/if-viewport-matches.js)

### DIFF
--- a/viewport/test/if-viewport-matches.js
+++ b/viewport/test/if-viewport-matches.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
 
 /**
  * WordPress dependencies
@@ -20,9 +20,9 @@ describe( 'ifViewportMatches()', () => {
 	it( 'should not render if query does not match', () => {
 		dispatch( 'core/viewport' ).setIsMatching( { '> wide': false } );
 		const EnhancedComponent = ifViewportMatches( '> wide' )( Component );
-		const wrapper = mount( <EnhancedComponent /> );
+		const wrapper = renderer.create( <EnhancedComponent /> );
 
-		expect( wrapper.find( Component ) ).toHaveLength( 0 );
+		expect( wrapper.root.findAllByType( Component ) ).toHaveLength( 0 );
 
 		wrapper.unmount();
 	} );
@@ -30,9 +30,8 @@ describe( 'ifViewportMatches()', () => {
 	it( 'should render if query does match', () => {
 		dispatch( 'core/viewport' ).setIsMatching( { '> wide': true } );
 		const EnhancedComponent = ifViewportMatches( '> wide' )( Component );
-		const wrapper = mount( <EnhancedComponent /> );
-
-		expect( wrapper.find( Component ).childAt( 0 ).type() ).toBe( 'div' );
+		const wrapper = renderer.create( <EnhancedComponent /> );
+		expect( wrapper.root.findByType( Component ).children[ 0 ].type ).toBe( 'div' );
 
 		wrapper.unmount();
 	} );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This switches all tests in `viewport/test/if-viewport-matches.js` from using enzyme.mount to `React.TestRenderer`.  This is because `enzyme` does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
