### PR TITLE
Switch tests away from using enzyme.mount (components/higher-order/with-focus-outside/test/index.js)

### DIFF
--- a/components/higher-order/with-focus-outside/test/index.js
+++ b/components/higher-order/with-focus-outside/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
 
 /**
  * WordPress dependencies
@@ -12,8 +12,11 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import withFocusOutside from '../';
+import ReactDOM from 'react-dom';
 
 jest.useFakeTimers();
+
+let wrapper, callback;
 
 describe( 'withFocusOutside', () => {
 	const EnhancedComponent = withFocusOutside(
@@ -33,13 +36,33 @@ describe( 'withFocusOutside', () => {
 		}
 	);
 
-	it( 'should not call handler if focus shifts to element within component', () => {
-		const callback = jest.fn();
-		const wrapper = mount( <EnhancedComponent onFocusOutside={ callback } /> );
+	// this is needed because TestUtils does not accept a stateless component.
+	// anything run through a HOC ends up as a stateless component.
+	const getTestComponent = ( WrappedComponent, props ) => {
+		class TestComponent extends Component {
+			render() {
+				return <WrappedComponent { ...props } />;
+			}
+		}
+		return <TestComponent />;
+	};
 
-		wrapper.find( 'input' ).at( 0 ).simulate( 'focus' );
-		wrapper.find( 'input' ).at( 0 ).simulate( 'blur' );
-		wrapper.find( 'input' ).at( 1 ).simulate( 'focus' );
+	const simulateEvent = ( event, position = 0 ) => {
+		const element = TestUtils.scryRenderedDOMComponentsWithTag( wrapper, 'input' );
+		TestUtils.Simulate[ event ]( element[ position ] );
+	};
+
+	beforeEach( () => {
+		callback = jest.fn();
+		wrapper = TestUtils.renderIntoDocument(
+			getTestComponent( EnhancedComponent, { onFocusOutside: callback } )
+		);
+	} );
+
+	it( 'should not call handler if focus shifts to element within component', () => {
+		simulateEvent( 'focus' );
+		simulateEvent( 'blur' );
+		simulateEvent( 'focus', 1 );
 
 		jest.runAllTimers();
 
@@ -47,16 +70,14 @@ describe( 'withFocusOutside', () => {
 	} );
 
 	it( 'should not call handler if focus transitions via click to button', () => {
-		const callback = jest.fn();
-		const wrapper = mount( <EnhancedComponent onFocusOutside={ callback } /> );
+		simulateEvent( 'focus' );
+		simulateEvent( 'mouseDown', 1 );
+		simulateEvent( 'blur' );
 
-		wrapper.find( 'input' ).at( 0 ).simulate( 'focus' );
-		wrapper.find( 'input' ).at( 1 ).simulate( 'mousedown' );
-		wrapper.find( 'input' ).at( 0 ).simulate( 'blur' );
 		// In most browsers, the input at index 1 would receive a focus event
 		// at this point, but this is not guaranteed, which is the intention of
 		// the normalization behavior tested here.
-		wrapper.find( 'input' ).at( 1 ).simulate( 'mouseup' );
+		simulateEvent( 'mouseUp', 1 );
 
 		jest.runAllTimers();
 
@@ -64,11 +85,8 @@ describe( 'withFocusOutside', () => {
 	} );
 
 	it( 'should call handler if focus doesn\'t shift to element within component', () => {
-		const callback = jest.fn();
-		const wrapper = mount( <EnhancedComponent onFocusOutside={ callback } /> );
-
-		wrapper.find( 'input' ).at( 0 ).simulate( 'focus' );
-		wrapper.find( 'input' ).at( 0 ).simulate( 'blur' );
+		simulateEvent( 'focus' );
+		simulateEvent( 'blur' );
 
 		jest.runAllTimers();
 
@@ -76,12 +94,12 @@ describe( 'withFocusOutside', () => {
 	} );
 
 	it( 'should cancel check when unmounting while queued', () => {
-		const callback = jest.fn();
-		const wrapper = mount( <EnhancedComponent onFocusOutside={ callback } /> );
+		simulateEvent( 'focus' );
+		simulateEvent( 'input' );
 
-		wrapper.find( 'input' ).at( 0 ).simulate( 'focus' );
-		wrapper.find( 'input' ).at( 0 ).simulate( 'blur' );
-		wrapper.unmount();
+		/* eslint-disable react/no-find-dom-node */
+		ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( wrapper ).parentNode );
+		/* eslint-enable react/no-find-dom-node */
 
 		jest.runAllTimers();
 

--- a/components/higher-order/with-focus-outside/test/index.js
+++ b/components/higher-order/with-focus-outside/test/index.js
@@ -14,9 +14,7 @@ import { Component } from '@wordpress/element';
 import withFocusOutside from '../';
 import ReactDOM from 'react-dom';
 
-jest.useFakeTimers();
-
-let wrapper, callback;
+let wrapper, onFocusOutside;
 
 describe( 'withFocusOutside', () => {
 	const EnhancedComponent = withFocusOutside(
@@ -47,15 +45,15 @@ describe( 'withFocusOutside', () => {
 		return <TestComponent />;
 	};
 
-	const simulateEvent = ( event, position = 0 ) => {
+	const simulateEvent = ( event, index = 0 ) => {
 		const element = TestUtils.scryRenderedDOMComponentsWithTag( wrapper, 'input' );
-		TestUtils.Simulate[ event ]( element[ position ] );
+		TestUtils.Simulate[ event ]( element[ index ] );
 	};
 
 	beforeEach( () => {
-		callback = jest.fn();
+		onFocusOutside = jest.fn();
 		wrapper = TestUtils.renderIntoDocument(
-			getTestComponent( EnhancedComponent, { onFocusOutside: callback } )
+			getTestComponent( EnhancedComponent, { onFocusOutside } )
 		);
 	} );
 
@@ -66,7 +64,7 @@ describe( 'withFocusOutside', () => {
 
 		jest.runAllTimers();
 
-		expect( callback ).not.toHaveBeenCalled();
+		expect( onFocusOutside ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not call handler if focus transitions via click to button', () => {
@@ -81,7 +79,7 @@ describe( 'withFocusOutside', () => {
 
 		jest.runAllTimers();
 
-		expect( callback ).not.toHaveBeenCalled();
+		expect( onFocusOutside ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should call handler if focus doesn\'t shift to element within component', () => {
@@ -90,7 +88,7 @@ describe( 'withFocusOutside', () => {
 
 		jest.runAllTimers();
 
-		expect( callback ).toHaveBeenCalled();
+		expect( onFocusOutside ).toHaveBeenCalled();
 	} );
 
 	it( 'should cancel check when unmounting while queued', () => {
@@ -103,6 +101,6 @@ describe( 'withFocusOutside', () => {
 
 		jest.runAllTimers();
 
-		expect( callback ).not.toHaveBeenCalled();
+		expect( onFocusOutside ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This switches all tests in `components/higher-order/with-focus-outside/test/index.js` from using enzyme.shallow  and enzyme.mount to `React.TestUtils`.  This is because `enzyme` does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
