### PR TITLE
Fix exception to do with saving a new shared block

### DIFF
--- a/core-blocks/block/edit.js
+++ b/core-blocks/block/edit.js
@@ -28,11 +28,19 @@ class SharedBlockEdit extends Component {
 		this.setTitle = this.setTitle.bind( this );
 		this.save = this.save.bind( this );
 
-		this.state = {
-			isEditing: !! ( sharedBlock && sharedBlock.isTemporary ),
-			title: null,
-			changedAttributes: null,
-		};
+		if ( sharedBlock && sharedBlock.isTemporary ) {
+			this.state = {
+				isEditing: true,
+				title: sharedBlock.title,
+				changedAttributes: {},
+			};
+		} else {
+			this.state = {
+				isEditing: false,
+				title: null,
+				changedAttributes: null,
+			};
+		}
 	}
 
 	componentDidMount() {

--- a/core-blocks/block/edit.js
+++ b/core-blocks/block/edit.js
@@ -29,12 +29,14 @@ class SharedBlockEdit extends Component {
 		this.save = this.save.bind( this );
 
 		if ( sharedBlock && sharedBlock.isTemporary ) {
+			// Start in edit mode when we're working with a newly created shared block
 			this.state = {
 				isEditing: true,
 				title: sharedBlock.title,
 				changedAttributes: {},
 			};
 		} else {
+			// Start in preview mode when we're working with an existing shared block
 			this.state = {
 				isEditing: false,
 				title: null,


### PR DESCRIPTION
Fixes #7517.

Newly created shared blocks had their `state.title` set to `null` which would cause an exception later when searching in the inserter.

The fix is to initialise state in the `SharedBlockEdit` constructor in a manner consistent with how this state is managed throughout the rest of the component (e.g. in `startEditing` and `stopEditing`). 

To test:

1. Create a new Page
2. Enter a Title and create a single Text Block
3. Click on the three-dot contextual menu, click "Convert to Shared Block"
4. Click on "Save" without changing the default name of the shared block ("Untitled shared block")
4. Click on the (+) in the top bar to add a new Block
5. The editor should not crash