### PR TITLE
Enhancements to the color mechanism in accordance with the latest changes

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -4,6 +4,9 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 
 - RichText `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.
 - RichText `onSetup` prop has been removed. The `unstableOnSetup` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.
+- `wp.editor.getColorName` has been removed. Please use `wp.editor.getColorObjectByColorValue` instead.
+- `wp.editor.getColorClass` has been renamed. Please use `wp.editor.getColorClassName` instead.
+- `value` property in color objects passed by `wp.editor.withColors` has been removed. Please use color property instead.
 
 ## 3.8.0
 

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -30,8 +30,8 @@ const { getComputedStyle } = window;
 
 const FallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	const { textColor, backgroundColor } = ownProps;
-	const backgroundColorValue = backgroundColor && backgroundColor.value;
-	const textColorValue = textColor && textColor.value;
+	const backgroundColorValue = backgroundColor && backgroundColor.color;
+	const textColorValue = textColor && textColor.color;
 	//avoid the use of querySelector if textColor color is known and verify if node is available.
 	const textNode = ! textColorValue && node ? node.querySelector( '[contenteditable="true"]' ) : null;
 	return {
@@ -84,15 +84,15 @@ class ButtonEdit extends Component {
 						formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
 						className={ classnames(
 							'wp-block-button__link', {
-								'has-background': backgroundColor.value,
+								'has-background': backgroundColor.color,
 								[ backgroundColor.class ]: backgroundColor.class,
-								'has-text-color': textColor.value,
+								'has-text-color': textColor.color,
 								[ textColor.class ]: textColor.class,
 							}
 						) }
 						style={ {
-							backgroundColor: backgroundColor.value,
-							color: textColor.value,
+							backgroundColor: backgroundColor.color,
+							color: textColor.color,
 						} }
 						keepPlaceholderOnFocus
 					/>
@@ -101,12 +101,12 @@ class ButtonEdit extends Component {
 							title={ __( 'Color Settings' ) }
 							colorSettings={ [
 								{
-									value: backgroundColor.value,
+									value: backgroundColor.color,
 									onChange: setBackgroundColor,
 									label: __( 'Background Color' ),
 								},
 								{
-									value: textColor.value,
+									value: textColor.color,
 									onChange: setTextColor,
 									label: __( 'Text Color' ),
 								},
@@ -115,8 +115,8 @@ class ButtonEdit extends Component {
 							<ContrastChecker
 								{ ...{
 									isLargeText: true,
-									textColor: textColor.value,
-									backgroundColor: backgroundColor.value,
+									textColor: textColor.color,
+									backgroundColor: backgroundColor.color,
 									fallbackBackgroundColor,
 									fallbackTextColor,
 								} }

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -10,7 +10,7 @@ import { omit, pick } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
-	getColorClass,
+	getColorClassName,
 } from '@wordpress/editor';
 
 /**
@@ -95,8 +95,8 @@ export const settings = {
 			customTextColor,
 		} = attributes;
 
-		const textClass = getColorClass( 'color', textColor );
-		const backgroundClass = getColorClass( 'background-color', backgroundColor );
+		const textClass = getColorClassName( 'color', textColor );
+		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
 		const buttonClasses = classnames( 'wp-block-button__link', {
 			'has-text-color': textColor || customTextColor,

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -175,12 +175,12 @@ class ParagraphBlock extends Component {
 						initialOpen={ false }
 						colorSettings={ [
 							{
-								value: backgroundColor.value,
+								value: backgroundColor.color,
 								onChange: setBackgroundColor,
 								label: __( 'Background Color' ),
 							},
 							{
-								value: textColor.value,
+								value: textColor.color,
 								onChange: setTextColor,
 								label: __( 'Text Color' ),
 							},
@@ -188,8 +188,8 @@ class ParagraphBlock extends Component {
 					>
 						<ContrastChecker
 							{ ...{
-								textColor: textColor.value,
-								backgroundColor: backgroundColor.value,
+								textColor: textColor.color,
+								backgroundColor: backgroundColor.color,
 								fallbackTextColor,
 								fallbackBackgroundColor,
 							} }
@@ -200,15 +200,15 @@ class ParagraphBlock extends Component {
 				<RichText
 					tagName="p"
 					className={ classnames( 'wp-block-paragraph', className, {
-						'has-background': backgroundColor.value,
+						'has-background': backgroundColor.color,
 						'has-drop-cap': dropCap,
 						[ backgroundColor.class ]: backgroundColor.class,
 						[ textColor.class ]: textColor.class,
 						[ fontSize.class ]: fontSize.class,
 					} ) }
 					style={ {
-						backgroundColor: backgroundColor.value,
-						color: textColor.value,
+						backgroundColor: backgroundColor.color,
+						color: textColor.color,
 						fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 						textAlign: align,
 					} }

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -12,7 +12,7 @@ import {
 	RawHTML,
 } from '@wordpress/element';
 import {
-	getColorClass,
+	getColorClassName,
 	getFontSizeClass,
 	RichText,
 } from '@wordpress/editor';
@@ -123,8 +123,8 @@ export const settings = {
 					customFontSize,
 				} = attributes;
 
-				const textClass = getColorClass( 'color', textColor );
-				const backgroundClass = getColorClass( 'background-color', backgroundColor );
+				const textClass = getColorClassName( 'color', textColor );
+				const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 				const fontSizeClass = fontSize && `is-${ fontSize }-text`;
 
 				const className = classnames( {
@@ -240,8 +240,8 @@ export const settings = {
 			customFontSize,
 		} = attributes;
 
-		const textClass = getColorClass( 'color', textColor );
-		const backgroundClass = getColorClass( 'background-color', backgroundColor );
+		const textClass = getColorClassName( 'color', textColor );
+		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 		const fontSizeClass = getFontSizeClass( fontSize );
 
 		const className = classnames( {

--- a/packages/editor/src/components/color-palette/control.js
+++ b/packages/editor/src/components/color-palette/control.js
@@ -10,13 +10,14 @@ import { sprintf, __ } from '@wordpress/i18n';
  */
 import ColorPalette from './';
 import withColorContext from './with-color-context';
-import { getColorName } from '../colors';
+import { getColorObjectByColorValue } from '../colors';
 
 // translators: first %s: The type of color (e.g. background color), second %s: the color name or value (e.g. red or #ff0000)
 const colorIndicatorAriaLabel = __( '(current %s: %s)' );
 
 export function ColorPaletteControl( { label, value, onChange, colors } ) {
-	const colorName = getColorName( colors, value );
+	const colorObject = getColorObjectByColorValue( colors, value );
+	const colorName = colorObject && colorObject.name;
 	const ariaLabel = sprintf( colorIndicatorAriaLabel, label.toLowerCase(), colorName || value );
 
 	const labelElement = (

--- a/packages/editor/src/components/colors/index.js
+++ b/packages/editor/src/components/colors/index.js
@@ -1,2 +1,8 @@
-export { getColorClass, getColorName } from './utils';
+export {
+	getColorClass,
+	getColorClassName,
+	getColorName,
+	getColorObjectByAttributeValues,
+	getColorObjectByColorValue,
+} from './utils';
 export { default as withColors } from './with-colors';

--- a/packages/editor/src/components/colors/utils.js
+++ b/packages/editor/src/components/colors/utils.js
@@ -4,24 +4,46 @@
 import { find, kebabCase } from 'lodash';
 
 /**
- * Returns the color value based on an array of named colors and the definedColor or the customColor value.
- *
- * @param {Array}   colors        Array of color objects containing the "name", "slug" and "color" value as properties.
- * @param {?string} definedColor  A string containing the color slug.
- * @param {?string} customColor   A string containing the customColor value.
- *
- * @return {?string} If definedColor is passed and the name is found in colors it returns the color for that name.
- * 					 Otherwise, the customColor parameter is returned.
+ * WordPress dependencies
  */
-export const getColorValue = ( colors, definedColor, customColor ) => {
+import deprecated from '@wordpress/deprecated';
+
+/**
+ * Provided an array of color objects as set by the theme or by the editor defaults,
+ * and the values of the defined color or custom color returns a color object describing the color.
+ *
+ * @param {Array}   colors       Array of color objects as set by the theme or by the editor defaults.
+ * @param {?string} definedColor A string containing the color slug.
+ * @param {?string} customColor  A string containing the customColor value.
+ *
+ * @return {?string} If definedColor is passed and the name is found in colors,
+ *                   the color object exactly as set by the theme or editor defaults is returned.
+ *                   Otherwise, an object that just sets the color is defined.
+ */
+export const getColorObjectByAttributeValues = ( colors, definedColor, customColor ) => {
 	if ( definedColor ) {
 		const colorObj = find( colors, { slug: definedColor } );
 
-		return colorObj && colorObj.color;
+		if ( colorObj ) {
+			return colorObj;
+		}
 	}
-	if ( customColor ) {
-		return customColor;
-	}
+	return {
+		color: customColor,
+	};
+};
+
+/**
+* Provided an array of color objects as set by the theme or by the editor defaults, and a color value returns the color object matching that value or undefined.
+*
+* @param {Array}   colors      Array of color objects as set by the theme or by the editor defaults.
+* @param {?string} colorValue  A string containing the color value.
+*
+* @return {?string} Returns the color object included in the colors array whose color property equals colorValue.
+*                   Returns undefined if no color object matches this requirement.
+*/
+export const getColorObjectByColorValue = ( colors, colorValue ) => {
+	return find( colors, { color: colorValue } );
 };
 
 /**
@@ -33,41 +55,36 @@ export const getColorValue = ( colors, definedColor, customColor ) => {
 * @return {?string} If colorValue is defined and matches a color part of the colors array, it returns the color name for that color.
 */
 export const getColorName = ( colors, colorValue ) => {
-	const colorObj = find( colors, { color: colorValue } );
+	deprecated( 'getColorName function', {
+		version: '3.9',
+		alternative: '`getColorObjectByColorValue` function',
+		plugin: 'Gutenberg',
+	} );
+	const colorObj = getColorObjectByColorValue( colors, colorValue );
 	return colorObj ? colorObj.name : undefined;
 };
 
 /**
- * Returns a function that receives the color value and sets it using the attribute for named colors or for custom colors.
- *
- * @param {Array}  colors                   Array of color objects containing the "name", "slug" and "color" value as properties.
- * @param {string} colorAttributeName       Name of the attribute where named colors are stored.
- * @param {string} customColorAttributeName Name of the attribute where custom colors are stored.
- * @param {string} setAttributes            A function that receives an object with the attributes to set.
- *
- * @return {function} A function that receives the color value and sets the attributes necessary to correctly store it.
- */
-export const setColorValue = ( colors, colorAttributeName, customColorAttributeName, setAttributes ) =>
-	( colorValue ) => {
-		const colorObj = find( colors, { color: colorValue } );
-		setAttributes( {
-			[ colorAttributeName ]: colorObj && colorObj.slug ? colorObj.slug : undefined,
-			[ customColorAttributeName ]: colorObj && colorObj.slug ? undefined : colorValue,
-		} );
-	};
-
-/**
- * Returns a class based on the context a color is being used and its name.
+ * Returns a class based on the context a color is being used and its slug.
  *
  * @param {string} colorContextName Context/place where color is being used e.g: background, text etc...
- * @param {string} colorName        Name of the color.
+ * @param {string} colorSlug        Slug of the color.
  *
  * @return {string} String with the class corresponding to the color in the provided context.
  */
-export function getColorClass( colorContextName, colorName ) {
-	if ( ! colorContextName || ! colorName ) {
+export function getColorClassName( colorContextName, colorSlug ) {
+	if ( ! colorContextName || ! colorSlug ) {
 		return;
 	}
 
-	return `has-${ kebabCase( colorName ) }-${ colorContextName }`;
+	return `has-${ kebabCase( colorSlug ) }-${ colorContextName }`;
+}
+
+export function getColorClass( colorContextName, colorSlug ) {
+	deprecated( 'getColorClass function', {
+		version: '3.9',
+		alternative: '`getColorClassName` function',
+		plugin: 'Gutenberg',
+	} );
+	return getColorClassName( colorContextName, colorSlug );
 }

--- a/packages/editor/src/components/panel-color-settings/index.js
+++ b/packages/editor/src/components/panel-color-settings/index.js
@@ -15,7 +15,7 @@ import { sprintf, __ } from '@wordpress/i18n';
  */
 import ColorPaletteControl from '../color-palette/control';
 import withColorContext from '../color-palette/with-color-context';
-import { getColorName } from '../colors';
+import { getColorObjectByColorValue } from '../colors';
 
 // translators: first %s: The type of color (e.g. background color), second %s: the color name or value (e.g. red or #ff0000)
 const colorIndicatorAriaLabel = __( '(%s: %s)' );
@@ -26,7 +26,8 @@ const renderColorIndicators = ( colorSettings, colors ) => {
 			return null;
 		}
 
-		const colorName = getColorName( colors, value );
+		const colorObject = getColorObjectByColorValue( colors, value );
+		const colorName = colorObject && colorObject.name;
 		const ariaLabel = sprintf( colorIndicatorAriaLabel, label.toLowerCase(), colorName || value );
 
 		return (

--- a/packages/editor/src/components/panel-color/index.js
+++ b/packages/editor/src/components/panel-color/index.js
@@ -14,10 +14,11 @@ import { ifCondition, compose } from '@wordpress/compose';
  */
 import ColorPalette from '../color-palette';
 import withColorContext from '../color-palette/with-color-context';
-import { getColorName } from '../colors';
+import { getColorObjectByColorValue } from '../colors';
 
 function PanelColor( { colors, title, colorValue, initialOpen, ...props } ) {
-	const colorName = getColorName( colors, colorValue );
+	const colorObject = getColorObjectByColorValue( colors, colorValue );
+	const colorName = colorObject && colorObject.name;
 	return (
 		<PanelColorComponent { ...{ title, colorName, colorValue, initialOpen } } >
 			<ColorPalette


### PR DESCRIPTION
BREAKING CHANGE (with back compatibility).

The color mechanism suffered many changes since it was created.  Namely the fact that now the identified for colors is not the name but a slug. 
This PR applies some changes to improve the code quality.
It also removes the deprecation logic that should be removed in this version.

It applies some changes to make sure withColors now passed all the information contained in the color object as set by the themes to the blocks using withColors HOC.

The breaking change is that now the color code passed in objects by withColors is named as "color" instead of "value".
That change was made because of two reasons:
- To be consistent with the withFontSizes HOC which name the font size value as size.
- To be consistent with the color object that themes set, which names the color code as color:

## How has this been tested?
Verify the colors of the button and paragraph continue to work as before.
