### PR TITLE
Point the package entry to src directly for native mobile

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -19,6 +19,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@wordpress/deprecated": "^1.0.0-alpha.2",
 		"@wordpress/element": "^1.0.0-alpha.2",

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -18,6 +18,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -19,7 +19,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"react-native": "build/index",
+	"react-native": "src/index",
 	"dependencies": {
 		"@wordpress/deprecated": "^1.0.0-alpha.2",
 		"@wordpress/is-shallow-equal": "1.0.2",


### PR DESCRIPTION
## Description
This PR sets the package entry point used by the native mobile app, directly to the `src` folder. This way, no prior building of the packages is needed for them to be consumed by the native app.

## How has this been tested?
Tested using the [relevant PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/66) on the native mobile repo.

## Types of changes
* Adds or sets the `react-native` entry point in the `package.json` for the `data`, `deprecated`, `element` packages, to point to the `index` (extension-less) module inside the `/src` folder.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
