### PR TITLE
Framework: Rename `UrlInput` component as `URLInput`

### DIFF
--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -14,7 +14,7 @@ import {
 	withFallbackStyles,
 } from '@wordpress/components';
 import {
-	UrlInput,
+	URLInput,
 	RichText,
 	BlockControls,
 	BlockAlignmentToolbar,
@@ -129,7 +129,7 @@ class ButtonEdit extends Component {
 						className="core-blocks-button__inline-link"
 						onSubmit={ ( event ) => event.preventDefault() }>
 						<Dashicon icon="admin-links" />
-						<UrlInput
+						<URLInput
 							value={ url }
 							onChange={ ( value ) => setAttributes( { url: value } ) }
 						/>

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -266,7 +266,7 @@ class ImageEdit extends Component {
 
 		const availableSizes = this.getAvailableSizes();
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && isLargeViewport;
-		const isLinkUrlInputDisabled = linkDestination !== LINK_DESTINATION_CUSTOM;
+		const isLinkURLInputDisabled = linkDestination !== LINK_DESTINATION_CUSTOM;
 
 		const getInspectorControls = ( imageWidth, imageHeight ) => (
 			<InspectorControls>
@@ -353,8 +353,8 @@ class ImageEdit extends Component {
 						label={ __( 'Link URL' ) }
 						value={ href || '' }
 						onChange={ this.onSetCustomHref }
-						placeholder={ ! isLinkUrlInputDisabled && 'https://' }
-						disabled={ isLinkUrlInputDisabled }
+						placeholder={ ! isLinkURLInputDisabled && 'https://' }
+						disabled={ isLinkURLInputDisabled }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -13,7 +13,8 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.utils.buildTermsTree` has been removed.
  - `wp.utils.decodeEntities` has been removed. Please use `wp.htmlEntities.decodeEntities` instead.
  - All references to a block's `uid` have been replaced with equivalent props and selectors for `clientId`.
- - The `MediaPlaceholder` component `onSelectUrl` prop has been renamed to `onSelectURL`.
+ - The `wp.editor.MediaPlaceholder` component `onSelectUrl` prop has been renamed to `onSelectURL`.
+ - The `wp.editor.UrlInput` component has been renamed to `wp.editor.URLInput`.
 
 ## 3.4.0
 

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -20,8 +20,8 @@ export { default as RichText } from './rich-text';
 export { default as RichTextProvider } from './rich-text/provider';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
-export { default as UrlInput } from './url-input';
-export { default as UrlInputButton } from './url-input/button';
+export { default as URLInput, UrlInput } from './url-input';
+export { default as URLInputButton, UrlInputButton } from './url-input/button';
 
 // Post Related Components
 export { default as AutosaveMonitor } from './autosave-monitor';

--- a/editor/components/rich-text/format-toolbar/index.js
+++ b/editor/components/rich-text/format-toolbar/index.js
@@ -19,7 +19,7 @@ import { prependHTTP } from '@wordpress/url';
  */
 import './style.scss';
 import PositionedAtSelection from './positioned-at-selection';
-import UrlInput from '../../url-input';
+import URLInput from '../../url-input';
 import { filterURLForDisplay } from '../../../utils/url';
 
 const FORMATTING_CONTROLS = [
@@ -232,7 +232,7 @@ class FormatToolbar extends Component {
 										onKeyDown={ this.onKeyDown }
 										onSubmit={ this.submitLink }>
 										<div className="editor-format-toolbar__link-modal-line">
-											<UrlInput value={ linkValue } onChange={ this.onChangeLinkValue } />
+											<URLInput value={ linkValue } onChange={ this.onChangeLinkValue } />
 											<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 											<IconButton
 												className="editor-format-toolbar__link-settings-toggle"

--- a/editor/components/url-input/button.js
+++ b/editor/components/url-input/button.js
@@ -10,13 +10,14 @@ import './style.scss';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
-import UrlInput from './';
+import URLInput from './';
 
-class UrlInputButton extends Component {
+class URLInputButton extends Component {
 	constructor() {
 		super( ...arguments );
 		this.toggle = this.toggle.bind( this );
@@ -62,7 +63,7 @@ class UrlInputButton extends Component {
 								label={ __( 'Close' ) }
 								onClick={ this.toggle }
 							/>
-							<UrlInput value={ url || '' } onChange={ onChange } />
+							<URLInput value={ url || '' } onChange={ onChange } />
 							<IconButton
 								icon="editor-break"
 								label={ __( 'Submit' ) }
@@ -76,4 +77,17 @@ class UrlInputButton extends Component {
 	}
 }
 
-export default UrlInputButton;
+export class UrlInputButton extends URLInputButton {
+	constructor() {
+		super( ...arguments );
+
+		deprecated( 'wp.editor.UrlInputButton', {
+			alternative: 'wp.editor.URLInputButton',
+			plugin: 'Gutenberg',
+			version: 'v3.4',
+			hint: 'The component has been renamed.',
+		} );
+	}
+}
+
+export default URLInputButton;

--- a/editor/components/url-input/index.js
+++ b/editor/components/url-input/index.js
@@ -16,13 +16,14 @@ import { UP, DOWN, ENTER } from '@wordpress/keycodes';
 import { Spinner, withSpokenMessages, Popover } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 import apiFetch from '@wordpress/api-fetch';
+import deprecated from '@wordpress/deprecated';
 
 // Since URLInput is rendered in the context of other inputs, but should be
 // considered a separate modal node, prevent keyboard events from propagating
 // as being considered from the input.
 const stopEventPropagation = ( event ) => event.stopPropagation();
 
-class UrlInput extends Component {
+class URLInput extends Component {
 	constructor() {
 		super( ...arguments );
 		this.onChange = this.onChange.bind( this );
@@ -239,4 +240,21 @@ class UrlInput extends Component {
 	}
 }
 
-export default withSpokenMessages( withInstanceId( UrlInput ) );
+export class UrlInput extends Component {
+	constructor() {
+		super( ...arguments );
+
+		deprecated( 'wp.editor.UrlInput', {
+			alternative: 'wp.editor.URLInput',
+			plugin: 'Gutenberg',
+			version: 'v3.5',
+			hint: 'The component has been renamed.',
+		} );
+	}
+
+	render() {
+		return <URLInput { ...this.props } />;
+	}
+}
+
+export default withSpokenMessages( withInstanceId( URLInput ) );

--- a/editor/components/url-input/index.js
+++ b/editor/components/url-input/index.js
@@ -240,6 +240,12 @@ class URLInput extends Component {
 	}
 }
 
+// TODO: As part of deprecation of UrlInput, the temporary passthrough
+// component needs access to the enhanced URLInput class, so it cannot be
+// enhanced as part of its export default. Once the temporary passthrough is
+// removed, this can be moved back to the export statement.
+URLInput = withSpokenMessages( withInstanceId( URLInput ) );
+
 export class UrlInput extends Component {
 	constructor() {
 		super( ...arguments );
@@ -257,4 +263,4 @@ export class UrlInput extends Component {
 	}
 }
 
-export default withSpokenMessages( withInstanceId( URLInput ) );
+export default URLInput;

--- a/editor/components/url-input/test/button.js
+++ b/editor/components/url-input/test/button.js
@@ -8,59 +8,59 @@ import ReactDOM from 'react-dom';
 /**
  * Internal dependencies
  */
-import UrlInput from '../';
-import UrlInputButton from '../button';
+import URLInput from '../';
+import URLInputButton from '../button';
 
-describe( 'UrlInputButton', () => {
+describe( 'URLInputButton', () => {
 	const clickEditLink = ( wrapper ) => wrapper.find( 'IconButton.components-toolbar__control' ).simulate( 'click' );
 
 	it( 'should have a valid class name in the wrapper tag', () => {
-		const wrapper = shallow( <UrlInputButton /> );
+		const wrapper = shallow( <URLInputButton /> );
 		expect( wrapper.hasClass( 'editor-url-input__button' ) ).toBe( true );
 	} );
 	it( 'should not have is-active class when url prop not defined', () => {
-		const wrapper = shallow( <UrlInputButton /> );
+		const wrapper = shallow( <URLInputButton /> );
 		expect( wrapper.find( 'IconButton' ).hasClass( 'is-active' ) ).toBe( false );
 	} );
 	it( 'should have is-active class name if url prop defined', () => {
-		const wrapper = shallow( <UrlInputButton url="https://example.com" /> );
+		const wrapper = shallow( <URLInputButton url="https://example.com" /> );
 		expect( wrapper.find( 'IconButton' ).hasClass( 'is-active' ) ).toBe( true );
 	} );
 	it( 'should have hidden form by default', () => {
-		const wrapper = shallow( <UrlInputButton /> );
+		const wrapper = shallow( <URLInputButton /> );
 		expect( wrapper.find( 'form' ) ).toHaveLength( 0 );
 		expect( wrapper.state().expanded ).toBe( false );
 	} );
 	it( 'should have visible form when Edit Link button clicked', () => {
-		const wrapper = shallow( <UrlInputButton /> );
+		const wrapper = shallow( <URLInputButton /> );
 		clickEditLink( wrapper );
 		expect( wrapper.find( 'form' ) ).toHaveLength( 1 );
 		expect( wrapper.state().expanded ).toBe( true );
 	} );
 	it( 'should call onChange function once when value changes once', () => {
 		const onChangeMock = jest.fn();
-		const wrapper = shallow( <UrlInputButton onChange={ onChangeMock } /> );
+		const wrapper = shallow( <URLInputButton onChange={ onChangeMock } /> );
 		clickEditLink( wrapper );
-		wrapper.find( UrlInput ).simulate( 'change' );
+		wrapper.find( URLInput ).simulate( 'change' );
 		expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
 	} );
 	it( 'should call onChange function twice when value changes twice', () => {
 		const onChangeMock = jest.fn();
-		const wrapper = shallow( <UrlInputButton onChange={ onChangeMock } /> );
+		const wrapper = shallow( <URLInputButton onChange={ onChangeMock } /> );
 		clickEditLink( wrapper );
-		wrapper.find( UrlInput ).simulate( 'change' );
-		wrapper.find( UrlInput ).simulate( 'change' );
+		wrapper.find( URLInput ).simulate( 'change' );
+		wrapper.find( URLInput ).simulate( 'change' );
 		expect( onChangeMock ).toHaveBeenCalledTimes( 2 );
 	} );
 	it( 'should close the form when user clicks Close button', () => {
-		const wrapper = shallow( <UrlInputButton /> );
+		const wrapper = shallow( <URLInputButton /> );
 		clickEditLink( wrapper );
 		expect( wrapper.state().expanded ).toBe( true );
 		wrapper.find( '.editor-url-input__back' ).simulate( 'click' );
 		expect( wrapper.state().expanded ).toBe( false );
 	} );
 	it( 'should close the form when user submits it', () => {
-		const wrapper = TestUtils.renderIntoDocument( <UrlInputButton /> );
+		const wrapper = TestUtils.renderIntoDocument( <URLInputButton /> );
 		const buttonElement = () => TestUtils.findRenderedDOMComponentWithClass(
 			wrapper,
 			'components-toolbar__control'


### PR DESCRIPTION
This pull request seeks to effect new capitalization guidelines around abbreviations (#7670) toward an API freeze. It deprecates the `wp.editor.UrlInput` component in favor of the corrected `wp.editor.URLInput` naming. 

**Testing instructions:**

Verify that there are no regressions in the use of the URLInput component (e.g. paragraph or button block link input).

Ensure that `wp.editor.UrlInput` works unaffected, but logs a deprecated warning.