### PR TITLE
Fix: make meta+A behaviour of selecting all blocks work on safari and firefox

### DIFF
--- a/packages/editor/src/components/writing-flow/index.js
+++ b/packages/editor/src/components/writing-flow/index.js
@@ -254,8 +254,9 @@ class WritingFlow extends Component {
 					event.preventDefault();
 				}
 
-				// Set in case the meta key doesn't get released.
-				this.isEntirelySelected = isEntirelySelected( target );
+				// After pressing primary + A we can assume isEntirelySelected is true.
+				// Calling right away isEntirelySelected after primary + A may still return false on some browsers.
+				this.isEntirelySelected = true;
 			}
 
 			return;


### PR DESCRIPTION
On safari and firefox isEntirelySelected( target ) called right after meta+A event is fired when meta key is not released in the middle returns false but the content gets selected anyway.
If the target is editable it is safe to assume TinyMCE will make sure all content gets selected so in this cases we set the value to true without calling isEntirelySelected.

Fixes: https://github.com/WordPress/gutenberg/issues/7445

## How has this been tested?
I added some paragraphs.
On safari and firefox, I checked that when we press meta+A in paragraph two times all the blocks get selected.
