### PR TITLE
Testing: Remove data-test attribute from UrlInputButton output

### DIFF
--- a/editor/components/url-input/button.js
+++ b/editor/components/url-input/button.js
@@ -62,7 +62,7 @@ class UrlInputButton extends Component {
 								label={ __( 'Close' ) }
 								onClick={ this.toggle }
 							/>
-							<UrlInput value={ url || '' } onChange={ onChange } data-test="UrlInput" />
+							<UrlInput value={ url || '' } onChange={ onChange } />
 							<IconButton
 								icon="editor-break"
 								label={ __( 'Submit' ) }

--- a/editor/components/url-input/test/button.js
+++ b/editor/components/url-input/test/button.js
@@ -8,6 +8,7 @@ import ReactDOM from 'react-dom';
 /**
  * Internal dependencies
  */
+import UrlInput from '../';
 import UrlInputButton from '../button';
 
 describe( 'UrlInputButton', () => {
@@ -40,15 +41,15 @@ describe( 'UrlInputButton', () => {
 		const onChangeMock = jest.fn();
 		const wrapper = shallow( <UrlInputButton onChange={ onChangeMock } /> );
 		clickEditLink( wrapper );
-		wrapper.find( '[data-test=\'UrlInput\']' ).simulate( 'change' );
+		wrapper.find( UrlInput ).simulate( 'change' );
 		expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
 	} );
 	it( 'should call onChange function twice when value changes twice', () => {
 		const onChangeMock = jest.fn();
 		const wrapper = shallow( <UrlInputButton onChange={ onChangeMock } /> );
 		clickEditLink( wrapper );
-		wrapper.find( '[data-test=\'UrlInput\']' ).simulate( 'change' );
-		wrapper.find( '[data-test=\'UrlInput\']' ).simulate( 'change' );
+		wrapper.find( UrlInput ).simulate( 'change' );
+		wrapper.find( UrlInput ).simulate( 'change' );
 		expect( onChangeMock ).toHaveBeenCalledTimes( 2 );
 	} );
 	it( 'should close the form when user clicks Close button', () => {


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/3550#discussion_r202700101

This pull request seeks to update test cases to avoid the need for an attribute output from the `UrlInputButton` component which is otherwise not referenced or used.

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

cc @hideokamoto 