### PR TITLE
Tags autocompleter keyboard interaction improvements.

### DIFF
--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
+import { BACKSPACE, ENTER, UP, DOWN, LEFT, RIGHT, SPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -105,31 +106,35 @@ class FormTokenField extends Component {
 		let preventDefault = false;
 
 		switch ( event.keyCode ) {
-			case 8: // backspace (delete to left)
+			case BACKSPACE:
 				preventDefault = this.handleDeleteKey( this.deleteTokenBeforeInput );
 				break;
-			case 13: // enter/return
+			case ENTER:
 				preventDefault = this.addCurrentToken();
 				break;
-			case 37: // left arrow
+			case LEFT:
 				preventDefault = this.handleLeftArrowKey();
 				break;
-			case 38: // up arrow
+			case UP:
 				preventDefault = this.handleUpArrowKey();
 				break;
-			case 39: // right arrow
+			case RIGHT:
 				preventDefault = this.handleRightArrowKey();
 				break;
-			case 40: // down arrow
+			case DOWN:
 				preventDefault = this.handleDownArrowKey();
 				break;
-			case 46: // delete (to right)
+			case DELETE:
 				preventDefault = this.handleDeleteKey( this.deleteTokenAfterInput );
 				break;
-			case 32: // space
+			case SPACE:
 				if ( this.props.tokenizeOnSpace ) {
 					preventDefault = this.addCurrentToken();
 				}
+				break;
+			case ESCAPE:
+				preventDefault = this.handleEscapeKey();
+				event.stopPropagation();
 				break;
 			default:
 				break;
@@ -251,8 +256,16 @@ class FormTokenField extends Component {
 	}
 
 	handleUpArrowKey() {
-		this.setState( ( state ) => ( {
-			selectedSuggestionIndex: Math.max( ( state.selectedSuggestionIndex || 0 ) - 1, 0 ),
+		this.setState( ( state, props ) => ( {
+			selectedSuggestionIndex: (
+				( state.selectedSuggestionIndex === 0 ? this.getMatchingSuggestions(
+					state.incompleteTokenValue,
+					props.suggestions,
+					props.value,
+					props.maxSuggestions,
+					props.saveTransform
+				).length : state.selectedSuggestionIndex ) - 1
+			),
 			selectedSuggestionScroll: true,
 		} ) );
 
@@ -261,19 +274,23 @@ class FormTokenField extends Component {
 
 	handleDownArrowKey() {
 		this.setState( ( state, props ) => ( {
-			selectedSuggestionIndex: Math.min(
-				( state.selectedSuggestionIndex + 1 ) || 0,
-				this.getMatchingSuggestions(
+			selectedSuggestionIndex: (
+				( state.selectedSuggestionIndex + 1 ) % this.getMatchingSuggestions(
 					state.incompleteTokenValue,
 					props.suggestions,
 					props.value,
 					props.maxSuggestions,
 					props.saveTransform
-				).length - 1
+				).length
 			),
 			selectedSuggestionScroll: true,
 		} ) );
 
+		return true; // preventDefault
+	}
+
+	handleEscapeKey() {
+		this.setState( initialState );
 		return true; // preventDefault
 	}
 

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -27,7 +27,6 @@ const initialState = {
 	isExpanded: false,
 	selectedSuggestionIndex: -1,
 	selectedSuggestionScroll: false,
-	showSuggestions: false,
 };
 
 class FormTokenField extends Component {
@@ -207,7 +206,6 @@ class FormTokenField extends Component {
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
 			isExpanded: false,
-			showSuggestions: false,
 		} );
 
 		this.props.onInputChange( tokenValue );
@@ -215,7 +213,6 @@ class FormTokenField extends Component {
 		if ( inputHasMinimumChars ) {
 			this.setState( {
 				isExpanded: hasVisibleSuggestions,
-				showSuggestions: hasVisibleSuggestions,
 			} );
 
 			if ( !! matchingSuggestions.length ) {
@@ -300,7 +297,6 @@ class FormTokenField extends Component {
 			isExpanded: false,
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
-			showSuggestions: false,
 		} );
 		return true; // preventDefault
 	}
@@ -391,7 +387,6 @@ class FormTokenField extends Component {
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
 			isExpanded: false,
-			showSuggestions: false,
 		} );
 
 		if ( this.state.isActive ) {
@@ -540,7 +535,7 @@ class FormTokenField extends Component {
 			instanceId,
 			className,
 		} = this.props;
-		const { showSuggestions } = this.state;
+		const { isExpanded } = this.state;
 		const classes = classnames( className, 'components-form-token-field', {
 			'is-active': this.state.isActive,
 			'is-disabled': disabled,
@@ -578,7 +573,7 @@ class FormTokenField extends Component {
 					{ this.renderTokensAndInput() }
 				</div>
 
-				{ showSuggestions && (
+				{ isExpanded && (
 					<SuggestionsList
 						instanceId={ instanceId }
 						match={ this.props.saveTransform( this.state.incompleteTokenValue ) }

--- a/packages/components/src/form-token-field/test/index.js
+++ b/packages/components/src/form-token-field/test/index.js
@@ -118,12 +118,16 @@ describe( 'FormTokenField', function() {
 
 	describe( 'displaying tokens', function() {
 		it( 'should render default tokens', function() {
+			wrapper.setState( {
+				showSuggestions: true,
+			} );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should display tokens with escaped special characters properly', function() {
 			wrapper.setState( {
 				tokens: fixtures.specialTokens.textEscaped,
+				showSuggestions: true,
 			} );
 			expect( getTokensHTML() ).toEqual( fixtures.specialTokens.htmlEscaped );
 		} );
@@ -137,6 +141,7 @@ describe( 'FormTokenField', function() {
 			// through unescaped to the HTML.
 			wrapper.setState( {
 				tokens: fixtures.specialTokens.textUnescaped,
+				showSuggestions: true,
 			} );
 			expect( getTokensHTML() ).toEqual( fixtures.specialTokens.htmlUnescaped );
 		} );
@@ -144,6 +149,9 @@ describe( 'FormTokenField', function() {
 
 	describe( 'suggestions', function() {
 		it( 'should not render suggestions unless we type at least two characters', function() {
+			wrapper.setState( {
+				showSuggestions: true,
+			} );
 			expect( getSuggestionsText() ).toEqual( [] );
 			setText( 'th' );
 			expect( getSuggestionsText() ).toEqual( fixtures.matchingSuggestions.th );
@@ -157,23 +165,28 @@ describe( 'FormTokenField', function() {
 		} );
 
 		it( 'suggestions that begin with match are boosted', function() {
+			wrapper.setState( {
+				showSuggestions: true,
+			} );
 			setText( 'so' );
 			expect( getSuggestionsText() ).toEqual( fixtures.matchingSuggestions.so );
 		} );
 
 		it( 'should match against the unescaped values of suggestions with special characters', function() {
-			setText( '& S' );
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
+				showSuggestions: true,
 			} );
+			setText( '& S' );
 			expect( getSuggestionsText() ).toEqual( fixtures.specialSuggestions.matchAmpersandUnescaped );
 		} );
 
 		it( 'should match against the unescaped values of suggestions with special characters (including spaces)', function() {
-			setText( 's &' );
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
+				showSuggestions: true,
 			} );
+			setText( 's &' );
 			expect( getSuggestionsText() ).toEqual( fixtures.specialSuggestions.matchAmpersandSequence );
 		} );
 
@@ -181,16 +194,23 @@ describe( 'FormTokenField', function() {
 			setText( 'amp' );
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
+				showSuggestions: true,
 			} );
 			expect( getSuggestionsText() ).toEqual( fixtures.specialSuggestions.matchAmpersandEscaped );
 		} );
 
 		it( 'should match suggestions even with trailing spaces', function() {
+			wrapper.setState( {
+				showSuggestions: true,
+			} );
 			setText( '  at  ' );
 			expect( getSuggestionsText() ).toEqual( fixtures.matchingSuggestions.at );
 		} );
 
 		it( 'should manage the selected suggestion based on both keyboard and mouse events', function() {
+			wrapper.setState( {
+				showSuggestions: true,
+			} );
 			setText( 'th' );
 			expect( getSuggestionsText() ).toEqual( fixtures.matchingSuggestions.th );
 			expect( getSelectedSuggestion() ).toBe( null );

--- a/packages/components/src/form-token-field/test/index.js
+++ b/packages/components/src/form-token-field/test/index.js
@@ -119,7 +119,7 @@ describe( 'FormTokenField', function() {
 	describe( 'displaying tokens', function() {
 		it( 'should render default tokens', function() {
 			wrapper.setState( {
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
@@ -127,7 +127,7 @@ describe( 'FormTokenField', function() {
 		it( 'should display tokens with escaped special characters properly', function() {
 			wrapper.setState( {
 				tokens: fixtures.specialTokens.textEscaped,
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			expect( getTokensHTML() ).toEqual( fixtures.specialTokens.htmlEscaped );
 		} );
@@ -141,7 +141,7 @@ describe( 'FormTokenField', function() {
 			// through unescaped to the HTML.
 			wrapper.setState( {
 				tokens: fixtures.specialTokens.textUnescaped,
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			expect( getTokensHTML() ).toEqual( fixtures.specialTokens.htmlUnescaped );
 		} );
@@ -150,7 +150,7 @@ describe( 'FormTokenField', function() {
 	describe( 'suggestions', function() {
 		it( 'should not render suggestions unless we type at least two characters', function() {
 			wrapper.setState( {
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			expect( getSuggestionsText() ).toEqual( [] );
 			setText( 'th' );
@@ -166,7 +166,7 @@ describe( 'FormTokenField', function() {
 
 		it( 'suggestions that begin with match are boosted', function() {
 			wrapper.setState( {
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			setText( 'so' );
 			expect( getSuggestionsText() ).toEqual( fixtures.matchingSuggestions.so );
@@ -175,7 +175,7 @@ describe( 'FormTokenField', function() {
 		it( 'should match against the unescaped values of suggestions with special characters', function() {
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			setText( '& S' );
 			expect( getSuggestionsText() ).toEqual( fixtures.specialSuggestions.matchAmpersandUnescaped );
@@ -184,7 +184,7 @@ describe( 'FormTokenField', function() {
 		it( 'should match against the unescaped values of suggestions with special characters (including spaces)', function() {
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			setText( 's &' );
 			expect( getSuggestionsText() ).toEqual( fixtures.specialSuggestions.matchAmpersandSequence );
@@ -194,14 +194,14 @@ describe( 'FormTokenField', function() {
 			setText( 'amp' );
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			expect( getSuggestionsText() ).toEqual( fixtures.specialSuggestions.matchAmpersandEscaped );
 		} );
 
 		it( 'should match suggestions even with trailing spaces', function() {
 			wrapper.setState( {
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			setText( '  at  ' );
 			expect( getSuggestionsText() ).toEqual( fixtures.matchingSuggestions.at );
@@ -209,7 +209,7 @@ describe( 'FormTokenField', function() {
 
 		it( 'should manage the selected suggestion based on both keyboard and mouse events', function() {
 			wrapper.setState( {
-				showSuggestions: true,
+				isExpanded: true,
 			} );
 			setText( 'th' );
 			expect( getSuggestionsText() ).toEqual( fixtures.matchingSuggestions.th );

--- a/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
+++ b/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
@@ -26,6 +26,7 @@ class TokenFieldWrapper extends Component {
 		this.state = {
 			tokenSuggestions: suggestions,
 			tokens: Object.freeze( [ 'foo', 'bar' ] ),
+			showSuggestions: false,
 		};
 		this.onTokensChange = this.onTokensChange.bind( this );
 	}
@@ -33,7 +34,7 @@ class TokenFieldWrapper extends Component {
 	render() {
 		return (
 			<TokenField
-				suggestions={ this.state.tokenSuggestions }
+				suggestions={ this.state.showSuggestions ? this.state.tokenSuggestions : null }
 				value={ this.state.tokens }
 				displayTransform={ unescapeAndFormatSpaces }
 				onChange={ this.onTokensChange }

--- a/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
+++ b/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
@@ -26,7 +26,7 @@ class TokenFieldWrapper extends Component {
 		this.state = {
 			tokenSuggestions: suggestions,
 			tokens: Object.freeze( [ 'foo', 'bar' ] ),
-			showSuggestions: false,
+			isExpanded: false,
 		};
 		this.onTokensChange = this.onTokensChange.bind( this );
 	}
@@ -34,7 +34,7 @@ class TokenFieldWrapper extends Component {
 	render() {
 		return (
 			<TokenField
-				suggestions={ this.state.showSuggestions ? this.state.tokenSuggestions : null }
+				suggestions={ this.state.isExpanded ? this.state.tokenSuggestions : null }
 				value={ this.state.tokens }
 				displayTransform={ unescapeAndFormatSpaces }
 				onChange={ this.onTokensChange }


### PR DESCRIPTION
## Description

This PR aims to improve keyboard interaction with the tags "autocompleter" (i.e. the flat term selector `FormTokenField`). 

- cycles through the suggestions when using the Down and Up arrow keys
- closes and resets the UI when pressing the Escape key

Also uses `@wordpress/keycodes` instead of numeric keycodes.

Consistency with similar UIs is improved too, as many other similar tools (mention autocompleter, slash inserter autocompleter, all the various menus) already cycle through the options and close on Escape.

## How has this been tested?
npm test

Fixes #8028 