### PR TITLE
Add @babel/runtime as a dependency for packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1770,7 +1770,6 @@
 			"version": "7.0.0-beta.53",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.53.tgz",
 			"integrity": "sha1-nfIq40gjzon3kAYFlLg+5XLixdI=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
 				"regenerator-runtime": "^0.12.0"
@@ -2987,27 +2986,36 @@
 		"@wordpress/a11y": {
 			"version": "file:packages/a11y",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/dom-ready": "file:packages/dom-ready"
 			}
 		},
 		"@wordpress/api-fetch": {
 			"version": "file:packages/api-fetch",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/i18n": "file:packages/i18n",
 				"jquery": "^3.3.1"
 			}
 		},
 		"@wordpress/autop": {
-			"version": "file:packages/autop"
+			"version": "file:packages/autop",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "file:packages/babel-plugin-import-jsx-pragma",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/babel-plugin-makepot": {
 			"version": "file:packages/babel-plugin-makepot",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.10"
 			}
@@ -3027,7 +3035,10 @@
 			}
 		},
 		"@wordpress/blob": {
-			"version": "file:packages/blob"
+			"version": "file:packages/blob",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/block-serialization-spec-parser": {
 			"version": "file:packages/block-serialization-spec-parser"
@@ -3039,6 +3050,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/compose": "file:packages/compose",
@@ -3331,6 +3343,7 @@
 		"@wordpress/compose": {
 			"version": "file:packages/compose",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10"
@@ -3339,6 +3352,7 @@
 		"@wordpress/core-data": {
 			"version": "file:packages/core-data",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"lodash": "^4.17.10",
@@ -3349,12 +3363,14 @@
 			"version": "file:packages/custom-templated-path-webpack-plugin",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"@wordpress/data": {
 			"version": "file:packages/data",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
@@ -3367,27 +3383,36 @@
 		"@wordpress/date": {
 			"version": "file:packages/date",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.16"
 			}
 		},
 		"@wordpress/deprecated": {
-			"version": "file:packages/deprecated"
+			"version": "file:packages/deprecated",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/dom": {
 			"version": "file:packages/dom",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"element-closest": "^2.0.2",
 				"lodash": "^4.17.10",
 				"tinymce": "^4.7.2"
 			}
 		},
 		"@wordpress/dom-ready": {
-			"version": "file:packages/dom-ready"
+			"version": "file:packages/dom-ready",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/element": {
 			"version": "file:packages/element",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10",
@@ -3406,14 +3431,21 @@
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "file:packages/hooks"
+			"version": "file:packages/hooks",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/html-entities": {
-			"version": "file:packages/html-entities"
+			"version": "file:packages/html-entities",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/i18n": {
 			"version": "file:packages/i18n",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"gettext-parser": "^1.3.1",
 				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
@@ -3421,12 +3453,16 @@
 			}
 		},
 		"@wordpress/is-shallow-equal": {
-			"version": "file:packages/is-shallow-equal"
+			"version": "file:packages/is-shallow-equal",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/jest-console": {
 			"version": "file:packages/jest-console",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"jest-matcher-utils": "^22.4.3",
 				"lodash": "^4.17.10"
 			}
@@ -3445,6 +3481,7 @@
 		"@wordpress/keycodes": {
 			"version": "file:packages/keycodes",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -3452,6 +3489,7 @@
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"lodash": "^4.17.10",
 				"webpack-sources": "^1.1.0"
 			}
@@ -3463,6 +3501,7 @@
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
@@ -3475,6 +3514,7 @@
 		"@wordpress/plugins": {
 			"version": "file:packages/plugins",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
@@ -3485,6 +3525,7 @@
 			"version": "file:packages/postcss-themes",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"postcss": "^6.0.16"
 			}
 		},
