### PR TITLE
ContrastChecker: Add font size logic inside the component; Add additional test cases;

### DIFF
--- a/core-blocks/paragraph/index.js
+++ b/core-blocks/paragraph/index.js
@@ -248,10 +248,10 @@ class ParagraphBlock extends Component {
 						textColor={ textColor.value }
 						backgroundColor={ backgroundColor.value }
 						{ ...{
+							fontSize,
 							fallbackBackgroundColor,
 							fallbackTextColor,
 						} }
-						isLargeText={ fontSize >= 18 }
 					/>
 				</InspectorControls>
 				<RichText

--- a/editor/components/contrast-checker/index.js
+++ b/editor/components/contrast-checker/index.js
@@ -14,7 +14,14 @@ import { Notice } from '@wordpress/components';
  */
 import './style.scss';
 
-function ContrastChecker( { backgroundColor, textColor, isLargeText, fallbackBackgroundColor, fallbackTextColor } ) {
+function ContrastChecker( {
+	backgroundColor,
+	fallbackBackgroundColor,
+	fallbackTextColor,
+	fontSize,
+	isLargeText,
+	textColor,
+} ) {
 	if ( ! ( backgroundColor || fallbackBackgroundColor ) || ! ( textColor || fallbackTextColor ) ) {
 		return null;
 	}
@@ -25,7 +32,7 @@ function ContrastChecker( { backgroundColor, textColor, isLargeText, fallbackBac
 	if ( hasTransparency || tinycolor.isReadable(
 		tinyBackgroundColor,
 		tinyTextColor,
-		{ level: 'AA', size: ( isLargeText ? 'large' : 'small' ) }
+		{ level: 'AA', size: ( isLargeText || ( isLargeText !== false && fontSize >= 18 ) ? 'large' : 'small' ) }
 	) ) {
 		return null;
 	}

--- a/editor/components/contrast-checker/test/__snapshots__/index.js.snap
+++ b/editor/components/contrast-checker/test/__snapshots__/index.js.snap
@@ -77,3 +77,79 @@ exports[`ContrastChecker should render messages when the textColor is valid, but
   </div>
 </ContrastChecker>
 `;
+
+exports[`ContrastChecker should take into consideration the font size passed 1`] = `
+<ContrastChecker
+  backgroundColor="#C44B4B"
+  fontSize={17}
+  textColor="#000000"
+>
+  <div
+    className="editor-contrast-checker"
+  >
+    <Notice
+      isDismissible={false}
+      status="warning"
+    >
+      <div
+        className="notice notice-alt notice-warning"
+      >
+        <p>
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </p>
+      </div>
+    </Notice>
+  </div>
+</ContrastChecker>
+`;
+
+exports[`ContrastChecker should take into consideration wherever text is large or not 1`] = `
+<ContrastChecker
+  backgroundColor="#C44B4B"
+  isLargeText={false}
+  textColor="#000000"
+>
+  <div
+    className="editor-contrast-checker"
+  >
+    <Notice
+      isDismissible={false}
+      status="warning"
+    >
+      <div
+        className="notice notice-alt notice-warning"
+      >
+        <p>
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </p>
+      </div>
+    </Notice>
+  </div>
+</ContrastChecker>
+`;
+
+exports[`ContrastChecker should use isLargeText to make decisions if both isLargeText and fontSize props are passed 1`] = `
+<ContrastChecker
+  backgroundColor="#C44B4B"
+  fontSize={18}
+  isLargeText={false}
+  textColor="#000000"
+>
+  <div
+    className="editor-contrast-checker"
+  >
+    <Notice
+      isDismissible={false}
+      status="warning"
+    >
+      <div
+        className="notice notice-alt notice-warning"
+      >
+        <p>
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </p>
+      </div>
+    </Notice>
+  </div>
+</ContrastChecker>
+`;

--- a/editor/components/contrast-checker/test/index.js
+++ b/editor/components/contrast-checker/test/index.js
@@ -88,6 +88,74 @@ describe( 'ContrastChecker', () => {
 		expect( componentWrapper ).toMatchSnapshot();
 	} );
 
+	test( 'should take into consideration wherever text is large or not', () => {
+		const componentWrapperSmallText = mount(
+			<ContrastChecker
+				backgroundColor="#C44B4B"
+				textColor="#000000"
+				isLargeText={ false }
+			/>
+		);
+
+		expect( componentWrapperSmallText ).toMatchSnapshot();
+
+		const componentWrapperLargeText = mount(
+			<ContrastChecker
+				backgroundColor="#C44B4B"
+				textColor="#000000"
+				isLargeText={ true }
+			/>
+		);
+
+		expect( componentWrapperLargeText.html() ).toBeNull();
+	} );
+
+	test( 'should take into consideration the font size passed', () => {
+		const componentWrapperSmallFontSize = mount(
+			<ContrastChecker
+				backgroundColor="#C44B4B"
+				textColor="#000000"
+				fontSize={ 17 }
+			/>
+		);
+
+		expect( componentWrapperSmallFontSize ).toMatchSnapshot();
+
+		const componentWrapperLargeText = mount(
+			<ContrastChecker
+				backgroundColor="#C44B4B"
+				textColor="#000000"
+				fontSize={ 18 }
+			/>
+		);
+
+		expect( componentWrapperLargeText.html() ).toBeNull();
+	} );
+
+	test( 'should use isLargeText to make decisions if both isLargeText and fontSize props are passed', () => {
+		const componentWrapper = mount(
+			<ContrastChecker
+				backgroundColor="#C44B4B"
+				textColor="#000000"
+				fontSize={ 17 }
+				isLargeText={ true }
+			/>
+		);
+
+		expect( componentWrapper.html() ).toBeNull();
+
+		const componentWrapperNoLargeText = mount(
+			<ContrastChecker
+				backgroundColor="#C44B4B"
+				textColor="#000000"
+				fontSize={ 18 }
+				isLargeText={ false }
+			/>
+		);
+
+		expect( componentWrapperNoLargeText ).toMatchSnapshot();
+	} );
+
 	test( 'should render null when the colors meet AA WCAG guidelines, with only fallback colors.', () => {
 		const componentWrapper = mount(
 			<ContrastChecker


### PR DESCRIPTION
Contrast checker included logic to differentiate between large and small text. The logic is dependent on fontSize so it makes sense to have for normal cases logic that uses the fontSize inside ContrastChecker checker. The logic is not just dependent on fontSize (e.g: if text is bold for the same fontSize the contrast may be valid) we allow users of the component to still rely on isLargetext prop and decide by them selfs if the text they contain is considered large or not.

## How has this been tested?
I created a paragraph I set the text color to "#C44B4B" and the background color to "#000000".
I checked that for font sizes medium an lower there is a contrast waring and for large font sizes, there is no contrast warning.