### PR TITLE
Add end 2 end test: should not revert title during a preview right after a save draft

### DIFF
--- a/test/e2e/specs/preview.test.js
+++ b/test/e2e/specs/preview.test.js
@@ -11,6 +11,7 @@ import {
 	newPost,
 	getUrl,
 	publishPost,
+	saveDraft,
 } from '../support/utils';
 
 describe( 'Preview', () => {
@@ -124,6 +125,43 @@ describe( 'Preview', () => {
 		// Title in preview should match updated input.
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
 		expect( previewTitle ).toBe( 'Hello World! And more.' );
+
+		await previewPage.close();
+	} );
+
+	it( 'Should not revert title during a preview right after a save draft', async () => {
+		const editorPage = page;
+
+		// Type aaaaa in the title filed.
+		await editorPage.type( '.editor-post-title__input', 'aaaaa' );
+		await editorPage.keyboard.press( 'Tab' );
+
+		// Save the post as a draft.
+		await editorPage.waitForSelector( '.editor-post-save-draft' );
+		await saveDraft();
+
+		// Open the preview page.
+		const previewPage = await openPreviewPage( editorPage );
+
+		// Title in preview should match input.
+		let previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'aaaaa' );
+
+		// Return to editor.
+		await editorPage.bringToFront();
+
+		// Append bbbbb to the title, and tab away from the title so blur event is triggered.
+		await editorPage.type( '.editor-post-title__input', 'bbbbb' );
+		await editorPage.keyboard.press( 'Tab' );
+
+		// Save draft and open the preview page right after.
+		await editorPage.waitForSelector( '.editor-post-save-draft' );
+		await saveDraft();
+		await waitForPreviewNavigation( previewPage );
+
+		// Title in preview should match updated input.
+		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'aaaaabbbbb' );
 
 		await previewPage.close();
 	} );


### PR DESCRIPTION
## Description
Adds an end 2 end test that verifies the we don't regress on issue https://github.com/WordPress/gutenberg/issues/7927.

The test does the following:
Adds a post.
Writes aaaa in title and clicks save draft.
Presses preview.
See the title is correctly previewed as aaaa.
Goes back to the editor ands appends bbbb to the title, presses save draft. Presses preview right after the post is saved.
Verify that on the preview of the post we see 'aaaabbbb' as the title of the post.

## How has this been tested?
Verify end 2 end tests run with success.
