### PR TITLE
Reapply box-sizing to slider thumbs.

### DIFF
--- a/packages/components/src/range-control/style.scss
+++ b/packages/components/src/range-control/style.scss
@@ -31,6 +31,7 @@
 	background: $dark-gray-500;
 	border: 4px solid transparent;
 	background-clip: padding-box;
+	box-sizing: border-box;
 }
 
 @mixin range-track() {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Specify the box-sizing in slider thumbs as Firefox does not inherit the box-sizing property on `-moz-range-thumb`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Visually checked against Chrome implementation.

## Screenshots <!-- if applicable -->
Firefox on the left, Chome on the right.
Note: disappearing slider is a gif artifact.

![thumb-size-fix](https://user-images.githubusercontent.com/519727/43114670-76a4a9c4-8f43-11e8-9bfa-ddaf691e658e.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for visual regression introduced PR #7545.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
