### PR TITLE
Switch tests away from enzyme.mount (components/higher-order/with-context/test/index.js)

### DIFF
--- a/components/higher-order/with-context/test/index.js
+++ b/components/higher-order/with-context/test/index.js
@@ -1,36 +1,59 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import withContext from '../';
 
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+class PassContext extends Component {
+	getChildContext() {
+		return this.props.value;
+	}
+
+	render() {
+		return this.props.children;
+	}
+}
+
+PassContext.childContextTypes = {
+	value: PropTypes.any,
+	settings: PropTypes.any,
+};
+
 describe( 'withContext', () => {
 	it( 'should return a new component which has context', () => {
-		const Component = withContext( 'value' )()( ( { value } ) => <div>{ value }</div> );
-		const wrapper = mount(
-			<Component />,
-			{ context: { value: 'ok' } }
+		const TestComponent = withContext( 'value' )()( ( { value } ) => <div>{ value }</div> );
+		const wrapper = renderer.create(
+			<PassContext value={ { value: 'ok' } }>
+				<TestComponent />
+			</PassContext>
 		);
 
-		expect( wrapper.text() ).toBe( 'ok' );
+		expect( wrapper.root.findByType( 'div' ).children[ 0 ] ).toBe( 'ok' );
 	} );
 
 	it( 'should allow specifying a context getter mapping', () => {
-		const Component = withContext( 'settings' )(
+		const TestComponent = withContext( 'settings' )(
 			( settings ) => ( { remap: settings.value } )
 		)(
 			( { ignore, remap } ) => <div>{ ignore }{ remap }</div>
 		);
 
-		const wrapper = mount(
-			<Component />,
-			{ context: { settings: { ignore: 'ignore', value: 'ok' } } }
+		const wrapper = renderer.create(
+			<PassContext value={ { settings: { ignore: 'ignore', value: 'ok' } } } >
+				<TestComponent />
+			</PassContext>
 		);
 
-		expect( wrapper.text() ).toBe( 'ok' );
+		expect( wrapper.root.findByType( 'div' ).children[ 0 ] ).toBe( 'ok' );
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This switches all tests in `components/higher-order/with-context/test/index.js` from using enzyme.mount to `React.TestRenderer`.  This is because `enzyme` does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
