### PR TITLE
Docs: Fix config and regenerate updated docs

### DIFF
--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -4,5 +4,5 @@
  - [**core/blocks**: Block Types Data](../../docs/data/data-core-blocks.md)
  - [**core/editor**: The Editor's Data](../../docs/data/data-core-editor.md)
  - [**core/edit-post**: The Editor's UI Data](../../docs/data/data-core-edit-post.md)
- - [**core/viewport**: The viewport module Data](../../docs/data/data-core-viewport.md)
- - [**core/nux**: The NUX (New User Experience) module Data](../../docs/data/data-core-nux.md)
+ - [**core/nux**: The NUX (New User Experience) Data](../../docs/data/data-core-nux.md)
+ - [**core/viewport**: The Viewport Data](../../docs/data/data-core-viewport.md)

--- a/docs/data/data-core-nux.md
+++ b/docs/data/data-core-nux.md
@@ -1,4 +1,4 @@
-# **core/nux**: The NUX (New User Experience) module Data
+# **core/nux**: The NUX (New User Experience) Data
 
 ## Selectors 
 

--- a/docs/data/data-core-viewport.md
+++ b/docs/data/data-core-viewport.md
@@ -1,4 +1,4 @@
-# **core/viewport**: The viewport module Data
+# **core/viewport**: The Viewport Data
 
 ## Selectors 
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -264,6 +264,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/compose",
+		"slug": "packages-compose",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/compose/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/core-data",
 		"slug": "packages-core-data",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/core-data/README.md",
@@ -315,6 +321,12 @@
 		"title": "@wordpress/hooks",
 		"slug": "packages-hooks",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/hooks/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/html-entities",
+		"slug": "packages-html-entities",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/html-entities/README.md",
 		"parent": "packages"
 	},
 	{
@@ -390,6 +402,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/viewport",
+		"slug": "packages-viewport",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/viewport/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/wordcount",
 		"slug": "packages-wordcount",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/wordcount/README.md",
@@ -432,18 +450,6 @@
 		"parent": "packages"
 	},
 	{
-		"title": "@wordpress/utils",
-		"slug": "packages-utils",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/utils/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/viewport",
-		"slug": "packages-viewport",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/viewport/README.md",
-		"parent": "packages"
-	},
-	{
 		"title": "Data Package Reference",
 		"slug": "data",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/README.md",
@@ -474,15 +480,15 @@
 		"parent": "data"
 	},
 	{
-		"title": "The viewport module Data",
-		"slug": "data-core-viewport",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/data-core-viewport.md",
+		"title": "The NUX (New User Experience) Data",
+		"slug": "data-core-nux",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/data-core-nux.md",
 		"parent": "data"
 	},
 	{
-		"title": "The NUX (New User Experience) module Data",
-		"slug": "data-core-nux",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/data-core-nux.md",
+		"title": "The Viewport Data",
+		"slug": "data-core-viewport",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/data-core-viewport.md",
 		"parent": "data"
 	}
 ]

--- a/docs/tool/config.js
+++ b/docs/tool/config.js
@@ -19,8 +19,6 @@ const gutenbergPackages = [
 	'edit-post',
 	'editor',
 	'nux',
-	'utils',
-	'viewport',
 ];
 
 module.exports = {
@@ -46,15 +44,15 @@ module.exports = {
 			selectors: [ path.resolve( root, 'edit-post/store/selectors.js' ) ],
 			actions: [ path.resolve( root, 'edit-post/store/actions.js' ) ],
 		},
-		'core/viewport': {
-			title: 'The viewport module Data',
-			selectors: [ path.resolve( root, 'viewport/store/selectors.js' ) ],
-			actions: [ path.resolve( root, 'viewport/store/actions.js' ) ],
-		},
 		'core/nux': {
-			title: 'The NUX (New User Experience) module Data',
+			title: 'The NUX (New User Experience) Data',
 			selectors: [ path.resolve( root, 'nux/store/selectors.js' ) ],
 			actions: [ path.resolve( root, 'nux/store/actions.js' ) ],
+		},
+		'core/viewport': {
+			title: 'The Viewport Data',
+			selectors: [ path.resolve( root, 'packages/viewport/src/store/selectors.js' ) ],
+			actions: [ path.resolve( root, 'packages/viewport/src/store/actions.js' ) ],
 		},
 	},
 	dataDocsOutput: path.resolve( __dirname, '../data' ),


### PR DESCRIPTION
## Description

Fixes the issue discovered by @aduth in https://github.com/WordPress/gutenberg/pull/7975#issuecomment-405351780:

> I think this may have broken `npm run docs:build`:
> 
> ```
> > gutenberg@3.2.0 docs:build /Users/andrew/Documents/Code/vvv/www/editor/htdocs/wp-content/plugins/gutenberg
> > node docs/tool
> 
> fs.js:646
>   return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
>                  ^
> 
> Error: ENOENT: no such file or directory, open '/Users/andrew/Documents/Code/vvv/www/editor/htdocs/wp-content/plugins/gutenberg/viewport/store/selectors.js'
>     at Object.fs.openSync (fs.js:646:18)
>     at Object.fs.readFileSync (fs.js:551:33)
>     at namespaceConfig.(anonymous function).forEach (/Users/andrew/Documents/Code/vvv/www/editor/htdocs/wp-content/plugins/gutenberg/docs/tool/parser.js:25:21)
>     at Array.forEach (<anonymous>)
>     at forEach (/Users/andrew/Documents/Code/vvv/www/editor/htdocs/wp-content/plugins/gutenberg/docs/tool/parser.js:24:28)
>     at Array.forEach (<anonymous>)
>     at Object.entries.forEach (/Users/andrew/Documents/Code/vvv/www/editor/htdocs/wp-content/plugins/gutenberg/docs/tool/parser.js:23:30)
>     at Array.forEach (<anonymous>)
>     at module.exports (/Users/andrew/Documents/Code/vvv/www/editor/htdocs/wp-content/plugins/gutenberg/docs/tool/parser.js:15:27)
>     at Object.<anonymous> (/Users/andrew/Documents/Code/vvv/www/editor/htdocs/wp-content/plugins/gutenberg/docs/tool/index.js:14:23)
> ```

This PR also regenerates docs after config was updated to reflect the current state of packages.