### PR TITLE
Block Edit: Remove legacy context API child context

### DIFF
--- a/core-blocks/test/helpers/index.js
+++ b/core-blocks/test/helpers/index.js
@@ -12,11 +12,7 @@ import {
 	getBlockType,
 	registerBlockType,
 } from '@wordpress/blocks';
-// Requiredd to register the editor's store
-import '@wordpress/editor';
-
-// Hack to avoid the wrapping HoCs.
-import { BlockEdit } from '../../../editor/components/block-edit';
+import { BlockEdit } from '@wordpress/editor';
 
 export const blockEditRender = ( name, settings ) => {
 	if ( ! getBlockType( name ) ) {

--- a/editor/components/block-edit/index.js
+++ b/editor/components/block-edit/index.js
@@ -1,13 +1,7 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
-import { Component, compose } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,21 +9,15 @@ import { Component, compose } from '@wordpress/element';
 import Edit from './edit';
 import { BlockEditContextProvider } from './context';
 
-export class BlockEdit extends Component {
+class BlockEdit extends Component {
 	constructor( props ) {
 		super( props );
+
 		this.setFocusedElement = this.setFocusedElement.bind( this );
+
 		this.state = {
 			focusedElement: null,
 			setFocusedElement: this.setFocusedElement,
-		};
-	}
-
-	getChildContext() {
-		const { canUserUseUnfilteredHTML } = this.props;
-
-		return {
-			canUserUseUnfilteredHTML,
 		};
 	}
 
@@ -61,13 +49,4 @@ export class BlockEdit extends Component {
 	}
 }
 
-BlockEdit.childContextTypes = {
-	canUserUseUnfilteredHTML: noop,
-};
-
-export default compose( [
-	withSelect( ( select ) => ( {
-		postType: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
-		canUserUseUnfilteredHTML: select( 'core/editor' ).canUserUseUnfilteredHTML(),
-	} ) ),
-] )( BlockEdit );
+export default BlockEdit;

--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -357,7 +357,7 @@ export class RichText extends Component {
 			plainText: this.pastedPlainText,
 			mode,
 			tagName: this.props.tagName,
-			canUserUseUnfilteredHTML: this.context.canUserUseUnfilteredHTML,
+			canUserUseUnfilteredHTML: this.props.canUserUseUnfilteredHTML,
 		} );
 
 		if ( typeof content === 'string' ) {
@@ -986,7 +986,6 @@ export class RichText extends Component {
 RichText.contextTypes = {
 	onUndo: noop,
 	onRedo: noop,
-	canUserUseUnfilteredHTML: noop,
 	onCreateUndoLevel: noop,
 };
 
@@ -1009,6 +1008,7 @@ const RichTextContainer = compose( [
 				isSelected: context.isSelected,
 			};
 		}
+
 		// Ensures that only one RichText component can be focused.
 		return {
 			isSelected: context.isSelected && context.focusedElement === ownProps.instanceId,
@@ -1017,9 +1017,11 @@ const RichTextContainer = compose( [
 	} ),
 	withSelect( ( select ) => {
 		const { isViewportMatch = identity } = select( 'core/viewport' ) || {};
+		const { canUserUseUnfilteredHTML } = select( 'core/editor' );
 
 		return {
 			isViewportSmall: isViewportMatch( '< small' ),
+			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 		};
 	} ),
 	withSafeTimeout,


### PR DESCRIPTION
This pull request seeks to refactor `BlockEdit` to remove use of the legacy context API (`getChildContext`).

It removes the need for `withSelect`, opting instead to omit `canUserUseUnfilteredHTML` from block context and consume directly from the single location where it is used (`RichText`). Presumably this was needed to be passed by context when `RichText` was not part of the editor directory. The `postType` prop, to the best of my knowledge, is not used at all.

**Testing instructions:**

Verify there are no other usage of the `canUserUseUnfilteredHTML` context.

Ensure there are no regressions in `RichText`'s use of the `canUserUseUnfilteredHTML` prop (see #4660).