### PR TITLE
Framework: Rename `MediaPlaceholder` `onSelectUrl` prop as `onSelectURL`

### DIFF
--- a/core-blocks/audio/edit.js
+++ b/core-blocks/audio/edit.js
@@ -33,12 +33,26 @@ class AudioEdit extends Component {
 		};
 
 		this.toggleAttribute = this.toggleAttribute.bind( this );
+		this.onSelectURL = this.onSelectURL.bind( this );
 	}
 
 	toggleAttribute( attribute ) {
 		return ( newValue ) => {
 			this.props.setAttributes( { [ attribute ]: newValue } );
 		};
+	}
+
+	onSelectURL( newSrc ) {
+		const { attributes, setAttributes } = this.props;
+		const { src } = attributes;
+
+		// Set the block's src from the edit component's state, and switch off
+		// the editing UI.
+		if ( newSrc !== src ) {
+			setAttributes( { src: newSrc, id: undefined } );
+		}
+
+		this.setState( { editing: false } );
 	}
 
 	render() {
@@ -61,14 +75,6 @@ class AudioEdit extends Component {
 			setAttributes( { src: media.url, id: media.id } );
 			this.setState( { src: media.url, editing: false } );
 		};
-		const onSelectUrl = ( newSrc ) => {
-			// set the block's src from the edit component's state, and switch off the editing UI
-			if ( newSrc !== src ) {
-				setAttributes( { src: newSrc, id: undefined } );
-			}
-			this.setState( { editing: false } );
-		};
-
 		if ( editing ) {
 			return (
 				<MediaPlaceholder
@@ -79,7 +85,7 @@ class AudioEdit extends Component {
 					} }
 					className={ className }
 					onSelect={ onSelectAudio }
-					onSelectUrl={ onSelectUrl }
+					onSelectURL={ this.onSelectURL }
 					accept="audio/*"
 					type="audio"
 					value={ this.props.attributes }

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -32,12 +32,26 @@ class VideoEdit extends Component {
 		};
 
 		this.toggleAttribute = this.toggleAttribute.bind( this );
+		this.onSelectURL = this.onSelectURL.bind( this );
 	}
 
 	toggleAttribute( attribute ) {
 		return ( newValue ) => {
 			this.props.setAttributes( { [ attribute ]: newValue } );
 		};
+	}
+
+	onSelectURL( newSrc ) {
+		const { attributes, setAttributes } = this.props;
+		const { src } = attributes;
+
+		// Set the block's src from the edit component's state, and switch off
+		// the editing UI.
+		if ( newSrc !== src ) {
+			setAttributes( { src: newSrc, id: undefined } );
+		}
+
+		this.setState( { editing: false } );
 	}
 
 	render() {
@@ -60,13 +74,6 @@ class VideoEdit extends Component {
 			setAttributes( { src: media.url, id: media.id } );
 			this.setState( { src: media.url, editing: false } );
 		};
-		const onSelectUrl = ( newSrc ) => {
-			// set the block's src from the edit component's state, and switch off the editing UI
-			if ( newSrc !== src ) {
-				setAttributes( { src: newSrc, id: undefined } );
-			}
-			this.setState( { editing: false } );
-		};
 
 		if ( editing ) {
 			return (
@@ -78,7 +85,7 @@ class VideoEdit extends Component {
 					} }
 					className={ className }
 					onSelect={ onSelectVideo }
-					onSelectUrl={ onSelectUrl }
+					onSelectURL={ this.onSelectURL }
 					accept="video/*"
 					type="video"
 					value={ this.props.attributes }

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -13,6 +13,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.utils.buildTermsTree` has been removed.
  - `wp.utils.decodeEntities` has been removed. Please use `wp.htmlEntities.decodeEntities` instead.
  - All references to a block's `uid` have been replaced with equivalent props and selectors for `clientId`.
+ - The `MediaPlaceholder` component `onSelectUrl` prop has been renamed to `onSelectURL`.
 
 ## 3.4.0
 

--- a/editor/components/media-placeholder/index.js
+++ b/editor/components/media-placeholder/index.js
@@ -15,6 +15,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -54,7 +55,25 @@ class MediaPlaceholder extends Component {
 	onSubmitSrc( event ) {
 		event.preventDefault();
 		if ( this.state.src ) {
-			this.props.onSelectUrl( this.state.src );
+			if ( this.props.onSelectUrl ) {
+				// TODO: In removing deprecation, ensure to simplify rendering
+				// to avoid checking for `onSelectUrl`. It also allows this
+				// function to be simplified to avoid truthiness test on
+				// `onSelectURL`, since it's required for the form invoking
+				// this function to be rendered at all.
+				deprecated( 'MediaPlaceholder `onSelectUrl` prop', {
+					alternative: '`onSelectURL` prop',
+					plugin: 'Gutenberg',
+					version: 'v3.5',
+					hint: 'The prop has been renamed.',
+				} );
+
+				this.props.onSelectUrl( this.state.src );
+			}
+
+			if ( this.props.onSelectURL ) {
+				this.props.onSelectURL( this.state.src );
+			}
 		}
 	}
 
@@ -82,6 +101,7 @@ class MediaPlaceholder extends Component {
 			labels,
 			onSelect,
 			value = {},
+			onSelectURL,
 			onSelectUrl,
 			onHTMLDrop = noop,
 			multiple = false,
@@ -101,7 +121,7 @@ class MediaPlaceholder extends Component {
 					onFilesDrop={ this.onFilesUpload }
 					onHTMLDrop={ onHTMLDrop }
 				/>
-				{ onSelectUrl && (
+				{ ( onSelectUrl || onSelectURL ) && (
 					<form onSubmit={ this.onSubmitSrc }>
 						<input
 							type="url"


### PR DESCRIPTION
This pull request seeks to effect new capitalization guidelines around abbreviations (#7670) toward an API freeze. It deprecates the `onSelectUrl` prop of the `wp.editor.MediaPlaceholder` component in favor of the corrected `onSelectURL` naming. 

**Testing instructions:**

Verify that there are no regressions in the use of the media placeholder (e.g. audio or video block URL input).

Ensure that `onSelectUrl` prop works unaffected, but logs a deprecated warning.