### PR TITLE
Add a template attribute to the column block.

### DIFF
--- a/core-blocks/columns/column.js
+++ b/core-blocks/columns/column.js
@@ -20,11 +20,16 @@ export const settings = {
 	icon: 'columns',
 
 	description: __( 'A single column within a columns block.' ),
-
+	attributes: {
+		template: {
+			type: 'array',
+		},
+	},
 	category: 'common',
 
-	edit() {
-		return <InnerBlocks templateLock={ false } />;
+	edit( { attributes }  ) {
+		const { template } = attributes
+		return <InnerBlocks templateLock={ false } template={template} />;
 	},
 
 	save() {


### PR DESCRIPTION
## Description
After splitting the columns block into `columns` and `column` and along with the depreciation of grouped layouts in #7841 there is no way to declare a columns block with a default template.

So back then we could have a "Features block" with this default inner block: 
```
<InnerBlocks
	templateLock={ false }
	layouts={ memoize( ( columns ) => {
		return Array.apply(null, Array(columns)).map((i, n) => ({
			name: `column-${ n + 1 }`,
			label: sprintf( __( 'Column %d' ), n + 1 ),
			icon: 'columns',
		} ) );
	} )(columns) }
	template={[
		['core/heading', {
			layout: 'column-1',
			content: 'Happiness'
		}],
		['core/heading', {
			layout: 'column-2',
			content: 'Flexibility'
		}],

		['core/paragraph', {
			layout: 'column-1',
			content: 'Lorem ipsum dolor sit amet elit do, consectetur adipiscing, sed eiusmod tempor incididunt ut labore et dolore magna aliqua.'
		}],
		['core/paragraph', {
			layout: 'column-2',
			content: 'Lorem ipsum dolor sit amet elit do, consectetur adipiscing, sed eiusmod tempor incididunt ut labore et dolore magna aliqua.'
		}]
	]}
/>
```

But now there is no way to do that because the column block doesn't take any props from parents.

This PR makes this possible by adding a template attribute to the column block which can be used like

```
<InnerBlocks
	templateLock={ 'all' }
	allowedBlocks={ [ 'core/column' ] }
	template={[
		[ 'core/column', {
			template: [
				['core/heading', {
					content: 'Happiness'
				}],
				['core/paragraph', {
					content: 'Lorem ipsum dolor sit amet elit do, consectetur adipiscing, sed eiusmod tempor incididunt ut labore et dolore magna aliqua.'
				}],
			]
		} ],
		[ 'core/column', {
			template: [
				['core/heading', {
					content: 'Flexibility'
				}],
				['core/paragraph', {
					content: 'Lorem ipsum dolor sit amet elit do, consectetur adipiscing, sed eiusmod tempor incididunt ut labore et dolore magna aliqua.'
				}],
			]
		} ],
	]}
/>
```
I know this is way too simple to be true, and I would love @aduth 's opinion on it.
Also, If this makes sense, I would love to try a "Features" block example on `gutenberg-examples` repository.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
