### PR TITLE
Writing Flow: Correct caret placement when merging to inline boundary

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -3,7 +3,6 @@
  */
 import classnames from 'classnames';
 import { get, reduce, size, castArray, first, last } from 'lodash';
-import tinymce from 'tinymce';
 
 /**
  * WordPress dependencies
@@ -149,17 +148,8 @@ export class BlockListBlock extends Component {
 
 		// In reverse case, need to explicitly place caret position.
 		if ( isReverse ) {
-			// Special case RichText component because the placeCaret utilities
-			// aren't working correctly. When merging two paragraph blocks, the
-			// focus is not moved to the correct position.
-			const editor = tinymce.get( target.getAttribute( 'id' ) );
-			if ( editor ) {
-				editor.selection.select( editor.getBody(), true );
-				editor.selection.collapse( false );
-			} else {
-				placeCaretAtHorizontalEdge( target, true );
-				placeCaretAtVerticalEdge( target, true );
-			}
+			placeCaretAtHorizontalEdge( target, true );
+			placeCaretAtVerticalEdge( target, true );
 		}
 	}
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -217,10 +217,15 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
 		return;
 	}
 
+	// Select on extent child of the container, not the container itself. This
+	// avoids the selection always being `endOffset` of 1 when placed at end,
+	// where `startContainer`, `endContainer` would always be container itself.
+	const rangeTarget = container[ isReverse ? 'lastChild' : 'firstChild' ];
+
 	const selection = window.getSelection();
 	const range = document.createRange();
 
-	range.selectNodeContents( container );
+	range.selectNodeContents( rangeTarget );
 	range.collapse( ! isReverse );
 
 	selection.removeAllRanges();

--- a/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`splitting and merging blocks Should merge into inline boundary position 1`] = `
+"<!-- wp:paragraph -->
+<p>Bar</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`splitting and merging blocks Should split and merge paragraph blocks using Enter and Backspace 1`] = `
 "<!-- wp:paragraph -->
 <p>First</p>

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -12,7 +12,7 @@ import {
 } from '../support/utils';
 
 describe( 'splitting and merging blocks', () => {
-	beforeAll( async () => {
+	beforeEach( async () => {
 		await newDesktopBrowserPage();
 		await newPost();
 	} );
@@ -56,6 +56,22 @@ describe( 'splitting and merging blocks', () => {
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'BeforeSecond:' );
+
+		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
+	} );
+
+	it( 'Should merge into inline boundary position', async () => {
+		// Regression Test: Caret should reset to end of inline boundary when
+		// backspacing to delete second paragraph.
+		await insertBlock( 'Paragraph' );
+		await pressWithModifier( 'mod', 'b' );
+		await page.keyboard.type( 'Foo' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Backspace' );
+
+		// Replace contents of first paragraph with "Bar".
+		await pressTimes( 'Backspace', 3 );
+		await page.keyboard.type( 'Bar' );
 
 		expect( await getHTMLFromCodeEditor() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
This pull request seeks to resolve an issue where backspacing to merge into a previous paragraph block which had ended with an inline boundary (e.g. bold) node could result in the caret being placed at the wrong position.

In the process, it simplifies the implementation of `BlockListBlock#focusTabbable`, avoiding the need for special-casing of RichText by correcting the underlying issue in `@wordpress/dom`'s `placeCaretAtHorizontalEdge` instead.

An end-to-end test case has been added which fails in the master branch.

**Testing instructions:**

Verify that caret is placed correctly when merging into inline boundary:

1. Navigate to Posts > Add New
2. Insert a paragraph block
3. Press Cmd+B (Ctrl+B) to bold
4. Type some characters
5. Press Enter
6. Press Backspace

**Expected:** Caret should be placed at end of inline boundary (within)
**Previously:** In the master branch, the caret position would be wrongly placed at one character before the end of the inline boundary.

Ensure end-to-end tests pass:

```
npm run test-e2e
```