### PR TITLE
Update node-sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7033,9 +7033,9 @@
 			}
 		},
 		"gaze": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-			"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
 			"dev": true,
 			"requires": {
 				"globule": "^1.0.0"
@@ -7499,13 +7499,13 @@
 			}
 		},
 		"globule": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-			"integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
 			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
-				"lodash": "~4.17.4",
+				"lodash": "~4.17.10",
 				"minimatch": "~3.0.2"
 			}
 		},
@@ -10883,8 +10883,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "git://github.com/sass/node-sass.git#a51eca7f8bafdc9bafab76d2305fedc64503304c",
-			"from": "git://github.com/sass/node-sass.git#v4.7.0",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
+			"integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -10899,10 +10900,10 @@
 				"lodash.mergewith": "^4.6.0",
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
-				"nan": "^2.3.2",
+				"nan": "^2.10.0",
 				"node-gyp": "^3.3.1",
 				"npmlog": "^4.0.0",
-				"request": "^2.79.0",
+				"request": "2.87.0",
 				"sass-graph": "^2.2.4",
 				"stdout-stream": "^1.4.0",
 				"true-case-path": "^1.0.2"
@@ -11010,6 +11011,34 @@
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
+					}
+				},
+				"request": {
+					"version": "2.87.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+					"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+					"dev": true,
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.6.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.1",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.1",
+						"har-validator": "~5.0.3",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.17",
+						"oauth-sign": "~0.8.2",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.1",
+						"safe-buffer": "^5.1.1",
+						"tough-cookie": "~2.3.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.1.0"
 					}
 				},
 				"strip-indent": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"glob": "7.1.2",
 		"lerna": "3.0.0-beta.21",
 		"mkdirp": "0.5.1",
-		"node-sass": "git://github.com/sass/node-sass.git#v4.7.0",
+		"node-sass": "4.9.2",
 		"path-type": "3.0.0",
 		"pegjs": "0.10.0",
 		"pegjs-loader": "0.5.4",


### PR DESCRIPTION
## Description

We've had to artificially hold back `node-sass` to 4.7.0, as more recent versions causes problems with `npm audit`. Version 4.9.1 fixed this, so we can upgrade again.

Upgrading `node-sass` to 4.9+ is a requirement for supporting Node 10.

## How has this been tested?

npm install
npm audit
npm run dev

No errors occur when building, and there don't appear to be any visual issues when using Gutenberg.
