### PR TITLE
Table of Contents: Remove inset shadow

### DIFF
--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -9,7 +9,6 @@
 		@include break-small {
 			max-height: calc(100vh - 120px);
 			overflow-y: auto;
-			box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
 		}
 	}
 


### PR DESCRIPTION
The inset shadow was causing the Table of Contents to look as though it was embedded into the page rather than floating on top of it. This shadow was added in in https://github.com/WordPress/gutenberg/pull/6586.

Since the new inserter doesn't have an inset shadow any more, I simply removed it.

| Before | After |
| - | - |
| <img width="725" alt="screen shot 2018-07-24 at 14 16 26" src="https://user-images.githubusercontent.com/612155/43116702-5853d888-8f4c-11e8-8e14-ebdec44df19d.png"> | <img width="724" alt="screen shot 2018-07-24 at 14 16 04" src="https://user-images.githubusercontent.com/612155/43116709-5f39fa88-8f4c-11e8-9d8c-2e9a3486dd45.png"> |