### PR TITLE
Blocks: Use do_blocks to render core blocks content

### DIFF
--- a/core-blocks/block/index.php
+++ b/core-blocks/block/index.php
@@ -22,14 +22,7 @@ function render_block_core_block( $attributes ) {
 		return '';
 	}
 
-	$blocks = gutenberg_parse_blocks( $shared_block->post_content );
-
-	$block = array_shift( $blocks );
-	if ( ! $block ) {
-		return '';
-	}
-
-	return gutenberg_render_block( $block );
+	return do_blocks( $shared_block->post_content );
 }
 
 register_block_type( 'core/block', array(


### PR DESCRIPTION
Fixes #6662 

This pull request seeks to resolve an issue where shared blocks which contain InnerBlocks content (e.g. Columns) would not render its content on the front-end.

**Implementation notes:**

The root cause is that we were parsing the content as blocks and relying on the parsed block's `innerHTML` to be the render output. For nested blocks, the `innerHTML` does not include its child block contents. It is also not possible to reconstruct this block on the server.

Instead, the approach here simply treats the shared block's content as if it were a post containing blocks, leveraging the `do_blocks` function to pass its content string. This should support not only inner blocks, but also dynamic block replacement (e.g. shared blocks in shared blocks).

This may also have a performance benefit, avoiding a costly full content parse in lieu of `do_blocks` simpler implementation.

**Testing instructions:**

Repeat steps to reproduce from #6662, noting there are no issues in the display of the shared Columns block on the front-end of the site.