### PR TITLE
Remove test from being skipped for button.js

### DIFF
--- a/components/button/test/index.js
+++ b/components/button/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
 
 /**
  * WordPress dependencies
@@ -103,17 +104,12 @@ describe( 'Button', () => {
 		} );
 	} );
 
-	// Disable reason: This test is desirable, but unsupported by Enzyme in
-	// the current version, as it depends on features new to React in 16.3.0.
-	//
-	// eslint-disable-next-line jest/no-disabled-tests
-	describe.skip( 'ref forwarding', () => {
+	describe( 'ref forwarding', () => {
 		it( 'should enable access to DOM element', () => {
 			const ref = createRef();
 
-			mount( <ButtonWithForwardedRef ref={ ref } /> );
-
-			expect( ref.current.nodeName ).toBe( 'button' );
+			TestUtils.renderIntoDocument( <ButtonWithForwardedRef ref={ ref } /> );
+			expect( ref.current.type ).toBe( 'button' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
The test in this pull was skipped because of enzyme incompatibility with forwardRef usage.  Ideally we should not be skipping tests because its easy to forget about them.  This pull uses `React.TestUtils` to test the ref forwarding.

Important to get this into master so we can track any regressions in other forwardRef work (such as #7557)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
