### PR TITLE
chore: Update re-resizable to version 4.7.1; Fix: Image&Spacer blocks don't work on IE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17000,9 +17000,9 @@
 			}
 		},
 		"re-resizable": {
-			"version": "4.4.8",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.4.8.tgz",
-			"integrity": "sha512-5Nm4FL5wz41/5SYz8yJIM1kCcftxNPXxv3Yfa5qhkrGasHPgYzmzbbu1pcYM9vuCHog79EVwKWuz7zxDH52Gfw=="
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.7.1.tgz",
+			"integrity": "sha512-pLJkPbZCe+3ml+9Q15z+R69qYZDsluj0KwrdFb8kSNaqDzYAveDUblf7voHH9hNTdKIiIvP8iIdGFFKSgffVaQ=="
 		},
 		"react": {
 			"version": "16.4.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"moment-timezone": "0.5.16",
 		"prop-types": "15.5.10",
 		"querystringify": "1.0.0",
-		"re-resizable": "4.4.8",
+		"re-resizable": "4.7.1",
 		"react": "16.4.1",
 		"react-autosize-textarea": "3.0.2",
 		"react-dom": "16.4.1",


### PR DESCRIPTION
The version we were using did not work on IE. The made image&spacer blocks crash on IE.

Fixes: https://github.com/WordPress/gutenberg/issues/8186

## How has this been tested?
I checked on IE that image & spacer blocks work correctly and we can use their resize functionality.
