### PR TITLE
Packages: Deprecated: Log message maximum once per session

### DIFF
--- a/packages/deprecated/src/index.js
+++ b/packages/deprecated/src/index.js
@@ -1,4 +1,12 @@
 /**
+ * Object map tracking messages which have been logged, for use in ensuring a
+ * message is only logged once.
+ *
+ * @type {Object}
+ */
+export const logged = Object.create( null );
+
+/**
  * Logs a message to notify developers about a deprecated feature.
  *
  * @param {string}  feature             Name of the deprecated feature.
@@ -17,6 +25,13 @@ export default function deprecated( feature, { version, alternative, plugin, lin
 	const hintMessage = hint ? ` Note: ${ hint }` : '';
 	const message = `${ feature } is deprecated and will be removed${ versionMessage }.${ useInsteadMessage }${ linkMessage }${ hintMessage }`;
 
+	// Skip if already logged.
+	if ( message in logged ) {
+		return;
+	}
+
 	// eslint-disable-next-line no-console
 	console.warn( message );
+
+	logged[ message ] = true;
 }

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -1,9 +1,15 @@
 /**
  * Internal dependencies
  */
-import deprecated from '../';
+import deprecated, { logged } from '../';
 
 describe( 'deprecated', () => {
+	afterEach( () => {
+		for ( const key in logged ) {
+			delete logged[ key ];
+		}
+	} );
+
 	it( 'should show a deprecation warning', () => {
 		deprecated( 'Eating meat' );
 
@@ -64,5 +70,14 @@ describe( 'deprecated', () => {
 		expect( console ).toHaveWarnedWith(
 			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead. Note: You may find it beneficial to transition gradually.'
 		);
+	} );
+
+	it( 'should show a message once', () => {
+		deprecated( 'Eating meat' );
+		deprecated( 'Eating meat' );
+
+		expect( console ).toHaveWarned();
+		// eslint-disable-next-line no-console
+		expect( console.warn ).toHaveBeenCalledTimes( 1 );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to enhance the deprecated module to log a message only once per session, keeping its own internal memoization cache and logging a message if only having not already logged the message.

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/deprecated/src/test/index.js
```