### PR TITLE
If a more recent revision/autosave exists, store its state on editor setup

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -193,10 +193,16 @@ saved state of the post.
 
 Post attribute value.
 
-### getAutosaveAttribute
+### getAutosaveAttribute (deprecated)
 
 Returns an attribute value of the current autosave revision for a post, or
 null if there is no autosave for the post.
+
+*Deprecated*
+
+Deprecated since 5.0. Callers should use the `getAutosave( postType, postId )` selector from the
+            '@wordpress/core-data' package and access properties on the returned autosave object
+            using getPostRawValue.
 
 *Parameters*
 
@@ -303,16 +309,22 @@ Returns true if the post can be autosaved, or false otherwise.
 *Parameters*
 
  * state: Global application state.
+ * autosave: A raw autosave object from the REST API.
 
 *Returns*
 
 Whether the post can be autosaved.
 
-### getAutosave
+### getAutosave (deprecated)
 
 Returns the current autosave, or null if one is not set (i.e. if the post
 has yet to be autosaved, or has been saved or published since the last
 autosave).
+
+*Deprecated*
+
+Deprecated since 5.0. Callers should use the `getAutosave( postType, postId )`
+			   selector from the '@wordpress/core-data' package.
 
 *Parameters*
 
@@ -322,9 +334,14 @@ autosave).
 
 Current autosave, if exists.
 
-### hasAutosave
+### hasAutosave (deprecated)
 
 Returns the true if there is an existing autosave, otherwise false.
+
+*Deprecated*
+
+Deprecated since 5.0. Callers should use the `getAutosave( postType, postId )` selector
+            from the '@wordpress/core-data' package and check for a truthy value.
 
 *Parameters*
 
@@ -752,14 +769,19 @@ post has been received, either by initialization or save.
 
  * post: Post object.
 
-### resetAutosave
+### resetAutosave (deprecated)
 
 Returns an action object used in signalling that the latest autosave of the
 post has been received, by initialization or autosave.
 
+*Deprecated*
+
+Deprecated since 5.0. Callers should use the `receiveAutosave( postId, autosave )`
+			   selector from the '@wordpress/core-data' package.
+
 *Parameters*
 
- * post: Autosave post object.
+ * newAutosave: Autosave post object.
 
 ### __experimentalRequestPostUpdateStart
 

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -200,7 +200,7 @@ null if there is no autosave for the post.
 
 *Deprecated*
 
-Deprecated since 5.0. Callers should use the `getAutosave( postType, postId )` selector from the
+Deprecated since 5.3. Callers should use the `getAutosave( postType, postId )` selector from the
             '@wordpress/core-data' package and access properties on the returned autosave object
             using getPostRawValue.
 
@@ -323,7 +323,7 @@ autosave).
 
 *Deprecated*
 
-Deprecated since 5.0. Callers should use the `getAutosave( postType, postId )`
+Deprecated since 5.3. Callers should use the `getAutosave( postType, postId )`
 			   selector from the '@wordpress/core-data' package.
 
 *Parameters*
@@ -340,7 +340,7 @@ Returns the true if there is an existing autosave, otherwise false.
 
 *Deprecated*
 
-Deprecated since 5.0. Callers should use the `getAutosave( postType, postId )` selector
+Deprecated since 5.3. Callers should use the `getAutosave( postType, postId )` selector
             from the '@wordpress/core-data' package and check for a truthy value.
 
 *Parameters*
@@ -776,7 +776,7 @@ post has been received, by initialization or autosave.
 
 *Deprecated*
 
-Deprecated since 5.0. Callers should use the `receiveAutosave( postId, autosave )`
+Deprecated since 5.3. Callers should use the `receiveAutosave( postId, autosave )`
 			   selector from the '@wordpress/core-data' package.
 
 *Parameters*

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -200,7 +200,7 @@ null if there is no autosave for the post.
 
 *Deprecated*
 
-Deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )` selector
+Deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )` selector
 			   from the '@wordpress/core-data' package and access properties on the returned
 			   autosave object using getPostRawValue.
 
@@ -323,7 +323,7 @@ autosave).
 
 *Deprecated*
 
-Deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )`
+Deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )`
 			   selector from the '@wordpress/core-data' package.
 
 *Parameters*
@@ -340,7 +340,7 @@ Returns the true if there is an existing autosave, otherwise false.
 
 *Deprecated*
 
-Deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )` selector
+Deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )` selector
             from the '@wordpress/core-data' package and check for a truthy value.
 
 *Parameters*
@@ -776,7 +776,7 @@ post has been received, by initialization or autosave.
 
 *Deprecated*
 
-Deprecated since 5.3. Callers should use the `receiveAutosave( postId, autosave )`
+Deprecated since 5.3. Callers should use the `receiveAutosaves( postId, autosave )`
 			   selector from the '@wordpress/core-data' package.
 
 *Parameters*

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -776,7 +776,7 @@ post has been received, by initialization or autosave.
 
 *Deprecated*
 
-Deprecated since 5.3. Callers should use the `receiveAutosaves( postId, autosave )`
+Deprecated since 5.4. Callers should use the `receiveAutosaves( postId, autosave )`
 			   selector from the '@wordpress/core-data' package.
 
 *Parameters*

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -200,9 +200,9 @@ null if there is no autosave for the post.
 
 *Deprecated*
 
-Deprecated since 5.3. Callers should use the `getAutosave( postType, postId )` selector from the
-            '@wordpress/core-data' package and access properties on the returned autosave object
-            using getPostRawValue.
+Deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )` selector
+			   from the '@wordpress/core-data' package and access properties on the returned
+			   autosave object using getPostRawValue.
 
 *Parameters*
 
@@ -323,7 +323,7 @@ autosave).
 
 *Deprecated*
 
-Deprecated since 5.3. Callers should use the `getAutosave( postType, postId )`
+Deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )`
 			   selector from the '@wordpress/core-data' package.
 
 *Parameters*
@@ -340,7 +340,7 @@ Returns the true if there is an existing autosave, otherwise false.
 
 *Deprecated*
 
-Deprecated since 5.3. Callers should use the `getAutosave( postType, postId )` selector
+Deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )` selector
             from the '@wordpress/core-data' package and check for a truthy value.
 
 *Parameters*

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -200,7 +200,7 @@ null if there is no autosave for the post.
 
 *Deprecated*
 
-Deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )` selector
+Deprecated since 5.6. Callers should use the `getAutosave( postType, postId, userId )` selector
 			   from the '@wordpress/core-data' package and access properties on the returned
 			   autosave object using getPostRawValue.
 
@@ -323,7 +323,7 @@ autosave).
 
 *Deprecated*
 
-Deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )`
+Deprecated since 5.6. Callers should use the `getAutosave( postType, postId, userId )`
 			   selector from the '@wordpress/core-data' package.
 
 *Parameters*
@@ -340,7 +340,7 @@ Returns the true if there is an existing autosave, otherwise false.
 
 *Deprecated*
 
-Deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )` selector
+Deprecated since 5.6. Callers should use the `getAutosave( postType, postId, userId )` selector
             from the '@wordpress/core-data' package and check for a truthy value.
 
 *Parameters*
@@ -776,7 +776,7 @@ post has been received, by initialization or autosave.
 
 *Deprecated*
 
-Deprecated since 5.4. Callers should use the `receiveAutosaves( postId, autosave )`
+Deprecated since 5.6. Callers should use the `receiveAutosaves( postId, autosave )`
 			   selector from the '@wordpress/core-data' package.
 
 *Parameters*

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -225,9 +225,9 @@ Returns the autosave for the post and author.
 
 The autosave for the post and author.
 
-### hasFetchedAutosave
+### hasFetchedAutosaves
 
-Returns true if the REST request for an autosave has completed.
+Returns true if the REST request for autosaves has completed.
 
 *Parameters*
 

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -181,6 +181,34 @@ https://developer.wordpress.org/rest-api/reference/
 Whether or not the user can perform the action,
                             or `undefined` if the OPTIONS request is still being made.
 
+### getAutosave
+
+Returns the latest autosave that is a child of the provided post id, if one exists.
+
+*Parameters*
+
+ * state: State tree.
+ * postType: The type of the parent post.
+ * postId: The id of the parent post.
+
+*Returns*
+
+The autosave object, or undefined if there is none.
+
+### hasFetchedAutosave
+
+Returns true if the REST request for an autosave has completed.
+
+*Parameters*
+
+ * state: State tree.
+ * postType: The type of the parent post.
+ * postId: The id of the parent post.
+
+*Returns*
+
+True if the REST request was completed. False otherwise.
+
 ## Actions
 
 ### receiveUserQuery
@@ -257,3 +285,13 @@ permission to perform an action on a REST resource.
 
  * key: A key that represents the action and REST resource.
  * isAllowed: Whether or not the user can perform the action.
+
+### receiveAutosave
+
+Returns an action object used in signalling that the latest autosave of the
+post has been received, by initialization or autosave.
+
+*Parameters*
+
+ * postId: The id of the post that is parent to the autosave.
+ * autosave: Autosave post object.

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -183,13 +183,15 @@ Whether or not the user can perform the action,
 
 ### getAutosave
 
-Returns the latest autosave that is a child of the provided post id, if one exists.
+Returns the latest autosave that is a child of the provided post id for the
+author, if one exists.
 
 *Parameters*
 
  * state: State tree.
  * postType: The type of the parent post.
  * postId: The id of the parent post.
+ * author: The author of the autosave.
 
 *Returns*
 

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -193,21 +193,37 @@ https://developer.wordpress.org/rest-api/reference/
 Whether or not the user can perform the action,
                             or `undefined` if the OPTIONS request is still being made.
 
-### getAutosave
+### getAutosaves
 
-Returns the latest autosave that is a child of the provided post id for the
-author, if one exists.
+Returns the latest autosaves for the post.
+
+May return multiple autosaves since the backend stores one autosave per
+author for each post.
 
 *Parameters*
 
  * state: State tree.
  * postType: The type of the parent post.
  * postId: The id of the parent post.
- * author: The author of the autosave.
 
 *Returns*
 
-The autosave object, or undefined if there is none.
+An array of autosaves for the post, or undefined if there is none.
+
+### getAutosave
+
+Returns the autosave for the post and author.
+
+*Parameters*
+
+ * state: State tree.
+ * postType: The type of the parent post.
+ * postId: The id of the parent post.
+ * authorId: The id of the author.
+
+*Returns*
+
+The autosave for the post and author.
 
 ### hasFetchedAutosave
 
@@ -215,7 +231,6 @@ Returns true if the REST request for an autosave has completed.
 
 *Parameters*
 
- * state: State tree.
  * state: State tree.
  * postType: The type of the parent post.
  * postId: The id of the parent post.
@@ -309,12 +324,12 @@ permission to perform an action on a REST resource.
  * key: A key that represents the action and REST resource.
  * isAllowed: Whether or not the user can perform the action.
 
-### receiveAutosave
+### receiveAutosaves
 
-Returns an action object used in signalling that the latest autosave of the
-post has been received, by initialization or autosave.
+Returns an action object used in signalling that the autosaves for a
+post have been received.
 
 *Parameters*
 
  * postId: The id of the post that is parent to the autosave.
- * autosave: Autosave post object.
+ * autosaves: Array of autosave post objects.

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -24,6 +24,18 @@ Returns all available authors.
 
 Authors list.
 
+### getCurrentUser
+
+Returns the current user.
+
+*Parameters*
+
+ * state: Data state.
+
+*Returns*
+
+Current user object.
+
 ### getUserQueryResults
 
 Returns all the users returned by a query ID.
