### PR TITLE
Fix: Shared Blocks: State memory leak, each time inserter is opened new blocks are added

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -112,15 +112,20 @@ export function resetBlocks( blocks ) {
  * Returns an action object used in signalling that blocks have been received.
  * Unlike resetBlocks, these should be appended to the existing known set, not
  * replacing.
+ * If the new blocks that are being received are replacing existing blocks,
+ * during the action dispatch it is possible to specify existing blocks that
+ * are removed before adding the new ones.
  *
- * @param {Object[]} blocks Array of block objects.
+ * @param {Object[]}       blocks            Array of block objects.
+ * @param {?Array<string>} clientIdsToRemove Array of clientIds.
  *
  * @return {Object} Action object.
  */
-export function receiveBlocks( blocks ) {
+export function receiveBlocks( blocks, clientIdsToRemove = [] ) {
 	return {
 		type: 'RECEIVE_BLOCKS',
 		blocks,
+		clientIdsToRemove,
 	};
 }
 


### PR DESCRIPTION
Each time the inserter was opened the shared blocks were requested and new blocks to represent them (used in their preview) were inserted.


## Description
This PR adds a flag to all blocks that are inserted as part of the share blocks mechanism ( are not part of the document). This flag is useful to know each blocks are part of the document and which blocks are not part of the document.
When inserting new shared blocks we remove the previous blocks that contained that flag (we remove the previous share blocks).

## How has this been tested?
Make sure you have some shared blocks (if not create some blocks before).
Write a post.
Add a block and write something.
Press the inserter.
Press the information icon and view the block count (it is high because all share blocks are counted even if they were not inserted in the document).
Press the inserter again.
View the block count again and verify it stayed the same (in master each time we open the inserter and check the block count the number increased).
