### PR TITLE
Change the text label from "Source Type" to "Image Size"

### DIFF
--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -278,7 +278,7 @@ class ImageEdit extends Component {
 					/>
 					{ ! isEmpty( availableSizes ) && (
 						<SelectControl
-							label={ __( 'Source Type' ) }
+							label={ __( 'Image Size' ) }
 							value={ url }
 							options={ map( availableSizes, ( size, name ) => ( {
 								value: size.source_url,


### PR DESCRIPTION
Fixes #7855.

## Description
I've changed the label on the Image block from "Source Type" to "Image Size".

## How has this been tested?
I ran `npm run dev` to test this.

## Screenshots
<img width="589" alt="image-size" src="https://user-images.githubusercontent.com/1377956/42490653-d9d0e20a-8454-11e8-9408-0cb3c12f553b.png">

## Types of changes
It's just a label change as "Source Type" is a developer friendly term but not a user friendly term.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
