### PR TITLE
Try darker bottom border color for input fields.

### DIFF
--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -164,7 +164,7 @@
 	outline-offset: -2px;
 }
 
-// Tabs, Inputs, Square buttons
+// Inputs
 @mixin input-style__neutral() {
 	outline-offset: -1px;
 	box-shadow: 0 0 0 transparent;
@@ -226,7 +226,7 @@
 @mixin editor-left( $selector ) {
 	#{$selector} {	/* Set left position when auto-fold is not on the body element. */
 		left: 0;
-		
+
 		@include break-medium() {
 			left: $admin-sidebar-width;
 		}

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -126,22 +126,34 @@ body.gutenberg-editor-page {
 	.input-control, // upstream name is .regular-text
 	input[type=text],
 	input[type=search],
-	input[type=radio],
 	input[type=tel],
 	input[type=time],
 	input[type=url],
 	input[type=week],
 	input[type=password],
-	input[type=checkbox],
-	input[type=color],
 	input[type=date],
 	input[type=datetime],
 	input[type=datetime-local],
 	input[type=email],
 	input[type=month],
 	input[type=number],
-	select,
 	textarea {
+		border: 1px solid $light-gray-700;
+		border-bottom-color: $dark-gray-500;
+		font-family: $default-font;
+		font-size: $default-font-size;
+		padding: 6px 8px;
+		@include input-style__neutral();
+
+		&:focus {
+			@include input-style__focus();
+		}
+	}
+
+	input[type=radio],
+	input[type=checkbox],
+	input[type=color],
+	select {
 		border: 1px solid $light-gray-700;
 		font-family: $default-font;
 		font-size: $default-font-size;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -4,6 +4,7 @@
 	padding: 0;
 	background-color: $white;
 	border: 1px solid $light-gray-700;
+	border-bottom-color: $dark-gray-500;
 	color: $dark-gray-700;
 	cursor: text;
 


### PR DESCRIPTION
## Description

This PR seeks to explore an improved color contrast ratio for input fields as discussed in #7053, by making the bottom border color use a darker gray.

Ideally, all form elements should have at least a contrast ratio of 3:1 with the adjacent background. See:
https://www.w3.org/TR/WCAG21/#non-text-contrast
https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html

Of course, this applies to the controls themselves (e.g. their borders). Text still needs a contrast ratio of 4.5:1.

Other form elements, for example radio buttons, checkboxes, and selects, should be discussed and addressed separately. 