### PR TITLE
Add a border between panels in the block sidebar

### DIFF
--- a/edit-post/components/sidebar/block-sidebar/style.scss
+++ b/edit-post/components/sidebar/block-sidebar/style.scss
@@ -1,5 +1,6 @@
 .edit-post-block-sidebar__panel .components-panel__body {
 	border: none;
+	border-top: 1px solid $light-gray-500;
 	margin: 0 -16px;
 
 	.components-base-control {
@@ -11,7 +12,6 @@
 	}
 
 	&:first-child {
-		border-top: 1px solid $light-gray-500;
 		margin-top: 16px;
 	}
 


### PR DESCRIPTION
## Description
Adds a border between panels in the block sidebar. Fixes #7686.

## How has this been tested?
Visually

## Screenshots
![_untitled____add_new_homepage_ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/43171017-189e0590-8f76-11e8-8b4c-dc03854de8b5.png)

## Types of changes
Non-breaking visual change

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
