### PR TITLE
Remove block switcher from header, add to multi block controls

### DIFF
--- a/edit-post/components/header/header-toolbar/index.js
+++ b/edit-post/components/header/header-toolbar/index.js
@@ -15,7 +15,6 @@ import {
 	TableOfContents,
 	EditorHistoryRedo,
 	EditorHistoryUndo,
-	MultiBlocksSwitcher,
 	NavigableToolbar,
 } from '@wordpress/editor';
 
@@ -34,7 +33,6 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport } ) {
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents />
-			<MultiBlocksSwitcher />
 			{ hasFixedToolbar && isLargeViewport && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar />

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -42,6 +42,7 @@ import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
 import BlockBreadcrumb from './breadcrumb';
 import BlockContextualToolbar from './block-contextual-toolbar';
+import BlockToolbar from '../block-toolbar';
 import BlockMultiControls from './multi-controls';
 import BlockMobileToolbar from './block-mobile-toolbar';
 import BlockInsertionPoint from './insertion-point';
@@ -408,6 +409,7 @@ export class BlockListBlock extends Component {
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldShowBreadcrumb = isHovered && ! isEmptyDefaultBlock;
 		const shouldShowContextualToolbar = ! showSideInserter && isSelected && ! isTypingWithinBlock && isValid && ( ! hasFixedToolbar || ! isLargeViewport );
+		const shouldShowMultiBlockToolbar = ! showSideInserter && isFirstMultiSelected && ( ! hasFixedToolbar || ! isLargeViewport );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
 
@@ -516,6 +518,7 @@ export class BlockListBlock extends Component {
 				) }
 				{ shouldShowBreadcrumb && <BlockBreadcrumb uid={ uid } isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' } /> }
 				{ shouldShowContextualToolbar && <BlockContextualToolbar /> }
+				{ shouldShowMultiBlockToolbar && <BlockContextualToolbar /> }
 				{ isFirstMultiSelected && <BlockMultiControls rootUID={ rootUID } /> }
 				<IgnoreNestedEvents
 					ref={ this.bindBlockNode }

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -42,7 +42,6 @@ import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
 import BlockBreadcrumb from './breadcrumb';
 import BlockContextualToolbar from './block-contextual-toolbar';
-import BlockToolbar from '../block-toolbar';
 import BlockMultiControls from './multi-controls';
 import BlockMobileToolbar from './block-mobile-toolbar';
 import BlockInsertionPoint from './insertion-point';

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -407,8 +407,7 @@ export class BlockListBlock extends Component {
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldShowBreadcrumb = isHovered && ! isEmptyDefaultBlock;
-		const shouldShowContextualToolbar = ! showSideInserter && isSelected && ! isTypingWithinBlock && isValid && ( ! hasFixedToolbar || ! isLargeViewport );
-		const shouldShowMultiBlockToolbar = ! showSideInserter && isFirstMultiSelected && ( ! hasFixedToolbar || ! isLargeViewport );
+		const shouldShowContextualToolbar = ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected ) && ( ! hasFixedToolbar || ! isLargeViewport );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
 
@@ -517,7 +516,6 @@ export class BlockListBlock extends Component {
 				) }
 				{ shouldShowBreadcrumb && <BlockBreadcrumb uid={ uid } isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' } /> }
 				{ shouldShowContextualToolbar && <BlockContextualToolbar /> }
-				{ shouldShowMultiBlockToolbar && <BlockContextualToolbar /> }
 				{ isFirstMultiSelected && <BlockMultiControls rootUID={ rootUID } /> }
 				<IgnoreNestedEvents
 					ref={ this.bindBlockNode }

--- a/editor/components/block-list/multi-controls.js
+++ b/editor/components/block-list/multi-controls.js
@@ -7,12 +7,15 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import BlockMover from '../block-mover';
 import BlockSettingsMenu from '../block-settings-menu';
+import NavigableToolbar from '../navigable-toolbar';
+import BlockSwitcher from '../block-switcher';
 
 function BlockListMultiControls( { multiSelectedBlockUids, rootUID, isSelecting, isFirst, isLast } ) {
 	if ( isSelecting ) {
@@ -20,6 +23,13 @@ function BlockListMultiControls( { multiSelectedBlockUids, rootUID, isSelecting,
 	}
 
 	return [
+		<NavigableToolbar
+			className="editor-block-contextual-toolbar"
+			aria-label={ __( 'Block Toolbar' ) }
+			key="toolbar"
+		>
+			<BlockSwitcher uids={ multiSelectedBlockUids } />
+		</NavigableToolbar>,
 		<BlockMover
 			key="mover"
 			rootUID={ rootUID }

--- a/editor/components/block-list/multi-controls.js
+++ b/editor/components/block-list/multi-controls.js
@@ -7,14 +7,12 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import BlockMover from '../block-mover';
 import BlockSettingsMenu from '../block-settings-menu';
-import BlockSwitcher from '../block-switcher';
 
 function BlockListMultiControls( { multiSelectedBlockUids, rootUID, isSelecting, isFirst, isLast } ) {
 	if ( isSelecting ) {

--- a/editor/components/block-list/multi-controls.js
+++ b/editor/components/block-list/multi-controls.js
@@ -14,7 +14,6 @@ import { __ } from '@wordpress/i18n';
  */
 import BlockMover from '../block-mover';
 import BlockSettingsMenu from '../block-settings-menu';
-import NavigableToolbar from '../navigable-toolbar';
 import BlockSwitcher from '../block-switcher';
 
 function BlockListMultiControls( { multiSelectedBlockUids, rootUID, isSelecting, isFirst, isLast } ) {
@@ -23,13 +22,6 @@ function BlockListMultiControls( { multiSelectedBlockUids, rootUID, isSelecting,
 	}
 
 	return [
-		<NavigableToolbar
-			className="editor-block-contextual-toolbar"
-			aria-label={ __( 'Block Toolbar' ) }
-			key="toolbar"
-		>
-			<BlockSwitcher uids={ multiSelectedBlockUids } />
-		</NavigableToolbar>,
 		<BlockMover
 			key="mover"
 			rootUID={ rootUID }

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -6,7 +6,7 @@ import { castArray, get, some } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { Dropdown, IconButton, Toolbar, PanelBody } from '@wordpress/components';
 import { getBlockType, getPossibleBlockTransformations, switchToBlockType, hasChildBlocks } from '@wordpress/blocks';
 import { compose, Component, Fragment } from '@wordpress/element';
@@ -65,7 +65,7 @@ export class BlockSwitcher extends Component {
 							onToggle();
 						}
 					};
-					const label = __( 'Change block type' );
+					const label = sprintf( _n( 'Change block type', 'Change type of %d blocks', blocks.length ), blocks.length );
 
 					return (
 						<Toolbar>

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -8,17 +8,26 @@ import { withSelect } from '@wordpress/data';
  */
 import './style.scss';
 import BlockSwitcher from '../block-switcher';
+import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 
-function BlockToolbar( { block, mode, selectedBlockUIDs } ) {
-	if ( selectedBlockUIDs.length < 2 && ( ! block || ! block.isValid || 'visual' !== mode ) ) {
+function BlockToolbar( { blockUIDs, isValid, mode } ) {
+	if ( blockUIDs.length > 1 ) {
+		return (
+			<div className="editor-block-toolbar">
+				<MultiBlocksSwitcher />
+			</div>
+		);
+	}
+
+	if ( ! isValid || 'visual' !== mode ) {
 		return null;
 	}
 
 	return (
 		<div className="editor-block-toolbar">
-			<BlockSwitcher uids={ selectedBlockUIDs.length > 1 ? selectedBlockUIDs : [ block.uid ] } />
+			<BlockSwitcher uids={ blockUIDs } />
 			<BlockControls.Slot />
 			<BlockFormatControls.Slot />
 		</div>
@@ -28,11 +37,11 @@ function BlockToolbar( { block, mode, selectedBlockUIDs } ) {
 export default withSelect( ( select ) => {
 	const { getSelectedBlock, getBlockMode, getMultiSelectedBlockUids } = select( 'core/editor' );
 	const block = getSelectedBlock();
-	const selectedBlockUIDs = getMultiSelectedBlockUids();
+	const blockUIDs = block ? [ block.uid ] : getMultiSelectedBlockUids();
 
 	return {
-		block,
+		blockUIDs,
+		isValid: block ? block.isValid : null,
 		mode: block ? getBlockMode( block.uid ) : null,
-		selectedBlockUIDs,
 	};
 } )( BlockToolbar );

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -11,8 +11,16 @@ import BlockSwitcher from '../block-switcher';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 
-function BlockToolbar( { block, mode } ) {
-	if ( ! block || ! block.isValid || mode !== 'visual' ) {
+function BlockToolbar( { block, mode, selectedBlockUIDs } ) {
+	if ( selectedBlockUIDs.length > 1 ) {
+		return (
+			<div className="editor-block-toolbar">
+				<BlockSwitcher uids={ selectedBlockUIDs } />
+			</div>
+		);
+	}
+
+	if ( ! block || ! block.isValid || 'visual' !== mode) {
 		return null;
 	}
 
@@ -26,11 +34,13 @@ function BlockToolbar( { block, mode } ) {
 }
 
 export default withSelect( ( select ) => {
-	const { getSelectedBlock, getBlockMode } = select( 'core/editor' );
+	const { getSelectedBlock, getBlockMode, getMultiSelectedBlockUids } = select( 'core/editor' );
 	const block = getSelectedBlock();
+	const selectedBlockUIDs = getMultiSelectedBlockUids();
 
 	return {
 		block,
 		mode: block ? getBlockMode( block.uid ) : null,
+		selectedBlockUIDs,
 	};
 } )( BlockToolbar );

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -12,7 +12,6 @@ import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 
 function BlockToolbar( { block, mode, selectedBlockUIDs } ) {
-
 	if ( selectedBlockUIDs.length < 2 && ( ! block || ! block.isValid || 'visual' !== mode ) ) {
 		return null;
 	}

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -12,21 +12,14 @@ import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 
 function BlockToolbar( { block, mode, selectedBlockUIDs } ) {
-	if ( selectedBlockUIDs.length > 1 ) {
-		return (
-			<div className="editor-block-toolbar">
-				<BlockSwitcher uids={ selectedBlockUIDs } />
-			</div>
-		);
-	}
 
-	if ( ! block || ! block.isValid || 'visual' !== mode) {
+	if ( selectedBlockUIDs.length < 2 && ( ! block || ! block.isValid || 'visual' !== mode ) ) {
 		return null;
 	}
 
 	return (
 		<div className="editor-block-toolbar">
-			<BlockSwitcher uids={ [ block.uid ] } />
+			<BlockSwitcher uids={ selectedBlockUIDs.length > 1 ? selectedBlockUIDs : [ block.uid ] } />
 			<BlockControls.Slot />
 			<BlockFormatControls.Slot />
 		</div>


### PR DESCRIPTION
## Description

Removed the block switcher from the header, and made it appear when selecting multiple blocks.

## How has this been tested?

Select multiple blocks and check the switcher is there.
