### PR TITLE
Align timepicker to calendar

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -44,6 +44,7 @@ $datepicker__border-color: $light-gray-500;
 	align-items: center;
 	justify-content: center;
 	margin-top: 10px;
+	max-width: 248px;
 
 	.components-time-picker__input {
 		width: 40px;


### PR DESCRIPTION
## Description
At tablet-ish screen sizes, the calendar in the pre-publish panel is aligned to the left of the panel, whilst the timepicker attached to it floats way out in the middle of the screen, making them seem disconnected. Adding a max-width to the timepicker solves this issue and doesn't seem to break when using different languages, zoom levels, or font sizes.

Fixes #7863.

## How has this been tested?
Tested in Chrome/Firefox on a Mac, in English, Hebrew, and Japanese (and at varying levels of zoom and font sizes). 

## Before:
<img width="728" alt="screenshot 2018-07-09 20 23 47" src="https://user-images.githubusercontent.com/376315/42509216-1ad5dd1c-8443-11e8-99c0-a23452098f1b.png">

## After:
<img width="725" alt="screenshot 2018-07-10 12 59 32" src="https://user-images.githubusercontent.com/376315/42509186-0d15fe28-8443-11e8-9b9c-fe5696fc2103.png">


## Types of changes
Simple bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
