### PR TITLE
When a post is updated, fire a wp.hooks.doAction event: 'editor.effects.postUpdated' POC

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -21,6 +21,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import apiRequest from '@wordpress/api-request';
+import { doAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -177,6 +178,14 @@ export default {
 
 		request.then(
 			( newPost ) => {
+				/**
+				 * Fires when a post is successfully updated.
+				 *
+				 * @param {Object}  newPost    The updated post object as returned from the REST API.
+				 * @param {boolean} isAutosave Whether this was an an autosave.
+				 */
+				doAction( 'editor.effects.postUpdated', newPost, isAutosave );
+
 				const reset = isAutosave ? resetAutosave : resetPost;
 				dispatch( reset( newPost ) );
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/4674

## Description
Trigger a wp.hooks action event for 'editor.effects.postUpdated' - fires when a post is  updated successfully.

## Types of changes
Includes inline docs that can be parsed eventually into a hooks guide.
Introduces a single action, we can add more on a case by case basis if they are needed.

Question: is it currently possible to respond to or detect publish actions with the `wp.data.subscribe` API? I don't think so  - if you could this might not be needed?


## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
