### PR TITLE
Improve JS package descriptions

### DIFF
--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/a11y",
 	"version": "1.1.1",
-	"description": "Collection of JS modules and tools for WordPress development",
+	"description": "Accessibility (a11y) utilities for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/api-fetch",
 	"version": "1.0.1",
-	"description": "Utility to call WordPress REST APIs",
+	"description": "Utility to make WordPress REST API requests",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/babel-plugin-import-jsx-pragma",
 	"version": "1.0.1",
-	"description": "Babel transform plugin for automatically injecting an import to be used as the pragma for the React JSX Transform plugin.",
+	"description": "Babel transform plugin for automatically injecting an import to be used as the pragma for the React JSX Transform plugin",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/babel-plugin-makepot",
 	"version": "2.0.1",
-	"description": "WordPress Babel i18n Plugin",
+	"description": "WordPress Babel internationalization (i18n) plugin",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/blob",
 	"version": "1.0.1",
-	"description": "Blob utils for WordPress",
+	"description": "Blob utilities for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/browserslist-config",
 	"version": "2.2.0",
-	"description": "WordPress Browserslist Shared Config",
+	"description": "WordPress Browserslist shared configuration",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/components",
 	"version": "1.0.1",
-	"description": "UI Compoonents for WordPress",
+	"description": "UI components for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/compose",
 	"version": "1.0.1",
-	"description": "WordPress Higher Order components",
+	"description": "WordPress higher-order components",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/compose",
 	"version": "1.0.1",
-	"description": "WordPress higher-order components",
+	"description": "WordPress higher-order components (HOCs)",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/dom-ready",
 	"version": "1.1.1",
-	"description": "Execute callback after the DOM is loaded.",
+	"description": "Execute callback after the DOM is loaded",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/dom",
 	"version": "1.0.1",
-	"description": "DOM utils module for WordPress",
+	"description": "DOM utilities module for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/hooks",
 	"version": "1.3.1",
-	"description": "WordPress Hooks library",
+	"description": "WordPress hooks library",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/html-entities",
 	"version": "1.0.1",
-	"description": "HTML entities utils for WordPress",
+	"description": "HTML entity utilties for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/i18n",
 	"version": "1.2.1",
-	"description": "WordPress i18n library",
+	"description": "WordPress internationalization (i18n) library",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/keycodes",
 	"version": "1.0.1",
-	"description": "Keycodes utilities for WordPress",
+	"description": "Keycodes utilities for WordPress; used to check for keyboard events across browsers/operating systems",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/keycodes",
 	"version": "1.0.1",
-	"description": "KeyCodes utilities for WordPress",
+	"description": "Keycodes utilities for WordPress",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/npm-package-json-lint-config",
 	"version": "1.1.1",
-	"description": "WordPress npm-package-json-lint shareable config",
+	"description": "WordPress npm-package-json-lint shareable configuration",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/wordcount",
 	"version": "1.1.1",
-	"description": "WordPress Word Count Utility",
+	"description": "WordPress word count utility",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [


### PR DESCRIPTION
## Description
I went in to fix a typo in the `@wordpress/components` package description, and ended up giving them all a bit of love.

## How has this been tested?
It has not been tested — the changes are only to text in the packages' `package.json` files.

## Types of changes
+ Applied sentence case to all descriptions
+ Expanded abbreviations (to words like internationalization, accessibility, utilities, etc.)
+ Removed trailing periods on a few descriptions
+ Improved the language in one or two cases