### PR TITLE
Make tooltips persist when hovering them

### DIFF
--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -1,5 +1,4 @@
 .components-tooltip.components-popover {
-	pointer-events: none;
 	z-index: z-index( '.components-tooltip' );
 
 	&:before {


### PR DESCRIPTION
Supersedes #7178
Fixes #7004

## Description

This PR supersedes the one by @anevins12 just because many files have moved recently and the previous PR is a bit stale.

A tooltip should persist when the mouse pointer is moved hover the tooltip itself. This is a specific WCAG requirement related to the WCAG 2.1 'Content on hover or focus' guideline:
https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus
> Persistent
The additional content remains visible until the hover or focus trigger is removed, the user dismisses it, or its information is no longer valid.

Rationale: https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html

See also the [Example 2](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html#example-2:-hoverable-tooltip) in the WCAG page linked above:

<img width="874" alt="screen shot 2018-05-30 at 10 45 22" src="https://user-images.githubusercontent.com/1682452/40709741-2b6909c2-63f7-11e8-9e38-7b05d3b65596.png">

> The tooltip itself is able to be hovered so the mouse pointer can be moved down to its bottom edge in order to view the tooltip text.

The screenshot in the WCAG example comes from Gmail. You can test it "live" there. They've implements persistent tooltips meaning they're still visible when the mouse pointer is moved over them:

<img width="392" alt="gmail tooltip" src="https://user-images.githubusercontent.com/1682452/40710047-eaeffe2c-63f7-11e8-9fd8-6b530c4fd8af.png">

This PR only concerns non-TinyMCE buttons, simply removing `pointer-events: none;` does what we need.

The TinyMCE fix is coming from #core, see conversation on Slack > #core-tinymce: https://wordpress.slack.com/archives/C0UCMQP0F/p1528130639000183

