### PR TITLE
Inserter: take into account children to disable blocks

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -579,20 +579,23 @@ const unfoldBlockIds = ( state, block ) => {
 };
 
 /**
- * Returns an array containing the top-level blocks,
+ * Returns an array containing the ids of the top-level blocks,
  * all blocks referenced by the existing top-level shared blocks,
  * and all the inner blocks of existing top-level nested blocks.
  *
  * @param {Object} state Global application state.
  *
- * @return {Array} All top-level, referenced, and inner blocks.
+ * @return {Array} All ids of top-level, referenced, and inner blocks.
  */
-export const getBlocksUnfolded = createSelector(
+export const getBlockIdsUnfolded = createSelector(
 	( state ) => {
-		const topLevelBlocks = getBlocks( state );
 		const clientIds = [];
-		topLevelBlocks.forEach( ( block ) => clientIds.push( ...unfoldBlockIds( state, block ) ) );
-		return [ ...topLevelBlocks, ...getBlocksByClientId( state, clientIds ) ];
+		const topLevelBlocks = getBlocks( state );
+		topLevelBlocks.forEach( ( block ) => {
+			clientIds.push( block.clientId );
+			clientIds.push( ...unfoldBlockIds( state, block ) );
+		} );
+		return clientIds;
 	},
 	( state ) => [
 		state.editor.present.blockOrder,
@@ -1582,7 +1585,7 @@ export const getInserterItems = createSelector(
 
 			let isDisabled = false;
 			if ( ! hasBlockSupport( blockType.name, 'multiple', true ) ) {
-				isDisabled = some( getBlocksUnfolded( state ), { name: blockType.name } );
+				isDisabled = some( getBlocksByClientId( state, getBlockIdsUnfolded( state ) ), { name: blockType.name } );
 			}
 
 			const isContextual = isArray( blockType.parent );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -576,10 +576,16 @@ export const getBlocks = createSelector(
  * @return {Array} ids of referenced and inner blocks.
  */
 const unfoldClientIds = ( state, block ) => {
-	const getClientIdsFromSharedBlock = ( globalState, sharedBlock ) =>
-		sharedBlock.name === 'core/block' ?
-			[ get( getSharedBlock( globalState, sharedBlock.attributes.ref ), [ 'clientId' ], null ) ] :
-			[ null ];
+	const getClientIdsFromSharedBlock = ( globalState, sharedBlock ) => {
+		if ( sharedBlock.name === 'core/block' ) {
+			const clientId = get( getSharedBlock( globalState, sharedBlock.attributes.ref ), [ 'clientId' ], null );
+			return [
+				clientId,
+				...unfoldClientIds( globalState, ...getBlocksByClientId( globalState, clientId ) ),
+			];
+		}
+		return [ null ];
+	};
 	const getClientIdsFromInnerBlock = ( globalState ) => ( innerBlock ) => [
 		innerBlock.clientId,
 		...unfoldClientIds( globalState, innerBlock ),

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -576,6 +576,10 @@ export const getBlocks = createSelector(
  * @return {Array} ids of referenced and inner blocks.
  */
 const unfoldClientIds = ( state, block ) => {
+	if ( ! block ) {
+		return [ null ];
+	}
+
 	const getClientIdsFromSharedBlock = ( globalState, sharedBlock ) => {
 		if ( sharedBlock.name === 'core/block' ) {
 			const clientId = get( getSharedBlock( globalState, sharedBlock.attributes.ref ), [ 'clientId' ], null );
@@ -587,7 +591,7 @@ const unfoldClientIds = ( state, block ) => {
 		return [ null ];
 	};
 	const getClientIdsFromInnerBlock = ( globalState ) => ( innerBlock ) => [
-		innerBlock.clientId,
+		get( innerBlock, [ 'clientId' ], null ),
 		...unfoldClientIds( globalState, innerBlock ),
 	];
 	return [

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -576,13 +576,17 @@ export const getBlocks = createSelector(
  * @return {Array} ids of referenced and inner blocks.
  */
 const unfoldClientIds = ( state, block ) => {
-	const getClientIdsFromInnerBlock = ( innerBlock ) => [
+	const getClientIdsFromSharedBlock = ( globalState, sharedBlock ) =>
+		sharedBlock.name === 'core/block' ?
+			[ get( getSharedBlock( globalState, sharedBlock.attributes.ref ), [ 'clientId' ], null ) ] :
+			[ null ];
+	const getClientIdsFromInnerBlock = ( globalState ) => ( innerBlock ) => [
 		innerBlock.clientId,
-		...unfoldClientIds( state, innerBlock ),
+		...unfoldClientIds( globalState, innerBlock ),
 	];
 	return [
-		block.name === 'core/block' ? get( getSharedBlock( state, block.attributes.ref ), [ 'clientId' ], null ) : null,
-		...flatMap( block.innerBlocks, getClientIdsFromInnerBlock ),
+		...getClientIdsFromSharedBlock( state, block ),
+		...flatMap( block.innerBlocks, getClientIdsFromInnerBlock( state ) ),
 	].filter( ( id ) => !! id );
 };
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -576,17 +576,14 @@ export const getBlocks = createSelector(
  * @return {Array} ids of referenced and inner blocks.
  */
 const unfoldClientIds = ( state, block ) => {
-	const clientIds = [];
-	if ( block.name === 'core/block' ) {
-		clientIds.push( get( getSharedBlock( state, block.attributes.ref ), [ 'clientId' ], null ) );
-	}
-	if ( block.innerBlocks.length > 0 ) {
-		block.innerBlocks.map( ( innerBlock ) => {
-			clientIds.push( innerBlock.clientId );
-			clientIds.push( ...unfoldClientIds( state, innerBlock ) );
-		} );
-	}
-	return clientIds.filter( ( id ) => !! id );
+	const getClientIdsFromInnerBlock = ( innerBlock ) => [
+		innerBlock.clientId,
+		...unfoldClientIds( state, innerBlock ),
+	];
+	return [
+		block.name === 'core/block' ? get( getSharedBlock( state, block.attributes.ref ), [ 'clientId' ], null ) : null,
+		...flatMap( block.innerBlocks, getClientIdsFromInnerBlock ),
+	].filter( ( id ) => !! id );
 };
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -3,6 +3,7 @@
  */
 import {
 	castArray,
+	flatMap,
 	find,
 	first,
 	get,
@@ -599,13 +600,9 @@ const unfoldClientIds = ( state, block ) => {
  */
 export const getClientIdsUnfolded = createSelector(
 	( state ) => {
-		const clientIds = [];
 		const topLevelBlocks = getBlocks( state );
-		topLevelBlocks.forEach( ( block ) => {
-			clientIds.push( block.clientId );
-			clientIds.push( ...unfoldClientIds( state, block ) );
-		} );
-		return clientIds;
+		const getClientIdsFromBlock = ( block ) => [ block.clientId, ...unfoldClientIds( state, block ) ];
+		return flatMap( topLevelBlocks, getClientIdsFromBlock );
 	},
 	( state ) => [
 		state.editor.present.blockOrder,

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -44,6 +44,7 @@ const {
 	getBlockName,
 	getBlock,
 	getBlocks,
+	getBlocksTopLevelAndReferenced,
 	getBlockCount,
 	hasSelectedBlock,
 	getSelectedBlock,
@@ -1727,6 +1728,39 @@ describe( 'selectors', () => {
 			expect( getBlocks( state ) ).toEqual( [
 				{ clientId: 123, name: 'core/paragraph', attributes: {}, innerBlocks: [] },
 				{ clientId: 23, name: 'core/heading', attributes: {}, innerBlocks: [] },
+			] );
+		} );
+	} );
+
+	describe( 'getBlocksTopLevelAndReferenced', () => {
+		it( 'should return the top level blocks and any block referenced by a existing top-level shared block', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocksByClientId: {
+							'uuid-2': { clientId: 'uuid-2', name: 'core/image', attributes: {} },
+							'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
+							'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
+							'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: { ref: 1 } },
+						},
+						blockOrder: {
+							'': [ 'uuid-6', 'uuid-8' ],
+						},
+						edits: {},
+					},
+				},
+				sharedBlocks: {
+					data: {
+						1: { clientId: 'uuid-2', title: 'SharedImage' },
+						3: { clientId: 'uuid-4', title: 'SharedParagraph' },
+					},
+				},
+			};
+			expect( getBlocksTopLevelAndReferenced( state ) ).toEqual( [
+				{ clientId: 'uuid-6', name: 'core/paragraph', attributes: {}, innerBlocks: [] },
+				{ clientId: 'uuid-8', name: 'core/block', attributes: { ref: 1 }, innerBlocks: [] },
+				{ clientId: 'uuid-2', name: 'core/image', attributes: {}, innerBlocks: [] },
 			] );
 		} );
 	} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -44,8 +44,8 @@ const {
 	getBlockName,
 	getBlock,
 	getBlocks,
-	getBlockIdsUnfolded,
 	getBlockCount,
+	getClientIdsUnfolded,
 	hasSelectedBlock,
 	getSelectedBlock,
 	getSelectedBlockClientId,
@@ -1732,7 +1732,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getBlockIdsUnfolded', () => {
+	describe( 'getClientIdsUnfolded', () => {
 		it( 'should return the ids for top-level blocks, any block referenced by a existing top-level shared block, and children of nested blocks.', () => {
 			const state = {
 				currentPost: {},
@@ -1774,7 +1774,7 @@ describe( 'selectors', () => {
 					},
 				},
 			};
-			expect( getBlockIdsUnfolded( state ) ).toEqual( [
+			expect( getClientIdsUnfolded( state ) ).toEqual( [
 				'uuid-6',
 				'uuid-8',
 				'uuid-2',

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1743,10 +1743,12 @@ describe( 'selectors', () => {
 							'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
 							'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
 							'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: { ref: 1 } },
-							'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: { } },
-							'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: { } },
-							'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: { } },
-							'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: { } },
+							'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: {} },
+							'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: {} },
+							'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: {} },
+							'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: {} },
+							'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 } },
+							'uuid-20': { clientId: 'uuid-20', name: 'core/gallery', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 'uuid-6', 'uuid-8', 'uuid-10' ],
@@ -1756,8 +1758,10 @@ describe( 'selectors', () => {
 							'uuid-8': [ ],
 							'uuid-10': [ 'uuid-12', 'uuid-14' ],
 							'uuid-12': [ 'uuid-16' ],
-							'uuid-14': [ ],
+							'uuid-14': [ 'uuid-18' ],
 							'uuid-16': [ ],
+							'uuid-18': [ ],
+							'uuid-20': [ ],
 						},
 						edits: {},
 					},
@@ -1766,6 +1770,7 @@ describe( 'selectors', () => {
 					data: {
 						1: { clientId: 'uuid-2', title: 'SharedImage' },
 						3: { clientId: 'uuid-4', title: 'SharedParagraph' },
+						5: { clientId: 'uuid-20', title: 'SharedGallery' },
 					},
 				},
 			};
@@ -1776,14 +1781,20 @@ describe( 'selectors', () => {
 					{ clientId: 'uuid-12', name: 'core/column', attributes: { }, innerBlocks: [
 						{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
 					] },
-					{ clientId: 'uuid-14', name: 'core/column', attributes: { }, innerBlocks: [] },
+					{ clientId: 'uuid-14', name: 'core/column', attributes: { }, innerBlocks: [
+						{ clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 }, innerBlocks: [] },
+					] },
 				] },
 				{ clientId: 'uuid-2', name: 'core/image', attributes: {}, innerBlocks: [] },
 				{ clientId: 'uuid-12', name: 'core/column', attributes: { }, innerBlocks: [
 					{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
 				] },
-				{ clientId: 'uuid-14', name: 'core/column', attributes: { }, innerBlocks: [] },
 				{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
+				{ clientId: 'uuid-14', name: 'core/column', attributes: { }, innerBlocks: [
+					{ clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 }, innerBlocks: [] },
+				] },
+				{ clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 }, innerBlocks: [] },
+				{ clientId: 'uuid-20', name: 'core/gallery', attributes: {}, innerBlocks: [] },
 			] );
 		} );
 	} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1749,9 +1749,14 @@ describe( 'selectors', () => {
 							'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: {} },
 							'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 } },
 							'uuid-20': { clientId: 'uuid-20', name: 'core/gallery', attributes: {} },
+							'uuid-22': { clientId: 'uuid-22', name: 'core/block', attributes: { ref: 7 } },
+							'uuid-24': { clientId: 'uuid-24', name: 'core/columns', attributes: { } },
+							'uuid-26': { clientId: 'uuid-26', name: 'core/column', attributes: { } },
+							'uuid-28': { clientId: 'uuid-28', name: 'core/column', attributes: { } },
+							'uuid-30': { clientId: 'uuid-30', name: 'core/paragraph', attributes: { } },
 						},
 						blockOrder: {
-							'': [ 'uuid-6', 'uuid-8', 'uuid-10' ],
+							'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
 							'uuid-2': [ ],
 							'uuid-4': [ ],
 							'uuid-6': [ ],
@@ -1762,6 +1767,10 @@ describe( 'selectors', () => {
 							'uuid-16': [ ],
 							'uuid-18': [ ],
 							'uuid-20': [ ],
+							'uuid-22': [ ],
+							'uuid-24': [ 'uuid-26', 'uuid-28' ],
+							'uuid-26': [ ],
+							'uuid-28': [ 'uuid-30' ],
 						},
 						edits: {},
 					},
@@ -1771,6 +1780,7 @@ describe( 'selectors', () => {
 						1: { clientId: 'uuid-2', title: 'SharedImage' },
 						3: { clientId: 'uuid-4', title: 'SharedParagraph' },
 						5: { clientId: 'uuid-20', title: 'SharedGallery' },
+						7: { clientId: 'uuid-24', title: 'SharedColumns' },
 					},
 				},
 			};
@@ -1784,6 +1794,11 @@ describe( 'selectors', () => {
 				'uuid-14',
 				'uuid-18',
 				'uuid-20',
+				'uuid-22',
+				'uuid-24',
+				'uuid-26',
+				'uuid-28',
+				'uuid-30',
 			] );
 		} );
 	} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -44,7 +44,7 @@ const {
 	getBlockName,
 	getBlock,
 	getBlocks,
-	getBlocksTopLevelAndReferenced,
+	getBlocksUnfolded,
 	getBlockCount,
 	hasSelectedBlock,
 	getSelectedBlock,
@@ -1732,7 +1732,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getBlocksTopLevelAndReferenced', () => {
+	describe( 'getBlocksUnfolded', () => {
 		it( 'should return the top level blocks and any block referenced by a existing top-level shared block', () => {
 			const state = {
 				currentPost: {},
@@ -1743,9 +1743,21 @@ describe( 'selectors', () => {
 							'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
 							'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
 							'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: { ref: 1 } },
+							'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: { } },
+							'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: { } },
+							'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: { } },
+							'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: { } },
 						},
 						blockOrder: {
-							'': [ 'uuid-6', 'uuid-8' ],
+							'': [ 'uuid-6', 'uuid-8', 'uuid-10' ],
+							'uuid-2': [ ],
+							'uuid-4': [ ],
+							'uuid-6': [ ],
+							'uuid-8': [ ],
+							'uuid-10': [ 'uuid-12', 'uuid-14' ],
+							'uuid-12': [ 'uuid-16' ],
+							'uuid-14': [ ],
+							'uuid-16': [ ],
 						},
 						edits: {},
 					},
@@ -1757,10 +1769,21 @@ describe( 'selectors', () => {
 					},
 				},
 			};
-			expect( getBlocksTopLevelAndReferenced( state ) ).toEqual( [
+			expect( getBlocksUnfolded( state ) ).toEqual( [
 				{ clientId: 'uuid-6', name: 'core/paragraph', attributes: {}, innerBlocks: [] },
 				{ clientId: 'uuid-8', name: 'core/block', attributes: { ref: 1 }, innerBlocks: [] },
+				{ clientId: 'uuid-10', name: 'core/columns', attributes: { }, innerBlocks: [
+					{ clientId: 'uuid-12', name: 'core/column', attributes: { }, innerBlocks: [
+						{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
+					] },
+					{ clientId: 'uuid-14', name: 'core/column', attributes: { }, innerBlocks: [] },
+				] },
 				{ clientId: 'uuid-2', name: 'core/image', attributes: {}, innerBlocks: [] },
+				{ clientId: 'uuid-12', name: 'core/column', attributes: { }, innerBlocks: [
+					{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
+				] },
+				{ clientId: 'uuid-14', name: 'core/column', attributes: { }, innerBlocks: [] },
+				{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
 			] );
 		} );
 	} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -44,7 +44,7 @@ const {
 	getBlockName,
 	getBlock,
 	getBlocks,
-	getBlocksUnfolded,
+	getBlockIdsUnfolded,
 	getBlockCount,
 	hasSelectedBlock,
 	getSelectedBlock,
@@ -1732,8 +1732,8 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getBlocksUnfolded', () => {
-		it( 'should return the top level blocks and any block referenced by a existing top-level shared block', () => {
+	describe( 'getBlockIdsUnfolded', () => {
+		it( 'should return the ids for top-level blocks, any block referenced by a existing top-level shared block, and children of nested blocks.', () => {
 			const state = {
 				currentPost: {},
 				editor: {
@@ -1774,27 +1774,16 @@ describe( 'selectors', () => {
 					},
 				},
 			};
-			expect( getBlocksUnfolded( state ) ).toEqual( [
-				{ clientId: 'uuid-6', name: 'core/paragraph', attributes: {}, innerBlocks: [] },
-				{ clientId: 'uuid-8', name: 'core/block', attributes: { ref: 1 }, innerBlocks: [] },
-				{ clientId: 'uuid-10', name: 'core/columns', attributes: { }, innerBlocks: [
-					{ clientId: 'uuid-12', name: 'core/column', attributes: { }, innerBlocks: [
-						{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
-					] },
-					{ clientId: 'uuid-14', name: 'core/column', attributes: { }, innerBlocks: [
-						{ clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 }, innerBlocks: [] },
-					] },
-				] },
-				{ clientId: 'uuid-2', name: 'core/image', attributes: {}, innerBlocks: [] },
-				{ clientId: 'uuid-12', name: 'core/column', attributes: { }, innerBlocks: [
-					{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
-				] },
-				{ clientId: 'uuid-16', name: 'core/quote', attributes: { }, innerBlocks: [] },
-				{ clientId: 'uuid-14', name: 'core/column', attributes: { }, innerBlocks: [
-					{ clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 }, innerBlocks: [] },
-				] },
-				{ clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 }, innerBlocks: [] },
-				{ clientId: 'uuid-20', name: 'core/gallery', attributes: {}, innerBlocks: [] },
+			expect( getBlockIdsUnfolded( state ) ).toEqual( [
+				'uuid-6',
+				'uuid-8',
+				'uuid-2',
+				'uuid-10',
+				'uuid-12',
+				'uuid-16',
+				'uuid-14',
+				'uuid-18',
+				'uuid-20',
 			] );
 		} );
 	} );
@@ -3284,7 +3273,7 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByClientId: {
-							block1: { name: 'core/test-block-b' },
+							block1: { clientId: 'block1', name: 'core/test-block-b' },
 						},
 						blockOrder: {
 							'': [ 'block1' ],

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -45,7 +45,7 @@ const {
 	getBlock,
 	getBlocks,
 	getBlockCount,
-	getClientIdsUnfolded,
+	getClientIdsWithDescendants,
 	hasSelectedBlock,
 	getSelectedBlock,
 	getSelectedBlockClientId,
@@ -1732,8 +1732,8 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getClientIdsUnfolded', () => {
-		it( 'should return the ids for top-level blocks, any block referenced by a existing top-level shared block, and children of nested blocks.', () => {
+	describe( 'getClientIdsWithDescendants', () => {
+		it( 'should return the ids for top-level blocks and their descendants of any depth (for nested blocks).', () => {
 			const state = {
 				currentPost: {},
 				editor: {
@@ -1742,18 +1742,18 @@ describe( 'selectors', () => {
 							'uuid-2': { clientId: 'uuid-2', name: 'core/image', attributes: {} },
 							'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
 							'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
-							'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: { ref: 1 } },
+							'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: {} },
 							'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: {} },
 							'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: {} },
 							'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: {} },
 							'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: {} },
-							'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: { ref: 5 } },
+							'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: {} },
 							'uuid-20': { clientId: 'uuid-20', name: 'core/gallery', attributes: {} },
-							'uuid-22': { clientId: 'uuid-22', name: 'core/block', attributes: { ref: 7 } },
-							'uuid-24': { clientId: 'uuid-24', name: 'core/columns', attributes: { } },
-							'uuid-26': { clientId: 'uuid-26', name: 'core/column', attributes: { } },
-							'uuid-28': { clientId: 'uuid-28', name: 'core/column', attributes: { } },
-							'uuid-30': { clientId: 'uuid-30', name: 'core/paragraph', attributes: { } },
+							'uuid-22': { clientId: 'uuid-22', name: 'core/block', attributes: {} },
+							'uuid-24': { clientId: 'uuid-24', name: 'core/columns', attributes: {} },
+							'uuid-26': { clientId: 'uuid-26', name: 'core/column', attributes: {} },
+							'uuid-28': { clientId: 'uuid-28', name: 'core/column', attributes: {} },
+							'uuid-30': { clientId: 'uuid-30', name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
@@ -1765,7 +1765,7 @@ describe( 'selectors', () => {
 							'uuid-12': [ 'uuid-16' ],
 							'uuid-14': [ 'uuid-18' ],
 							'uuid-16': [ ],
-							'uuid-18': [ ],
+							'uuid-18': [ 'uuid-24' ],
 							'uuid-20': [ ],
 							'uuid-22': [ ],
 							'uuid-24': [ 'uuid-26', 'uuid-28' ],
@@ -1775,26 +1775,16 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				sharedBlocks: {
-					data: {
-						1: { clientId: 'uuid-2', title: 'SharedImage' },
-						3: { clientId: 'uuid-4', title: 'SharedParagraph' },
-						5: { clientId: 'uuid-20', title: 'SharedGallery' },
-						7: { clientId: 'uuid-24', title: 'SharedColumns' },
-					},
-				},
 			};
-			expect( getClientIdsUnfolded( state ) ).toEqual( [
+			expect( getClientIdsWithDescendants( state ) ).toEqual( [
 				'uuid-6',
 				'uuid-8',
-				'uuid-2',
 				'uuid-10',
-				'uuid-12',
-				'uuid-16',
-				'uuid-14',
-				'uuid-18',
-				'uuid-20',
 				'uuid-22',
+				'uuid-12',
+				'uuid-14',
+				'uuid-16',
+				'uuid-18',
 				'uuid-24',
 				'uuid-26',
 				'uuid-28',


### PR DESCRIPTION
Refs #7957 

When evaluating whether a block should be disabled or not, the inserter should take into account children of nested blocks ~as well as the blocks referenced by the existing shared blocks, as well as the~ - see https://github.com/WordPress/gutenberg/pull/8075#issuecomment-410619478.

### Testing

After this PR, it shouldn't be possible to add a `More` block if there is one nested `More` block:

![duplicate-bug-nested-fix](https://user-images.githubusercontent.com/583546/43008691-fc94c83a-8c3b-11e8-932f-02a0a4475222.gif)
