### PR TITLE
Data module: Add built-in support for persisting stores

### DIFF
--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -3,7 +3,7 @@
  */
 import { registerCoreBlocks } from '@wordpress/core-blocks';
 import { render, unmountComponentAtNode } from '@wordpress/element';
-import { dispatch } from '@wordpress/data';
+import { dispatch, setupPersistence } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -14,6 +14,11 @@ import './hooks';
 import store from './store';
 import { initializeMetaBoxState } from './store/actions';
 import Editor from './editor';
+
+/**
+ * Module Constants
+ */
+const STORAGE_KEY = `WP_EDIT_POST_DATA_${ window.userSettings.uid }`;
 
 /**
  * Reinitializes the editor after the user chooses to reboot the editor after
@@ -88,3 +93,5 @@ export { default as PluginPostStatusInfo } from './components/sidebar/plugin-pos
 export { default as PluginPrePublishPanel } from './components/sidebar/plugin-pre-publish-panel';
 export { default as PluginSidebar } from './components/sidebar/plugin-sidebar';
 export { default as PluginSidebarMoreMenuItem } from './components/header/plugin-sidebar-more-menu-item';
+
+setupPersistence( STORAGE_KEY );

--- a/edit-post/store/index.js
+++ b/edit-post/store/index.js
@@ -3,8 +3,7 @@
  */
 import {
 	registerStore,
-	withRehydration,
-	loadAndPersist,
+	restrictPersistence,
 } from '@wordpress/data';
 
 /**
@@ -14,20 +13,14 @@ import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import * as actions from './actions';
 import * as selectors from './selectors';
-
-/**
- * Module Constants
- */
-const STORAGE_KEY = `WP_EDIT_POST_PREFERENCES_${ window.userSettings.uid }`;
-
 const store = registerStore( 'core/edit-post', {
-	reducer: withRehydration( reducer, 'preferences', STORAGE_KEY ),
+	reducer: restrictPersistence( reducer, 'preferences' ),
 	actions,
 	selectors,
+	persist: true,
 } );
 
 applyMiddlewares( store );
-loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 store.dispatch( { type: 'INIT' } );
 
 export default store;

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -7,11 +7,8 @@ import { forOwn } from 'lodash';
  * WordPress Dependencies
  */
 import {
-	registerReducer,
-	registerSelectors,
-	registerActions,
-	withRehydration,
-	loadAndPersist,
+	registerStore,
+	restrictPersistence,
 } from '@wordpress/data';
 
 /**
@@ -27,16 +24,15 @@ import { validateTokenSettings } from '../components/rich-text/tokens';
 /**
  * Module Constants
  */
-const STORAGE_KEY = `GUTENBERG_PREFERENCES_${ window.userSettings.uid }`;
 const MODULE_KEY = 'core/editor';
 
-const store = applyMiddlewares(
-	registerReducer( MODULE_KEY, withRehydration( reducer, 'preferences', STORAGE_KEY ) )
-);
-loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
-
-registerSelectors( MODULE_KEY, selectors );
-registerActions( MODULE_KEY, actions );
+const store = registerStore( MODULE_KEY, {
+	reducer: restrictPersistence( reducer, 'preferences' ),
+	selectors,
+	actions,
+	persist: true,
+} );
+applyMiddlewares( store );
 
 forOwn( tokens, ( { name, settings } ) => {
 	settings = validateTokenSettings( name, settings, store.getState() );

--- a/editor/utils/with-history/test/index.js
+++ b/editor/utils/with-history/test/index.js
@@ -16,6 +16,8 @@ describe( 'withHistory', () => {
 			past: [],
 			present: 0,
 			future: [],
+			lastAction: null,
+			shouldCreateUndoLevel: false,
 		} );
 	} );
 
@@ -23,21 +25,26 @@ describe( 'withHistory', () => {
 		const reducer = withHistory()( counter );
 
 		let state;
+		const action = { type: 'INCREMENT' };
 		state = reducer( undefined, {} );
-		state = reducer( state, { type: 'INCREMENT' } );
+		state = reducer( state, action );
 
 		expect( state ).toEqual( {
 			past: [ 0 ],
 			present: 1,
 			future: [],
+			lastAction: action,
+			shouldCreateUndoLevel: false,
 		} );
 
-		state = reducer( state, { type: 'INCREMENT' } );
+		state = reducer( state, action );
 
 		expect( state ).toEqual( {
 			past: [ 0, 1 ],
 			present: 2,
 			future: [],
+			lastAction: action,
+			shouldCreateUndoLevel: false,
 		} );
 	} );
 
