### PR TITLE
Give File block a low files transform priority

### DIFF
--- a/core-blocks/file/index.js
+++ b/core-blocks/file/index.js
@@ -77,6 +77,9 @@ export const settings = {
 			{
 				type: 'files',
 				isMatch: ( files ) => files.length === 1,
+				// We define a lower priorty (higher number) than the default of 10. This
+				// ensures that the File block is only created as a fallback.
+				priority: 15,
 				transform: ( files ) => {
 					const file = files[ 0 ];
 					const blobURL = createBlobURL( file );


### PR DESCRIPTION
Fixes #8022.

As implemented, the File block files transform has identical priority as any other file transform, when in fact this should be the fallback. For example, dropping an image should take advantage of the Image block's files transform before this one.

Setting the priority to `15` decreases the priority relative to other transforms which default to `10`.

To test:

1. Create a new post
2. Drag and drop a .jpg into Gutenberg—an Image block should be created
3. Drag and drop a .pdf into Gutenberg—a File block should be created