### PR TITLE
Implemented Gallery Drag and Drop Reordering

### DIFF
--- a/core-blocks/gallery/sortable.js
+++ b/core-blocks/gallery/sortable.js
@@ -1,0 +1,100 @@
+import { SortableContainer, SortableElement, arrayMove } from 'react-sortable-hoc';
+
+const { Component } = wp.element;
+
+class Sortable extends Component {
+	//constructor
+	constructor() {
+		super( ...arguments );
+
+		this.focusIndex = null;
+
+		this.onSortStart = this.onSortStart.bind( this );
+		this.onSortEnd = this.onSortEnd.bind( this );
+	}
+
+	/**
+     * Get the sortable list:
+	 * @return {function} the Container creator
+     */
+	getSortableList() {
+		const { items, children, className, dropZone } = this.props;
+
+		//create the sortable container:
+		return SortableContainer( () => {
+			//loop through all available children
+			return (
+				<ul className={ `components-sortable ${ className }` }>
+					{ dropZone }
+					{ children[ 0 ].map( ( child, index ) => {
+						child.props.tabindex = '0';
+
+						//generate a SortableElement using the item and the child
+						const SortableItem = SortableElement( () => {
+							return ( child );
+						} );
+
+						//set a temporary class so we can find it post-render:
+						if ( index === this.focusIndex ) {
+							child.props.class = `sortable-focus ${ child.props.className }`;
+						}
+
+						//display Sortable Element
+						return (
+							<SortableItem key={ `item-${ index }` } index={ index } item={ items[ index ] } />
+						);
+					} ) }
+				</ul>
+			);
+		} );
+	}
+
+	render() {
+		const items = this.props.items;
+		const SortableList = this.getSortableList();
+
+		return (
+		//return the sortable list, with props from our upper-lever component
+			<SortableList
+				axis="xy"
+				items={ items }
+				onSortStart={ this.onSortStart }
+				onSortEnd={ this.onSortEnd }
+				pressDelay={ 300 }
+			/>
+		);
+	}
+
+	/*************************************/
+	/**         Events                    */
+	/*************************************/
+
+	/**
+     * What to do on sort start ?
+     * @param {Object} object with access to the element, its index and the collection
+	 * @param {Event} event with the event info
+     */
+	onSortStart( { node, index, collection }, event ) {
+		//run the corresponding function in the upper-lever component:
+		if ( typeof ( this.props.onSortStart ) === 'function' ) {
+			this.props.onSortStart( { node, index, collection }, event );
+		}
+	}
+
+	/**
+     * What to do on sort end?
+     *
+     * @param {Object} object holding old and new indexes and the collection
+     */
+	onSortEnd( { oldIndex, newIndex } ) {
+		//create a new items array:
+		const _items = arrayMove( this.props.items, oldIndex, newIndex );
+
+		//and run the corresponding function in the upper-lever component:
+		if ( typeof ( this.props.onSortEnd ) === 'function' ) {
+			this.props.onSortEnd( _items );
+		}
+	}
+}
+
+export default Sortable;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"prop-types": "15.5.10",
 		"react": "16.4.1",
 		"react-dom": "16.4.1",
+		"react-sortable-hoc": "0.8.3",
 		"redux": "3.7.2",
 		"refx": "3.0.0",
 		"rememo": "3.0.0"

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -168,6 +168,23 @@ class GalleryEdit extends Component {
 			/>
 		);
 
