### PR TITLE
Fix warning when adding an image block

### DIFF
--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -353,7 +353,7 @@ class ImageEdit extends Component {
 						label={ __( 'Link URL' ) }
 						value={ href || '' }
 						onChange={ this.onSetCustomHref }
-						placeholder={ ! isLinkURLInputDisabled && 'https://' }
+						placeholder={ ! isLinkURLInputDisabled ? 'https://' : undefined }
 						disabled={ isLinkURLInputDisabled }
 					/>
 				</PanelBody>


### PR DESCRIPTION
## Description
Fixes #8026

Resolves issue where a TextControl component in the Image Block's settings was triggering a warning when the `isLinkURLInputDisabled` is true

## How has this been tested?
- Manual testing with `SCRIPT_DEBUG` enabled

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
