### PR TITLE
Update `package-lock.json` with `eslint-scope` version `3.7.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,64 +50,414 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.52.tgz",
-			"integrity": "sha1-TVv/WDhfE7FbIlfF+p36LSmY5hU=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.53.tgz",
+			"integrity": "sha1-WZYGKDdcvu+WoH7f4co4t1bwGqg=",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.52.tgz",
-			"integrity": "sha1-+xiOUKa6TD+zO1Ggc36qNxfpR1k=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.53.tgz",
+			"integrity": "sha1-RFZwliPX2vqivulPglUD9MDs6Fs=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/helper-explode-assignable-expression": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.52.tgz",
-			"integrity": "sha1-ZPapFIgHdHwu9AjwRL36FhVfr1c=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.53.tgz",
+			"integrity": "sha1-e9fn419EOf03NfAC5hIyGGv5zs8=",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52",
+				"@babel/types": "7.0.0-beta.53",
 				"esutils": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.52.tgz",
-			"integrity": "sha1-to9X5iv5xJ833dLyhWInGyb2Ggc=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.53.tgz",
+			"integrity": "sha1-ld6Lq9A/nmz08rVkoDhwjBOP/jE=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-beta.52",
-				"@babel/traverse": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/helper-hoist-variables": "7.0.0-beta.53",
+				"@babel/traverse": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.5",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.53",
+						"@babel/template": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/generator": "7.0.0-beta.53",
+						"@babel/helper-function-name": "7.0.0-beta.53",
+						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
+						"invariant": "^2.2.0",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.52.tgz",
-			"integrity": "sha1-WcEVnUMgUAc/Zec7PQWlSpA+Imc=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.53.tgz",
+			"integrity": "sha1-SOniJlRTeHl1BD76qx7a0jnqlpU=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52",
+				"@babel/helper-function-name": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53",
 				"lodash": "^4.17.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.53",
+						"@babel/template": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.52.tgz",
-			"integrity": "sha1-CJNxHad4YdMKX1U3yPLhkEE6fgk=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.53.tgz",
+			"integrity": "sha1-1bytK2tH9ATAruillk3/2TEkc6g=",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/traverse": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.5",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.53",
+						"@babel/template": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/generator": "7.0.0-beta.53",
+						"@babel/helper-function-name": "7.0.0-beta.53",
+						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
+						"invariant": "^2.2.0",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -131,105 +481,514 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.52.tgz",
-			"integrity": "sha1-zNhIDj4Z2Rziy2MbSjdHl1g+ios=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.53.tgz",
+			"integrity": "sha1-TCfjuHP6CcWtbpPrQHBMIA+EE3w=",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.52.tgz",
-			"integrity": "sha1-sJjFTztyQFsqyOn2PiLj8GzJJxk=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.53.tgz",
+			"integrity": "sha1-D7Dviy07kD0cO/Qm2kp0V14BnOQ=",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.52.tgz",
-			"integrity": "sha1-cIQOg66JH5RwLGxhN4fEjuPJZbs=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.53.tgz",
+			"integrity": "sha1-5zXmqjClBLD52Fw4ptRwqfSqgdk=",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52",
+				"@babel/types": "7.0.0-beta.53",
 				"lodash": "^4.17.5"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.52.tgz",
-			"integrity": "sha1-vIRE6tJSo3LJKJlq4XM96vOwjJA=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.53.tgz",
+			"integrity": "sha1-e6IUzcyPhiPy0Xl96v8f80mqzhM=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.52",
-				"@babel/helper-simple-access": "7.0.0-beta.52",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.52",
-				"@babel/template": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52",
+				"@babel/helper-module-imports": "7.0.0-beta.53",
+				"@babel/helper-simple-access": "7.0.0-beta.53",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.53",
+				"@babel/template": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53",
 				"lodash": "^4.17.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.52.tgz",
-			"integrity": "sha1-Cq1lII8ttf60fDk/W6JtpaWwRhc=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.53.tgz",
+			"integrity": "sha1-j8eO9MD2n4uzu980zSMsIBIEFMg=",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.52.tgz",
-			"integrity": "sha1-LwWMX3w6X+S8IZA2sueOEb3et60=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.53.tgz",
+			"integrity": "sha1-1kRYY2/8JYtCcUqd2Trrb4uM8+0=",
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.52.tgz",
-			"integrity": "sha1-StjHcgSXr7zY+JfIobKtA+vNMGE=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.53.tgz",
+			"integrity": "sha1-bp0hl7Vid54iVWWUaumoXCFbIl4=",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.52.tgz",
-			"integrity": "sha1-Gcxn9GT4cJAf576F5DjHcLX0HLg=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.53.tgz",
+			"integrity": "sha1-uDSnVy3sF2OJ/6x+djV5WGSQySI=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.52",
-				"@babel/helper-wrap-function": "7.0.0-beta.52",
-				"@babel/template": "7.0.0-beta.52",
-				"@babel/traverse": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+				"@babel/helper-wrap-function": "7.0.0-beta.53",
+				"@babel/template": "7.0.0-beta.53",
+				"@babel/traverse": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.5",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.53",
+						"@babel/template": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/generator": "7.0.0-beta.53",
+						"@babel/helper-function-name": "7.0.0-beta.53",
+						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
+						"invariant": "^2.2.0",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.52.tgz",
-			"integrity": "sha1-XGSKd/4mP8eZPT27RMzWF+96bNE=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.53.tgz",
+			"integrity": "sha1-M5tb3BAilElbGifFWBMjBuG3vKc=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "7.0.0-beta.52",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.52",
-				"@babel/traverse": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/helper-member-expression-to-functions": "7.0.0-beta.53",
+				"@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+				"@babel/traverse": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.5",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.53",
+						"@babel/template": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/generator": "7.0.0-beta.53",
+						"@babel/helper-function-name": "7.0.0-beta.53",
+						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
+						"invariant": "^2.2.0",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.52.tgz",
-			"integrity": "sha1-0plc6cTJ8D/nKvkiNzZ3qOtkJO4=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.53.tgz",
+			"integrity": "sha1-cvbbmr5C+GgfpvAo79WdgVRHUrM=",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52",
+				"@babel/template": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53",
 				"lodash": "^4.17.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -242,15 +1001,132 @@
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.52.tgz",
-			"integrity": "sha1-NhSOkxdimcKKHSvv24/hzDt5tLQ=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.53.tgz",
+			"integrity": "sha1-q/sr+pQBBCurJXwBkPWtbbjfFdU=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.52",
-				"@babel/template": "7.0.0-beta.52",
-				"@babel/traverse": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/helper-function-name": "7.0.0-beta.53",
+				"@babel/template": "7.0.0-beta.53",
+				"@babel/traverse": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.5",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.53",
+						"@babel/template": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/generator": "7.0.0-beta.53",
+						"@babel/helper-function-name": "7.0.0-beta.53",
+						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
+						"invariant": "^2.2.0",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helpers": {
@@ -290,415 +1166,600 @@
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.52.tgz",
-			"integrity": "sha1-99BAc+u1CsjPwz6MlyW+tgu0G/E=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.53.tgz",
+			"integrity": "sha1-XFnvZm0Xwn3LVoa3XsMr622MUNY=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-remap-async-to-generator": "7.0.0-beta.52",
-				"@babel/plugin-syntax-async-generators": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-remap-async-to-generator": "7.0.0-beta.53",
+				"@babel/plugin-syntax-async-generators": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.52.tgz",
-			"integrity": "sha1-0RTNvbZcirAm+EAznwSEBpxpx14=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.53.tgz",
+			"integrity": "sha1-5rXwusUBg48W6PPG00sAs+pANdk=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.52.tgz",
-			"integrity": "sha1-wIptIR0fb4Tpdx5e/uHl+SYgY4o=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.53.tgz",
+			"integrity": "sha1-i6DVywtncv66DwxY5u1+oj/S8gI=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.52.tgz",
-			"integrity": "sha1-N5Gpp8KkpU+zmqT7cO142LghDKM=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.53.tgz",
+			"integrity": "sha1-YAlUHdmG6OsKkKJRFSMAEQLn3EM=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-regex": "7.0.0-beta.52",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-regex": "7.0.0-beta.53",
 				"regexpu-core": "^4.2.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.52.tgz",
-			"integrity": "sha1-UtmfDjjK3sgkBYLz+3ksgZDbJMY=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.53.tgz",
+			"integrity": "sha1-gpvvbxUBeentC7lDM58qMSM6qSE=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.52.tgz",
-			"integrity": "sha1-7Veyylq1vPkxxBmxEejfAxj49l4=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.53.tgz",
+			"integrity": "sha1-IjzIl3IzOcsiCqghbGVQhv60U5g=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.52.tgz",
-			"integrity": "sha1-ZymAeHTqbNn9IQTEZiY3ckRBUk4=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.53.tgz",
+			"integrity": "sha1-nb12jD8QnwKyT7oXNllp+iXrRYw=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.52.tgz",
-			"integrity": "sha1-HlpWjLR3ryXumgf2yGW3OwUz6ek=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.53.tgz",
+			"integrity": "sha1-pc9szGqrNp/CyleuH0pjs9w4Jes=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.52.tgz",
-			"integrity": "sha1-hefoTM8GXnKS7GABnsthazYMvxg=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.53.tgz",
+			"integrity": "sha1-p19fqEl6rBcp0DO/QcJQQWudHgQ=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.52.tgz",
-			"integrity": "sha1-mQ3AhkoXNNY/E4+ORHE/MK1orz4=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.53.tgz",
+			"integrity": "sha1-REx2HMQhXJeptVb/WMp7p99dQVM=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-remap-async-to-generator": "7.0.0-beta.52"
+				"@babel/helper-module-imports": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-remap-async-to-generator": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.52.tgz",
-			"integrity": "sha1-h69/PzmJtpTnXpc+hPjJxWhajFA=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.53.tgz",
+			"integrity": "sha1-CkMiGhsMkM1NCfG0a5Wd0khlf3M=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.52.tgz",
-			"integrity": "sha1-UumU13CFxv3wWy2JZUdV7ACOtUo=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.53.tgz",
+			"integrity": "sha1-nv1uUMofo5jcqnEZYh2j8fu4IbY=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
 				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.52.tgz",
-			"integrity": "sha1-CLG2ZKd2m2hcPs4vPqsBgy8nIBk=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.53.tgz",
+			"integrity": "sha1-XcLsMb8emAZqzfDEiHt3RMFL7G4=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.52",
-				"@babel/helper-define-map": "7.0.0-beta.52",
-				"@babel/helper-function-name": "7.0.0-beta.52",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-replace-supers": "7.0.0-beta.52",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.52",
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+				"@babel/helper-define-map": "7.0.0-beta.53",
+				"@babel/helper-function-name": "7.0.0-beta.53",
+				"@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-replace-supers": "7.0.0-beta.53",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.53",
 				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.53",
+						"@babel/template": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.52.tgz",
-			"integrity": "sha1-19b/V+lrbfGJP1zsSmGiVWqfH0M=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.53.tgz",
+			"integrity": "sha1-l0fiYIKulO2lMPmNLCBZ6NLbwAU=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.52.tgz",
-			"integrity": "sha1-q0vgYlW+cgVZhjwDvK+qjkP0rIo=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.53.tgz",
+			"integrity": "sha1-DwrbDhptzTWjZkEBYJ7AYv8SenY=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.52.tgz",
-			"integrity": "sha1-yu/q2YcKBkEOvIB9B7MbhfxGzTw=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.53.tgz",
+			"integrity": "sha1-TEZHMaRf8Fm36TOsdswFzHBlGkA=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-regex": "7.0.0-beta.52",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-regex": "7.0.0-beta.53",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.52.tgz",
-			"integrity": "sha1-mNzPUZmovonrFZwxb2ik6kT5nOY=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.53.tgz",
+			"integrity": "sha1-D1WZE6v6GCOcpOCPc+7DbF5XuB8=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.52.tgz",
-			"integrity": "sha1-5lyoSLWGv00rL9GEq3U4P7VWcnc=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.53.tgz",
+			"integrity": "sha1-PiZxeSBMd1GdhBepsZnyUiIejZU=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.52.tgz",
-			"integrity": "sha1-QuZ43pKzk4fnuzpeeEsAt//oXqc=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.53.tgz",
+			"integrity": "sha1-+gZSFeGFacj3TdUktXIeEdzKlzs=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.52.tgz",
-			"integrity": "sha1-JAHbt7+K8BSYRSgwNPObEnzMTV4=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.53.tgz",
+			"integrity": "sha1-Kzpbs2TB4cV+zL/iXGv1XygEET4=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-function-name": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.53",
+						"@babel/template": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.53",
+						"@babel/parser": "7.0.0-beta.53",
+						"@babel/types": "7.0.0-beta.53",
+						"lodash": "^4.17.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.52.tgz",
-			"integrity": "sha1-bphhqGmHANviey65diyYz1Ho528=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.53.tgz",
+			"integrity": "sha1-vsTxROmpbvUSHRQwx+vl/QiGV8k=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.52.tgz",
-			"integrity": "sha1-ZUtvO0Cu+dmoN2eCDXXLV6JW/cA=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.53.tgz",
+			"integrity": "sha1-WFTXOeZ5IzqId8C0GCaca+t6Miw=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-module-transforms": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.52.tgz",
-			"integrity": "sha1-AQTvGDzcL9Q9CGAhHMzOee8YAX4=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.53.tgz",
+			"integrity": "sha1-68P7ocWmyHQ7kJQD7NPn42gcr6U=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-simple-access": "7.0.0-beta.52"
+				"@babel/helper-module-transforms": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-simple-access": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.52.tgz",
-			"integrity": "sha1-OCI4J9x5SG398SWrZIhu03gGJtc=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.53.tgz",
+			"integrity": "sha1-uA/NnBWXLcaCMhT1JIUnhgu/BY4=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-hoist-variables": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.52.tgz",
-			"integrity": "sha1-DF9+mOqrsYtczVALX30j7TwoQOk=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.53.tgz",
+			"integrity": "sha1-Kjar5AodpnbkOhwwcVeOJ70tZ50=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-module-transforms": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.52.tgz",
-			"integrity": "sha1-Vz9HRkB3PNjaKimDKRudbUcbCPo=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.53.tgz",
+			"integrity": "sha1-m3Sz1TtOhUzw42DwLCpEAwccagE=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.52.tgz",
-			"integrity": "sha1-BjVCiKswNIDaL+OmgYbU5Fgqfb8=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.53.tgz",
+			"integrity": "sha1-4sTwbts0s9eksnV7oYgp0N8gKcs=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-replace-supers": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-replace-supers": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.52.tgz",
-			"integrity": "sha1-Qr5WV1GxtOv4YdxryLCu9P1Chgg=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.53.tgz",
+			"integrity": "sha1-7+YM7IzsoNGdXG+hrnm8TjMnnVY=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "7.0.0-beta.52",
-				"@babel/helper-get-function-arity": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-call-delegate": "7.0.0-beta.53",
+				"@babel/helper-get-function-arity": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+			},
+			"dependencies": {
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.53"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.53",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.52.tgz",
-			"integrity": "sha1-ZY5Jy2+Po17XOR+uFVyELHoSVVs=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.53.tgz",
+			"integrity": "sha1-ZYC3v2Zl8UyFgrn8JmygHwDgoEc=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/plugin-syntax-jsx": "7.0.0-beta.52"
+				"@babel/helper-builder-react-jsx": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/plugin-syntax-jsx": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.52.tgz",
-			"integrity": "sha1-VP/kudfQ0zi5rUbh7JmzYKVSTJ8=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.53.tgz",
+			"integrity": "sha1-T+u/YISvoMHJ7ISX3mjAaV/p2gs=",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.52.tgz",
-			"integrity": "sha1-EsUJAApuOo98w87dFaTawGU+YKQ=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.53.tgz",
+			"integrity": "sha1-TefM/ewGl98PcKRqaCKTcUnI4rU=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-module-imports": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.52.tgz",
-			"integrity": "sha1-8813dkPWaHiEKhutW5W0zAtey5c=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.53.tgz",
+			"integrity": "sha1-38SIG2vXZYoAMew7gWPliPCJjUs=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.52.tgz",
-			"integrity": "sha1-NDcJpt0zwLXO/0nyZ66WySJZZSI=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.53.tgz",
+			"integrity": "sha1-g+j2Rsok8cmCKPnxREz2DL1JOLw=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.52.tgz",
-			"integrity": "sha1-XIrz1qSNZY4MvW+2djH4pIierCs=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.53.tgz",
+			"integrity": "sha1-D888mUq92Lq1m6l4L+TZ+KVF1uc=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-regex": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-regex": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.52.tgz",
-			"integrity": "sha1-u9I1slntE09BPoyzHfy4LVD0E2g=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.53.tgz",
+			"integrity": "sha1-+msLQXEA0j4tsUwd9HorGzl48dk=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.52.tgz",
-			"integrity": "sha1-dwcNQJ+OGZw4kR4rWDXbdhuaVtc=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.53.tgz",
+			"integrity": "sha1-ZarocamqQPYRSDZlcxIJrr1cKis=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52"
+				"@babel/helper-plugin-utils": "7.0.0-beta.53"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.52.tgz",
-			"integrity": "sha1-n5Xi/TfqxlWU2jXpDngmKVXYbLs=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.53.tgz",
+			"integrity": "sha1-CvdOyAGefVnji+ZNt/YikZQv7SU=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/helper-regex": "7.0.0-beta.52",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/helper-regex": "7.0.0-beta.53",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.52.tgz",
-			"integrity": "sha1-HoM/uGmPUeNFrX0z+6sm0M6BmJ0=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.53.tgz",
+			"integrity": "sha1-KyBL9CZ14WbdpaJ1bEHrvyKbs34=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.52",
-				"@babel/helper-plugin-utils": "7.0.0-beta.52",
-				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.52",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.52",
-				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.52",
-				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.52",
-				"@babel/plugin-syntax-async-generators": "7.0.0-beta.52",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.52",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.52",
-				"@babel/plugin-transform-arrow-functions": "7.0.0-beta.52",
-				"@babel/plugin-transform-async-to-generator": "7.0.0-beta.52",
-				"@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.52",
-				"@babel/plugin-transform-block-scoping": "7.0.0-beta.52",
-				"@babel/plugin-transform-classes": "7.0.0-beta.52",
-				"@babel/plugin-transform-computed-properties": "7.0.0-beta.52",
-				"@babel/plugin-transform-destructuring": "7.0.0-beta.52",
-				"@babel/plugin-transform-dotall-regex": "7.0.0-beta.52",
-				"@babel/plugin-transform-duplicate-keys": "7.0.0-beta.52",
-				"@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.52",
-				"@babel/plugin-transform-for-of": "7.0.0-beta.52",
-				"@babel/plugin-transform-function-name": "7.0.0-beta.52",
-				"@babel/plugin-transform-literals": "7.0.0-beta.52",
-				"@babel/plugin-transform-modules-amd": "7.0.0-beta.52",
-				"@babel/plugin-transform-modules-commonjs": "7.0.0-beta.52",
-				"@babel/plugin-transform-modules-systemjs": "7.0.0-beta.52",
-				"@babel/plugin-transform-modules-umd": "7.0.0-beta.52",
-				"@babel/plugin-transform-new-target": "7.0.0-beta.52",
-				"@babel/plugin-transform-object-super": "7.0.0-beta.52",
-				"@babel/plugin-transform-parameters": "7.0.0-beta.52",
-				"@babel/plugin-transform-regenerator": "7.0.0-beta.52",
-				"@babel/plugin-transform-shorthand-properties": "7.0.0-beta.52",
-				"@babel/plugin-transform-spread": "7.0.0-beta.52",
-				"@babel/plugin-transform-sticky-regex": "7.0.0-beta.52",
-				"@babel/plugin-transform-template-literals": "7.0.0-beta.52",
-				"@babel/plugin-transform-typeof-symbol": "7.0.0-beta.52",
-				"@babel/plugin-transform-unicode-regex": "7.0.0-beta.52",
+				"@babel/helper-module-imports": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.53",
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.53",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.53",
+				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.53",
+				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.53",
+				"@babel/plugin-syntax-async-generators": "7.0.0-beta.53",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.53",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.53",
+				"@babel/plugin-transform-arrow-functions": "7.0.0-beta.53",
+				"@babel/plugin-transform-async-to-generator": "7.0.0-beta.53",
+				"@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.53",
+				"@babel/plugin-transform-block-scoping": "7.0.0-beta.53",
+				"@babel/plugin-transform-classes": "7.0.0-beta.53",
+				"@babel/plugin-transform-computed-properties": "7.0.0-beta.53",
+				"@babel/plugin-transform-destructuring": "7.0.0-beta.53",
+				"@babel/plugin-transform-dotall-regex": "7.0.0-beta.53",
+				"@babel/plugin-transform-duplicate-keys": "7.0.0-beta.53",
+				"@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.53",
+				"@babel/plugin-transform-for-of": "7.0.0-beta.53",
+				"@babel/plugin-transform-function-name": "7.0.0-beta.53",
+				"@babel/plugin-transform-literals": "7.0.0-beta.53",
+				"@babel/plugin-transform-modules-amd": "7.0.0-beta.53",
+				"@babel/plugin-transform-modules-commonjs": "7.0.0-beta.53",
+				"@babel/plugin-transform-modules-systemjs": "7.0.0-beta.53",
+				"@babel/plugin-transform-modules-umd": "7.0.0-beta.53",
+				"@babel/plugin-transform-new-target": "7.0.0-beta.53",
+				"@babel/plugin-transform-object-super": "7.0.0-beta.53",
+				"@babel/plugin-transform-parameters": "7.0.0-beta.53",
+				"@babel/plugin-transform-regenerator": "7.0.0-beta.53",
+				"@babel/plugin-transform-shorthand-properties": "7.0.0-beta.53",
+				"@babel/plugin-transform-spread": "7.0.0-beta.53",
+				"@babel/plugin-transform-sticky-regex": "7.0.0-beta.53",
+				"@babel/plugin-transform-template-literals": "7.0.0-beta.53",
+				"@babel/plugin-transform-typeof-symbol": "7.0.0-beta.53",
+				"@babel/plugin-transform-unicode-regex": "7.0.0-beta.53",
 				"browserslist": "^3.0.0",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
@@ -706,21 +1767,13 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.52.tgz",
-			"integrity": "sha1-PztCuCuStOGig/x43xuy/Uuo0Mc=",
+			"version": "7.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.53.tgz",
+			"integrity": "sha1-nfIq40gjzon3kAYFlLg+5XLixdI=",
 			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
 				"regenerator-runtime": "^0.12.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.5.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/template": {
@@ -4719,12 +5772,6 @@
 				"readable-stream": "^2.3.5"
 			}
 		},
-		"clorox": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/clorox/-/clorox-1.0.3.tgz",
-			"integrity": "sha512-w3gKAUKMJYmmaJyc+p+iDrDtLvsFasrx/y6/zWo2U1TZfsz3y4Vl4T9PHCZrOwk1eMTOSRI6xHdpDR4PhTdy8Q==",
-			"dev": true
-		},
 		"cmd-shim": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
@@ -6682,9 +7729,9 @@
 			}
 		},
 		"eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+			"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
@@ -8147,9 +9194,9 @@
 			}
 		},
 		"get-caller-file": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
@@ -11335,9 +12382,9 @@
 			"integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
 		},
 		"js-base64": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
-			"integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.6.tgz",
+			"integrity": "sha512-O9SR2NVICx6rCqh1qsU91QZ5IoNa+2T1ROJ0OQlfvATKGmnjsAvg3r0E5ufPZ4a95jdKTPXhFWiE/sOZ7a5Rtg==",
 			"dev": true
 		},
 		"js-beautify": {
@@ -11699,6 +12746,12 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
+		},
+		"kleur": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-1.0.1.tgz",
+			"integrity": "sha512-8srIZ5BK5PCJw1L/JN741xgNfSjuQNK9ImYbYzv7ZUD3WPfuywaY+yd7lQOphJ+2vwXnMLnRZoAh5X+orRt4LQ==",
 			"dev": true
 		},
 		"lazy-cache": {
@@ -16464,12 +17517,12 @@
 			"dev": true
 		},
 		"prompts": {
-			"version": "0.1.11",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.11.tgz",
-			"integrity": "sha512-6ZFzPasWMEgZ/cDpQQshV/l/fWISILGjq4VctCipG6RVfaO4FAafGR8iKXSFxoHIYgPcPYuDupyLtVNc/aDG8Q==",
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.12.tgz",
+			"integrity": "sha512-pgR1GE1JM8q8UsHVIgjdK62DPwvrf0kvaKWJ/mfMoCm2lwfIReX/giQ1p0AlMoUXNhQap/8UiOdqi3bOROm/eg==",
 			"dev": true,
 			"requires": {
-				"clorox": "^1.0.3",
+				"kleur": "^1.0.0",
 				"sisteransi": "^0.1.1"
 			}
 		},
@@ -19338,13 +20391,10 @@
 			"dev": true
 		},
 		"use": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"dev": true,
-			"requires": {
-				"kind-of": "^6.0.2"
-			}
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"util": {
 			"version": "0.10.4",


### PR DESCRIPTION
## Description

This PR regenerates the `package-lock.json` file from scratch, notable changes:

• Bumps `eslint-scope` from `3.7.1` to `3.7.3`
• Bumps Babel v7 beta packages from `7.0.0-beta.52` to `7.0.0-beta.53`

Bumping `eslint-scope` to `3.7.3` ensures that the [compromised  `3.7.2` release](https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes) will not be used.

<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Build Tools

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
