### PR TITLE
Fix: Blocks: Make backspace behavior of quote, verse and performated consistent

### DIFF
--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -2,7 +2,7 @@
  * WordPress
  */
 import { __ } from '@wordpress/i18n';
-import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
+import { children, createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
 
 export const name = 'core/preformatted';
@@ -58,7 +58,7 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, className } ) {
+	edit( { attributes, mergeBlocks, setAttributes, className } ) {
 		const { content } = attributes;
 
 		return (
@@ -72,6 +72,7 @@ export const settings = {
 				} }
 				placeholder={ __( 'Write preformatted text…' ) }
 				wrapperClassName={ className }
+				onMerge={ mergeBlocks }
 			/>
 		);
 	},
@@ -80,5 +81,11 @@ export const settings = {
 		const { content } = attributes;
 
 		return <RichText.Content tagName="pre" value={ content } />;
+	},
+
+	merge( attributes, attributesToMerge ) {
+		return {
+			content: children.concat( attributes.content, attributesToMerge.content ),
+		};
 	},
 };

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -8,7 +8,7 @@ import { castArray, get, isString, isEmpty, omit } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
+import { children, createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
 import {
 	BlockControls,
 	AlignmentToolbar,
@@ -231,6 +231,14 @@ export const settings = {
 				{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>
 		);
+	},
+
+	merge( attributes, attributesToMerge ) {
+		return {
+			...attributes,
+			value: attributes.value.concat( attributesToMerge.value ),
+			citation: children.concat( attributes.citation, attributesToMerge.citation ),
+		};
 	},
 
 	deprecated: [

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { createBlock } from '@wordpress/blocks';
+import { children, createBlock } from '@wordpress/blocks';
 import {
 	RichText,
 	BlockControls,
@@ -53,7 +53,7 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, className } ) {
+	edit( { attributes, setAttributes, className, mergeBlocks } ) {
 		const { textAlign, content } = attributes;
 
 		return (
@@ -77,6 +77,7 @@ export const settings = {
 					style={ { textAlign: textAlign } }
 					placeholder={ __( 'Write…' ) }
 					wrapperClassName={ className }
+					onMerge={ mergeBlocks }
 				/>
 			</Fragment>
 		);
@@ -93,5 +94,11 @@ export const settings = {
 				value={ content }
 			/>
 		);
+	},
+
+	merge( attributes, attributesToMerge ) {
+		return {
+			content: children.concat( attributes.content, attributesToMerge.content ),
+		};
 	},
 };


### PR DESCRIPTION
In list, heading, and paragraph if we had a paragraph before and pressed backspace the contents of the blocks would be merged with the paragraph. If we had a block of the same type before, the contents would be merged on backspace. And if had a paragraph after the block and pressed backspace there the contents of the paragraph would be appended to the contents of the block.

These behaviors make sense but on the quote, verse and performated they were not available.

This PR adds simple merge functions to each of the three blocks and passes the onMerge handler to the RichText component they use.

Fixes: https://github.com/WordPress/gutenberg/issues/5057


## How has this been tested?
For each of the 3 blocks ( quote, verse and performated ) I made the following stepts: 

- Added two blocks of the same type with some content. Pressed backspace on the second block and verified the blocks merged.
- Added a paragrah with content and one of the blocks after pressed backspace on the start of the block and verified the contents of the block merged with the paragraph.
- Added a block and a paragraph pressed backspace at the start of the paragraph and verified that the contents of the paragraph joined the block.