### PR TITLE
Fix: Multiple block warning min height.

### DIFF
--- a/edit-post/hooks/validate-multiple-use/index.js
+++ b/edit-post/hooks/validate-multiple-use/index.js
@@ -69,7 +69,7 @@ const withMultipleValidation = createHigherOrderComponent( ( BlockEdit ) => {
 		const outboundType = getOutboundType( props.name );
 
 		return [
-			<div key="invalid-preview" style={ { minHeight: '100px' } }>
+			<div key="invalid-preview" style={ { minHeight: '60px' } }>
 				<BlockEdit key="block-edit" { ...props } />
 			</div>,
 			<Warning


### PR DESCRIPTION
## Description
The min-height style, for multiple block warnings, was not correct and the design was not right.

## How has this been tested?
I pasted the following string in the code editor:
```
<!-- wp:subhead -->
<p class="wp-block-subhead">Subhead 1</p>
<!-- /wp:subhead -->

<!-- wp:subhead -->
<p class="wp-block-subhead">Subhead 2</p>
<!-- /wp:subhead -->
```
I checked the design of the multiple block warning looks good.

## Screenshots <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/11271197/43593880-d50af782-9670-11e8-912b-ff2c37483ebc.png)



After:

![image](https://user-images.githubusercontent.com/11271197/43593873-cf9b7826-9670-11e8-96a5-f92898f30438.png)
