### PR TITLE
Build: Change package build step to async flow

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -161,13 +161,13 @@ async function buildScssFile( styleFile ) {
 		to: 'dest/app.css',
 	} );
 
-	const resultRTL = await postcss( [ require( 'rtlcss' )() ] ).process( result, {
+	const resultRTL = await postcss( [ require( 'rtlcss' )() ] ).process( result.css, {
 		from: 'src/app.css',
 		to: 'dest/app.css',
 	} );
 
 	await writeFile( outputFile, result.css );
-	await writeFile( outputFileRTL, resultRTL );
+	await writeFile( outputFileRTL, resultRTL.css );
 }
 
 /**

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -156,12 +156,12 @@ async function buildScssFile( styleFile ) {
 		),
 	} );
 
-	const result = postcss( require( './post-css-config' ) ).process( builtSass.css, {
+	const result = await postcss( require( './post-css-config' ) ).process( builtSass.css, {
 		from: 'src/app.css',
 		to: 'dest/app.css',
 	} );
 
-	const resultRTL = postcss( [ require( 'rtlcss' )() ] ).process( result, {
+	const resultRTL = await postcss( [ require( 'rtlcss' )() ] ).process( result, {
 		from: 'src/app.css',
 		to: 'dest/app.css',
 	} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4545,12 +4545,6 @@
 			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
 			"dev": true
 		},
-		"bindings": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-			"integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-			"dev": true
-		},
 		"block-stream": {
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -6749,16 +6743,6 @@
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
 			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
 			"dev": true
-		},
-		"deasync": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.13.tgz",
-			"integrity": "sha512-/6ngYM7AapueqLtvOzjv9+11N2fHDSrkxeMF1YPE20WIfaaawiBg+HZH1E5lHrcJxlKR42t6XPOEmMmqcAsU1g==",
-			"dev": true,
-			"requires": {
-				"bindings": "~1.2.1",
-				"nan": "^2.0.7"
-			}
 		},
 		"debug": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
 		"cross-env": "3.2.4",
 		"cssnano": "4.0.3",
 		"enzyme": "3.7.0",
-		"deasync": "0.1.13",
 		"deep-freeze": "0.0.1",
 		"doctrine": "2.1.0",
 		"eslint-plugin-jest": "21.5.0",


### PR DESCRIPTION
This pull request seeks to adapt the package build script to perform builds in parallel, rather than in sequence. In practice, this unfortunately does not appear to make a significant difference, reducing the build time for me from about 12s to 10s. It seems that the style build takes a significant part of the time of package build.

Noting also that this is not a total conversion. `getPackages` should be made to be asynchronous, but is touched by other scripts as well. As such, it was decided to be left as a separate task.

**Testing instructions:**

There should be no regressions in the build of packages.