### PR TITLE
Additional keyboard shortcuts for the navigateRegions component

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -67,7 +67,9 @@ export default createHigherOrderComponent(
 							bindGlobal
 							shortcuts={ {
 								'ctrl+`': this.focusNextRegion,
+								'shift+alt+n': this.focusNextRegion,
 								'ctrl+shift+`': this.focusPreviousRegion,
+								'shift+alt+p': this.focusPreviousRegion,
 							} }
 						/>
 						<WrappedComponent { ...this.props } />


### PR DESCRIPTION
## Description

This PR adds additional keyboard shortcuts to navigate through the `navigateRegions` sections. See the related issue #3218 where testing with different keyboard layouts proved the current shortcut `Ctrl+backtick` is not usable with all keyboard layouts. At the very least, the backtick key is not available on the Italian, Dutch, Finnish, French, and likely more keyboard layouts.

The additional shortcuts are:
- `shift+alt+n` to go to the next region
- `shift+alt+p` to go to the previous region
- the previous shortcuts are preserved

I've tested this on the following browsers:
- Mac: Firefox, Chrome, Safari, Opera
- Windows 10: Firefox, Chrome, Edge, IE11

and the new shortcuts seem to work without any conflict. Pending some more testing from the a11y team and anyone willing to test 🙂Some testing on a GNU-Linux distro would be nice.

If / when merged, I'd suggest to move #3218 to the accessibility Project instead of closing it, as the original idea of providing a mechanism to re-map and customize the keyboard shortcuts could be a nice improvement for the future.
