### PR TITLE
Components: Deprecate `withContext` HOC and remove its usage

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -20,6 +20,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.utils.mediaUpload` has been removed. Please use `wp.editor.mediaUpload` instead.
  - `wp.utils.preloadImage` has been removed.
  - `supports.wideAlign` has been removed from the Block API. Please use `supports.alignWide` instead.
+ - `wp.components.withContext` has been removed. Please use `wp.element.createContext` instead. See: https://reactjs.org/docs/context.html.
 
 ## 3.5.0
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -2,6 +2,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 
 ## 3.8.0
 
+ - `wp.components.withContext` has been removed. Please use `wp.element.createContext` instead. See: https://reactjs.org/docs/context.html.
  - `wp.coreBlocks.registerCoreBlocks` has been removed. Please use `wp.blockLibrary.registerCoreBlocks` instead.
 
 ## 3.7.0
@@ -20,7 +21,6 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.utils.mediaUpload` has been removed. Please use `wp.editor.mediaUpload` instead.
  - `wp.utils.preloadImage` has been removed.
  - `supports.wideAlign` has been removed from the Block API. Please use `supports.alignWide` instead.
- - `wp.components.withContext` has been removed. Please use `wp.element.createContext` instead. See: https://reactjs.org/docs/context.html.
 
 ## 3.5.0
 

