### PR TITLE
Cover Image: Change the label from "Background Dimness" to "Background Opacity".

### DIFF
--- a/core-blocks/cover-image/index.js
+++ b/core-blocks/cover-image/index.js
@@ -161,7 +161,7 @@ export const settings = {
 								onChange={ toggleParallax }
 							/>
 							<RangeControl
-								label={ __( 'Background Dimness' ) }
+								label={ __( 'Background Opacity' ) }
 								value={ dimRatio }
 								onChange={ setDimRatio }
 								min={ 0 }


### PR DESCRIPTION
Fixes #7853.

## Description
I've change the label on the Cover Image block "Background Dimness" slider to "Background Opacity".

## How has this been tested?
I ran `npm run dev` to test this.

## Screenshots

<img width="553" alt="background-opacity" src="https://user-images.githubusercontent.com/1377956/42488996-d890549c-844b-11e8-8852-bd3fa15d0d1d.png">


## Types of changes
It's just a label change as dimness isn't a commonly used word.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
