### PR TITLE
remove unnecessary default prop from test (inserter/test/menu.js)

### DIFF
--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -93,7 +93,6 @@ const items = [
 
 const DEFAULT_PROPS = {
 	position: 'top center',
-	instanceID: 1,
 	items: items,
 	debouncedSpeak: noop,
 	fetchSharedBlocks: noop,


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
See https://github.com/WordPress/gutenberg/pull/7773/files#r202718599 for comment raising this issue.  There is no necessity for this prop to be set because we aren’t testing anything explicitly requiring that prop.  Originally it was intended to mock the `instanceId` prop provided by the `withInstanceId` HOC but was implemented with an incorrect name.  As mentioned, its not needed at all so just removing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Verified test still passes locally.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
