### PR TITLE
Switch tests away from using enzyme.mount (components/toggle-control/test/index.js)

### DIFF
--- a/components/toggle-control/test/index.js
+++ b/components/toggle-control/test/index.js
@@ -1,20 +1,37 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
 
 /**
  * Internal dependencies
  */
 import ToggleControl from '../';
 
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+// this is needed because TestUtils does not accept a stateless component.
+// anything run through a HOC ends up as a stateless component.
+const getTestComponent = ( WrappedComponent, props ) => {
+	class TestComponent extends Component {
+		render() {
+			return <WrappedComponent { ...this.props } />;
+		}
+	}
+	return <TestComponent { ...props } />;
+};
+
 describe( 'ToggleControl', () => {
 	it( 'triggers change callback with numeric value', () => {
 		// Mount: With shallow, cannot find input child of BaseControl
 		const onChange = jest.fn();
-		const wrapper = mount( <ToggleControl onChange={ onChange } /> );
-
-		wrapper.find( 'input' ).simulate( 'change', { target: { checked: true } } );
+		const wrapper = renderer.create(
+			getTestComponent( ToggleControl, { onChange } )
+		);
+		wrapper.root.findByType( 'input' ).props.onChange( { target: { checked: true } } );
 
 		expect( onChange ).toHaveBeenCalledWith( true );
 	} );
@@ -23,21 +40,25 @@ describe( 'ToggleControl', () => {
 		it( 'does not render input with describedby if no help prop', () => {
 			// Mount: With shallow, cannot find input child of BaseControl
 			const onChange = jest.fn();
-			const wrapper = mount( <ToggleControl onChange={ onChange } /> );
+			const wrapper = renderer.create(
+				getTestComponent( ToggleControl, { onChange } )
+			);
 
-			const input = wrapper.find( 'input' );
+			const input = wrapper.root.findByType( 'input' );
 
-			expect( input.prop( 'aria-describedby' ) ).toBeUndefined();
+			expect( input.props[ 'aria-describedby' ] ).toBeUndefined();
 		} );
 
 		it( 'renders input with describedby if help prop', () => {
 			// Mount: With shallow, cannot find input child of BaseControl
 			const onChange = jest.fn();
-			const wrapper = mount( <ToggleControl help onChange={ onChange } /> );
+			const wrapper = renderer.create(
+				getTestComponent( ToggleControl, { help: true, onChange } )
+			);
 
-			const input = wrapper.find( 'input' );
+			const input = wrapper.root.findByType( 'input' );
 
-			expect( input.prop( 'aria-describedby' ) ).toMatch( /^inspector-toggle-control-.*__help$/ );
+			expect( input.props[ 'aria-describedby' ] ).toMatch( /^inspector-toggle-control-.*__help$/ );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This switches all tests in `components/toggle-control/test/index.js` from using enzyme.mount to `React.TestRenderer`.  This is because `enzyme` does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
