### PR TITLE
Fix: Color picker panels: padding bottom

### DIFF
--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -3,6 +3,7 @@ $color-palette-circle-spacing: 14px;
 
 .components-color-palette {
 	margin-right: -14px;
+	overflow: hidden;
 
 	.components-color-palette__clear {
 		float: right;


### PR DESCRIPTION
## Description
The Clear button (Zurücksetzen) has a `float: right`. To clear the float I added `overflow: hidden` to the parent
Fixes #8173

## Screenshots
**Before**:
![bildschirmfoto 2018-07-24 um 18 53 09](https://user-images.githubusercontent.com/695201/43154502-d25b16f0-8f74-11e8-83f6-973be1765aa5.png)

**After**:
![bildschirmfoto 2018-07-24 um 18 52 59](https://user-images.githubusercontent.com/695201/43154481-c0d036fe-8f74-11e8-8d26-9d50dad6fd0e.png)

