### PR TITLE
Optimise heading line heights

### DIFF
--- a/core-blocks/heading/editor.scss
+++ b/core-blocks/heading/editor.scss
@@ -15,6 +15,7 @@
 
 	h2 {
 		font-size: 1.95em;
+		line-height: 1.4;
 	}
 
 	h3 {
@@ -31,5 +32,16 @@
 
 	h6 {
 		font-size: 0.8em;
+	}
+
+	// Adjust line spacing for larger headings.
+	h1.editor-rich-text__tinymce,
+	h2.editor-rich-text__tinymce,
+	h3.editor-rich-text__tinymce {
+		line-height: 1.4;
+	}
+
+	h4.editor-rich-text__tinymce {
+		line-height: 1.5;
 	}
 }

--- a/core-blocks/heading/editor.scss
+++ b/core-blocks/heading/editor.scss
@@ -15,7 +15,6 @@
 
 	h2 {
 		font-size: 1.95em;
-		line-height: 1.4;
 	}
 
 	h3 {


### PR DESCRIPTION
Update line-height for h1-h4 headings as discussed in #7930. Note: I've needed to add specificity to these styles due to a conflict with a line-height being set at 1.8 on `.editor-rich-text__tinymce` elsewhere in the SCSS. I tested and this approach doesn't seem to cause any conflicts, but it's not impossible I missed something!

## Before
![screen shot 2018-07-15 at 19 22 34](https://user-images.githubusercontent.com/376315/42736884-7fc883f2-8865-11e8-9d21-6fdfe2c78802.png)

## After
![screen shot 2018-07-15 at 19 29 09](https://user-images.githubusercontent.com/376315/42736881-79a379dc-8865-11e8-8826-a97ef6b56f1d.png)



## How has this been tested?
Tested in Firefox/Chrome at different screen sizes.

## Types of changes
Style tweak.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
