### PR TITLE
Core Blocks: Fix: Subhead enter behaviour; Add: Split and merge functions;

### DIFF
--- a/core-blocks/subhead/index.js
+++ b/core-blocks/subhead/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { concatChildren, Fragment } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import {
 	RichText,
@@ -67,7 +67,7 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, className } ) {
+	edit( { attributes, setAttributes, className, insertBlocksAfter, mergeBlocks } ) {
 		const { align, content, placeholder } = attributes;
 
 		return (
@@ -91,6 +91,18 @@ export const settings = {
 					style={ { textAlign: align } }
 					className={ className }
 					placeholder={ placeholder || __( 'Write subheading…' ) }
+					onMerge={ mergeBlocks }
+					onSplit={
+						insertBlocksAfter ?
+							( before, after, ...blocks ) => {
+								setAttributes( { content: before } );
+								insertBlocksAfter( [
+									...blocks,
+									createBlock( 'core/paragraph', { content: after } ),
+								] );
+							} :
+							undefined
+					}
 				/>
 			</Fragment>
 		);
@@ -107,5 +119,11 @@ export const settings = {
 				value={ content }
 			/>
 		);
+	},
+
+	merge( attributes, attributesToMerge ) {
+		return {
+			content: concatChildren( attributes.content, attributesToMerge.content ),
+		};
 	},
 };


### PR DESCRIPTION
This PR adds onSplit and onMerge logic, this makes sure when enter is pressed on subhead a new paragraph is created instead of adding a new line. When pressing backspace on a paragraph with a subhead before it now we add the content of the paragraph to the subhead.


Fixes: https://github.com/WordPress/gutenberg/issues/7871, https://github.com/WordPress/gutenberg/issues/5475.


## How has this been tested?
Add a subhead press enter verify a new paragraph is created.
Add a subhead add some content press enter in the middle, verify the content was divided between the subhead and a new paragraph.
Add a subhead with some content. Add a paragraph below the subhead with some content. Press backspace on the paragraph and verify the contents of the paragraph were appended to the subhead.
