### PR TITLE
chore: Improve eslint checks for deep imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,16 +35,15 @@ module.exports = {
 		'no-restricted-syntax': [
 			'error',
 			// NOTE: We can't include the forward slash in our regex or
-			// we'll get a `SyntaxError`
-			// (Invalid regular expression: \ at end of pattern)
-			// here. That's why we use \\u002F in the regexs below.
+			// we'll get a `SyntaxError` (Invalid regular expression: \ at end of pattern)
+			// here. That's why we use \\u002F in the regexes below.
 			{
 				selector: 'ImportDeclaration[source.value=/^@wordpress\\u002F.+\\u002F/]',
 				message: 'Path access on WordPress dependencies is not allowed.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^api-request(\\u002F|$)/]',
-				message: 'Use @wordpress/api-request as import path instead.',
+				selector: 'ImportDeclaration[source.value=/^api-fetch(\\u002F|$)/]',
+				message: 'Use @wordpress/api-fetch as import path instead.',
 			},
 			{
 				selector: 'ImportDeclaration[source.value=/^blob(\\u002F|$)/]',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,68 +34,72 @@ module.exports = {
 	rules: {
 		'no-restricted-syntax': [
 			'error',
+			// NOTE: We can't include the forward slash in our regex or
+			// we'll get a `SyntaxError`
+			// (Invalid regular expression: \ at end of pattern)
+			// here. That's why we use \\u002F in the regexs below.
 			{
 				selector: 'ImportDeclaration[source.value=/^@wordpress\\u002F.+\\u002F/]',
 				message: 'Path access on WordPress dependencies is not allowed.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^api-fetch$/]',
-				message: 'Use @wordpress/api-fetch as import path instead.',
+				selector: 'ImportDeclaration[source.value=/^api-request(\\u002F|$)/]',
+				message: 'Use @wordpress/api-request as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^blob$/]',
+				selector: 'ImportDeclaration[source.value=/^blob(\\u002F|$)/]',
 				message: 'Use @wordpress/blob as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^blocks$/]',
+				selector: 'ImportDeclaration[source.value=/^blocks(\\u002F|$)/]',
 				message: 'Use @wordpress/blocks as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^components$/]',
+				selector: 'ImportDeclaration[source.value=/^components(\\u002F|$)/]',
 				message: 'Use @wordpress/components as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^data$/]',
+				selector: 'ImportDeclaration[source.value=/^data(\\u002F|$)/]',
 				message: 'Use @wordpress/data as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^date$/]',
+				selector: 'ImportDeclaration[source.value=/^date(\\u002F|$)/]',
 				message: 'Use @wordpress/date as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^deprecated$/]',
+				selector: 'ImportDeclaration[source.value=/^deprecated(\\u002F|$)/]',
 				message: 'Use @wordpress/deprecated as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^dom$/]',
+				selector: 'ImportDeclaration[source.value=/^dom(\\u002F|$)/]',
 				message: 'Use @wordpress/dom as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^editor$/]',
+				selector: 'ImportDeclaration[source.value=/^editor(\\u002F|$)/]',
 				message: 'Use @wordpress/editor as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^element$/]',
+				selector: 'ImportDeclaration[source.value=/^element(\\u002F|$)/]',
 				message: 'Use @wordpress/element as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^keycodes$/]',
+				selector: 'ImportDeclaration[source.value=/^keycodes(\\u002F|$)/]',
 				message: 'Use @wordpress/keycodes as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^utils$/]',
+				selector: 'ImportDeclaration[source.value=/^utils(\\u002F|$)/]',
 				message: 'Use @wordpress/utils as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^edit-post$/]',
+				selector: 'ImportDeclaration[source.value=/^edit-post(\\u002F|$)/]',
 				message: 'Use @wordpress/edit-post as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^viewport$/]',
+				selector: 'ImportDeclaration[source.value=/^viewport(\\u002F|$)/]',
 				message: 'Use @wordpress/viewport as import path instead.',
 			},
 			{
-				selector: 'ImportDeclaration[source.value=/^plugins$/]',
+				selector: 'ImportDeclaration[source.value=/^plugins(\\u002F|$)/]',
 				message: 'Use @wordpress/plugins as import path instead.',
 			},
 			{


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/pull/7941#discussion_r203129769

I tested this locally with the existing codebase; it threw no errors but adding either:

* `import { DEFAULT_CONTROLS } from 'editor/components/block-alignment-toolbar';`
* `import { DEFAULT_CONTROLS } from 'editor';`

would cause errors, which is the intended effect.