### PR TITLE
Testing: Update test for babel-preset-default

### DIFF
--- a/packages/babel-preset-default/test/__snapshots__/index.js.snap
+++ b/packages/babel-preset-default/test/__snapshots__/index.js.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Babel preset default transpilation works properly 1`] = `
+"\\"use strict\\";
+
+require(\\"regenerator-runtime/runtime\\");
+
+require(\\"core-js/modules/es7.symbol.async-iterator\\");
+
+require(\\"core-js/modules/es6.symbol\\");
+
+require(\\"core-js/modules/es6.promise\\");
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err); } _next(undefined); }); }; }
+
+function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
+
+function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
+
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume(\\"next\\", arg); return; } settle(result.done ? \\"return\\" : \\"normal\\", arg); }, function (err) { resume(\\"throw\\", err); }); } catch (err) { settle(\\"throw\\", err); } } function settle(type, value) { switch (type) { case \\"return\\": front.resolve({ value: value, done: true }); break; case \\"throw\\": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== \\"function\\") { this.return = undefined; } }
+
+if (typeof Symbol === \\"function\\" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
+
+_AsyncGenerator.prototype.next = function (arg) { return this._invoke(\\"next\\", arg); };
+
+_AsyncGenerator.prototype.throw = function (arg) { return this._invoke(\\"throw\\", arg); };
+
+_AsyncGenerator.prototype.return = function (arg) { return this._invoke(\\"return\\", arg); };
+
+function _AwaitValue(value) { this.wrapped = value; }
+
+describe('Babel preset default', function () {
+  function foo() {
+    return _foo.apply(this, arguments);
+  }
+
+  function _foo() {
+    _foo = _wrapAsyncGenerator(
+    /*#__PURE__*/
+    regeneratorRuntime.mark(function _callee() {
+      return regeneratorRuntime.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.next = 2;
+              return _awaitAsyncGenerator(1);
+
+            case 2:
+              _context.next = 4;
+              return 2;
+
+            case 4:
+            case \\"end\\":
+              return _context.stop();
+          }
+        }
+      }, _callee, this);
+    }));
+    return _foo.apply(this, arguments);
+  }
+
+  test('support for async generator functions',
+  /*#__PURE__*/
+  _asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee2() {
+    var generator;
+    return regeneratorRuntime.wrap(function _callee2$(_context2) {
+      while (1) {
+        switch (_context2.prev = _context2.next) {
+          case 0:
+            generator = foo();
+            _context2.t0 = expect;
+            _context2.next = 4;
+            return generator.next();
+
+          case 4:
+            _context2.t1 = _context2.sent;
+            _context2.t2 = {
+              done: false,
+              value: 2
+            };
+            (0, _context2.t0)(_context2.t1).toEqual(_context2.t2);
+
+          case 7:
+          case \\"end\\":
+            return _context2.stop();
+        }
+      }
+    }, _callee2, this);
+  })));
+});"
+`;

--- a/packages/babel-preset-default/test/fixtures/input.js
+++ b/packages/babel-preset-default/test/fixtures/input.js
@@ -1,0 +1,15 @@
+describe( 'Babel preset default', () => {
+	async function* foo() {
+		await 1;
+		yield 2;
+	}
+
+	test( 'support for async generator functions', async () => {
+		const generator = foo();
+
+		expect( await generator.next() ).toEqual( {
+			done: false,
+			value: 2,
+		} );
+	} );
+} );

--- a/packages/babel-preset-default/test/index.js
+++ b/packages/babel-preset-default/test/index.js
@@ -1,15 +1,24 @@
+/**
+ * External dependencies
+ */
+import path from 'path';
+import { readFileSync } from 'fs';
+import { transform } from 'babel-core';
+
+/**
+ * Internal dependencies
+ */
+import babelPresetDefault from '../';
+
 describe( 'Babel preset default', () => {
-	async function* foo() {
-		await 1;
-		yield 2;
-	}
+	test( 'transpilation works properly', () => {
+		const input = readFileSync( path.join( __dirname, '/fixtures/input.js' ) );
 
-	test( 'support for async generator functions', async () => {
-		const generator = foo();
-
-		expect( await generator.next() ).toEqual( {
-			done: false,
-			value: 2,
+		const output = transform( input, {
+			configFile: false,
+			presets: [ babelPresetDefault ],
 		} );
+
+		expect( output.code ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description

This PR updates test for `babel-preset-default` package to be snapshot based to ensure that transpilation works as expected. This new approach was suggested by @aduth over the existing test case.

## How has this been tested?
`npm test`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
