### PR TITLE
Properly convert successive shortcodes

### DIFF
--- a/blocks/api/raw-handling/test/shortcode-converter.js
+++ b/blocks/api/raw-handling/test/shortcode-converter.js
@@ -36,7 +36,31 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 <p>Bar</p>` );
 	} );
 
-	it( 'should convert multiple instances of the same shortcode', () => {
+	it( 'should convert two instances of the same shortcode', () => {
+		const original = `<p>[foo one]</p>
+<p>[foo two]</p>`;
+
+		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
+		expect( transformed[ 0 ] ).toEqual( '<p>' );
+		const firstExpectedBlock = createBlock( 'core/shortcode', {
+			text: '[foo one]',
+		} );
+		// uid will always be random.
+		firstExpectedBlock.uid = transformed[ 1 ].uid;
+		expect( transformed[ 1 ] ).toEqual( firstExpectedBlock );
+		expect( transformed[ 2 ] ).toEqual( `</p>
+<p>` );
+		const secondExpectedBlock = createBlock( 'core/shortcode', {
+			text: '[foo two]',
+		} );
+		// uid will always be random.
+		secondExpectedBlock.uid = transformed[ 3 ].uid;
+		expect( transformed[ 3 ] ).toEqual( secondExpectedBlock );
+		expect( transformed[ 4 ] ).toEqual( '</p>' );
+		expect( transformed ).toHaveLength( 5 );
+	} );
+
+	it( 'should convert four instances of the same shortcode', () => {
 		const original = `<p>[foo one]</p>
 <p>[foo two]</p>
 <p>[foo three]</p>

--- a/blocks/api/raw-handling/test/shortcode-converter.js
+++ b/blocks/api/raw-handling/test/shortcode-converter.js
@@ -35,4 +35,46 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 
 <p>Bar</p>` );
 	} );
+
+	it( 'should convert multiple instances of the same shortcode', () => {
+		const original = `<p>[foo one]</p>
+<p>[foo two]</p>
+<p>[foo three]</p>
+<p>[foo four]</p>`;
+
+		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
+		expect( transformed[ 0 ] ).toEqual( '<p>' );
+		const firstExpectedBlock = createBlock( 'core/shortcode', {
+			text: '[foo one]',
+		} );
+		// uid will always be random.
+		firstExpectedBlock.uid = transformed[ 1 ].uid;
+		expect( transformed[ 1 ] ).toEqual( firstExpectedBlock );
+		expect( transformed[ 2 ] ).toEqual( `</p>
+<p>` );
+		const secondExpectedBlock = createBlock( 'core/shortcode', {
+			text: '[foo two]',
+		} );
+		// uid will always be random.
+		secondExpectedBlock.uid = transformed[ 3 ].uid;
+		expect( transformed[ 3 ] ).toEqual( secondExpectedBlock );
+		expect( transformed[ 4 ] ).toEqual( `</p>
+<p>` );
+		const thirdExpectedBlock = createBlock( 'core/shortcode', {
+			text: '[foo three]',
+		} );
+		// uid will always be random.
+		thirdExpectedBlock.uid = transformed[ 5 ].uid;
+		expect( transformed[ 5 ] ).toEqual( thirdExpectedBlock );
+		expect( transformed[ 6 ] ).toEqual( `</p>
+<p>` );
+		const fourthExpectedBlock = createBlock( 'core/shortcode', {
+			text: '[foo four]',
+		} );
+		// uid will always be random.
+		fourthExpectedBlock.uid = transformed[ 5 ].uid;
+		expect( transformed[ 5 ] ).toEqual( fourthExpectedBlock );
+		expect( transformed[ 8 ] ).toEqual( '</p>' );
+		expect( transformed ).toHaveLength( 9 );
+	} );
 } );

--- a/blocks/api/raw-handling/test/shortcode-converter.js
+++ b/blocks/api/raw-handling/test/shortcode-converter.js
@@ -96,8 +96,8 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 			text: '[foo four]',
 		} );
 		// uid will always be random.
-		fourthExpectedBlock.uid = transformed[ 5 ].uid;
-		expect( transformed[ 5 ] ).toEqual( fourthExpectedBlock );
+		fourthExpectedBlock.uid = transformed[ 7 ].uid;
+		expect( transformed[ 7 ] ).toEqual( fourthExpectedBlock );
 		expect( transformed[ 8 ] ).toEqual( '</p>' );
 		expect( transformed ).toHaveLength( 9 );
 	} );

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -145,7 +145,7 @@ export function string( options ) {
  */
 export function regexp( tag ) {
 	return new RegExp( '\\[(\\[?)(' + tag + ')(?![\\w-])([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*(?:\\[(?!\\/\\2\\])[^\\[]*)*)(\\[\\/\\2\\]))?)(\\]?)', 'g' );
-};
+}
 
 /**
  * Parse shortcode attributes.

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -143,9 +143,9 @@ export function string( options ) {
  *
  * @return {RegExp} Shortcode RegExp.
  */
-export const regexp = memize( ( tag ) => {
+export const regexp = ( tag ) => {
 	return new RegExp( '\\[(\\[?)(' + tag + ')(?![\\w-])([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*(?:\\[(?!\\/\\2\\])[^\\[]*)*)(\\[\\/\\2\\]))?)(\\]?)', 'g' );
-} );
+};
 
 /**
  * Parse shortcode attributes.

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -143,7 +143,7 @@ export function string( options ) {
  *
  * @return {RegExp} Shortcode RegExp.
  */
-export const regexp = ( tag ) => {
+export function regexp( tag ) {
 	return new RegExp( '\\[(\\[?)(' + tag + ')(?![\\w-])([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*(?:\\[(?!\\/\\2\\])[^\\[]*)*)(\\[\\/\\2\\]))?)(\\]?)', 'g' );
 };
 


### PR DESCRIPTION
## Description

Removes `memize()` call around `wp.shortcode.regexp()` to avoid buggy behavior when converting successive shortcodes.

Fixes #7030

## How has this been tested?

1. Add the following code to a Classic Editor post:

```
[foo one]

[foo two]

[foo three]
```

2. Open the post in Gutenberg.
3. Hit 'Convert to Blocks' and see that all shortcode instances have been converted to blocks.

![multipleshortcodes](https://user-images.githubusercontent.com/36432/42576867-3205e834-84d8-11e8-8e6c-c2b9ec20c432.gif)

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
