### PR TITLE
Fix: getInserterItems caching bug; Add: new test case;

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1584,7 +1584,7 @@ export const getInserterItems = createSelector(
 			[ 'desc', 'desc' ]
 		);
 	},
-	( state, editorAllowedBlockTypes, parentUID ) => [
+	( state, parentUID ) => [
 		state.blockListSettings[ parentUID ],
 		state.editor.present.blockOrder,
 		state.editor.present.blocksByUID,

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -3142,6 +3142,64 @@ describe( 'selectors', () => {
 			] );
 		} );
 
+		it( 'should correctly cache the return values', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUID: {
+							block1: { name: 'core/test-block-a' },
+							block2: { name: 'core/test-block-a' },
+						},
+						blockOrder: {},
+						edits: {},
+					},
+				},
+				sharedBlocks: {
+					data: {
+						1: { uid: 'block1', title: 'Shared Block 1' },
+						2: { uid: 'block1', title: 'Shared Block 2' },
+					},
+				},
+				currentPost: {},
+				preferences: {
+					insertUsage: {},
+				},
+				blockListSettings: {},
+				settings: {},
+			};
+
+			const stateSecondBlockRestricted = {
+				...state,
+				blockListSettings: {
+					block2: {
+						allowedBlocks: [ 'core/test-block-b' ],
+					},
+				},
+			};
+
+			const firstBlockFirstCall = getInserterItems( state, 'block1' );
+			const firstBlockSecondCall = getInserterItems( stateSecondBlockRestricted, 'block1' );
+			expect( firstBlockFirstCall ).toBe( firstBlockSecondCall );
+			expect( firstBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
+				'core/test-block-b',
+				'core/test-block-a',
+				'core/block/1',
+				'core/block/2',
+			] );
+
+			const secondBlockFirstCall = getInserterItems( state, 'block2' );
+			const secondBlockSecondCall = getInserterItems( stateSecondBlockRestricted, 'block2' );
+			expect( secondBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
+				'core/test-block-b',
+				'core/test-block-a',
+				'core/block/1',
+				'core/block/2',
+			] );
+			expect( secondBlockSecondCall.map( ( item ) => item.id ) ).toEqual( [
+				'core/test-block-b',
+			] );
+		} );
+
 		it( 'should set isDisabled when a block with `multiple: false` has been used', () => {
 			const state = {
 				editor: {


### PR DESCRIPTION
The editorAllowedBlockTypes parameter was not removed from the dependents computation function. This the selector cache behave in unexpected ways.
This bug was causing problems in PR https://github.com/WordPress/gutenberg/pull/7414.

## How has this been tested?
In PR https://github.com/WordPress/gutenberg/pull/7414 add the Half Media block. Verify in the media placeholder we have the inserter visible add a block, remove the block and verify the inserter is not visible again. Write something in any block and the inserter appears. If we merge this PR in the other branch the bug stops happening.
Revert the change to getInserterItems and verify our test case fails.

