### PR TITLE
Improve usage and documentation of the landmark region labels.

### DIFF
--- a/components/higher-order/navigate-regions/README.md
+++ b/components/higher-order/navigate-regions/README.md
@@ -1,6 +1,6 @@
 # navigateRegions
 
-`navigateRegions` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) adding keyboard navigation to switch between the different DOM elements marked as "regions" (role="region"). These regions should be focusable (By adding a tabIndex attribute for example)
+`navigateRegions` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) adding keyboard navigation to switch between the different DOM elements marked as "regions" (role="region"). These regions should be focusable (By adding a tabIndex attribute for example). For better accessibility, these elements must be properly labelled to briefly describe the purpose of the content in the region. For more details, see "ARIA landmarks" in the [WAI-ARIA specification](https://www.w3.org/TR/wai-aria/).
 
 ## Example:
 
@@ -8,9 +8,9 @@
 function MyLayout() {
 	return (
 		<div>
-			<div role="region" tabIndex="-1">Header</div>
-			<div role="region" tabIndex="-1">Content</div>
-			<div role="region" tabIndex="-1">Sidebar</div>
+			<div role="region" tabIndex="-1" aria-label="Header">Header</div>
+			<div role="region" tabIndex="-1" aria-label="Content">Content</div>
+			<div role="region" tabIndex="-1" aria-label="Sidebar">Sidebar</div>
 		</div>
 	);
 }

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -34,7 +34,8 @@ function Header( {
 	return (
 		<div
 			role="region"
-			aria-label={ __( 'Editor toolbar' ) }
+			/* translators: accessibility text for the top bar landmark region. */
+			aria-label={ __( 'Editor top bar' ) }
 			className="edit-post-header"
 			tabIndex="-1"
 		>

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -61,7 +61,8 @@ function Layout( {
 
 	const publishLandmarkProps = {
 		role: 'region',
-		'aria-label': __( 'Publish' ),
+		/* translators: accessibility text for the publish landmark region. */
+		'aria-label': __( 'Editor publish' ),
 		tabIndex: -1,
 	};
 	return (
@@ -76,7 +77,13 @@ function Layout( {
 			} } />
 			<AutosaveMonitor />
 			<Header />
-			<div className="edit-post-layout__content" role="region" aria-label={ __( 'Editor content' ) } tabIndex="-1">
+			<div
+				className="edit-post-layout__content"
+				role="region"
+				/* translators: accessibility text for the content landmark region. */
+				aria-label={ __( 'Editor content' ) }
+				tabIndex="-1"
+			>
 				<EditorNotices />
 				<PreserveScrollInReorder />
 				<EditorModeKeyboardShortcuts />


### PR DESCRIPTION
## Description

This PR aims to improve the aria-labels used for the navigable region landmarks and clarify their usage in the related README. Please refer to the related issue #7938 for more details.

- changes the label "Editor toolbar" to "Editor top bar"
- changes the label "Publish" to "Editor publish"

Worth reminding these labels are not visible and screen readers will automatically add the word "region" so they will announce:
- "Editor top bar region"
- "Editor publish region"

Also, adds some translators comments and clarifies the aria-label usage in the README.

Fixes #7938 

## How has this been tested?
npm test
