### PR TITLE
[Enhancement] Change color of links in gallery block caption

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -77,6 +77,16 @@
 			border: $border-width solid $dark-gray-500;
 		}
 	}
+
+	.editor-rich-text .editor-rich-text__tinymce {
+		a {
+			color: #fff;
+		}
+
+		&:focus a[data-mce-selected] {
+			color: #007FAC;
+		}
+	}
 }
 
 .block-library-gallery-item__inline-menu {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -84,7 +84,7 @@
 		}
 
 		&:focus a[data-mce-selected] {
-			color: rgba(0,0,0,0.2);
+			color: rgba(0, 0, 0, 0.2);
 		}
 	}
 }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -80,11 +80,11 @@
 
 	.editor-rich-text .editor-rich-text__tinymce {
 		a {
-			color: #fff;
+			color: $white;
 		}
 
 		&:focus a[data-mce-selected] {
-			color: #007FAC;
+			color: rgba(0,0,0,0.2);
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR addresses #7952 which reports the low readability links in image captions in the gallery block against the dark gradient background. This changes the default blue link color to white so that it is readable.

## How has this been tested?
This has been tested by making sure the link color is white so that it is well readable against the dark gradient background, which turns to blue when the link background is changed to white when it is focused.

This was tested in WP 4.9.7, Gutenberg 3.2.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-7952-min](https://user-images.githubusercontent.com/20284937/42827200-bb9562da-8a07-11e8-9d33-4bce1a929165.gif)

## Types of changes
This PR just adds CSS specific to the gallery block editor which changes the link color to white, and blue when it is focused, i.e. when the background turns white.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
