### PR TITLE
Fix for ie-11 grallery grid wrapping

### DIFF
--- a/core-blocks/gallery/style.scss
+++ b/core-blocks/gallery/style.scss
@@ -3,6 +3,7 @@
 	flex-wrap: wrap;
 	list-style-type: none;
 	padding: 0px;
+	width: 100%;
 	// allow gallery items to go edge to edge
 	margin: 0 -8px 0 -8px;
 
@@ -38,7 +39,7 @@
 			text-align: center;
 			font-size: $default-font-size;
 			background: linear-gradient( 0deg, rgba( $color: $black, $alpha: 0.7 ) 0, rgba($color: $black, $alpha: 0.3) 60%, transparent );
-	
+
 			img {
 				display: inline;
 			}
@@ -61,19 +62,19 @@
 	// Responsive fallback value, 2 columns
 	& .blocks-gallery-image,
 	& .blocks-gallery-item {
-		width: calc( 100% / 2 - 16px );
+		width: calc( 50% - 16px );
 	}
 
 	&.columns-1 .blocks-gallery-image,
 	&.columns-1 .blocks-gallery-item {
-		width: calc(100% / 1 - 16px);
+		width: calc(100% - 16px);
 	}
 
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
 			&.columns-#{ $i } .blocks-gallery-item {
-				width: calc(100% / #{ $i } - 16px );
+				width: calc(#{ 100/$i }% - 16px );
 			}
 		}
 	}


### PR DESCRIPTION
## Description
In IE 11 the gallery grid was wrapping due to bad calculations made by the browser.

## How has this been tested?
I compiled the whole gutenberg package and installed it on my wordpress installation. 
The bug is fixed.

## Screenshots <!-- if applicable -->

## Types of changes
Added width 100% to the gallery parent block to avoid grid collapsing horizontally.
Changed the sass "for" loop making the percentage calculated by the preprocessor. 

## Checklist:
- [y] My code is tested.
- [y] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [y] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [y] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
