### PR TITLE
Block List: Insert blocks after as default block

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -326,7 +326,7 @@ export class BlockListBlock extends Component {
 			case ENTER:
 				// Insert default block after current block if enter and event
 				// not already handled by descendant.
-				this.props.onInsertDefaultBlock( this.props.order + 1 );
+				this.props.onInsertDefaultBlockAfter();
 				event.preventDefault();
 				break;
 
@@ -655,7 +655,10 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 			blocks = blocks.map( ( block ) => cloneBlock( block, { layout } ) );
 			insertBlocks( blocks, index, rootUID );
 		},
-		onInsertDefaultBlock: insertDefaultBlock,
+		onInsertDefaultBlockAfter() {
+			const { order, rootUID } = ownProps;
+			insertDefaultBlock( {}, rootUID, order + 1 );
+		},
 		onRemove( uid ) {
 			removeBlock( uid );
 		},

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/dom';
 import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
 import {
-	createBlock,
 	cloneBlock,
 	getBlockType,
 	getSaveElement,
@@ -327,9 +326,7 @@ export class BlockListBlock extends Component {
 			case ENTER:
 				// Insert default block after current block if enter and event
 				// not already handled by descendant.
-				this.props.onInsertBlocks( [
-					createBlock( 'core/paragraph' ),
-				], this.props.order + 1 );
+				this.props.onInsertDefaultBlock( this.props.order + 1 );
 				event.preventDefault();
 				break;
 
@@ -638,6 +635,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		updateBlockAttributes,
 		selectBlock,
 		insertBlocks,
+		insertDefaultBlock,
 		removeBlock,
 		mergeBlocks,
 		replaceBlocks,
@@ -657,6 +655,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 			blocks = blocks.map( ( block ) => cloneBlock( block, { layout } ) );
 			insertBlocks( blocks, index, rootUID );
 		},
+		onInsertDefaultBlock: insertDefaultBlock,
 		onRemove( uid ) {
 			removeBlock( uid );
 		},

--- a/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/adding-blocks.test.js.snap
@@ -5,6 +5,38 @@ exports[`adding blocks Should insert content using the placeholder and the regul
 <p>Paragraph block</p>
 <!-- /wp:paragraph -->
 
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\">
+	<p>Quote block</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\" /></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`adding blocks Should insert content using the placeholder and the regular inserter 2`] = `
+"<!-- wp:paragraph -->
+<p>Paragraph block</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\">
+	<p>Quote block</p>
+</blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`adding blocks Should insert content using the placeholder and the regular inserter 3`] = `
+"<!-- wp:paragraph -->
+<p>Paragraph block</p>
+<!-- /wp:paragraph -->
+
 <!-- wp:paragraph -->
 <p>Second paragraph</p>
 <!-- /wp:paragraph -->

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -2,7 +2,12 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage, insertBlock } from '../support/utils';
+import {
+	newPost,
+	newDesktopBrowserPage,
+	insertBlock,
+	getEditedPostContent,
+} from '../support/utils';
 
 describe( 'adding blocks', () => {
 	beforeAll( async () => {
@@ -34,6 +39,22 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Quote block' );
 
+		// Arrow down into default appender.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+
+		// Focus should be moved to block focus boundary on a block which does
+		// not have its own inputs (e.g. image). Proceeding to press enter will
+		// append the default block. Pressing backspace on the focused block
+		// will remove it.
+		await page.keyboard.type( '/image' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
 		// Using the regular inserter
 		await insertBlock( 'Code' );
 		await page.keyboard.type( 'Code block' );
@@ -53,9 +74,6 @@ describe( 'adding blocks', () => {
 		const codeEditorButton = ( await page.$x( '//button[contains(text(), \'Code Editor\')]' ) )[ 0 ];
 		await codeEditorButton.click( 'button' );
 
-		// Assertions
-		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-
-		expect( textEditorContent ).toMatchSnapshot();
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/adding-inline-tokens.test.js
+++ b/test/e2e/specs/adding-inline-tokens.test.js
@@ -10,7 +10,7 @@ import uuid from 'uuid/v4';
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage, getHTMLFromCodeEditor, insertBlock } from '../support/utils';
+import { newPost, newDesktopBrowserPage, getEditedPostContent, insertBlock } from '../support/utils';
 
 describe( 'adding inline tokens', () => {
 	beforeAll( async () => {
@@ -42,6 +42,6 @@ describe( 'adding inline tokens', () => {
 
 		// Check the content.
 		const regex = new RegExp( '<!-- wp:paragraph -->\\s*<p>a\\u00A0<img class="wp-image-\\d+" style="width:10px" src="[^"]+\\/' + filename + '\\.png" alt="" \\/><\\/p>\\s*<!-- \\/wp:paragraph -->' );
-		expect( await getHTMLFromCodeEditor() ).toMatch( regex );
+		expect( await getEditedPostContent() ).toMatch( regex );
 	} );
 } );

--- a/test/e2e/specs/formatting-controls.test.js
+++ b/test/e2e/specs/formatting-controls.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage, pressWithModifier, getHTMLFromCodeEditor } from '../support/utils';
+import { newPost, newDesktopBrowserPage, pressWithModifier, getEditedPostContent } from '../support/utils';
 
 describe( 'Formatting Controls', () => {
 	beforeAll( async () => {
@@ -29,7 +29,7 @@ describe( 'Formatting Controls', () => {
 		await pressWithModifier( 'Mod', 'b' );
 
 		// Check content
-		const content = await getHTMLFromCodeEditor();
+		const content = await getEditedPostContent();
 		expect( content ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -6,7 +6,7 @@ import {
 	newPost,
 	newDesktopBrowserPage,
 	insertBlock,
-	getHTMLFromCodeEditor,
+	getEditedPostContent,
 	pressTimes,
 	pressWithModifier,
 } from '../support/utils';
@@ -28,21 +28,16 @@ describe( 'splitting and merging blocks', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Assert that there are now two paragraph blocks with correct content
-		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Press Backspace to merge paragraph blocks
-		await page.click( '.is-selected' );
-		await page.keyboard.press( 'Home' );
 		await page.keyboard.press( 'Backspace' );
 
 		// Ensure that caret position is correctly placed at the between point.
 		await page.keyboard.type( 'Between' );
-		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
-		// Workaround: When transitioning back from Code to Visual, the caret
-		// is placed at the beginning of the selected paragraph. Ideally this
-		// should persist selection between modes.
-		await pressTimes( 'ArrowRight', 5 ); // After "First"
-		await pressTimes( 'Delete', 7 ); // Delete "Between"
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressTimes( 'Backspace', 7 ); // Delete "Between"
 
 		// Edge case: Without ensuring that the editor still has focus when
 		// restoring a bookmark, the caret may be inadvertently moved back to
@@ -57,6 +52,6 @@ describe( 'splitting and merging blocks', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'BeforeSecond:' );
 
-		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/style-variation.test.js
+++ b/test/e2e/specs/style-variation.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import '../support/bootstrap';
-import { newPost, newDesktopBrowserPage, insertBlock, getHTMLFromCodeEditor } from '../support/utils';
+import { newPost, newDesktopBrowserPage, insertBlock, getEditedPostContent } from '../support/utils';
 
 describe( 'adding blocks', () => {
 	beforeAll( async () => {
@@ -25,7 +25,7 @@ describe( 'adding blocks', () => {
 		await styleVariations[ 1 ].click();
 
 		// Check the content
-		const content = await getHTMLFromCodeEditor();
+		const content = await getEditedPostContent();
 		expect( content ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/undo.test.js
+++ b/test/e2e/specs/undo.test.js
@@ -6,7 +6,7 @@ import {
 	newPost,
 	newDesktopBrowserPage,
 	pressWithModifier,
-	getHTMLFromCodeEditor,
+	getEditedPostContent,
 } from '../support/utils';
 
 describe( 'undo', () => {
@@ -31,7 +31,7 @@ describe( 'undo', () => {
 		await pressWithModifier( 'mod', 'z' ); // Strip 1st paragraph text
 		await pressWithModifier( 'mod', 'z' ); // Strip 1st paragraph block
 
-		expect( await getHTMLFromCodeEditor() ).toBe( '' );
+		expect( await getEditedPostContent() ).toBe( '' );
 
 		// Should have no more history.
 		const undoButton = await page.$( '.editor-history__undo:not( :disabled )' );

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -5,7 +5,7 @@ import '../support/bootstrap';
 import {
 	newPost,
 	newDesktopBrowserPage,
-	getHTMLFromCodeEditor,
+	getEditedPostContent,
 	pressWithModifier,
 	pressTimes,
 } from '../support/utils';
@@ -71,7 +71,7 @@ describe( 'adding blocks', () => {
 		activeElementText = await page.evaluate( () => document.activeElement.textContent );
 		expect( activeElementText ).toBe( 'First paragraph' );
 
-		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	it( 'should navigate around inline boundaries', async () => {
@@ -140,6 +140,6 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'Before' );
 
-		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -144,17 +144,23 @@ export async function switchToEditor( mode ) {
 	await button.click( 'button' );
 }
 
-export async function getHTMLFromCodeEditor() {
-	await switchToEditor( 'Code' );
-	const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-	await switchToEditor( 'Visual' );
+/**
+ * Returns a promise which resolves with the edited post content (HTML string).
+ *
+ * @return {Promise} Promise resolving with post content markup.
+ */
+export async function getEditedPostContent() {
+	const content = await page.evaluate( () => {
+		const { select } = window.wp.data;
+		return select( 'core/editor' ).getEditedPostContent();
+	} );
 
 	// Globally guard against zero-width characters.
-	if ( REGEXP_ZWSP.test( textEditorContent ) ) {
+	if ( REGEXP_ZWSP.test( content ) ) {
 		throw new Error( 'Unexpected zero-width space character in editor content.' );
 	}
 
-	return textEditorContent;
+	return content;
 }
 
 /**


### PR DESCRIPTION
Salvaged from #6452

This pull request seeks to normalize the behavior of `BlockListBlock`'s "Enter" key handling to insert the _default_ block, not explicitly the paragraph block.

**Testing instructions:**

There should be no change in behavior. Notably, pressing Enter while the Image block placeholder is selected should still insert a paragraph (which is the default block unless otherwise configured).