### PR TITLE
Point to src/index for the ReactNative entrypoint

### DIFF
--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -19,6 +19,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/element": "file:../element",


### PR DESCRIPTION
## Description
This PR adds a React-Native specific entrypoint to the `compose` package, to have it point directly to the `src` folder and in the usual way Metro expects modules to be specified: no `.js` extension so the proper module variant can be picked up.

## How has this been tested?
Tested against the [mobile ReactNative app](https://github.com/wordpress-mobile/gutenberg-mobile).

## Types of changes
New feature: add an additional entrypoint to the `compose` package, specific for ReactNative

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
