### PR TITLE
Entities: Rename baseUrl entities property as baseURL

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -15,9 +15,9 @@ import { getEntitiesByKind } from './selectors';
 import { addEntities } from './actions';
 
 export const defaultEntities = [
-	{ name: 'postType', kind: 'root', key: 'slug', baseUrl: '/wp/v2/types' },
-	{ name: 'media', kind: 'root', baseUrl: '/wp/v2/media', plural: 'mediaItems' },
-	{ name: 'taxonomy', kind: 'root', key: 'slug', baseUrl: '/wp/v2/taxonomies', plural: 'taxonomies' },
+	{ name: 'postType', kind: 'root', key: 'slug', baseURL: '/wp/v2/types' },
+	{ name: 'media', kind: 'root', baseURL: '/wp/v2/media', plural: 'mediaItems' },
+	{ name: 'taxonomy', kind: 'root', key: 'slug', baseURL: '/wp/v2/taxonomies', plural: 'taxonomies' },
 ];
 
 export const kinds = [
@@ -34,7 +34,7 @@ async function loadPostTypeEntities() {
 	return map( postTypes, ( postType, name ) => {
 		return {
 			kind: 'postType',
-			baseUrl: '/wp/v2/' + postType.rest_base,
+			baseURL: '/wp/v2/' + postType.rest_base,
 			name,
 		};
 	} );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -50,7 +50,7 @@ export async function* getEntityRecord( state, kind, name, key ) {
 	if ( ! entity ) {
 		return;
 	}
-	const record = await apiRequest( { path: `${ entity.baseUrl }/${ key }?context=edit` } );
+	const record = await apiRequest( { path: `${ entity.baseURL }/${ key }?context=edit` } );
 	yield receiveEntityRecords( kind, name, record );
 }
 
@@ -67,7 +67,7 @@ export async function* getEntityRecords( state, kind, name ) {
 	if ( ! entity ) {
 		return;
 	}
-	const records = await apiRequest( { path: `${ entity.baseUrl }?context=edit` } );
+	const records = await apiRequest( { path: `${ entity.baseURL }?context=edit` } );
 	yield receiveEntityRecords( kind, name, Object.values( records ) );
 }
 

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -80,7 +80,7 @@ describe( 'getKindEntities', () => {
 		const fulfillment = getKindEntities( state, 'postType' );
 		const received = ( await fulfillment.next() ).value;
 		expect( received ).toEqual( addEntities( [ {
-			baseUrl: '/wp/v2/posts',
+			baseURL: '/wp/v2/posts',
 			kind: 'postType',
 			name: 'post',
 		} ] ) );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -56,7 +56,7 @@ describe( 'getEntityRecord', () => {
 		const state = {
 			entities: {
 				config: [
-					{ name: 'postType', kind: 'root', baseUrl: '/wp/v2/types' },
+					{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
 				],
 			},
 		};
@@ -69,7 +69,7 @@ describe( 'getEntityRecord', () => {
 		const fulfillment = getEntityRecord( { entities: {} }, 'postType', 'post', 10 );
 		const receivedEntities = ( await fulfillment.next() ).value;
 		expect( receivedEntities ).toEqual( addEntities( [ {
-			baseUrl: '/wp/v2/posts',
+			baseURL: '/wp/v2/posts',
 			kind: 'postType',
 			name: 'post',
 		} ] ) );
@@ -96,7 +96,7 @@ describe( 'getEntityRecords', () => {
 		const state = {
 			entities: {
 				config: [
-					{ name: 'postType', kind: 'root', baseUrl: '/wp/v2/types' },
+					{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
 				],
 			},
 		};


### PR DESCRIPTION
This pull request seeks to effect new capitalization guidelines around abbreviations (#7670) toward an API freeze. It deprecates the `baseUrl` property of the `core-data` module entities in favor of the corrected `baseURL` naming. I had thought this may have been part of a public API, though I do not think that we expose this currently? (cc @youknowriad)

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Verify no regressions in the retrieval of entities data (unlikely editor would load at all if it was not working).