### PR TITLE
Fix: Color palette button, :focus state issue

### DIFF
--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -65,8 +65,8 @@ $color-palette-circle-spacing: 14px;
 			width: 32px;
 			height: 32px;
 			position: absolute;
-			top: -3px;
-			left: -3px;
+			top: -2px;
+			left: -2px;
 			border-radius: 50%;
 		}
 	}


### PR DESCRIPTION
## Description
Color palette button not centered inside focus circle.
Steps to reproduce issue:
1) Click Add Block button
2) Select Paragraph
3) Go to Block properties -> Background color 
4) Click on colored circle

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
Manually tested using FF developer tools
Environment:
1) Chrome - Version 67.0.3396.99 (Official Build) (64-bit)
2) Firefox 57.0 (64-bit)


## Screenshots
![palette-btn-focus-issue](https://user-images.githubusercontent.com/7103128/43037451-bc425272-8d15-11e8-888e-cb4fa15db80d.png)


## Types of changes
CSS style changes

