### PR TITLE
Fixes template example so that it is correct

### DIFF
--- a/editor/components/inner-blocks/README.md
+++ b/editor/components/inner-blocks/README.md
@@ -73,14 +73,14 @@ The template is defined as a list of block items. Such blocks can have predefine
 More information about templates can be found in [template docs](https://wordpress.org/gutenberg/handbook/templates/).
 
 ```jsx
-const TEMPLATE = [ 'core/columns', {}, [
+const TEMPLATE = [ [ 'core/columns', {}, [
     [ 'core/column', {}, [
         [ 'core/image' ],
     ] ],
     [ 'core/column', {}, [
         [ 'core/paragraph', { placeholder: 'Enter side content...' } ],
     ] ],
-] ];
+] ] ];
 ...
 <InnerBlocks
     template={ TEMPLATE }


### PR DESCRIPTION
The template example requires an additional enclosing array.

## Description
The example code does not work and errors out.  This change adds the correct format.

## How has this been tested?
I have tested the new correct documentation locally and it works on the latest version.

## Types of changes
Documentation fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
