### PR TITLE
Improve Parser Performance

### DIFF
--- a/bin/create-php-parser.js
+++ b/bin/create-php-parser.js
@@ -10,6 +10,7 @@ const peg = fs.readFileSync( 'blocks/api/post.pegjs', 'utf8' );
 const parser = pegjs.generate(
 	peg,
 	{
+		cache: true,
 		plugins: [ phpegjs ],
 		phpegjs: {
 			parserNamespace: null,

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -196,7 +196,7 @@ Block_Void
   }
 
 Block_Balanced
-  = s:Block_Start children:( $(!"<!--" .)+ / $(!Block_End .) / Block )* e:Block_End
+  = s:Block_Start children:( $(!"<!--" .)+ / Block / $(!Block_End .) )* e:Block_End
   {
     /** <?php
     list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -161,7 +161,7 @@ function partition( predicate, list ) {
 //////////////////////////////////////////////////////
 
 Block_List
-  = pre:$(!Block .)*
+  = pre:$((!"<!--" .)+ / (!Block .))*
     bs:(b:Block html:$((!Block .)*) { /** <?php return array( $b, $html ); ?> **/ return [ b, html ] })*
     post:$(.*)
   { /** <?php return peg_join_blocks( $pre, $bs, $post ); ?> **/
@@ -196,7 +196,7 @@ Block_Void
   }
 
 Block_Balanced
-  = s:Block_Start children:(Block / $(!Block_End .))* e:Block_End
+  = s:Block_Start children:( $(!"<!--" .)+ / $(!Block_End .) / Block )* e:Block_End
   {
     /** <?php
     list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
@@ -269,7 +269,12 @@ Core_Block_Name
   }
 
 Block_Name_Part
-  = $( [a-z][a-z0-9_-]* )
+  = "paragraph"
+  / "list"
+  / "heading"
+  / "image"
+  / "table"
+  / $( [a-z][a-z0-9_-]* )
 
 Block_Attributes
   "JSON-encoded attributes embedded in a block's opening comment"

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -1032,46 +1032,46 @@ class Gutenberg_PEG_Parser {
           $s3 = $s4;
         }
         if ($s3 === $this->peg_FAILED) {
-          $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
-          $s5 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s6 = $this->peg_parseBlock_End();
-          $this->peg_silentFails--;
-          if ($s6 === $this->peg_FAILED) {
-            $s5 = null;
-          } else {
-            $this->peg_currPos = $s5;
-            $s5 = $this->peg_FAILED;
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            if ($this->input_length > $this->peg_currPos) {
-              $s6 = $this->input_substr($this->peg_currPos, 1);
-              $this->peg_currPos++;
+          $s3 = $this->peg_parseBlock();
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
+            $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s6 = $this->peg_parseBlock_End();
+            $this->peg_silentFails--;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
             } else {
-              $s6 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c2);
-              }
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
             }
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c2);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s4;
               $s4 = $this->peg_FAILED;
             }
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
-          }
-          if ($s4 !== $this->peg_FAILED) {
-            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
-          } else {
-            $s3 = $s4;
-          }
-          if ($s3 === $this->peg_FAILED) {
-            $s3 = $this->peg_parseBlock();
+            if ($s4 !== $this->peg_FAILED) {
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+            } else {
+              $s3 = $s4;
+            }
           }
         }
         while ($s3 !== $this->peg_FAILED) {
@@ -1171,46 +1171,46 @@ class Gutenberg_PEG_Parser {
             $s3 = $s4;
           }
           if ($s3 === $this->peg_FAILED) {
-            $s3 = $this->peg_currPos;
-            $s4 = $this->peg_currPos;
-            $s5 = $this->peg_currPos;
-            $this->peg_silentFails++;
-            $s6 = $this->peg_parseBlock_End();
-            $this->peg_silentFails--;
-            if ($s6 === $this->peg_FAILED) {
-              $s5 = null;
-            } else {
-              $this->peg_currPos = $s5;
-              $s5 = $this->peg_FAILED;
-            }
-            if ($s5 !== $this->peg_FAILED) {
-              if ($this->input_length > $this->peg_currPos) {
-                $s6 = $this->input_substr($this->peg_currPos, 1);
-                $this->peg_currPos++;
+            $s3 = $this->peg_parseBlock();
+            if ($s3 === $this->peg_FAILED) {
+              $s3 = $this->peg_currPos;
+              $s4 = $this->peg_currPos;
+              $s5 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s6 = $this->peg_parseBlock_End();
+              $this->peg_silentFails--;
+              if ($s6 === $this->peg_FAILED) {
+                $s5 = null;
               } else {
-                $s6 = $this->peg_FAILED;
-                if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c2);
-                }
+                $this->peg_currPos = $s5;
+                $s5 = $this->peg_FAILED;
               }
-              if ($s6 !== $this->peg_FAILED) {
-                $s5 = array($s5, $s6);
-                $s4 = $s5;
+              if ($s5 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s6 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s6 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c2);
+                  }
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  $s5 = array($s5, $s6);
+                  $s4 = $s5;
+                } else {
+                  $this->peg_currPos = $s4;
+                  $s4 = $this->peg_FAILED;
+                }
               } else {
                 $this->peg_currPos = $s4;
                 $s4 = $this->peg_FAILED;
               }
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-            if ($s4 !== $this->peg_FAILED) {
-              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
-            } else {
-              $s3 = $s4;
-            }
-            if ($s3 === $this->peg_FAILED) {
-              $s3 = $this->peg_parseBlock();
+              if ($s4 !== $this->peg_FAILED) {
+                $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+              } else {
+                $s3 = $s4;
+              }
             }
           }
         }

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -264,8 +264,6 @@ class Gutenberg_PEG_Parser {
     private $peg_c32;
     private $peg_c33;
     private $peg_c34;
-    private $peg_c35;
-    private $peg_c36;
 
     private function peg_f0($pre, $b, $html) { return array( $b, $html ); }
     private function peg_f1($pre, $bs, $post) { return peg_join_blocks( $pre, $bs, $post ); }
@@ -941,26 +939,88 @@ class Gutenberg_PEG_Parser {
         $s2 = array();
         $s3 = $this->peg_currPos;
         $s4 = array();
-        if (Gutenberg_PEG_peg_char_class_test($this->peg_c7, $this->input_substr($this->peg_currPos, 1))) {
-          $s5 = $this->input_substr($this->peg_currPos, 1);
-          $this->peg_currPos++;
+        $s5 = $this->peg_currPos;
+        $s6 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+          $s7 = $this->peg_c0;
+          $this->peg_currPos += 4;
         } else {
-          $s5 = $this->peg_FAILED;
+          $s7 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c8);
+              $this->peg_fail($this->peg_c1);
           }
+        }
+        $this->peg_silentFails--;
+        if ($s7 === $this->peg_FAILED) {
+          $s6 = null;
+        } else {
+          $this->peg_currPos = $s6;
+          $s6 = $this->peg_FAILED;
+        }
+        if ($s6 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s7 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s7 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c2);
+            }
+          }
+          if ($s7 !== $this->peg_FAILED) {
+            $s6 = array($s6, $s7);
+            $s5 = $s6;
+          } else {
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s5;
+          $s5 = $this->peg_FAILED;
         }
         if ($s5 !== $this->peg_FAILED) {
           while ($s5 !== $this->peg_FAILED) {
             $s4[] = $s5;
-            if (Gutenberg_PEG_peg_char_class_test($this->peg_c7, $this->input_substr($this->peg_currPos, 1))) {
-              $s5 = $this->input_substr($this->peg_currPos, 1);
-              $this->peg_currPos++;
+            $s5 = $this->peg_currPos;
+            $s6 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+              $s7 = $this->peg_c0;
+              $this->peg_currPos += 4;
             } else {
-              $s5 = $this->peg_FAILED;
+              $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c8);
+                  $this->peg_fail($this->peg_c1);
               }
+            }
+            $this->peg_silentFails--;
+            if ($s7 === $this->peg_FAILED) {
+              $s6 = null;
+            } else {
+              $this->peg_currPos = $s6;
+              $s6 = $this->peg_FAILED;
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s7 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s7 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c2);
+                }
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = array($s6, $s7);
+                $s5 = $s6;
+              } else {
+                $this->peg_currPos = $s5;
+                $s5 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
             }
           }
         } else {
@@ -972,6 +1032,50 @@ class Gutenberg_PEG_Parser {
           $s3 = $s4;
         }
         if ($s3 === $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s6 = $this->peg_parseBlock_End();
+          $this->peg_silentFails--;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
+          } else {
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c2);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_parseBlock();
+          }
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
           $s3 = $this->peg_currPos;
           $s4 = array();
           $s5 = $this->peg_currPos;
@@ -1110,180 +1214,6 @@ class Gutenberg_PEG_Parser {
             }
           }
         }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_currPos;
-          $s4 = array();
-          if (Gutenberg_PEG_peg_char_class_test($this->peg_c7, $this->input_substr($this->peg_currPos, 1))) {
-            $s5 = $this->input_substr($this->peg_currPos, 1);
-            $this->peg_currPos++;
-          } else {
-            $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c8);
-            }
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            while ($s5 !== $this->peg_FAILED) {
-              $s4[] = $s5;
-              if (Gutenberg_PEG_peg_char_class_test($this->peg_c7, $this->input_substr($this->peg_currPos, 1))) {
-                $s5 = $this->input_substr($this->peg_currPos, 1);
-                $this->peg_currPos++;
-              } else {
-                $s5 = $this->peg_FAILED;
-                if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c8);
-                }
-              }
-            }
-          } else {
-            $s4 = $this->peg_FAILED;
-          }
-          if ($s4 !== $this->peg_FAILED) {
-            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
-          } else {
-            $s3 = $s4;
-          }
-          if ($s3 === $this->peg_FAILED) {
-            $s3 = $this->peg_currPos;
-            $s4 = array();
-            $s5 = $this->peg_currPos;
-            $s6 = $this->peg_currPos;
-            $this->peg_silentFails++;
-            if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-              $s7 = $this->peg_c0;
-              $this->peg_currPos += 4;
-            } else {
-              $s7 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c1);
-              }
-            }
-            $this->peg_silentFails--;
-            if ($s7 === $this->peg_FAILED) {
-              $s6 = null;
-            } else {
-              $this->peg_currPos = $s6;
-              $s6 = $this->peg_FAILED;
-            }
-            if ($s6 !== $this->peg_FAILED) {
-              if ($this->input_length > $this->peg_currPos) {
-                $s7 = $this->input_substr($this->peg_currPos, 1);
-                $this->peg_currPos++;
-              } else {
-                $s7 = $this->peg_FAILED;
-                if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c2);
-                }
-              }
-              if ($s7 !== $this->peg_FAILED) {
-                $s6 = array($s6, $s7);
-                $s5 = $s6;
-              } else {
-                $this->peg_currPos = $s5;
-                $s5 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s5;
-              $s5 = $this->peg_FAILED;
-            }
-            if ($s5 !== $this->peg_FAILED) {
-              while ($s5 !== $this->peg_FAILED) {
-                $s4[] = $s5;
-                $s5 = $this->peg_currPos;
-                $s6 = $this->peg_currPos;
-                $this->peg_silentFails++;
-                if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-                  $s7 = $this->peg_c0;
-                  $this->peg_currPos += 4;
-                } else {
-                  $s7 = $this->peg_FAILED;
-                  if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c1);
-                  }
-                }
-                $this->peg_silentFails--;
-                if ($s7 === $this->peg_FAILED) {
-                  $s6 = null;
-                } else {
-                  $this->peg_currPos = $s6;
-                  $s6 = $this->peg_FAILED;
-                }
-                if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_length > $this->peg_currPos) {
-                    $s7 = $this->input_substr($this->peg_currPos, 1);
-                    $this->peg_currPos++;
-                  } else {
-                    $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c2);
-                    }
-                  }
-                  if ($s7 !== $this->peg_FAILED) {
-                    $s6 = array($s6, $s7);
-                    $s5 = $s6;
-                  } else {
-                    $this->peg_currPos = $s5;
-                    $s5 = $this->peg_FAILED;
-                  }
-                } else {
-                  $this->peg_currPos = $s5;
-                  $s5 = $this->peg_FAILED;
-                }
-              }
-            } else {
-              $s4 = $this->peg_FAILED;
-            }
-            if ($s4 !== $this->peg_FAILED) {
-              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
-            } else {
-              $s3 = $s4;
-            }
-            if ($s3 === $this->peg_FAILED) {
-              $s3 = $this->peg_currPos;
-              $s4 = $this->peg_currPos;
-              $s5 = $this->peg_currPos;
-              $this->peg_silentFails++;
-              $s6 = $this->peg_parseBlock_End();
-              $this->peg_silentFails--;
-              if ($s6 === $this->peg_FAILED) {
-                $s5 = null;
-              } else {
-                $this->peg_currPos = $s5;
-                $s5 = $this->peg_FAILED;
-              }
-              if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_length > $this->peg_currPos) {
-                  $s6 = $this->input_substr($this->peg_currPos, 1);
-                  $this->peg_currPos++;
-                } else {
-                  $s6 = $this->peg_FAILED;
-                  if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c2);
-                  }
-                }
-                if ($s6 !== $this->peg_FAILED) {
-                  $s5 = array($s5, $s6);
-                  $s4 = $s5;
-                } else {
-                  $this->peg_currPos = $s4;
-                  $s4 = $this->peg_FAILED;
-                }
-              } else {
-                $this->peg_currPos = $s4;
-                $s4 = $this->peg_FAILED;
-              }
-              if ($s4 !== $this->peg_FAILED) {
-                $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
-              } else {
-                $s3 = $s4;
-              }
-              if ($s3 === $this->peg_FAILED) {
-                $s3 = $this->peg_parseBlock();
-              }
-            }
-          }
-        }
         if ($s2 !== $this->peg_FAILED) {
           $s3 = $this->peg_parseBlock_End();
           if ($s3 !== $this->peg_FAILED) {
@@ -1365,13 +1295,13 @@ class Gutenberg_PEG_Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
-                    $s7 = $this->peg_c9;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
+                    $s7 = $this->peg_c7;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c10);
+                        $this->peg_fail($this->peg_c8);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
@@ -1435,13 +1365,13 @@ class Gutenberg_PEG_Parser {
       if ($s1 !== $this->peg_FAILED) {
         $s2 = $this->peg_parse__();
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c11) {
-            $s3 = $this->peg_c11;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c12);
+                $this->peg_fail($this->peg_c10);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
@@ -1449,13 +1379,13 @@ class Gutenberg_PEG_Parser {
             if ($s4 !== $this->peg_FAILED) {
               $s5 = $this->peg_parse__();
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
-                  $s6 = $this->peg_c9;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
+                  $s6 = $this->peg_c7;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c10);
+                      $this->peg_fail($this->peg_c8);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -1526,13 +1456,13 @@ class Gutenberg_PEG_Parser {
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_parseBlock_Name_Part();
       if ($s2 !== $this->peg_FAILED) {
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c13) {
-          $s3 = $this->peg_c13;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c11) {
+          $s3 = $this->peg_c11;
           $this->peg_currPos++;
         } else {
           $s3 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c14);
+              $this->peg_fail($this->peg_c12);
           }
         }
         if ($s3 !== $this->peg_FAILED) {
@@ -1602,87 +1532,87 @@ class Gutenberg_PEG_Parser {
         return $cached["result"];
       }
 
-      if ($this->input_substr($this->peg_currPos, 9) === $this->peg_c15) {
-        $s0 = $this->peg_c15;
+      if ($this->input_substr($this->peg_currPos, 9) === $this->peg_c13) {
+        $s0 = $this->peg_c13;
         $this->peg_currPos += 9;
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c16);
+            $this->peg_fail($this->peg_c14);
         }
       }
       if ($s0 === $this->peg_FAILED) {
-        if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c17) {
-          $s0 = $this->peg_c17;
+        if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c15) {
+          $s0 = $this->peg_c15;
           $this->peg_currPos += 4;
         } else {
           $s0 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c18);
+              $this->peg_fail($this->peg_c16);
           }
         }
         if ($s0 === $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 7) === $this->peg_c19) {
-            $s0 = $this->peg_c19;
+          if ($this->input_substr($this->peg_currPos, 7) === $this->peg_c17) {
+            $s0 = $this->peg_c17;
             $this->peg_currPos += 7;
           } else {
             $s0 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c20);
+                $this->peg_fail($this->peg_c18);
             }
           }
           if ($s0 === $this->peg_FAILED) {
-            if ($this->input_substr($this->peg_currPos, 5) === $this->peg_c21) {
-              $s0 = $this->peg_c21;
+            if ($this->input_substr($this->peg_currPos, 5) === $this->peg_c19) {
+              $s0 = $this->peg_c19;
               $this->peg_currPos += 5;
             } else {
               $s0 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c22);
+                  $this->peg_fail($this->peg_c20);
               }
             }
             if ($s0 === $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 5) === $this->peg_c23) {
-                $s0 = $this->peg_c23;
+              if ($this->input_substr($this->peg_currPos, 5) === $this->peg_c21) {
+                $s0 = $this->peg_c21;
                 $this->peg_currPos += 5;
               } else {
                 $s0 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c24);
+                    $this->peg_fail($this->peg_c22);
                 }
               }
               if ($s0 === $this->peg_FAILED) {
                 $s0 = $this->peg_currPos;
                 $s1 = $this->peg_currPos;
-                if (Gutenberg_PEG_peg_char_class_test($this->peg_c25, $this->input_substr($this->peg_currPos, 1))) {
+                if (Gutenberg_PEG_peg_char_class_test($this->peg_c23, $this->input_substr($this->peg_currPos, 1))) {
                   $s2 = $this->input_substr($this->peg_currPos, 1);
                   $this->peg_currPos++;
                 } else {
                   $s2 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c26);
+                      $this->peg_fail($this->peg_c24);
                   }
                 }
                 if ($s2 !== $this->peg_FAILED) {
                   $s3 = array();
-                  if (Gutenberg_PEG_peg_char_class_test($this->peg_c27, $this->input_substr($this->peg_currPos, 1))) {
+                  if (Gutenberg_PEG_peg_char_class_test($this->peg_c25, $this->input_substr($this->peg_currPos, 1))) {
                     $s4 = $this->input_substr($this->peg_currPos, 1);
                     $this->peg_currPos++;
                   } else {
                     $s4 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c28);
+                        $this->peg_fail($this->peg_c26);
                     }
                   }
                   while ($s4 !== $this->peg_FAILED) {
                     $s3[] = $s4;
-                    if (Gutenberg_PEG_peg_char_class_test($this->peg_c27, $this->input_substr($this->peg_currPos, 1))) {
+                    if (Gutenberg_PEG_peg_char_class_test($this->peg_c25, $this->input_substr($this->peg_currPos, 1))) {
                       $s4 = $this->input_substr($this->peg_currPos, 1);
                       $this->peg_currPos++;
                     } else {
                       $s4 = $this->peg_FAILED;
                       if ($this->peg_silentFails === 0) {
-                          $this->peg_fail($this->peg_c28);
+                          $this->peg_fail($this->peg_c26);
                       }
                     }
                   }
@@ -1727,13 +1657,13 @@ class Gutenberg_PEG_Parser {
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c30) {
-        $s3 = $this->peg_c30;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c28) {
+        $s3 = $this->peg_c28;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c31);
+            $this->peg_fail($this->peg_c29);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -1742,40 +1672,40 @@ class Gutenberg_PEG_Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c32) {
-          $s8 = $this->peg_c32;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c30) {
+          $s8 = $this->peg_c30;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c33);
+              $this->peg_fail($this->peg_c31);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
           $s9 = $this->peg_parse__();
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c34;
+            $s10 = $this->peg_c32;
             if ($s10 !== $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c13) {
-                $s11 = $this->peg_c13;
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c11) {
+                $s11 = $this->peg_c11;
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c14);
+                    $this->peg_fail($this->peg_c12);
                 }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
-                  $s12 = $this->peg_c9;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
+                  $s12 = $this->peg_c7;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c10);
+                      $this->peg_fail($this->peg_c8);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1835,40 +1765,40 @@ class Gutenberg_PEG_Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c32) {
-            $s8 = $this->peg_c32;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c30) {
+            $s8 = $this->peg_c30;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c33);
+                $this->peg_fail($this->peg_c31);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
             $s9 = $this->peg_parse__();
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c34;
+              $s10 = $this->peg_c32;
               if ($s10 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c13) {
-                  $s11 = $this->peg_c13;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c11) {
+                  $s11 = $this->peg_c11;
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c14);
+                      $this->peg_fail($this->peg_c12);
                   }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
-                    $s12 = $this->peg_c9;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
+                    $s12 = $this->peg_c7;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c10);
+                        $this->peg_fail($this->peg_c8);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1924,13 +1854,13 @@ class Gutenberg_PEG_Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c32) {
-            $s5 = $this->peg_c32;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c30) {
+            $s5 = $this->peg_c30;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c33);
+                $this->peg_fail($this->peg_c31);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1962,7 +1892,7 @@ class Gutenberg_PEG_Parser {
       if ($s0 === $this->peg_FAILED) {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c29);
+            $this->peg_fail($this->peg_c27);
         }
       }
 
@@ -1982,25 +1912,25 @@ class Gutenberg_PEG_Parser {
       }
 
       $s0 = array();
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c35, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c33, $this->input_substr($this->peg_currPos, 1))) {
         $s1 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c36);
+            $this->peg_fail($this->peg_c34);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         while ($s1 !== $this->peg_FAILED) {
           $s0[] = $s1;
-          if (Gutenberg_PEG_peg_char_class_test($this->peg_c35, $this->input_substr($this->peg_currPos, 1))) {
+          if (Gutenberg_PEG_peg_char_class_test($this->peg_c33, $this->input_substr($this->peg_currPos, 1))) {
             $s1 = $this->input_substr($this->peg_currPos, 1);
             $this->peg_currPos++;
           } else {
             $s1 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c36);
+                $this->peg_fail($this->peg_c34);
             }
           }
         }
@@ -2034,36 +1964,34 @@ class Gutenberg_PEG_Parser {
     $this->peg_c4 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
     $this->peg_c5 = "/-->";
     $this->peg_c6 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
-    $this->peg_c7 = array(array(60,60));
-    $this->peg_c8 = array( "type" => "class", "value" => "[<]", "description" => "[<]" );
-    $this->peg_c9 = "-->";
-    $this->peg_c10 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c11 = "/wp:";
-    $this->peg_c12 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
-    $this->peg_c13 = "/";
-    $this->peg_c14 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c15 = "paragraph";
-    $this->peg_c16 = array( "type" => "literal", "value" => "paragraph", "description" => "\"paragraph\"" );
-    $this->peg_c17 = "list";
-    $this->peg_c18 = array( "type" => "literal", "value" => "list", "description" => "\"list\"" );
-    $this->peg_c19 = "heading";
-    $this->peg_c20 = array( "type" => "literal", "value" => "heading", "description" => "\"heading\"" );
-    $this->peg_c21 = "image";
-    $this->peg_c22 = array( "type" => "literal", "value" => "image", "description" => "\"image\"" );
-    $this->peg_c23 = "table";
-    $this->peg_c24 = array( "type" => "literal", "value" => "table", "description" => "\"table\"" );
-    $this->peg_c25 = array(array(97,122));
-    $this->peg_c26 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
-    $this->peg_c27 = array(array(97,122), array(48,57), array(95,95), array(45,45));
-    $this->peg_c28 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
-    $this->peg_c29 = array("type" => "other", "description" => "JSON-encoded attributes embedded in a block's opening comment" );
-    $this->peg_c30 = "{";
-    $this->peg_c31 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c32 = "}";
-    $this->peg_c33 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c34 = "";
-    $this->peg_c35 = array(array(32,32), array(9,9), array(13,13), array(10,10));
-    $this->peg_c36 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c7 = "-->";
+    $this->peg_c8 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
+    $this->peg_c9 = "/wp:";
+    $this->peg_c10 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
+    $this->peg_c11 = "/";
+    $this->peg_c12 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
+    $this->peg_c13 = "paragraph";
+    $this->peg_c14 = array( "type" => "literal", "value" => "paragraph", "description" => "\"paragraph\"" );
+    $this->peg_c15 = "list";
+    $this->peg_c16 = array( "type" => "literal", "value" => "list", "description" => "\"list\"" );
+    $this->peg_c17 = "heading";
+    $this->peg_c18 = array( "type" => "literal", "value" => "heading", "description" => "\"heading\"" );
+    $this->peg_c19 = "image";
+    $this->peg_c20 = array( "type" => "literal", "value" => "image", "description" => "\"image\"" );
+    $this->peg_c21 = "table";
+    $this->peg_c22 = array( "type" => "literal", "value" => "table", "description" => "\"table\"" );
+    $this->peg_c23 = array(array(97,122));
+    $this->peg_c24 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c25 = array(array(97,122), array(48,57), array(95,95), array(45,45));
+    $this->peg_c26 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c27 = array("type" => "other", "description" => "JSON-encoded attributes embedded in a block's opening comment" );
+    $this->peg_c28 = "{";
+    $this->peg_c29 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c30 = "}";
+    $this->peg_c31 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c32 = "";
+    $this->peg_c33 = array(array(32,32), array(9,9), array(13,13), array(10,10));
+    $this->peg_c34 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
 
     $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
     $peg_startRuleFunction  = array($this, "peg_parseBlock_List");

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -74,6 +74,7 @@ class Gutenberg_PEG_Parser {
     private $peg_silentFails      = 0;
     private $input                = array();
     private $input_length         = 0;
+    public $peg_cache = array();
 
     private function cleanup_state() {
       $this->peg_currPos          = 0;
@@ -85,7 +86,7 @@ class Gutenberg_PEG_Parser {
       $this->peg_silentFails      = 0;
       $this->input                = array();
       $this->input_length         = 0;
-
+      $this->peg_cache = array();
     }
 
     private function input_substr($start, $length) {
@@ -253,6 +254,18 @@ class Gutenberg_PEG_Parser {
     private $peg_c22;
     private $peg_c23;
     private $peg_c24;
+    private $peg_c25;
+    private $peg_c26;
+    private $peg_c27;
+    private $peg_c28;
+    private $peg_c29;
+    private $peg_c30;
+    private $peg_c31;
+    private $peg_c32;
+    private $peg_c33;
+    private $peg_c34;
+    private $peg_c35;
+    private $peg_c36;
 
     private function peg_f0($pre, $b, $html) { return array( $b, $html ); }
     private function peg_f1($pre, $bs, $post) { return peg_join_blocks( $pre, $bs, $post ); }
@@ -291,43 +304,106 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseBlock_List() {
 
+      $key    = $this->peg_currPos * 12 + 0;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = array();
-      $s3 = $this->peg_currPos;
+      $s3 = array();
       $s4 = $this->peg_currPos;
+      $s5 = $this->peg_currPos;
       $this->peg_silentFails++;
-      $s5 = $this->peg_parseBlock();
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+        $s6 = $this->peg_c0;
+        $this->peg_currPos += 4;
+      } else {
+        $s6 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c1);
+        }
+      }
       $this->peg_silentFails--;
-      if ($s5 === $this->peg_FAILED) {
-        $s4 = null;
+      if ($s6 === $this->peg_FAILED) {
+        $s5 = null;
+      } else {
+        $this->peg_currPos = $s5;
+        $s5 = $this->peg_FAILED;
+      }
+      if ($s5 !== $this->peg_FAILED) {
+        if ($this->input_length > $this->peg_currPos) {
+          $s6 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s6 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c2);
+          }
+        }
+        if ($s6 !== $this->peg_FAILED) {
+          $s5 = array($s5, $s6);
+          $s4 = $s5;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
       } else {
         $this->peg_currPos = $s4;
         $s4 = $this->peg_FAILED;
       }
       if ($s4 !== $this->peg_FAILED) {
-        if ($this->input_length > $this->peg_currPos) {
-          $s5 = $this->input_substr($this->peg_currPos, 1);
-          $this->peg_currPos++;
-        } else {
-          $s5 = $this->peg_FAILED;
-          if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c0);
+        while ($s4 !== $this->peg_FAILED) {
+          $s3[] = $s4;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+            $s6 = $this->peg_c0;
+            $this->peg_currPos += 4;
+          } else {
+            $s6 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c1);
+            }
+          }
+          $this->peg_silentFails--;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
+          } else {
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c2);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
           }
         }
-        if ($s5 !== $this->peg_FAILED) {
-          $s4 = array($s4, $s5);
-          $s3 = $s4;
-        } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
       } else {
-        $this->peg_currPos = $s3;
         $s3 = $this->peg_FAILED;
       }
-      while ($s3 !== $this->peg_FAILED) {
-        $s2[] = $s3;
+      if ($s3 === $this->peg_FAILED) {
         $s3 = $this->peg_currPos;
         $s4 = $this->peg_currPos;
         $this->peg_silentFails++;
@@ -346,7 +422,7 @@ class Gutenberg_PEG_Parser {
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c0);
+                $this->peg_fail($this->peg_c2);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -359,6 +435,131 @@ class Gutenberg_PEG_Parser {
         } else {
           $this->peg_currPos = $s3;
           $s3 = $this->peg_FAILED;
+        }
+      }
+      while ($s3 !== $this->peg_FAILED) {
+        $s2[] = $s3;
+        $s3 = array();
+        $s4 = $this->peg_currPos;
+        $s5 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+          $s6 = $this->peg_c0;
+          $this->peg_currPos += 4;
+        } else {
+          $s6 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c1);
+          }
+        }
+        $this->peg_silentFails--;
+        if ($s6 === $this->peg_FAILED) {
+          $s5 = null;
+        } else {
+          $this->peg_currPos = $s5;
+          $s5 = $this->peg_FAILED;
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s6 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s6 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c2);
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = array($s5, $s6);
+            $s4 = $s5;
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          while ($s4 !== $this->peg_FAILED) {
+            $s3[] = $s4;
+            $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+              $s6 = $this->peg_c0;
+              $this->peg_currPos += 4;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c1);
+              }
+            }
+            $this->peg_silentFails--;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c2);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          }
+        } else {
+          $s3 = $this->peg_FAILED;
+        }
+        if ($s3 === $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s5 = $this->peg_parseBlock();
+          $this->peg_silentFails--;
+          if ($s5 === $this->peg_FAILED) {
+            $s4 = null;
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c2);
+              }
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $s4 = array($s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
         }
       }
       if ($s2 !== $this->peg_FAILED) {
@@ -391,7 +592,7 @@ class Gutenberg_PEG_Parser {
             } else {
               $s9 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c0);
+                  $this->peg_fail($this->peg_c2);
               }
             }
             if ($s9 !== $this->peg_FAILED) {
@@ -425,7 +626,7 @@ class Gutenberg_PEG_Parser {
               } else {
                 $s9 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c0);
+                    $this->peg_fail($this->peg_c2);
                 }
               }
               if ($s9 !== $this->peg_FAILED) {
@@ -482,7 +683,7 @@ class Gutenberg_PEG_Parser {
               } else {
                 $s9 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c0);
+                    $this->peg_fail($this->peg_c2);
                 }
               }
               if ($s9 !== $this->peg_FAILED) {
@@ -516,7 +717,7 @@ class Gutenberg_PEG_Parser {
                 } else {
                   $s9 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c0);
+                      $this->peg_fail($this->peg_c2);
                   }
                 }
                 if ($s9 !== $this->peg_FAILED) {
@@ -558,7 +759,7 @@ class Gutenberg_PEG_Parser {
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c0);
+                $this->peg_fail($this->peg_c2);
             }
           }
           while ($s5 !== $this->peg_FAILED) {
@@ -569,7 +770,7 @@ class Gutenberg_PEG_Parser {
             } else {
               $s5 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c0);
+                  $this->peg_fail($this->peg_c2);
               }
             }
           }
@@ -595,29 +796,49 @@ class Gutenberg_PEG_Parser {
         $s0 = $this->peg_FAILED;
       }
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseBlock() {
+
+      $key    = $this->peg_currPos * 12 + 1;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
 
       $s0 = $this->peg_parseBlock_Void();
       if ($s0 === $this->peg_FAILED) {
         $s0 = $this->peg_parseBlock_Balanced();
       }
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseBlock_Void() {
 
+      $key    = $this->peg_currPos * 12 + 2;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
-        $s1 = $this->peg_c1;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+        $s1 = $this->peg_c0;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c2);
+            $this->peg_fail($this->peg_c1);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -699,48 +920,145 @@ class Gutenberg_PEG_Parser {
         $s0 = $this->peg_FAILED;
       }
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseBlock_Balanced() {
 
+      $key    = $this->peg_currPos * 12 + 3;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_parseBlock_Start();
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_parseBlock();
+        $s3 = $this->peg_currPos;
+        $s4 = array();
+        if (Gutenberg_PEG_peg_char_class_test($this->peg_c7, $this->input_substr($this->peg_currPos, 1))) {
+          $s5 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s5 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c8);
+          }
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          while ($s5 !== $this->peg_FAILED) {
+            $s4[] = $s5;
+            if (Gutenberg_PEG_peg_char_class_test($this->peg_c7, $this->input_substr($this->peg_currPos, 1))) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c8);
+              }
+            }
+          }
+        } else {
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+        } else {
+          $s3 = $s4;
+        }
         if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
+          $s4 = array();
           $s5 = $this->peg_currPos;
+          $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s6 = $this->peg_parseBlock_End();
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+            $s7 = $this->peg_c0;
+            $this->peg_currPos += 4;
+          } else {
+            $s7 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c1);
+            }
+          }
           $this->peg_silentFails--;
-          if ($s6 === $this->peg_FAILED) {
-            $s5 = null;
+          if ($s7 === $this->peg_FAILED) {
+            $s6 = null;
+          } else {
+            $this->peg_currPos = $s6;
+            $s6 = $this->peg_FAILED;
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s7 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s7 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c2);
+              }
+            }
+            if ($s7 !== $this->peg_FAILED) {
+              $s6 = array($s6, $s7);
+              $s5 = $s6;
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
           } else {
             $this->peg_currPos = $s5;
             $s5 = $this->peg_FAILED;
           }
           if ($s5 !== $this->peg_FAILED) {
-            if ($this->input_length > $this->peg_currPos) {
-              $s6 = $this->input_substr($this->peg_currPos, 1);
-              $this->peg_currPos++;
-            } else {
-              $s6 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c0);
+            while ($s5 !== $this->peg_FAILED) {
+              $s4[] = $s5;
+              $s5 = $this->peg_currPos;
+              $s6 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+                $s7 = $this->peg_c0;
+                $this->peg_currPos += 4;
+              } else {
+                $s7 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c1);
+                }
+              }
+              $this->peg_silentFails--;
+              if ($s7 === $this->peg_FAILED) {
+                $s6 = null;
+              } else {
+                $this->peg_currPos = $s6;
+                $s6 = $this->peg_FAILED;
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s7 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s7 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c2);
+                  }
+                }
+                if ($s7 !== $this->peg_FAILED) {
+                  $s6 = array($s6, $s7);
+                  $s5 = $s6;
+                } else {
+                  $this->peg_currPos = $s5;
+                  $s5 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s5;
+                $s5 = $this->peg_FAILED;
               }
             }
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
           } else {
-            $this->peg_currPos = $s4;
             $s4 = $this->peg_FAILED;
           }
           if ($s4 !== $this->peg_FAILED) {
@@ -748,10 +1066,6 @@ class Gutenberg_PEG_Parser {
           } else {
             $s3 = $s4;
           }
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_parseBlock();
           if ($s3 === $this->peg_FAILED) {
             $s3 = $this->peg_currPos;
             $s4 = $this->peg_currPos;
@@ -772,7 +1086,7 @@ class Gutenberg_PEG_Parser {
               } else {
                 $s6 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c0);
+                    $this->peg_fail($this->peg_c2);
                 }
               }
               if ($s6 !== $this->peg_FAILED) {
@@ -790,6 +1104,183 @@ class Gutenberg_PEG_Parser {
               $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
             } else {
               $s3 = $s4;
+            }
+            if ($s3 === $this->peg_FAILED) {
+              $s3 = $this->peg_parseBlock();
+            }
+          }
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_currPos;
+          $s4 = array();
+          if (Gutenberg_PEG_peg_char_class_test($this->peg_c7, $this->input_substr($this->peg_currPos, 1))) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c8);
+            }
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            while ($s5 !== $this->peg_FAILED) {
+              $s4[] = $s5;
+              if (Gutenberg_PEG_peg_char_class_test($this->peg_c7, $this->input_substr($this->peg_currPos, 1))) {
+                $s5 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s5 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c8);
+                }
+              }
+            }
+          } else {
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
+            $s4 = array();
+            $s5 = $this->peg_currPos;
+            $s6 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+              $s7 = $this->peg_c0;
+              $this->peg_currPos += 4;
+            } else {
+              $s7 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c1);
+              }
+            }
+            $this->peg_silentFails--;
+            if ($s7 === $this->peg_FAILED) {
+              $s6 = null;
+            } else {
+              $this->peg_currPos = $s6;
+              $s6 = $this->peg_FAILED;
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s7 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s7 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c2);
+                }
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = array($s6, $s7);
+                $s5 = $s6;
+              } else {
+                $this->peg_currPos = $s5;
+                $s5 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              while ($s5 !== $this->peg_FAILED) {
+                $s4[] = $s5;
+                $s5 = $this->peg_currPos;
+                $s6 = $this->peg_currPos;
+                $this->peg_silentFails++;
+                if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+                  $s7 = $this->peg_c0;
+                  $this->peg_currPos += 4;
+                } else {
+                  $s7 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c1);
+                  }
+                }
+                $this->peg_silentFails--;
+                if ($s7 === $this->peg_FAILED) {
+                  $s6 = null;
+                } else {
+                  $this->peg_currPos = $s6;
+                  $s6 = $this->peg_FAILED;
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  if ($this->input_length > $this->peg_currPos) {
+                    $s7 = $this->input_substr($this->peg_currPos, 1);
+                    $this->peg_currPos++;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c2);
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $s6 = array($s6, $s7);
+                    $s5 = $s6;
+                  } else {
+                    $this->peg_currPos = $s5;
+                    $s5 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s5;
+                  $s5 = $this->peg_FAILED;
+                }
+              }
+            } else {
+              $s4 = $this->peg_FAILED;
+            }
+            if ($s4 !== $this->peg_FAILED) {
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+            } else {
+              $s3 = $s4;
+            }
+            if ($s3 === $this->peg_FAILED) {
+              $s3 = $this->peg_currPos;
+              $s4 = $this->peg_currPos;
+              $s5 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s6 = $this->peg_parseBlock_End();
+              $this->peg_silentFails--;
+              if ($s6 === $this->peg_FAILED) {
+                $s5 = null;
+              } else {
+                $this->peg_currPos = $s5;
+                $s5 = $this->peg_FAILED;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s6 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s6 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c2);
+                  }
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  $s5 = array($s5, $s6);
+                  $s4 = $s5;
+                } else {
+                  $this->peg_currPos = $s4;
+                  $s4 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+              if ($s4 !== $this->peg_FAILED) {
+                $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+              } else {
+                $s3 = $s4;
+              }
+              if ($s3 === $this->peg_FAILED) {
+                $s3 = $this->peg_parseBlock();
+              }
             }
           }
         }
@@ -812,19 +1303,29 @@ class Gutenberg_PEG_Parser {
         $s0 = $this->peg_FAILED;
       }
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseBlock_Start() {
 
+      $key    = $this->peg_currPos * 12 + 4;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
-        $s1 = $this->peg_c1;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+        $s1 = $this->peg_c0;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c2);
+            $this->peg_fail($this->peg_c1);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -864,13 +1365,13 @@ class Gutenberg_PEG_Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
-                    $s7 = $this->peg_c7;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+                    $s7 = $this->peg_c9;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c8);
+                        $this->peg_fail($this->peg_c10);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
@@ -906,31 +1407,41 @@ class Gutenberg_PEG_Parser {
         $s0 = $this->peg_FAILED;
       }
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseBlock_End() {
 
+      $key    = $this->peg_currPos * 12 + 5;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
-        $s1 = $this->peg_c1;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+        $s1 = $this->peg_c0;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c2);
+            $this->peg_fail($this->peg_c1);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = $this->peg_parse__();
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c9) {
-            $s3 = $this->peg_c9;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c11) {
+            $s3 = $this->peg_c11;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c10);
+                $this->peg_fail($this->peg_c12);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
@@ -938,13 +1449,13 @@ class Gutenberg_PEG_Parser {
             if ($s4 !== $this->peg_FAILED) {
               $s5 = $this->peg_parse__();
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
-                  $s6 = $this->peg_c7;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+                  $s6 = $this->peg_c9;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c8);
+                      $this->peg_fail($this->peg_c10);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -976,32 +1487,52 @@ class Gutenberg_PEG_Parser {
         $s0 = $this->peg_FAILED;
       }
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseBlock_Name() {
+
+      $key    = $this->peg_currPos * 12 + 6;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
 
       $s0 = $this->peg_parseNamespaced_Block_Name();
       if ($s0 === $this->peg_FAILED) {
         $s0 = $this->peg_parseCore_Block_Name();
       }
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseNamespaced_Block_Name() {
 
+      $key    = $this->peg_currPos * 12 + 7;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_parseBlock_Name_Part();
       if ($s2 !== $this->peg_FAILED) {
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c11) {
-          $s3 = $this->peg_c11;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c13) {
+          $s3 = $this->peg_c13;
           $this->peg_currPos++;
         } else {
           $s3 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c12);
+              $this->peg_fail($this->peg_c14);
           }
         }
         if ($s3 !== $this->peg_FAILED) {
@@ -1027,10 +1558,20 @@ class Gutenberg_PEG_Parser {
         $s0 = $s1;
       }
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseCore_Block_Name() {
+
+      $key    = $this->peg_currPos * 12 + 8;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
@@ -1046,78 +1587,153 @@ class Gutenberg_PEG_Parser {
       }
       $s0 = $s1;
 
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
       return $s0;
     }
 
     private function peg_parseBlock_Name_Part() {
 
-      $s0 = $this->peg_currPos;
-      $s1 = $this->peg_currPos;
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c13, $this->input_substr($this->peg_currPos, 1))) {
-        $s2 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
+      $key    = $this->peg_currPos * 12 + 9;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      if ($this->input_substr($this->peg_currPos, 9) === $this->peg_c15) {
+        $s0 = $this->peg_c15;
+        $this->peg_currPos += 9;
       } else {
-        $s2 = $this->peg_FAILED;
+        $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c14);
+            $this->peg_fail($this->peg_c16);
         }
       }
-      if ($s2 !== $this->peg_FAILED) {
-        $s3 = array();
-        if (Gutenberg_PEG_peg_char_class_test($this->peg_c15, $this->input_substr($this->peg_currPos, 1))) {
-          $s4 = $this->input_substr($this->peg_currPos, 1);
-          $this->peg_currPos++;
+      if ($s0 === $this->peg_FAILED) {
+        if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c17) {
+          $s0 = $this->peg_c17;
+          $this->peg_currPos += 4;
         } else {
-          $s4 = $this->peg_FAILED;
+          $s0 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c16);
+              $this->peg_fail($this->peg_c18);
           }
         }
-        while ($s4 !== $this->peg_FAILED) {
-          $s3[] = $s4;
-          if (Gutenberg_PEG_peg_char_class_test($this->peg_c15, $this->input_substr($this->peg_currPos, 1))) {
-            $s4 = $this->input_substr($this->peg_currPos, 1);
-            $this->peg_currPos++;
+        if ($s0 === $this->peg_FAILED) {
+          if ($this->input_substr($this->peg_currPos, 7) === $this->peg_c19) {
+            $s0 = $this->peg_c19;
+            $this->peg_currPos += 7;
           } else {
-            $s4 = $this->peg_FAILED;
+            $s0 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c16);
+                $this->peg_fail($this->peg_c20);
+            }
+          }
+          if ($s0 === $this->peg_FAILED) {
+            if ($this->input_substr($this->peg_currPos, 5) === $this->peg_c21) {
+              $s0 = $this->peg_c21;
+              $this->peg_currPos += 5;
+            } else {
+              $s0 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c22);
+              }
+            }
+            if ($s0 === $this->peg_FAILED) {
+              if ($this->input_substr($this->peg_currPos, 5) === $this->peg_c23) {
+                $s0 = $this->peg_c23;
+                $this->peg_currPos += 5;
+              } else {
+                $s0 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c24);
+                }
+              }
+              if ($s0 === $this->peg_FAILED) {
+                $s0 = $this->peg_currPos;
+                $s1 = $this->peg_currPos;
+                if (Gutenberg_PEG_peg_char_class_test($this->peg_c25, $this->input_substr($this->peg_currPos, 1))) {
+                  $s2 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s2 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c26);
+                  }
+                }
+                if ($s2 !== $this->peg_FAILED) {
+                  $s3 = array();
+                  if (Gutenberg_PEG_peg_char_class_test($this->peg_c27, $this->input_substr($this->peg_currPos, 1))) {
+                    $s4 = $this->input_substr($this->peg_currPos, 1);
+                    $this->peg_currPos++;
+                  } else {
+                    $s4 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c28);
+                    }
+                  }
+                  while ($s4 !== $this->peg_FAILED) {
+                    $s3[] = $s4;
+                    if (Gutenberg_PEG_peg_char_class_test($this->peg_c27, $this->input_substr($this->peg_currPos, 1))) {
+                      $s4 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s4 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c28);
+                      }
+                    }
+                  }
+                  if ($s3 !== $this->peg_FAILED) {
+                    $s2 = array($s2, $s3);
+                    $s1 = $s2;
+                  } else {
+                    $this->peg_currPos = $s1;
+                    $s1 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s1;
+                  $s1 = $this->peg_FAILED;
+                }
+                if ($s1 !== $this->peg_FAILED) {
+                  $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+                } else {
+                  $s0 = $s1;
+                }
+              }
             }
           }
         }
-        if ($s3 !== $this->peg_FAILED) {
-          $s2 = array($s2, $s3);
-          $s1 = $s2;
-        } else {
-          $this->peg_currPos = $s1;
-          $s1 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s1;
-        $s1 = $this->peg_FAILED;
       }
-      if ($s1 !== $this->peg_FAILED) {
-        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
-      } else {
-        $s0 = $s1;
-      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
 
       return $s0;
     }
 
     private function peg_parseBlock_Attributes() {
 
+      $key    = $this->peg_currPos * 12 + 10;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
       $this->peg_silentFails++;
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c18) {
-        $s3 = $this->peg_c18;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c30) {
+        $s3 = $this->peg_c30;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c19);
+            $this->peg_fail($this->peg_c31);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -1126,40 +1742,40 @@ class Gutenberg_PEG_Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c20) {
-          $s8 = $this->peg_c20;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c32) {
+          $s8 = $this->peg_c32;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c21);
+              $this->peg_fail($this->peg_c33);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
           $s9 = $this->peg_parse__();
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c22;
+            $s10 = $this->peg_c34;
             if ($s10 !== $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c11) {
-                $s11 = $this->peg_c11;
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c13) {
+                $s11 = $this->peg_c13;
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c12);
+                    $this->peg_fail($this->peg_c14);
                 }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
-                  $s12 = $this->peg_c7;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+                  $s12 = $this->peg_c9;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c8);
+                      $this->peg_fail($this->peg_c10);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1199,7 +1815,7 @@ class Gutenberg_PEG_Parser {
           } else {
             $s7 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c0);
+                $this->peg_fail($this->peg_c2);
             }
           }
           if ($s7 !== $this->peg_FAILED) {
@@ -1219,40 +1835,40 @@ class Gutenberg_PEG_Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c20) {
-            $s8 = $this->peg_c20;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c32) {
+            $s8 = $this->peg_c32;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c21);
+                $this->peg_fail($this->peg_c33);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
             $s9 = $this->peg_parse__();
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c22;
+              $s10 = $this->peg_c34;
               if ($s10 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c11) {
-                  $s11 = $this->peg_c11;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c13) {
+                  $s11 = $this->peg_c13;
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c12);
+                      $this->peg_fail($this->peg_c14);
                   }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c7) {
-                    $s12 = $this->peg_c7;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+                    $s12 = $this->peg_c9;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c8);
+                        $this->peg_fail($this->peg_c10);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1292,7 +1908,7 @@ class Gutenberg_PEG_Parser {
             } else {
               $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c0);
+                  $this->peg_fail($this->peg_c2);
               }
             }
             if ($s7 !== $this->peg_FAILED) {
@@ -1308,13 +1924,13 @@ class Gutenberg_PEG_Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c20) {
-            $s5 = $this->peg_c20;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c32) {
+            $s5 = $this->peg_c32;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c21);
+                $this->peg_fail($this->peg_c33);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1346,41 +1962,53 @@ class Gutenberg_PEG_Parser {
       if ($s0 === $this->peg_FAILED) {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c17);
+            $this->peg_fail($this->peg_c29);
         }
       }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
 
       return $s0;
     }
 
     private function peg_parse__() {
 
+      $key    = $this->peg_currPos * 12 + 11;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
       $s0 = array();
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c23, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c35, $this->input_substr($this->peg_currPos, 1))) {
         $s1 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c24);
+            $this->peg_fail($this->peg_c36);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         while ($s1 !== $this->peg_FAILED) {
           $s0[] = $s1;
-          if (Gutenberg_PEG_peg_char_class_test($this->peg_c23, $this->input_substr($this->peg_currPos, 1))) {
+          if (Gutenberg_PEG_peg_char_class_test($this->peg_c35, $this->input_substr($this->peg_currPos, 1))) {
             $s1 = $this->input_substr($this->peg_currPos, 1);
             $this->peg_currPos++;
           } else {
             $s1 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c24);
+                $this->peg_fail($this->peg_c36);
             }
           }
         }
       } else {
         $s0 = $this->peg_FAILED;
       }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
 
       return $s0;
     }
@@ -1399,31 +2027,43 @@ class Gutenberg_PEG_Parser {
     $this->input_length = count($this->input);
 
     $this->peg_FAILED = new stdClass;
-    $this->peg_c0 = array("type" => "any", "description" => "any character" );
-    $this->peg_c1 = "<!--";
-    $this->peg_c2 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c0 = "<!--";
+    $this->peg_c1 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c2 = array("type" => "any", "description" => "any character" );
     $this->peg_c3 = "wp:";
     $this->peg_c4 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
     $this->peg_c5 = "/-->";
     $this->peg_c6 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
-    $this->peg_c7 = "-->";
-    $this->peg_c8 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c9 = "/wp:";
-    $this->peg_c10 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
-    $this->peg_c11 = "/";
-    $this->peg_c12 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c13 = array(array(97,122));
-    $this->peg_c14 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
-    $this->peg_c15 = array(array(97,122), array(48,57), array(95,95), array(45,45));
-    $this->peg_c16 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
-    $this->peg_c17 = array("type" => "other", "description" => "JSON-encoded attributes embedded in a block's opening comment" );
-    $this->peg_c18 = "{";
-    $this->peg_c19 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c20 = "}";
-    $this->peg_c21 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c22 = "";
-    $this->peg_c23 = array(array(32,32), array(9,9), array(13,13), array(10,10));
-    $this->peg_c24 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c7 = array(array(60,60));
+    $this->peg_c8 = array( "type" => "class", "value" => "[<]", "description" => "[<]" );
+    $this->peg_c9 = "-->";
+    $this->peg_c10 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
+    $this->peg_c11 = "/wp:";
+    $this->peg_c12 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
+    $this->peg_c13 = "/";
+    $this->peg_c14 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
+    $this->peg_c15 = "paragraph";
+    $this->peg_c16 = array( "type" => "literal", "value" => "paragraph", "description" => "\"paragraph\"" );
+    $this->peg_c17 = "list";
+    $this->peg_c18 = array( "type" => "literal", "value" => "list", "description" => "\"list\"" );
+    $this->peg_c19 = "heading";
+    $this->peg_c20 = array( "type" => "literal", "value" => "heading", "description" => "\"heading\"" );
+    $this->peg_c21 = "image";
+    $this->peg_c22 = array( "type" => "literal", "value" => "image", "description" => "\"image\"" );
+    $this->peg_c23 = "table";
+    $this->peg_c24 = array( "type" => "literal", "value" => "table", "description" => "\"table\"" );
+    $this->peg_c25 = array(array(97,122));
+    $this->peg_c26 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c27 = array(array(97,122), array(48,57), array(95,95), array(45,45));
+    $this->peg_c28 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c29 = array("type" => "other", "description" => "JSON-encoded attributes embedded in a block's opening comment" );
+    $this->peg_c30 = "{";
+    $this->peg_c31 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c32 = "}";
+    $this->peg_c33 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c34 = "";
+    $this->peg_c35 = array(array(32,32), array(9,9), array(13,13), array(10,10));
+    $this->peg_c36 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
 
     $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
     $peg_startRuleFunction  = array($this, "peg_parseBlock_List");
@@ -1486,6 +2126,8 @@ class Gutenberg_PEG_Parser {
     /* END initializer code */
 
     $peg_result = call_user_func($peg_startRuleFunction);
+
+    $this->peg_cache = array();
 
     if ($peg_result !== $this->peg_FAILED && $this->peg_currPos === $this->input_length) {
       $this->cleanup_state(); // Free up memory


### PR DESCRIPTION
## Description

The PHP parser has some performance issues on larger posts, I've been doing a bit of tweaking to get some more speed out of it.

The `Block_List` `pre` rule now does a simple search for strings that aren't `<!--`. Its a reasonable assumption that the vast majority of strings that do match this will be the start of a block, so we're probably going to the `bs` rule once it does match.

The `Block_Balanced` `children` rule has a similar simple search, for the same reason.

The `Block_Name_Part` rule explicitly defines a handful of block names. This feels a bit weird to be doing in the parser, but `$( [a-z][a-z0-9_-]* )` is such a slow rule to match, that I think it's worth it.

I've also enabled pegjs' internal caching on the PHP parser, as this appear to give a decent boost, too.

## How has this been tested?

Comparing the current parser with this PR, I get some pretty clear performance gains:

| File | Current | This PR | Improvement |
| --- | --- | --- | --- |
| [demo-post.html](https://raw.githubusercontent.com/dmsnell/gutenberg-document-library/master/library/demo-post.html) | 29.8ms | 7.3ms | 4x |
| [shortcode-shortcomings.html](https://raw.githubusercontent.com/dmsnell/gutenberg-document-library/master/library/shortcode-shortcomings.html) | 77.9ms | 16.5ms | 4x |
| [redesigning-chrome-desktop.html](https://raw.githubusercontent.com/dmsnell/gutenberg-document-library/master/library/redesigning-chrome-desktop.html) | 227.9ms | 52.6ms | 4x |
| [web-at-maximum-fps.html](https://raw.githubusercontent.com/dmsnell/gutenberg-document-library/master/library/web-at-maximum-fps.html) | 169.1ms | 41.3ms | 4x |
| [early-adopting-the-future.html](https://raw.githubusercontent.com/dmsnell/gutenberg-document-library/master/library/early-adopting-the-future.html) | 270.8ms | 62.9ms | 4x |
| [pygmalian-raw-html.html](https://raw.githubusercontent.com/dmsnell/gutenberg-document-library/master/library/pygmalian-raw-html.html) | 421.9ms | 254.6ms | 1x |
| [moby-dick-parsed.html](https://raw.githubusercontent.com/dmsnell/gutenberg-document-library/master/library/moby-dick-parsed.html) | 5402.3ms | 1197.7ms | 4x |
