### PR TITLE
Switch away from using enzyme.mount in tests (components/higher-order/with-filters/test/index.js)

### DIFF
--- a/components/higher-order/with-filters/test/index.js
+++ b/components/higher-order/with-filters/test/index.js
@@ -1,35 +1,62 @@
 /**
  * External dependencies
  */
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
+import ReactDOM from 'react-dom';
 
 /**
  * WordPress dependencies
  */
 import { addFilter, removeAllFilters, removeFilter } from '@wordpress/hooks';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import withFilters from '..';
 
+const assertExpectedHtml = ( wrapper, containerTag, expectedHTML ) => {
+	const element = TestUtils.findRenderedDOMComponentWithTag( wrapper, containerTag );
+	expect( element.outerHTML ).toBe( expectedHTML );
+};
+
+// this is needed because TestUtils does not accept a stateless component.
+// anything run through a HOC ends up as a stateless component.
+const getTestComponent = ( WrappedComponent ) => {
+	class TestComponent extends Component {
+		render() {
+			return <WrappedComponent { ...this.props } />;
+		}
+	}
+	return <TestComponent />;
+};
+
 describe( 'withFilters', () => {
-	let wrapper;
+	let shallowWrapper, wrapper;
 
 	const hookName = 'EnhancedComponent';
 	const MyComponent = () => <div>My component</div>;
 
 	afterEach( () => {
-		wrapper.unmount();
+		if ( wrapper ) {
+			/* eslint-disable react/no-find-dom-node */
+			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( wrapper ).parentNode );
+		}
+		if ( shallowWrapper ) {
+			shallowWrapper.unmount();
+		}
+		/* eslint-enable react/no-find-dom-node */
 		removeAllFilters( hookName );
 	} );
 
 	it( 'should display original component when no filters applied', () => {
 		const EnhancedComponent = withFilters( hookName )( MyComponent );
 
-		wrapper = shallow( <EnhancedComponent /> );
+		shallowWrapper = shallow( <EnhancedComponent /> );
 
-		expect( wrapper.html() ).toBe( '<div>My component</div>' );
+		expect( shallowWrapper.html() ).toBe( '<div>My component</div>' );
+		shallowWrapper.unmount();
 	} );
 
 	it( 'should display a component overridden by the filter', () => {
@@ -41,9 +68,9 @@ describe( 'withFilters', () => {
 		);
 		const EnhancedComponent = withFilters( hookName )( MyComponent );
 
-		wrapper = shallow( <EnhancedComponent /> );
+		shallowWrapper = shallow( <EnhancedComponent /> );
 
-		expect( wrapper.html() ).toBe( '<div>Overridden component</div>' );
+		expect( shallowWrapper.html() ).toBe( '<div>Overridden component</div>' );
 	} );
 
 	it( 'should display two components composed by the filter', () => {
@@ -60,9 +87,9 @@ describe( 'withFilters', () => {
 		);
 		const EnhancedComponent = withFilters( hookName )( MyComponent );
 
-		wrapper = shallow( <EnhancedComponent /> );
+		shallowWrapper = shallow( <EnhancedComponent /> );
 
-		expect( wrapper.html() ).toBe( '<div><div>My component</div><div>Composed component</div></div>' );
+		expect( shallowWrapper.html() ).toBe( '<div><div>My component</div><div>Composed component</div></div>' );
 	} );
 
 	it( 'should not re-render component when new filter added before component was mounted', () => {
@@ -82,12 +109,16 @@ describe( 'withFilters', () => {
 		);
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
 
-		wrapper = mount( <EnhancedComponent /> );
+		wrapper = TestUtils.renderIntoDocument( getTestComponent( EnhancedComponent ) );
 
 		jest.runAllTimers();
 
 		expect( spy ).toHaveBeenCalledTimes( 1 );
-		expect( wrapper.html() ).toBe( '<blockquote><div>Spied component</div></blockquote>' );
+		assertExpectedHtml(
+			wrapper,
+			'blockquote',
+			'<blockquote><div>Spied component</div></blockquote>'
+		);
 	} );
 
 	it( 'should re-render component once when new filter added after component was mounted', () => {
@@ -98,7 +129,7 @@ describe( 'withFilters', () => {
 		};
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
 
-		wrapper = mount( <EnhancedComponent /> );
+		wrapper = TestUtils.renderIntoDocument( getTestComponent( EnhancedComponent ) );
 
 		spy.mockClear();
 		addFilter(
@@ -113,7 +144,11 @@ describe( 'withFilters', () => {
 		jest.runAllTimers();
 
 		expect( spy ).toHaveBeenCalledTimes( 1 );
-		expect( wrapper.html() ).toBe( '<blockquote><div>Spied component</div></blockquote>' );
+		assertExpectedHtml(
+			wrapper,
+			'blockquote',
+			'<blockquote><div>Spied component</div></blockquote>'
+		);
 	} );
 
 	it( 'should re-render component once when two filters added in the same animation frame', () => {
@@ -123,7 +158,7 @@ describe( 'withFilters', () => {
 			return <div>Spied component</div>;
 		};
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
-		wrapper = mount( <EnhancedComponent /> );
+		wrapper = TestUtils.renderIntoDocument( getTestComponent( EnhancedComponent ) );
 
 		spy.mockClear();
 
@@ -148,7 +183,11 @@ describe( 'withFilters', () => {
 		jest.runAllTimers();
 
 		expect( spy ).toHaveBeenCalledTimes( 1 );
-		expect( wrapper.html() ).toBe( '<section><blockquote><div>Spied component</div></blockquote></section>' );
+		assertExpectedHtml(
+			wrapper,
+			'section',
+			'<section><blockquote><div>Spied component</div></blockquote></section>'
+		);
 	} );
 
 	it( 'should re-render component twice when new filter added and removed in two different animation frames', () => {
@@ -158,7 +197,7 @@ describe( 'withFilters', () => {
 			return <div>Spied component</div>;
 		};
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
-		wrapper = mount( <EnhancedComponent /> );
+		wrapper = TestUtils.renderIntoDocument( getTestComponent( EnhancedComponent ) );
 
 		spy.mockClear();
 		addFilter(
@@ -179,7 +218,11 @@ describe( 'withFilters', () => {
 		jest.runAllTimers();
 
 		expect( spy ).toHaveBeenCalledTimes( 2 );
-		expect( wrapper.html() ).toBe( '<div>Spied component</div>' );
+		assertExpectedHtml(
+			wrapper,
+			'div',
+			'<div>Spied component</div>'
+		);
 	} );
 
 	it( 'should re-render both components once each when one filter added', () => {
@@ -190,12 +233,12 @@ describe( 'withFilters', () => {
 		};
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
 		const CombinedComponents = () => (
-			<div>
+			<section>
 				<EnhancedComponent />
 				<EnhancedComponent />
-			</div>
+			</section>
 		);
-		wrapper = mount( <CombinedComponents /> );
+		wrapper = TestUtils.renderIntoDocument( getTestComponent( CombinedComponents ) );
 
 		spy.mockClear();
 		addFilter(
@@ -210,6 +253,10 @@ describe( 'withFilters', () => {
 		jest.runAllTimers();
 
 		expect( spy ).toHaveBeenCalledTimes( 2 );
-		expect( wrapper.html() ).toBe( '<div><blockquote><div>Spied component</div></blockquote><blockquote><div>Spied component</div></blockquote></div>' );
+		assertExpectedHtml(
+			wrapper,
+			'section',
+			'<section><blockquote><div>Spied component</div></blockquote><blockquote><div>Spied component</div></blockquote></section>'
+		);
 	} );
 } );

--- a/components/higher-order/with-filters/test/index.js
+++ b/components/higher-order/with-filters/test/index.js
@@ -17,7 +17,9 @@ import { Component } from '@wordpress/element';
 import withFilters from '..';
 
 const assertExpectedHtml = ( wrapper, expectedHTML ) => {
+	/* eslint-disable react/no-find-dom-node */
 	const element = ReactDOM.findDOMNode( wrapper );
+	/* eslint-enable react/no-find-dom-node */
 	expect( element.outerHTML ).toBe( expectedHTML );
 };
 

--- a/components/higher-order/with-filters/test/index.js
+++ b/components/higher-order/with-filters/test/index.js
@@ -16,8 +16,8 @@ import { Component } from '@wordpress/element';
  */
 import withFilters from '..';
 
-const assertExpectedHtml = ( wrapper, containerTag, expectedHTML ) => {
-	const element = TestUtils.findRenderedDOMComponentWithTag( wrapper, containerTag );
+const assertExpectedHtml = ( wrapper, expectedHTML ) => {
+	const element = ReactDOM.findDOMNode( wrapper );
 	expect( element.outerHTML ).toBe( expectedHTML );
 };
 
@@ -116,7 +116,6 @@ describe( 'withFilters', () => {
 		expect( spy ).toHaveBeenCalledTimes( 1 );
 		assertExpectedHtml(
 			wrapper,
-			'blockquote',
 			'<blockquote><div>Spied component</div></blockquote>'
 		);
 	} );
@@ -146,7 +145,6 @@ describe( 'withFilters', () => {
 		expect( spy ).toHaveBeenCalledTimes( 1 );
 		assertExpectedHtml(
 			wrapper,
-			'blockquote',
 			'<blockquote><div>Spied component</div></blockquote>'
 		);
 	} );
@@ -185,7 +183,6 @@ describe( 'withFilters', () => {
 		expect( spy ).toHaveBeenCalledTimes( 1 );
 		assertExpectedHtml(
 			wrapper,
-			'section',
 			'<section><blockquote><div>Spied component</div></blockquote></section>'
 		);
 	} );
@@ -220,7 +217,6 @@ describe( 'withFilters', () => {
 		expect( spy ).toHaveBeenCalledTimes( 2 );
 		assertExpectedHtml(
 			wrapper,
-			'div',
 			'<div>Spied component</div>'
 		);
 	} );
@@ -255,7 +251,6 @@ describe( 'withFilters', () => {
 		expect( spy ).toHaveBeenCalledTimes( 2 );
 		assertExpectedHtml(
 			wrapper,
-			'section',
 			'<section><blockquote><div>Spied component</div></blockquote><blockquote><div>Spied component</div></blockquote></section>'
 		);
 	} );

--- a/components/higher-order/with-filters/test/index.js
+++ b/components/higher-order/with-filters/test/index.js
@@ -58,7 +58,6 @@ describe( 'withFilters', () => {
 		shallowWrapper = shallow( <EnhancedComponent /> );
 
 		expect( shallowWrapper.html() ).toBe( '<div>My component</div>' );
-		shallowWrapper.unmount();
 	} );
 
 	it( 'should display a component overridden by the filter', () => {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This switches all tests in `components/higher-order/with-filters/test/index.js` from using enzyme.mount to `React.TestUtilities`.  This is because `enzyme` does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
