### PR TITLE
Add missing aria-label to audio and video blocks input fields

### DIFF
--- a/core-blocks/audio/test/__snapshots__/index.js.snap
+++ b/core-blocks/audio/test/__snapshots__/index.js.snap
@@ -60,6 +60,7 @@ exports[`core/audio block edit matches snapshot 1`] = `
     </div>
     <form>
       <input
+        aria-label="Audio"
         class="components-placeholder__input"
         placeholder="Enter URL here…"
         type="url"

--- a/core-blocks/video/test/__snapshots__/index.js.snap
+++ b/core-blocks/video/test/__snapshots__/index.js.snap
@@ -60,6 +60,7 @@ exports[`core/video block edit matches snapshot 1`] = `
     </div>
     <form>
       <input
+        aria-label="Video"
         class="components-placeholder__input"
         placeholder="Enter URL here…"
         type="url"

--- a/editor/components/media-placeholder/index.js
+++ b/editor/components/media-placeholder/index.js
@@ -126,9 +126,11 @@ class MediaPlaceholder extends Component {
 						<input
 							type="url"
 							className="components-placeholder__input"
+							aria-label={ labels.title }
 							placeholder={ __( 'Enter URL here…' ) }
 							onChange={ this.onChangeSrc }
-							value={ this.state.src } />
+							value={ this.state.src }
+						/>
 						<Button
 							isLarge
 							type="submit">


### PR DESCRIPTION
The audio and video blocks input fields are unlabelled. While there's a visible text that could be used as a `<label>` element or targeted with `aria-labelledby`:

<img width="659" alt="screen shot 2018-07-21 at 17 20 53" src="https://user-images.githubusercontent.com/1682452/43037186-e6a65d84-8d0a-11e8-998a-5071acb22dc8.png">

for consistency with the other embed blocks this PR simply adds an `aria-label` attribute.

Further improvements should be considered for all similar blocks and for the future I'd propose to evaluate to use a real `<label>` element.