@@ -53,6 +60,8 @@ describe( 'withHistory', () => {
 			past: [],
 			present: 0,
 			future: [ 1 ],
+			lastAction: null,
+			shouldCreateUndoLevel: false,
 		} );
 	} );
 
@@ -76,6 +85,8 @@ describe( 'withHistory', () => {
 			past: [ 0 ],
 			present: 1,
 			future: [],
+			lastAction: null,
+			shouldCreateUndoLevel: false,
 		} );
 	} );
 
@@ -98,6 +109,8 @@ describe( 'withHistory', () => {
 			past: [],
 			present: 1,
 			future: [],
+			lastAction: null,
+			shouldCreateUndoLevel: false,
 		} );
 	} );
 
@@ -113,6 +126,8 @@ describe( 'withHistory', () => {
 			past: [ 0 ], // Needs at least one history
 			present: 2,
 			future: [],
+			lastAction: { type: 'INCREMENT' },
+			shouldCreateUndoLevel: false,
 		} );
 	} );
 
@@ -137,6 +152,8 @@ describe( 'withHistory', () => {
 			past: [ 0 ],
 			present: 1,
 			future: [],
+			lastAction: { type: 'INCREMENT' },
+			shouldCreateUndoLevel: false,
 		} );
 
 		state = reducer( state, { type: 'INCREMENT' } );
@@ -145,6 +162,8 @@ describe( 'withHistory', () => {
 			past: [ 0 ],
 			present: 2,
 			future: [],
+			lastAction: { type: 'INCREMENT' },
+			shouldCreateUndoLevel: false,
 		} );
 	} );
 
@@ -162,6 +181,8 @@ describe( 'withHistory', () => {
 			past: [ 0 ],
 			present: 1,
 			future: [],
+			lastAction: null,
+			shouldCreateUndoLevel: true,
 		} );
 
 		state = reducer( state, { type: 'INCREMENT' } );
@@ -170,6 +191,8 @@ describe( 'withHistory', () => {
 			past: [ 0, 1 ],
 			present: 2,
 			future: [],
+			lastAction: { type: 'INCREMENT' },
+			shouldCreateUndoLevel: false,
 		} );
 	} );
 } );

--- a/packages/data/src/deprecated.js
+++ b/packages/data/src/deprecated.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
+ * Internal dependencies
+ */
+import { getPersistenceStorage } from './persist';
+
+/**
+ * Adds the rehydration behavior to redux reducers.
+ *
+ * @param {Function} reducer    The reducer to enhance.
+ * @param {string}   reducerKey The reducer key to persist.
+ * @param {string}   storageKey The storage key to use.
+ *
+ * @return {Function} Enhanced reducer.
+ */
+export function withRehydration( reducer, reducerKey, storageKey ) {
+	deprecated( 'wp.data.withRehydration', {
+		version: '3.6',
+		plugin: 'Gutenberg',
+		hint: 'See https://github.com/WordPress/gutenberg/pull/8146 for more details',
+	} );
+
+	// EnhancedReducer with auto-rehydration
+	const enhancedReducer = ( state, action ) => {
+		const nextState = reducer( state, action );
+
+		if ( action.type === 'REDUX_REHYDRATE' && action.storageKey === storageKey ) {
+			return {
+				...nextState,
+				[ reducerKey ]: action.payload,
+			};
+		}
+
+		return nextState;
+	};
+
+	return enhancedReducer;
+}
+
+/**
+ * Loads the initial state and persist on changes.
+ *
+ * This should be executed after the reducer's registration.
+ *
+ * @param {Object}   store      Store to enhance.
+ * @param {Function} reducer    The reducer function. Used to get default values and to allow custom serialization by the reducers.
+ * @param {string}   reducerKey The reducer key to persist (example: reducerKey.subReducerKey).
+ * @param {string}   storageKey The storage key to use.
+ */
+export function loadAndPersist( store, reducer, reducerKey, storageKey ) {
+	deprecated( 'wp.data.loadAndPersist', {
+		version: '3.6',
+		plugin: 'Gutenberg',
+		hint: 'See https://github.com/WordPress/gutenberg/pull/8146 for more details',
+	} );
+
+	// Load initially persisted value
+	const persistedString = getPersistenceStorage().getItem( storageKey );
+	if ( persistedString ) {
+		const persistedState = {
+			...get( reducer( undefined, { type: '@@gutenberg/init' } ), reducerKey ),
+			...JSON.parse( persistedString ),
+		};
+
+		store.dispatch( {
+			type: 'REDUX_REHYDRATE',
+			payload: persistedState,
+			storageKey,
+		} );
+	}
+
+	// Persist updated preferences
+	let currentStateValue = get( store.getState(), reducerKey );
+	store.subscribe( () => {
+		const newStateValue = get( store.getState(), reducerKey );
+		if ( newStateValue !== currentStateValue ) {
+			currentStateValue = newStateValue;
+			const stateToSave = get( reducer( store.getState(), { type: 'SERIALIZE' } ), reducerKey );
+			getPersistenceStorage().setItem( storageKey, JSON.stringify( stateToSave ) );
+		}
+	} );
+}

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -7,7 +7,7 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import defaultRegistry from './default-registry';
-export { loadAndPersist, withRehydration } from './persist';
+export { restrictPersistence, setPersistenceStorage } from './persist';
 export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
 export { default as RegistryProvider } from './components/registry-provider';