@@ -3594,15 +3635,20 @@
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@wordpress/url": {
-			"version": "file:packages/url"
+			"version": "file:packages/url",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			}
 		},
 		"@wordpress/viewport": {
 			"version": "file:packages/viewport",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
@@ -3612,6 +3658,7 @@
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -6826,8 +6873,7 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -18591,8 +18637,7 @@
 		"regenerator-runtime": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz",
-			"integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w==",
-			"dev": true
+			"integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w=="
 		},
 		"regenerator-transform": {
 			"version": "0.13.3",

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/dom-ready": "file:../dom-ready"
 	},
 	"publishConfig": {

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/i18n": "file:../i18n",
 		"jquery": "^3.3.1"
 	},

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -18,10 +18,10 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"publishConfig": {
-		"access": "public"
-	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -20,5 +20,8 @@
 	"module": "build-module/index.js",
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -34,5 +34,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -25,6 +25,9 @@
 	],
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
+	},
 	"devDependencies": {
 		"@babel/core": "^7.0.0-beta.52",
 		"@babel/plugin-syntax-jsx": "^7.0.0-beta.52"
@@ -34,8 +37,5 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -25,6 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10"
 	},

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -21,9 +21,7 @@
 	"engines": {
 		"node": ">=8"
 	},
-	"files": [
-		"index.js"
-	],
+	"main": "index.js",
 	"dependencies": {
 		"@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.52",
 		"@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.52",

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -18,10 +18,10 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"publishConfig": {
-		"access": "public"
-	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -20,5 +20,8 @@
 	"module": "build-module/index.js",
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -16,11 +16,6 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"files": [
-		"build",
-		"build-module",
-		"build-style"
-	],
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"lodash": "^4.17.10",

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -24,6 +24,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"escape-string-regexp": "^1.0.5"
 	},
 	"devDependencies": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -21,6 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.16"
 	},

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -21,5 +21,8 @@
 	"react-native": "src/index",
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -18,11 +18,10 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"react-native": "src/index",
-	"publishConfig": {
-		"access": "public"
-	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -18,10 +18,10 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"publishConfig": {
-		"access": "public"
-	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -20,5 +20,8 @@
 	"module": "build-module/index.js",
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"element-closest": "^2.0.2",
 		"lodash": "^4.17.10",
 		"tinymce": "^4.7.2"

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,6 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,13 +18,13 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
+	},
 	"devDependencies": {
 		"benchmark": "^2.1.4"
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -23,5 +23,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -21,5 +21,8 @@
 	"module": "build-module/index.js",
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -19,10 +19,10 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"publishConfig": {
-		"access": "public"
-	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,6 +22,7 @@
 		"pot-to-php": "./tools/pot-to-php.js"
 	},
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"gettext-parser": "^1.3.1",
 		"jed": "^1.1.1",
 		"lodash": "^4.17.10",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -30,5 +30,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -20,6 +20,9 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
+	},
 	"devDependencies": {
 		"benchmark": "^2.1.4",
 		"fbjs": "^0.8.16",
@@ -30,8 +33,5 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -25,6 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"jest-matcher-utils": "^22.4.3",
 		"lodash": "^4.17.10"
 	},

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -23,6 +23,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"lodash": "^4.17.10",
 		"webpack-sources": "^1.1.0"
 	},

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -26,8 +26,5 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"scripts": {
-		"test": "echo \"Error: run tests from root\" && exit 1"
 	}
 }

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -26,6 +26,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"postcss": "^6.0.16"
 	},
 	"publishConfig": {

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -18,10 +18,10 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"publishConfig": {
-		"access": "public"
-	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -20,5 +20,8 @@
 	"module": "build-module/index.js",
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
 	}
 }

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {


### PR DESCRIPTION
Closes #7936.

This is a follow up to https://github.com/WordPress/gutenberg/pull/8057 

For many of our transpiled packages we publish a bundle that refers to `@babel/runtime` but does not require it as an explicit dependency in package.json. To not confuse consumers of these packages, let's declare this dependency in each one that needs it!

Should fix https://github.com/WordPress/gutenberg/issues/7936

### Testing Instructions

- Verify that `@babel/runtime` is added to the package.json for each package that we transpile.
- Verify that there are no regressions when running Gutenberg