### PR TITLE
Improve IntelliSense support when using VS Code

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@wordpress/*": ["./*", "./packages/*/src"]
+		}
+	},
+	"exclude": [
+		"build",
+		"build-module",
+		"coverage",
+		"node_modules",
+		"test/e2e/test-plugins",
+		"vendor"
+	]
+}


### PR DESCRIPTION
Improves IntelliSense support in Visual Studio Code by providing a [`jsconfig.json` file](https://code.visualstudio.com/docs/languages/jsconfig) that correctly maps `@wordpress/` paths to their source location.

This lets developers cmd+click on symbols to navigate to where they're defined:

![navigation](https://user-images.githubusercontent.com/612155/42920412-d3fca39e-8b59-11e8-8a8a-3302efe0f962.gif)

It also improves the hints shown when using symbols imported from `@wordpress/` paths:

![hints](https://user-images.githubusercontent.com/612155/42920434-ee5f10d2-8b59-11e8-96e9-2809f45af92b.gif)