### PR TITLE
Support 'preload' attribute for Video Block

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	Disabled,
 	IconButton,
 	PanelBody,
 	SelectControl,
@@ -129,7 +130,13 @@ class AudioEdit extends Component {
 					</PanelBody>
 				</InspectorControls>
 				<figure className={ className }>
-					<audio controls="controls" src={ src } />
+					{ /*
+						Disable the audio tag so the user clicking on it won't play the
+						file or change the position slider when the controls are enabled.
+					*/ }
+					<Disabled>
+						<audio controls="controls" src={ src } />
+					</Disabled>
 					{ ( ( caption && caption.length ) || !! isSelected ) && (
 						<RichText
 							tagName="figcaption"

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	Disabled,
 	IconButton,
 	PanelBody,
 	SelectControl,
@@ -151,8 +152,9 @@ class VideoEdit extends Component {
 						/>
 						<SelectControl
 							label={ __( 'Preload' ) }
-							value={ preload }
-							onChange={ ( value ) => setAttributes( { preload: value } ) }
+							value={ undefined !== preload ? preload : 'none' }
+							// `undefined` is required for the preload attribute to be unset.
+							onChange={ ( value ) => setAttributes( { preload: ( 'none' !== value ) ? value : undefined } ) }
 							options={ [
 								{ value: 'auto', label: __( 'Auto' ) },
 								{ value: 'metadata', label: __( 'Metadata' ) },
@@ -162,7 +164,13 @@ class VideoEdit extends Component {
 					</PanelBody>
 				</InspectorControls>
 				<figure className={ className }>
-					<video controls src={ src } />
+					{ /*
+						Disable the video tag so the user clicking on it won't play the
+						video when the controls are enabled.
+					*/ }
+					<Disabled>
+						<video controls={ controls } src={ src } />
+					</Disabled>
 					{ ( ( caption && caption.length ) || !! isSelected ) && (
 						<RichText
 							tagName="figcaption"

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -152,9 +152,8 @@ class VideoEdit extends Component {
 						/>
 						<SelectControl
 							label={ __( 'Preload' ) }
-							value={ undefined !== preload ? preload : 'none' }
-							// `undefined` is required for the preload attribute to be unset.
-							onChange={ ( value ) => setAttributes( { preload: ( 'none' !== value ) ? value : undefined } ) }
+							value={ preload }
+							onChange={ ( value ) => setAttributes( { preload: value } ) }
 							options={ [
 								{ value: 'auto', label: __( 'Auto' ) },
 								{ value: 'metadata', label: __( 'Metadata' ) },

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	IconButton,
 	PanelBody,
+	SelectControl,
 	Toolbar,
 	ToggleControl,
 	withNotices,
@@ -73,7 +74,7 @@ class VideoEdit extends Component {
 	}
 
 	render() {
-		const { autoplay, caption, controls, loop, muted, src } = this.props.attributes;
+		const { autoplay, caption, controls, loop, muted, preload, src } = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
 		const switchToEditing = () => {
@@ -147,6 +148,17 @@ class VideoEdit extends Component {
 							label={ __( 'Playback Controls' ) }
 							onChange={ this.toggleAttribute( 'controls' ) }
 							checked={ controls }
+						/>
+						<SelectControl
+							label={ __( 'Preload' ) }
+							value={ undefined !== preload ? preload : 'metadata' }
+							// `undefined` is required for the preload attribute to be unset.
+							onChange={ ( value ) => setAttributes( { preload: ( 'metadata' !== value ) ? value : undefined } ) }
+							options={ [
+								{ value: 'auto', label: __( 'Auto' ) },
+								{ value: 'metadata', label: __( 'Metadata' ) },
+								{ value: 'none', label: __( 'None' ) },
+							] }
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -151,9 +151,8 @@ class VideoEdit extends Component {
 						/>
 						<SelectControl
 							label={ __( 'Preload' ) }
-							value={ undefined !== preload ? preload : 'metadata' }
-							// `undefined` is required for the preload attribute to be unset.
-							onChange={ ( value ) => setAttributes( { preload: ( 'metadata' !== value ) ? value : undefined } ) }
+							value={ preload }
+							onChange={ ( value ) => setAttributes( { preload: value } ) }
 							options={ [
 								{ value: 'auto', label: __( 'Auto' ) },
 								{ value: 'metadata', label: __( 'Metadata' ) },

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -110,7 +110,7 @@ export const settings = {
 						controls={ controls }
 						loop={ loop }
 						muted={ muted }
-						preload={ preload !== 'metadata' ? preload : null }
+						preload={ preload }
 						src={ src }
 					/>
 				) }

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -110,7 +110,7 @@ export const settings = {
 						controls={ controls }
 						loop={ loop }
 						muted={ muted }
-						preload={ preload }
+						preload={ preload !== 'metadata' ? preload : undefined }
 						src={ src }
 					/>
 				) }

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -63,6 +63,7 @@ export const settings = {
 			source: 'attribute',
 			selector: 'video',
 			attribute: 'preload',
+			default: 'metadata',
 		},
 		src: {
 			type: 'string',
@@ -109,7 +110,7 @@ export const settings = {
 						controls={ controls }
 						loop={ loop }
 						muted={ muted }
-						preload={ preload }
+						preload={ preload !== 'metadata' ? preload : null }
 						src={ src }
 					/>
 				) }

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -58,6 +58,12 @@ export const settings = {
 			selector: 'video',
 			attribute: 'muted',
 		},
+		preload: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'video',
+			attribute: 'preload',
+		},
 		src: {
 			type: 'string',
 			source: 'attribute',
@@ -94,16 +100,17 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { autoplay, caption, controls, loop, muted, src } = attributes;
+		const { autoplay, caption, controls, loop, muted, preload, src } = attributes;
 		return (
 			<figure>
 				{ src && (
 					<video
 						autoPlay={ autoplay }
 						controls={ controls }
-						src={ src }
 						loop={ loop }
 						muted={ muted }
+						preload={ preload }
+						src={ src }
 					/>
 				) }
 				{ caption && caption.length > 0 && (

--- a/test/integration/full-content/fixtures/core__video.json
+++ b/test/integration/full-content/fixtures/core__video.json
@@ -9,6 +9,7 @@
             "controls": true,
             "loop": false,
             "muted": false,
+            "preload": "metadata",
             "src": "https://awesome-fake.video/file.mp4"
         },
         "innerBlocks": [],


### PR DESCRIPTION
## Description
This PR adds the preload attribute to the video block. 
As in the Classic editor the default is "metadata" and no attribute is set.

>If not set, its default value is browser-defined (i.e. each browser may have its own default value). The spec advises it to be set to metadata. 
(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-preload).

`auto` sets `preload="auto"` and `none` sets `preload="none"`

The design is the same as the preload in Audio, see #7590

**Gutenberg**
![bildschirmfoto 2018-07-12 um 13 20 03](https://user-images.githubusercontent.com/695201/42630534-56ce7c08-85d7-11e8-923c-9946516b5cd1.png)

**Classic Editor**
![bildschirmfoto 2018-07-12 um 13 21 31](https://user-images.githubusercontent.com/695201/42630556-6ea3b488-85d7-11e8-8ef0-7da593e9c716.png)


related #7501

