### PR TITLE
Remove margin-bottom from last element

### DIFF
--- a/edit-post/components/sidebar/block-sidebar/style.scss
+++ b/edit-post/components/sidebar/block-sidebar/style.scss
@@ -4,14 +4,13 @@
 
 	.components-base-control {
 		margin: 0 0 1em 0;
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	.components-panel__body-toggle {
 		color: $dark-gray-500;
-	}
-
-	> div:last-child {
-		margin-bottom: 0;
 	}
 
 	&:first-child {

--- a/edit-post/components/sidebar/block-sidebar/style.scss
+++ b/edit-post/components/sidebar/block-sidebar/style.scss
@@ -10,6 +10,10 @@
 		color: $dark-gray-500;
 	}
 
+	> div:last-child {
+		margin-bottom: 0;
+	}
+
 	&:first-child {
 		border-top: 1px solid $light-gray-500;
 		margin-top: 16px;

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -76,6 +76,9 @@
 	div.components-toolbar {
 		box-shadow: none;
 		margin-bottom: 1.5em;
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	p + div.components-toolbar {

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -9,4 +9,5 @@
 
 .components-base-control__help {
 	font-style: italic;
+	margin-bottom: 0;
 }


### PR DESCRIPTION
## Description
Removes the margin-bottom from the last element in the panel body and control help texts.
Fixes #8174

## Screenshots
**Before:**
![bildschirmfoto 2018-07-24 um 18 36 56](https://user-images.githubusercontent.com/695201/43153224-fa41b844-8f70-11e8-9a74-286f2729d5dc.png)

**After:**
![bildschirmfoto 2018-07-24 um 18 37 04](https://user-images.githubusercontent.com/695201/43153231-fc57bfe8-8f70-11e8-8e1a-c3eb7ccf3d17.png)