@@ -33,3 +33,4 @@ export const registerReducer = defaultRegistry.registerReducer;
 export const registerActions = defaultRegistry.registerActions;
 export const registerSelectors = defaultRegistry.registerSelectors;
 export const registerResolvers = defaultRegistry.registerResolvers;
+export const setupPersistence = defaultRegistry.setupPersistence;

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -12,6 +12,7 @@ export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
 export { default as RegistryProvider } from './components/registry-provider';
 export { createRegistry } from './registry';
+export { withRehydration, loadAndPersist } from './deprecated';
 
 /**
  * The combineReducers helper function turns an object whose values are different

--- a/packages/data/src/persist.js
+++ b/packages/data/src/persist.js
@@ -1,5 +1,5 @@
 // Defaults to the local storage.
-let persistenceStorage = window.localStorage;
+let persistenceStorage;
 
 /**
  * Sets a different persistence storage.
@@ -8,6 +8,15 @@ let persistenceStorage = window.localStorage;
  */
 export function setPersistenceStorage( storage ) {
 	persistenceStorage = storage;
+}
+
+/**
+ * Get the persistence storage handler.
+ *
+ * @return {Object} Persistence storage.
+ */
+export function getPersistenceStorage() {
+	return persistenceStorage || window.localStorage;
 }
 
 /**
@@ -71,13 +80,4 @@ export function restrictPersistence( reducer, keyToPersist ) {
 
 		return nextState;
 	};
-}
-
-/**
- * Get the persistence storage handler.
- *
- * @return {Object} Persistence storage.
- */
-export function getPersistenceStorage() {
-	return persistenceStorage;
 }