+		const formFileUpload = (
+			isSelected &&
+				<li className="blocks-gallery-item has-add-item-button">
+					<FormFileUpload
+						multiple
+						isLarge
+						className="core-blocks-gallery-add-item-button"
+						onChange={ this.uploadFromFiles }
+						accept="image/*"
+						icon="insert"
+					>
+						{ __( 'Upload an image' ) }
+					</FormFileUpload>
+				</li>
+
+		);
+
 		const controls = (
 			<BlockControls>
 				{ !! images.length && (
@@ -244,7 +261,8 @@ class GalleryEdit extends Component {
 				<Sortable className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }
 					items={ images }
 					onSortEnd={ this.onSortEnd }
-					dropZone={ dropZone }
+					firstNode={ dropZone }
+					lastNode={ formFileUpload }
 				>
 					{ images.map( ( img, index ) => (
 						<li className="blocks-gallery-item" key={ img.id || img.url }>
@@ -260,20 +278,6 @@ class GalleryEdit extends Component {
 							/>
 						</li>
 					) ) }
-					{ isSelected &&
-						<li className="blocks-gallery-item has-add-item-button">
-							<FormFileUpload
-								multiple
-								isLarge
-								className="block-library-gallery-add-item-button"
-								onChange={ this.uploadFromFiles }
-								accept="image/*"
-								icon="insert"
-							>
-								{ __( 'Upload an image' ) }
-							</FormFileUpload>
-						</li>
-					}
 				</Sortable>
 			</Fragment>
 		);

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -57,6 +57,7 @@ class GalleryEdit extends Component {
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.addFiles = this.addFiles.bind( this );
 		this.uploadFromFiles = this.uploadFromFiles.bind( this );
+		this.onSortEnd = this.onSortEnd.bind( this );
 
 		this.state = {
 			selectedImage: null,
@@ -153,6 +154,10 @@ class GalleryEdit extends Component {
 		}
 	}
 
+	onSortEnd( images ) {
+		this.props.setAttributes( { images } );
+	}
+
 	render() {
 		const { attributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
@@ -238,7 +243,7 @@ class GalleryEdit extends Component {
 				{ noticeUI }
 				<Sortable className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }
 					items={ images }
-					onSortEnd={ ( images ) => this.props.setAttributes( { images } ) }
+					onSortEnd={ this.onSortEnd }
 					dropZone={ dropZone }
 				>
 					{ images.map( ( img, index ) => (

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -64,11 +64,11 @@ class GalleryEdit extends Component {
 		};
 	}
 
-	onSelectImage( index ) {
+	onSelectImage( id ) {
 		return () => {
-			if ( this.state.selectedImage !== index ) {
+			if ( this.state.selectedImage !== id ) {
 				this.setState( {
-					selectedImage: index,
+					selectedImage: id,
 				} );
 			}
 		};
@@ -270,9 +270,9 @@ class GalleryEdit extends Component {
 								url={ img.url }
 								alt={ img.alt }
 								id={ img.id }
-								isSelected={ isSelected && this.state.selectedImage === index }
+								isSelected={ isSelected && this.state.selectedImage === img.id }
 								onRemove={ this.onRemoveImage( index ) }
-								onSelect={ this.onSelectImage( index ) }
+								onSelect={ this.onSelectImage( img.id ) }
 								setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
 								caption={ img.caption }
 								tabIndex={ '0' }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import { filter, pick } from 'lodash';
+import Sortable from './sortable';
 
 /**
  * WordPress dependencies
@@ -235,8 +236,11 @@ class GalleryEdit extends Component {
 					</PanelBody>
 				</InspectorControls>
 				{ noticeUI }
-				<ul className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
-					{ dropZone }
+				<Sortable className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }
+					items={ images }
+					onSortEnd={ ( images ) => this.props.setAttributes( { images } ) }
+					dropZone={ dropZone }
+				>
 					{ images.map( ( img, index ) => (
 						<li className="blocks-gallery-item" key={ img.id || img.url }>
 							<GalleryImage
@@ -265,7 +269,7 @@ class GalleryEdit extends Component {
 							</FormFileUpload>
 						</li>
 					}
-				</ul>
+				</Sortable>
 			</Fragment>
 		);
 	}

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -275,6 +275,7 @@ class GalleryEdit extends Component {
 								onSelect={ this.onSelectImage( index ) }
 								setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
 								caption={ img.caption }
+								tabIndex={ '0' }
 							/>
 						</li>
 					) ) }

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -61,7 +61,7 @@ class Sortable extends Component {
 				items={ items }
 				onSortStart={ this.onSortStart }
 				onSortEnd={ this.onSortEnd }
-				pressDelay={ 300 }
+				distance={ 10 }
 			/>
 		);
 	}

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -8,12 +8,12 @@ import { Component } from '@wordpress/element';
  */
 import { SortableContainer, SortableElement, arrayMove } from 'react-sortable-hoc';
 
+const SortableItem = SortableElement( ( { children } ) => children );
+
 class Sortable extends Component {
 	//constructor
 	constructor() {
 		super( ...arguments );
-
-		this.focusIndex = null;
 
 		this.onSortStart = this.onSortStart.bind( this );
 		this.onSortEnd = this.onSortEnd.bind( this );
@@ -27,7 +27,7 @@ class Sortable extends Component {
 	 * @return {function} the Container creator
      */
 	getSortableList() {
-		const { items, children, className, firstNode, lastNode } = this.props;
+		const { children, className, firstNode, lastNode } = this.props;
 
 		//create the sortable container:
 		return SortableContainer( () => {
@@ -36,19 +36,11 @@ class Sortable extends Component {
 				<ul className={ `components-sortable ${ className }` }>
 					{ firstNode }
 					{ children.map( ( child, index ) => {
-						//generate a SortableElement using the item and the child
-						const SortableItem = SortableElement( () => {
-							return ( child );
-						} );
-
-						//set a temporary class so we can find it post-render:
-						if ( index === this.focusIndex ) {
-							child.props.class = `sortable-focus ${ child.props.className }`;
-						}
-
 						//display Sortable Element
 						return (
-							<SortableItem key={ `item-${ index }` } index={ index } item={ items[ index ] } />
+							<SortableItem key={ `item-${ index }` } index={ index }>
+								{ child }
+							</SortableItem>
 						);
 					} ) }
 					{ lastNode }

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -1,6 +1,12 @@
-import { SortableContainer, SortableElement, arrayMove } from 'react-sortable-hoc';
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
 
-const { Component } = wp.element;
+/**
+ * Internal dependencies
+ */
+import { SortableContainer, SortableElement, arrayMove } from 'react-sortable-hoc';
 
 class Sortable extends Component {
 	//constructor

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -75,7 +75,7 @@ class Sortable extends Component {
 				onSortStart={ this.onSortStart }
 				onSortEnd={ this.onSortEnd }
 				distance={ 10 }
-				helperClass={ this.props.className }
+				helperClass={ 'dragged-element' }
 			/>
 		);
 	}

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -62,6 +62,7 @@ class Sortable extends Component {
 				onSortStart={ this.onSortStart }
 				onSortEnd={ this.onSortEnd }
 				distance={ 10 }
+				helperClass={ this.props.className }
 			/>
 		);
 	}

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -36,8 +36,6 @@ class Sortable extends Component {
 				<ul className={ `components-sortable ${ className }` }>
 					{ firstNode }
 					{ children.map( ( child, index ) => {
-						child.props.tabindex = '0';
-
 						//generate a SortableElement using the item and the child
 						const SortableItem = SortableElement( () => {
 							return ( child );

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -11,7 +11,6 @@ import { SortableContainer, SortableElement, arrayMove } from 'react-sortable-ho
 const SortableItem = SortableElement( ( { children } ) => children );
 
 class Sortable extends Component {
-	//constructor
 	constructor() {
 		super( ...arguments );
 
@@ -23,9 +22,9 @@ class Sortable extends Component {
 	}
 
 	/**
-     * Get the sortable list:
+	 * Get the sortable list:
 	 * @return {function} the Container creator
-     */
+	 */
 	getSortableList() {
 		const { children, className, firstNode, lastNode } = this.props;
 
@@ -86,10 +85,10 @@ class Sortable extends Component {
 	/*************************************/
 
 	/**
-     * What to do on sort start ?
-     * @param {Object} object with access to the element, its index and the collection
+	 * What to do on sort start ?
+	 * @param {Object} object with access to the element, its index and the collection
 	 * @param {Event} event with the event info
-     */
+	 */
 	onSortStart( { node, index, collection }, event ) {
 		//run the corresponding function in the upper-lever component:
 		if ( typeof ( this.props.onSortStart ) === 'function' ) {
@@ -98,10 +97,10 @@ class Sortable extends Component {
 	}
 
 	/**
-     * What to do on sort end?
-     *
-     * @param {Object} object holding old and new indexes and the collection
-     */
+	 * What to do on sort end?
+	 *
+	 * @param {Object} object holding old and new indexes and the collection
+	 */
 	onSortEnd( { oldIndex, newIndex } ) {
 		//create a new items array:
 		const _items = arrayMove( this.props.items, oldIndex, newIndex );

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -11,6 +11,9 @@ class Sortable extends Component {
 
 		this.onSortStart = this.onSortStart.bind( this );
 		this.onSortEnd = this.onSortEnd.bind( this );
+		this.state = {
+			justSorted: false,
+		};
 	}
 
 	/**
@@ -48,6 +51,21 @@ class Sortable extends Component {
 				</ul>
 			);
 		} );
+	}
+
+	shouldComponentUpdate( nextProps ) {
+		const should = nextProps.items.every( ( item, index ) => {
+			return this.props.items[ index ] === item;
+		} );
+		const justSorted = this.state.justSorted;
+		if ( justSorted ) {
+			this.setState( {
+				justSorted: false,
+			} );
+		}
+		const lengthChanged = nextProps.items.length !== this.props.items.length;
+
+		return should || justSorted || lengthChanged;
 	}
 
 	render() {
@@ -91,6 +109,9 @@ class Sortable extends Component {
 	onSortEnd( { oldIndex, newIndex } ) {
 		//create a new items array:
 		const _items = arrayMove( this.props.items, oldIndex, newIndex );
+		this.setState( {
+			justSorted: true,
+		} );
 
 		//and run the corresponding function in the upper-lever component:
 		if ( typeof ( this.props.onSortEnd ) === 'function' ) {

--- a/packages/block-library/src/gallery/sortable.js
+++ b/packages/block-library/src/gallery/sortable.js
@@ -18,15 +18,15 @@ class Sortable extends Component {
 	 * @return {function} the Container creator
      */
 	getSortableList() {
-		const { items, children, className, dropZone } = this.props;
+		const { items, children, className, firstNode, lastNode } = this.props;
 
 		//create the sortable container:
 		return SortableContainer( () => {
 			//loop through all available children
 			return (
 				<ul className={ `components-sortable ${ className }` }>
-					{ dropZone }
-					{ children[ 0 ].map( ( child, index ) => {
+					{ firstNode }
+					{ children.map( ( child, index ) => {
 						child.props.tabindex = '0';
 
 						//generate a SortableElement using the item and the child
@@ -44,6 +44,7 @@ class Sortable extends Component {
 							<SortableItem key={ `item-${ index }` } index={ index } item={ items[ index ] } />
 						);
 					} ) }
+					{ lastNode }
 				</ul>
 			);
 		} );

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,4 +1,5 @@
-.wp-block-gallery {
+.wp-block-gallery,
+.dragged-element {
 	display: flex;
 	flex-wrap: wrap;
 	list-style-type: none;
@@ -7,13 +8,15 @@
 	margin: 0 -8px 0 -8px;
 
 	.blocks-gallery-image,
-	.blocks-gallery-item {
+	.blocks-gallery-item,
+	&.blocks-gallery-item {
 		margin: 8px;
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;
 		justify-content: center;
 		position: relative;
+		transform-origin: top left;
 
 		figure {
 			margin: 0;
@@ -93,5 +96,16 @@
 	&.alignright {
 		max-width: $content-width / 2;
 		width: 100%;
+	}
+}
+
+.blocks-gallery-item.dragged-element {
+	figure {
+		img {
+			width: 100%;
+		}
+		.editor-rich-text {
+			overflow: hidden;
+		}
 	}
 }


### PR DESCRIPTION
## Description
    Implemented Gallery Drag and Drop Reordering
    * Created new Sortable HOC for wrapping the Gallery Images
    * Added react-sortable-hoc dependency

Addresses Issue #743

## Screenshots
![ezgif-1-88a02762a5](https://user-images.githubusercontent.com/3190666/43881861-3c9e9c8a-9b73-11e8-8d9f-a0158a14b676.gif)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

- [ ] My code is tested.
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->

## KNOWN ISSUES:
    * Selected image styles are not displayed properly while dragged (this is because
      react-sortable-hoc creates a copy of the dragged element right before the </body>
      tag, but for these images, the style depend on the <ul> parent)
