### PR TITLE
Added video block creation by dropping

### DIFF
--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -38,7 +38,7 @@ class VideoEdit extends Component {
 	}
 
 	componentDidMount() {
-		const { attributes, setAttributes } = this.props;
+		const { attributes, noticeOperations, setAttributes } = this.props;
 		const { id, src = '' } = attributes;
 		if ( ! id && src.indexOf( 'blob:' ) === 0 ) {
 			const file = getBlobByURL( src );
@@ -47,6 +47,10 @@ class VideoEdit extends Component {
 					filesList: [ file ],
 					onFileChange: ( [ { url } ] ) => {
 						setAttributes( { src: url } );
+					},
+					onError: ( message ) => {
+						this.setState( { editing: true } );
+						noticeOperations.createErrorNotice( message );
 					},
 					allowedType: 'video',
 				} );

--- a/core-blocks/video/edit.js
+++ b/core-blocks/video/edit.js
@@ -15,7 +15,9 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	RichText,
+	editorMediaUpload,
 } from '@wordpress/editor';
+import { getBlobByURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -33,6 +35,23 @@ class VideoEdit extends Component {
 
 		this.toggleAttribute = this.toggleAttribute.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
+	}
+
+	componentDidMount() {
+		const { attributes, setAttributes } = this.props;
+		const { id, src = '' } = attributes;
+		if ( ! id && src.indexOf( 'blob:' ) === 0 ) {
+			const file = getBlobByURL( src );
+			if ( file ) {
+				editorMediaUpload( {
+					filesList: [ file ],
+					onFileChange: ( [ { url } ] ) => {
+						setAttributes( { src: url } );
+					},
+					allowedType: 'video',
+				} );
+			}
+		}
 	}
 
 	toggleAttribute( attribute ) {

--- a/core-blocks/video/index.js
+++ b/core-blocks/video/index.js
@@ -7,6 +7,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/editor';
+import { createBlock } from '@wordpress/blocks';
+import { createBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -66,6 +68,27 @@ export const settings = {
 			selector: 'video',
 			attribute: 'src',
 		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'files',
+				isMatch( files ) {
+					return files.length === 1 && files[ 0 ].type.indexOf( 'video/' ) === 0;
+				},
+				transform( files ) {
+					const file = files[ 0 ];
+					// We don't need to upload the media directly here
+					// It's already done as part of the `componentDidMount`
+					// in the video block
+					const block = createBlock( 'core/video', {
+						src: createBlobURL( file ),
+					} );
+					return block;
+				},
+			},
+		],
 	},
 
 	supports: {


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/8021
## Description
Dropping a video file on an insertion point now creates a Video Block
instead of a File Block.

This was done by adding the corresponding transform for the Video Block
It supports immediate preview until upload.


## How has this been tested?
Included tests and manually

## Screenshots
Before:
![dropvideobefore](https://user-images.githubusercontent.com/3190666/43053140-97fb6940-8df0-11e8-88e0-1dc42fe3d7ad.gif)

After:
![dropvideoafters](https://user-images.githubusercontent.com/3190666/43053142-9cfc691c-8df0-11e8-8105-52af749e4917.gif)



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
