### PR TITLE
Update spacing in prepublish panel titles

### DIFF
--- a/editor/components/post-publish-panel/prepublish.js
+++ b/editor/components/post-publish-panel/prepublish.js
@@ -30,13 +30,13 @@ function PostPublishPanelPrepublish( {
 			{ hasPublishAction && (
 				<Fragment>
 					<PanelBody initialOpen={ false } title={ [
-						__( 'Visibility: ' ),
+						__( 'Visibility:' ),
 						<span className="editor-post-publish-panel__link" key="label"><PostVisibilityLabel /></span>,
 					] }>
 						<PostVisibility />
 					</PanelBody>
 					<PanelBody initialOpen={ false } title={ [
-						__( 'Publish: ' ),
+						__( 'Publish:' ),
 						<span className="editor-post-publish-panel__link" key="label"><PostScheduleLabel /></span>,
 					] }>
 						<PostSchedule />

--- a/editor/components/post-publish-panel/style.scss
+++ b/editor/components/post-publish-panel/style.scss
@@ -44,6 +44,7 @@
 
 .editor-post-publish-panel__link {
 	color: $blue-medium-700;
+	padding-left: 4px;
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
## Description
Adds missing spaces to the prepublish panel titles, fixing #7842.

## Before:
<img width="282" alt="screenshot 2018-07-09 20 06 39" src="https://user-images.githubusercontent.com/376315/42474924-f75667da-83c0-11e8-9ecf-77140a85e6ea.png">

## After:
<img width="304" alt="screenshot 2018-07-09 20 05 07" src="https://user-images.githubusercontent.com/376315/42474934-fde8912c-83c0-11e8-87f5-316454f369d7.png">

## How has this been tested?
Tested on my local install Mac Chrome/Firefox, using English and Hebrew to test RTL-conversion.

## Types of changes
Super-quick three-line bug fix!

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
