### PR TITLE
Backup and restore global `$post` when preloading API data

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1071,8 +1071,8 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Ensure the global $post remains the same after
 	// API data is preloaded. Because API preloading
 	// can call the_content and other filters, callbacks
-	// can unexpectedly modify $post and cause the sky
-	// to fall on Gutenberg's head.
+	// can unexpectedly modify $post resulting in issues
+	// like https://github.com/WordPress/gutenberg/issues/7468.
 	$backup_global_post = $post;
 
 	$preload_data = array_reduce(
@@ -1081,7 +1081,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		array()
 	);
 
-	// Restore the global $post we started with.
+	// Restore the global $post as it was before API preloading.
 	$post = $backup_global_post;
 
 	wp_add_inline_script(

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1068,11 +1068,21 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
 	);
 
+	// Ensure the global $post remains the same after
+	// API data is preloaded. Because API preloading
+	// can call the_content and other filters, callbacks
+	// can unexpectedly modify $post and cause the sky
+	// to fall on Gutenberg's head.
+	$backup_global_post = $post;
+
 	$preload_data = array_reduce(
 		$preload_paths,
 		'gutenberg_preload_api_request',
 		array()
 	);
+
+	// Restore the global $post we started with.
+	$post = $backup_global_post;
 
 	wp_add_inline_script(
 		'wp-api-request',


### PR DESCRIPTION
## Description

Backs up the global `$post` prior to calling `gutenberg_preload_api_request()`, and then restores the global `$post` afterwards. Doing so helps mitigate, but doesn't fix entirely, the impact of shortcode callbacks modifying the global `$post`.

If there's ever a better solution to this, the abstraction will likely be implemented in https://core.trac.wordpress.org/ticket/18408. However, a broader solution has the potential for lots of nasty side effects, so this localized solution seems most appropriate.

Fixes #7468

## How has this been tested?

0. Install and activate the [Display Posts Shortcode](https://wordpress.org/plugins/display-posts-shortcode/) plugin.
1. Make sure you have a few published posts.
2. Create a new draft post in the Classic Editor with the `[display-posts]` shortcode:

<img width="976" alt="image" src="https://user-images.githubusercontent.com/36432/42570828-03e4daa4-84ca-11e8-9af8-3eeb604f2ff5.png">

3. Open the draft post in Gutenberg.

Without this pull request, Gutenberg should open a seemingly random post. With this pull request, Gutenberg should open the correct post.

## Types of changes

Bug fix.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
