### PR TITLE
Docs: Add example for registerBlockType hook

### DIFF
--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -15,19 +15,23 @@ _Example:_
 Ensure that List blocks are saved with the canonical generated class name (`wp-block-list`):
 
 ```js
-addFilter( 'blocks.registerBlockType', 'my-plugin/class-names/list-block', ( settings, name ) => {
+function addListBlockClassName( settings, name ) {
 	if ( name !== 'core/list' ) {
 		return settings;
 	}
 
-	return {
-		...settings,
-		supports: {
-			...settings.supports,
-			className: true,
-		},
-	};
-} );
+	return Object.assign( {}, settings, {
+		supports: Object.assign( {}, settings.supports, {
+			className: true
+		} ),
+	} );
+}
+
+wp.hooks.addFilter(
+	'blocks.registerBlockType',
+	'my-plugin/class-names/list-block',
+	addListBlockClassName
+);
 ```
 
 #### `blocks.getSaveElement`

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -10,6 +10,26 @@ To modify the behavior of existing blocks, Gutenberg exposes the following Filte
 
 Used to filter the block settings. It receives the block settings and the name of the block the registered block as arguments.
 
+_Example:_
+
+Ensure that List blocks are saved with the canonical generated class name (`wp-block-list`):
+
+```js
+addFilter( 'blocks.registerBlockType', 'my-plugin/class-names/list-block', ( settings, name ) => {
+	if ( name !== 'core/list' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		supports: {
+			...settings.supports,
+			className: true,
+		},
+	};
+} );
+```
+
 #### `blocks.getSaveElement`
 
 A filter that applies to the result of a block's `save` function. This filter is used to replace or extend the element, for example using `wp.element.cloneElement` to modify the element's props or replace its children, or returning an entirely new element.


### PR DESCRIPTION
## Description

Add the example provided in https://github.com/WordPress/gutenberg/pull/5651#issuecomment-403438653 to the Extensibility documentation.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
