### PR TITLE
Only disable `wpautop` on the main TinyMCE instance for the page

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -73,21 +73,19 @@ function _gutenberg_utf8_split( $str ) {
  * Disables wpautop behavior in classic editor when post contains blocks, to
  * prevent removep from invalidating paragraph blocks.
  *
- * @param  array $settings Original editor settings.
- * @return array           Filtered settings.
+ * @param  array  $settings  Original editor settings.
+ * @param  string $editor_id ID for the editor instance.
+ * @return array             Filtered settings.
  */
-function gutenberg_disable_editor_settings_wpautop( $settings ) {
+function gutenberg_disable_editor_settings_wpautop( $settings, $editor_id ) {
 	$post = get_post();
-	// _content_editor_dfw is a private setting only used on the main
-	// editor instance. We can use it as an identifier.
-	if ( isset( $settings['_content_editor_dfw'] )
-		&& is_object( $post ) && gutenberg_post_has_blocks( $post ) ) {
+	if ( 'content' === $editor_id && is_object( $post ) && gutenberg_post_has_blocks( $post ) ) {
 		$settings['wpautop'] = false;
 	}
 
 	return $settings;
 }
-add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
+add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop', 10, 2 );
 
 /**
  * Add TinyMCE fixes for the Classic Editor.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -78,7 +78,9 @@ function _gutenberg_utf8_split( $str ) {
  */
 function gutenberg_disable_editor_settings_wpautop( $settings ) {
 	$post = get_post();
-	if ( is_object( $post ) && gutenberg_post_has_blocks( $post ) ) {
+	// _content_editor_dfw is a private setting only used on the main
+	// editor instance.
+	if ( is_object( $post ) && gutenberg_post_has_blocks( $post ) && isset( $settings['_content_editor_dfw'] ) ) {
 		$settings['wpautop'] = false;
 	}
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -79,8 +79,9 @@ function _gutenberg_utf8_split( $str ) {
 function gutenberg_disable_editor_settings_wpautop( $settings ) {
 	$post = get_post();
 	// _content_editor_dfw is a private setting only used on the main
-	// editor instance.
-	if ( is_object( $post ) && gutenberg_post_has_blocks( $post ) && isset( $settings['_content_editor_dfw'] ) ) {
+	// editor instance. We can use it as an identifier.
+	if ( isset( $settings['_content_editor_dfw'] )
+		&& is_object( $post ) && gutenberg_post_has_blocks( $post ) ) {
 		$settings['wpautop'] = false;
 	}
 

--- a/test/e2e/specs/classic-editor.test.js
+++ b/test/e2e/specs/classic-editor.test.js
@@ -24,42 +24,4 @@ describe( 'classic editor', () => {
 		const textEditorContent = await page.$eval( '.wp-editor-area', ( element ) => element.value );
 		expect( textEditorContent ).toEqual( 'Typing in classic editor' );
 	} );
-
-	it( 'Should have wpautop disabled on a post containing blocks', async () => {
-		// Click the Text mode.
-		await page.click( '#content-html' );
-
-		// Enter some block text.
-		const original = `<!-- wp:paragraph -->
-<p>Foo bar four five six</p>
-<!-- /wp:paragraph -->
-
-This is another set of text`;
-		await page.type( '#content', original );
-
-		const initialTextEditorContent = await page.$eval( '.wp-editor-area', ( element ) => element.value );
-		expect( initialTextEditorContent ).toEqual( original );
-
-		// Save the post so that TinyMCE loads with wpautop disabled.
-		await Promise.all( [
-			page.waitForNavigation(),
-			page.click( '#save-post' ),
-		] );
-
-		// Switch to Visual mode.
-		await page.click( '#content-tmce' );
-		await page.click( '#content_ifr' );
-
-		// Switch back to Text mode.
-		await page.click( '#content-html' );
-
-		// Expected text is wrapped in `<p>` because `removep()` isn't run
-		// when switching out of Visual mode.
-		const expected = `<!-- wp:paragraph -->
-<p>Foo bar four five six</p>
-<!-- /wp:paragraph -->
-<p>This is another set of text</p>`;
-		const textEditorContent = await page.$eval( '.wp-editor-area', ( element ) => element.value );
-		expect( textEditorContent ).toEqual( expected );
-	} );
 } );

--- a/test/e2e/specs/classic-editor.test.js
+++ b/test/e2e/specs/classic-editor.test.js
@@ -24,4 +24,36 @@ describe( 'classic editor', () => {
 		const textEditorContent = await page.$eval( '.wp-editor-area', ( element ) => element.value );
 		expect( textEditorContent ).toEqual( 'Typing in classic editor' );
 	} );
+
+	it( 'Should have wpautop disabled on a post containing blocks', async () => {
+		// Click the Text mode.
+		await page.click( '#content-html' );
+
+		// Enter some block text.
+		const original = `<!-- wp:paragraph -->
+<p>Foo bar four five six</p>
+<!-- /wp:paragraph -->
+
+This is another set of text`;
+		await page.keyboard.type( original );
+
+		// Save the post so that TinyMCE loads with wpautop disabled.
+		await page.click( '#save-post' );
+
+		// Switch to Visual mode.
+		await page.click( '#content-tmce' );
+		await page.click( '#content_ifr' );
+
+		// Switch back to Text mode.
+		await page.click( '#content-html' );
+
+		// Expected text is wrapped in `<p>` because `removep()` isn't run
+		// when switching out of Visual mode.
+		const expected = `<!-- wp:paragraph -->
+<p>Foo bar four five six</p>
+<!-- /wp:paragraph -->
+<p>This is another set of text</p>`;
+		const textEditorContent = await page.$eval( '.wp-editor-area', ( element ) => element.value );
+		expect( textEditorContent ).toEqual( expected );
+	} );
 } );

--- a/test/e2e/specs/classic-editor.test.js
+++ b/test/e2e/specs/classic-editor.test.js
@@ -35,10 +35,16 @@ describe( 'classic editor', () => {
 <!-- /wp:paragraph -->
 
 This is another set of text`;
-		await page.keyboard.type( original );
+		await page.type( '#content', original );
+
+		const initialTextEditorContent = await page.$eval( '.wp-editor-area', ( element ) => element.value );
+		expect( initialTextEditorContent ).toEqual( original );
 
 		// Save the post so that TinyMCE loads with wpautop disabled.
-		await page.click( '#save-post' );
+		await Promise.all( [
+			page.waitForNavigation(),
+			page.click( '#save-post' ),
+		] );
 
 		// Switch to Visual mode.
 		await page.click( '#content-tmce' );


### PR DESCRIPTION
## Description

`content` is a TinyMCE editor id we can use to identify this main TinyMCE instance. We don't want to disable `wpautop` on _all_ editor instances on the page, because plugins could be
dependent on it.

From #2708
Related https://github.com/WordPress/gutenberg/issues/4672#issuecomment-404498852

## How has this been tested?

1. Create a new post in the Classic Editor and add the following post content in Text Mode:

```
<!-- wp:paragraph -->
<p>Foo bar four five six</p>
<!-- /wp:paragraph -->

This is another set of text
```

2. Save the post while in Text mode.
3. Switch to Visual Mode, and then back to Text Mode.

![tinymcewpautop](https://user-images.githubusercontent.com/36432/43263619-a32ad81e-9098-11e8-9225-08f24748245c.gif)

4. Observe that the content now appears like this:

```
<!-- wp:paragraph -->
<p>Foo bar four five six</p>
<!-- /wp:paragraph -->
<p>This is another set of text</p>
```

This expected output reflects the expected behavior when `wpautop` is disabled. When TinyMCE `wpautop` is _disabled_, TinyMCE forces a root node (`<p>`) on the individual line of text. If `wpautop` were to be _enabled_, then `removep` would be run on the switch back to Text Mode and both instances of `<p>` tags would be removed.

See https://github.com/WordPress/gutenberg/issues/4672#issuecomment-404498852 for more background.

## Types of changes

Bug fix.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
