### PR TITLE
Update/use unfiltered html selector

### DIFF
--- a/editor/components/block-edit/index.js
+++ b/editor/components/block-edit/index.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { noop, get } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
 import { Component, compose } from '@wordpress/element';
-import { withAPIData } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -27,13 +26,10 @@ export class BlockEdit extends Component {
 	}
 
 	getChildContext() {
-		const { user } = this.props;
+		const { canUserUseUnfilteredHTML } = this.props;
 
 		return {
-			canUserUseUnfilteredHTML: get( user.data, [
-				'capabilities',
-				'unfiltered_html',
-			], false ),
+			canUserUseUnfilteredHTML,
 		};
 	}
 
@@ -72,8 +68,6 @@ BlockEdit.childContextTypes = {
 export default compose( [
 	withSelect( ( select ) => ( {
 		postType: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
-	} ) ),
-	withAPIData( ( { postType } ) => ( {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+		canUserUseUnfilteredHTML: select( 'core/editor' ).canUserUseUnfilteredHTML(),
 	} ) ),
 ] )( BlockEdit );

--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -1,18 +1,13 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, withAPIData } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 import { getUnknownTypeHandlerName, rawHandler, serialize } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-export function UnknownConverter( { block, onReplace, small, user, role } ) {
+export function UnknownConverter( { block, onReplace, small, canUserUseUnfilteredHTML, role } ) {
 	if ( ! block || getUnknownTypeHandlerName() !== block.name ) {
 		return null;
 	}
@@ -23,7 +18,7 @@ export function UnknownConverter( { block, onReplace, small, user, role } ) {
 		onReplace( block.uid, rawHandler( {
 			HTML: serialize( block ),
 			mode: 'BLOCKS',
-			canUserUseUnfilteredHTML: get( user, [ 'data', 'capabilities', 'unfiltered_html' ], false ),
+			canUserUseUnfilteredHTML,
 		} ) );
 	};
 
@@ -42,16 +37,14 @@ export function UnknownConverter( { block, onReplace, small, user, role } ) {
 
 export default compose(
 	withSelect( ( select, { uid } ) => {
-		const { getBlock, getCurrentPostType } = select( 'core/editor' );
+		const { canUserUseUnfilteredHTML, getBlock, getCurrentPostType } = select( 'core/editor' );
 		return {
 			block: getBlock( uid ),
 			postType: getCurrentPostType(),
+			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
 		onReplace: dispatch( 'core/editor' ).replaceBlocks,
-	} ) ),
-	withAPIData( ( { postType } ) => ( {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 	} ) ),
 )( UnknownConverter );


### PR DESCRIPTION
Depends on #7667

This PR substitutes the remaining uses of unfiltered_html capability and withAPIData.

We want to deprecate withAPIData soon (#7390 and #7397), and also prevent the direct use of user capabilities in client code (#6361).