### PR TITLE
Fix: Transforms: Audio and Video to file transform bug; Add: getTextElements function:

### DIFF
--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -8,7 +8,7 @@ import { includes } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { createBlobURL } from '@wordpress/blob';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, children } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 
 /**
@@ -97,7 +97,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/file', {
 						href: attributes.src,
-						fileName: attributes.caption && attributes.caption.join(),
+						fileName: attributes.caption && children.toText( attributes.caption ),
 						textLinkHref: attributes.src,
 						id: attributes.id,
 					} );
@@ -109,7 +109,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/file', {
 						href: attributes.src,
-						fileName: attributes.caption && attributes.caption.join(),
+						fileName: attributes.caption && children.toText( attributes.caption ),
 						textLinkHref: attributes.src,
 						id: attributes.id,
 					} );
@@ -121,7 +121,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/file', {
 						href: attributes.url,
-						fileName: attributes.caption && attributes.caption.join(),
+						fileName: attributes.caption && children.toText( attributes.caption ),
 						textLinkHref: attributes.url,
 						id: attributes.id,
 					} );

--- a/packages/blocks/src/api/children.js
+++ b/packages/blocks/src/api/children.js
@@ -6,7 +6,7 @@ import { castArray } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { renderToString } from '@wordpress/element';
+import { renderToString, getTextElements } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -101,6 +101,19 @@ export function toHTML( children ) {
 }
 
 /**
+ * Given a block node, returns its text content.
+ *
+ * @param {WPBlockChildren} children Block node(s) to convert to text string.
+ *
+ * @return {string} String with the text content of a block node.
+ */
+export function toText( children ) {
+	const element = getSerializeCapableElement( children );
+
+	return getTextElements( element ).join( '' );
+}
+
+/**
  * Given a selector, returns an hpq matcher generating a WPBlockChildren value
  * matching the selector result.
  *
@@ -129,4 +142,5 @@ export default {
 	fromDOM,
 	toHTML,
 	matcher,
+	toText,
 };

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -13,7 +13,7 @@ import {
 	isValidElement,
 	StrictMode,
 } from 'react';
-import { isString } from 'lodash';
+import { flatMap, isArray, isString } from 'lodash';
 
 export { Children };
 
@@ -132,4 +132,25 @@ export function switchChildrenNodeName( children, nodeName ) {
 		const { children: childrenProp, ...props } = elt.props;
 		return createElement( nodeName, { key: index, ...props }, childrenProp );
 	} );
+}
+
+/**
+ * Function that returns an array of all the text elements
+ * descendants of the element passed.
+ *
+ * @param {?Array|string|WPElement} element Element object, a string representing a text node
+ *                                          or an array of nodes.
+ *
+ * @return {?Array} An array of all text nodes present on the tree of the element passed.
+ */
+export function getTextElements( element ) {
+	if ( isString( element ) ) {
+		return element;
+	}
+	if ( isArray( element ) ) {
+		return flatMap( element, ( child ) => getTextElements( child ) );
+	}
+	if ( element && element.props && element.props.children ) {
+		return getTextElements( element.props.children );
+	}
 }


### PR DESCRIPTION
The audio and video to file transform contain a bug where if formats were used (e.g: bold, italic, ...)  the caption was not correctly parsed.
Here we add a new function getTextElements that returns an array of all the text nodes present in an elements hierarchy, and we make use of that function to solve the bug in the transform.

Fixes: https://github.com/WordPress/gutenberg/issues/7626

## How has this been tested?
Add a an audio block, add a caption with formats e.g: bold, italic etc.. Transform to file block and verify things work as expected.
Repeat the steps for the video block.

