### PR TITLE
Fix: Regression on the color picker width

### DIFF
--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -144,7 +144,7 @@ $color-palette-circle-spacing: 14px;
 	background-clip: content-box, content-box, content-box, content-box, content-box, content-box, padding-box, padding-box, padding-box, padding-box, padding-box, padding-box;
 }
 
-.components-color-palette__picker:not(.is-mobile) .components-popover__content {
-	// ChromePicker has a hardcoded width of 225px, so we need to override the popover min-width.
-	min-width: 225px;
+.components-color-palette__picker:not(.is-mobile).components-popover .components-popover__content {
+	// ChromePicker has a hardcoded width, so we need to override the popover min-width.
+	min-width: unset;
 }


### PR DESCRIPTION
Regressed in: https://github.com/WordPress/gutenberg/pull/7640 (PR not in any way related, I think it just changed the source order making a CSS rule lose effect).

We had a CSS rule to overwrite the min-width set on the popover component. Both rules had the same specificity so when the code changed order the rule stopped overwriting. The specificity was increased.

Besides that, we were setting a hardcoded min-width value equal to the current width value of ChromePicker. If ChromePicker starts using 220px or 230px our design would break. Now we use unset so we remove the effect of the rule we apply on the popover.

## How has this been tested?
I added a paragraph and checked that the custom color picker appears correctly.

## Screenshots <!-- if applicable -->
Before:
<img width="276" alt="screen shot 2018-07-20 at 17 38 39" src="https://user-images.githubusercontent.com/11271197/43020444-e59a156a-8c57-11e8-9130-405e5a022b15.png">
After:
<img width="222" alt="screen shot 2018-07-20 at 19 40 51" src="https://user-images.githubusercontent.com/11271197/43020453-eb719c7e-8c57-11e8-9f59-dc7acb45dcca.png">
