### PR TITLE
Add a function to register a block style variation

### DIFF
--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -41,6 +41,7 @@ export {
 	getChildBlockNames,
 	hasChildBlocks,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
+	registerBlockStyle,
 } from './registration';
 export {
 	isUnmodifiedDefaultBlock,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -312,7 +312,7 @@ export function isSharedBlock( blockOrType ) {
 /**
  * Returns an array with the child blocks of a given block.
  *
- * @param {string} blockName Block type name.
+ * @param {string} blockName Name of block (example: “latest-posts”).
  *
  * @return {Array} Array of child block names.
  */
@@ -323,7 +323,7 @@ export const getChildBlockNames = ( blockName ) => {
 /**
  * Returns a boolean indicating if a block has child blocks or not.
  *
- * @param {string} blockName Block type name.
+ * @param {string} blockName Name of block (example: “latest-posts”).
  *
  * @return {boolean} True if a block contains child blocks and false otherwise.
  */
@@ -332,10 +332,10 @@ export const hasChildBlocks = ( blockName ) => {
 };
 
 /**
- * Registers a new block style variation for the given block
+ * Registers a new block style variation for the given block.
  *
- * @param {string} blockName      Block type name.
- * @param {Object} styleVariation Block style variation.
+ * @param {string} blockName      Name of block (example: “core/latest-posts”).
+ * @param {Object} styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
  */
 export const registerBlockStyleVariation = ( blockName, styleVariation ) => {
 	addFilter( 'blocks.registerBlockType', blockName + '/' + styleVariation.name, ( settings, name ) => {

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -337,7 +337,7 @@ export const hasChildBlocks = ( blockName ) => {
  * @param {string} blockName      Name of block (example: “core/latest-posts”).
  * @param {Object} styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
  */
-export const registerBlockStyleVariation = ( blockName, styleVariation ) => {
+export const registerBlockStyle = ( blockName, styleVariation ) => {
 	addFilter( 'blocks.registerBlockType', blockName + '/' + styleVariation.name, ( settings, name ) => {
 		if ( blockName !== name ) {
 			return settings;

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -338,7 +338,7 @@ export const hasChildBlocks = ( blockName ) => {
  * @param {Object} styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
  */
 export const registerBlockStyle = ( blockName, styleVariation ) => {
-	addFilter( 'blocks.registerBlockType', blockName + '/' + styleVariation.name, ( settings, name ) => {
+	addFilter( 'blocks.registerBlockType', `${ blockName }/${ styleVariation.name }`, ( settings, name ) => {
 		if ( blockName !== name ) {
 			return settings;
 		}

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -8,7 +8,7 @@ import { get, isFunction, some } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { applyFilters } from '@wordpress/hooks';
+import { applyFilters, addFilter } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
 
 /**
@@ -329,4 +329,26 @@ export const getChildBlockNames = ( blockName ) => {
  */
 export const hasChildBlocks = ( blockName ) => {
 	return select( 'core/blocks' ).hasChildBlocks( blockName );
+};
+
+/**
+ * Registers a new block style variation for the given block
+ *
+ * @param {string} blockName      Block type name.
+ * @param {Object} styleVariation Block style variation.
+ */
+export const registerBlockStyleVariation = ( blockName, styleVariation ) => {
+	addFilter( 'blocks.registerBlockType', blockName + '/' + styleVariation.name, ( settings, name ) => {
+		if ( blockName !== name ) {
+			return settings;
+		}
+
+		return {
+			...settings,
+			styles: [
+				...get( settings, [ 'styles' ], [] ),
+				styleVariation,
+			],
+		};
+	} );
 };

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -24,7 +24,7 @@ import {
 	hasBlockSupport,
 	isSharedBlock,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
-	registerBlockStyleVariation,
+	registerBlockStyle,
 } from '../registration';
 
 describe( 'blocks', () => {
@@ -597,14 +597,14 @@ describe( 'blocks', () => {
 		} );
 	} );
 
-	describe( 'registerBlockStyleVariation', () => {
+	describe( 'registerBlockStyle', () => {
 		afterEach( () => {
 			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-without-styles/big' );
 			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-without-styles/small' );
 		} );
 
 		it( 'should add styles', () => {
-			registerBlockStyleVariation( 'my-plugin/block-without-styles', { name: 'big', label: 'Big style' } );
+			registerBlockStyle( 'my-plugin/block-without-styles', { name: 'big', label: 'Big style' } );
 			const settings = registerBlockType( 'my-plugin/block-without-styles', defaultBlockSettings );
 
 			expect( settings.styles ).toEqual( [
@@ -613,8 +613,8 @@ describe( 'blocks', () => {
 		} );
 
 		it( 'should accumulate styles', () => {
-			registerBlockStyleVariation( 'my-plugin/block-without-styles', { name: 'small', label: 'Small style' } );
-			registerBlockStyleVariation( 'my-plugin/block-without-styles', { name: 'big', label: 'Big style' } );
+			registerBlockStyle( 'my-plugin/block-without-styles', { name: 'small', label: 'Small style' } );
+			registerBlockStyle( 'my-plugin/block-without-styles', { name: 'big', label: 'Big style' } );
 			const settings = registerBlockType( 'my-plugin/block-without-styles', {
 				...defaultBlockSettings,
 				styles: [ { name: 'normal', label: 'Normal style' } ],

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -24,6 +24,7 @@ import {
 	hasBlockSupport,
 	isSharedBlock,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
+	registerBlockStyleVariation,
 } from '../registration';
 
 describe( 'blocks', () => {
@@ -593,6 +594,37 @@ describe( 'blocks', () => {
 		it( 'should return false for other blocks', () => {
 			const block = { name: 'core/paragraph' };
 			expect( isSharedBlock( block ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'registerBlockStyleVariation', () => {
+		afterEach( () => {
+			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-without-styles/big' );
+			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-without-styles/small' );
+		} );
+
+		it( 'should add styles', () => {
+			registerBlockStyleVariation( 'my-plugin/block-without-styles', { name: 'big', label: 'Big style' } );
+			const settings = registerBlockType( 'my-plugin/block-without-styles', defaultBlockSettings );
+
+			expect( settings.styles ).toEqual( [
+				{ name: 'big', label: 'Big style' },
+			] );
+		} );
+
+		it( 'should accumulate styles', () => {
+			registerBlockStyleVariation( 'my-plugin/block-without-styles', { name: 'small', label: 'Small style' } );
+			registerBlockStyleVariation( 'my-plugin/block-without-styles', { name: 'big', label: 'Big style' } );
+			const settings = registerBlockType( 'my-plugin/block-without-styles', {
+				...defaultBlockSettings,
+				styles: [ { name: 'normal', label: 'Normal style' } ],
+			} );
+
+			expect( settings.styles ).toEqual( [
+				{ name: 'normal', label: 'Normal style' },
+				{ name: 'small', label: 'Small style' },
+				{ name: 'big', label: 'Big style' },
+			] );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a helper function to easily add a new block style variation as this is a common extensibility pattern.

**Testing instructions**

 - add `wp.blocks. registerBlockStyle( 'core/paragraph', { name: 'big', label: 'Big Style' })`
 - The call should be executed before the initialization of the editor (`registerCoreBlocks`)
 - Notice the new style variation appearing in the paragraph block's switcher.

Related #7551