### PR TITLE
Fix files configuration entry in package.json for @wordpress/babel-preset-default

### DIFF
--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -21,10 +21,7 @@
 	"engines": {
 		"node": ">=8"
 	},
-	"files": [
-		"build",
-		"build-module"
-	],
+	"files": [ "index.js" ],
 	"dependencies": {
 		"@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.52",
 		"@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.52",

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -21,7 +21,9 @@
 	"engines": {
 		"node": ">=8"
 	},
-	"files": [ "index.js" ],
+	"files": [
+		"index.js"
+	],
 	"dependencies": {
 		"@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.52",
 		"@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.52",


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

The package doesn’t have `build` and `build-module` directories so the published entrypoint should be `index.js`.

When I went to install the package in a plugin it was installed with no `index.js` entrypoint in the node_modules/wordpress/babel-preset-default folder.  Thus all builds of my plugin failed with:

```
Module build failed (from ./node_modules/babel-loader/lib/index.js):
    Error: Cannot find module '@wordpress/babel-preset-default' from '/Users/dethier/webprojects/vagrant/www/ee-alpha-testing/wp-content/plugins/event-espresso-core'
```
For testing this will likely require just doing the various npm script runs.

The published package is currently broken because of this so another release will need done.