### PR TITLE
Improve pre-publish panel styling

### DIFF
--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -26,7 +26,7 @@ function PostPublishPanelPrepublish( {
 	return (
 		<div className="editor-post-publish-panel__prepublish">
 			<div><strong>{ hasPublishAction ? __( 'Are you ready to publish?' ) : __( 'Are you ready to submit for review?' ) }</strong></div>
-			<p>{ hasPublishAction ? __( 'Here, you can do a last-minute check up of your settings below, before you publish.' ) : __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' ) }</p>
+			<p>{ hasPublishAction ? __( 'Double-check your settings, then use the button to publish your post.' ) : __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' ) }</p>
 			{ hasPublishAction && (
 				<Fragment>
 					<PanelBody initialOpen={ false } title={ [

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -1,5 +1,5 @@
 .editor-post-publish-panel {
-	background: $light-gray-300;
+	background: $white;
 	color: $dark-gray-500;
 }
 

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -61,10 +61,6 @@
 		background: $white;
 		margin-left: -16px;
 		margin-right: -16px;
-
-		.components-panel__body-toggle {
-			//font-weight: 400;
-		}
 	}
 
 	.editor-post-visibility__dialog-legend {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -1,5 +1,5 @@
 .editor-post-publish-panel {
-	background: $white;
+	background: $light-gray-300;
 	color: $dark-gray-500;
 }
 
@@ -12,6 +12,7 @@
 }
 
 .editor-post-publish-panel__header {
+	background: $white;
 	padding-left: 16px;
 	height: $header-height;
 	border-bottom: $border-width solid $light-gray-500;
@@ -44,6 +45,7 @@
 
 .editor-post-publish-panel__link {
 	color: $blue-medium-700;
+	font-weight: 400;
 	padding-left: 4px;
 	text-decoration: underline;
 }
@@ -51,15 +53,17 @@
 .editor-post-publish-panel__prepublish {
 	padding: 16px;
 
+	strong {
+		color: $dark-gray-900;
+	}
+
 	.components-panel__body {
+		background: $white;
 		margin-left: -16px;
 		margin-right: -16px;
-		margin-bottom: -16px;
-		margin-top: 10px;
-		border: none;
 
 		.components-panel__body-toggle {
-			font-weight: 400;
+			//font-weight: 400;
 		}
 	}
 


### PR DESCRIPTION
## Before
This resolves #7878 and resolves #7873, by clarifying the microcopy used in the prompt here, and adjusting the styling to be more consistent with other sidebars in the UI.

<img width="973" alt="screenshot 2018-07-10 20 44 31" src="https://user-images.githubusercontent.com/376315/42539376-d9f05656-8492-11e8-83fb-6cd9ae115d1c.png">


## After
<img width="1130" alt="screenshot 2018-07-10 22 35 26" src="https://user-images.githubusercontent.com/376315/42539361-cab8b232-8492-11e8-8b82-f65fe1442ebc.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


## Types of changes
Style & copy tweak.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
