### PR TITLE
Update local install instructions and add add more verbose instructions when node versions don't match

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,43 @@ To test the plugin, or to contribute to it, you can clone this repository and bu
 
 ### Local Environment
 
-First, you need a WordPress Environment to run the plugin on. The quickest way to get up and running is to use the provided docker setup. Just install [docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/) on your machine and run `./bin/setup-local-env.sh`.
+First, you need a WordPress Environment to run the plugin on. The quickest way to get up and running is to use the provided docker setup. Install [docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/) by following the most recent instructions on the docker site.
+ 
+In the folder of your preference, clone this project and enter the working directory:
+```bash
+git clone git@github.com:WordPress/gutenberg.git
+cd gutenberg 
+```
+
+Then, run a setup script to check if docker and node are configured properly and starts the local WordPress instance. You may need to run this script multiple times if prompted.
+```
+./bin/setup-local-env.sh
+``` 
+
+If everything was successful, you'll see the following ascii art:
+```
+Welcome to...
+
+,⁻⁻⁻·       .                 |
+|  ،⁓’.   . |---  ,---. ,---. |---. ,---. ,---. ,---.
+|   | |   | |     |---' |   | |   | |---' |     |   |
+`---' `---' `---’ `---’ '   ` `---' `---’ `     `---|
+                                                `---'
+```
 
 The WordPress installation should be available at `http://localhost:8888` (username: `admin`, password: `password`).
 Inside the "docker" directory, you can use any docker command to interact with your containers. If this port is in use, you can override it in your `docker-compose.override.yml` file. If you're running [e2e tests](https://wordpress.org/gutenberg/handbook/reference/testing-overview/#end-to-end-testing), this change will be used correctly.
+
+To bring down this local WordPress instance later run:
+```
+docker-compose down
+```
+
+If you'd like to see your changes reflected in this local WordPress instance, run:
+```
+npm install
+npm run dev
+```
 
 Alternatively, you can use your own local WordPress environment and clone this repository right into your `wp-content/plugins` directory.
 

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -60,7 +60,7 @@ fi
 # Check if the current node version is up to date.
 if [ "$TRAVIS" != "true" ] && [ "$(nvm current)" != "$(nvm version-remote --lts)" ]; then
 	echo -e $(warning_message "Node version does not match the latest long term support version. Please run this command to install and use it:" )
-	echo -e $(warning_message "$(action_format "nvm install; nvm use")" )
+	echo -e $(warning_message "$(action_format "nvm install")" )
 	echo -e $(warning_message "After that, re-run the setup script to continue." )
 	exit 1
 fi

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -59,12 +59,8 @@ fi
 
 # Check if the current node version is up to date.
 if [ "$TRAVIS" != "true" ] && [ "$(nvm current)" != "$(nvm version-remote --lts)" ]; then
-	echo -en $(status_message "Updating Node..." )
-	nvm install >/dev/null 2>&1
-	echo ' done!'
-
-	echo -e $(warning_message "A new node version was installed, please run this command to use it:" )
-	echo -e $(warning_message "$(action_format "nvm use")" )
+	echo -e $(warning_message "Node version does not match the latest long term support version. Please run this command to install and use it:" )
+	echo -e $(warning_message "$(action_format "nvm install; nvm use")" )
 	echo -e $(warning_message "After that, re-run the setup script to continue." )
 	exit 1
 fi


### PR DESCRIPTION
I'm happy to pull this out to two separate issues, but wanted to put up a PR while this is fresh in my mind.

While running through local environment setup steps, I ran `bin/install-node-nvm.sh` and got stuck at the Node update step. Locally, if I don't have `v8.11.3` installed (not shown in `nvm ls`), it exits with an error code of 1 and unhelpfully prints the following:
```
$ ./bin/setup-local-env.sh
STATUS: Updating Node..$
```

New suggested output is now:
```
$ ./bin/setup-local-env.sh
WARNING: Node version does not match the latest long term support version. Please run this command to install and use it:
WARNING: nvm install
WARNING: After that, re-run the setup script to continue.
```

Running `nvm install` manually appear to work fine, and reads appropriately from the .nvmrc file, so I'm not sure why that is happening. I've suggested a script update to prompt the user to `nvm install; nvm use;` since we exit out anyway after the install. Let me know if other folks can reproduce this.

Because I ran into this issue, I didn't realize that docker-compose would be triggered by `bin/install-node-nvm.sh`, until I read through the script. I've added a few README suggestions to clarify what the setup script does, and what it looks like when it runs successfully. 