### PR TITLE
Rich Text: Pasting a URL when a URL is selected should link it

### DIFF
--- a/editor/components/rich-text/index.js
+++ b/editor/components/rich-text/index.js
@@ -277,14 +277,13 @@ export class RichText extends Component {
 		window.console.log( 'Received HTML:\n\n', HTML );
 		window.console.log( 'Received plain text:\n\n', this.pastedPlainText );
 
-		// There is a selection, check if a link is pasted.
+		// There is a selection, check if a URL is pasted.
 		if ( ! this.editor.selection.isCollapsed() ) {
 			const linkRegExp = /^(?:https?:)?\/\/\S+$/i;
 			const pastedText = event.content.replace( /<[^>]+>/g, '' ).trim();
-			const selectedText = this.editor.selection.getContent().replace( /<[^>]+>/g, '' ).trim();
 
-			// The pasted text is a link, and the selected text is not.
-			if ( linkRegExp.test( pastedText ) && ! linkRegExp.test( selectedText ) ) {
+			// A URL was pasted, turn the selection into a link
+			if ( linkRegExp.test( pastedText ) ) {
 				this.editor.execCommand( 'mceInsertLink', false, {
 					href: this.editor.dom.decode( pastedText ),
 				} );


### PR DESCRIPTION
## Description
Fixes #7010.

When a URL is selected, pasting a URL should turn the URL into a link. This matches the Classic Editor functionality.

## How has this been tested?
1. Add a paragraph block.
1. Type some text, paste a URL, type some more text.
1. Highlight the pasted URL and paste the URL again.

## Screenshots <!-- if applicable -->
![linking](https://user-images.githubusercontent.com/612155/43116086-6baf14a4-8f49-11e8-812c-2148b52dd412.gif)