### PR TITLE
Shared blocks: Fix: Name field isn't focused when a shared block is created

### DIFF
--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -23,6 +23,13 @@ class SharedBlockEditPanel extends Component {
 		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
 	}
 
+	componentDidMount() {
+		// Select the input text when the form opens.
+		if ( this.props.isEditing && this.titleField.current ) {
+			this.titleField.current.select();
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		// Select the input text only once when the form opens.
 		if ( ! prevProps.isEditing && this.props.isEditing ) {


### PR DESCRIPTION
## Description
This PR makes sure when we use the option to convert to a shared block name field is automatically selected.
Before we had logic using componentDidUpdate but this logic was not used when the component is mounted so now we apply similar logic on the mount.
Fixes: https://github.com/WordPress/gutenberg/issues/7972


## How has this been tested?
Create a block
Click More Options and select Convert to Shared Block
Verify the name field is selected.
