### PR TITLE
Blocks: Rename wideAlign to alignWide

### DIFF
--- a/core-blocks/button/index.js
+++ b/core-blocks/button/index.js
@@ -74,7 +74,7 @@ export const settings = {
 
 	supports: {
 		align: true,
-		wideAlign: false,
+		alignWide: false,
 	},
 
 	styles: [

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -328,7 +328,23 @@ parent: [ 'core/columns' ],
 
 * **Type:** `Object`
 
-Optional block extended support features. The following options are supported, and should be specified as a boolean `true` or `false` value:
+Optional block extended support features. The following options are supported:
+
+- `align` (default `false`): This property adds block controls which allow to change block's alignment. _Important: It doesn't work with dynamic blocks yet._
+
+```js
+// Add the support for block's alignment (left, center, right, wide, full).
+align: true,
+// Pick which alignment options to display.
+align: [ 'left', 'right', 'full' ],
+```
+
+- `alignWide` (default `true`): Gutenberg allows to enable [wide alignment](../docs/extensibility/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
+
+```js
+// Remove the support for wide alignment.
+alignWide: false,
+```
 
 - `anchor` (default `false`): Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -6,6 +6,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.utils.getMimeTypesArray` has been removed.
  - `wp.utils.mediaUpload` has been removed. Please use `wp.editor.mediaUpload` instead.
  - `wp.utils.preloadImage` has been removed.
+ - `supports.wideAlign` has been removed from the Block API. Please use `supports.alignWide` instead.
 
 ## 3.5.0
 

--- a/editor/hooks/align.js
+++ b/editor/hooks/align.js
@@ -8,6 +8,7 @@ import { assign, includes } from 'lodash';
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport, getBlockSupport } from '@wordpress/blocks';
 
@@ -55,7 +56,13 @@ export function getBlockValidAlignments( blockName ) {
 		validAlignments.push( 'left', 'center', 'right' );
 
 		// ...including wide alignments unless explicitly `false`.
-		if ( hasBlockSupport( blockName, 'wideAlign', true ) ) {
+		if ( getBlockSupport( blockName, 'wideAlign' ) === false ) {
+			deprecated( 'supports.wideAlign in Block API', {
+				version: '3.6',
+				alternative: 'supports.alignWide',
+				plugin: 'Gutenberg',
+			} );
+		} else if ( hasBlockSupport( blockName, 'alignWide', true ) ) {
 			validAlignments.push( 'wide', 'full' );
 		}
 	}

--- a/editor/hooks/test/align.js
+++ b/editor/hooks/test/align.js
@@ -95,7 +95,7 @@ describe( 'align', () => {
 				...blockSettings,
 				supports: {
 					align: true,
-					wideAlign: false,
+					alignWide: false,
 				},
 			} );
 			const validAlignments = getBlockValidAlignments( 'core/foo' );
@@ -128,7 +128,7 @@ describe( 'align', () => {
 				...blockSettings,
 				supports: {
 					align: true,
-					wideAlign: false,
+					alignWide: false,
 				},
 			} );
 
@@ -153,7 +153,7 @@ describe( 'align', () => {
 				...blockSettings,
 				supports: {
 					align: true,
-					wideAlign: false,
+					alignWide: false,
 				},
 			} );
 
@@ -181,7 +181,7 @@ describe( 'align', () => {
 				...blockSettings,
 				supports: {
 					align: true,
-					wideAlign: false,
+					alignWide: false,
 				},
 			} );
 

--- a/phpunit/fixtures/long-content.html
+++ b/phpunit/fixtures/long-content.html
@@ -66,7 +66,7 @@
 <p>Blocks can be anything you need. For instance, you may want to add a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>
 <!-- /wp:paragraph -->
 <!-- wp:gallery {"columns":2} -->
-<div class="wp-block-gallery alignnone columns-2 is-cropped">
+<div class="wp-block-gallery columns-2 is-cropped">
 <figure class="blocks-gallery-item"><img src="https://cldup.com/n0g6ME5VKC.jpg" alt="" /></figure>
 <figure class="blocks-gallery-item"><img src="https://cldup.com/ZjESfxPI3R.jpg" alt="" /></figure>
 <figure class="blocks-gallery-item"><img src="https://cldup.com/EKNF8xD2UM.jpg" alt="" /></figure>
@@ -108,7 +108,7 @@ https://vimeo.com/22439234
 <p>You can build any block you like, static or dynamic, decorative or plain. Here&#x27;s a pullquote block:</p>
 <!-- /wp:paragraph -->
 <!-- wp:pullquote -->
-<blockquote class="wp-block-pullquote alignnone">
+<blockquote class="wp-block-pullquote">
 <p>Code is Poetry</p>
 <cite>The WordPress community</cite>
 </blockquote>

--- a/post-content.js
+++ b/post-content.js
@@ -82,7 +82,7 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:gallery {"columns":2} -->',
-			'<ul class="wp-block-gallery alignnone columns-2 is-cropped">',
+			'<ul class="wp-block-gallery columns-2 is-cropped">',
 			'<li class="blocks-gallery-item"><figure><img src="https://cldup.com/n0g6ME5VKC.jpg" alt="" /></figure></li>',
 			'<li class="blocks-gallery-item"><figure><img src="https://cldup.com/ZjESfxPI3R.jpg" alt="" /></figure></li>',
 			'<li class="blocks-gallery-item"><figure><img src="https://cldup.com/EKNF8xD2UM.jpg" alt="" /></figure></li>',
@@ -133,7 +133,7 @@ window._wpGutenbergDefaultPost = {
 			'<!-- /wp:paragraph -->',
 
 			'<!-- wp:pullquote -->',
-			'<blockquote class="wp-block-pullquote alignnone"><p>Code is Poetry</p><cite>The WordPress community</cite></blockquote>',
+			'<blockquote class="wp-block-pullquote"><p>Code is Poetry</p><cite>The WordPress community</cite></blockquote>',
 			'<!-- /wp:pullquote -->',
 
 			'<!-- wp:paragraph {"align":"center"} -->',


### PR DESCRIPTION
## Description

At the moment we are able to use PHP hook to enable wide alignment with the following PHP code:

```php
add_theme_support( 'align-wide' );
```

We also provide undocumented `supports` option in Block API named `wideAlign`.

This PR renames it to `alignWide` to align with PHP. In addition, it adds missing documentation for this option, as well as another option which plays a similar purpose `align`.

## How has this been tested?
`npm test`

Add support for wide alignment to your theme with the following PHP code:
```php
add_theme_support( 'align-wide' );
```

Make sure that Button block doesn't have wide alignment (full and wide) options available.

Use deprecated `supports.wideAlign` option with one of your blocks and ensure you see the deprecation warning.

## Types of changes
BREAKIN CHANGE

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
