### PR TITLE
Make tooltips dismissable

### DIFF
--- a/edit-post/components/header/more-menu/test/__snapshots__/index.js.snap
+++ b/edit-post/components/header/more-menu/test/__snapshots__/index.js.snap
@@ -28,6 +28,7 @@ exports[`MoreMenu should match snapshot 1`] = `
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
+              onMouseDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -38,6 +39,7 @@ exports[`MoreMenu should match snapshot 1`] = `
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
+                onMouseDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 type="button"

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -67,6 +67,8 @@ export class BlockMover extends Component {
 					aria-disabled={ isFirst }
 					onFocus={ this.onFocus }
 					onBlur={ this.onBlur }
+					onMouseEnter={ this.onFocus }
+					onMouseLeave={ this.onBlur }
 				/>
 				<IconButton
 					className="editor-block-mover__control"
@@ -77,6 +79,8 @@ export class BlockMover extends Component {
 					aria-disabled={ isLast }
 					onFocus={ this.onFocus }
 					onBlur={ this.onBlur }
+					onMouseEnter={ this.onFocus }
+					onMouseLeave={ this.onBlur }
 				/>
 				<span id={ `editor-block-mover__up-description-${ instanceId }` } className="editor-block-mover__description">
 					{

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -89,6 +89,8 @@ export class BlockSettingsMenu extends Component {
 								focus={ focus }
 								onFocus={ this.onFocus }
 								onBlur={ this.onBlur }
+								onMouseEnter={ this.onFocus }
+								onMouseLeave={ this.onBlur }
 							/>
 						);
 					} }

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -119,7 +119,9 @@ class Tooltip extends Component {
 	createToggleIsOver( eventName, isDelayed ) {
 		return ( event ) => {
 			// Preserve original child callback behavior
-			this.emitToChild( eventName, event );
+			if ( event.type !== 'mousedown' ) {
+				this.emitToChild( eventName, event );
+			}
 
 			// Mouse events behave unreliably in React for disabled elements,
 			// firing on mouseenter but not mouseleave.  Further, the default
@@ -165,6 +167,7 @@ class Tooltip extends Component {
 			ref: this.bindNode,
 			onMouseEnter: this.createToggleIsOver( 'onMouseEnter', true ),
 			onMouseLeave: this.createToggleIsOver( 'onMouseLeave' ),
+			onMouseDown: this.createToggleIsOver( 'onMouseDown' ),
 			onClick: this.createToggleIsOver( 'onClick' ),
 			onFocus: this.createToggleIsOver( 'onFocus' ),
 			onBlur: this.createToggleIsOver( 'onBlur' ),

--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -1,5 +1,6 @@
 .components-tooltip.components-popover {
 	z-index: z-index( '.components-tooltip' );
+	cursor: default;
 
 	&:before {
 		border-color: transparent;


### PR DESCRIPTION
Work in progress, please don't merge.

This PR is a first attempt to improve the tooltips behaviour after #8033. As mentioned there and in the related issue, tooltips should persist when hovered. However, as correctly pointed out, they should also be dismissable by users.

WCAG reference:
Success Criterion 1.4.13 Content on Hover or Focus
https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus
https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html
there are 3 items to address to meet the requirement:

- dismissable
- hoverable
- persistent

More details on #8033 and the related issue.

By making use of `onMouseDown` this PR seeks to solve two issues:
- makes the tooltips dismissable when clicking on them
- prevents the `click` event to be passed to the button and trigger the associated action
- also adds a `cursor: default` style to the tooltip

Todo:
- ideally, tooltips should be dismissable also when pressing Escape; honestly, I have no idea how to implement it
- seems to me the persistent tooltips work pretty well except for the block side controls: the Move Up, Move Down, and More Options buttons. Worth noting these controls may completely change if #6224 gets in (they would be moved underneath the block). Otherwise, there will be the need of further changes:
  - when hovering a block and then hovering the movers or the ellipsis button, the tooltips don't persist because the button themselves are not rendered; seems to me this happens because the hovered left or right areas can be null when hovering the tooltips (see screenshot below)
  - the tooltips on the block movers should be positioned differently depending if the block has a wide/full alignment or not

Any help would be greatly appreciated.

![screen shot 2018-07-23 at 15 20 45](https://user-images.githubusercontent.com/1682452/43094515-763a60ea-8eb3-11e8-89af-8fbe6be66735.png)
