### PR TITLE
Page Attributes: Fix: Parent-Dropdown missing for custom post-type.

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -487,14 +487,15 @@ add_filter( 'rest_request_before_callbacks', 'gutenberg_handle_early_callback_ch
  *
  * @see https://core.trac.wordpress.org/ticket/43998
  *
- * @param array  $query_params JSON Schema-formatted collection parameters.
- * @param string $post_type    Post type being accessed.
+ * @param array        $query_params JSON Schema-formatted collection parameters.
+ * @param WP_Post_Type $post_type    Post type object being accessed.
  * @return array
  */
 function gutenberg_filter_post_collection_parameters( $query_params, $post_type ) {
-	$post_types = array( 'page', 'wp_block' );
-	if ( in_array( $post_type->name, $post_types, true )
-		&& isset( $query_params['per_page'] ) ) {
+	if (
+		isset( $query_params['per_page'] ) &&
+		( $post_type->hierarchical || 'wp_block' === $post_type->name )
+	) {
 		// Change from '1' to '-1', which means unlimited.
 		$query_params['per_page']['minimum'] = -1;
 		// Default sanitize callback is 'absint', which won't work in our case.
@@ -513,8 +514,10 @@ function gutenberg_filter_post_collection_parameters( $query_params, $post_type 
  * @return array
  */
 function gutenberg_filter_post_query_arguments( $prepared_args, $request ) {
-	$post_types = array( 'page', 'wp_block' );
-	if ( in_array( $prepared_args['post_type'], $post_types, true ) ) {
+	if (
+		is_post_type_hierarchical( $prepared_args['post_type'] ) ||
+		'wp_block' === $prepared_args['post_type']
+	) {
 		// Avoid triggering 'rest_post_invalid_page_number' error
 		// which will need to be addressed in https://core.trac.wordpress.org/ticket/43998.
 		if ( -1 === $prepared_args['posts_per_page'] ) {


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/7926
Regressed in: https://github.com/WordPress/gutenberg/pull/6657

We were allowing unbound requests for pages because pages have a parent picker UI that needed unbound requests. Pages were not the only CPT's that allow choosing a parent post. This commit makes sure we allow unbound requests for all hierarchical post types.

Here we try to keep the same logic added in https://github.com/WordPress/gutenberg/pull/6657 but we apply it to all Hierarchical CPT's and not just pages.

A minor correction to the documentation was also applied, the parameter $post_type of the function gutenberg_filter_post_collection_parameters is a (WP_Post_Type) oject not a string. https://developer.wordpress.org/reference/hooks/rest_this-post_type_collection_params/

## How has this been tested?
I added a hierarchical CPT and verified the Parent page picker appeared in the page attributes settings:
```
 function myplugin_register_hierarchical_book_type() {
    $args = array(
        'public' => true,
        'label'  => 'Books Hierarchical',
        'show_in_rest' => true,
        'hierarchical'       => true,
        'supports'       => array( 'page-attributes' ),
    );
    register_post_type( 'book_lock', $args );
}
add_action( 'init', 'myplugin_register_hierarchical_book_type' );
```