--- a/packages/blocks/src/block-content-provider/index.js
+++ b/packages/blocks/src/block-content-provider/index.js
@@ -1,12 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { Component, RawHTML } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { createContext, RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { serialize } from '../api';
+
+const { Consumer, Provider } = createContext( {
+	BlockContent: () => {},
+} );
 
 /**
  * An internal block component used in block content serialization to inject
@@ -14,6 +19,8 @@ import { serialize } from '../api';
  * component in which it is nested. The component provides a pre-bound
  * `BlockContent` component via context, which is used by the developer-facing
  * `InnerBlocks.Content` component to render block content.
+ *
+ * @return {WPElement} Element with BlockContent injected via context.
  *
  * @example
  *
@@ -23,28 +30,43 @@ import { serialize } from '../api';
  * </BlockContentProvider>
  * ```
  */
-class BlockContentProvider extends Component {
-	getChildContext() {
-		const { innerBlocks } = this.props;
+const BlockContentProvider = ( { children, innerBlocks } ) => {
+	const BlockContent = () => {
+		// Value is an array of blocks, so defer to block serializer
+		const html = serialize( innerBlocks );
 
-		return {
-			BlockContent() {
-				// Value is an array of blocks, so defer to block serializer
-				const html = serialize( innerBlocks );
+		// Use special-cased raw HTML tag to avoid default escaping
+		return <RawHTML>{ html }</RawHTML>;
+	};
 
-				// Use special-cased raw HTML tag to avoid default escaping
-				return <RawHTML>{ html }</RawHTML>;
-			},
-		};
-	}
-
-	render() {
-		return this.props.children;
-	}
-}
-
-BlockContentProvider.childContextTypes = {
-	BlockContent: () => {},
+	return (
+		<Provider value={ { BlockContent } }>
+			{ children }
+		</Provider>
+	);
 };
+
+/**
+ * A Higher Order Component used to inject BlockContent context to the
+ * wrapped component.
+ *
+ * @param {Function} mapContextToProps Function called on every context change,
+ *                                     expected to return object of props to
+ *                                     merge with the component's own props.
+ *
+ * @return {Component} Enhanced component with injected context as props.
+ */
+export const withBlockContentContext = ( mapContextToProps ) => createHigherOrderComponent( ( OriginalComponent ) => {
+	return ( props ) => (
+		<Consumer>
+			{ ( context ) => (
+				<OriginalComponent
+					{ ...props }
+					{ ...mapContextToProps( context, props ) }
+				/>
+			) }
+		</Consumer>
+	);
+}, 'withBlockContentContext' );
 
 export default BlockContentProvider;

--- a/packages/blocks/src/block-content-provider/index.js
+++ b/packages/blocks/src/block-content-provider/index.js
@@ -9,9 +9,7 @@ import { createContext, RawHTML } from '@wordpress/element';
  */
 import { serialize } from '../api';
 
-const { Consumer, Provider } = createContext( {
-	BlockContent: () => {},
-} );
+const { Consumer, Provider } = createContext( () => {} );
 
 /**
  * An internal block component used in block content serialization to inject
@@ -20,8 +18,6 @@ const { Consumer, Provider } = createContext( {
  * `BlockContent` component via context, which is used by the developer-facing
  * `InnerBlocks.Content` component to render block content.
  *
- * @return {WPElement} Element with BlockContent injected via context.
- *
  * @example
  *
  * ```jsx
@@ -29,6 +25,8 @@ const { Consumer, Provider } = createContext( {
  * 	{ blockSaveElement }
  * </BlockContentProvider>
  * ```
+ *
+ * @return {WPElement} Element with BlockContent injected via context.
  */
 const BlockContentProvider = ( { children, innerBlocks } ) => {
 	const BlockContent = () => {

--- a/packages/blocks/src/block-content-provider/index.js
+++ b/packages/blocks/src/block-content-provider/index.js
@@ -40,29 +40,25 @@ const BlockContentProvider = ( { children, innerBlocks } ) => {
 	};
 
 	return (
-		<Provider value={ { BlockContent } }>
+		<Provider value={ BlockContent }>
 			{ children }
 		</Provider>
 	);
 };
 
 /**
- * A Higher Order Component used to inject BlockContent context to the
+ * A Higher Order Component used to inject BlockContent using context to the
  * wrapped component.
  *
- * @param {Function} mapContextToProps Function called on every context change,
- *                                     expected to return object of props to
- *                                     merge with the component's own props.
- *
- * @return {Component} Enhanced component with injected context as props.
+ * @return {Component} Enhanced component with injected BlockContent as prop.
  */
-export const withBlockContentContext = ( mapContextToProps ) => createHigherOrderComponent( ( OriginalComponent ) => {
+export const withBlockContentContext = createHigherOrderComponent( ( OriginalComponent ) => {
 	return ( props ) => (
 		<Consumer>
 			{ ( context ) => (
 				<OriginalComponent
 					{ ...props }
-					{ ...mapContextToProps( context, props ) }
+					BlockContent={ context }
 				/>
 			) }
 		</Consumer>

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -9,3 +9,4 @@
 // and then stored as objects in state, from which it is then rendered for editing.
 import './store';
 export * from './api';
+export { withBlockContentContext } from './block-content-provider';

--- a/packages/components/src/higher-order/with-context/index.js
+++ b/packages/components/src/higher-order/with-context/index.js
@@ -8,9 +8,17 @@ import { noop } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 
 export default ( contextName ) => ( mapSettingsToProps ) => createHigherOrderComponent(
 	( OriginalComponent ) => {
+		deprecated( 'wp.components.withContext', {
+			version: '3.6',
+			alternative: 'wp.element.createContext',
+			plugin: 'Gutenberg',
+			hint: 'https://reactjs.org/docs/context.html',
+		} );
+
 		class WrappedComponent extends Component {
 			render() {
 				const extraProps = mapSettingsToProps ?

--- a/packages/components/src/higher-order/with-context/index.js
+++ b/packages/components/src/higher-order/with-context/index.js
@@ -13,7 +13,7 @@ import deprecated from '@wordpress/deprecated';
 export default ( contextName ) => ( mapSettingsToProps ) => createHigherOrderComponent(
 	( OriginalComponent ) => {
 		deprecated( 'wp.components.withContext', {
-			version: '3.6',
+			version: '3.8',
 			alternative: 'wp.element.createContext',
 			plugin: 'Gutenberg',
 			hint: 'https://reactjs.org/docs/context.html',

--- a/packages/components/src/higher-order/with-context/test/index.js
+++ b/packages/components/src/higher-order/with-context/test/index.js
@@ -39,6 +39,7 @@ describe( 'withContext', () => {
 		);
 
 		expect( wrapper.root.findByType( 'div' ).children[ 0 ] ).toBe( 'ok' );
+		expect( console ).toHaveWarned();
 	} );
 
 	it( 'should allow specifying a context getter mapping', () => {

--- a/packages/components/src/higher-order/with-context/test/index.js
+++ b/packages/components/src/higher-order/with-context/test/index.js
@@ -5,14 +5,17 @@ import renderer from 'react-test-renderer';
 import PropTypes from 'prop-types';
 
 /**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import withContext from '../';
 
-/**
- * WordPress dependencies
- */
-import { Component } from '@wordpress/element';
+jest.mock( '@wordpress/deprecated', () => jest.fn() );
 
 class PassContext extends Component {
 	getChildContext() {
@@ -39,7 +42,7 @@ describe( 'withContext', () => {
 		);
 
 		expect( wrapper.root.findByType( 'div' ).children[ 0 ] ).toBe( 'ok' );
-		expect( console ).toHaveWarned();
+		expect( deprecated ).toHaveBeenCalled();
 	} );
 
 	it( 'should allow specifying a context getter mapping', () => {

--- a/packages/editor/src/components/inner-blocks/index.js
+++ b/packages/editor/src/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, identity, isEqual, map } from 'lodash';
+import { pick, isEqual, map } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -149,8 +149,6 @@ InnerBlocks = compose( [
 ] )( InnerBlocks );
 
 InnerBlocks.Content = withBlockContentContext(
-	identity
-)(
 	( { BlockContent } ) => <BlockContent />
 );
 

--- a/packages/editor/src/components/inner-blocks/index.js
+++ b/packages/editor/src/components/inner-blocks/index.js
@@ -1,17 +1,16 @@
 /**
  * External dependencies
  */
-import { pick, isEqual, map } from 'lodash';
+import { pick, identity, isEqual, map } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-import { withContext } from '@wordpress/components';
 import { withViewportMatch } from '@wordpress/viewport';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
+import { synchronizeBlocksWithTemplate, withBlockContentContext } from '@wordpress/blocks';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { compose } from '@wordpress/compose';
 
@@ -149,10 +148,13 @@ InnerBlocks = compose( [
 	} ),
 ] )( InnerBlocks );
 
-InnerBlocks.Content = ( { BlockContent } ) => {
-	return <BlockContent />;
-};
-
-InnerBlocks.Content = withContext( 'BlockContent' )()( InnerBlocks.Content );
+InnerBlocks.Content = withBlockContentContext(
+	identity
+)(
+	( { BlockContent } ) => {
+		console.log( BlockContent );
+		return <BlockContent />;
+	}
+);
 
 export default InnerBlocks;

--- a/packages/editor/src/components/inner-blocks/index.js
+++ b/packages/editor/src/components/inner-blocks/index.js
@@ -151,10 +151,7 @@ InnerBlocks = compose( [
 InnerBlocks.Content = withBlockContentContext(
 	identity
 )(
-	( { BlockContent } ) => {
-		console.log( BlockContent );
-		return <BlockContent />;
-	}
+	( { BlockContent } ) => <BlockContent />
 );
 
 export default InnerBlocks;

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -31,6 +31,7 @@
 import {
 	flowRight,
 	isEmpty,
+	isFunction,
 	castArray,
 	omit,
 	startsWith,
@@ -41,7 +42,11 @@ import {
 /**
  * Internal dependencies
  */
-import { Fragment, RawHTML } from './';
+import {
+	Fragment,
+	StrictMode,
+} from './react';
+import RawHTML from './raw-html';
 
 /**
  * Valid attribute types.
@@ -455,6 +460,7 @@ export function renderElement( element, context = {} ) {
 	const { type: tagName, props } = element;
 
 	switch ( tagName ) {
+		case StrictMode:
 		case Fragment:
 			return renderChildren( props.children, context );
 
@@ -469,8 +475,6 @@ export function renderElement( element, context = {} ) {
 				},
 				context
 			);
-		default:
-			throw new Error( tagName );
 	}
 
 	switch ( typeof tagName ) {
@@ -483,6 +487,19 @@ export function renderElement( element, context = {} ) {
 			}
 
 			return renderElement( tagName( props, context ), context );
+		case 'object':
+			if ( tagName === null ) {
+				return;
+			}
+
+			if ( tagName._context && props.children ) {
+				tagName._context._currentValue = props.value;
+				return renderChildren( props.children, context );
+			}
+
+			if ( tagName._currentValue && isFunction( props.children ) ) {
+				return renderElement( props.children( tagName._currentValue ), context );
+			}
 	}
 
 	return '';

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -469,6 +469,8 @@ export function renderElement( element, context = {} ) {
 				},
 				context
 			);
+		default:
+			throw new Error( tagName );
 	}
 
 	switch ( typeof tagName ) {

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -8,10 +8,12 @@ import { noop } from 'lodash';
  */
 import {
 	Component,
+	createContext,
 	createElement,
 	Fragment,
-	RawHTML,
-} from '../';
+	StrictMode,
+} from '../react';
+import RawHTML from '../raw-html';
 import serialize, {
 	escapeAmpersand,
 	escapeQuotationMark,
@@ -298,10 +300,80 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( 'Hello' );
 	} );
 
+	it( 'renders StrictMode with undefined children', () => {
+		const result = renderElement( <StrictMode /> );
+
+		expect( result ).toBe( '' );
+	} );
+
+	it( 'renders StrictMode as its inner children', () => {
+		const result = renderElement( <StrictMode>Hello</StrictMode> );
+
+		expect( result ).toBe( 'Hello' );
+	} );
+
 	it( 'renders Fragment with undefined children', () => {
 		const result = renderElement( <Fragment /> );
 
 		expect( result ).toBe( '' );
+	} );
+
+	it( 'renders default value from Context API', () => {
+		const { Consumer } = createContext( {
+			value: 'default',
+		} );
+
+		const result = renderElement(
+			<Consumer>
+				{ ( context ) => context.value }
+			</Consumer>
+		);
+
+		expect( result ).toBe( 'default' );
+	} );
+
+	it( 'renders provided value through Context API', () => {
+		const { Consumer, Provider } = createContext( {
+			value: 'default',
+		} );
+
+		const result = renderElement(
+			<Provider value={ { value: 'provided' } }>
+				<Consumer>
+					{ ( context ) => context.value }
+				</Consumer>
+			</Provider>
+		);
+
+		expect( result ).toBe( 'provided' );
+	} );
+
+	it( 'renders proper value through Context API when multiple providers present', () => {
+		const { Consumer, Provider } = createContext( {
+			value: 'default',
+		} );
+
+		const result = renderElement(
+			<Fragment>
+				<Provider value={ { value: '1st provided' } }>
+					<Consumer>
+						{ ( context ) => context.value }
+					</Consumer>
+				</Provider>
+				{ '|' }
+				<Provider value={ { value: '2nd provided' } }>
+					<Consumer>
+						{ ( context ) => context.value }
+					</Consumer>
+				</Provider>
+				{ '|' }
+				<Consumer>
+					{ ( context ) => context.value }
+				</Consumer>
+			</Fragment>
+		);
+
+		expect( result ).toBe( '1st provided|2nd provided|default' );
 	} );
 
 	it( 'renders RawHTML as its unescaped children', () => {

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -376,7 +376,7 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( '1st provided|2nd provided|default' );
 	} );
 
-	it( 'renders proper value through Context API when nested providers', () => {
+	it( 'renders proper value through Context API when nested providers present', () => {
 		const { Consumer, Provider } = createContext( {
 			value: 'default',
 		} );

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -118,7 +118,7 @@ describe( 'serialize()', () => {
 		expect( result ).toBe( '<div ok="good"></div>' );
 	} );
 
-	it( 'should render with context', () => {
+	it( 'should render with context (legacy)', () => {
 		class Provider extends Component {
 			getChildContext() {
 				return {

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -376,6 +376,28 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( '1st provided|2nd provided|default' );
 	} );
 
+	it( 'renders proper value through Context API when nested providers', () => {
+		const { Consumer, Provider } = createContext( {
+			value: 'default',
+		} );
+
+		const result = renderElement(
+			<Provider value={ { value: 'outer provided' } }>
+				<Provider value={ { value: 'inner provided' } }>
+					<Consumer>
+						{ ( context ) => context.value }
+					</Consumer>
+				</Provider>
+				{ '|' }
+				<Consumer>
+					{ ( context ) => context.value }
+				</Consumer>
+			</Provider>
+		);
+
+		expect( result ).toBe( 'inner provided|outer provided' );
+	} );
+
 	it( 'renders RawHTML as its unescaped children', () => {
 		const result = renderElement( <RawHTML>{ '<img/>' }</RawHTML> );
 


### PR DESCRIPTION
## Description
It's part of our efforts to stablize API.

## How has this been tested?
`npm test`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
