### PR TITLE
Blocks: Create an Audio block on audio file drop

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -35,7 +35,7 @@ class AudioEdit extends Component {
 	}
 
 	componentDidMount() {
-		const { attributes, setAttributes } = this.props;
+		const { attributes, noticeOperations, setAttributes } = this.props;
 		const { id, src = '' } = attributes;
 
 		if ( ! id && src.indexOf( 'blob:' ) === 0 ) {
@@ -46,6 +46,11 @@ class AudioEdit extends Component {
 					filesList: [ file ],
 					onFileChange: ( [ { url } ] ) => {
 						setAttributes( { src: url } );
+					},
+					onError: ( e ) => {
+						setAttributes( { src: undefined, id: undefined } );
+						this.setState( { editing: true } );
+						noticeOperations.createErrorNotice( e );
 					},
 					allowedType: 'audio',
 				} );

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -17,7 +17,7 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	RichText,
-	editorMediaUpload,
+	mediaUpload,
 } from '@wordpress/editor';
 import { getBlobByURL } from '@wordpress/blob';
 
@@ -42,7 +42,7 @@ class AudioEdit extends Component {
 			const file = getBlobByURL( src );
 
 			if ( file ) {
-				editorMediaUpload( {
+				mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ { id: mediaId, url } ] ) => {
 						setAttributes( { id: mediaId, src: url } );

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -44,8 +44,8 @@ class AudioEdit extends Component {
 			if ( file ) {
 				editorMediaUpload( {
 					filesList: [ file ],
-					onFileChange: ( [ { url } ] ) => {
-						setAttributes( { src: url } );
+					onFileChange: ( [ { id: mediaId, url } ] ) => {
+						setAttributes( { id: mediaId, src: url } );
 					},
 					onError: ( e ) => {
 						setAttributes( { src: undefined, id: undefined } );

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -17,7 +17,9 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	RichText,
+	editorMediaUpload,
 } from '@wordpress/editor';
+import { getBlobByURL } from '@wordpress/blob';
 
 class AudioEdit extends Component {
 	constructor() {
@@ -30,6 +32,25 @@ class AudioEdit extends Component {
 
 		this.toggleAttribute = this.toggleAttribute.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
+	}
+
+	componentDidMount() {
+		const { attributes, setAttributes } = this.props;
+		const { id, src = '' } = attributes;
+
+		if ( ! id && src.indexOf( 'blob:' ) === 0 ) {
+			const file = getBlobByURL( src );
+
+			if ( file ) {
+				editorMediaUpload( {
+					filesList: [ file ],
+					onFileChange: ( [ { url } ] ) => {
+						setAttributes( { src: url } );
+					},
+					allowedType: 'audio',
+				} );
+			}
+		}
 	}
 
 	toggleAttribute( attribute ) {

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -8,6 +8,8 @@ import { RichText } from '@wordpress/editor';
  * Internal dependencies
  */
 import edit from './edit';
+import { createBlock } from '@wordpress/blocks';
+import { createBlobURL } from '@wordpress/blob';
 
 export const name = 'core/audio';
 
@@ -53,6 +55,28 @@ export const settings = {
 			selector: 'audio',
 			attribute: 'preload',
 		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'files',
+				isMatch( files ) {
+					return files.length === 1 && files[ 0 ].type.indexOf( 'audio/' ) === 0;
+				},
+				transform( files ) {
+					const file = files[ 0 ];
+					// We don't need to upload the media directly here
+					// It's already done as part of the `componentDidMount`
+					// in the audio block
+					const block = createBlock( 'core/audio', {
+						src: createBlobURL( file ),
+					} );
+
+					return block;
+				},
+			},
+		],
 	},
 
 	supports: {


### PR DESCRIPTION
## Description

Fix #8020

Automatically create an Audio block when drag-and-dropping an audio file from the computer.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Environment: local Docker
Tested manually and via `npm test`.

## Screenshots <!-- if applicable -->

![jul-19-2018 14-48-57](https://user-images.githubusercontent.com/2070010/42946535-03133ff4-8b63-11e8-97e1-9696ec118bd5.gif)

If the upload fails, the block will display the `MediaPlaceholder` with an error notice containing the upload error.
I'm not entirely sure how this will be localized though.
Also: the idea is to immediately empty the `src` attribute of the audio file, in order to remove the `blob:` filename, but for some reasons it takes quite a while for `setAttribute` to update the placeholder.

<img width="610" alt="screen shot 2018-07-19 at 16 51 17" src="https://user-images.githubusercontent.com/2070010/42954296-4280e040-8b74-11e8-9bf1-e5b885ed9ce8.png">

## Types of changes

New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
