### PR TITLE
Block Movers: Hide movers if there are no blocks before and after.

### DIFF
--- a/packages/editor/src/components/block-mover/index.js
+++ b/packages/editor/src/components/block-mover/index.js
@@ -47,7 +47,7 @@ export class BlockMover extends Component {
 		const { onMoveUp, onMoveDown, isFirst, isLast, clientIds, blockType, firstIndex, isLocked, instanceId, isHidden } = this.props;
 		const { isFocused } = this.state;
 		const blocksCount = castArray( clientIds ).length;
-		if ( isLocked ) {
+		if ( isLocked || ( isFirst && isLast ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
## Description
If there are no blocks before or after the group of selected blocks, it is not possible to move the blocks anywhere.
In that case, we should not show the movers. Not showing the movers for this cases makes the UI cleaner in nested contexts as discovered in https://github.com/WordPress/gutenberg/pull/7414.

## How has this been tested?
I added Added a single paragraph and verified the movers did not appear.
I multi-selected some blocks without having non selected blocks before and after and verified the movers did not appear.
I repeated the tests for blocks inside a column.
I checked that when blocks could be moved the movers appear.

