### PR TITLE
Use correct color for primary button bottom border.

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -61,7 +61,7 @@
 
 	&.is-primary {
 		background: color( theme( button ) );
-		border-color: color( theme( button ) shade( 20% ) ) color( theme( button ) shade( 25% ) ) color( theme( primary ) shade( 25% ) );
+		border-color: color( theme( button ) shade( 20% ) ) color( theme( button ) shade( 25% ) ) color( theme( button ) shade( 25% ) );
 		box-shadow: inset 0 -1px 0 color( theme( button ) shade( 25% ) );
 		color: $white;
 		text-decoration: none;


### PR DESCRIPTION
## Description
The primary button has incorrect bottom border color. Instead of `button` it uses `primary` as the base for shading.

## Screenshots
**Before (note the bottom border color of the primary button):**
<img width="334" alt="screenshot 2018-07-26 13 50 33" src="https://user-images.githubusercontent.com/478735/43261044-9ee3f428-90db-11e8-9fa8-cab3cc7b8f52.png">

**After:**
<img width="332" alt="screenshot 2018-07-26 13 50 05" src="https://user-images.githubusercontent.com/478735/43261052-a35847f2-90db-11e8-9ccf-83b43f5248ec.png">

## Types of changes
Bug fix.

