### PR TITLE
Remove filler spaces from empty constructs.

### DIFF
--- a/packages/components/src/navigable-container/test/index.js
+++ b/packages/components/src/navigable-container/test/index.js
@@ -32,7 +32,7 @@ function fireKeyDown( container, keyCode, shiftKey ) {
 		},
 		preventDefault: () => {},
 		nativeEvent: {
-			stopImmediatePropagation: () => { },
+			stopImmediatePropagation: () => {},
 		},
 		keyCode,
 		shiftKey,

--- a/packages/editor/src/components/block-list/breadcrumb.js
+++ b/packages/editor/src/components/block-list/breadcrumb.js
@@ -47,7 +47,7 @@ export class BlockBreadcrumb extends Component {
 		} );
 	}
 
-	render( ) {
+	render() {
 		const { clientId, rootClientId } = this.props;
 
 		return (

--- a/packages/editor/src/utils/media-upload/test/media-upload.js
+++ b/packages/editor/src/utils/media-upload/test/media-upload.js
@@ -19,7 +19,7 @@ describe( 'mediaUpload', () => {
 	const onFileChangeSpy = jest.fn();
 
 	it( 'should do nothing on no files', () => {
-		mediaUpload( { filesList: [ ], onFileChange: onFileChangeSpy, allowedType: 'image' } );
+		mediaUpload( { filesList: [], onFileChange: onFileChangeSpy, allowedType: 'image' } );
 		expect( onFileChangeSpy ).not.toHaveBeenCalled();
 	} );
 


### PR DESCRIPTION
Quick coding standards PR to [remove filler spaces in empty constructs](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#spacing).

Note:
One of them was in a test file, removed anyway to strip any occurrences from the codebase.
