### PR TITLE
Add block warning overwrite

### DIFF
--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -36,12 +36,12 @@ export class BlockInvalidWarning extends Component {
 	}
 
 	render() {
-		const { convertToHTML, convertToBlocks, convertToClassic, overwriteBlock, block } = this.props;
+		const { convertToHTML, convertToBlocks, convertToClassic, attemptBlockRecovery, block } = this.props;
 		const hasHTMLBlock = !! getBlockType( 'core/html' );
 		const { compare } = this.state;
 		const hiddenActions = [
 			{ title: __( 'Convert to Classic Block' ), onClick: convertToClassic },
-			{ title: __( 'Overwrite with Valid Block' ), onClick: overwriteBlock },
+			{ title: __( 'Attempt Block Recovery' ), onClick: attemptBlockRecovery },
 		];
 
 		if ( compare ) {
@@ -97,7 +97,7 @@ const blockToHTML = ( block ) => createBlock( 'core/html', {
 const blockToBlocks = ( block ) => rawHandler( {
 	HTML: block.originalContent,
 } );
-const blockOverwrite = ( { name, attributes } ) => createBlock( name, attributes );
+const recoverBlock = ( { name, attributes, innerBlocks } ) => createBlock( name, attributes, innerBlocks );
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => ( {
@@ -116,8 +116,8 @@ export default compose( [
 			convertToBlocks() {
 				replaceBlock( block.clientId, blockToBlocks( block ) );
 			},
-			overwriteBlock() {
-				replaceBlock( block.clientId, blockOverwrite( block ) );
+			attemptBlockRecovery() {
+				replaceBlock( block.clientId, recoverBlock( block ) );
 			},
 		};
 	} ),

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -41,7 +41,7 @@ export class BlockInvalidWarning extends Component {
 		const { compare } = this.state;
 		const hiddenActions = [
 			{ title: __( 'Convert to Classic Block' ), onClick: convertToClassic },
-			{ title: __( 'Overwrite with Valid Block' ), onCLick: overwriteBlock },
+			{ title: __( 'Overwrite with Valid Block' ), onClick: overwriteBlock },
 		];
 
 		if ( compare ) {

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -36,11 +36,12 @@ export class BlockInvalidWarning extends Component {
 	}
 
 	render() {
-		const { convertToHTML, convertToBlocks, convertToClassic, block } = this.props;
+		const { convertToHTML, convertToBlocks, convertToClassic, overwriteBlock, block } = this.props;
 		const hasHTMLBlock = !! getBlockType( 'core/html' );
 		const { compare } = this.state;
 		const hiddenActions = [
 			{ title: __( 'Convert to Classic Block' ), onClick: convertToClassic },
+			{ title: __( 'Overwrite with Valid Block' ), onCLick: overwriteBlock },
 		];
 
 		if ( compare ) {
@@ -96,6 +97,7 @@ const blockToHTML = ( block ) => createBlock( 'core/html', {
 const blockToBlocks = ( block ) => rawHandler( {
 	HTML: block.originalContent,
 } );
+const blockOverwrite = ( { name, attributes } ) => createBlock( name, attributes );
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => ( {
@@ -113,6 +115,9 @@ export default compose( [
 			},
 			convertToBlocks() {
 				replaceBlock( block.clientId, blockToBlocks( block ) );
+			},
+			overwriteBlock() {
+				replaceBlock( block.clientId, blockOverwrite( block ) );
 			},
 		};
 	} ),


### PR DESCRIPTION
## Description
Adds an option to the invalid block warning menu to fix the problem by re-creating the block with the current content, overwriting anything that is invalid. This was suggested in #7604

This is similar to the 'convert to blocks' option, but ensures the block stays of the same type. Contrast this with 'convert to blocks' which could convert to another block type, and could end in multiple blocks.

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44906590-3dee2f00-ad0d-11e8-9a3a-7b2113aebde1.jpg)

In a lot of situations 'overwrite' and 'convert to blocks' will result in the same conversion so it's debatable whether this is a useful enough conversion to include but I'm raising it here for opinion. This is the same overwrite function that used to exist in older versions of Gutenberg.

## How has this been tested?

1. Add a paragraph block
2. Edit block HTML and paste `<p>this is a paragraph</p><blockquote>invalid content</blockquote>`
3. Deselect the block to trigger invalid block warning
4. Pick 'Convert to blocks'
5. Verify that the invalid block is converted to two blocks - a corrected paragraph and a blockquote
![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44906652-6e35cd80-ad0d-11e8-9652-af1cbc19ac1f.jpg)
6. Reset block HTML to (2) and pick 'Overwrite with valid block'
7. Verify that the invalid block is converted to the first paragraph 'this is a paragraph', with the blockquote removed

## Types of changes
New feature for invalid block warning. Should not affect anything else

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
