### PR TITLE
Packages: Standardize description and title of packages

### DIFF
--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -1,6 +1,6 @@
-# @wordpress/a11y
+# Accessibility (a11y)
 
-Collection of JS modules for enhancing accessibility.
+Accessibility utilities for WordPress.
 
 ## Installation
 

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/a11y",
 	"version": "1.1.1",
-	"description": "Accessibility (a11y) utilities for WordPress",
+	"description": "Accessibility (a11y) utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -1,6 +1,6 @@
-# @wordpress/api-fetch
+# API Fetch
 
-Wrapper around `window.fetch` to call WordPress REST APIs.
+Utility to make WordPress REST API requests. It's a wrapper around `window.fetch`.
 
 ## Installation
 

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/api-fetch",
 	"version": "1.0.1",
-	"description": "Utility to make WordPress REST API requests",
+	"description": "Utility to make WordPress REST API requests.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/autop/README.md
+++ b/packages/autop/README.md
@@ -1,4 +1,4 @@
-# @wordpress/autop
+# Autop
 
 JavaScript port of WordPress's automatic paragraph function `autop` and the `removep` reverse behavior.
 

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/autop",
 	"version": "1.1.1",
-	"description": "WordPress's automatic paragraph functions `autop` and `removep`",
+	"description": "WordPress's automatic paragraph functions `autop` and `removep`.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/babel-plugin-import-jsx-pragma/README.md
+++ b/packages/babel-plugin-import-jsx-pragma/README.md
@@ -1,5 +1,4 @@
-Babel Plugin Import JSX Pragma
-======
+# Babel Plugin Import JSX Pragma
 
 Babel transform plugin for automatically injecting an import to be used as the pragma for the [React JSX Transform plugin](http://babeljs.io/docs/en/babel-plugin-transform-react-jsx).
 

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/babel-plugin-import-jsx-pragma",
 	"version": "1.0.1",
-	"description": "Babel transform plugin for automatically injecting an import to be used as the pragma for the React JSX Transform plugin",
+	"description": "Babel transform plugin for automatically injecting an import to be used as the pragma for the React JSX Transform plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/babel-plugin-makepot/README.md
+++ b/packages/babel-plugin-makepot/README.md
@@ -1,5 +1,4 @@
-Babel Plugin Makepot
-======
+# Babel Plugin Makepot
 
 Babel plugin used to scan JavaScript files for use of localization functions. It then compiles these into a [gettext POT formatted](https://en.wikipedia.org/wiki/Gettext) file as a template for translation. By default the output file will be written to `gettext.pot` of the root project directory. This can be overridden using the `"output"` option of the plugin.
 

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/babel-plugin-makepot",
 	"version": "2.0.1",
-	"description": "WordPress Babel internationalization (i18n) plugin",
+	"description": "WordPress Babel internationalization (i18n) plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/babel-preset-default/README.md
+++ b/packages/babel-preset-default/README.md
@@ -1,4 +1,4 @@
-# @wordpress/babel-preset-default
+# Babel Preset Default
 
 Default [Babel](https://babeljs.io/) preset for WordPress development.
 

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/babel-preset-default",
 	"version": "2.0.2",
-	"description": "Default Babel preset for WordPress development",
+	"description": "Default Babel preset for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -1,6 +1,6 @@
-# @wordpress/blob
+# Blob
 
-Blob utils for WordPress.
+Blob utilities for WordPress.
 
 ## Installation
 

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/blob",
 	"version": "1.0.1",
-	"description": "Blob utilities for WordPress",
+	"description": "Blob utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/block-serialization-spec-parser/README.md
+++ b/packages/block-serialization-spec-parser/README.md
@@ -1,4 +1,4 @@
-# @wordpress/block-serialization-spec-parser
+# Block Serialization Spec Parser
 
 This library contains the grammar file (`grammar.pegjs`) for WordPress posts which is a block serialization _specification_ which is used to generate the actual _parser_ which is also bundled in this package.
 

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/block-serialization-spec-parser",
 	"version": "1.0.0",
-	"description": "Block serialization specification parser for WordPress posts",
+	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,4 +1,4 @@
-# @wordpress/blocks
+# Blocks
 
 "Block" is the abstract term used to describe units of markup that, composed
 together, form the content or layout of a webpage. The idea combines concepts

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/blocks",
 	"version": "1.0.0",
-	"description": "Block API for WordPress",
+	"description": "Block API for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,4 +1,4 @@
-# @wordpress/browserslist-config
+# Browserslist Config
 
 [WordPress Browserslist](https://make.wordpress.org/core/handbook/best-practices/browser-support/) shareable config for [Browserslist](https://www.npmjs.com/package/browserslist).
 

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/browserslist-config",
 	"version": "2.2.0",
-	"description": "WordPress Browserslist shared configuration",
+	"description": "WordPress Browserslist shared configuration.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,5 +1,4 @@
-Components
-==========
+# Components
 
 This packages includes a library of generic WordPress components to be used for creating common UI elements shared between screens and features of the WordPress dashboard.
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/components",
 	"version": "1.0.1",
-	"description": "UI components for WordPress",
+	"description": "UI components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -1,6 +1,6 @@
-# @wordpress/compose
+# Compose
 
-The `compose` package is a collection of handy [Higher Order Components](https://facebook.github.io/react/docs/higher-order-components.html) you can use to wrap your WordPress components and provide some basic features like: State, instanceId, pure...
+The `compose` package is a collection of handy [Higher Order Components](https://facebook.github.io/react/docs/higher-order-components.html) (HOCs) you can use to wrap your WordPress components and provide some basic features like: state, instance id, pure...
 
 ## Installation
 

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/compose",
 	"version": "1.0.1",
-	"description": "WordPress higher-order components (HOCs)",
+	"description": "WordPress higher-order components (HOCs).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -1,5 +1,4 @@
-Core Data
-=========
+# Core Data
 
 Core Data is a [data module](../data) intended to simplify access to and manipulation of core WordPress entities. It registers its own store and provides a number of selectors which resolve data from the WordPress REST API automatically, along with dispatching action creators to manipulate data.
 

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/core-data",
 	"version": "1.0.1",
-	"description": "Access to and manipulation of core WordPress entities",
+	"description": "Access to and manipulation of core WordPress entities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/custom-templated-path-webpack-plugin",
 	"version": "1.1.2",
-	"description": "Webpack plugin for creating custom path template tags",
+	"description": "Webpack plugin for creating custom path template tags.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,4 +1,4 @@
-# @wordpress/data
+# Data
 
 WordPress' data module serves as a hub to manage application state for both plugins and WordPress itself, providing tools to manage data within and between distinct modules. It is designed as a modular pattern for organizing and sharing data: simple enough to satisfy the needs of a small plugin, while scalable to serve the requirements of a complex single-page application.
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/data",
 	"version": "1.0.1",
-	"description": "Data module for WordPress",
+	"description": "Data module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -1,4 +1,4 @@
-# @wordpress/date
+# Date
 
 Date module for WordPress.
 

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/date",
 	"version": "1.0.1",
-	"description": "Date module for WordPress",
+	"description": "Date module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/deprecated/README.md
+++ b/packages/deprecated/README.md
@@ -1,6 +1,6 @@
-# @wordpress/deprecated
+# Deprecated
 
-Logs a message to notify developers about a deprecated feature.
+Deprecation utility for WordPress. Logs a message to notify developers about a deprecated feature.
 
 ## Installation
 

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/deprecated",
 	"version": "1.0.1",
-	"description": "Deprecation utility for WordPress",
+	"description": "Deprecation utility for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/dom-ready/README.md
+++ b/packages/dom-ready/README.md
@@ -1,6 +1,6 @@
-# @wordpress/dom-ready
+# DOM Ready
 
-Executes a function after the DOM has loaded.
+Execute callback after the DOM is loaded.
 
 ## Installation
 

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/dom-ready",
 	"version": "1.1.1",
-	"description": "Execute callback after the DOM is loaded",
+	"description": "Execute callback after the DOM is loaded.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -1,6 +1,6 @@
-# @wordpress/dom
+# DOM
 
-DOM utils module for WordPress.
+DOM utilities module for WordPress.
 
 ## Installation
 

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/dom",
 	"version": "1.0.1",
-	"description": "DOM utilities module for WordPress",
+	"description": "DOM utilities module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -1,4 +1,4 @@
-# @wordpress/element
+# Element
 
 Element is, quite simply, an abstraction layer atop [React](https://reactjs.org/).
 

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/element",
 	"version": "1.0.1",
-	"description": "Element React module for WordPress",
+	"description": "Element React module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,4 +1,4 @@
-# @wordpress/hooks
+# Hooks
 
 A lightweight & efficient EventManager for JavaScript.
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/hooks",
 	"version": "1.3.1",
-	"description": "WordPress hooks library",
+	"description": "WordPress hooks library.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/html-entities/README.md
+++ b/packages/html-entities/README.md
@@ -1,6 +1,6 @@
-# @wordpress/html-entities
+# HTML Entities
 
-HTML entities utils for WordPress.
+HTML entity utilities for WordPress.
 
 ## Installation
 

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/html-entities",
 	"version": "1.0.1",
-	"description": "HTML entity utilties for WordPress",
+	"description": "HTML entity utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,5 +1,4 @@
-@wordpress/i18n
-======
+# Internationalization (i18n)
 
 Internationalization utilities for client-side localization.
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/i18n",
 	"version": "1.2.1",
-	"description": "WordPress internationalization (i18n) library",
+	"description": "WordPress internationalization (i18n) library.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/is-shallow-equal/README.md
+++ b/packages/is-shallow-equal/README.md
@@ -1,4 +1,4 @@
-# @wordpress/is-shallow-equal
+# Is Shallow Equal
 
 A function for performing a shallow comparison between two objects or arrays. Two values have shallow equality when all of their members are strictly equal to the corresponding member of the other.
 

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/is-shallow-equal",
 	"version": "1.1.1",
-	"description": "Test for shallow equality between two objects or arrays",
+	"description": "Test for shallow equality between two objects or arrays.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/jest-console/README.md
+++ b/packages/jest-console/README.md
@@ -1,4 +1,4 @@
-# @wordpress/jest-console
+# Jest Console
 
 Custom [Jest](http://facebook.github.io/jest/) matchers for the [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console)
 object to test JavaScript code in WordPress.

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/jest-console",
 	"version": "2.0.1",
-	"description": "Custom Jest matchers for the Console object",
+	"description": "Custom Jest matchers for the Console object.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/jest-preset-default/README.md
+++ b/packages/jest-preset-default/README.md
@@ -1,4 +1,4 @@
-# @wordpress/jest-preset-default
+# Jest Preset Default
 
 Default [Jest](https://facebook.github.io/jest/) preset for WordPress development.
 

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/jest-preset-default",
 	"version": "2.0.1",
-	"description": "Default Jest preset for WordPress development",
+	"description": "Default Jest preset for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -1,4 +1,4 @@
-# @wordpress/keycodes
+# Keycodes
 
 Keycodes utilities for WordPress, used to check the key pressed in events like `onKeyDown`. Contains keycodes constants for keyboard keys like `DOWN`, `UP`, `ENTER`, etc.
 

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/keycodes",
 	"version": "1.0.1",
-	"description": "Keycodes utilities for WordPress; used to check for keyboard events across browsers/operating systems",
+	"description": "Keycodes utilities for WordPress. Used to check for keyboard events across browsers/operating systems.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/library-export-default-webpack-plugin/README.md
+++ b/packages/library-export-default-webpack-plugin/README.md
@@ -1,6 +1,6 @@
-# @wordpress/library-export-default-webpack-plugin
+# Library Export Default Webpack Plugin
 
-Webpack plugin for exporting default property for selected libraries. Implementation is based on the Webpack's core plugin [ExportPropertyMainTemplatePlugin](https://github.com/webpack/webpack/blob/51b0df77e4f366163730ee465f01458bfad81f34/lib/ExportPropertyMainTemplatePlugin.js). The only difference is that this plugin allows to whitelist all entry point names where the default export of your entry point will be assigned to the library target.  
+Webpack plugin for exporting `default` property for selected libraries which use ES Harmony Modules. Implementation is based on the Webpack's core plugin [ExportPropertyMainTemplatePlugin](https://github.com/webpack/webpack/blob/51b0df77e4f366163730ee465f01458bfad81f34/lib/ExportPropertyMainTemplatePlugin.js). The only difference is that this plugin allows to whitelist all entry point names where the default export of your entry point will be assigned to the library target.  
 
 **Note**: This plugin targets Webpack 4.0 and newer, and is not compatible with older versions.
 

--- a/packages/library-export-default-webpack-plugin/README.md
+++ b/packages/library-export-default-webpack-plugin/README.md
@@ -1,8 +1,8 @@
 # Library Export Default Webpack Plugin
 
-Webpack plugin for exporting `default` property for selected libraries which use ES Harmony Modules. Implementation is based on the Webpack's core plugin [ExportPropertyMainTemplatePlugin](https://github.com/webpack/webpack/blob/51b0df77e4f366163730ee465f01458bfad81f34/lib/ExportPropertyMainTemplatePlugin.js). The only difference is that this plugin allows to whitelist all entry point names where the default export of your entry point will be assigned to the library target.  
+Webpack plugin for exporting `default` property for selected libraries which use ES6 Modules. Implementation is based on the Webpack's core plugin [ExportPropertyMainTemplatePlugin](https://github.com/webpack/webpack/blob/51b0df77e4f366163730ee465f01458bfad81f34/lib/ExportPropertyMainTemplatePlugin.js). The only difference is that this plugin allows to whitelist all entry point names where the default export of your entry point will be assigned to the library target.  
 
-**Note**: This plugin targets Webpack 4.0 and newer, and is not compatible with older versions.
+**Note**: This plugin requires Webpack 4.0 and newer, and is not compatible with older versions.
 
 ## Installation
 

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/library-export-default-webpack-plugin",
 	"version": "1.0.1",
-	"description": "Webpack plugin for exporting default property for selected libraries",
+	"description": "Webpack plugin for exporting default property for selected libraries.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/npm-package-json-lint-config/README.md
+++ b/packages/npm-package-json-lint-config/README.md
@@ -1,6 +1,6 @@
-# `@wordpress/npm-package-json-lint-config`
+# NPM Package.json Lint Config
 
-> WordPress [npm-package-json-lint](https://github.com/tclindner/npm-package-json-lint) shareable config
+WordPress [npm-package-json-lint](https://github.com/tclindner/npm-package-json-lint) shareable configuration.
 
 ## Installation
 

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/npm-package-json-lint-config",
 	"version": "1.1.1",
-	"description": "WordPress npm-package-json-lint shareable configuration",
+	"description": "WordPress npm-package-json-lint shareable configuration.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/nux/README.md
+++ b/packages/nux/README.md
@@ -1,6 +1,6 @@
-# @wordpress/nux
+# New User eXperience (NUX)
 
-The NUX (New User eXperience) module exposes components, and `wp.data` methods useful for onboarding a new user to the WordPress admin interface. Specifically, it exposes _tips_ and _guides_.
+The NUX module exposes components, and `wp.data` methods useful for onboarding a new user to the WordPress admin interface. Specifically, it exposes _tips_ and _guides_.
 
 A _tip_ is a component that points to an element in the UI and contains text that explains the element's functionality. The user can dismiss a tip, in which case it never shows again. The user can also disable tips entirely. Information about tips is persisted between sessions using `localStorage`.
 

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/nux",
 	"version": "1.0.0",
-	"description": "NUX (New User eXperience) module for WordPress",
+	"description": "NUX (New User eXperience) module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -1,4 +1,4 @@
-# @wordpress/plugins
+# Plugins
 
 Plugins module for WordPress.
 

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/plugins",
 	"version": "1.0.1",
-	"description": "Plugins module for WordPress",
+	"description": "Plugins module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/postcss-themes/README.md
+++ b/packages/postcss-themes/README.md
@@ -1,6 +1,6 @@
-# @wordpress/postcss-themes
+# PostCSS Themes
 
-PostCSS Plugin to generate theme colors
+PostCSS plugin to generate theme colors.
 
 ## Installation
 

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/postcss-themes",
 	"version": "1.0.1",
-	"description": "PostCSS plugin to generate theme colors",
+	"description": "PostCSS plugin to generate theme colors.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -1,6 +1,6 @@
-# @wordpress/scripts
+# Scripts
 
-A collection of JS scripts for WordPress development.
+Collection of JS scripts for WordPress development.
 
 ## Installation
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/scripts",
 	"version": "2.0.2",
-	"description": "Collection of JS scripts for WordPress development",
+	"description": "Collection of JS scripts for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/shortcode/README.md
+++ b/packages/shortcode/README.md
@@ -1,6 +1,6 @@
-# @wordpress/shortcode
+# Shortcode
 
-Shortcode utils for WordPress.
+Shortcode module for WordPress.
 
 ## Installation
 

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/shortcode",
 	"version": "1.0.1",
-	"description": "Shortcode module for WordPress",
+	"description": "Shortcode module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -1,6 +1,6 @@
-# @wordpress/url
+# URL
 
-A collection of utilities to manipulate URLs
+A collection of utilities to manipulate URLs.
 
 ## Installation
 

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/url",
 	"version": "1.2.1",
-	"description": "WordPress URL utilities",
+	"description": "WordPress URL utilities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/viewport/README.md
+++ b/packages/viewport/README.md
@@ -1,4 +1,4 @@
-# @wordpress/viewport
+# Viewport
 
 Viewport is a module for responding to changes in the browser viewport size. It registers its own [data module](https://github.com/WordPress/gutenberg/tree/master/packages/data), updated in response to browser media queries on a standard set of supported breakpoints. This data and the included higher-order components can be used in your own modules and components to implement viewport-dependent behaviors.
 

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/viewport",
 	"version": "1.0.1",
-	"description": "Viewport module for WordPress",
+	"description": "Viewport module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/wordcount/README.md
+++ b/packages/wordcount/README.md
@@ -1,6 +1,6 @@
-# @wordpress/wordcount
+# Word Count
 
-A utility to count words
+WordPress word count utility.
 
 ## Installation
 

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/wordcount",
 	"version": "1.1.1",
-	"description": "WordPress word count utility",
+	"description": "WordPress word count utility.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [


### PR DESCRIPTION
## Description
Inspired by #8121.

It adds a period to every description field as discussed in #8121. It also changes all titles in `README.md` files to follow one style which is a capitalized name of the package. In case we use abbreviations it provides both full and short form.

/cc @chrisvanpatten 
