### PR TITLE
export PureComponent

### DIFF
--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -7,11 +7,12 @@ import {
 	createRef,
 	forwardRef,
 	Component,
+	PureComponent,
 	cloneElement,
 	Children,
 	Fragment,
 	isValidElement,
-	StrictMode,
+	StrictMode
 } from 'react';
 import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
 import { isString } from 'lodash';
@@ -22,6 +23,7 @@ import { isString } from 'lodash';
 import serialize from './serialize';
 import { RawHTML } from './index-common';
 export * from './deprecated';
+
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -78,6 +80,11 @@ export { unmountComponentAtNode };
  * A base class to create WordPress Components (Refs, state and lifecycle hooks)
  */
 export { Component };
+
+/**
+ * A base class to create WordPress Components with. (shouldComponentUpdate is handled automatically)
+ */
+export {PureComponent};
 
 /**
  * Creates a copy of an element with extended props.
@@ -195,3 +202,4 @@ export function switchChildrenNodeName( children, nodeName ) {
  * @return {WPElement} Dangerously-rendering element.
  */
 export { RawHTML };
+

--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -12,6 +12,7 @@ import {
 	renderToString,
 	switchChildrenNodeName,
 	RawHTML,
+	PureComponent
 } from '../';
 
 describe( 'element', () => {
@@ -149,4 +150,10 @@ describe( 'element', () => {
 			expect( element.prop( 'children' ) ).toBe( undefined );
 		} );
 	} );
+
+	describe( 'PureComponent', () => {
+		it( 'Exports pure component', () => {
+			expect( typeof PureComponent ).toBe( 'function' );
+		});
+	});
 } );


### PR DESCRIPTION
## Description
I added an export for `React.PureComponent` and a test to prove its exported as a function.  #8118

## How has this been tested?
I wrote a unit test to prove `element.PureComponent` is a function. 

## Checklist:
- [ x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. Not applicable
- [x] My code has proper inline documentation.
