### PR TITLE
Components: Update Dashicon to latest build

### DIFF
--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -6,14 +6,16 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 !!! */
 
 /**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 
-/**
- * External dependencies
- */
-export default class Dashicon extends wp.element.Component {
+export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {
 		return (
 			this.props.icon !== nextProps.icon ||


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/3952
Related: https://github.com/WordPress/dashicons/pull/305
Related: https://github.com/Automattic/wp-calypso/pull/25590#issuecomment-404233976 (cc @jsnajdr)

This pull request seeks to incorporate the latest version of the Dashicons React component generated from the `WordPress/dashicons` repository, which defines the component class using the `@wordpress/element` module dependency, rather than relying on the presence of a `wp.element.Component` global.

**Testing instructions:**

Verify there are no regressions in the display of icons throughout the application.