### PR TITLE
Fix: Tooltips not shown on IconButtons with Dotip childs

### DIFF
--- a/edit-post/components/header/header-toolbar/index.js
+++ b/edit-post/components/header/header-toolbar/index.js
@@ -30,11 +30,12 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport } ) {
 			className="edit-post-header-toolbar"
 			aria-label={ __( 'Editor Toolbar' ) }
 		>
-			<Inserter position="bottom right">
+			<div>
+				<Inserter position="bottom right" />
 				<DotTip id="core/editor.inserter">
 					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!' ) }
 				</DotTip>
-			</Inserter>
+			</div>
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents />

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -54,18 +54,19 @@ function Header( {
 						forceIsDirty={ hasActiveMetaboxes }
 						forceIsSaving={ isSaving }
 					/>
-					<IconButton
-						icon="admin-generic"
-						label={ __( 'Settings' ) }
-						onClick={ toggleGeneralSidebar }
-						isToggled={ isEditorSidebarOpened }
-						aria-expanded={ isEditorSidebarOpened }
-						shortcut={ shortcuts.toggleSidebar.display }
-					>
+					<div>
+						<IconButton
+							icon="admin-generic"
+							label={ __( 'Settings' ) }
+							onClick={ toggleGeneralSidebar }
+							isToggled={ isEditorSidebarOpened }
+							aria-expanded={ isEditorSidebarOpened }
+							shortcut={ shortcuts.toggleSidebar.display }
+						/>
 						<DotTip id="core/editor.settings">
 							{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” to open it.' ) }
 						</DotTip>
-					</IconButton>
+					</div>
 					<PinnedPlugins.Slot />
 					<MoreMenu />
 				</div>


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/7510

## Description
Icon button had a condition where tooltips were not shown if the child's existed.
This caused tooltips to not show when DotTip components were added inside some IconButtons. Besides, that DotTips cannot be nested inside Tooltips or tooltips will render while the user interects with tooltips and the events to disable tooltips may not be handled. This PR adds a dotTip prop to IconButton, so the component can render tooltip and dotTips as siblings.

## How has this been tested?
Created an empty post.
Verified a tooltip appears on side inserter (at the side of "Write your story").
Verified that a tooltip appears on sidebar toggle.