### PR TITLE
Add @babel/runtime as a dependency to @wordpress/components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,6 +24,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/compose": "file:../compose",


### PR DESCRIPTION
Currently we publish a bundle that refers to `@babel/runtime` but does not require it as an explicit dependency in `package.json`. To not confuse consumers of this package, let's declare this dependency!