### PR TITLE
Add `audio/video settings` title to settings panel

### DIFF
--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -103,7 +103,7 @@ class AudioEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody>
+					<PanelBody title={ __( 'Audio Settings' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }
 							onChange={ this.toggleAttribute( 'autoplay' ) }

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -102,7 +102,7 @@ class VideoEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody title={ __( 'Video Options' ) }>
+					<PanelBody title={ __( 'Video Settings' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }
 							onChange={ this.toggleAttribute( 'autoplay' ) }


### PR DESCRIPTION
## Description
This PR adds `Video Settings` and `Audio Settings` as title to the settings panel to become more consistent with the other blocks.

**Video**:
![bildschirmfoto 2018-07-13 um 00 12 06](https://user-images.githubusercontent.com/695201/42662377-abe304b6-8631-11e8-90c1-bfdff2996a0b.png)

**Audio**:
![bildschirmfoto 2018-07-13 um 00 20 27](https://user-images.githubusercontent.com/695201/42662622-9219a2a0-8632-11e8-9e7b-91266c2447f2.png)

