### PR TITLE
Allow ID attributes on any elements

### DIFF
--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -109,14 +109,20 @@ describe( 'removeInvalidHTML', () => {
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
 	} );
 
+	it( 'should keep id attributes', () => {
+		const input = '<p id="foo">test</p>';
+		const output = '<p id="foo">test</p>';
+		expect( removeInvalidHTML( input, schema ) ).toBe( output );
+	} );
+
 	it( 'should remove multiple attributes', () => {
-		const input = '<p class="test" id="test">test</p>';
+		const input = '<p class="test" style="test">test</p>';
 		const output = '<p>test</p>';
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
 	} );
 
 	it( 'should deep remove attributes', () => {
-		const input = '<p class="test">test <em id="test">test</em></p>';
+		const input = '<p class="test">test <em style="test">test</em></p>';
 		const output = '<p>test <em>test</em></p>';
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
 	} );

--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -109,20 +109,20 @@ describe( 'removeInvalidHTML', () => {
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
 	} );
 
-	it( 'should keep id attributes', () => {
+	it( 'should remove id attributes', () => {
 		const input = '<p id="foo">test</p>';
-		const output = '<p id="foo">test</p>';
+		const output = '<p>test</p>';
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
 	} );
 
 	it( 'should remove multiple attributes', () => {
-		const input = '<p class="test" style="test">test</p>';
+		const input = '<p class="test" id="test">test</p>';
 		const output = '<p>test</p>';
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
 	} );
 
 	it( 'should deep remove attributes', () => {
-		const input = '<p class="test">test <em style="test">test</em></p>';
+		const input = '<p class="test">test <em id="test">test</em></p>';
 		const output = '<p>test <em>test</em></p>';
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
 	} );

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -197,7 +197,7 @@ function cleanNodeList( nodeList, doc, schema, inline ) {
 				if ( node.hasAttributes() ) {
 					// Strip invalid attributes.
 					Array.from( node.attributes ).forEach( ( { name } ) => {
-						if ( name !== 'class' && ! includes( attributes, name ) ) {
+						if ( name !== 'class' && name !== 'id' && ! includes( attributes, name ) ) {
 							node.removeAttribute( name );
 						}
 					} );


### PR DESCRIPTION
## Description

The ID attribute is frequently used to create intra-page links, or to link to specific parts of a page.

Removing them when we convert existing posts to blocks causes those links to suddenly start failing.

It's worth noting that this PR intentionally _does not_ create UI for editing the `id` attribute. The workflow for adding an `id` attribute in Classic involves switching to Text view, the workflow for Gutenberg currently remains the same. This PR is solely to address the data loss that can occur when a post is converted.

## How has this been tested?

Create a post in the Classic Editor with this content:

`<h2 id="foo">Bar</h2>`

Open that post in Gutenberg, and convert it to blocks.

Check the Code view, to see that the `id` attribute is still set correctly.

Preview the post, and add the `#foo` anchor to the URL, and check that the page jumps to the heading.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.