### PR TITLE
Switch tests away from using enzyme.mount (components/higher-order/with-state/test/index.js)

### DIFF
--- a/components/higher-order/with-state/test/index.js
+++ b/components/higher-order/with-state/test/index.js
@@ -1,12 +1,28 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
  */
 import withState from '../';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+// this is needed because TestUtils does not accept a stateless component.
+// anything run through a HOC ends up as a stateless component.
+const getTestComponent = ( WrappedComponent ) => {
+	class TestComponent extends Component {
+		render() {
+			return <WrappedComponent { ...this.props } />;
+		}
+	}
+	return <TestComponent />;
+};
 
 describe( 'withState', () => {
 	it( 'should pass initial state and allow updates', () => {
@@ -16,10 +32,11 @@ describe( 'withState', () => {
 			</button>
 		) );
 
-		const wrapper = mount( <EnhancedComponent /> );
+		const wrapper = TestUtils.renderIntoDocument( getTestComponent( EnhancedComponent ) );
+		const buttonElement = () => TestUtils.findRenderedDOMComponentWithTag( wrapper, 'button' );
 
-		expect( wrapper.html() ).toBe( '<button>0</button>' );
-		wrapper.find( 'button' ).simulate( 'click' );
-		expect( wrapper.html() ).toBe( '<button>1</button>' );
+		expect( buttonElement().outerHTML ).toBe( '<button>0</button>' );
+		TestUtils.Simulate.click( buttonElement() );
+		expect( buttonElement().outerHTML ).toBe( '<button>1</button>' );
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This switches all tests in `components/higher-order/with-state/test/index.js` from using enzyme.mount to `React.TestUtils`.  This is because `enzyme` does not fully support React 16.3+ (and movement to do so is really slow). This will fix issues with breakage due to the enzyme incompatibility as components receive React 16.3+ features (such as `forwardRef` usage in #7557).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
