### PR TITLE
[Fix] Top margin for notices in block sidebar

### DIFF
--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -56,7 +56,7 @@
 		}
 	}
 
-	p {
+	div:not(.notice) > p {
 		margin-top: 0;
 	}
 


### PR DESCRIPTION
## Description
This PR addresses #7935 which reports the unavailability of the top margin for notices in the block sidebar due to [this rule](https://github.com/WordPress/gutenberg/blob/f920f2d36ed3f97e6a6ae85dcbd11e67462fd41b/edit-post/components/sidebar/style.scss#L59-L61).

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added a paragraph block with some text.
3. Set the background and text to the same color to trigger the contrast checker notice.
4. Made sure there's correct top margin in the notice.

This was tested in WP 4.9.7, Gutenberg 3.2.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
<img width="1147" alt="pull-7935" src="https://user-images.githubusercontent.com/20284937/42832081-e80b8cd6-8a11-11e8-9e51-06d6b51f232d.png">

## Types of changes
This PR modifies the [mentioned rule](https://github.com/WordPress/gutenberg/blob/f920f2d36ed3f97e6a6ae85dcbd11e67462fd41b/edit-post/components/sidebar/style.scss#L59-L61) so that it only applies if its parent `div` doesn't have the `.notice` class.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
