### PR TITLE
Tests: Fix block icons end to end test

### DIFF
--- a/test/e2e/specs/block-icons.test.js
+++ b/test/e2e/specs/block-icons.test.js
@@ -7,6 +7,7 @@ import {
 	newDesktopBrowserPage,
 	insertBlock,
 	searchForBlock,
+	selectBlockByClientId,
 } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
@@ -35,9 +36,16 @@ async function getFirstInserterIcon() {
 }
 
 describe( 'Correctly Renders Block Icons on Inserter and Inspector', () => {
-	const dashIconRegex = /<svg.*class=".*dashicons-cart.*?">.*<\/svg>/;
+	const dashIconRegex = /<svg.*?class=".*?dashicons-cart.*?">.*?<\/svg>/;
 	const circleString = '<circle cx="10" cy="10" r="10" fill="red" stroke="blue" stroke-width="10"></circle>';
 	const svgIcon = `<svg width="20" height="20" viewBox="0 0 20 20">${ circleString }</svg>`;
+
+	const getBlockIdFromBlockName = async ( blockName ) => {
+		return await page.$eval(
+			`[data-type="${ blockName }"] > .editor-block-list__block-edit`,
+			( el ) => el.getAttribute( 'data-block' )
+		);
+	};
 
 	const validateSvgIcon = ( iconHtml ) => {
 		expect( iconHtml ).toMatch( svgIcon );
@@ -81,7 +89,7 @@ describe( 'Correctly Renders Block Icons on Inserter and Inspector', () => {
 
 		it( 'Renders correctly the icon on the inspector', async () => {
 			await insertBlock( blockTitle );
-			await page.focus( `[data-type="${ blockName }"]` );
+			await selectBlockByClientId( await getBlockIdFromBlockName( blockName ) );
 			validateIcon( await getInnerHTML( INSPECTOR_ICON_SELECTOR ) );
 		} );
 	}
@@ -116,7 +124,7 @@ describe( 'Correctly Renders Block Icons on Inserter and Inspector', () => {
 
 		it( 'Renders the icon in the inspector with the correct colors', async () => {
 			await insertBlock( blockTitle );
-			await page.focus( `[data-type="${ blockName }"]` );
+			await selectBlockByClientId( await getBlockIdFromBlockName( blockName ) );
 			validateDashIcon(
 				await getInnerHTML( INSPECTOR_ICON_SELECTOR )
 			);
@@ -137,7 +145,7 @@ describe( 'Correctly Renders Block Icons on Inserter and Inspector', () => {
 
 		it( 'Renders correctly the icon on the inspector', async () => {
 			await insertBlock( blockTitle );
-			await page.focus( `[data-type="${ blockName }"]` );
+			await selectBlockByClientId( await getBlockIdFromBlockName( blockName ) );
 			validateSvgIcon(
 				await getInnerHTML( INSPECTOR_ICON_SELECTOR )
 			);

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -256,6 +256,17 @@ export async function publishPost() {
 }
 
 /**
+ * Given the clientId of a block, selects the block on the editor.
+ *
+ * @param {string} clientId Identified of the block.
+ */
+export async function selectBlockByClientId( clientId ) {
+	await page.evaluate( ( id ) => {
+		wp.data.dispatch( 'core/editor' ).selectBlock( id );
+	}, clientId );
+}
+
+/**
  * Clicks on the button in the header which opens Document Settings sidebar when it is closed.
  */
 export async function openDocumentSettingsSidebar() {


### PR DESCRIPTION
When we insert a block it gets focused. Now we focus the nested child block that is inserted in the test blocks. So we are sure the selection of the parent block happens after events that may change the focus.
Before if the tests executed at a slow speed the focus may have been the child instead of the parent required for this tests.

We make the regex used here non-greedy.