### PR TITLE
Fix spacer block resizing

### DIFF
--- a/core-blocks/spacer/index.js
+++ b/core-blocks/spacer/index.js
@@ -51,7 +51,7 @@ export const settings = {
 							bottom: 'core-blocks-spacer__resize-handler-bottom',
 						} }
 						enable={ {
-							top: true,
+							top: false,
 							right: false,
 							bottom: true,
 							left: false,


### PR DESCRIPTION
Fixes #7755.

The sibling inserter was preventing a user from being able to resize the spacer using the top drag handle.

![spacer-resizing](https://user-images.githubusercontent.com/612155/42434808-cd215156-8397-11e8-971c-001c590726ce.gif)

To test:

1. Insert a spacer block
2. Check that it can be resized using both drag handles
2. Insert an image block
2. Check that it can be resized using both drag handles
