### PR TITLE
Rename Shared Blocks to Reusable Blocks

### DIFF
--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -12,7 +12,7 @@ import { withInstanceId } from '@wordpress/compose';
  */
 import './style.scss';
 
-class SharedBlockEditPanel extends Component {
+class ReusableBlockEditPanel extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -63,14 +63,14 @@ class SharedBlockEditPanel extends Component {
 		return (
 			<Fragment>
 				{ ( ! isEditing && ! isSaving ) && (
-					<div className="shared-block-edit-panel">
-						<b className="shared-block-edit-panel__info">
+					<div className="reusable-block-edit-panel">
+						<b className="reusable-block-edit-panel__info">
 							{ title }
 						</b>
 						<Button
 							ref={ this.editButton }
 							isLarge
-							className="shared-block-edit-panel__button"
+							className="reusable-block-edit-panel__button"
 							onClick={ onEdit }
 						>
 							{ __( 'Edit' ) }
@@ -78,10 +78,10 @@ class SharedBlockEditPanel extends Component {
 					</div>
 				) }
 				{ ( isEditing || isSaving ) && (
-					<form className="shared-block-edit-panel" onSubmit={ this.handleFormSubmit }>
+					<form className="reusable-block-edit-panel" onSubmit={ this.handleFormSubmit }>
 						<label
-							htmlFor={ `shared-block-edit-panel__title-${ instanceId }` }
-							className="shared-block-edit-panel__label"
+							htmlFor={ `reusable-block-edit-panel__title-${ instanceId }` }
+							className="reusable-block-edit-panel__label"
 						>
 							{ __( 'Name:' ) }
 						</label>
@@ -89,11 +89,11 @@ class SharedBlockEditPanel extends Component {
 							ref={ this.titleField }
 							type="text"
 							disabled={ isSaving }
-							className="shared-block-edit-panel__title"
+							className="reusable-block-edit-panel__title"
 							value={ title }
 							onChange={ this.handleTitleChange }
 							onKeyDown={ this.handleTitleKeyDown }
-							id={ `shared-block-edit-panel__title-${ instanceId }` }
+							id={ `reusable-block-edit-panel__title-${ instanceId }` }
 						/>
 						<Button
 							type="submit"
@@ -101,14 +101,14 @@ class SharedBlockEditPanel extends Component {
 							isLarge
 							isBusy={ isSaving }
 							disabled={ ! title || isSaving }
-							className="shared-block-edit-panel__button"
+							className="reusable-block-edit-panel__button"
 						>
 							{ __( 'Save' ) }
 						</Button>
 						<Button
 							isLarge
 							disabled={ isSaving }
-							className="shared-block-edit-panel__button"
+							className="reusable-block-edit-panel__button"
 							onClick={ onCancel }
 						>
 							{ __( 'Cancel' ) }
@@ -120,4 +120,4 @@ class SharedBlockEditPanel extends Component {
 	}
 }
 
-export default withInstanceId( SharedBlockEditPanel );
+export default withInstanceId( ReusableBlockEditPanel );

--- a/core-blocks/block/edit-panel/style.scss
+++ b/core-blocks/block/edit-panel/style.scss
@@ -1,4 +1,4 @@
-.editor-block-list__layout .shared-block-edit-panel {
+.editor-block-list__layout .reusable-block-edit-panel {
 	align-items: center;
 	background: $light-gray-100;
 	color: $dark-gray-500;
@@ -17,39 +17,39 @@
 		padding: 10px $block-padding;
 	}
 
-	.shared-block-edit-panel__spinner {
+	.reusable-block-edit-panel__spinner {
 		margin: 0 5px;
 	}
 
-	.shared-block-edit-panel__info {
+	.reusable-block-edit-panel__info {
 		margin-right: auto;
 	}
 
-	.shared-block-edit-panel__label {
+	.reusable-block-edit-panel__label {
 		margin-right: $item-spacing;
 		white-space: nowrap;
 		font-weight: 600;
 	}
 
-	.shared-block-edit-panel__title {
+	.reusable-block-edit-panel__title {
 		flex: 1 1 100%;
 		font-size: 14px;
 		height: 30px;
 		margin: #{ $item-spacing / 2 } 0 $item-spacing;
 	}
 
-	.components-button.shared-block-edit-panel__button {
+	.components-button.reusable-block-edit-panel__button {
 		margin: 0 5px 0 0;
 	}
 
 	@include break-large() {
 		flex-wrap: nowrap;
 
-		.shared-block-edit-panel__title {
+		.reusable-block-edit-panel__title {
 			margin: 0;
 		}
 
-		.components-button.shared-block-edit-panel__button {
+		.components-button.reusable-block-edit-panel__button {
 			margin: 0 0 0 5px;
 		}
 	}

--- a/core-blocks/block/edit.js
+++ b/core-blocks/block/edit.js
@@ -16,11 +16,11 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import SharedBlockEditPanel from './edit-panel';
-import SharedBlockIndicator from './indicator';
+import ReusableBlockEditPanel from './edit-panel';
+import ReusableBlockIndicator from './indicator';
 
-class SharedBlockEdit extends Component {
-	constructor( { sharedBlock } ) {
+class ReusableBlockEdit extends Component {
+	constructor( { reusableBlock } ) {
 		super( ...arguments );
 
 		this.startEditing = this.startEditing.bind( this );
@@ -29,15 +29,15 @@ class SharedBlockEdit extends Component {
 		this.setTitle = this.setTitle.bind( this );
 		this.save = this.save.bind( this );
 
-		if ( sharedBlock && sharedBlock.isTemporary ) {
-			// Start in edit mode when we're working with a newly created shared block
+		if ( reusableBlock && reusableBlock.isTemporary ) {
+			// Start in edit mode when we're working with a newly created reusable block
 			this.state = {
 				isEditing: true,
-				title: sharedBlock.title,
+				title: reusableBlock.title,
 				changedAttributes: {},
 			};
 		} else {
-			// Start in preview mode when we're working with an existing shared block
+			// Start in preview mode when we're working with an existing reusable block
 			this.state = {
 				isEditing: false,
 				title: null,
@@ -47,17 +47,17 @@ class SharedBlockEdit extends Component {
 	}
 
 	componentDidMount() {
-		if ( ! this.props.sharedBlock ) {
-			this.props.fetchSharedBlock();
+		if ( ! this.props.reusableBlock ) {
+			this.props.fetchReusableBlock();
 		}
 	}
 
 	startEditing() {
-		const { sharedBlock } = this.props;
+		const { reusableBlock } = this.props;
 
 		this.setState( {
 			isEditing: true,
-			title: sharedBlock.title,
+			title: reusableBlock.title,
 			changedAttributes: {},
 		} );
 	}
@@ -83,10 +83,10 @@ class SharedBlockEdit extends Component {
 	}
 
 	save() {
-		const { sharedBlock, onUpdateTitle, updateAttributes, block, onSave } = this.props;
+		const { reusableBlock, onUpdateTitle, updateAttributes, block, onSave } = this.props;
 		const { title, changedAttributes } = this.state;
 
-		if ( title !== sharedBlock.title ) {
+		if ( title !== reusableBlock.title ) {
 			onUpdateTitle( title );
 		}
 
@@ -97,14 +97,14 @@ class SharedBlockEdit extends Component {
 	}
 
 	render() {
-		const { isSelected, sharedBlock, block, isFetching, isSaving } = this.props;
+		const { isSelected, reusableBlock, block, isFetching, isSaving } = this.props;
 		const { isEditing, title, changedAttributes } = this.state;
 
-		if ( ! sharedBlock && isFetching ) {
+		if ( ! reusableBlock && isFetching ) {
 			return <Placeholder><Spinner /></Placeholder>;
 		}
 
-		if ( ! sharedBlock || ! block ) {
+		if ( ! reusableBlock || ! block ) {
 			return <Placeholder>{ __( 'Block has been deleted or is unavailable.' ) }</Placeholder>;
 		}
 
@@ -127,17 +127,17 @@ class SharedBlockEdit extends Component {
 			<Fragment>
 				{ element }
 				{ ( isSelected || isEditing ) && (
-					<SharedBlockEditPanel
+					<ReusableBlockEditPanel
 						isEditing={ isEditing }
-						title={ title !== null ? title : sharedBlock.title }
-						isSaving={ isSaving && ! sharedBlock.isTemporary }
+						title={ title !== null ? title : reusableBlock.title }
+						isSaving={ isSaving && ! reusableBlock.isTemporary }
 						onEdit={ this.startEditing }
 						onChangeTitle={ this.setTitle }
 						onSave={ this.save }
 						onCancel={ this.stopEditing }
 					/>
 				) }
-				{ ! isSelected && ! isEditing && <SharedBlockIndicator title={ sharedBlock.title } /> }
+				{ ! isSelected && ! isEditing && <ReusableBlockIndicator title={ reusableBlock.title } /> }
 			</Fragment>
 		);
 	}
@@ -146,35 +146,35 @@ class SharedBlockEdit extends Component {
 export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
-			getSharedBlock,
-			isFetchingSharedBlock,
-			isSavingSharedBlock,
+			getReusableBlock,
+			isFetchingReusableBlock,
+			isSavingReusableBlock,
 			getBlock,
 		} = select( 'core/editor' );
 		const { ref } = ownProps.attributes;
-		const sharedBlock = getSharedBlock( ref );
+		const reusableBlock = getReusableBlock( ref );
 
 		return {
-			sharedBlock,
-			isFetching: isFetchingSharedBlock( ref ),
-			isSaving: isSavingSharedBlock( ref ),
-			block: sharedBlock ? getBlock( sharedBlock.clientId ) : null,
+			reusableBlock,
+			isFetching: isFetchingReusableBlock( ref ),
+			isSaving: isSavingReusableBlock( ref ),
+			block: reusableBlock ? getBlock( reusableBlock.clientId ) : null,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const {
-			fetchSharedBlocks,
+			fetchReusableBlocks,
 			updateBlockAttributes,
-			updateSharedBlockTitle,
-			saveSharedBlock,
+			updateReusableBlockTitle,
+			saveReusableBlock,
 		} = dispatch( 'core/editor' );
 		const { ref } = ownProps.attributes;
 
 		return {
-			fetchSharedBlock: partial( fetchSharedBlocks, ref ),
+			fetchReusableBlock: partial( fetchReusableBlocks, ref ),
 			updateAttributes: updateBlockAttributes,
-			onUpdateTitle: partial( updateSharedBlockTitle, ref ),
-			onSave: partial( saveSharedBlock, ref ),
+			onUpdateTitle: partial( updateReusableBlockTitle, ref ),
+			onSave: partial( saveReusableBlock, ref ),
 		};
 	} ),
-] )( SharedBlockEdit );
+] )( ReusableBlockEdit );

--- a/core-blocks/block/index.js
+++ b/core-blocks/block/index.js
@@ -11,8 +11,8 @@ import edit from './edit';
 export const name = 'core/block';
 
 export const settings = {
-	title: __( 'Shared Block' ),
-	category: 'shared',
+	title: __( 'Reusable Block' ),
+	category: 'reusable',
 
 	attributes: {
 		ref: {

--- a/core-blocks/block/index.php
+++ b/core-blocks/block/index.php
@@ -17,12 +17,12 @@ function render_block_core_block( $attributes ) {
 		return '';
 	}
 
-	$shared_block = get_post( $attributes['ref'] );
-	if ( ! $shared_block || 'wp_block' !== $shared_block->post_type ) {
+	$reusable_block = get_post( $attributes['ref'] );
+	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
 		return '';
 	}
 
-	return do_blocks( $shared_block->post_content );
+	return do_blocks( $reusable_block->post_content );
 }
 
 register_block_type( 'core/block', array(

--- a/core-blocks/block/indicator/index.js
+++ b/core-blocks/block/indicator/index.js
@@ -9,16 +9,16 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import './style.scss';
 
-function SharedBlockIndicator( { title } ) {
-	// translators: %s: title/name of the shared block
-	const tooltipText = sprintf( __( 'Shared Block: %s' ), title );
+function ReusableBlockIndicator( { title } ) {
+	// translators: %s: title/name of the reusable block
+	const tooltipText = sprintf( __( 'Reusable Block: %s' ), title );
 	return (
 		<Tooltip text={ tooltipText }>
-			<span className="shared-block-indicator">
+			<span className="reusable-block-indicator">
 				<Dashicon icon="controls-repeat" />
 			</span>
 		</Tooltip>
 	);
 }
 
-export default SharedBlockIndicator;
+export default ReusableBlockIndicator;

--- a/core-blocks/block/indicator/style.scss
+++ b/core-blocks/block/indicator/style.scss
@@ -1,4 +1,4 @@
-.editor-block-list__layout .shared-block-indicator {
+.editor-block-list__layout .reusable-block-indicator {
 	background: $white;
 	border-left: 1px dashed $light-gray-500;
 	color: $dark-gray-500;

--- a/core-blocks/index.js
+++ b/core-blocks/index.js
@@ -35,7 +35,7 @@ import * as more from './more';
 import * as nextpage from './nextpage';
 import * as preformatted from './preformatted';
 import * as pullquote from './pullquote';
-import * as sharedBlock from './block';
+import * as reusableBlock from './block';
 import * as separator from './separator';
 import * as shortcode from './shortcode';
 import * as spacer from './spacer';
@@ -79,7 +79,7 @@ export const registerCoreBlocks = () => {
 		preformatted,
 		pullquote,
 		separator,
-		sharedBlock,
+		reusableBlock,
 		spacer,
 		subhead,
 		table,

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -878,36 +878,36 @@ Returns the user notices array.
 
 List of notices.
 
-### isSavingSharedBlock
+### isSavingReusableBlock
 
-Returns whether or not the shared block with the given ID is being saved.
+Returns whether or not the reusable block with the given ID is being saved.
 
 *Parameters*
 
  * state: Global application state.
- * ref: The shared block's ID.
+ * ref: The reusable block's ID.
 
 *Returns*
 
-Whether or not the shared block is being saved.
+Whether or not the reusable block is being saved.
 
-### isFetchingSharedBlock
+### isFetchingReusableBlock
 
-Returns true if the shared block with the given ID is being fetched, or
+Returns true if the reusable block with the given ID is being fetched, or
 false otherwise.
 
 *Parameters*
 
  * state: Global application state.
- * ref: The shared block's ID.
+ * ref: The reusable block's ID.
 
 *Returns*
 
-Whether the shared block is being fetched.
+Whether the reusable block is being fetched.
 
-### getSharedBlocks
+### getReusableBlocks
 
-Returns an array of all shared blocks.
+Returns an array of all reusable blocks.
 
 *Parameters*
 
@@ -915,7 +915,7 @@ Returns an array of all shared blocks.
 
 *Returns*
 
-An array of all shared blocks.
+An array of all reusable blocks.
 
 ### getStateBeforeOptimisticTransaction
 
@@ -1343,65 +1343,65 @@ Returns an action object used to remove a notice.
 
  * id: The notice id.
 
-### fetchSharedBlocks
+### fetchReusableBlocks
 
-Returns an action object used to fetch a single shared block or all shared
-blocks from the REST API into the store.
+Returns an action object used to fetch a single reusable block or all
+reusable blocks from the REST API into the store.
 
 *Parameters*
 
- * id: If given, only a single shared block with this ID will
+ * id: If given, only a single reusable block with this ID will
                     be fetched.
 
-### receiveSharedBlocks
+### receiveReusableBlocks
 
-Returns an action object used in signalling that shared blocks have been
+Returns an action object used in signalling that reusable blocks have been
 received. `results` is an array of objects containing:
- - `sharedBlock` - Details about how the shared block is persisted.
+ - `reusableBlock` - Details about how the reusable block is persisted.
  - `parsedBlock` - The original block.
 
 *Parameters*
 
- * results: Shared blocks received.
+ * results: Reusable blocks received.
 
-### saveSharedBlock
+### saveReusableBlock
 
-Returns an action object used to save a shared block that's in the store to
+Returns an action object used to save a reusable block that's in the store to
 the REST API.
 
 *Parameters*
 
- * id: The ID of the shared block to save.
+ * id: The ID of the reusable block to save.
 
-### deleteSharedBlock
+### deleteReusableBlock
 
-Returns an action object used to delete a shared block via the REST API.
+Returns an action object used to delete a reusable block via the REST API.
 
 *Parameters*
 
- * id: The ID of the shared block to delete.
+ * id: The ID of the reusable block to delete.
 
-### updateSharedBlockTitle
+### updateReusableBlockTitle
 
-Returns an action object used in signalling that a shared block's title is
+Returns an action object used in signalling that a reusable block's title is
 to be updated.
 
 *Parameters*
 
- * id: The ID of the shared block to update.
+ * id: The ID of the reusable block to update.
  * title: The new title.
 
 ### convertBlockToStatic
 
-Returns an action object used to convert a shared block into a static block.
+Returns an action object used to convert a reusable block into a static block.
 
 *Parameters*
 
  * clientId: The client ID of the block to attach.
 
-### convertBlockToShared
+### convertBlockToReusable
 
-Returns an action object used to convert a static block into a shared block.
+Returns an action object used to convert a static block into a reusable block.
 
 *Parameters*
 

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -39,7 +39,7 @@ $z-layers: (
 
 	// Should have higher index than the inset/underlay used for dragging
 	'.components-placeholder__fieldset': 1,
-	'.editor-block-list__block-edit .shared-block-edit-panel *': 1,
+	'.editor-block-list__block-edit .reusable-block-edit-panel *': 1,
 
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -19,7 +19,7 @@ import {
 	cloneBlock,
 	getBlockType,
 	getSaveElement,
-	isSharedBlock,
+	isReusableBlock,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
@@ -412,7 +412,7 @@ export class BlockListBlock extends Component {
 			'is-multi-selected': isPartOfMultiSelection,
 			'is-selected-parent': shouldAppearSelectedParent,
 			'is-hovered': isHovered && ! isEmptyDefaultBlock,
-			'is-shared': isSharedBlock( blockType ),
+			'is-reusable': isReusableBlock( blockType ),
 			'is-hidden': dragging,
 			'is-typing': isTypingWithinBlock,
 		} );

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -98,8 +98,8 @@
 		visibility: hidden;
 	}
 
-	.editor-block-list__block-edit .shared-block-edit-panel * {
-		z-index: z-index( '.editor-block-list__block-edit .shared-block-edit-panel *' );
+	.editor-block-list__block-edit .reusable-block-edit-panel * {
+		z-index: z-index( '.editor-block-list__block-edit .reusable-block-edit-panel *' );
 	}
 }
 
@@ -328,8 +328,8 @@
 		transition: opacity 0.2s;
 	}
 
-	// Shared blocks
-	&.is-shared > .editor-block-list__block-edit:before {
+	// Reusable blocks
+	&.is-reusable > .editor-block-list__block-edit:before {
 		// Use opacity to work in various editor styles.
 		outline: $border-width dashed $dark-opacity-light-500;
 

--- a/editor/components/block-preview/style.scss
+++ b/editor/components/block-preview/style.scss
@@ -23,7 +23,7 @@
 			height: auto;
 		}
 
-		> .shared-block-indicator {
+		> .reusable-block-indicator {
 			display: none;
 		}
 	}

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -20,8 +20,8 @@ import './style.scss';
 import BlockModeToggle from './block-mode-toggle';
 import BlockDuplicateButton from './block-duplicate-button';
 import BlockRemoveButton from './block-remove-button';
-import SharedBlockConvertButton from './shared-block-convert-button';
-import SharedBlockDeleteButton from './shared-block-delete-button';
+import ReusableBlockConvertButton from './reusable-block-convert-button';
+import ReusableBlockDeleteButton from './reusable-block-delete-button';
 import BlockHTMLConvertButton from './block-html-convert-button';
 import BlockUnknownConvertButton from './block-unknown-convert-button';
 import _BlockSettingsMenuFirstItem from './block-settings-menu-first-item';
@@ -121,7 +121,7 @@ export class BlockSettingsMenu extends Component {
 								role="menuitem"
 							/>
 							{ count === 1 && (
-								<SharedBlockConvertButton
+								<ReusableBlockConvertButton
 									clientId={ firstBlockClientId }
 									onToggle={ onClose }
 									itemsRole="menuitem"
@@ -129,7 +129,7 @@ export class BlockSettingsMenu extends Component {
 							) }
 							<div className="editor-block-settings-menu__separator" />
 							{ count === 1 && (
-								<SharedBlockDeleteButton
+								<ReusableBlockDeleteButton
 									clientId={ firstBlockClientId }
 									onToggle={ onClose }
 									itemsRole="menuitem"

--- a/editor/components/block-settings-menu/reusable-block-convert-button.js
+++ b/editor/components/block-settings-menu/reusable-block-convert-button.js
@@ -9,15 +9,15 @@ import { noop } from 'lodash';
 import { Fragment } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { isSharedBlock } from '@wordpress/blocks';
+import { isReusableBlock } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-export function SharedBlockConvertButton( {
+export function ReusableBlockConvertButton( {
 	isVisible,
 	isStaticBlock,
 	onConvertToStatic,
-	onConvertToShared,
+	onConvertToReusable,
 	itemsRole,
 } ) {
 	if ( ! isVisible ) {
@@ -30,10 +30,10 @@ export function SharedBlockConvertButton( {
 				<IconButton
 					className="editor-block-settings-menu__control"
 					icon="controls-repeat"
-					onClick={ onConvertToShared }
+					onClick={ onConvertToReusable }
 					role={ itemsRole }
 				>
-					{ __( 'Convert to Shared Block' ) }
+					{ __( 'Convert to Reusable Block' ) }
 				</IconButton>
 			) }
 			{ ! isStaticBlock && (
@@ -52,7 +52,7 @@ export function SharedBlockConvertButton( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getBlock, getSharedBlock } = select( 'core/editor' );
+		const { getBlock, getReusableBlock } = select( 'core/editor' );
 		const { getFallbackBlockName } = select( 'core/blocks' );
 
 		const block = getBlock( clientId );
@@ -61,15 +61,15 @@ export default compose( [
 		}
 
 		return {
-			// Hide 'Convert to Shared Block' on Classic blocks. Showing it causes a
+			// Hide 'Convert to Reusable Block' on Classic blocks. Showing it causes a
 			// confusing UX, because of its similarity to the 'Convert to Blocks' button.
 			isVisible: block.name !== getFallbackBlockName(),
-			isStaticBlock: ! isSharedBlock( block ) || ! getSharedBlock( block.attributes.ref ),
+			isStaticBlock: ! isReusableBlock( block ) || ! getReusableBlock( block.attributes.ref ),
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, onToggle = noop } ) => {
 		const {
-			convertBlockToShared,
+			convertBlockToReusable,
 			convertBlockToStatic,
 		} = dispatch( 'core/editor' );
 
@@ -78,10 +78,10 @@ export default compose( [
 				convertBlockToStatic( clientId );
 				onToggle();
 			},
-			onConvertToShared() {
-				convertBlockToShared( clientId );
+			onConvertToReusable() {
+				convertBlockToReusable( clientId );
 				onToggle();
 			},
 		};
 	} ),
-] )( SharedBlockConvertButton );
+] )( ReusableBlockConvertButton );

--- a/editor/components/block-settings-menu/reusable-block-convert-button.js
+++ b/editor/components/block-settings-menu/reusable-block-convert-button.js
@@ -33,7 +33,7 @@ export function ReusableBlockConvertButton( {
 					onClick={ onConvertToReusable }
 					role={ itemsRole }
 				>
-					{ __( 'Convert to Reusable Block' ) }
+					{ __( 'Add to Reusable Blocks' ) }
 				</IconButton>
 			) }
 			{ ! isStaticBlock && (
@@ -61,7 +61,7 @@ export default compose( [
 		}
 
 		return {
-			// Hide 'Convert to Reusable Block' on Classic blocks. Showing it causes a
+			// Hide 'Add to Reusable Blocks' on Classic blocks. Showing it causes a
 			// confusing UX, because of its similarity to the 'Convert to Blocks' button.
 			isVisible: block.name !== getFallbackBlockName(),
 			isStaticBlock: ! isReusableBlock( block ) || ! getReusableBlock( block.attributes.ref ),

--- a/editor/components/block-settings-menu/reusable-block-delete-button.js
+++ b/editor/components/block-settings-menu/reusable-block-delete-button.js
@@ -25,7 +25,7 @@ export function ReusableBlockDeleteButton( { reusableBlock, onDelete, itemsRole 
 			onClick={ () => onDelete( reusableBlock.id ) }
 			role={ itemsRole }
 		>
-			{ __( 'Delete Reusable Block' ) }
+			{ __( 'Remove from Reusable Blocks' ) }
 		</IconButton>
 	);
 }

--- a/editor/components/block-settings-menu/reusable-block-delete-button.js
+++ b/editor/components/block-settings-menu/reusable-block-delete-button.js
@@ -9,11 +9,11 @@ import { noop } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { isSharedBlock } from '@wordpress/blocks';
+import { isReusableBlock } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-export function SharedBlockDeleteButton( { sharedBlock, onDelete, itemsRole } ) {
-	if ( ! sharedBlock ) {
+export function ReusableBlockDeleteButton( { reusableBlock, onDelete, itemsRole } ) {
+	if ( ! reusableBlock ) {
 		return null;
 	}
 
@@ -21,26 +21,26 @@ export function SharedBlockDeleteButton( { sharedBlock, onDelete, itemsRole } ) 
 		<IconButton
 			className="editor-block-settings-menu__control"
 			icon="no"
-			disabled={ sharedBlock.isTemporary }
-			onClick={ () => onDelete( sharedBlock.id ) }
+			disabled={ reusableBlock.isTemporary }
+			onClick={ () => onDelete( reusableBlock.id ) }
 			role={ itemsRole }
 		>
-			{ __( 'Delete Shared Block' ) }
+			{ __( 'Delete Reusable Block' ) }
 		</IconButton>
 	);
 }
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getBlock, getSharedBlock } = select( 'core/editor' );
+		const { getBlock, getReusableBlock } = select( 'core/editor' );
 		const block = getBlock( clientId );
 		return {
-			sharedBlock: block && isSharedBlock( block ) ? getSharedBlock( block.attributes.ref ) : null,
+			reusableBlock: block && isReusableBlock( block ) ? getReusableBlock( block.attributes.ref ) : null,
 		};
 	} ),
 	withDispatch( ( dispatch, { onToggle = noop } ) => {
 		const {
-			deleteSharedBlock,
+			deleteReusableBlock,
 		} = dispatch( 'core/editor' );
 
 		return {
@@ -48,15 +48,15 @@ export default compose( [
 				// TODO: Make this a <Confirm /> component or similar
 				// eslint-disable-next-line no-alert
 				const hasConfirmed = window.confirm( __(
-					'Are you sure you want to delete this Shared Block?\n\n' +
+					'Are you sure you want to delete this Reusable Block?\n\n' +
 					'It will be permanently removed from all posts and pages that use it.'
 				) );
 
 				if ( hasConfirmed ) {
-					deleteSharedBlock( id );
+					deleteReusableBlock( id );
 					onToggle();
 				}
 			},
 		};
 	} ),
-] )( SharedBlockDeleteButton );
+] )( ReusableBlockDeleteButton );

--- a/editor/components/block-settings-menu/test/__snapshots__/reusable-block-delete-button.js.snap
+++ b/editor/components/block-settings-menu/test/__snapshots__/reusable-block-delete-button.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SharedBlockDeleteButton matches the snapshot 1`] = `
+exports[`ReusableBlockDeleteButton matches the snapshot 1`] = `
 <IconButton
   className="editor-block-settings-menu__control"
   icon="no"
   onClick={[Function]}
 >
-  Delete Shared Block
+  Delete Reusable Block
 </IconButton>
 `;

--- a/editor/components/block-settings-menu/test/__snapshots__/reusable-block-delete-button.js.snap
+++ b/editor/components/block-settings-menu/test/__snapshots__/reusable-block-delete-button.js.snap
@@ -6,6 +6,6 @@ exports[`ReusableBlockDeleteButton matches the snapshot 1`] = `
   icon="no"
   onClick={[Function]}
 >
-  Delete Reusable Block
+  Remove from Reusable Blocks
 </IconButton>
 `;

--- a/editor/components/block-settings-menu/test/reusable-block-convert-button.js
+++ b/editor/components/block-settings-menu/test/reusable-block-convert-button.js
@@ -26,7 +26,7 @@ describe( 'ReusableBlockConvertButton', () => {
 			/>
 		);
 		const button = wrapper.find( 'IconButton' ).first();
-		expect( button.children().text() ).toBe( 'Convert to Reusable Block' );
+		expect( button.children().text() ).toBe( 'Add to Reusable Blocks' );
 		button.simulate( 'click' );
 		expect( onConvert ).toHaveBeenCalled();
 	} );

--- a/editor/components/block-settings-menu/test/reusable-block-convert-button.js
+++ b/editor/components/block-settings-menu/test/reusable-block-convert-button.js
@@ -6,35 +6,35 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { SharedBlockConvertButton } from '../shared-block-convert-button';
+import { ReusableBlockConvertButton } from '../reusable-block-convert-button';
 
-describe( 'SharedBlockConvertButton', () => {
+describe( 'ReusableBlockConvertButton', () => {
 	it( 'should not render when isVisible false', () => {
 		const wrapper = shallow(
-			<SharedBlockConvertButton isVisible={ false } />
+			<ReusableBlockConvertButton isVisible={ false } />
 		);
 		expect( wrapper.children() ).not.toExist();
 	} );
 
-	it( 'should allow converting a static block to a shared block', () => {
+	it( 'should allow converting a static block to a reusable block', () => {
 		const onConvert = jest.fn();
 		const wrapper = shallow(
-			<SharedBlockConvertButton
+			<ReusableBlockConvertButton
 				isVisible
 				isStaticBlock
-				onConvertToShared={ onConvert }
+				onConvertToReusable={ onConvert }
 			/>
 		);
 		const button = wrapper.find( 'IconButton' ).first();
-		expect( button.children().text() ).toBe( 'Convert to Shared Block' );
+		expect( button.children().text() ).toBe( 'Convert to Reusable Block' );
 		button.simulate( 'click' );
 		expect( onConvert ).toHaveBeenCalled();
 	} );
 
-	it( 'should allow converting a shared block to static', () => {
+	it( 'should allow converting a reusable block to static', () => {
 		const onConvert = jest.fn();
 		const wrapper = shallow(
-			<SharedBlockConvertButton
+			<ReusableBlockConvertButton
 				isVisible
 				isStaticBlock={ false }
 				onConvertToStatic={ onConvert }

--- a/editor/components/block-settings-menu/test/reusable-block-delete-button.js
+++ b/editor/components/block-settings-menu/test/reusable-block-delete-button.js
@@ -7,14 +7,14 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { SharedBlockDeleteButton } from '../shared-block-delete-button';
+import { ReusableBlockDeleteButton } from '../reusable-block-delete-button';
 
-describe( 'SharedBlockDeleteButton', () => {
+describe( 'ReusableBlockDeleteButton', () => {
 	it( 'matches the snapshot', () => {
 		const wrapper = shallow(
-			<SharedBlockDeleteButton
+			<ReusableBlockDeleteButton
 				role="menuitem"
-				sharedBlock={ { id: 123 } }
+				reusableBlock={ { id: 123 } }
 				onDelete={ noop }
 			/>
 		);
@@ -22,11 +22,11 @@ describe( 'SharedBlockDeleteButton', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'should allow deleting a shared block', () => {
+	it( 'should allow deleting a reusable block', () => {
 		const onDelete = jest.fn();
 		const wrapper = shallow(
-			<SharedBlockDeleteButton
-				sharedBlock={ { id: 123 } }
+			<ReusableBlockDeleteButton
+				reusableBlock={ { id: 123 } }
 				onDelete={ onDelete }
 			/>
 		);

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -25,7 +25,7 @@ import {
 	withSpokenMessages,
 	PanelBody,
 } from '@wordpress/components';
-import { getCategories, isSharedBlock } from '@wordpress/blocks';
+import { getCategories, isReusableBlock } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withInstanceId, compose, withSafeTimeout } from '@wordpress/compose';
 
@@ -65,7 +65,7 @@ export class InserterMenu extends Component {
 			filterValue: '',
 			hoveredItem: null,
 			suggestedItems: [],
-			sharedItems: [],
+			reusableItems: [],
 			itemsPerCategory: {},
 			openPanels: [ 'suggested' ],
 		};
@@ -77,7 +77,7 @@ export class InserterMenu extends Component {
 
 	componentDidMount() {
 		// This could be replaced by a resolver.
-		this.props.fetchSharedBlocks();
+		this.props.fetchReusableBlocks();
 		this.filter();
 	}
 
@@ -147,13 +147,13 @@ export class InserterMenu extends Component {
 			suggestedItems = filter( items, ( item ) => item.utility > 0 ).slice( 0, maxSuggestedItems );
 		}
 
-		const sharedItems = filter( filteredItems, { category: 'shared' } );
+		const reusableItems = filter( filteredItems, { category: 'reusable' } );
 
 		const getCategoryIndex = ( item ) => {
 			return findIndex( getCategories(), ( category ) => category.slug === item.category );
 		};
 		const itemsPerCategory = flow(
-			( itemList ) => filter( itemList, ( item ) => item.category !== 'shared' ),
+			( itemList ) => filter( itemList, ( item ) => item.category !== 'reusable' ),
 			( itemList ) => sortBy( itemList, getCategoryIndex ),
 			( itemList ) => groupBy( itemList, 'category' )
 		)( filteredItems );
@@ -162,8 +162,8 @@ export class InserterMenu extends Component {
 		if ( filterValue !== this.state.filterValue ) {
 			if ( ! filterValue ) {
 				openPanels = [ 'suggested' ];
-			} else if ( sharedItems.length ) {
-				openPanels = [ 'shared' ];
+			} else if ( reusableItems.length ) {
+				openPanels = [ 'reusable' ];
 			} else if ( filteredItems.length ) {
 				const firstCategory = find( getCategories(), ( { slug } ) => itemsPerCategory[ slug ] && itemsPerCategory[ slug ].length );
 				openPanels = [ firstCategory.slug ];
@@ -175,7 +175,7 @@ export class InserterMenu extends Component {
 			childItems,
 			filterValue,
 			suggestedItems,
-			sharedItems,
+			reusableItems,
 			itemsPerCategory,
 			openPanels,
 		} );
@@ -183,7 +183,7 @@ export class InserterMenu extends Component {
 
 	render() {
 		const { instanceId, onSelect, rootClientId } = this.props;
-		const { childItems, filterValue, hoveredItem, suggestedItems, sharedItems, itemsPerCategory, openPanels } = this.state;
+		const { childItems, filterValue, hoveredItem, suggestedItems, reusableItems, itemsPerCategory, openPanels } = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
 		const isSearching = !! filterValue;
 
@@ -249,23 +249,23 @@ export class InserterMenu extends Component {
 							</PanelBody>
 						);
 					} ) }
-					{ !! sharedItems.length && (
+					{ !! reusableItems.length && (
 						<PanelBody
-							title={ __( 'Shared' ) }
-							opened={ isPanelOpen( 'shared' ) }
-							onToggle={ this.onTogglePanel( 'shared' ) }
+							title={ __( 'Reusable' ) }
+							opened={ isPanelOpen( 'reusable' ) }
+							onToggle={ this.onTogglePanel( 'reusable' ) }
 							icon="controls-repeat"
-							ref={ this.bindPanel( 'shared' ) }
+							ref={ this.bindPanel( 'reusable' ) }
 						>
-							<BlockTypesList items={ sharedItems } onSelect={ onSelect } onHover={ this.onHover } />
+							<BlockTypesList items={ reusableItems } onSelect={ onSelect } onHover={ this.onHover } />
 						</PanelBody>
 					) }
-					{ isEmpty( suggestedItems ) && isEmpty( sharedItems ) && isEmpty( itemsPerCategory ) && (
+					{ isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory ) && (
 						<p className="editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
 					) }
 				</div>
 
-				{ hoveredItem && isSharedBlock( hoveredItem ) &&
+				{ hoveredItem && isReusableBlock( hoveredItem ) &&
 					<BlockPreview name={ hoveredItem.name } attributes={ hoveredItem.initialAttributes } />
 				}
 			</div>
@@ -288,7 +288,7 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
-		fetchSharedBlocks: dispatch( 'core/editor' ).fetchSharedBlocks,
+		fetchReusableBlocks: dispatch( 'core/editor' ).fetchReusableBlocks,
 		showInsertionPoint: dispatch( 'core/editor' ).showInsertionPoint,
 		hideInsertionPoint: dispatch( 'core/editor' ).hideInsertionPoint,
 	} ) ),

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -71,12 +71,12 @@ const textEmbedItem = {
 	utility: 0,
 };
 
-const sharedItem = {
+const reusableItem = {
 	id: 'core/block/123',
 	name: 'core/block',
 	initialAttributes: { ref: 123 },
-	title: 'My shared block',
-	category: 'shared',
+	title: 'My reusable block',
+	category: 'reusable',
 	isDisabled: false,
 	utility: 0,
 };
@@ -88,14 +88,14 @@ const items = [
 	moreItem,
 	youtubeItem,
 	textEmbedItem,
-	sharedItem,
+	reusableItem,
 ];
 
 const DEFAULT_PROPS = {
 	position: 'top center',
 	items: items,
 	debouncedSpeak: noop,
-	fetchSharedBlocks: noop,
+	fetchReusableBlocks: noop,
 	setTimeout: noop,
 };
 
@@ -220,11 +220,11 @@ describe( 'InserterMenu', () => {
 		assertNoResultsMessageNotToBePresent( element );
 	} );
 
-	it( 'should show shared items in the shared tab', () => {
+	it( 'should show reusable items in the reusable tab', () => {
 		const element = initializeAllClosedMenuStateAndReturnElement();
-		const sharedTab = getTabButtonWithContent( element, 'Shared' );
+		const reusableTab = getTabButtonWithContent( element, 'Reusable' );
 
-		TestUtils.Simulate.click( sharedTab );
+		TestUtils.Simulate.click( reusableTab );
 
 		assertOpenedPanels( element, 1 );
 
@@ -233,7 +233,7 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( visibleBlocks ).toHaveLength( 1 );
-		expect( visibleBlocks[ 0 ].textContent ).toBe( 'My shared block' );
+		expect( visibleBlocks[ 0 ].textContent ).toBe( 'My reusable block' );
 
 		assertNoResultsMessageNotToBePresent( element );
 	} );

--- a/editor/hooks/default-autocompleters.js
+++ b/editor/hooks/default-autocompleters.js
@@ -17,7 +17,7 @@ import { blockAutocompleter, userAutocompleter } from '../components';
 
 const defaultAutocompleters = [ userAutocompleter ];
 
-const fetchSharedBlocks = once( () => dispatch( 'core/editor' ).fetchSharedBlocks() );
+const fetchReusableBlocks = once( () => dispatch( 'core/editor' ).fetchReusableBlocks() );
 
 function setDefaultCompleters( completers, blockName ) {
 	if ( ! completers ) {
@@ -28,12 +28,12 @@ function setDefaultCompleters( completers, blockName ) {
 			completers.push( clone( blockAutocompleter ) );
 
 			/*
-			 * NOTE: This is a hack to help ensure shared blocks are loaded
+			 * NOTE: This is a hack to help ensure reusable blocks are loaded
 			 * so they may be included in the block completer. It can be removed
 			 * once we have a way for completers to Promise options while
 			 * store-based data dependencies are being resolved.
 			 */
-			fetchSharedBlocks();
+			fetchReusableBlocks();
 		}
 	}
 	return completers;

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -11,6 +11,7 @@ import {
 	getDefaultBlockName,
 	createBlock,
 } from '@wordpress/blocks';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Returns an action object used in signalling that editor has initialized with
@@ -765,4 +766,64 @@ export function unregisterToken( name ) {
 		type: 'UNREGISTER_TOKEN',
 		name,
 	};
+}
+
+export function fetchSharedBlocks( id ) {
+	deprecated( 'fetchSharedBlocks', {
+		alternative: 'fetchReusableBlocks',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return fetchReusableBlocks( id );
+}
+
+export function receiveSharedBlocks( results ) {
+	deprecated( 'receiveSharedBlocks', {
+		alternative: 'receiveReusableBlocks',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return receiveReusableBlocks( results );
+}
+
+export function saveSharedBlock( id ) {
+	deprecated( 'saveSharedBlock', {
+		alternative: 'saveReusableBlock',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return saveReusableBlock( id );
+}
+
+export function deleteSharedBlock( id ) {
+	deprecated( 'deleteSharedBlock', {
+		alternative: 'deleteReusableBlock',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return deleteReusableBlock( id );
+}
+
+export function updateSharedBlockTitle( id, title ) {
+	deprecated( 'updateSharedBlockTitle', {
+		alternative: 'updateReusableBlockTitle',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return updateReusableBlockTitle( id, title );
+}
+
+export function convertBlockToSaved( clientId ) {
+	deprecated( 'convertBlockToSaved', {
+		alternative: 'convertBlockToReusable',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return convertBlockToReusable( clientId );
 }

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -596,86 +596,86 @@ export const createErrorNotice = partial( createNotice, 'error' );
 export const createWarningNotice = partial( createNotice, 'warning' );
 
 /**
- * Returns an action object used to fetch a single shared block or all shared
- * blocks from the REST API into the store.
+ * Returns an action object used to fetch a single reusable block or all
+ * reusable blocks from the REST API into the store.
  *
- * @param {?string} id If given, only a single shared block with this ID will
+ * @param {?string} id If given, only a single reusable block with this ID will
  *                     be fetched.
  *
  * @return {Object} Action object.
  */
-export function fetchSharedBlocks( id ) {
+export function fetchReusableBlocks( id ) {
 	return {
-		type: 'FETCH_SHARED_BLOCKS',
+		type: 'FETCH_REUSABLE_BLOCKS',
 		id,
 	};
 }
 
 /**
- * Returns an action object used in signalling that shared blocks have been
+ * Returns an action object used in signalling that reusable blocks have been
  * received. `results` is an array of objects containing:
- *  - `sharedBlock` - Details about how the shared block is persisted.
+ *  - `reusableBlock` - Details about how the reusable block is persisted.
  *  - `parsedBlock` - The original block.
  *
- * @param {Object[]} results Shared blocks received.
+ * @param {Object[]} results Reusable blocks received.
  *
  * @return {Object} Action object.
  */
-export function receiveSharedBlocks( results ) {
+export function receiveReusableBlocks( results ) {
 	return {
-		type: 'RECEIVE_SHARED_BLOCKS',
+		type: 'RECEIVE_REUSABLE_BLOCKS',
 		results,
 	};
 }
 
 /**
- * Returns an action object used to save a shared block that's in the store to
+ * Returns an action object used to save a reusable block that's in the store to
  * the REST API.
  *
- * @param {Object} id The ID of the shared block to save.
+ * @param {Object} id The ID of the reusable block to save.
  *
  * @return {Object} Action object.
  */
-export function saveSharedBlock( id ) {
+export function saveReusableBlock( id ) {
 	return {
-		type: 'SAVE_SHARED_BLOCK',
+		type: 'SAVE_REUSABLE_BLOCK',
 		id,
 	};
 }
 
 /**
- * Returns an action object used to delete a shared block via the REST API.
+ * Returns an action object used to delete a reusable block via the REST API.
  *
- * @param {number} id The ID of the shared block to delete.
+ * @param {number} id The ID of the reusable block to delete.
  *
  * @return {Object} Action object.
  */
-export function deleteSharedBlock( id ) {
+export function deleteReusableBlock( id ) {
 	return {
-		type: 'DELETE_SHARED_BLOCK',
+		type: 'DELETE_REUSABLE_BLOCK',
 		id,
 	};
 }
 
 /**
- * Returns an action object used in signalling that a shared block's title is
+ * Returns an action object used in signalling that a reusable block's title is
  * to be updated.
  *
- * @param {number} id    The ID of the shared block to update.
+ * @param {number} id    The ID of the reusable block to update.
  * @param {string} title The new title.
  *
  * @return {Object} Action object.
  */
-export function updateSharedBlockTitle( id, title ) {
+export function updateReusableBlockTitle( id, title ) {
 	return {
-		type: 'UPDATE_SHARED_BLOCK_TITLE',
+		type: 'UPDATE_REUSABLE_BLOCK_TITLE',
 		id,
 		title,
 	};
 }
 
 /**
- * Returns an action object used to convert a shared block into a static block.
+ * Returns an action object used to convert a reusable block into a static block.
  *
  * @param {string} clientId The client ID of the block to attach.
  *
@@ -689,15 +689,15 @@ export function convertBlockToStatic( clientId ) {
 }
 
 /**
- * Returns an action object used to convert a static block into a shared block.
+ * Returns an action object used to convert a static block into a reusable block.
  *
  * @param {string} clientId The client ID of the block to detach.
  *
  * @return {Object} Action object.
  */
-export function convertBlockToShared( clientId ) {
+export function convertBlockToReusable( clientId ) {
 	return {
-		type: 'CONVERT_BLOCK_TO_SHARED',
+		type: 'CONVERT_BLOCK_TO_REUSABLE',
 		clientId,
 	};
 }

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -44,13 +44,13 @@ import {
 	getTemplateLock,
 } from './selectors';
 import {
-	fetchSharedBlocks,
-	saveSharedBlocks,
-	deleteSharedBlocks,
-	convertBlockToShared,
+	fetchReusableBlocks,
+	saveReusableBlocks,
+	deleteReusableBlocks,
+	convertBlockToReusable,
 	convertBlockToStatic,
-	receiveSharedBlocks,
-} from './effects/shared-blocks';
+	receiveReusableBlocks,
+} from './effects/reusable-blocks';
 import {
 	requestPostUpdate,
 	requestPostUpdateSuccess,
@@ -216,18 +216,18 @@ export default {
 
 		return setTemplateValidity( isValid );
 	},
-	FETCH_SHARED_BLOCKS: ( action, store ) => {
-		fetchSharedBlocks( action, store );
+	FETCH_REUSABLE_BLOCKS: ( action, store ) => {
+		fetchReusableBlocks( action, store );
 	},
-	SAVE_SHARED_BLOCK: ( action, store ) => {
-		saveSharedBlocks( action, store );
+	SAVE_REUSABLE_BLOCK: ( action, store ) => {
+		saveReusableBlocks( action, store );
 	},
-	DELETE_SHARED_BLOCK: ( action, store ) => {
-		deleteSharedBlocks( action, store );
+	DELETE_REUSABLE_BLOCK: ( action, store ) => {
+		deleteReusableBlocks( action, store );
 	},
-	RECEIVE_SHARED_BLOCKS: receiveSharedBlocks,
+	RECEIVE_REUSABLE_BLOCKS: receiveReusableBlocks,
 	CONVERT_BLOCK_TO_STATIC: convertBlockToStatic,
-	CONVERT_BLOCK_TO_SHARED: convertBlockToShared,
+	CONVERT_BLOCK_TO_REUSABLE: convertBlockToReusable,
 	CREATE_NOTICE( { notice: { content, spokenMessage } } ) {
 		const message = spokenMessage || content;
 		speak( message, 'assertive' );

--- a/editor/store/effects/posts.js
+++ b/editor/store/effects/posts.js
@@ -44,7 +44,7 @@ const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 /**
  * Request Post Update Effect handler
  *
- * @param {Object} action  the fetchSharedBlocks action object.
+ * @param {Object} action  the fetchReusableBlocks action object.
  * @param {Object} store   Redux Store.
  */
 export const requestPostUpdate = async ( action, store ) => {

--- a/editor/store/effects/reusable-blocks.js
+++ b/editor/store/effects/reusable-blocks.js
@@ -232,7 +232,7 @@ export const convertBlockToReusable = ( action, store ) => {
 	const reusableBlock = {
 		id: uniqueId( 'reusable' ),
 		clientId: parsedBlock.clientId,
-		title: __( 'Untitled reusable block' ),
+		title: __( 'Untitled Reusable Block' ),
 	};
 
 	dispatch( receiveReusableBlocksAction( [ {

--- a/editor/store/effects/test/reusable-blocks.js
+++ b/editor/store/effects/test/reusable-blocks.js
@@ -18,27 +18,27 @@ import '@wordpress/core-data'; // Needed to load the core store
  * Internal dependencies
  */
 import {
-	fetchSharedBlocks,
-	saveSharedBlocks,
-	receiveSharedBlocks,
-	deleteSharedBlocks,
+	fetchReusableBlocks,
+	saveReusableBlocks,
+	receiveReusableBlocks,
+	deleteReusableBlocks,
 	convertBlockToStatic,
-	convertBlockToShared,
-} from '../shared-blocks';
+	convertBlockToReusable,
+} from '../reusable-blocks';
 import {
 	resetBlocks,
 	receiveBlocks,
-	saveSharedBlock,
-	deleteSharedBlock,
+	saveReusableBlock,
+	deleteReusableBlock,
 	removeBlocks,
-	convertBlockToShared as convertBlockToSharedAction,
+	convertBlockToReusable as convertBlockToReusableAction,
 	convertBlockToStatic as convertBlockToStaticAction,
-	receiveSharedBlocks as receiveSharedBlocksAction,
-	fetchSharedBlocks as fetchSharedBlocksAction,
+	receiveReusableBlocks as receiveReusableBlocksAction,
+	fetchReusableBlocks as fetchReusableBlocksAction,
 } from '../../actions';
 import reducer from '../../reducer';
 
-describe( 'shared blocks effects', () => {
+describe( 'reusable blocks effects', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/test-block', {
 			title: 'Test block',
@@ -49,7 +49,7 @@ describe( 'shared blocks effects', () => {
 			},
 		} );
 		registerBlockType( 'core/block', {
-			title: 'Shared Block',
+			title: 'Reusable Block',
 			category: 'common',
 			save: () => null,
 			attributes: {
@@ -63,8 +63,8 @@ describe( 'shared blocks effects', () => {
 		unregisterBlockType( 'core/block' );
 	} );
 
-	describe( 'fetchSharedBlocks', () => {
-		it( 'should fetch multiple shared blocks', async () => {
+	describe( 'fetchReusableBlocks', () => {
+		it( 'should fetch multiple reusable blocks', async () => {
 			const blockPromise = Promise.resolve( [
 				{
 					id: 123,
@@ -87,12 +87,12 @@ describe( 'shared blocks effects', () => {
 			const dispatch = jest.fn();
 			const store = { getState: noop, dispatch };
 
-			await fetchSharedBlocks( fetchSharedBlocksAction(), store );
+			await fetchReusableBlocks( fetchReusableBlocksAction(), store );
 
 			expect( dispatch ).toHaveBeenCalledWith(
-				receiveSharedBlocksAction( [
+				receiveReusableBlocksAction( [
 					{
-						sharedBlock: {
+						reusableBlock: {
 							id: 123,
 							title: 'My cool block',
 							content: '<!-- wp:test-block {"name":"Big Bird"} /-->',
@@ -105,12 +105,12 @@ describe( 'shared blocks effects', () => {
 				] )
 			);
 			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'FETCH_SHARED_BLOCKS_SUCCESS',
+				type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
 				id: undefined,
 			} );
 		} );
 
-		it( 'should fetch a single shared block', async () => {
+		it( 'should fetch a single reusable block', async () => {
 			const blockPromise = Promise.resolve( {
 				id: 123,
 				title: 'My cool block',
@@ -131,12 +131,12 @@ describe( 'shared blocks effects', () => {
 			const dispatch = jest.fn();
 			const store = { getState: noop, dispatch };
 
-			await fetchSharedBlocks( fetchSharedBlocksAction( 123 ), store );
+			await fetchReusableBlocks( fetchReusableBlocksAction( 123 ), store );
 
 			expect( dispatch ).toHaveBeenCalledWith(
-				receiveSharedBlocksAction( [
+				receiveReusableBlocksAction( [
 					{
-						sharedBlock: {
+						reusableBlock: {
 							id: 123,
 							title: 'My cool block',
 							content: '<!-- wp:test-block {"name":"Big Bird"} /-->',
@@ -149,7 +149,7 @@ describe( 'shared blocks effects', () => {
 				] )
 			);
 			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'FETCH_SHARED_BLOCKS_SUCCESS',
+				type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
 				id: 123,
 			} );
 		} );
@@ -174,10 +174,10 @@ describe( 'shared blocks effects', () => {
 			const dispatch = jest.fn();
 			const store = { getState: noop, dispatch };
 
-			await fetchSharedBlocks( fetchSharedBlocksAction(), store );
+			await fetchReusableBlocks( fetchReusableBlocksAction(), store );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'FETCH_SHARED_BLOCKS_FAILURE',
+				type: 'FETCH_REUSABLE_BLOCKS_FAILURE',
 				error: {
 					code: 'unknown_error',
 					message: 'An unknown error occurred.',
@@ -186,8 +186,8 @@ describe( 'shared blocks effects', () => {
 		} );
 	} );
 
-	describe( 'saveSharedBlocks', () => {
-		it( 'should save a shared block and swap its id', async () => {
+	describe( 'saveReusableBlocks', () => {
+		it( 'should save a reusable block and swap its id', async () => {
 			const savePromise = Promise.resolve( { id: 456 } );
 			const postTypePromise = Promise.resolve( {
 				slug: 'wp_block', rest_base: 'blocks',
@@ -201,21 +201,21 @@ describe( 'shared blocks effects', () => {
 				return savePromise;
 			} );
 
-			const sharedBlock = { id: 123, title: 'My cool block' };
+			const reusableBlock = { id: 123, title: 'My cool block' };
 			const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 			const state = reduce( [
-				receiveSharedBlocksAction( [ { sharedBlock, parsedBlock } ] ),
+				receiveReusableBlocksAction( [ { reusableBlock, parsedBlock } ] ),
 				receiveBlocks( [ parsedBlock ] ),
 			], reducer, undefined );
 
 			const dispatch = jest.fn();
 			const store = { getState: () => state, dispatch };
 
-			await saveSharedBlocks( saveSharedBlock( 123 ), store );
+			await saveReusableBlocks( saveReusableBlock( 123 ), store );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'SAVE_SHARED_BLOCK_SUCCESS',
+				type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
 				id: 123,
 				updatedId: 456,
 			} );
@@ -235,41 +235,41 @@ describe( 'shared blocks effects', () => {
 				return savePromise;
 			} );
 
-			const sharedBlock = { id: 123, title: 'My cool block' };
+			const reusableBlock = { id: 123, title: 'My cool block' };
 			const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 			const state = reduce( [
-				receiveSharedBlocksAction( [ { sharedBlock, parsedBlock } ] ),
+				receiveReusableBlocksAction( [ { reusableBlock, parsedBlock } ] ),
 				receiveBlocks( [ parsedBlock ] ),
 			], reducer, undefined );
 
 			const dispatch = jest.fn();
 			const store = { getState: () => state, dispatch };
-			await saveSharedBlocks( saveSharedBlock( 123 ), store );
+			await saveReusableBlocks( saveReusableBlock( 123 ), store );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'SAVE_SHARED_BLOCK_FAILURE',
+				type: 'SAVE_REUSABLE_BLOCK_FAILURE',
 				id: 123,
 			} );
 		} );
 	} );
 
-	describe( 'receiveSharedBlocks', () => {
+	describe( 'receiveReusableBlocks', () => {
 		it( 'should receive parsed blocks', () => {
-			const action = receiveSharedBlocksAction( [
+			const action = receiveReusableBlocksAction( [
 				{
 					parsedBlock: { clientId: 'broccoli' },
 				},
 			] );
 
-			expect( receiveSharedBlocks( action ) ).toEqual( receiveBlocks( [
+			expect( receiveReusableBlocks( action ) ).toEqual( receiveBlocks( [
 				{ clientId: 'broccoli' },
 			] ) );
 		} );
 	} );
 
-	describe( 'deleteSharedBlocks', () => {
-		it( 'should delete a shared block', async () => {
+	describe( 'deleteReusableBlocks', () => {
+		it( 'should delete a reusable block', async () => {
 			const deletePromise = Promise.resolve( {} );
 			const postTypePromise = Promise.resolve( {
 				slug: 'wp_block', rest_base: 'blocks',
@@ -284,22 +284,22 @@ describe( 'shared blocks effects', () => {
 			} );
 
 			const associatedBlock = createBlock( 'core/block', { ref: 123 } );
-			const sharedBlock = { id: 123, title: 'My cool block' };
+			const reusableBlock = { id: 123, title: 'My cool block' };
 			const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 			const state = reduce( [
 				resetBlocks( [ associatedBlock ] ),
-				receiveSharedBlocksAction( [ { sharedBlock, parsedBlock } ] ),
+				receiveReusableBlocksAction( [ { reusableBlock, parsedBlock } ] ),
 				receiveBlocks( [ parsedBlock ] ),
 			], reducer, undefined );
 
 			const dispatch = jest.fn();
 			const store = { getState: () => state, dispatch };
 
-			await deleteSharedBlocks( deleteSharedBlock( 123 ), store );
+			await deleteReusableBlocks( deleteReusableBlock( 123 ), store );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'REMOVE_SHARED_BLOCK',
+				type: 'REMOVE_REUSABLE_BLOCK',
 				id: 123,
 				optimist: expect.any( Object ),
 			} );
@@ -309,7 +309,7 @@ describe( 'shared blocks effects', () => {
 			);
 
 			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'DELETE_SHARED_BLOCK_SUCCESS',
+				type: 'DELETE_REUSABLE_BLOCK_SUCCESS',
 				id: 123,
 				optimist: expect.any( Object ),
 			} );
@@ -329,53 +329,53 @@ describe( 'shared blocks effects', () => {
 				return deletePromise;
 			} );
 
-			const sharedBlock = { id: 123, title: 'My cool block' };
+			const reusableBlock = { id: 123, title: 'My cool block' };
 			const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 			const state = reduce( [
-				receiveSharedBlocksAction( [ { sharedBlock, parsedBlock } ] ),
+				receiveReusableBlocksAction( [ { reusableBlock, parsedBlock } ] ),
 				receiveBlocks( [ parsedBlock ] ),
 			], reducer, undefined );
 
 			const dispatch = jest.fn();
 			const store = { getState: () => state, dispatch };
 
-			await deleteSharedBlocks( deleteSharedBlock( 123 ), store );
+			await deleteReusableBlocks( deleteReusableBlock( 123 ), store );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'DELETE_SHARED_BLOCK_FAILURE',
+				type: 'DELETE_REUSABLE_BLOCK_FAILURE',
 				id: 123,
 				optimist: expect.any( Object ),
 			} );
 		} );
 
-		it( 'should not save shared blocks with temporary IDs', async () => {
-			const sharedBlock = { id: 'shared1', title: 'My cool block' };
+		it( 'should not save reusable blocks with temporary IDs', async () => {
+			const reusableBlock = { id: 'reusable1', title: 'My cool block' };
 			const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 			const state = reduce( [
-				receiveSharedBlocksAction( [ { sharedBlock, parsedBlock } ] ),
+				receiveReusableBlocksAction( [ { reusableBlock, parsedBlock } ] ),
 				receiveBlocks( [ parsedBlock ] ),
 			], reducer, undefined );
 
 			const dispatch = jest.fn();
 			const store = { getState: () => state, dispatch };
 
-			await deleteSharedBlocks( deleteSharedBlock( 'shared1' ), store );
+			await deleteReusableBlocks( deleteReusableBlock( 'reusable1' ), store );
 
 			expect( dispatch ).not.toHaveBeenCalled();
 		} );
 	} );
 
 	describe( 'convertBlockToStatic', () => {
-		it( 'should convert a shared block into a static block', () => {
+		it( 'should convert a reusable block into a static block', () => {
 			const associatedBlock = createBlock( 'core/block', { ref: 123 } );
-			const sharedBlock = { id: 123, title: 'My cool block' };
+			const reusableBlock = { id: 123, title: 'My cool block' };
 			const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' } );
 
 			const state = reduce( [
 				resetBlocks( [ associatedBlock ] ),
-				receiveSharedBlocksAction( [ { sharedBlock, parsedBlock } ] ),
+				receiveReusableBlocksAction( [ { reusableBlock, parsedBlock } ] ),
 				receiveBlocks( [ parsedBlock ] ),
 			], reducer, undefined );
 
@@ -398,29 +398,29 @@ describe( 'shared blocks effects', () => {
 		} );
 	} );
 
-	describe( 'convertBlockToShared', () => {
-		it( 'should convert a static block into a shared block', () => {
+	describe( 'convertBlockToReusable', () => {
+		it( 'should convert a static block into a reusable block', () => {
 			const staticBlock = createBlock( 'core/block', { ref: 123 } );
 			const state = reducer( undefined, resetBlocks( [ staticBlock ] ) );
 
 			const dispatch = jest.fn();
 			const store = { getState: () => state, dispatch };
 
-			convertBlockToShared( convertBlockToSharedAction( staticBlock.clientId ), store );
+			convertBlockToReusable( convertBlockToReusableAction( staticBlock.clientId ), store );
 
 			expect( dispatch ).toHaveBeenCalledWith(
-				receiveSharedBlocksAction( [ {
-					sharedBlock: {
-						id: expect.stringMatching( /^shared/ ),
+				receiveReusableBlocksAction( [ {
+					reusableBlock: {
+						id: expect.stringMatching( /^reusable/ ),
 						clientId: staticBlock.clientId,
-						title: 'Untitled shared block',
+						title: 'Untitled reusable block',
 					},
 					parsedBlock: staticBlock,
 				} ] )
 			);
 
 			expect( dispatch ).toHaveBeenCalledWith(
-				saveSharedBlock( expect.stringMatching( /^shared/ ) ),
+				saveReusableBlock( expect.stringMatching( /^reusable/ ) ),
 			);
 
 			expect( dispatch ).toHaveBeenCalledWith( {
@@ -429,7 +429,7 @@ describe( 'shared blocks effects', () => {
 				blocks: [
 					expect.objectContaining( {
 						name: 'core/block',
-						attributes: { ref: expect.stringMatching( /^shared/ ) },
+						attributes: { ref: expect.stringMatching( /^reusable/ ) },
 					} ),
 				],
 				time: expect.any( Number ),

--- a/editor/store/effects/test/reusable-blocks.js
+++ b/editor/store/effects/test/reusable-blocks.js
@@ -413,7 +413,7 @@ describe( 'reusable blocks effects', () => {
 					reusableBlock: {
 						id: expect.stringMatching( /^reusable/ ),
 						clientId: staticBlock.clientId,
-						title: 'Untitled reusable block',
+						title: 'Untitled Reusable Block',
 					},
 					parsedBlock: staticBlock,
 				} ] )

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -23,7 +23,7 @@ import {
 /**
  * WordPress dependencies
  */
-import { isSharedBlock } from '@wordpress/blocks';
+import { isReusableBlock } from '@wordpress/blocks';
 import { combineReducers } from '@wordpress/data';
 
 /**
@@ -377,10 +377,10 @@ export const editor = flow( [
 			case 'REMOVE_BLOCKS':
 				return omit( state, action.clientIds );
 
-			case 'SAVE_SHARED_BLOCK_SUCCESS': {
+			case 'SAVE_REUSABLE_BLOCK_SUCCESS': {
 				const { id, updatedId } = action;
 
-				// If a temporary shared block is saved, we swap the temporary id with the final one
+				// If a temporary reusable block is saved, we swap the temporary id with the final one
 				if ( id === updatedId ) {
 					return state;
 				}
@@ -720,7 +720,7 @@ export function provisionalBlockClientId( state = null, action ) {
 
 		case 'UPDATE_BLOCK_ATTRIBUTES':
 		case 'UPDATE_BLOCK':
-		case 'CONVERT_BLOCK_TO_SHARED':
+		case 'CONVERT_BLOCK_TO_REUSABLE':
 			const { clientId } = action;
 			if ( clientId === state ) {
 				return null;
@@ -830,7 +830,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 			return action.blocks.reduce( ( prevState, block ) => {
 				let id = block.name;
 				const insert = { name: block.name };
-				if ( isSharedBlock( block ) ) {
+				if ( isReusableBlock( block ) ) {
 					insert.ref = block.attributes.ref;
 					id += '/' + block.attributes.ref;
 				}
@@ -848,7 +848,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 				};
 			}, state );
 
-		case 'REMOVE_SHARED_BLOCK':
+		case 'REMOVE_REUSABLE_BLOCK':
 			return {
 				...state,
 				insertUsage: omitBy( state.insertUsage, ( { insert } ) => insert.ref === action.id ),
@@ -919,12 +919,12 @@ export function notices( state = [], action ) {
 	return state;
 }
 
-export const sharedBlocks = combineReducers( {
+export const reusableBlocks = combineReducers( {
 	data( state = {}, action ) {
 		switch ( action.type ) {
-			case 'RECEIVE_SHARED_BLOCKS': {
+			case 'RECEIVE_REUSABLE_BLOCKS': {
 				return reduce( action.results, ( nextState, result ) => {
-					const { id, title } = result.sharedBlock;
+					const { id, title } = result.reusableBlock;
 					const { clientId } = result.parsedBlock;
 
 					const value = { clientId, title };
@@ -941,7 +941,7 @@ export const sharedBlocks = combineReducers( {
 				}, state );
 			}
 
-			case 'UPDATE_SHARED_BLOCK_TITLE': {
+			case 'UPDATE_REUSABLE_BLOCK_TITLE': {
 				const { id, title } = action;
 
 				if ( ! state[ id ] || state[ id ].title === title ) {
@@ -957,10 +957,10 @@ export const sharedBlocks = combineReducers( {
 				};
 			}
 
-			case 'SAVE_SHARED_BLOCK_SUCCESS': {
+			case 'SAVE_REUSABLE_BLOCK_SUCCESS': {
 				const { id, updatedId } = action;
 
-				// If a temporary shared block is saved, we swap the temporary id with the final one
+				// If a temporary reusable block is saved, we swap the temporary id with the final one
 				if ( id === updatedId ) {
 					return state;
 				}
@@ -972,7 +972,7 @@ export const sharedBlocks = combineReducers( {
 				};
 			}
 
-			case 'REMOVE_SHARED_BLOCK': {
+			case 'REMOVE_REUSABLE_BLOCK': {
 				const { id } = action;
 				return omit( state, id );
 			}
@@ -983,7 +983,7 @@ export const sharedBlocks = combineReducers( {
 
 	isFetching( state = {}, action ) {
 		switch ( action.type ) {
-			case 'FETCH_SHARED_BLOCKS': {
+			case 'FETCH_REUSABLE_BLOCKS': {
 				const { id } = action;
 				if ( ! id ) {
 					return state;
@@ -995,8 +995,8 @@ export const sharedBlocks = combineReducers( {
 				};
 			}
 
-			case 'FETCH_SHARED_BLOCKS_SUCCESS':
-			case 'FETCH_SHARED_BLOCKS_FAILURE': {
+			case 'FETCH_REUSABLE_BLOCKS_SUCCESS':
+			case 'FETCH_REUSABLE_BLOCKS_FAILURE': {
 				const { id } = action;
 				return omit( state, id );
 			}
@@ -1007,14 +1007,14 @@ export const sharedBlocks = combineReducers( {
 
 	isSaving( state = {}, action ) {
 		switch ( action.type ) {
-			case 'SAVE_SHARED_BLOCK':
+			case 'SAVE_REUSABLE_BLOCK':
 				return {
 					...state,
 					[ action.id ]: true,
 				};
 
-			case 'SAVE_SHARED_BLOCK_SUCCESS':
-			case 'SAVE_SHARED_BLOCK_FAILURE': {
+			case 'SAVE_REUSABLE_BLOCK_SUCCESS':
+			case 'SAVE_REUSABLE_BLOCK_FAILURE': {
 				const { id } = action;
 				return omit( state, id );
 			}
@@ -1134,7 +1134,7 @@ export default optimist( combineReducers( {
 	preferences,
 	saving,
 	notices,
-	sharedBlocks,
+	reusableBlocks,
 	template,
 	autosave,
 	settings,

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1456,7 +1456,7 @@ function getInsertUsage( state, id ) {
 
 /**
  * Determines the items that appear in the the inserter. Includes both static
- * items (e.g. a regular block type) and dynamic items (e.g. a shared block).
+ * items (e.g. a regular block type) and dynamic items (e.g. a reusable block).
  *
  * Each item object contains what's necessary to display a button in the
  * inserter and handle its selection.
@@ -1560,12 +1560,12 @@ export const getInserterItems = createSelector(
 			};
 		};
 
-		const shouldIncludeSharedBlock = ( sharedBlock ) => {
+		const shouldIncludeReusableBlock = ( reusableBlock ) => {
 			if ( ! canInsertBlockType( state, 'core/block', parentClientId ) ) {
 				return false;
 			}
 
-			const referencedBlock = getBlock( state, sharedBlock.clientId );
+			const referencedBlock = getBlock( state, reusableBlock.clientId );
 			if ( ! referencedBlock ) {
 				return false;
 			}
@@ -1582,23 +1582,23 @@ export const getInserterItems = createSelector(
 			return true;
 		};
 
-		const buildSharedBlockInserterItem = ( sharedBlock ) => {
-			const id = `core/block/${ sharedBlock.id }`;
+		const buildReusableBlockInserterItem = ( reusableBlock ) => {
+			const id = `core/block/${ reusableBlock.id }`;
 
-			const referencedBlock = getBlock( state, sharedBlock.clientId );
+			const referencedBlock = getBlock( state, reusableBlock.clientId );
 			const referencedBlockType = getBlockType( referencedBlock.name );
 
 			const { time, count = 0 } = getInsertUsage( state, id ) || {};
-			const utility = calculateUtility( 'shared', count, false );
+			const utility = calculateUtility( 'reusable', count, false );
 			const frecency = calculateFrecency( time, count );
 
 			return {
 				id,
 				name: 'core/block',
-				initialAttributes: { ref: sharedBlock.id },
-				title: sharedBlock.title,
+				initialAttributes: { ref: reusableBlock.id },
+				title: reusableBlock.title,
 				icon: referencedBlockType.icon,
-				category: 'shared',
+				category: 'reusable',
 				keywords: [],
 				isDisabled: false,
 				utility,
@@ -1610,12 +1610,12 @@ export const getInserterItems = createSelector(
 			.filter( shouldIncludeBlockType )
 			.map( buildBlockTypeInserterItem );
 
-		const sharedBlockInserterItems = getSharedBlocks( state )
-			.filter( shouldIncludeSharedBlock )
-			.map( buildSharedBlockInserterItem );
+		const reusableBlockInserterItems = getReusableBlocks( state )
+			.filter( shouldIncludeReusableBlock )
+			.map( buildReusableBlockInserterItem );
 
 		return orderBy(
-			[ ...blockTypeInserterItems, ...sharedBlockInserterItems ],
+			[ ...blockTypeInserterItems, ...reusableBlockInserterItems ],
 			[ 'utility', 'frecency' ],
 			[ 'desc', 'desc' ]
 		);
@@ -1627,22 +1627,22 @@ export const getInserterItems = createSelector(
 		state.preferences.insertUsage,
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
-		state.sharedBlocks.data,
+		state.reusableBlocks.data,
 		getBlockTypes(),
 	],
 );
 
 /**
- * Returns the shared block with the given ID.
+ * Returns the reusable block with the given ID.
  *
  * @param {Object}        state Global application state.
- * @param {number|string} ref   The shared block's ID.
+ * @param {number|string} ref   The reusable block's ID.
  *
- * @return {Object} The shared block, or null if none exists.
+ * @return {Object} The reusable block, or null if none exists.
  */
-export const getSharedBlock = createSelector(
+export const getReusableBlock = createSelector(
 	( state, ref ) => {
-		const block = state.sharedBlocks.data[ ref ];
+		const block = state.reusableBlocks.data[ ref ];
 		if ( ! block ) {
 			return null;
 		}
@@ -1656,44 +1656,44 @@ export const getSharedBlock = createSelector(
 		};
 	},
 	( state, ref ) => [
-		state.sharedBlocks.data[ ref ],
+		state.reusableBlocks.data[ ref ],
 	],
 );
 
 /**
- * Returns whether or not the shared block with the given ID is being saved.
+ * Returns whether or not the reusable block with the given ID is being saved.
  *
  * @param {Object} state Global application state.
- * @param {string} ref   The shared block's ID.
+ * @param {string} ref   The reusable block's ID.
  *
- * @return {boolean} Whether or not the shared block is being saved.
+ * @return {boolean} Whether or not the reusable block is being saved.
  */
-export function isSavingSharedBlock( state, ref ) {
-	return state.sharedBlocks.isSaving[ ref ] || false;
+export function isSavingReusableBlock( state, ref ) {
+	return state.reusableBlocks.isSaving[ ref ] || false;
 }
 
 /**
- * Returns true if the shared block with the given ID is being fetched, or
+ * Returns true if the reusable block with the given ID is being fetched, or
  * false otherwise.
  *
  * @param {Object} state Global application state.
- * @param {string} ref   The shared block's ID.
+ * @param {string} ref   The reusable block's ID.
  *
- * @return {boolean} Whether the shared block is being fetched.
+ * @return {boolean} Whether the reusable block is being fetched.
  */
-export function isFetchingSharedBlock( state, ref ) {
-	return !! state.sharedBlocks.isFetching[ ref ];
+export function isFetchingReusableBlock( state, ref ) {
+	return !! state.reusableBlocks.isFetching[ ref ];
 }
 
 /**
- * Returns an array of all shared blocks.
+ * Returns an array of all reusable blocks.
  *
  * @param {Object} state Global application state.
  *
- * @return {Array} An array of all shared blocks.
+ * @return {Array} An array of all reusable blocks.
  */
-export function getSharedBlocks( state ) {
-	return map( state.sharedBlocks.data, ( value, ref ) => getSharedBlock( state, ref ) );
+export function getReusableBlocks( state ) {
+	return map( state.reusableBlocks.data, ( value, ref ) => getReusableBlock( state, ref ) );
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1996,3 +1996,43 @@ export function getProvisionalBlockUID( state ) {
 
 	return getProvisionalBlockClientId( state );
 }
+
+export function getSharedBlock( state, ref ) {
+	deprecated( 'getSharedBlock', {
+		alternative: 'getReusableBlock',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return getReusableBlock( state, ref );
+}
+
+export function isSavingSharedBlock( state, ref ) {
+	deprecated( 'isSavingSharedBlock', {
+		alternative: 'isSavingReusableBlock',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return isSavingReusableBlock( state, ref );
+}
+
+export function isFetchingSharedBlock( state, ref ) {
+	deprecated( 'isFetchingSharedBlock', {
+		alternative: 'isFetchingReusableBlock',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return isFetchingReusableBlock( state, ref );
+}
+
+export function getSharedBlocks( state ) {
+	deprecated( 'getSharedBlocks', {
+		alternative: 'getReusableBlocks',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return getReusableBlocks( state );
+}

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -5,11 +5,11 @@ import {
 	replaceBlocks,
 	startTyping,
 	stopTyping,
-	fetchSharedBlocks,
-	saveSharedBlock,
-	deleteSharedBlock,
+	fetchReusableBlocks,
+	saveReusableBlock,
+	deleteReusableBlock,
 	convertBlockToStatic,
-	convertBlockToShared,
+	convertBlockToReusable,
 	toggleSelection,
 	setupEditor,
 	resetPost,
@@ -460,34 +460,34 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'fetchSharedBlocks', () => {
-		it( 'should return the FETCH_SHARED_BLOCKS action', () => {
-			expect( fetchSharedBlocks() ).toEqual( {
-				type: 'FETCH_SHARED_BLOCKS',
+	describe( 'fetchReusableBlocks', () => {
+		it( 'should return the FETCH_REUSABLE_BLOCKS action', () => {
+			expect( fetchReusableBlocks() ).toEqual( {
+				type: 'FETCH_REUSABLE_BLOCKS',
 			} );
 		} );
 
 		it( 'should take an optional id argument', () => {
-			expect( fetchSharedBlocks( 123 ) ).toEqual( {
-				type: 'FETCH_SHARED_BLOCKS',
+			expect( fetchReusableBlocks( 123 ) ).toEqual( {
+				type: 'FETCH_REUSABLE_BLOCKS',
 				id: 123,
 			} );
 		} );
 	} );
 
-	describe( 'saveSharedBlock', () => {
-		it( 'should return the SAVE_SHARED_BLOCK action', () => {
-			expect( saveSharedBlock( 123 ) ).toEqual( {
-				type: 'SAVE_SHARED_BLOCK',
+	describe( 'saveReusableBlock', () => {
+		it( 'should return the SAVE_REUSABLE_BLOCK action', () => {
+			expect( saveReusableBlock( 123 ) ).toEqual( {
+				type: 'SAVE_REUSABLE_BLOCK',
 				id: 123,
 			} );
 		} );
 	} );
 
-	describe( 'deleteSharedBlock', () => {
-		it( 'should return the DELETE_SHARED_BLOCK action', () => {
-			expect( deleteSharedBlock( 123 ) ).toEqual( {
-				type: 'DELETE_SHARED_BLOCK',
+	describe( 'deleteReusableBlock', () => {
+		it( 'should return the DELETE_REUSABLE_BLOCK action', () => {
+			expect( deleteReusableBlock( 123 ) ).toEqual( {
+				type: 'DELETE_REUSABLE_BLOCK',
 				id: 123,
 			} );
 		} );
@@ -503,11 +503,11 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'convertBlockToShared', () => {
-		it( 'should return the CONVERT_BLOCK_TO_SHARED action', () => {
+	describe( 'convertBlockToReusable', () => {
+		it( 'should return the CONVERT_BLOCK_TO_REUSABLE action', () => {
 			const clientId = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
-			expect( convertBlockToShared( clientId ) ).toEqual( {
-				type: 'CONVERT_BLOCK_TO_SHARED',
+			expect( convertBlockToReusable( clientId ) ).toEqual( {
+				type: 'CONVERT_BLOCK_TO_REUSABLE',
 				clientId,
 			} );
 		} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -33,7 +33,7 @@ import {
 	provisionalBlockClientId,
 	blocksMode,
 	isInsertionPointVisible,
-	sharedBlocks,
+	reusableBlocks,
 	template,
 	blockListSettings,
 	autosave,
@@ -493,7 +493,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should update the shared block reference if the temporary id is swapped', () => {
+		it( 'should update the reusable block reference if the temporary id is swapped', () => {
 			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
@@ -508,7 +508,7 @@ describe( 'state', () => {
 			} );
 
 			const state = editor( deepFreeze( original ), {
-				type: 'SAVE_SHARED_BLOCK_SUCCESS',
+				type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
 				id: 'random-clientId',
 				updatedId: 3,
 			} );
@@ -1646,7 +1646,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should remove recorded shared blocks that are deleted', () => {
+		it( 'should remove recorded reusable blocks that are deleted', () => {
 			const initialState = {
 				insertUsage: {
 					'core/block/123': {
@@ -1658,7 +1658,7 @@ describe( 'state', () => {
 			};
 
 			const state = preferences( deepFreeze( initialState ), {
-				type: 'REMOVE_SHARED_BLOCK',
+				type: 'REMOVE_REUSABLE_BLOCK',
 				id: 123,
 			} );
 
@@ -1799,7 +1799,7 @@ describe( 'state', () => {
 		const PROVISIONAL_UPDATE_ACTION_TYPES = [
 			'UPDATE_BLOCK_ATTRIBUTES',
 			'UPDATE_BLOCK',
-			'CONVERT_BLOCK_TO_SHARED',
+			'CONVERT_BLOCK_TO_REUSABLE',
 		];
 
 		const PROVISIONAL_REPLACE_ACTION_TYPES = [
@@ -1911,9 +1911,9 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'sharedBlocks()', () => {
+	describe( 'reusableBlocks()', () => {
 		it( 'should start out empty', () => {
-			const state = sharedBlocks( undefined, {} );
+			const state = reusableBlocks( undefined, {} );
 			expect( state ).toEqual( {
 				data: {},
 				isFetching: {},
@@ -1921,11 +1921,11 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should add received shared blocks', () => {
-			const state = sharedBlocks( {}, {
-				type: 'RECEIVE_SHARED_BLOCKS',
+		it( 'should add received reusable blocks', () => {
+			const state = reusableBlocks( {}, {
+				type: 'RECEIVE_REUSABLE_BLOCKS',
 				results: [ {
-					sharedBlock: {
+					reusableBlock: {
 						id: 123,
 						title: 'My cool block',
 					},
@@ -1944,7 +1944,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should update a shared block', () => {
+		it( 'should update a reusable block', () => {
 			const initialState = {
 				data: {
 					123: { clientId: '', title: '' },
@@ -1953,8 +1953,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = sharedBlocks( initialState, {
-				type: 'UPDATE_SHARED_BLOCK_TITLE',
+			const state = reusableBlocks( initialState, {
+				type: 'UPDATE_REUSABLE_BLOCK_TITLE',
 				id: 123,
 				title: 'My block',
 			} );
@@ -1968,17 +1968,17 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( "should update the shared block's id if it was temporary", () => {
+		it( "should update the reusable block's id if it was temporary", () => {
 			const initialState = {
 				data: {
-					shared1: { clientId: '', title: '' },
+					reusable1: { clientId: '', title: '' },
 				},
 				isSaving: {},
 			};
 
-			const state = sharedBlocks( initialState, {
-				type: 'SAVE_SHARED_BLOCK_SUCCESS',
-				id: 'shared1',
+			const state = reusableBlocks( initialState, {
+				type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
+				id: 'reusable1',
 				updatedId: 123,
 			} );
 
@@ -1991,7 +1991,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should remove a shared block', () => {
+		it( 'should remove a reusable block', () => {
 			const id = 123;
 			const initialState = {
 				data: {
@@ -2009,8 +2009,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = sharedBlocks( deepFreeze( initialState ), {
-				type: 'REMOVE_SHARED_BLOCK',
+			const state = reusableBlocks( deepFreeze( initialState ), {
+				type: 'REMOVE_REUSABLE_BLOCK',
 				id,
 			} );
 
@@ -2021,7 +2021,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should indicate that a shared block is fetching', () => {
+		it( 'should indicate that a reusable block is fetching', () => {
 			const id = 123;
 			const initialState = {
 				data: {},
@@ -2029,8 +2029,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = sharedBlocks( initialState, {
-				type: 'FETCH_SHARED_BLOCKS',
+			const state = reusableBlocks( initialState, {
+				type: 'FETCH_REUSABLE_BLOCKS',
 				id,
 			} );
 
@@ -2043,7 +2043,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should stop indicating that a shared block is saving when the fetch succeeded', () => {
+		it( 'should stop indicating that a reusable block is saving when the fetch succeeded', () => {
 			const id = 123;
 			const initialState = {
 				data: {
@@ -2055,8 +2055,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = sharedBlocks( initialState, {
-				type: 'FETCH_SHARED_BLOCKS_SUCCESS',
+			const state = reusableBlocks( initialState, {
+				type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
 				id,
 				updatedId: id,
 			} );
@@ -2070,7 +2070,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should stop indicating that a shared block is fetching when there is an error', () => {
+		it( 'should stop indicating that a reusable block is fetching when there is an error', () => {
 			const id = 123;
 			const initialState = {
 				data: {},
@@ -2080,8 +2080,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = sharedBlocks( initialState, {
-				type: 'FETCH_SHARED_BLOCKS_FAILURE',
+			const state = reusableBlocks( initialState, {
+				type: 'FETCH_REUSABLE_BLOCKS_FAILURE',
 				id,
 			} );
 
@@ -2092,7 +2092,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should indicate that a shared block is saving', () => {
+		it( 'should indicate that a reusable block is saving', () => {
 			const id = 123;
 			const initialState = {
 				data: {},
@@ -2100,8 +2100,8 @@ describe( 'state', () => {
 				isSaving: {},
 			};
 
-			const state = sharedBlocks( initialState, {
-				type: 'SAVE_SHARED_BLOCK',
+			const state = reusableBlocks( initialState, {
+				type: 'SAVE_REUSABLE_BLOCK',
 				id,
 			} );
 
@@ -2114,7 +2114,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should stop indicating that a shared block is saving when the save succeeded', () => {
+		it( 'should stop indicating that a reusable block is saving when the save succeeded', () => {
 			const id = 123;
 			const initialState = {
 				data: {
@@ -2126,8 +2126,8 @@ describe( 'state', () => {
 				},
 			};
 
-			const state = sharedBlocks( initialState, {
-				type: 'SAVE_SHARED_BLOCK_SUCCESS',
+			const state = reusableBlocks( initialState, {
+				type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
 				id,
 				updatedId: id,
 			} );
@@ -2141,7 +2141,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should stop indicating that a shared block is saving when there is an error', () => {
+		it( 'should stop indicating that a reusable block is saving when there is an error', () => {
 			const id = 123;
 			const initialState = {
 				data: {},
@@ -2151,8 +2151,8 @@ describe( 'state', () => {
 				},
 			};
 
-			const state = sharedBlocks( initialState, {
-				type: 'SAVE_SHARED_BLOCK_FAILURE',
+			const state = reusableBlocks( initialState, {
+				type: 'SAVE_REUSABLE_BLOCK_FAILURE',
 				id,
 			} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -76,11 +76,11 @@ const {
 	didPostSaveRequestFail,
 	getSuggestedPostFormat,
 	getNotices,
-	getSharedBlock,
-	isSavingSharedBlock,
-	isFetchingSharedBlock,
+	getReusableBlock,
+	isSavingReusableBlock,
+	isFetchingReusableBlock,
 	isSelectionEnabled,
-	getSharedBlocks,
+	getReusableBlocks,
 	getStateBeforeOptimisticTransaction,
 	isPublishingPost,
 	canInsertBlockType,
@@ -105,8 +105,8 @@ describe( 'selectors', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/block', {
 			save: () => null,
-			category: 'shared',
-			title: 'Shared Block Stub',
+			category: 'reusable',
+			title: 'Reusable Block Stub',
 			supports: {
 				inserter: false,
 			},
@@ -3059,7 +3059,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getInserterItems', () => {
-		it( 'should properly list block type and shared block items', () => {
+		it( 'should properly list block type and reusable block items', () => {
 			const state = {
 				editor: {
 					present: {
@@ -3070,9 +3070,9 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {
-						1: { clientId: 'block1', title: 'Shared Block 1' },
+						1: { clientId: 'block1', title: 'Reusable Block 1' },
 					},
 				},
 				currentPost: {},
@@ -3099,16 +3099,16 @@ describe( 'selectors', () => {
 				frecency: 0,
 				hasChildBlocks: false,
 			} );
-			const sharedBlockItem = items.find( ( item ) => item.id === 'core/block/1' );
-			expect( sharedBlockItem ).toEqual( {
+			const reusableBlockItem = items.find( ( item ) => item.id === 'core/block/1' );
+			expect( reusableBlockItem ).toEqual( {
 				id: 'core/block/1',
 				name: 'core/block',
 				initialAttributes: { ref: 1 },
-				title: 'Shared Block 1',
+				title: 'Reusable Block 1',
 				icon: {
 					src: 'test',
 				},
-				category: 'shared',
+				category: 'reusable',
 				keywords: [],
 				isDisabled: false,
 				utility: 0,
@@ -3128,10 +3128,10 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {
-						1: { clientId: 'block1', title: 'Shared Block 1' },
-						2: { clientId: 'block1', title: 'Shared Block 2' },
+						1: { clientId: 'block1', title: 'Reusable Block 1' },
+						2: { clientId: 'block1', title: 'Reusable Block 2' },
 					},
 				},
 				currentPost: {},
@@ -3165,10 +3165,10 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {
-						1: { clientId: 'block1', title: 'Shared Block 1' },
-						2: { clientId: 'block1', title: 'Shared Block 2' },
+						1: { clientId: 'block1', title: 'Reusable Block 1' },
+						2: { clientId: 'block1', title: 'Reusable Block 2' },
 					},
 				},
 				currentPost: {},
@@ -3224,7 +3224,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {},
 				},
 				currentPost: {},
@@ -3248,7 +3248,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {},
 				},
 				currentPost: {},
@@ -3272,7 +3272,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {},
 				},
 				currentPost: {},
@@ -3285,9 +3285,9 @@ describe( 'selectors', () => {
 				settings: {},
 			};
 			const items = getInserterItems( state );
-			const sharedBlock2Item = items.find( ( item ) => item.id === 'core/test-block-b' );
-			expect( sharedBlock2Item.utility ).toBe( INSERTER_UTILITY_MEDIUM );
-			expect( sharedBlock2Item.frecency ).toBe( 2.5 );
+			const reusableBlock2Item = items.find( ( item ) => item.id === 'core/test-block-b' );
+			expect( reusableBlock2Item.utility ).toBe( INSERTER_UTILITY_MEDIUM );
+			expect( reusableBlock2Item.frecency ).toBe( 2.5 );
 		} );
 
 		it( 'should give contextual blocks a high utility', () => {
@@ -3303,7 +3303,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {},
 				},
 				currentPost: {},
@@ -3319,10 +3319,10 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getSharedBlock', () => {
-		it( 'should return a shared block', () => {
+	describe( 'getReusableBlock', () => {
+		it( 'should return a reusable block', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {
 						8109: {
 							clientId: 'foo',
@@ -3332,8 +3332,8 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const actualSharedBlock = getSharedBlock( state, 8109 );
-			expect( actualSharedBlock ).toEqual( {
+			const actualReusableBlock = getReusableBlock( state, 8109 );
+			expect( actualReusableBlock ).toEqual( {
 				id: 8109,
 				isTemporary: false,
 				clientId: 'foo',
@@ -3341,11 +3341,11 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		it( 'should return a temporary shared block', () => {
+		it( 'should return a temporary reusable block', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {
-						shared1: {
+						reusable1: {
 							clientId: 'foo',
 							title: 'My cool block',
 						},
@@ -3353,106 +3353,106 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const actualSharedBlock = getSharedBlock( state, 'shared1' );
-			expect( actualSharedBlock ).toEqual( {
-				id: 'shared1',
+			const actualReusableBlock = getReusableBlock( state, 'reusable1' );
+			expect( actualReusableBlock ).toEqual( {
+				id: 'reusable1',
 				isTemporary: true,
 				clientId: 'foo',
 				title: 'My cool block',
 			} );
 		} );
 
-		it( 'should return null when no shared block exists', () => {
+		it( 'should return null when no reusable block exists', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {},
 				},
 			};
 
-			const sharedBlock = getSharedBlock( state, 123 );
-			expect( sharedBlock ).toBeNull();
+			const reusableBlock = getReusableBlock( state, 123 );
+			expect( reusableBlock ).toBeNull();
 		} );
 	} );
 
-	describe( 'isSavingSharedBlock', () => {
+	describe( 'isSavingReusableBlock', () => {
 		it( 'should return false when the block is not being saved', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					isSaving: {},
 				},
 			};
 
-			const isSaving = isSavingSharedBlock( state, 5187 );
+			const isSaving = isSavingReusableBlock( state, 5187 );
 			expect( isSaving ).toBe( false );
 		} );
 
 		it( 'should return true when the block is being saved', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					isSaving: {
 						5187: true,
 					},
 				},
 			};
 
-			const isSaving = isSavingSharedBlock( state, 5187 );
+			const isSaving = isSavingReusableBlock( state, 5187 );
 			expect( isSaving ).toBe( true );
 		} );
 	} );
 
-	describe( 'isFetchingSharedBlock', () => {
+	describe( 'isFetchingReusableBlock', () => {
 		it( 'should return false when the block is not being fetched', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					isFetching: {},
 				},
 			};
 
-			const isFetching = isFetchingSharedBlock( state, 5187 );
+			const isFetching = isFetchingReusableBlock( state, 5187 );
 			expect( isFetching ).toBe( false );
 		} );
 
 		it( 'should return true when the block is being fetched', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					isFetching: {
 						5187: true,
 					},
 				},
 			};
 
-			const isFetching = isFetchingSharedBlock( state, 5187 );
+			const isFetching = isFetchingReusableBlock( state, 5187 );
 			expect( isFetching ).toBe( true );
 		} );
 	} );
 
-	describe( 'getSharedBlocks', () => {
-		it( 'should return an array of shared blocks', () => {
+	describe( 'getReusableBlocks', () => {
+		it( 'should return an array of reusable blocks', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {
 						123: { clientId: 'carrot' },
-						shared1: { clientId: 'broccoli' },
+						reusable1: { clientId: 'broccoli' },
 					},
 				},
 			};
 
-			const sharedBlocks = getSharedBlocks( state );
-			expect( sharedBlocks ).toEqual( [
+			const reusableBlocks = getReusableBlocks( state );
+			expect( reusableBlocks ).toEqual( [
 				{ id: 123, isTemporary: false, clientId: 'carrot' },
-				{ id: 'shared1', isTemporary: true, clientId: 'broccoli' },
+				{ id: 'reusable1', isTemporary: true, clientId: 'broccoli' },
 			] );
 		} );
 
-		it( 'should return an empty array when no shared blocks exist', () => {
+		it( 'should return an empty array when no reusable blocks exist', () => {
 			const state = {
-				sharedBlocks: {
+				reusableBlocks: {
 					data: {},
 				},
 			};
 
-			const sharedBlocks = getSharedBlocks( state );
-			expect( sharedBlocks ).toEqual( [] );
+			const reusableBlocks = getReusableBlocks( state );
+			expect( reusableBlocks ).toEqual( [] );
 		} );
 	} );
 

--- a/lib/class-wp-rest-blocks-controller.php
+++ b/lib/class-wp-rest-blocks-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Shared blocks REST API: WP_REST_Blocks_Controller class
+ * Reusable blocks REST API: WP_REST_Blocks_Controller class
  *
  * @package gutenberg
  * @since 0.10.0
@@ -8,7 +8,7 @@
 
 /**
  * Controller which provides a REST endpoint for Gutenberg to read, create,
- * edit and delete shared blocks. Blocks are stored as posts with the wp_block
+ * edit and delete reusable blocks. Blocks are stored as posts with the wp_block
  * post type.
  *
  * @since 0.10.0

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1051,8 +1051,8 @@ function get_block_categories( $post ) {
 			'title' => __( 'Embeds', 'gutenberg' ),
 		),
 		array(
-			'slug'  => 'shared',
-			'title' => __( 'Shared Blocks', 'gutenberg' ),
+			'slug'  => 'reusable',
+			'title' => __( 'Reusable Blocks', 'gutenberg' ),
 		),
 	);
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -37,7 +37,7 @@ export {
 	getBlockTypes,
 	getBlockSupport,
 	hasBlockSupport,
-	isSharedBlock,
+	isReusableBlock,
 	getChildBlockNames,
 	hasChildBlocks,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -38,6 +38,7 @@ export {
 	getBlockSupport,
 	hasBlockSupport,
 	isReusableBlock,
+	isSharedBlock,
 	getChildBlockNames,
 	hasChildBlocks,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -10,6 +10,7 @@ import { get, isFunction, some } from 'lodash';
  */
 import { applyFilters, addFilter } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -307,6 +308,16 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
  */
 export function isReusableBlock( blockOrType ) {
 	return blockOrType.name === 'core/block';
+}
+
+export function isSharedBlock( blockOrType ) {
+	deprecated( 'isSharedBlock', {
+		alternative: 'isReusableBlock',
+		version: '3.6',
+		plugin: 'Gutenberg',
+	} );
+
+	return isReusableBlock( blockOrType );
 }
 
 /**

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -297,15 +297,15 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
 }
 
 /**
- * Determines whether or not the given block is a shared block. This is a
+ * Determines whether or not the given block is a reusable block. This is a
  * special block type that is used to point to a global block stored via the
  * API.
  *
  * @param {Object} blockOrType Block or Block Type to test.
  *
- * @return {boolean} Whether the given block is a shared block.
+ * @return {boolean} Whether the given block is a reusable block.
  */
-export function isSharedBlock( blockOrType ) {
+export function isReusableBlock( blockOrType ) {
 	return blockOrType.name === 'core/block';
 }
 

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -22,7 +22,7 @@ import {
 	getBlockTypes,
 	getBlockSupport,
 	hasBlockSupport,
-	isSharedBlock,
+	isReusableBlock,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 	registerBlockStyle,
 } from '../registration';
@@ -585,15 +585,15 @@ describe( 'blocks', () => {
 		} );
 	} );
 
-	describe( 'isSharedBlock', () => {
-		it( 'should return true for a shared block', () => {
+	describe( 'isReusableBlock', () => {
+		it( 'should return true for a reusable block', () => {
 			const block = { name: 'core/block' };
-			expect( isSharedBlock( block ) ).toBe( true );
+			expect( isReusableBlock( block ) ).toBe( true );
 		} );
 
 		it( 'should return false for other blocks', () => {
 			const block = { name: 'core/paragraph' };
-			expect( isSharedBlock( block ) ).toBe( false );
+			expect( isReusableBlock( block ) ).toBe( false );
 		} );
 	} );
 

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -18,7 +18,7 @@ export const DEFAULT_CATEGORIES = [
 	{ slug: 'layout', title: __( 'Layout Elements' ) },
 	{ slug: 'widgets', title: __( 'Widgets' ) },
 	{ slug: 'embed', title: __( 'Embeds' ) },
-	{ slug: 'shared', title: __( 'Shared Blocks' ) },
+	{ slug: 'reusable', title: __( 'Reusable Blocks' ) },
 ];
 
 /**

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -236,7 +236,7 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 	/**
 	 * Exhaustively check that each role either can or cannot create, edit,
-	 * update, and delete shared blocks.
+	 * update, and delete reusable blocks.
 	 *
 	 * @dataProvider data_capabilities
 	 */

--- a/phpunit/class-reusable-blocks-render-test.php
+++ b/phpunit/class-reusable-blocks-render-test.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Shared block rendering tests.
+ * Reusable block rendering tests.
  *
  * @package Gutenberg
  */
 
 /**
- * Tests shared block rendering.
+ * Tests reusable block rendering.
  */
-class Shared_Blocks_Render_Test extends WP_UnitTestCase {
+class Reusable_Blocks_Render_Test extends WP_UnitTestCase {
 	/**
 	 * Fake user ID.
 	 *
@@ -67,7 +67,7 @@ class Shared_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering of a shared block.
+	 * Test rendering of a reusable block.
 	 */
 	public function test_render() {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/block' );
@@ -76,7 +76,7 @@ class Shared_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering of a shared block when 'ref' is missing, which should fail by
+	 * Test rendering of a reusable block when 'ref' is missing, which should fail by
 	 * rendering an empty string.
 	 */
 	public function test_ref_empty() {
@@ -86,7 +86,7 @@ class Shared_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering of a shared block when 'ref' points to wrong post type, which
+	 * Test rendering of a reusable block when 'ref' points to wrong post type, which
 	 * should fail by rendering an empty string.
 	 */
 	public function test_ref_wrong_post_type() {

--- a/test/e2e/specs/reusable-blocks.test.js
+++ b/test/e2e/specs/reusable-blocks.test.js
@@ -19,7 +19,7 @@ function waitForAndAcceptDialog() {
 	} );
 }
 
-describe( 'Shared Blocks', () => {
+describe( 'Reusable Blocks', () => {
 	beforeAll( async () => {
 		await newDesktopBrowserPage();
 		await newPost();
@@ -43,9 +43,9 @@ describe( 'Shared Blocks', () => {
 		await page.mouse.move( 200, 300 );
 		await page.mouse.move( 250, 350 );
 
-		// Convert block to a shared block
+		// Convert block to a reusable block
 		await page.click( 'button[aria-label="More Options"]' );
-		const convertButton = await page.waitForXPath( '//button[text()="Convert to Shared Block"]' );
+		const convertButton = await page.waitForXPath( '//button[text()="Convert to Reusable Block"]' );
 		await convertButton.click();
 
 		// Wait for creation to finish
@@ -56,25 +56,25 @@ describe( 'Shared Blocks', () => {
 		// Select all of the text in the title field by triple-clicking on it. We
 		// triple-click because, on Mac, Mod+A doesn't work. This step can be removed
 		// when https://github.com/WordPress/gutenberg/issues/7972 is fixed
-		await page.click( '.shared-block-edit-panel__title', { clickCount: 3 } );
+		await page.click( '.reusable-block-edit-panel__title', { clickCount: 3 } );
 
-		// Give the shared block a title
+		// Give the reusable block a title
 		await page.keyboard.type( 'Greeting block' );
 
-		// Save the shared block
+		// Save the reusable block
 		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
 		await saveButton.click();
 
 		// Wait for saving to finish
 		await page.waitForXPath( '//button[text()="Edit"]' );
 
-		// Check that we have a shared block on the page
+		// Check that we have a reusable block on the page
 		const block = await page.$( '.editor-block-list__block[data-type="core/block"]' );
 		expect( block ).not.toBeNull();
 
 		// Check that its title is displayed
 		const title = await page.$eval(
-			'.shared-block-edit-panel__info',
+			'.reusable-block-edit-panel__info',
 			( element ) => element.innerText
 		);
 		expect( title ).toBe( 'Greeting block' );
@@ -89,9 +89,9 @@ describe( 'Shared Blocks', () => {
 		await page.mouse.move( 200, 300 );
 		await page.mouse.move( 250, 350 );
 
-		// Convert block to a shared block
+		// Convert block to a reusable block
 		await page.click( 'button[aria-label="More Options"]' );
-		const convertButton = await page.waitForXPath( '//button[text()="Convert to Shared Block"]' );
+		const convertButton = await page.waitForXPath( '//button[text()="Convert to Reusable Block"]' );
 		await convertButton.click();
 
 		// Wait for creation to finish
@@ -99,30 +99,30 @@ describe( 'Shared Blocks', () => {
 			'//*[contains(@class, "notice-success")]/*[text()="Block created."]'
 		);
 
-		// Save the shared block
+		// Save the reusable block
 		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
 		await saveButton.click();
 
 		// Wait for saving to finish
 		await page.waitForXPath( '//button[text()="Edit"]' );
 
-		// Check that we have a shared block on the page
+		// Check that we have a reusable block on the page
 		const block = await page.$( '.editor-block-list__block[data-type="core/block"]' );
 		expect( block ).not.toBeNull();
 
 		// Check that it is untitled
 		const title = await page.$eval(
-			'.shared-block-edit-panel__info',
+			'.reusable-block-edit-panel__info',
 			( element ) => element.innerText
 		);
-		expect( title ).toBe( 'Untitled shared block' );
+		expect( title ).toBe( 'Untitled reusable block' );
 	} );
 
 	it( 'can be inserted and edited', async () => {
-		// Insert the shared block we created above
+		// Insert the reusable block we created above
 		await insertBlock( 'Greeting block' );
 
-		// Put the shared block in edit mode
+		// Put the reusable block in edit mode
 		const [ editButton ] = await page.$x( '//button[text()="Edit"]' );
 		await editButton.click();
 
@@ -133,20 +133,20 @@ describe( 'Shared Blocks', () => {
 		await pressWithModifier( 'Shift', 'Tab' );
 		await page.keyboard.type( 'Oh! ' );
 
-		// Save the shared block
+		// Save the reusable block
 		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
 		await saveButton.click();
 
 		// Wait for saving to finish
 		await page.waitForXPath( '//button[text()="Edit"]' );
 
-		// Check that we have a shared block on the page
+		// Check that we have a reusable block on the page
 		const block = await page.$( '.editor-block-list__block[data-type="core/block"]' );
 		expect( block ).not.toBeNull();
 
 		// Check that its title is displayed
 		const title = await page.$eval(
-			'.shared-block-edit-panel__info',
+			'.reusable-block-edit-panel__info',
 			( element ) => element.innerText
 		);
 		expect( title ).toBe( 'Surprised greeting block' );
@@ -160,7 +160,7 @@ describe( 'Shared Blocks', () => {
 	} );
 
 	it( 'can be converted to a regular block', async () => {
-		// Insert the shared block we edited above
+		// Insert the reusable block we edited above
 		await insertBlock( 'Surprised greeting block' );
 
 		// Convert block to a regular block
@@ -183,12 +183,12 @@ describe( 'Shared Blocks', () => {
 	} );
 
 	it( 'can be deleted', async () => {
-		// Insert the shared block we edited above
+		// Insert the reusable block we edited above
 		await insertBlock( 'Surprised greeting block' );
 
 		// Delete the block and accept the confirmation dialog
 		await page.click( 'button[aria-label="More Options"]' );
-		const convertButton = await page.waitForXPath( '//button[text()="Delete Shared Block"]' );
+		const convertButton = await page.waitForXPath( '//button[text()="Delete Reusable Block"]' );
 		await Promise.all( [ waitForAndAcceptDialog(), convertButton.click() ] );
 
 		// Check that we have an empty post again

--- a/test/e2e/specs/reusable-blocks.test.js
+++ b/test/e2e/specs/reusable-blocks.test.js
@@ -45,7 +45,7 @@ describe( 'Reusable Blocks', () => {
 
 		// Convert block to a reusable block
 		await page.click( 'button[aria-label="More Options"]' );
-		const convertButton = await page.waitForXPath( '//button[text()="Convert to Reusable Block"]' );
+		const convertButton = await page.waitForXPath( '//button[text()="Add to Reusable Blocks"]' );
 		await convertButton.click();
 
 		// Wait for creation to finish
@@ -91,7 +91,7 @@ describe( 'Reusable Blocks', () => {
 
 		// Convert block to a reusable block
 		await page.click( 'button[aria-label="More Options"]' );
-		const convertButton = await page.waitForXPath( '//button[text()="Convert to Reusable Block"]' );
+		const convertButton = await page.waitForXPath( '//button[text()="Add to Reusable Blocks"]' );
 		await convertButton.click();
 
 		// Wait for creation to finish
@@ -115,7 +115,7 @@ describe( 'Reusable Blocks', () => {
 			'.reusable-block-edit-panel__info',
 			( element ) => element.innerText
 		);
-		expect( title ).toBe( 'Untitled reusable block' );
+		expect( title ).toBe( 'Untitled Reusable Block' );
 	} );
 
 	it( 'can be inserted and edited', async () => {
@@ -188,7 +188,7 @@ describe( 'Reusable Blocks', () => {
 
 		// Delete the block and accept the confirmation dialog
 		await page.click( 'button[aria-label="More Options"]' );
-		const convertButton = await page.waitForXPath( '//button[text()="Delete Reusable Block"]' );
+		const convertButton = await page.waitForXPath( '//button[text()="Remove from Reusable Blocks"]' );
 		await Promise.all( [ waitForAndAcceptDialog(), convertButton.click() ] );
 
 		// Check that we have an empty post again


### PR DESCRIPTION
This is the first half of https://github.com/WordPress/gutenberg/issues/7887.

Renames all 'shared block' references to 'reusable block', and changes the copy of the associated UI controls to match what was suggested in https://github.com/WordPress/gutenberg/issues/7887#issuecomment-407390960.

To test:
1. Ensure tests pass
2. Click around in Gutenberg and look for any regressions