### PR TITLE
Remove Text Columns block from insertion menus

### DIFF
--- a/core-blocks/text-columns/index.js
+++ b/core-blocks/text-columns/index.js
@@ -15,6 +15,7 @@ import {
 	InspectorControls,
 	RichText,
 } from '@wordpress/editor';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -25,6 +26,9 @@ import './editor.scss';
 export const name = 'core/text-columns';
 
 export const settings = {
+	// Use an empty parent array to indicate this block should no longer be available for insertion.
+	parent: [],
+
 	title: __( 'Text Columns' ),
 
 	description: __( 'Add text, and display it in two or more columns. Like a newspaper! This block is experimental.' ),
@@ -63,6 +67,12 @@ export const settings = {
 
 	edit: ( ( { attributes, setAttributes, className } ) => {
 		const { width, content, columns } = attributes;
+
+		deprecated( 'The Text Columns block', {
+			version: 'a future version',
+			alternative: 'the Columns block',
+			plugin: 'Gutenberg',
+		} );
 
 		return (
 			<Fragment>

--- a/core-blocks/text-columns/index.js
+++ b/core-blocks/text-columns/index.js
@@ -26,8 +26,10 @@ import './editor.scss';
 export const name = 'core/text-columns';
 
 export const settings = {
-	// Use an empty parent array to indicate this block should no longer be available for insertion.
-	parent: [],
+	// Disable insertion as this block is deprecated and ultimately replaced by the Columns block.
+	supports: {
+		inserter: false,
+	},
 
 	title: __( 'Text Columns' ),
 
@@ -69,7 +71,6 @@ export const settings = {
 		const { width, content, columns } = attributes;
 
 		deprecated( 'The Text Columns block', {
-			version: 'a future version',
 			alternative: 'the Columns block',
 			plugin: 'Gutenberg',
 		} );

--- a/core-blocks/text-columns/test/index.js
+++ b/core-blocks/text-columns/test/index.js
@@ -10,8 +10,7 @@ describe( 'core/text-columns', () => {
 
 		expect( wrapper ).toMatchSnapshot();
 		expect( console ).toHaveWarnedWith(
-			'The Text Columns block is deprecated and will be removed from Gutenberg in a future version. ' +
-			'Please use the Columns block instead.'
+			'The Text Columns block is deprecated and will be removed. Please use the Columns block instead.'
 		);
 	} );
 } );

--- a/core-blocks/text-columns/test/index.js
+++ b/core-blocks/text-columns/test/index.js
@@ -9,5 +9,9 @@ describe( 'core/text-columns', () => {
 		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
+		expect( console ).toHaveWarnedWith(
+			'The Text Columns block is deprecated and will be removed from Gutenberg in a future version. ' +
+			'Please use the Columns block instead.'
+		);
 	} );
 } );

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -15,6 +15,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - All references to a block's `uid` have been replaced with equivalent props and selectors for `clientId`.
  - The `wp.editor.MediaPlaceholder` component `onSelectUrl` prop has been renamed to `onSelectURL`.
  - The `wp.editor.UrlInput` component has been renamed to `wp.editor.URLInput`.
+ - The Text Columns block has been removed. Please use the Columns block instead.
 
 ## 3.4.0
 


### PR DESCRIPTION
## Description
This is a simple PR to remove the Text Columns block from the block library and other insertion menus. It also prints a deprecation warning when loading a Text Columns block in the editor.

Closes #6506.
NOTE: It doesn't do everything called for in #6506 but follows Matías' direction on the issue and addresses the concern for the Try Gutenberg callout.

## How has this been tested?
* Ran unit and e2e tests.
* Loaded the editor and verified that the `core/text-columns` block is not present in the block library or the block autocompletion menu.
* Loaded a post with a pre-existing Text Columns block and observed that the block was loaded as a Text Columns block and editable.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
