### PR TITLE
Hide 'Convert to Shared Block' button on Classic blocks

### DIFF
--- a/editor/components/block-settings-menu/html-converter.js
+++ b/editor/components/block-settings-menu/html-converter.js
@@ -12,7 +12,7 @@ export function HTMLConverter( { block, onReplace, small, canUserUseUnfilteredHT
 		return null;
 	}
 
-	const label = __( 'Convert to blocks' );
+	const label = __( 'Convert to Blocks' );
 
 	const convertToBlocks = () => {
 		onReplace( block.uid, rawHandler( {

--- a/editor/components/block-settings-menu/test/shared-block-convert-button.js
+++ b/editor/components/block-settings-menu/test/shared-block-convert-button.js
@@ -9,19 +9,25 @@ import { shallow } from 'enzyme';
 import { SharedBlockConvertButton } from '../shared-block-convert-button';
 
 describe( 'SharedBlockConvertButton', () => {
+	it( 'should not render when isVisble false', () => {
+		const wrapper = shallow(
+			<SharedBlockConvertButton isVisible={ false } />
+		);
+		expect( wrapper.children() ).toBeEmpty();
+	} );
+
 	it( 'should allow converting a static block to a shared block', () => {
 		const onConvert = jest.fn();
 		const wrapper = shallow(
 			<SharedBlockConvertButton
-				sharedBlock={ null }
+				isVisible
+				isStaticBlock
 				onConvertToShared={ onConvert }
 			/>
 		);
-
-		const text = wrapper.find( 'IconButton' ).children().text();
-		expect( text ).toEqual( 'Convert to Shared Block' );
-
-		wrapper.find( 'IconButton' ).simulate( 'click' );
+		const button = wrapper.find( 'IconButton' ).first();
+		expect( button.children().text() ).toBe( 'Convert to Shared Block' );
+		button.simulate( 'click' );
 		expect( onConvert ).toHaveBeenCalled();
 	} );
 
@@ -29,15 +35,14 @@ describe( 'SharedBlockConvertButton', () => {
 		const onConvert = jest.fn();
 		const wrapper = shallow(
 			<SharedBlockConvertButton
-				sharedBlock={ {} }
+				isVisible
+				isStaticBlock={ false }
 				onConvertToStatic={ onConvert }
 			/>
 		);
-
-		const text = wrapper.find( 'IconButton' ).first().children().text();
-		expect( text ).toEqual( 'Convert to Regular Block' );
-
-		wrapper.find( 'IconButton' ).first().simulate( 'click' );
+		const button = wrapper.find( 'IconButton' ).first();
+		expect( button.children().text() ).toBe( 'Convert to Regular Block' );
+		button.simulate( 'click' );
 		expect( onConvert ).toHaveBeenCalled();
 	} );
 } );

--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -12,7 +12,7 @@ export function UnknownConverter( { block, onReplace, small, canUserUseUnfiltere
 		return null;
 	}
 
-	const label = __( 'Convert to blocks' );
+	const label = __( 'Convert to Blocks' );
 
 	const convertToBlocks = () => {
 		onReplace( block.uid, rawHandler( {


### PR DESCRIPTION
Fixes #5941.

Showing the _Convert to Shared Block_ button on Classic blocks is confusing because of its similarity to the _Convert to Blocks_ button. 

I hardcoded this check because we don't want to expose any new public APIs to implement this, see https://github.com/WordPress/gutenberg/pull/5970.

To test:

1. Add a Classic block
2. Click the _More Options_ button to the right
3. See that there isn't an option to _Convert to Shared Block_
4. Add a non-Classic block (e.g. Paragraph)
2. Click the _More Options_ button to the right
3. See that there **is** an option to _Convert to Shared Block_