### PR TITLE
Add link to support forum

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -65,6 +65,12 @@ function gutenberg_menu() {
 
 	if ( current_user_can( 'edit_posts' ) ) {
 		$submenu['gutenberg'][] = array(
+			__( 'Support', 'gutenberg' ),
+			'edit_posts',
+			__( ' https://wordpress.org/support/plugin/gutenberg', 'gutenberg' ),
+		);
+
+		$submenu['gutenberg'][] = array(
 			__( 'Feedback', 'gutenberg' ),
 			'edit_posts',
 			'http://wordpressdotorg.polldaddy.com/s/gutenberg-support',

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -67,7 +67,7 @@ function gutenberg_menu() {
 		$submenu['gutenberg'][] = array(
 			__( 'Support', 'gutenberg' ),
 			'edit_posts',
-			__( ' https://wordpress.org/support/plugin/gutenberg', 'gutenberg' ),
+			__( 'https://wordpress.org/support/plugin/gutenberg', 'gutenberg' ),
 		);
 
 		$submenu['gutenberg'][] = array(


### PR DESCRIPTION
## Description
This PR adds a `Support` (https://wordpress.org/support/plugin/gutenberg) link to the Gutenberg submenu. 
Related: #7900

## Screenshots
![bildschirmfoto 2018-07-17 um 13 04 46](https://user-images.githubusercontent.com/695201/42813777-5d14ddb6-89c2-11e8-9e97-f21e47e3b200.png)

