### PR TITLE
Framework: Reorder package.json devDependencies alphabetically

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
 		"uuid": "3.1.0"
 	},
 	"devDependencies": {
-		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
+		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 		"@wordpress/browserslist-config": "file:packages/browserslist-config",
 		"@wordpress/custom-templated-path-webpack-plugin": "file:packages/custom-templated-path-webpack-plugin",


### PR DESCRIPTION
This pull request seeks to update `package.json` to apply correct alphabetical ordering to `devDependencies`. This change was observed with a simple `npm install`, likely related to the merge of packages in #7805.

**Testing instructions:**

Ensure npm installs without issue:

```
npm install
```

Should be no impact on the application.