### PR TITLE
Block options: disable mode toggle when block is in warning state

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -500,6 +500,7 @@ export class BlockListBlock extends Component {
 						clientIds={ clientId }
 						rootClientId={ rootClientId }
 						isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'right' || isTypingWithinBlock }
+						canEdit={ isValid }
 					/>
 				) }
 				{ shouldShowBreadcrumb && (

--- a/packages/editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -12,7 +12,7 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-export function BlockModeToggle( { blockType, mode, onToggleMode, small = false } ) {
+export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, enabled = true } ) {
 	if ( ! hasBlockSupport( blockType, 'html', true ) ) {
 		return null;
 	}
@@ -25,6 +25,7 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false 
 		<MenuItem
 			className="editor-block-settings-menu__control"
 			onClick={ onToggleMode }
+			disabled={ ! enabled }
 			icon="html"
 			label={ small ? label : undefined }
 		>

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -66,6 +66,7 @@ export class BlockSettingsMenu extends Component {
 			onSelect,
 			focus,
 			isHidden,
+			canEdit,
 			onDuplicate,
 			onRemove,
 			canDuplicate,
@@ -142,6 +143,7 @@ export class BlockSettingsMenu extends Component {
 								<BlockModeToggle
 									clientId={ firstBlockClientId }
 									onToggle={ onClose }
+									enabled={ canEdit }
 								/>
 							) }
 							{ count === 1 && (

--- a/packages/editor/src/components/block-settings-menu/test/block-mode-toggle.js
+++ b/packages/editor/src/components/block-settings-menu/test/block-mode-toggle.js
@@ -24,9 +24,10 @@ describe( 'BlockModeToggle', () => {
 				mode="visual"
 			/>
 		);
-		const text = wrapper.find( 'MenuItem' ).first().prop( 'children' );
+		const button = wrapper.find( 'MenuItem' ).first();
 
-		expect( text ).toEqual( 'Edit as HTML' );
+		expect( button.prop( 'children' ) ).toEqual( 'Edit as HTML' );
+		expect( button.prop( 'disabled' ) ).toBe( false );
 	} );
 
 	it( 'should render the Visual mode button', () => {
@@ -36,8 +37,22 @@ describe( 'BlockModeToggle', () => {
 				mode="html"
 			/>
 		);
-		const text = wrapper.find( 'MenuItem' ).first().prop( 'children' );
+		const button = wrapper.find( 'MenuItem' ).first();
 
-		expect( text ).toEqual( 'Edit visually' );
+		expect( button.prop( 'children' ) ).toEqual( 'Edit visually' );
+		expect( button.prop( 'disabled' ) ).toBe( false );
+	} );
+
+	it( 'should render a disabled button', () => {
+		const wrapper = shallow(
+			<BlockModeToggle
+				blockType={ { supports: { html: true } } }
+				mode="html"
+				enabled={ false }
+			/>
+		);
+		const button = wrapper.find( 'MenuItem' ).first();
+
+		expect( button.prop( 'disabled' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
## Description
If you put a block into a warning state the block option 'Edit visually' and 'Edit as HTML' are still available and toggle state, but have no outward effect on the block.

To avoid user confusion this PR disables the mode toggle option when a block is showing a warning. As soon as the warning is cleared the option is restored.

![another_post___ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/43366571-e31f2a6e-9337-11e8-8b45-4d44177fd0ab.jpg)

Fixes #7743 

## How has this been tested?

Additional unit tests have been added to test the mode toggle enable/disable.

Manually test that the 'edit visually' and 'edit as HTML' options are removed from the block 'more options' menu:
- Add a paragraph block, edit as HTML, and remove the trailing `</p>` to trigger an invalid block warning
- Access the block 'more options' menu and verify that the 'edit visually' and 'edit as HTML' options are removed (see above screenshot)
- From a developer console type `wp.blocks.registerBlockType( 'myplugin/mr-crashy', { title: 'Mr. Crashy', category: 'common', icon: 'warning', edit() { throw new Error(); }, save() { return ''; } } );`
- Add `Mr Crashy` block to a post
- Verify that the crashed block 'more options' also does not show 'edit visually' and 'edit as HTML'

## Types of changes

This PR changes the behaviour of an existing feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
