### PR TITLE
Support using the subhead multiple times on a page/post

### DIFF
--- a/core-blocks/subhead/index.js
+++ b/core-blocks/subhead/index.js
@@ -27,10 +27,6 @@ export const settings = {
 
 	category: 'common',
 
-	supports: {
-		multiple: false,
-	},
-
 	attributes: {
 		content: {
 			type: 'array',


### PR DESCRIPTION
## Description
Removes the `supports.multiple = false` setting on the subhead block so it can be used in multiple instances in a page/post/etc.

Fixes #8140.

## How has this been tested?
Test by creating a page or post and adding the `subhead` block multiple times

## Screenshots
![_untitled____ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/43080760-7d205e6e-8e5e-11e8-952e-bc479268997b.png)

## Types of changes
Changes subhead so it can be used multiple times

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
