### PR TITLE
Introduce 'editor.PostFeaturedImage.imageSize' filter for Featured Image

### DIFF
--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -165,7 +165,7 @@ wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-data-align', withDa
 
 ### `editor.PostFeaturedImage.imageSize`
 
-Used to modify the image size displayed in the Post Featured Image component. It defaults to `'post-thumbnail'`, and will fail back to the `full` image size when the specified image size doesn't exist on the media object. It's modeled after the `admin_post_thumbnail_size` filter in the Classic Editor.
+Used to modify the image size displayed in the Post Featured Image component. It defaults to `'post-thumbnail'`, and will fail back to the `full` image size when the specified image size doesn't exist in the media object. It's modeled after the `admin_post_thumbnail_size` filter in the Classic Editor.
 
 _Example:_
 

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -170,7 +170,7 @@ Used to modify the image size displayed in the Post Featured Image component. It
 _Example:_
 
 ```
-var withImageSize = function() {
+var withImageSize = function( size, mediaId, postId ) {
 	return 'large';
 };
 

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -163,6 +163,20 @@ var withDataAlign = wp.compose.createHigherOrderComponent( function( BlockListBl
 wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-data-align', withDataAlign );
 ```
 
+### `editor.PostFeaturedImage.imageSize`
+
+Used to modify the image size displayed in the Post Featured Image component. It defaults to `'post-thumbnail'`, and will fail back to the `full` image size when the specified image size doesn't exist on the media object. It's modeled after the `admin_post_thumbnail_size` filter in the Classic Editor.
+
+_Example:_
+
+```
+var withImageSize = function() {
+	return 'large';
+};
+
+wp.hooks.addFilter( 'editor.PostFeaturedImage.imageSize', 'my-plugin/with-image-size', withImageSize );
+```
+
 ## Removing Blocks
 
 ### Using a blacklist

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { has, get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { Button, Spinner, ResponsiveWrapper, withFilters } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -22,8 +23,25 @@ import MediaUpload from '../media-upload';
 const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
 const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
 
-function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
+function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
+
+	let mediaWidth,
+		mediaHeight,
+		mediaSourceUrl;
+	if ( media ) {
+		let mediaSize = 'post-thumbnail';
+		mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', mediaSize, media.id, currentPostId );
+		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {
+			mediaWidth = media.media_details.sizes[ mediaSize ].width;
+			mediaHeight = media.media_details.sizes[ mediaSize ].height;
+			mediaSourceUrl = media.media_details.sizes[ mediaSize ].source_url;
+		} else {
+			mediaWidth = media.media_details.width;
+			mediaHeight = media.media_details.height;
+			mediaSourceUrl = media.source_url;
+		}
+	}
 
 	return (
 		<PostFeaturedImageCheck>
@@ -38,10 +56,10 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 							<Button className="editor-post-featured-image__preview" onClick={ open }>
 								{ media &&
 									<ResponsiveWrapper
-										naturalWidth={ media.media_details.width }
-										naturalHeight={ media.media_details.height }
+										naturalWidth={ mediaWidth }
+										naturalHeight={ mediaHeight }
 									>
-										<img src={ media.source_url } alt={ __( 'Featured image' ) } />
+										<img src={ mediaSourceUrl } alt={ __( 'Featured image' ) } />
 									</ResponsiveWrapper>
 								}
 								{ ! media && <Spinner /> }
@@ -89,11 +107,12 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 
 const applyWithSelect = withSelect( ( select ) => {
 	const { getMedia, getPostType } = select( 'core' );
-	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
 	const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
 	return {
 		media: featuredImageId ? getMedia( featuredImageId ) : null,
+		currentPostId: getCurrentPostId(),
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		featuredImageId,
 	};

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -30,8 +30,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 		mediaHeight,
 		mediaSourceUrl;
 	if ( media ) {
-		let mediaSize = 'post-thumbnail';
-		mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', mediaSize, media.id, currentPostId );
+		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'post-thumbnail', media.id, currentPostId );
 		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {
 			mediaWidth = media.media_details.sizes[ mediaSize ].width;
 			mediaHeight = media.media_details.sizes[ mediaSize ].height;

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -26,9 +26,7 @@ const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
 function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
 
-	let mediaWidth,
-		mediaHeight,
-		mediaSourceUrl;
+	let mediaWidth, mediaHeight, mediaSourceUrl;
 	if ( media ) {
 		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'post-thumbnail', media.id, currentPostId );
 		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {


### PR DESCRIPTION
## Description

Adds a `editor.PostFeaturedImage.imageSize` filter for the image size displayed in the Post Featured Image component. Modeling the behavior of the existing `admin_post_thumbnail_size` filter [[ref](https://developer.wordpress.org/reference/hooks/admin_post_thumbnail_size/)], it defaults to `'post-thumbnail'` as the default image size and fails back to the full image size when the specified image size doesn't exist.

It appears the current behavior was defined in #894 (71f1d3a056495852f930d4ceb42e4a5d8e9b0a56) without any specific discussion about media sizes.

Fixes #7505 

## How has this been tested?

1. Open a new Gutenberg post and assign a featured image.

2. Add the following filter in the Console:

```
var withImageSize = function() {
	return 'large';
};

wp.hooks.addFilter( 'editor.PostFeaturedImage.imageSize', 'my-plugin/with-image-size', withImageSize );
```

3. Close and re-open the Post Featured Image component.
4. Use the Console Inspector to see that the image size has changed.

## Screenshots

<img width="799" alt="image" src="https://user-images.githubusercontent.com/36432/43201826-72406978-8fce-11e8-9fa4-70f52764164c.png">

## Types of changes

Enhancement.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
