### PR TITLE
Switch away from using enzyme.mount in tests (viewport/test/with-viewport-match.js)

### DIFF
--- a/viewport/test/with-viewport-match.js
+++ b/viewport/test/with-viewport-match.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import renderer from 'react-test-renderer';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/viewport/test/with-viewport-match.js
+++ b/viewport/test/with-viewport-match.js
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { dispatch } from '@wordpress/data';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,14 +17,28 @@ import '../store';
 import withViewportMatch from '../with-viewport-match';
 
 describe( 'withViewportMatch()', () => {
-	const Component = () => <div>Hello</div>;
+	const ChildComponent = () => <div>Hello</div>;
+
+	// this is needed because TestUtils does not accept a stateless component.
+	// anything run through a HOC ends up as a stateless component.
+	const getTestComponent = ( WrappedComponent ) => {
+		class TestComponent extends Component {
+			render() {
+				return <WrappedComponent { ...this.props } />;
+			}
+		}
+		return <TestComponent />;
+	};
 
 	it( 'should render with result of query as custom prop name', () => {
 		dispatch( 'core/viewport' ).setIsMatching( { '> wide': true } );
-		const EnhancedComponent = withViewportMatch( { isWide: '> wide' } )( Component );
-		const wrapper = mount( <EnhancedComponent /> );
+		const EnhancedComponent = withViewportMatch(
+			{ isWide: '> wide' }
+		)( ChildComponent );
+		const wrapper = renderer.create( getTestComponent( EnhancedComponent ) );
 
-		expect( wrapper.find( Component ).props() ).toEqual( { isWide: true } );
+		expect( wrapper.root.findByType( ChildComponent ).props.isWide )
+			.toBe( true );
 
 		wrapper.unmount();
 	} );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This switches all tests in `viewport/test/with-viewport-match.js` from using enzyme.mount to `React.TestUtils`.  This is because `enzyme` does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
