### PR TITLE
doAction when a deprecated feature is encountered

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -201,7 +201,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-deprecated',
 		gutenberg_url( 'build/deprecated/index.js' ),
-		array(),
+		array( 'wp-hooks' ),
 		filemtime( gutenberg_dir_path() . 'build/deprecated/index.js' ),
 		true
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2414,7 +2414,8 @@
 		"@wordpress/deprecated": {
 			"version": "file:packages/deprecated",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@wordpress/hooks": "file:packages/hooks"
 			}
 		},
 		"@wordpress/dom": {

--- a/packages/deprecated/CHANGELOG.md
+++ b/packages/deprecated/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.1.0 (Unreleased)
+
+### New Feature
+
+- Call `doAction` hook when a deprecated feature is encountered ([#8110](https://github.com/WordPress/gutenberg/pull/8110))

--- a/packages/deprecated/README.md
+++ b/packages/deprecated/README.md
@@ -25,4 +25,8 @@ deprecated( 'Eating meat', {
 // Logs: 'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead. Note: You may find it beneficial to transition gradually.'
 ```
 
+## Hook
+
+The `wp.deprecated` action is fired with three parameters: the name of the deprecated feature, the options object passed to deprecated, and the message sent to the console.  
+
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/deprecated/README.md
+++ b/packages/deprecated/README.md
@@ -27,6 +27,18 @@ deprecated( 'Eating meat', {
 
 ## Hook
 
-The `wp.deprecated` action is fired with three parameters: the name of the deprecated feature, the options object passed to deprecated, and the message sent to the console.  
+The `deprecated` action is fired with three parameters: the name of the deprecated feature, the options object passed to deprecated, and the message sent to the console.
+
+_Example:_
+
+```js
+import { addAction } from '@wordpress/hooks';
+
+function addDeprecationAlert( message, { version } ) {
+	alert( `Deprecation: ${ message }. Version: ${ version }` );	
+}
+
+addAction( 'deprecated', 'my-plugin/add-deprecation-alert', addDeprecationAlert );
+```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -19,7 +19,8 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@wordpress/hooks": "^1.3.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.0.0-beta.56",
-		"@wordpress/hooks": "^1.3.1"
+		"@wordpress/hooks": "file:../hooks"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/deprecated/src/index.js
+++ b/packages/deprecated/src/index.js
@@ -53,7 +53,7 @@ export default function deprecated( feature, options = {} ) {
 	 * @param {?string} options.plugin      Plugin name if it's a plugin feature
 	 * @param {?string} options.link        Link to documentation
 	 * @param {?string} options.hint        Additional message to help transition away from the deprecated feature.
-	 * @param {?string} message				Message sent to console.warn
+	 * @param {?string} message             Message sent to console.warn
 	 */
 	doAction( 'wp.deprecated', feature, options, message );
 

--- a/packages/deprecated/src/index.js
+++ b/packages/deprecated/src/index.js
@@ -1,3 +1,4 @@
+import { doAction } from '@wordpress/hooks';
 /**
  * Object map tracking messages which have been logged, for use in ensuring a
  * message is only logged once.
@@ -29,6 +30,20 @@ export default function deprecated( feature, { version, alternative, plugin, lin
 	if ( message in logged ) {
 		return;
 	}
+
+	/**
+	 * Fires whenever a deprecated feature is encountered
+	 *
+	 * @param {string}  feature             Name of the deprecated feature.
+	 * @param {?Object} options             Personalisation options
+	 * @param {?string} options.version     Version in which the feature will be removed.
+	 * @param {?string} options.alternative Feature to use instead
+	 * @param {?string} options.plugin      Plugin name if it's a plugin feature
+	 * @param {?string} options.link        Link to documentation
+	 * @param {?string} options.hint        Additional message to help transition away from the deprecated feature.
+	 * @param {?string} message				Message sent to console.warn
+	 */
+	doAction( 'wp.deprecated', feature, options, message );
 
 	// eslint-disable-next-line no-console
 	console.warn( message );

--- a/packages/deprecated/src/index.js
+++ b/packages/deprecated/src/index.js
@@ -1,4 +1,8 @@
+/**
+ * WordPress dependencies
+ */
 import { doAction } from '@wordpress/hooks';
+
 /**
  * Object map tracking messages which have been logged, for use in ensuring a
  * message is only logged once.
@@ -18,14 +22,15 @@ export const logged = Object.create( null );
  * @param {?string} options.link        Link to documentation
  * @param {?string} options.hint        Additional message to help transition away from the deprecated feature.
  */
-export default function deprecated( feature, { version, alternative, plugin, link, hint } = {} ) {
-	const options = {
+export default function deprecated( feature, options = {} ) {
+	const {
 		version,
 		alternative,
 		plugin,
 		link,
 		hint,
-	};
+	} = options;
+
 	const pluginMessage = plugin ? ` from ${ plugin }` : '';
 	const versionMessage = version ? `${ pluginMessage } in ${ version }` : '';
 	const useInsteadMessage = alternative ? ` Please use ${ alternative } instead.` : '';

--- a/packages/deprecated/src/index.js
+++ b/packages/deprecated/src/index.js
@@ -19,6 +19,13 @@ export const logged = Object.create( null );
  * @param {?string} options.hint        Additional message to help transition away from the deprecated feature.
  */
 export default function deprecated( feature, { version, alternative, plugin, link, hint } = {} ) {
+	const options = {
+		version,
+		alternative,
+		plugin,
+		link,
+		hint,
+	};
 	const pluginMessage = plugin ? ` from ${ plugin }` : '';
 	const versionMessage = version ? `${ pluginMessage } in ${ version }` : '';
 	const useInsteadMessage = alternative ? ` Please use ${ alternative } instead.` : '';

--- a/packages/deprecated/src/index.js
+++ b/packages/deprecated/src/index.js
@@ -55,7 +55,7 @@ export default function deprecated( feature, options = {} ) {
 	 * @param {?string} options.hint        Additional message to help transition away from the deprecated feature.
 	 * @param {?string} message             Message sent to console.warn
 	 */
-	doAction( 'wp.deprecated', feature, options, message );
+	doAction( 'deprecated', feature, options, message );
 
 	// eslint-disable-next-line no-console
 	console.warn( message );

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -2,6 +2,10 @@
  * Internal dependencies
  */
 import deprecated, { logged } from '../';
+/**
+ * WordPress dependencies
+ */
+import { didAction } from '@wordpress/hooks';
 
 describe( 'deprecated', () => {
 	afterEach( () => {
@@ -79,5 +83,12 @@ describe( 'deprecated', () => {
 		expect( console ).toHaveWarned();
 		// eslint-disable-next-line no-console
 		expect( console.warn ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should do an action', () => {
+		deprecated( 'pork' );
+
+		expect( didAction( 'wp.deprecated' ) ).toBeTrue();
+
 	} );
 } );

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -86,8 +86,9 @@ describe( 'deprecated', () => {
 	} );
 
 	it( 'should do an action', () => {
-		deprecated( 'pork' );
+		deprecated( 'turkey', { alternative: 'tofurky' } );
 
+		expect( console ).toHaveWarned();
 		expect( didAction( 'wp.deprecated' ) ).toBeTruthy();
 	} );
 } );

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -88,7 +88,6 @@ describe( 'deprecated', () => {
 	it( 'should do an action', () => {
 		deprecated( 'pork' );
 
-		expect( didAction( 'wp.deprecated' ) ).toBeTrue();
-
+		expect( didAction( 'wp.deprecated' ) ).toBeTruthy();
 	} );
 } );

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -89,6 +89,6 @@ describe( 'deprecated', () => {
 		deprecated( 'turkey', { alternative: 'tofurky' } );
 
 		expect( console ).toHaveWarned();
-		expect( didAction( 'wp.deprecated' ) ).toBeTruthy();
+		expect( didAction( 'deprecated' ) ).toBeTruthy();
 	} );
 } );

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -1,11 +1,12 @@
 /**
- * Internal dependencies
- */
-import deprecated, { logged } from '../';
-/**
  * WordPress dependencies
  */
 import { didAction } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import deprecated, { logged } from '../';
 
 describe( 'deprecated', () => {
 	afterEach( () => {


### PR DESCRIPTION
## Description
Whenever a deprecated feature is encountered, an action should be fired.  This is necessary for [log deprecated notices](https://wordpress.org/plugins/log-deprecated-notices/) to be able to easily log these deprecations or for other plugins to handle and do something when somethign deprecarted is encountered.

## How has this been tested?
Added this js to the page:
`wp.hooks.addAction( 'wp.deprecated', 'yo.dawg', function( feature, options, message ){
alert( 'DEPRECATED!' );
console.log( feature, options, message );
});`

There is also a unit test.  ¯\\_(ツ)_/¯

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This adds a new dependency to the deprecated package. Not sure if this needs to be tested specially with packages or we need to do something special. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
