### PR TITLE
Rich Text: Update TinyMCE component to use componentDidUpdate

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -114,23 +114,23 @@ export default class TinyMCE extends Component {
 		return false;
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		this.configureIsPlaceholderVisible( nextProps.isPlaceholderVisible );
+	componentDidUpdate( prevProps ) {
+		this.configureIsPlaceholderVisible( this.props.isPlaceholderVisible );
 
-		if ( ! isEqual( this.props.style, nextProps.style ) ) {
+		if ( ! isEqual( prevProps.style, this.props.style ) ) {
 			this.editorNode.setAttribute( 'style', '' );
-			Object.assign( this.editorNode.style, nextProps.style );
+			Object.assign( this.editorNode.style, this.props.style );
 		}
 
-		if ( ! isEqual( this.props.className, nextProps.className ) ) {
-			this.editorNode.className = classnames( nextProps.className, 'editor-rich-text__tinymce' );
+		if ( ! isEqual( prevProps.className, this.props.className ) ) {
+			this.editorNode.className = classnames( this.props.className, 'editor-rich-text__tinymce' );
 		}
 
-		const { removedKeys, updatedKeys } = diffAriaProps( this.props, nextProps );
+		const { removedKeys, updatedKeys } = diffAriaProps( prevProps, this.props );
 		removedKeys.forEach( ( key ) =>
 			this.editorNode.removeAttribute( key ) );
 		updatedKeys.forEach( ( key ) =>
-			this.editorNode.setAttribute( key, nextProps[ key ] ) );
+			this.editorNode.setAttribute( key, this.props[ key ] ) );
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
This pull request seeks to update the TinyMCE component to avoid usage of the deprecated `componentWillReceiveProps` React function, which will log warnings when using the `React.StrictMode` component.

**Implementation notes:**

Since this lifecycle method operates on the bound DOM node, it is a fairly straight-forward conversion. In fact, this probably should have been implemented using `componentDidUpdate` all along.

There's probably some broader refactoring that could be done here to avoid the manual DOM mutations. This pull request is only meant to address the deprecated lifecycle usage.

**Testing instructions:**

Verify that there are no regressions in the behavior covered by this method:

- Placeholder visibility
- Styles application
- Classname application
- Aria key application