--- a/packages/data/src/persist.js
+++ b/packages/data/src/persist.js
@@ -47,6 +47,14 @@ export function restrictPersistence( reducer, keyToPersist ) {
 		const nextState = reducer( state, action );
 
 		if ( action.type === 'SERIALIZE' ) {
+			// Returning the same instance if the state is kept identical avoids reserializing again
+			if (
+				action.previousState &&
+				action.previousState[ keyToPersist ] === nextState[ keyToPersist ]
+			) {
+				return action.previousState;
+			}
+
 			return { [ keyToPersist ]: nextState[ keyToPersist ] };
 		}
 

--- a/packages/data/src/persist.js
+++ b/packages/data/src/persist.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { get } from 'lodash';
-
 // Defaults to the local storage.
 let persistenceStorage = window.localStorage;
 
@@ -19,63 +14,62 @@ export function setPersistenceStorage( storage ) {
  * Adds the rehydration behavior to redux reducers.
  *
  * @param {Function} reducer    The reducer to enhance.
- * @param {string}   reducerKey The reducer key to persist.
  * @param {string}   storageKey The storage key to use.
  *
  * @return {Function} Enhanced reducer.
  */
-export function withRehydration( reducer, reducerKey, storageKey ) {
+export function withRehydration( reducer ) {
 	// EnhancedReducer with auto-rehydration
 	const enhancedReducer = ( state, action ) => {
-		const nextState = reducer( state, action );
-
-		if ( action.type === 'REDUX_REHYDRATE' && action.storageKey === storageKey ) {
-			return {
-				...nextState,
-				[ reducerKey ]: action.payload,
-			};
+		if ( action.type === 'REDUX_REHYDRATE' ) {
+			return reducer( action.payload, {
+				...action,
+				previousState: state,
+			} );
 		}
 
-		return nextState;
+		return reducer( state, action );
 	};
 
 	return enhancedReducer;
 }
 
 /**
- * Loads the initial state and persist on changes.
+ * Higher-order reducer used to persist just one key from the reducer state.
  *
- * This should be executed after the reducer's registration.
+ * @param {function} reducer    Reducer function.
+ * @param {string} keyToPersist The reducer key to persist.
  *
- * @param {Object}   store      Store to enhance.
- * @param {Function} reducer    The reducer function. Used to get default values and to allow custom serialization by the reducers.
- * @param {string}   reducerKey The reducer key to persist (example: reducerKey.subReducerKey).
- * @param {string}   storageKey The storage key to use.
+ * @return {function} Updated reducer.
  */
-export function loadAndPersist( store, reducer, reducerKey, storageKey ) {
-	// Load initially persisted value
-	const persistedString = persistenceStorage.getItem( storageKey );
-	if ( persistedString ) {
-		const persistedState = {
-			...get( reducer( undefined, { type: '@@gutenberg/init' } ), reducerKey ),
-			...JSON.parse( persistedString ),
-		};
+export function restrictPersistence( reducer, keyToPersist ) {
+	return ( state, action ) => {
+		const nextState = reducer( state, action );
 
-		store.dispatch( {
-			type: 'REDUX_REHYDRATE',
-			payload: persistedState,
-			storageKey,
-		} );
-	}
-
-	// Persist updated preferences
-	let currentStateValue = get( store.getState(), reducerKey );
-	store.subscribe( () => {
-		const newStateValue = get( store.getState(), reducerKey );
-		if ( newStateValue !== currentStateValue ) {
-			currentStateValue = newStateValue;
-			const stateToSave = get( reducer( store.getState(), { type: 'SERIALIZE' } ), reducerKey );
-			persistenceStorage.setItem( storageKey, JSON.stringify( stateToSave ) );
+		if ( action.type === 'SERIALIZE' ) {
+			return { [ keyToPersist ]: nextState[ keyToPersist ] };
 		}
-	} );
+
+		if ( action.type === 'REDUX_REHYDRATE' ) {
+			return {
+				...action.previousState,
+				...state,
+				[ keyToPersist ]: {
+					...action.previousState[ keyToPersist ],
+					...state[ keyToPersist ],
+				},
+			};
+		}
+
+		return nextState;
+	};
+}
+
+/**
+ * Get the persistence storage handler.
+ *
+ * @return {Object} Persistence storage.
+ */
+export function getPersistenceStorage() {
+	return persistenceStorage;
 }

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -319,13 +319,13 @@ export function createRegistry( storeConfigs = {} ) {
 		const persistedString = persistenceStorage.getItem( storageKey );
 		if ( persistedString ) {
 			const persistedData = JSON.parse( persistedString );
-			Object.entries( namespaces ).forEach( ( [ reducerKey, { reducer, store, persist } ] ) => {
+			Object.entries( namespaces ).forEach( ( [ reducerKey, { store, persist } ] ) => {
 				if ( ! persist ) {
 					return;
 				}
 
 				const persistedState = {
-					...reducer( undefined, { type: '@@gutenberg/init' } ),
+					...store.getState(),
 					...get( persistedData, reducerKey ),
 				};
 

--- a/packages/nux/src/store/index.js
+++ b/packages/nux/src/store/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { registerStore, withRehydration, loadAndPersist } from '@wordpress/data';
+import { registerStore, restrictPersistence } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,11 +14,10 @@ const REDUCER_KEY = 'preferences';
 const STORAGE_KEY = `GUTENBERG_NUX_${ window.userSettings.uid }`;
 
 const store = registerStore( 'core/nux', {
-	reducer: withRehydration( reducer, REDUCER_KEY, STORAGE_KEY ),
+	reducer: restrictPersistence( reducer, REDUCER_KEY, STORAGE_KEY ),
 	actions,
 	selectors,
+	persist: true,
 } );
-
-loadAndPersist( store, reducer, REDUCER_KEY, STORAGE_KEY );
 
 export default store;

--- a/packages/nux/src/store/index.js
+++ b/packages/nux/src/store/index.js
@@ -11,10 +11,9 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 
 const REDUCER_KEY = 'preferences';
-const STORAGE_KEY = `GUTENBERG_NUX_${ window.userSettings.uid }`;
 
 const store = registerStore( 'core/nux', {
-	reducer: restrictPersistence( reducer, REDUCER_KEY, STORAGE_KEY ),
+	reducer: restrictPersistence( reducer, REDUCER_KEY ),
 	actions,
 	selectors,
 	persist: true,


### PR DESCRIPTION
Related #8081 

This PR adds a built-in mechanism to the data module to persist the registry.

It works this way:

 - When registring a store that you want to persist, pass a `persist: true` to the `registerStore` function call.
 - To trigger persistance and initial loading you just call `registry.setupPersistence( storageKey )`

This allows us to persist the entire registry in one call instead of spreading this call to multiple packages. It also allows us to avoid depending ono `window.userSettings` in several packages to generate the unique uid for persistence.

**Testing instructions**

 - Open Gutenberg
 - Close the sidebar
 - Reload the page
 - The sidebar should stay closed.