@@ -204,6 +216,7 @@ Returns true if the REST request for an autosave has completed.
 *Parameters*
 
  * state: State tree.
+ * state: State tree.
  * postType: The type of the parent post.
  * postId: The id of the parent post.
 
@@ -221,6 +234,14 @@ Returns an action object used in signalling that authors have been received.
 
  * queryID: Query ID.
  * users: Users received.
+
+### receiveCurrentUser
+
+Returns an action used in signalling that the current user has been received.
+
+*Parameters*
+
+ * currentUser: Current user object.
 
 ### addEntities
 

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -332,4 +332,4 @@ post have been received.
 *Parameters*
 
  * postId: The id of the post that is parent to the autosave.
- * autosaves: Array of autosave post objects.
+ * autosaves: An array of autosaves or singular autosave object.

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (Unreleased)
+
+### New features
+- The `getAutosave` selector has been added.
+- The `receiveAutosave` action has been added.
+
 ## 2.0.16 (2019-01-03)
 
 ### Bug Fixes

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.1.0 (Unreleased)
 
 ### New features
-- The `getAutosave` selector has been added.
-- The `receiveAutosave` action has been added.
+- The `getAutosave`, `getAutosaves` and `getCurrentUser` selectors have been added.
+- The `receiveAutosaves` and `receiveCurrentUser` actions have been added.
 
 ## 2.0.16 (2019-01-03)
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -161,18 +161,18 @@ export function receiveUserPermission( key, isAllowed ) {
 }
 
 /**
- * Returns an action object used in signalling that the latest autosave of the
- * post has been received, by initialization or autosave.
+ * Returns an action object used in signalling that the autosaves for a
+ * post have been received.
  *
- * @param {number} postId   The id of the post that is parent to the autosave.
- * @param {Object} autosave Autosave post object.
+ * @param {number} postId    The id of the post that is parent to the autosave.
+ * @param {Array}  autosaves Array of autosave post objects.
  *
  * @return {Object} Action object.
  */
-export function receiveAutosave( postId, autosave ) {
+export function receiveAutosaves( postId, autosaves ) {
 	return {
-		type: 'RECEIVE_AUTOSAVE',
+		type: 'RECEIVE_AUTOSAVES',
 		postId,
-		autosave,
+		autosaves,
 	};
 }

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -159,3 +159,20 @@ export function receiveUserPermission( key, isAllowed ) {
 		isAllowed,
 	};
 }
+
+/**
+ * Returns an action object used in signalling that the latest autosave of the
+ * post has been received, by initialization or autosave.
+ *
+ * @param {number} postId   The id of the post that is parent to the autosave.
+ * @param {Object} autosave Autosave post object.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveAutosave( postId, autosave ) {
+	return {
+		type: 'RECEIVE_AUTOSAVE',
+		postId,
+		autosave,
+	};
+}

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -30,6 +30,20 @@ export function receiveUserQuery( queryID, users ) {
 }
 
 /**
+ * Returns an action used in signalling that the current user has been received.
+ *
+ * @param {Object} currentUser Current user object.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveCurrentUser( currentUser ) {
+	return {
+		type: 'RECEIVE_CURRENT_USER',
+		currentUser,
+	};
+}
+
+/**
  * Returns an action object used in adding new entities.
  *
  * @param {Array} entities  Entities received.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -178,8 +178,8 @@ export function receiveUserPermission( key, isAllowed ) {
  * Returns an action object used in signalling that the autosaves for a
  * post have been received.
  *
- * @param {number} postId    The id of the post that is parent to the autosave.
- * @param {Array}  autosaves Array of autosave post objects.
+ * @param {number}       postId    The id of the post that is parent to the autosave.
+ * @param {Array|Object} autosaves An array of autosaves or singular autosave object.
  *
  * @return {Object} Action object.
  */
@@ -187,6 +187,6 @@ export function receiveAutosaves( postId, autosaves ) {
 	return {
 		type: 'RECEIVE_AUTOSAVES',
 		postId,
-		autosaves,
+		autosaves: castArray( autosaves ),
 	};
 }

--- a/packages/core-data/src/controls.js
+++ b/packages/core-data/src/controls.js
@@ -32,6 +32,23 @@ export function select( selectorName, ...args ) {
 	};
 }
 
