### PR TITLE
chore: Columns: Documentation: Add documentation to ALLOWED_BLOCKS 

### DIFF
--- a/core-blocks/columns/index.js
+++ b/core-blocks/columns/index.js
@@ -23,6 +23,15 @@ import {
 import './style.scss';
 import './editor.scss';
 
+/**
+ * Allowed blocks constant is passed to InnerBlocks precisely as specified here.
+ * The contents of the array should never change.
+ * The array should contain the name of each block that is allowed.
+ * In columns block, the only block we allow is 'core/column'.
+ *
+ * @constant
+ * @type {string[]}
+*/
 const ALLOWED_BLOCKS = [ 'core/column' ];
 
 /**


### PR DESCRIPTION
This PR adds documentation to the ALLOWED_BLOCKS constant as suggested by @aduth in https://github.com/WordPress/gutenberg/pull/7720#pullrequestreview-135880486.
