### PR TITLE
Remove unused autocompleter backcompat case

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -274,14 +274,6 @@ export class Autocomplete extends Component {
 				onReplace( [ value ] );
 			} else if ( 'insert-at-caret' === action ) {
 				this.insertCompletion( range, value );
-			} else if ( 'backcompat' === action ) {
-				// NOTE: This block should be removed once we no longer support the old completer interface.
-				const onSelect = value;
-				const deprecatedOptionObject = option.value;
-				const selectionResult = onSelect( deprecatedOptionObject.value, range, query );
-				if ( selectionResult !== undefined ) {
-					this.insertCompletion( range, selectionResult );
-				}
 			}
 		}
 


### PR DESCRIPTION
## Description
This PR removes a backcompat case that has been unused since we merged #6559.

## How has this been tested?
* Ran unit and e2e tests.
* Manually tested block and user completers which exercise both supported completion actions `insert-at-caret` and `replace`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
