### PR TITLE
Fix colspan bug in table block for tables with <thead> tags

### DIFF
--- a/core-blocks/table/theme.scss
+++ b/core-blocks/table/theme.scss
@@ -6,7 +6,6 @@
 
 	tbody {
 		width: 100%;
-		display: table;
 		min-width: $break-mobile / 2;
 	}
 


### PR DESCRIPTION
Fixes: #7688 

Removing `display: table` from the `tbody` tag in the table block appears to solve the issue. I didn't see any negative effects from this in my testing, but it could use some additional testing to make sure there isn't a scenario I didn't come across. 

Tagging @jasmussen since he added this line originally in 24011e3 in case it's required for something. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
