### PR TITLE
Fix initial focus on the first NUX tip popover

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -61,7 +61,9 @@ class Popover extends Component {
 	componentDidMount() {
 		this.toggleWindowEvents( true );
 		this.refresh();
-		this.focus();
+		setTimeout( () => {
+			this.focus();
+		}, 0 );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -61,6 +61,10 @@ class Popover extends Component {
 	componentDidMount() {
 		this.toggleWindowEvents( true );
 		this.refresh();
+		/*
+		 * Without the setTimeout, the dom node is not being focused. Related:
+		 * https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
+		 */
 		setTimeout( () => {
 			this.focus();
 		}, 0 );
@@ -111,9 +115,7 @@ class Popover extends Component {
 			return;
 		}
 
-		// Without the setTimeout, the dom node is not being focused
-		// Related https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
-		const focusNode = ( domNode ) => setTimeout( () => domNode.focus() );
+		const focusNode = ( domNode ) => domNode.focus();
 
 		// Boolean values for focusOnMount deprecated in 3.2–remove
 		// `focusOnMount === true` check in 3.4.

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -61,11 +61,14 @@ class Popover extends Component {
 	componentDidMount() {
 		this.toggleWindowEvents( true );
 		this.refresh();
+
 		/*
 		 * Without the setTimeout, the dom node is not being focused. Related:
 		 * https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example
+		 *
+		 * TODO: Treat the cause, not the symptom.
 		 */
-		setTimeout( () => {
+		this.focusTimeout = setTimeout( () => {
 			this.focus();
 		}, 0 );
 	}
@@ -78,6 +81,8 @@ class Popover extends Component {
 
 	componentWillUnmount() {
 		this.toggleWindowEvents( false );
+
+		clearTimeout( this.focusTimeout );
 	}
 
 	toggleWindowEvents( isListening ) {
@@ -115,15 +120,18 @@ class Popover extends Component {
 			return;
 		}
 
-		const focusNode = ( domNode ) => domNode.focus();
-
 		// Boolean values for focusOnMount deprecated in 3.2–remove
 		// `focusOnMount === true` check in 3.4.
 		if ( focusOnMount === 'firstElement' || focusOnMount === true ) {
 			// Find first tabbable node within content and shift focus, falling
 			// back to the popover panel itself.
 			const firstTabbable = focus.tabbable.find( this.contentNode.current )[ 0 ];
-			focusNode( firstTabbable ? firstTabbable : this.contentNode.current );
+
+			if ( firstTabbable ) {
+				firstTabbable.focus();
+			} else {
+				this.contentNode.current.focus();
+			}
 
 			return;
 		}
@@ -131,7 +139,7 @@ class Popover extends Component {
 		if ( focusOnMount === 'container' ) {
 			// Focus the popover panel itself so items in the popover are easily
 			// accessed via keyboard navigation.
-			focusNode( this.contentNode.current );
+			this.contentNode.current.focus();
 
 			return;
 		}

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -75,7 +75,7 @@ describe( 'Popover', () => {
 				);
 				expect( document.activeElement ).toBe( content );
 				done();
-			} );
+			}, 1 );
 
 			jest.runAllTimers();
 		} );

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -42,11 +42,11 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   <WithSelect(WithDispatch(Inserter))
     position="top right"
   >
-    <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
+    <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
       Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
+    </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
 `;
@@ -72,11 +72,11 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   <WithSelect(WithDispatch(Inserter))
     position="top right"
   >
-    <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
+    <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
       Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
+    </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
 `;
@@ -102,11 +102,11 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   <WithSelect(WithDispatch(Inserter))
     position="top right"
   >
-    <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
+    <WithSelect(WithDispatch(DotTip))
       id="core/editor.inserter"
     >
       Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
+    </WithSelect(WithDispatch(DotTip))>
   </WithSelect(WithDispatch(Inserter))>
 </div>
 `;

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -8,10 +8,10 @@ exports[`PostPreviewButton render() should match the snapshot 1`] = `
   onClick={[Function]}
 >
   Preview
-  <WithSafeTimeout(WithSelect(WithDispatch(DotTip)))
+  <WithSelect(WithDispatch(DotTip))
     id="core/editor.preview"
   >
     Click ‘Preview’ to load a preview of this page, so you can make sure you’re happy with your blocks.
-  </WithSafeTimeout(WithSelect(WithDispatch(DotTip)))>
+  </WithSelect(WithDispatch(DotTip))>
 </Button>
 `;

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { compose, withSafeTimeout } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 import { Popover, Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -44,7 +44,6 @@ export function DotTip( {
 }
 
 export default compose(
-	withSafeTimeout,
 	withSelect( ( select, { id } ) => {
 		const { isTipVisible, getAssociatedGuide } = select( 'core/nux' );
 		const associatedGuide = getAssociatedGuide( id );


### PR DESCRIPTION
## Description

This PR seeks to fix a regression in the way initial focus is set on the first NUX "tip". In Gutenberg 3.2.0 initial focus was set on the tip container:

![screen shot 2018-07-25 at 18 59 28](https://user-images.githubusercontent.com/1682452/43219905-e9d225ce-9048-11e8-911a-1484ad3f498b.png)

This doesn't appear to happen any longer after recent refactoring of some related components. For more details, please see the related issue #8205.

- uses `setTimeout()` in the popover component on the call to the function that sets focus; worth noting the `focus()` function was already using `setTimeout()` internally but seems that now it must be used on the call to the function itself
- removes `withSafeTimeout` from the DotTip component, as it doesn't use a `setTimeout()` any longer
- adjusts a related test

To test:
- first, verify the bug on current master
- clear your browser local storage to make the tips appear
- create a new post: the first tooltip appears
- verify initial focus is _not_ on the first tip (e.g. press Tab and see the first focused element is the admin "skip link")

Then switch to this branch, build and:
- clear your browser local storage 
- create a new post: the first tooltip appears
- verify focus _is_ on the first tip (e.g. press Tab and see the tab order starts from the tip container; tabbing is also constrained within the tooltip)
- check all the other cases where the popover `focusOnMount` prop is used, for example: inserter, more menu, publish panel, block add link popover, etc., and that there are no regressions

Fixes #8205 