+/**
+ * Dispatches a control action for triggering a registry select that has a
+ * resolver.
+ *
+ * @param {string}  selectorName
+ * @param {Array}   args  Arguments for the select.
+ *
+ * @return {Object} control descriptor.
+ */
+export function resolveSelect( selectorName, ...args ) {
+	return {
+		type: 'RESOLVE_SELECT',
+		selectorName,
+		args,
+	};
+}
+
 const controls = {
 	API_FETCH( { request } ) {
 		return triggerApiFetch( request );
@@ -40,6 +57,30 @@ const controls = {
 	SELECT: createRegistryControl( ( registry ) => ( { selectorName, args } ) => {
 		return registry.select( 'core' )[ selectorName ]( ...args );
 	} ),
+
+	RESOLVE_SELECT: createRegistryControl(
+		( registry ) => ( { selectorName, args } ) => {
+			return new Promise( ( resolve ) => {
+				const hasFinished = () => registry.select( 'core/data' )
+					.hasFinishedResolution( 'core', selectorName, args );
+				const getResult = () => registry.select( 'core' )[ selectorName ]
+					.apply( null, args );
+
+				// trigger the selector (to trigger the resolver)
+				const result = getResult();
+				if ( hasFinished() ) {
+					return resolve( result );
+				}
+
+				const unsubscribe = registry.subscribe( () => {
+					if ( hasFinished() ) {
+						unsubscribe();
+						resolve( getResult() );
+					}
+				} );
+			} );
+		}
+	),
 };
 
 export default controls;

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -64,6 +64,14 @@ export function users( state = { byId: {}, queries: {} }, action ) {
 	return state;
 }
 
+/**
+ * Reducer managing current user state.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
 export function currentUser( state = {}, action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_CURRENT_USER':

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -272,6 +272,7 @@ export function autosaves( state = {}, action ) {
 export default combineReducers( {
 	terms,
 	users,
+	currentUser,
 	taxonomies,
 	themeSupports,
 	entities,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -64,6 +64,15 @@ export function users( state = { byId: {}, queries: {} }, action ) {
 	return state;
 }
 
+export function currentUser( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_CURRENT_USER':
+			return action.currentUser;
+	}
+
+	return state;
+}
+
 /**
  * Reducer managing taxonomies.
  *

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -238,6 +238,28 @@ export function userPermissions( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning autosaves keyed by their parent's post id.
+ *
+ * @param  {Object} state  Current state.
+ * @param  {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function autosaves( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_AUTOSAVE':
+			const { postId, autosave } = action;
+
+			return {
+				[ postId ]: autosave,
+				...state,
+			};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	terms,
 	users,
@@ -246,4 +268,5 @@ export default combineReducers( {
 	entities,
 	embedPreviews,
 	userPermissions,
+	autosaves,
 } );

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -248,12 +248,12 @@ export function userPermissions( state = {}, action ) {
  */
 export function autosaves( state = {}, action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_AUTOSAVE':
-			const { postId, autosave } = action;
+		case 'RECEIVE_AUTOSAVES':
+			const { postId, autosaves: autosavesData } = action;
 
 			return {
-				[ postId ]: autosave,
 				...state,
+				[ postId ]: autosavesData,
 			};
 	}
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -18,9 +18,10 @@ import {
 	receiveThemeSupports,
 	receiveEmbedPreview,
 	receiveUserPermission,
+	receiveAutosave,
 } from './actions';
 import { getKindEntities } from './entities';
-import { apiFetch } from './controls';
+import { apiFetch, select } from './controls';
 
 /**
  * Requests authors from the REST API.
@@ -168,4 +169,19 @@ export function* canUser( action, resource, id ) {
 	const key = compact( [ action, resource, id ] ).join( '/' );
 	const isAllowed = includes( allowHeader, method );
 	yield receiveUserPermission( key, isAllowed );
+}
+
+/**
+ * Request autosave data from the REST API.
+ *
+ * @param {string} postType The type of the parent post.
+ * @param {number} postId   The id of the parent post.
+ */
+export function* getAutosave( postType, postId ) {
+	const { baseURL } = yield select( 'getEntity', 'postType', postType );
+	const autosaveResponse = yield apiFetch( { path: `${ baseURL }/${ postId }/autosaves?context=edit` } );
+
+	if ( autosaveResponse && autosaveResponse[ 0 ] ) {
+		yield receiveAutosave( postId, autosaveResponse[ 0 ] );
+	}
 }

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -18,7 +18,7 @@ import {
 	receiveThemeSupports,
 	receiveEmbedPreview,
 	receiveUserPermission,
-	receiveAutosave,
+	receiveAutosaves,
 } from './actions';
 import { getKindEntities } from './entities';
 import { apiFetch, resolveSelect } from './controls';
@@ -177,11 +177,11 @@ export function* canUser( action, resource, id ) {
  * @param {string} postType The type of the parent post.
  * @param {number} postId   The id of the parent post.
  */
-export function* getAutosave( postType, postId ) {
+export function* getAutosaves( postType, postId ) {
 	const { rest_base: restBase } = yield resolveSelect( 'getPostType', postType );
-	const autosaveResponse = yield apiFetch( { path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit` } );
+	const autosaves = yield apiFetch( { path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit` } );
 
-	if ( autosaveResponse && autosaveResponse[ 0 ] ) {
-		yield receiveAutosave( postId, autosaveResponse[ 0 ] );
+	if ( autosaves && autosaves.length ) {
+		yield receiveAutosaves( postId, autosaves );
 	}
 }

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -21,7 +21,7 @@ import {
 	receiveAutosave,
 } from './actions';
 import { getKindEntities } from './entities';
-import { apiFetch, select } from './controls';
+import { apiFetch, resolveSelect } from './controls';
 
 /**
  * Requests authors from the REST API.
@@ -178,8 +178,8 @@ export function* canUser( action, resource, id ) {
  * @param {number} postId   The id of the parent post.
  */
 export function* getAutosave( postType, postId ) {
-	const { baseURL } = yield select( 'getEntity', 'postType', postType );
-	const autosaveResponse = yield apiFetch( { path: `${ baseURL }/${ postId }/autosaves?context=edit` } );
+	const { rest_base: restBase } = yield resolveSelect( 'getPostType', postType );
+	const autosaveResponse = yield apiFetch( { path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit` } );
 
 	if ( autosaveResponse && autosaveResponse[ 0 ] ) {
 		yield receiveAutosave( postId, autosaveResponse[ 0 ] );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -194,3 +194,16 @@ export function* getAutosaves( postType, postId ) {
 		yield receiveAutosaves( postId, autosaves );
 	}
 }
+
+/**
+ * Request autosave data from the REST API.
+ *
+ * This resolver exists to ensure the underlying autosaves are fetched via
+ * `getAutosaves` when a call to the `getAutosave` selector is made.
+ *
+ * @param {string} postType The type of the parent post.
+ * @param {number} postId   The id of the parent post.
+ */
+export function* getAutosave( postType, postId ) {
+	yield resolveSelect( 'getAutosaves', postType, postId );
+}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -14,6 +14,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import {
 	receiveUserQuery,
+	receiveCurrentUser,
 	receiveEntityRecords,
 	receiveThemeSupports,
 	receiveEmbedPreview,
@@ -29,6 +30,14 @@ import { apiFetch, resolveSelect } from './controls';
 export function* getAuthors() {
 	const users = yield apiFetch( { path: '/wp/v2/users/?who=authors&per_page=-1' } );
 	yield receiveUserQuery( 'authors', users );
+}
+
+/**
+ * Requests the current user from the REST API.
+ */
+export function* getCurrentUser() {
+	const currentUser = yield apiFetch( { path: '/wp/v2/users/me' } );
+	yield receiveCurrentUser( currentUser );
 }
 
 /**

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -204,15 +204,17 @@ export function canUser( state, action, resource, id ) {
 }
 
 /**
- * Returns the latest autosave that is a child of the provided post id, if one exists.
+ * Returns the latest autosaves for the post.
+ *
+ * The backend stores one autosave per user per post.
  *
  * @param {Object} state    State tree.
  * @param {string} postType The type of the parent post.
  * @param {number} postId   The id of the parent post.
  *
- * @return {?Object} The autosave object, or undefined if there is none.
+ * @return {?Object} An array of autosaves for the post, or undefined if there is none.
  */
-export function getAutosave( state, postType, postId ) {
+export function getAutosaves( state, postType, postId ) {
 	return state.autosaves[ postId ];
 }
 
@@ -226,5 +228,5 @@ export function getAutosave( state, postType, postId ) {
  * @return {boolean} True if the REST request was completed. False otherwise.
  */
 export const hasFetchedAutosave = createRegistrySelector( ( select ) => ( state, postType, postId ) => {
-	return select( 'core/data' ).hasFinishedResolution( REDUCER_KEY, 'getAutosave', [ postType, postId ] );
+	return select( 'core/data' ).hasFinishedResolution( REDUCER_KEY, 'getAutosaves', [ postType, postId ] );
 } );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -217,7 +217,8 @@ export function canUser( state, action, resource, id ) {
 /**
  * Returns the latest autosaves for the post.
  *
- * The backend stores one autosave per user per post.
+ * May return multiple autosaves since the backend stores one autosave per
+ * author for each post.
  *
  * @param {Object} state    State tree.
  * @param {string} postType The type of the parent post.
@@ -227,6 +228,21 @@ export function canUser( state, action, resource, id ) {
  */
 export function getAutosaves( state, postType, postId ) {
 	return state.autosaves[ postId ];
+}
+
+/**
+ * Returns the autosave for the post and author.
+ *
+ * @param {Object} state    State tree.
+ * @param {string} postType The type of the parent post.
+ * @param {number} postId   The id of the parent post.
+ * @param {number} authorId The id of the author.
+ *
+ * @return {?Object} The autosave for the post and author.
+ */
+export function getAutosave( state, postType, postId, authorId ) {
+	const autosaves = state.autosaves[ postId ];
+	return find( autosaves, { author: authorId } );
 }
 
 /**

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -250,7 +250,7 @@ export function getAutosave( state, postType, postId, authorId ) {
 }
 
 /**
- * Returns true if the REST request for an autosave has completed.
+ * Returns true if the REST request for autosaves has completed.
  *
  * @param {Object} state State tree.
  * @param {string} postType The type of the parent post.
@@ -258,6 +258,6 @@ export function getAutosave( state, postType, postId, authorId ) {
  *
  * @return {boolean} True if the REST request was completed. False otherwise.
  */
-export const hasFetchedAutosave = createRegistrySelector( ( select ) => ( state, postType, postId ) => {
+export const hasFetchedAutosaves = createRegistrySelector( ( select ) => ( state, postType, postId ) => {
 	return select( 'core/data' ).hasFinishedResolution( REDUCER_KEY, 'getAutosaves', [ postType, postId ] );
 } );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -202,3 +202,29 @@ export function canUser( state, action, resource, id ) {
 	const key = compact( [ action, resource, id ] ).join( '/' );
 	return get( state, [ 'userPermissions', key ] );
 }
+
+/**
+ * Returns the latest autosave that is a child of the provided post id, if one exists.
+ *
+ * @param {Object} state    State tree.
+ * @param {string} postType The type of the parent post.
+ * @param {number} postId   The id of the parent post.
+ *
+ * @return {?Object} The autosave object, or undefined if there is none.
+ */
+export function getAutosave( state, postType, postId ) {
+	return state.autosaves[ postId ];
+}
+
+/**
+ * Returns true if the REST request for an autosave has completed.
+ *
+ * @param {Object} state State tree.
+ * @param {string} postType The type of the parent post.
+ * @param {number} postId   The id of the parent post.
+ *
+ * @return {boolean} True if the REST request was completed. False otherwise.
+ */
+export const hasFetchedAutosave = createRegistrySelector( ( select ) => ( state, postType, postId ) => {
+	return select( 'core/data' ).hasFinishedResolution( REDUCER_KEY, 'getAutosave', [ postType, postId ] );
+} );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -224,7 +224,7 @@ export function canUser( state, action, resource, id ) {
  * @param {string} postType The type of the parent post.
  * @param {number} postId   The id of the parent post.
  *
- * @return {?Object} An array of autosaves for the post, or undefined if there is none.
+ * @return {?Array} An array of autosaves for the post, or undefined if there is none.
  */
 export function getAutosaves( state, postType, postId ) {
 	return state.autosaves[ postId ];
@@ -241,6 +241,10 @@ export function getAutosaves( state, postType, postId ) {
  * @return {?Object} The autosave for the post and author.
  */
 export function getAutosave( state, postType, postId, authorId ) {
+	if ( authorId === undefined ) {
+		return;
+	}
+
 	const autosaves = state.autosaves[ postId ];
 	return find( autosaves, { author: authorId } );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -41,6 +41,17 @@ export function getAuthors( state ) {
 }
 
 /**
+ * Returns the current user.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Object} Current user object.
+ */
+export function getCurrentUser( state ) {
+	return state.currentUser;
+}
+
+/**
  * Returns all the users returned by a query ID.
  *
  * @param {Object} state   Data state.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -259,5 +259,5 @@ export function getAutosave( state, postType, postId, authorId ) {
  * @return {boolean} True if the REST request was completed. False otherwise.
  */
 export const hasFetchedAutosaves = createRegistrySelector( ( select ) => ( state, postType, postId ) => {
-	return select( 'core/data' ).hasFinishedResolution( REDUCER_KEY, 'getAutosaves', [ postType, postId ] );
+	return select( REDUCER_KEY ).hasFinishedResolution( 'getAutosaves', [ postType, postId ] );
 } );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { saveEntityRecord, receiveEntityRecords, receiveUserPermission } from '../actions';
+import { saveEntityRecord, receiveEntityRecords, receiveUserPermission, receiveAutosaves } from '../actions';
 
 describe( 'saveEntityRecord', () => {
 	it( 'triggers a POST request for a new record', async () => {
@@ -65,6 +65,26 @@ describe( 'receiveUserPermission', () => {
 			type: 'RECEIVE_USER_PERMISSION',
 			key: 'create/media',
 			isAllowed: true,
+		} );
+	} );
+} );
+
+describe( 'receiveAutosaves', () => {
+	it( 'builds an action object', () => {
+		const postId = 1;
+		const autosaves = [
+			{
+				content: 'test 1',
+			},
+			{
+				content: 'test 2',
+			},
+		];
+
+		expect( receiveAutosaves( postId, autosaves ) ).toEqual( {
+			type: 'RECEIVE_AUTOSAVES',
+			postId,
+			autosaves,
 		} );
 	} );
 } );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { saveEntityRecord, receiveEntityRecords, receiveUserPermission, receiveAutosaves } from '../actions';
+import { saveEntityRecord, receiveEntityRecords, receiveUserPermission, receiveAutosaves, receiveCurrentUser } from '../actions';
 
 describe( 'saveEntityRecord', () => {
 	it( 'triggers a POST request for a new record', async () => {
@@ -85,6 +85,16 @@ describe( 'receiveAutosaves', () => {
 			type: 'RECEIVE_AUTOSAVES',
 			postId,
 			autosaves,
+		} );
+	} );
+} );
+
+describe( 'receiveCurrentUser', () => {
+	it( 'builds an action object', () => {
+		const currentUser = { id: 1 };
+		expect( receiveCurrentUser( currentUser ) ).toEqual( {
+			type: 'RECEIVE_CURRENT_USER',
+			currentUser,
 		} );
 	} );
 } );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -87,6 +87,19 @@ describe( 'receiveAutosaves', () => {
 			autosaves,
 		} );
 	} );
+
+	it( 'converts singular autosaves into an array', () => {
+		const postId = 1;
+		const autosave = {
+			content: 'test 1',
+		};
+
+		expect( receiveAutosaves( postId, autosave ) ).toEqual( {
+			type: 'RECEIVE_AUTOSAVES',
+			postId,
+			autosaves: [ autosave ],
+		} );
+	} );
 } );
 
 describe( 'receiveCurrentUser', () => {

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -148,8 +148,8 @@ describe( 'autosaves', () => {
 		expect( state ).toEqual( {} );
 	} );
 
-	it( 'returns the current state with the new autosave merged in, keyed by its parent post id', () => {
-		const existingAutosave = {
+	it( 'returns the current state with the new autosaves merged in, keyed by the parent post id', () => {
+		const existingAutosaves = [ {
 			title: {
 				raw: 'Some',
 			},
@@ -160,9 +160,9 @@ describe( 'autosaves', () => {
 				raw: 'autosave',
 			},
 			status: 'publish',
-		};
+		} ];
 
-		const newAutosave = {
+		const newAutosaves = [ {
 			title: {
 				raw: 'The Title',
 			},
@@ -173,17 +173,55 @@ describe( 'autosaves', () => {
 				raw: 'The Excerpt',
 			},
 			status: 'draft',
-		};
+		} ];
 
-		const state = autosaves( { 1: existingAutosave }, {
-			type: 'RECEIVE_AUTOSAVE',
+		const state = autosaves( { 1: existingAutosaves }, {
+			type: 'RECEIVE_AUTOSAVES',
 			postId: 2,
-			autosave: newAutosave,
+			autosaves: newAutosaves,
 		} );
 
 		expect( state ).toEqual( {
-			1: existingAutosave,
-			2: newAutosave,
+			1: existingAutosaves,
+			2: newAutosaves,
+		} );
+	} );
+
+	it( 'overwrites any existing state if new autosaves are received with the same post id', () => {
+		const existingAutosaves = [ {
+			title: {
+				raw: 'Some',
+			},
+			content: {
+				raw: 'other',
+			},
+			excerpt: {
+				raw: 'autosave',
+			},
+			status: 'publish',
+		} ];
+
+		const newAutosaves = [ {
+			title: {
+				raw: 'The Title',
+			},
+			content: {
+				raw: 'The Content',
+			},
+			excerpt: {
+				raw: 'The Excerpt',
+			},
+			status: 'draft',
+		} ];
+
+		const state = autosaves( { 1: existingAutosaves }, {
+			type: 'RECEIVE_AUTOSAVES',
+			postId: 1,
+			autosaves: newAutosaves,
+		} );
+
+		expect( state ).toEqual( {
+			1: newAutosaves,
 		} );
 	} );
 } );

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -7,7 +7,7 @@ import { filter } from 'lodash';
 /**
  * Internal dependencies
  */
-import { terms, entities, embedPreviews, userPermissions, autosaves } from '../reducer';
+import { terms, entities, embedPreviews, userPermissions, autosaves, currentUser } from '../reducer';
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -223,5 +223,34 @@ describe( 'autosaves', () => {
 		expect( state ).toEqual( {
 			1: newAutosaves,
 		} );
+	} );
+} );
+
+describe( 'currentUser', () => {
+	it( 'returns an empty object by default', () => {
+		const state = currentUser( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns the current user', () => {
+		const currentUserData = { id: 1 };
+
+		const state = currentUser( {}, {
+			type: 'RECEIVE_CURRENT_USER',
+			currentUser: currentUserData,
+		} );
+
+		expect( state ).toEqual( currentUserData );
+	} );
+
+	it( 'overwrites any existing current user state', () => {
+		const currentUserData = { id: 2 };
+
+		const state = currentUser( { id: 1 }, {
+			type: 'RECEIVE_CURRENT_USER',
+			currentUser: currentUserData,
+		} );
+
+		expect( state ).toEqual( currentUserData );
 	} );
 } );

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -7,7 +7,7 @@ import { filter } from 'lodash';
 /**
  * Internal dependencies
  */
-import { terms, entities, embedPreviews, userPermissions } from '../reducer';
+import { terms, entities, embedPreviews, userPermissions, autosaves } from '../reducer';
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -137,6 +137,53 @@ describe( 'userPermissions()', () => {
 
 		expect( state ).toEqual( {
 			'create/media': true,
+		} );
+	} );
+} );
+
+describe( 'autosaves', () => {
+	it( 'returns an empty object by default', () => {
+		const state = autosaves( undefined, {} );
+
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns the current state with the new autosave merged in, keyed by its parent post id', () => {
+		const existingAutosave = {
+			title: {
+				raw: 'Some',
+			},
+			content: {
+				raw: 'other',
+			},
+			excerpt: {
+				raw: 'autosave',
+			},
+			status: 'publish',
+		};
+
+		const newAutosave = {
+			title: {
+				raw: 'The Title',
+			},
+			content: {
+				raw: 'The Content',
+			},
+			excerpt: {
+				raw: 'The Excerpt',
+			},
+			status: 'draft',
+		};
+
+		const state = autosaves( { 1: existingAutosave }, {
+			type: 'RECEIVE_AUTOSAVE',
+			postId: 2,
+			autosave: newAutosave,
+		} );
+
+		expect( state ).toEqual( {
+			1: existingAutosave,
+			2: newAutosave,
 		} );
 	} );
 } );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { getEntityRecord, getEntityRecords, getEmbedPreview, canUser, getAutosave } from '../resolvers';
-import { receiveEntityRecords, receiveEmbedPreview, receiveUserPermission, receiveAutosave } from '../actions';
+import { getEntityRecord, getEntityRecords, getEmbedPreview, canUser, getAutosaves } from '../resolvers';
+import { receiveEntityRecords, receiveEmbedPreview, receiveUserPermission, receiveAutosaves } from '../actions';
 import { apiFetch } from '../controls';
 
 describe( 'getEntityRecord', () => {
@@ -160,19 +160,19 @@ describe( 'canUser', () => {
 	} );
 } );
 
-describe( 'getAutosave', () => {
+describe( 'getAutosaves', () => {
 	const SUCCESSFUL_RESPONSE = [ {
 		title: 'test title',
 		excerpt: 'test excerpt',
 		content: 'test content',
 	} ];
 
-	it( 'yields with fetched autosave post', async () => {
+	it( 'yields with fetched autosaves', async () => {
 		const postType = 'post';
 		const postId = 1;
-		const baseURL = '/wp/v2/posts';
-		const postEntity = { name: 'post', kind: 'postType', baseURL };
-		const fulfillment = getAutosave( postType, postId );
+		const restBase = 'posts';
+		const postEntity = { rest_base: restBase };
+		const fulfillment = getAutosaves( postType, postId );
 
 		// Trigger generator
 		fulfillment.next();
@@ -180,27 +180,27 @@ describe( 'getAutosave', () => {
 		// Trigger generator with the postEntity and assert that correct path is formed
 		// in the apiFetch request.
 		const { value: apiFetchAction } = fulfillment.next( postEntity );
-		expect( apiFetchAction.request ).toEqual( { path: `${ baseURL }/${ postId }/autosaves?context=edit` } );
+		expect( apiFetchAction.request ).toEqual( { path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit` } );
 
 		// Provide apiFetch response and trigger Action
 		const received = ( await fulfillment.next( SUCCESSFUL_RESPONSE ) ).value;
-		expect( received ).toEqual( receiveAutosave( 1, SUCCESSFUL_RESPONSE[ 0 ] ) );
+		expect( received ).toEqual( receiveAutosaves( 1, SUCCESSFUL_RESPONSE ) );
 	} );
 
-	it( 'yields undefined if no autosave exists for the post', async () => {
+	it( ' yields undefined if no autosaves exist for the post', async () => {
 		const postType = 'post';
 		const postId = 1;
-		const baseURL = '/wp/v2/posts';
-		const entities = { name: 'post', kind: 'postType', baseURL };
-		const fulfillment = getAutosave( postType, postId );
+		const restBase = 'posts';
+		const postEntity = { rest_base: restBase };
+		const fulfillment = getAutosaves( postType, postId );
 
 		// Trigger generator
 		fulfillment.next();
 
 		// Trigger generator with the postEntity and assert that correct path is formed
 		// in the apiFetch request.
-		const { value: apiFetchAction } = fulfillment.next( entities );
-		expect( apiFetchAction.request ).toEqual( { path: `${ baseURL }/${ postId }/autosaves?context=edit` } );
+		const { value: apiFetchAction } = fulfillment.next( postEntity );
+		expect( apiFetchAction.request ).toEqual( { path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit` } );
 
 		// Provide apiFetch response and trigger Action
 		const received = ( await fulfillment.next( [] ) ).value;

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { getEntityRecord, getEntityRecords, getEmbedPreview, canUser, getAutosaves } from '../resolvers';
-import { receiveEntityRecords, receiveEmbedPreview, receiveUserPermission, receiveAutosaves } from '../actions';
+import { getEntityRecord, getEntityRecords, getEmbedPreview, canUser, getAutosaves, getCurrentUser } from '../resolvers';
+import { receiveEntityRecords, receiveEmbedPreview, receiveUserPermission, receiveAutosaves, receiveCurrentUser } from '../actions';
 import { apiFetch } from '../controls';
 
 describe( 'getEntityRecord', () => {
@@ -208,3 +208,19 @@ describe( 'getAutosaves', () => {
 	} );
 } );
 
+describe( 'getCurrentUser', () => {
+	const SUCCESSFUL_RESPONSE = {
+		id: 1,
+	};
+
+	it( 'yields with fetched user', async () => {
+		const fulfillment = getCurrentUser();
+
+		// Trigger generator
+		fulfillment.next();
+
+		// Provide apiFetch response and trigger Action
+		const received = ( await fulfillment.next( SUCCESSFUL_RESPONSE ) ).value;
+		expect( received ).toEqual( receiveCurrentUser( SUCCESSFUL_RESPONSE ) );
+	} );
+} );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -13,6 +13,7 @@ import {
 	isPreviewEmbedFallback,
 	canUser,
 	getAutosaves,
+	getCurrentUser,
 } from '../selectors';
 
 describe( 'getEntityRecord', () => {
@@ -176,5 +177,25 @@ describe( 'getAutosaves', () => {
 		const result = getAutosaves( state, postType, postId );
 
 		expect( result ).toEqual( autosaves );
+	} );
+} );
+
+describe( 'getCurrentUser', () => {
+	it( 'returns undefined if no user exists in state', () => {
+		const state = {};
+
+		expect( getCurrentUser( state ) ).toBeUndefined();
+	} );
+
+	it( 'returns the user object when a user exists in state', () => {
+		const currentUser = {
+			id: 1,
+		};
+
+		const state = {
+			currentUser,
+		};
+
+		expect( getCurrentUser( state ) ).toEqual( currentUser );
 	} );
 } );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -12,7 +12,7 @@ import {
 	getEmbedPreview,
 	isPreviewEmbedFallback,
 	canUser,
-	getAutosave,
+	getAutosaves,
 } from '../selectors';
 
 describe( 'getEntityRecord', () => {
@@ -147,34 +147,34 @@ describe( 'canUser', () => {
 	} );
 } );
 
-describe( 'getAutosave', () => {
-	it( 'returns undefined for the provided post id if no autosave exists for it in state', () => {
+describe( 'getAutosaves', () => {
+	it( 'returns undefined for the provided post id if no autosaves exist for it in state', () => {
 		const postType = 'post';
 		const postId = 2;
-		const autosave = { title: { raw: '' }, excerpt: { raw: '' }, content: { raw: '' } };
+		const autosaves = [ { title: { raw: '' }, excerpt: { raw: '' }, content: { raw: '' } } ];
 		const state = {
 			autosaves: {
-				1: autosave,
+				1: autosaves,
 			},
 		};
 
-		const result = getAutosave( state, postType, postId );
+		const result = getAutosaves( state, postType, postId );
 
 		expect( result ).toBeUndefined();
 	} );
 
-	it( 'returns the autosave for the provided post id, if it exists in state', () => {
+	it( 'returns the autosaves for the provided post id when they exist in state', () => {
 		const postType = 'post';
 		const postId = 1;
-		const autosave = { title: { raw: '' }, excerpt: { raw: '' }, content: { raw: '' } };
+		const autosaves = [ { title: { raw: '' }, excerpt: { raw: '' }, content: { raw: '' } } ];
 		const state = {
 			autosaves: {
-				[ postId ]: autosave,
+				1: autosaves,
 			},
 		};
 
-		const result = getAutosave( state, postType, postId );
+		const result = getAutosaves( state, postType, postId );
 
-		expect( result ).toEqual( autosave );
+		expect( result ).toEqual( autosaves );
 	} );
 } );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	getEmbedPreview,
 	isPreviewEmbedFallback,
 	canUser,
+	getAutosave,
 	getAutosaves,
 	getCurrentUser,
 } from '../selectors';
@@ -145,6 +146,59 @@ describe( 'canUser', () => {
 			},
 		} );
 		expect( canUser( state, 'create', 'media', 123 ) ).toBe( false );
+	} );
+} );
+
+describe( 'getAutosave', () => {
+	const testAutosave = { author: 1, title: { raw: '' }, excerpt: { raw: '' }, content: { raw: '' } };
+
+	it( 'returns undefined if no autosaves exist for the post id in state', () => {
+		const postType = 'post';
+		const postId = 2;
+		const author = 2;
+		const state = {
+			autosaves: {
+				1: [ testAutosave ],
+				2: [ testAutosave ],
+			},
+		};
+
+		const result = getAutosave( state, postType, postId, author );
+
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'returns undefined if there are autosaves for the post id, but none matching the autosave for the author', () => {
+		const postType = 'post';
+		const postId = 1;
+		const author = 2;
+		const state = {
+			autosaves: {
+				[ postId ]: [ testAutosave ],
+				2: [ testAutosave ],
+			},
+		};
+
+		const result = getAutosave( state, postType, postId, author );
+
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'returns the autosave for the post id and author when it exists in state', () => {
+		const postType = 'post';
+		const postId = 1;
+		const author = 2;
+		const expectedAutosave = { author, title: { raw: '' }, excerpt: { raw: '' }, content: { raw: '' } };
+		const state = {
+			autosaves: {
+				[ postId ]: [ testAutosave, expectedAutosave ],
+				2: [ testAutosave ],
+			},
+		};
+
+		const result = getAutosave( state, postType, postId, author );
+
+		expect( result ).toEqual( expectedAutosave );
 	} );
 } );
 

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -168,6 +168,20 @@ describe( 'getAutosave', () => {
 		expect( result ).toBeUndefined();
 	} );
 
+	it( 'returns undefined if an authorId is not provided (or undefined)', () => {
+		const postType = 'post';
+		const postId = 1;
+		const state = {
+			autosaves: {
+				1: [ testAutosave ],
+			},
+		};
+
+		const result = getAutosave( state, postType, postId );
+
+		expect( result ).toBeUndefined();
+	} );
+
 	it( 'returns undefined if there are autosaves for the post id, but none matching the autosave for the author', () => {
 		const postType = 'post';
 		const postId = 1;

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	getEmbedPreview,
 	isPreviewEmbedFallback,
 	canUser,
+	getAutosave,
 } from '../selectors';
 
 describe( 'getEntityRecord', () => {
@@ -143,5 +144,37 @@ describe( 'canUser', () => {
 			},
 		} );
 		expect( canUser( state, 'create', 'media', 123 ) ).toBe( false );
+	} );
+} );
+
+describe( 'getAutosave', () => {
+	it( 'returns undefined for the provided post id if no autosave exists for it in state', () => {
+		const postType = 'post';
+		const postId = 2;
+		const autosave = { title: { raw: '' }, excerpt: { raw: '' }, content: { raw: '' } };
+		const state = {
+			autosaves: {
+				1: autosave,
+			},
+		};
+
+		const result = getAutosave( state, postType, postId );
+
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'returns the autosave for the provided post id, if it exists in state', () => {
+		const postType = 'post';
+		const postId = 1;
+		const autosave = { title: { raw: '' }, excerpt: { raw: '' }, content: { raw: '' } };
+		const state = {
+			autosaves: {
+				[ postId ]: autosave,
+			},
+		};
+
+		const result = getAutosave( state, postType, postId );
+
+		expect( result ).toEqual( autosave );
 	} );
 } );

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -15,6 +15,9 @@
 ### Deprecations
 
 - `EditorGlobalKeyboardShortcuts` has been deprecated in favor of `VisualEditorGlobalKeyboardShortcuts`.
+- The `getAutosave`, `getAutosaveAttribute`, and `hasAutosave` selectors are deprecated. Please use the `getAutosave` selector in the `@wordpress/core-data` package.
+- The `resetAutosave` action is deprecated. An equivalent action `receiveAutosave` has been added to the `@wordpress/core-data` package.
+- The `isEditedPostAutosaveable` action now requires that the parameter `autosave` is provided.
 
 ### Bug Fixes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 9.1.1 (Unreleased)
+## 9.2.0 (Unreleased)
+
+### Deprecations
+- The `getAutosave`, `getAutosaveAttribute`, and `hasAutosave` selectors are deprecated. Please use the `getAutosave` selector in the `@wordpress/core-data` package.
+- The `resetAutosave` action is deprecated. An equivalent action `receiveAutosaves` has been added to the `@wordpress/core-data` package.
 
 ### Internal
 
@@ -15,8 +19,6 @@
 ### Deprecations
 
 - `EditorGlobalKeyboardShortcuts` has been deprecated in favor of `VisualEditorGlobalKeyboardShortcuts`.
-- The `getAutosave`, `getAutosaveAttribute`, and `hasAutosave` selectors are deprecated. Please use the `getAutosave` selector in the `@wordpress/core-data` package.
-- The `resetAutosave` action is deprecated. An equivalent action `receiveAutosaves` has been added to the `@wordpress/core-data` package.
 
 ### Bug Fixes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - `EditorGlobalKeyboardShortcuts` has been deprecated in favor of `VisualEditorGlobalKeyboardShortcuts`.
 - The `getAutosave`, `getAutosaveAttribute`, and `hasAutosave` selectors are deprecated. Please use the `getAutosave` selector in the `@wordpress/core-data` package.
-- The `resetAutosave` action is deprecated. An equivalent action `receiveAutosave` has been added to the `@wordpress/core-data` package.
+- The `resetAutosave` action is deprecated. An equivalent action `receiveAutosaves` has been added to the `@wordpress/core-data` package.
 - The `isEditedPostAutosaveable` action now requires that the parameter `autosave` is provided.
 
 ### Bug Fixes

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -17,7 +17,6 @@
 - `EditorGlobalKeyboardShortcuts` has been deprecated in favor of `VisualEditorGlobalKeyboardShortcuts`.
 - The `getAutosave`, `getAutosaveAttribute`, and `hasAutosave` selectors are deprecated. Please use the `getAutosave` selector in the `@wordpress/core-data` package.
 - The `resetAutosave` action is deprecated. An equivalent action `receiveAutosaves` has been added to the `@wordpress/core-data` package.
-- The `isEditedPostAutosaveable` action now requires that the parameter `autosave` is provided.
 
 ### Bug Fixes
 

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -68,13 +68,16 @@ export default compose( [
 			getCurrentPostId,
 		} = select( 'core/editor' );
 		const {
+			getCurrentUser,
 			getAutosave,
 		} = select( 'core' );
 
 		const { autosaveInterval } = select( 'core/editor' ).getEditorSettings();
 		const postType = getEditedPostAttribute( 'type' );
 		const postId = getCurrentPostId();
-		const autosave = getAutosave( postType, postId );
+		const currentUser = getCurrentUser();
+		const currentUserId = currentUser ? currentUser.id : null;
+		const autosave = getAutosave( postType, postId, currentUserId );
 
 		return {
 			isDirty: isEditedPostDirty(),

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -64,13 +64,21 @@ export default compose( [
 			isEditedPostAutosaveable,
 			getReferenceByDistinctEdits,
 			isAutosavingPost,
+			getEditedPostAttribute,
+			getCurrentPostId,
 		} = select( 'core/editor' );
+		const {
+			getAutosave,
+		} = select( 'core' );
 
 		const { autosaveInterval } = select( 'core/editor' ).getEditorSettings();
+		const postType = getEditedPostAttribute( 'type' );
+		const postId = getCurrentPostId();
+		const autosave = getAutosave( postType, postId );
 
 		return {
 			isDirty: isEditedPostDirty(),
-			isAutosaveable: isEditedPostAutosaveable(),
+			isAutosaveable: isEditedPostAutosaveable( autosave ),
 			editsReference: getReferenceByDistinctEdits(),
 			isAutosaving: isAutosavingPost(),
 			autosaveInterval,

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -64,24 +64,13 @@ export default compose( [
 			isEditedPostAutosaveable,
 			getReferenceByDistinctEdits,
 			isAutosavingPost,
-			getEditedPostAttribute,
-			getCurrentPostId,
 		} = select( 'core/editor' );
-		const {
-			getCurrentUser,
-			getAutosave,
-		} = select( 'core' );
 
 		const { autosaveInterval } = select( 'core/editor' ).getEditorSettings();
-		const postType = getEditedPostAttribute( 'type' );
-		const postId = getCurrentPostId();
-		const currentUser = getCurrentUser();
-		const currentUserId = currentUser ? currentUser.id : null;
-		const autosave = getAutosave( postType, postId, currentUserId );
 
 		return {
 			isDirty: isEditedPostDirty(),
-			isAutosaveable: isEditedPostAutosaveable( autosave ),
+			isAutosaveable: isEditedPostAutosaveable(),
 			editsReference: getReferenceByDistinctEdits(),
 			isAutosaving: isAutosavingPost(),
 			autosaveInterval,

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -168,7 +168,7 @@ export class PostPreviewButton extends Component {
 	}
 
 	render() {
-		const { previewLink, currentPostLink, isSaveable } = this.props;
+		const { previewLink, currentPostLink, isEnabled } = this.props;
 
 		// Link to the `?preview=true` URL if we have it, since this lets us see
 		// changes that were autosaved since the post was last published. Otherwise,
@@ -181,7 +181,7 @@ export class PostPreviewButton extends Component {
 				className="editor-post-preview"
 				href={ href }
 				target={ this.getWindowTarget() }
-				disabled={ ! isSaveable }
+				disabled={ ! isEnabled }
 				onClick={ this.openPreviewWindow }
 			>
 				{ _x( 'Preview', 'imperative verb' ) }
@@ -211,7 +211,7 @@ export default compose( [
 		} = select( 'core/editor' );
 		const {
 			getPostType,
-			hasFetchedAutosave,
+			hasFetchedAutosaves,
 		} = select( 'core' );
 
 		const previewLink = getEditedPostPreviewLink();
@@ -223,7 +223,7 @@ export default compose( [
 			postId: getCurrentPostId(),
 			currentPostLink: getCurrentPostAttribute( 'link' ),
 			previewLink: forcePreviewLink !== undefined ? forcePreviewLink : previewLink,
-			isSaveable: isEditedPostSaveable() && hasFetchedAutosave( postTypeName, postId ),
+			isEnabled: isEditedPostSaveable() && hasFetchedAutosaves( postTypeName, postId ),
 			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable(),
 			isViewable: get( postType, [ 'viewable' ], false ),
 			isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -211,6 +211,7 @@ export default compose( [
 		} = select( 'core/editor' );
 		const {
 			getAutosave,
+			getCurrentUser,
 			getPostType,
 			hasFetchedAutosave,
 		} = select( 'core' );
@@ -219,7 +220,9 @@ export default compose( [
 		const postTypeName = getEditedPostAttribute( 'type' );
 		const postType = getPostType( postTypeName );
 		const postId = getCurrentPostId();
-		const autosave = getAutosave( postTypeName, postId );
+		const currentUser = getCurrentUser();
+		const currentUserId = currentUser ? currentUser.id : null;
+		const autosave = getAutosave( postTypeName, postId, currentUserId );
 
 		return {
 			postId: getCurrentPostId(),

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -168,7 +168,7 @@ export class PostPreviewButton extends Component {
 	}
 
 	render() {
-		const { previewLink, currentPostLink, isEnabled } = this.props;
+		const { previewLink, currentPostLink, isSaveable } = this.props;
 
 		// Link to the `?preview=true` URL if we have it, since this lets us see
 		// changes that were autosaved since the post was last published. Otherwise,
@@ -181,7 +181,7 @@ export class PostPreviewButton extends Component {
 				className="editor-post-preview"
 				href={ href }
 				target={ this.getWindowTarget() }
-				disabled={ ! isEnabled }
+				disabled={ ! isSaveable }
 				onClick={ this.openPreviewWindow }
 			>
 				{ _x( 'Preview', 'imperative verb' ) }
@@ -211,19 +211,16 @@ export default compose( [
 		} = select( 'core/editor' );
 		const {
 			getPostType,
-			hasFetchedAutosaves,
 		} = select( 'core' );
 
 		const previewLink = getEditedPostPreviewLink();
-		const postTypeName = getEditedPostAttribute( 'type' );
-		const postType = getPostType( postTypeName );
-		const postId = getCurrentPostId();
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 		return {
 			postId: getCurrentPostId(),
 			currentPostLink: getCurrentPostAttribute( 'link' ),
 			previewLink: forcePreviewLink !== undefined ? forcePreviewLink : previewLink,
-			isEnabled: isEditedPostSaveable() && hasFetchedAutosaves( postTypeName, postId ),
+			isSaveable: isEditedPostSaveable(),
 			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable(),
 			isViewable: get( postType, [ 'viewable' ], false ),
 			isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -210,17 +210,23 @@ export default compose( [
 			getEditedPostPreviewLink,
 		} = select( 'core/editor' );
 		const {
+			getAutosave,
 			getPostType,
+			hasFetchedAutosave,
 		} = select( 'core' );
 
 		const previewLink = getEditedPostPreviewLink();
-		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+		const postTypeName = getEditedPostAttribute( 'type' );
+		const postType = getPostType( postTypeName );
+		const postId = getCurrentPostId();
+		const autosave = getAutosave( postTypeName, postId );
+
 		return {
 			postId: getCurrentPostId(),
 			currentPostLink: getCurrentPostAttribute( 'link' ),
 			previewLink: forcePreviewLink !== undefined ? forcePreviewLink : previewLink,
-			isSaveable: isEditedPostSaveable(),
-			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable(),
+			isSaveable: isEditedPostSaveable() && hasFetchedAutosave( postTypeName, postId ),
+			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable( autosave ),
 			isViewable: get( postType, [ 'viewable' ], false ),
 			isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,
 		};

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -210,8 +210,6 @@ export default compose( [
 			getEditedPostPreviewLink,
 		} = select( 'core/editor' );
 		const {
-			getAutosave,
-			getCurrentUser,
 			getPostType,
 			hasFetchedAutosave,
 		} = select( 'core' );
@@ -220,16 +218,13 @@ export default compose( [
 		const postTypeName = getEditedPostAttribute( 'type' );
 		const postType = getPostType( postTypeName );
 		const postId = getCurrentPostId();
-		const currentUser = getCurrentUser();
-		const currentUserId = currentUser ? currentUser.id : null;
-		const autosave = getAutosave( postTypeName, postId, currentUserId );
 
 		return {
 			postId: getCurrentPostId(),
 			currentPostLink: getCurrentPostAttribute( 'link' ),
 			previewLink: forcePreviewLink !== undefined ? forcePreviewLink : previewLink,
 			isSaveable: isEditedPostSaveable() && hasFetchedAutosave( postTypeName, postId ),
-			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable( autosave ),
+			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable(),
 			isViewable: get( postType, [ 'viewable' ], false ),
 			isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,
 		};

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] = `
 <ForwardRef(Button)
   className="editor-post-preview"
-  disabled={false}
+  disabled={true}
   href="https://wordpress.org/?p=1"
   isLarge={true}
   onClick={[Function]}
@@ -26,7 +26,7 @@ exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] 
 exports[`PostPreviewButton render() should render previewLink if provided 1`] = `
 <ForwardRef(Button)
   className="editor-post-preview"
-  disabled={false}
+  disabled={true}
   href="https://wordpress.org/?p=1&preview=true"
   isLarge={true}
   onClick={[Function]}

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] = `
 <ForwardRef(Button)
   className="editor-post-preview"
-  disabled={true}
+  disabled={false}
   href="https://wordpress.org/?p=1"
   isLarge={true}
   onClick={[Function]}
@@ -26,7 +26,7 @@ exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] 
 exports[`PostPreviewButton render() should render previewLink if provided 1`] = `
 <ForwardRef(Button)
   className="editor-post-preview"
-  disabled={true}
+  disabled={false}
   href="https://wordpress.org/?p=1&preview=true"
   isLarge={true}
   onClick={[Function]}

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -348,7 +348,7 @@ export function* savePost( options = {} ) {
 	let method = 'PUT';
 	if ( isAutosave ) {
 		const currentUser = yield resolveSelect( 'core', 'getCurrentUser' );
-		const currentUserId = currentUser ? currentUser.id : null;
+		const currentUserId = currentUser ? currentUser.id : undefined;
 		const autosavePost = yield resolveSelect( 'core', 'getAutosave', post.type, post.id, currentUserId );
 		const mappedAutosavePost = mapValues( pick( autosavePost, AUTOSAVE_PROPERTIES ), getPostRawValue );
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -99,7 +99,7 @@ export function resetPost( post ) {
  * Returns an action object used in signalling that the latest autosave of the
  * post has been received, by initialization or autosave.
  *
- * @deprecated since 5.3. Callers should use the `receiveAutosaves( postId, autosave )`
+ * @deprecated since 5.4. Callers should use the `receiveAutosaves( postId, autosave )`
  * 			   selector from the '@wordpress/core-data' package.
  *
  * @param {Object} newAutosave Autosave post object.

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -99,7 +99,7 @@ export function resetPost( post ) {
  * Returns an action object used in signalling that the latest autosave of the
  * post has been received, by initialization or autosave.
  *
- * @deprecated since 5.0. Callers should use the `receiveAutosave( postId, autosave )`
+ * @deprecated since 5.3. Callers should use the `receiveAutosave( postId, autosave )`
  * 			   selector from the '@wordpress/core-data' package.
  *
  * @param {Object} newAutosave Autosave post object.

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -99,7 +99,7 @@ export function resetPost( post ) {
  * Returns an action object used in signalling that the latest autosave of the
  * post has been received, by initialization or autosave.
  *
- * @deprecated since 5.4. Callers should use the `receiveAutosaves( postId, autosave )`
+ * @deprecated since 5.6. Callers should use the `receiveAutosaves( postId, autosave )`
  * 			   selector from the '@wordpress/core-data' package.
  *
  * @param {Object} newAutosave Autosave post object.

--- a/packages/editor/src/store/constants.js
+++ b/packages/editor/src/store/constants.js
@@ -19,3 +19,4 @@ export const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
 export const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 export const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
 export const ONE_MINUTE_IN_MS = 60 * 1000;
+export const AUTOSAVE_PROPERTIES = [ 'title', 'excerpt', 'content' ];

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -750,37 +750,9 @@ export const blockListSettings = ( state = {}, action ) => {
 };
 
 /**
- * Reducer returning the most recent autosave.
- *
- * @param  {Object} state  The autosave object.
- * @param  {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function autosave( state = null, action ) {
-	switch ( action.type ) {
-		case 'RESET_AUTOSAVE':
-			const { post } = action;
-			const [ title, excerpt, content ] = [
-				'title',
-				'excerpt',
-				'content',
-			].map( ( field ) => getPostRawValue( post[ field ] ) );
-
-			return {
-				title,
-				excerpt,
-				content,
-			};
-	}
-
-	return state;
-}
-
-/**
  * Reducer returning the post preview link.
  *
- * @param {string?} state  The preview link
+ * @param {string?} state  The preview link.
  * @param {Object}  action Dispatched action.
  *
  * @return {string?} Updated state.
@@ -855,7 +827,6 @@ export default optimist( combineReducers( {
 	postLock,
 	reusableBlocks,
 	template,
-	autosave,
 	previewLink,
 	postSavingLock,
 	isReady,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -326,7 +326,7 @@ export function getEditedPostAttribute( state, attributeName ) {
  * Returns an attribute value of the current autosave revision for a post, or
  * null if there is no autosave for the post.
  *
- * @deprecated since 5.0. Callers should use the `getAutosave( postType, postId )` selector from the
+ * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId )` selector from the
  *             '@wordpress/core-data' package and access properties on the returned autosave object
  *             using getPostRawValue.
  *
@@ -563,7 +563,7 @@ export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => fu
  * has yet to be autosaved, or has been saved or published since the last
  * autosave).
  *
- * @deprecated since 5.0. Callers should use the `getAutosave( postType, postId )`
+ * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId )`
  * 			   selector from the '@wordpress/core-data' package.
  *
  * @param {Object} state Editor state.
@@ -585,7 +585,7 @@ export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
 /**
  * Returns the true if there is an existing autosave, otherwise false.
  *
- * @deprecated since 5.0. Callers should use the `getAutosave( postType, postId )` selector
+ * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId )` selector
  *             from the '@wordpress/core-data' package and check for a truthy value.
  *
  * @param {Object} state Global application state.

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -326,7 +326,7 @@ export function getEditedPostAttribute( state, attributeName ) {
  * Returns an attribute value of the current autosave revision for a post, or
  * null if there is no autosave for the post.
  *
- * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )` selector
+ * @deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )` selector
  * 			   from the '@wordpress/core-data' package and access properties on the returned
  * 			   autosave object using getPostRawValue.
  *
@@ -554,7 +554,7 @@ export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => fu
  * has yet to be autosaved, or has been saved or published since the last
  * autosave).
  *
- * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )`
+ * @deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )`
  * 			   selector from the '@wordpress/core-data' package.
  *
  * @param {Object} state Editor state.
@@ -577,7 +577,7 @@ export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
 /**
  * Returns the true if there is an existing autosave, otherwise false.
  *
- * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )` selector
+ * @deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )` selector
  *             from the '@wordpress/core-data' package and check for a truthy value.
  *
  * @param {Object} state Global application state.

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -326,9 +326,9 @@ export function getEditedPostAttribute( state, attributeName ) {
  * Returns an attribute value of the current autosave revision for a post, or
  * null if there is no autosave for the post.
  *
- * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId )` selector from the
- *             '@wordpress/core-data' package and access properties on the returned autosave object
- *             using getPostRawValue.
+ * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )` selector
+ * 			   from the '@wordpress/core-data' package and access properties on the returned
+ * 			   autosave object using getPostRawValue.
  *
  * @param {Object} state         Global application state.
  * @param {string} attributeName Autosave attribute name.
@@ -337,7 +337,7 @@ export function getEditedPostAttribute( state, attributeName ) {
  */
 export const getAutosaveAttribute = createRegistrySelector( ( select ) => ( state, attributeName ) => {
 	deprecated( '`wp.data.select( \'core/editor\' ).getAutosaveAttribute( attributeName )`', {
-		alternative: '`wp.data.select( \'core\' ).getAutosave( postType, postId )`',
+		alternative: '`wp.data.select( \'core\' ).getAutosave( postType, postId, userId )`',
 		plugin: 'Gutenberg',
 	} );
 
@@ -347,7 +347,8 @@ export const getAutosaveAttribute = createRegistrySelector( ( select ) => ( stat
 
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
-	const autosave = select( 'core' ).getAutosave( postType, postId );
+	const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
+	const autosave = select( 'core' ).getAutosave( postType, postId, currentUserId );
 
 	if ( autosave ) {
 		return getPostRawValue( autosave[ attributeName ] );
@@ -531,7 +532,8 @@ export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => fu
 
 		const postType = getCurrentPostType( state );
 		const postId = getCurrentPostId( state );
-		autosave = select( 'core' ).getAutosave( postType, postId );
+		const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
+		autosave = select( 'core' ).getAutosave( postType, postId, currentUserId );
 	}
 
 	// A post must contain a title, an excerpt, or non-empty content to be valid for autosaving.
@@ -563,7 +565,7 @@ export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => fu
  * has yet to be autosaved, or has been saved or published since the last
  * autosave).
  *
- * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId )`
+ * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )`
  * 			   selector from the '@wordpress/core-data' package.
  *
  * @param {Object} state Editor state.
@@ -572,20 +574,21 @@ export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => fu
  */
 export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
 	deprecated( '`wp.data.select( \'core/editor\' ).getAutosave()`', {
-		alternative: '`wp.data.select( \'core\' ).getAutosave( postType, postId )`',
+		alternative: '`wp.data.select( \'core\' ).getAutosave( postType, postId, userId )`',
 		plugin: 'Gutenberg',
 	} );
 
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
-	const autosave = select( 'core' ).getAutosave( postType, postId );
+	const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
+	const autosave = select( 'core' ).getAutosave( postType, postId, currentUserId );
 	return mapValues( pick( autosave, AUTOSAVE_PROPERTIES ), getPostRawValue );
 } );
 
 /**
  * Returns the true if there is an existing autosave, otherwise false.
  *
- * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId )` selector
+ * @deprecated since 5.3. Callers should use the `getAutosave( postType, postId, userId )` selector
  *             from the '@wordpress/core-data' package and check for a truthy value.
  *
  * @param {Object} state Global application state.
@@ -594,13 +597,14 @@ export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
  */
 export const hasAutosave = createRegistrySelector( ( select ) => ( state ) => {
 	deprecated( '`wp.data.select( \'core/editor\' ).hasAutosave()`', {
-		alternative: '`!! wp.data.select( \'core\' ).getAutosave( postType, postId )`',
+		alternative: '`!! wp.data.select( \'core\' ).getAutosave( postType, postId, userId )`',
 		plugin: 'Gutenberg',
 	} );
 
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
-	return !! select( 'core' ).getAutosave( postType, postId );
+	const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
+	return !! select( 'core' ).getAutosave( postType, postId, currentUserId );
 } );
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -519,27 +519,16 @@ export function isEditedPostEmpty( state ) {
  *
  * @return {boolean} Whether the post can be autosaved.
  */
-export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => function( state, autosave ) {
-	if ( arguments.length === 1 ) {
-		// Note: if this deprecation is removed, the selector can also be
-		// reverted to a normal selector instead of a registry selector.
-		// Unit tests will also need to be updated to reflect the removal
-		// of the registry selector.
-		deprecated( '`wp.data.select( \'core/editor\' ).isEditedPostAutosaveable()`', {
-			alternative: '`wp.data.select( \'core/editor\' ).isEditedPostAutosaveable( autosave )`',
-			plugin: 'Gutenberg',
-		} );
-
-		const postType = getCurrentPostType( state );
-		const postId = getCurrentPostId( state );
-		const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
-		autosave = select( 'core' ).getAutosave( postType, postId, currentUserId );
-	}
-
+export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => function( state ) {
 	// A post must contain a title, an excerpt, or non-empty content to be valid for autosaving.
 	if ( ! isEditedPostSaveable( state ) ) {
 		return false;
 	}
+
+	const postType = getCurrentPostType( state );
+	const postId = getCurrentPostId( state );
+	const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
+	const autosave = select( 'core' ).getAutosave( postType, postId, currentUserId );
 
 	// If we don't already have an autosave, the post is autosaveable.
 	if ( ! autosave ) {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -527,8 +527,20 @@ export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => fu
 
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
+	const hasFetchedAutosave = select( 'core' ).hasFetchedAutosaves( postType, postId );
 	const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
+
+	// Disable reason - this line causes the side-effect of fetching the autosave
+	// via a resolver, moving below the return would result in the autosave never
+	// being fetched.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const autosave = select( 'core' ).getAutosave( postType, postId, currentUserId );
+
+	// If any existing autosaves have not yet been fetched, this function is
+	// unable to determine if the post is autosaveable, so return false.
+	if ( ! hasFetchedAutosave ) {
+		return false;
+	}
 
 	// If we don't already have an autosave, the post is autosaveable.
 	if ( ! autosave ) {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -326,7 +326,7 @@ export function getEditedPostAttribute( state, attributeName ) {
  * Returns an attribute value of the current autosave revision for a post, or
  * null if there is no autosave for the post.
  *
- * @deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )` selector
+ * @deprecated since 5.6. Callers should use the `getAutosave( postType, postId, userId )` selector
  * 			   from the '@wordpress/core-data' package and access properties on the returned
  * 			   autosave object using getPostRawValue.
  *
@@ -566,7 +566,7 @@ export const isEditedPostAutosaveable = createRegistrySelector( ( select ) => fu
  * has yet to be autosaved, or has been saved or published since the last
  * autosave).
  *
- * @deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )`
+ * @deprecated since 5.6. Callers should use the `getAutosave( postType, postId, userId )`
  * 			   selector from the '@wordpress/core-data' package.
  *
  * @param {Object} state Editor state.
@@ -589,7 +589,7 @@ export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
 /**
  * Returns the true if there is an existing autosave, otherwise false.
  *
- * @deprecated since 5.4. Callers should use the `getAutosave( postType, postId, userId )` selector
+ * @deprecated since 5.6. Callers should use the `getAutosave( postType, postId, userId )` selector
  *             from the '@wordpress/core-data' package and check for a truthy value.
  *
  * @param {Object} state Global application state.

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -55,6 +55,7 @@ const postType = {
 		item_published: 'Post published',
 	},
 };
+const postId = 44;
 const postTypeSlug = 'post';
 
 describe( 'Post generator actions', () => {
@@ -85,7 +86,8 @@ describe( 'Post generator actions', () => {
 				return postObject;
 			};
 			currentPost = () => ( {
-				id: 44,
+				id: postId,
+				type: postTypeSlug,
 				title: 'bar',
 				content: 'bar',
 				excerpt: 'crackers',
@@ -106,13 +108,7 @@ describe( 'Post generator actions', () => {
 				return postObject;
 			};
 			autoSavePost = { status: 'autosave', bar: 'foo' };
-			autoSavePostToSend = () => (
-				{
-					...editPostToSendOptimistic(),
-					bar: 'foo',
-					status: 'autosave',
-				}
-			);
+			autoSavePostToSend = () => editPostToSendOptimistic();
 			savedPost = () => (
 				{
 					...currentPost(),
@@ -273,14 +269,16 @@ describe( 'Post generator actions', () => {
 				},
 			],
 			[
-				'yield action for selecting the autoSavePost',
+				'yield action for selecting the autosavePost',
 				( isAutosaving ) => isAutosaving,
 				() => {
 					const { value } = fulfillment.next();
 					expect( value ).toEqual(
 						select(
-							STORE_KEY,
-							'getAutosave'
+							'core',
+							'getAutosave',
+							postTypeSlug,
+							postId
 						)
 					);
 				},
@@ -357,13 +355,12 @@ describe( 'Post generator actions', () => {
 				'yields action for dispatch the appropriate reset action',
 				() => {
 					const { value } = fulfillment.next( savedPost() );
-					expect( value ).toEqual(
-						dispatch(
-							STORE_KEY,
-							isAutosave ? 'resetAutosave' : 'resetPost',
-							savedPost()
-						)
-					);
+
+					if ( isAutosave ) {
+						expect( value ).toEqual( dispatch( 'core', 'receiveAutosave', postId, savedPost() ) );
+					} else {
+						expect( value ).toEqual( dispatch( STORE_KEY, 'resetPost', savedPost() ) );
+					}
 				},
 			],
 			[
@@ -662,17 +659,6 @@ describe( 'Editor actions', () => {
 			const result = actions.resetPost( post );
 			expect( result ).toEqual( {
 				type: 'RESET_POST',
-				post,
-			} );
-		} );
-	} );
-
-	describe( 'resetAutosave', () => {
-		it( 'should return the RESET_AUTOSAVE action', () => {
-			const post = {};
-			const result = actions.resetAutosave( post );
-			expect( result ).toEqual( {
-				type: 'RESET_AUTOSAVE',
 				post,
 			} );
 		} );

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -57,6 +57,7 @@ const postType = {
 };
 const postId = 44;
 const postTypeSlug = 'post';
+const userId = 1;
 
 describe( 'Post generator actions', () => {
 	describe( 'savePost()', () => {
@@ -64,6 +65,7 @@ describe( 'Post generator actions', () => {
 			edits,
 			currentPost,
 			currentPostStatus,
+			currentUser,
 			editPostToSendOptimistic,
 			autoSavePost,
 			autoSavePostToSend,
@@ -93,6 +95,7 @@ describe( 'Post generator actions', () => {
 				excerpt: 'crackers',
 				status: currentPostStatus,
 			} );
+			currentUser = { id: userId };
 			editPostToSendOptimistic = () => {
 				const postObject = {
 					...edits(),
@@ -134,6 +137,7 @@ describe( 'Post generator actions', () => {
 			fulfillment.next( postType );
 			fulfillment.next();
 			if ( isAutosaving ) {
+				fulfillment.next( currentUser );
 				fulfillment.next();
 			} else {
 				fulfillment.next();
@@ -269,16 +273,27 @@ describe( 'Post generator actions', () => {
 				},
 			],
 			[
-				'yield action for selecting the autosavePost',
+				'yields action for selecting the currentUser',
 				( isAutosaving ) => isAutosaving,
 				() => {
 					const { value } = fulfillment.next();
 					expect( value ).toEqual(
-						select(
+						resolveSelect( 'core', 'getCurrentUser' )
+					);
+				},
+			],
+			[
+				'yields action for selecting the autosavePost',
+				( isAutosaving ) => isAutosaving,
+				() => {
+					const { value } = fulfillment.next( currentUser );
+					expect( value ).toEqual(
+						resolveSelect(
 							'core',
 							'getAutosave',
 							postTypeSlug,
-							postId
+							postId,
+							userId
 						)
 					);
 				},
@@ -357,7 +372,7 @@ describe( 'Post generator actions', () => {
 					const { value } = fulfillment.next( savedPost() );
 
 					if ( isAutosave ) {
-						expect( value ).toEqual( dispatch( 'core', 'receiveAutosave', postId, savedPost() ) );
+						expect( value ).toEqual( dispatch( 'core', 'receiveAutosaves', postId, savedPost() ) );
 					} else {
 						expect( value ).toEqual( dispatch( STORE_KEY, 'resetPost', savedPost() ) );
 					}

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -17,7 +17,6 @@ import {
 	preferences,
 	saving,
 	reusableBlocks,
-	autosave,
 	postSavingLock,
 	previewLink,
 } from '../reducer';
@@ -799,38 +798,6 @@ describe( 'state', () => {
 				data: {},
 				isFetching: {},
 				isSaving: {},
-			} );
-		} );
-	} );
-
-	describe( 'autosave', () => {
-		it( 'returns null by default', () => {
-			const state = autosave( undefined, {} );
-
-			expect( state ).toBe( null );
-		} );
-
-		it( 'returns subset of received autosave post properties', () => {
-			const state = autosave( undefined, {
-				type: 'RESET_AUTOSAVE',
-				post: {
-					title: {
-						raw: 'The Title',
-					},
-					content: {
-						raw: 'The Content',
-					},
-					excerpt: {
-						raw: 'The Excerpt',
-					},
-					status: 'draft',
-				},
-			} );
-
-			expect( state ).toEqual( {
-				title: 'The Title',
-				content: 'The Content',
-				excerpt: 'The Excerpt',
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -44,15 +44,12 @@ const {
 	isCurrentPostScheduled,
 	isEditedPostPublishable,
 	isEditedPostSaveable,
-	isEditedPostAutosaveable,
-	getAutosave,
-	hasAutosave,
+	isEditedPostAutosaveable: isEditedPostAutosaveableRegistrySelector,
 	isEditedPostEmpty,
 	isEditedPostBeingScheduled,
 	isEditedPostDateFloating,
 	getCurrentPostAttribute,
 	getEditedPostAttribute,
-	getAutosaveAttribute,
 	isSavingPost,
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
@@ -613,42 +610,6 @@ describe( 'selectors', () => {
 				a: 1,
 				b: 2,
 			} );
-		} );
-	} );
-
-	describe( 'getAutosaveAttribute', () => {
-		it( 'returns null if there is no autosave', () => {
-			const state = {
-				autosave: null,
-			};
-
-			expect( getAutosaveAttribute( state, 'title' ) ).toBeNull();
-		} );
-
-		it( 'returns undefined for an attribute which is not set', () => {
-			const state = {
-				autosave: {},
-			};
-
-			expect( getAutosaveAttribute( state, 'foo' ) ).toBeUndefined();
-		} );
-
-		it( 'returns undefined for object prototype member', () => {
-			const state = {
-				autosave: {},
-			};
-
-			expect( getAutosaveAttribute( state, 'valueOf' ) ).toBeUndefined();
-		} );
-
-		it( 'returns the attribute value', () => {
-			const state = {
-				autosave: {
-					title: 'Hello World',
-				},
-			};
-
-			expect( getAutosaveAttribute( state, 'title' ) ).toBe( 'Hello World' );
 		} );
 	} );
 
@@ -1305,7 +1266,16 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditedPostAutosaveable', () => {
+		// isEditedPostAutosaveable is only implemented as a registry selector
+		// to handle a deprecation. None of the tests here trigger the deprecation,
+		// so create the selector without passing it a registry.
+		const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector();
+
 		it( 'should return false if the post is not saveable', () => {
+			const autosave = {
+				title: 'sassel',
+			};
+
 			const state = {
 				editor: {
 					present: {
@@ -1322,15 +1292,12 @@ describe( 'selectors', () => {
 				saving: {
 					requesting: true,
 				},
-				autosave: {
-					title: 'sassel',
-				},
 			};
 
-			expect( isEditedPostAutosaveable( state ) ).toBe( false );
+			expect( isEditedPostAutosaveable( state, autosave ) ).toBe( false );
 		} );
 
-		it( 'should return true if there is not yet an autosave', () => {
+		it( 'should return true if there is no autosave', () => {
 			const state = {
 				editor: {
 					present: {
@@ -1345,13 +1312,17 @@ describe( 'selectors', () => {
 					title: 'sassel',
 				},
 				saving: {},
-				autosave: null,
 			};
 
-			expect( isEditedPostAutosaveable( state ) ).toBe( true );
+			expect( isEditedPostAutosaveable( state, null ) ).toBe( true );
 		} );
 
 		it( 'should return false if none of title, excerpt, or content have changed', () => {
+			const autosave = {
+				title: 'foo',
+				excerpt: 'foo',
+			};
+
 			const state = {
 				editor: {
 					present: {
@@ -1368,16 +1339,17 @@ describe( 'selectors', () => {
 					excerpt: 'foo',
 				},
 				saving: {},
-				autosave: {
-					title: 'foo',
-					excerpt: 'foo',
-				},
 			};
 
-			expect( isEditedPostAutosaveable( state ) ).toBe( false );
+			expect( isEditedPostAutosaveable( state, autosave ) ).toBe( false );
 		} );
 
 		it( 'should return true if content has changes', () => {
+			const autosave = {
+				title: 'foo',
+				excerpt: 'foo',
+			};
+
 			const state = {
 				editor: {
 					present: {
@@ -1393,18 +1365,19 @@ describe( 'selectors', () => {
 					excerpt: 'foo',
 				},
 				saving: {},
-				autosave: {
-					title: 'foo',
-					excerpt: 'foo',
-				},
 			};
 
-			expect( isEditedPostAutosaveable( state ) ).toBe( true );
+			expect( isEditedPostAutosaveable( state, autosave ) ).toBe( true );
 		} );
 
 		it( 'should return true if title or excerpt have changed', () => {
 			for ( const variantField of [ 'title', 'excerpt' ] ) {
 				for ( const constantField of without( [ 'title', 'excerpt' ], variantField ) ) {
+					const autosave = {
+						[ constantField ]: 'foo',
+						[ variantField ]: 'bar',
+					};
+
 					const state = {
 						editor: {
 							present: {
@@ -1421,58 +1394,11 @@ describe( 'selectors', () => {
 							content: 'foo',
 						},
 						saving: {},
-						autosave: {
-							[ constantField ]: 'foo',
-							[ variantField ]: 'bar',
-						},
 					};
 
-					expect( isEditedPostAutosaveable( state ) ).toBe( true );
+					expect( isEditedPostAutosaveable( state, autosave ) ).toBe( true );
 				}
 			}
-		} );
-	} );
-
-	describe( 'getAutosave', () => {
-		it( 'returns null if there is no autosave', () => {
-			const state = {
-				autosave: null,
-			};
-
-			const result = getAutosave( state );
-
-			expect( result ).toBe( null );
-		} );
-
-		it( 'returns the autosave', () => {
-			const autosave = { title: '', excerpt: '', content: '' };
-			const state = { autosave };
-
-			const result = getAutosave( state );
-
-			expect( result ).toEqual( autosave );
-		} );
-	} );
-
-	describe( 'hasAutosave', () => {
-		it( 'returns false if there is no autosave', () => {
-			const state = {
-				autosave: null,
-			};
-
-			const result = hasAutosave( state );
-
-			expect( result ).toBe( false );
-		} );
-
-		it( 'returns true if there is a autosave', () => {
-			const state = {
-				autosave: { title: '', excerpt: '', content: '' },
-			};
-
-			const result = hasAutosave( state );
-
-			expect( result ).toBe( true );
 		} );
 	} );
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1266,15 +1266,15 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditedPostAutosaveable', () => {
-		// isEditedPostAutosaveable is only implemented as a registry selector
-		// to handle a deprecation. None of the tests here trigger the deprecation,
-		// so create the selector without passing it a registry.
-		const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector();
-
 		it( 'should return false if the post is not saveable', () => {
-			const autosave = {
-				title: 'sassel',
-			};
+			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
+				getCurrentUser() {},
+				getAutosave() {
+					return {
+						title: 'sassel',
+					};
+				},
+			} ) );
 
 			const state = {
 				editor: {
@@ -1294,10 +1294,15 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostAutosaveable( state, autosave ) ).toBe( false );
+			expect( isEditedPostAutosaveable( state ) ).toBe( false );
 		} );
 
 		it( 'should return true if there is no autosave', () => {
+			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
+				getCurrentUser() {},
+				getAutosave() {},
+			} ) );
+
 			const state = {
 				editor: {
 					present: {
@@ -1314,14 +1319,19 @@ describe( 'selectors', () => {
 				saving: {},
 			};
 
-			expect( isEditedPostAutosaveable( state, null ) ).toBe( true );
+			expect( isEditedPostAutosaveable( state ) ).toBe( true );
 		} );
 
 		it( 'should return false if none of title, excerpt, or content have changed', () => {
-			const autosave = {
-				title: 'foo',
-				excerpt: 'foo',
-			};
+			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
+				getCurrentUser() {},
+				getAutosave() {
+					return {
+						title: 'foo',
+						excerpt: 'foo',
+					};
+				},
+			} ) );
 
 			const state = {
 				editor: {
@@ -1341,14 +1351,19 @@ describe( 'selectors', () => {
 				saving: {},
 			};
 
-			expect( isEditedPostAutosaveable( state, autosave ) ).toBe( false );
+			expect( isEditedPostAutosaveable( state ) ).toBe( false );
 		} );
 
 		it( 'should return true if content has changes', () => {
-			const autosave = {
-				title: 'foo',
-				excerpt: 'foo',
-			};
+			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
+				getCurrentUser() {},
+				getAutosave() {
+					return {
+						title: 'foo',
+						excerpt: 'foo',
+					};
+				},
+			} ) );
 
 			const state = {
 				editor: {
@@ -1367,16 +1382,21 @@ describe( 'selectors', () => {
 				saving: {},
 			};
 
-			expect( isEditedPostAutosaveable( state, autosave ) ).toBe( true );
+			expect( isEditedPostAutosaveable( state ) ).toBe( true );
 		} );
 
 		it( 'should return true if title or excerpt have changed', () => {
 			for ( const variantField of [ 'title', 'excerpt' ] ) {
 				for ( const constantField of without( [ 'title', 'excerpt' ], variantField ) ) {
-					const autosave = {
-						[ constantField ]: 'foo',
-						[ variantField ]: 'bar',
-					};
+					const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
+						getCurrentUser() {},
+						getAutosave() {
+							return {
+								[ constantField ]: 'foo',
+								[ variantField ]: 'bar',
+							};
+						},
+					} ) );
 
 					const state = {
 						editor: {
@@ -1396,7 +1416,7 @@ describe( 'selectors', () => {
 						saving: {},
 					};
 
-					expect( isEditedPostAutosaveable( state, autosave ) ).toBe( true );
+					expect( isEditedPostAutosaveable( state ) ).toBe( true );
 				}
 			}
 		} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1266,9 +1266,46 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditedPostAutosaveable', () => {
+		it( 'should return false if existing autosaves have not yet been fetched', () => {
+			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
+				getCurrentUser() {},
+				hasFetchedAutosaves() {
+					return false;
+				},
+				getAutosave() {
+					return {
+						title: 'sassel',
+					};
+				},
+			} ) );
+
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							value: [],
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
+				currentPost: {
+					title: 'sassel',
+				},
+				saving: {
+					requesting: true,
+				},
+			};
+
+			expect( isEditedPostAutosaveable( state ) ).toBe( false );
+		} );
+
 		it( 'should return false if the post is not saveable', () => {
 			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
 				getCurrentUser() {},
+				hasFetchedAutosaves() {
+					return true;
+				},
 				getAutosave() {
 					return {
 						title: 'sassel',
@@ -1300,6 +1337,9 @@ describe( 'selectors', () => {
 		it( 'should return true if there is no autosave', () => {
 			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
 				getCurrentUser() {},
+				hasFetchedAutosaves() {
+					return true;
+				},
 				getAutosave() {},
 			} ) );
 
@@ -1325,6 +1365,9 @@ describe( 'selectors', () => {
 		it( 'should return false if none of title, excerpt, or content have changed', () => {
 			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
 				getCurrentUser() {},
+				hasFetchedAutosaves() {
+					return true;
+				},
 				getAutosave() {
 					return {
 						title: 'foo',
@@ -1357,6 +1400,9 @@ describe( 'selectors', () => {
 		it( 'should return true if content has changes', () => {
 			const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
 				getCurrentUser() {},
+				hasFetchedAutosaves() {
+					return true;
+				},
 				getAutosave() {
 					return {
 						title: 'foo',
@@ -1390,6 +1436,9 @@ describe( 'selectors', () => {
 				for ( const constantField of without( [ 'title', 'excerpt' ], variantField ) ) {
 					const isEditedPostAutosaveable = isEditedPostAutosaveableRegistrySelector( () => ( {
 						getCurrentUser() {},
+						hasFetchedAutosaves() {
+							return true;
+						},
 						getAutosave() {
 							return {
 								[ constantField ]: 'foo',


### PR DESCRIPTION
closes #7416

Attempts to resolve an issue whereby the editor is unaware of the existence of
a more recent autosave, resulting in attempts to perform an autosave fail.

## Description
This PR results in autosave state being fetched when the editor loads (via a resolver). This request is preloaded (will require a core patch). Changes include:
- Migration of autosave state from '@wordpress/editor' to '@wordpress/core-data'.
- Addition of resolver for 'getAutosave' selector.
- Disabling of the preview button until autosave state is fetched.
- Deprecation of old selectors/actions

## How has this been tested?
- Manual testing - follow the steps in #7416
- Added unit tests

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
