### PR TITLE
Fix deletion of custom block classes

### DIFF
--- a/packages/editor/src/hooks/custom-class-name.js
+++ b/packages/editor/src/hooks/custom-class-name.js
@@ -136,15 +136,21 @@ export function addParsedDifference( blockAttributes, blockType, innerHTML ) {
 		// To determine difference, serialize block given the known set of
 		// attributes. If there are classes which are mismatched with the
 		// incoming HTML of the block, add to filtered result.
+		// If existing classes have been removed then ensure they don't appear in the output
 		const serialized = getSaveContent( blockType, blockAttributes );
+		const blockClasses = blockAttributes.className ? blockAttributes.className.split( ' ' ) : [];
 		const classes = getHTMLRootElementClasses( serialized );
 		const parsedClasses = getHTMLRootElementClasses( innerHTML );
 		const customClasses = difference( parsedClasses, classes );
 
-		const filteredClassName = compact( [
-			blockAttributes.className,
+		// The remaining classes consist of the block's current classes (with default classes removed if they don't already exist in the block)
+		// along with any custom classes, removing any class that doesn't appear in the innerHTML
+		const remaining = [
+			...classes.filter( ( item ) => blockClasses.indexOf( item ) !== -1 ),
 			...customClasses,
-		] ).join( ' ' );
+		].filter( ( item ) => parsedClasses.indexOf( item ) !== -1 );
+
+		const filteredClassName = compact( remaining ).join( ' ' );
 
 		if ( filteredClassName ) {
 			blockAttributes.className = filteredClassName;

--- a/packages/editor/src/hooks/test/custom-class-name.js
+++ b/packages/editor/src/hooks/test/custom-class-name.js
@@ -10,7 +10,7 @@ import { getHTMLRootElementClasses } from '../custom-class-name';
 
 describe( 'custom className', () => {
 	const blockSettings = {
-		save: () => <div />,
+		save: () => <div className="default" />,
 		category: 'common',
 		title: 'block title',
 	};
@@ -95,7 +95,7 @@ describe( 'custom className', () => {
 			const attributes = addParsedDifference(
 				{ className: 'foo' },
 				blockSettings,
-				'<div class="foo bar baz"></div>'
+				'<div class="default foo bar baz"></div>'
 			);
 
 			expect( attributes.className ).toBe( 'foo bar baz' );
@@ -115,7 +115,7 @@ describe( 'custom className', () => {
 			const attributes = addParsedDifference(
 				{},
 				blockSettings,
-				'<div class="foo"></div>'
+				'<div class="default foo"></div>'
 			);
 
 			expect( attributes.className ).toBe( 'foo' );
@@ -123,12 +123,12 @@ describe( 'custom className', () => {
 
 		it( 'should remove the custom class and retain default class', () => {
 			const attributes = addParsedDifference(
-				{ className: 'default custom' },
+				{ className: 'custom1 custom2' },
 				blockSettings,
-				'<div class="default"></div>'
+				'<div class="default custom1"></div>'
 			);
 
-			expect( attributes.className ).toBe( 'default' );
+			expect( attributes.className ).toBe( 'custom1' );
 		} );
 
 		it( 'should remove the custom class from an element originally without a class', () => {
@@ -143,12 +143,12 @@ describe( 'custom className', () => {
 
 		it( 'should remove the custom classes and retain default and other custom class', () => {
 			const attributes = addParsedDifference(
-				{ className: 'default custom1 custom2 custom3' },
+				{ className: 'custom1 custom2 custom3' },
 				blockSettings,
 				'<div class="default custom1 custom3"></div>'
 			);
 
-			expect( attributes.className ).toBe( 'default custom1 custom3' );
+			expect( attributes.className ).toBe( 'custom1 custom3' );
 		} );
 	} );
 } );

--- a/packages/editor/src/hooks/test/custom-class-name.js
+++ b/packages/editor/src/hooks/test/custom-class-name.js
@@ -110,5 +110,45 @@ describe( 'custom className', () => {
 
 			expect( attributes.className ).toBeUndefined();
 		} );
+
+		it( 'should add a custom class name to an element without a class', () => {
+			const attributes = addParsedDifference(
+				{},
+				blockSettings,
+				'<div class="foo"></div>'
+			);
+
+			expect( attributes.className ).toBe( 'foo' );
+		} );
+
+		it( 'should remove the custom class and retain default class', () => {
+			const attributes = addParsedDifference(
+				{ className: 'default custom' },
+				blockSettings,
+				'<div class="default"></div>'
+			);
+
+			expect( attributes.className ).toBe( 'default' );
+		} );
+
+		it( 'should remove the custom class from an element originally without a class', () => {
+			const attributes = addParsedDifference(
+				{ className: 'foo' },
+				blockSettings,
+				'<div></div>'
+			);
+
+			expect( attributes.className ).toBeUndefined();
+		} );
+
+		it( 'should remove the custom classes and retain default and other custom class', () => {
+			const attributes = addParsedDifference(
+				{ className: 'default custom1 custom2 custom3' },
+				blockSettings,
+				'<div class="default custom1 custom3"></div>'
+			);
+
+			expect( attributes.className ).toBe( 'default custom1 custom3' );
+		} );
 	} );
 } );


### PR DESCRIPTION
If you add a custom class to a block and then remove that custom class it will flag the block as invalid. This is because the custom class becomes part of the block attributes, and is then added back by the 'custom class name' filter.  The expected HTML then doesn't match the current HTML, and a warning is triggered.

You can reproduce the problem as follows:

1. Create a quote block
2. Edit the HTML of the quote block and add another class in the `<blockquote>`:
`<blockquote class="wp-block-quote newclass”><p>fdsfsdfsdd</p></blockquote>`
3. Tab out of the editor and notice that no warning is shown
4. Edit HTML again and remove the `newclass`
5. Tab out and trigger a validation failure, even though the HTML is the default

This may or may not be expected behaviour, but it seems like removing the custom class shouldn't trigger a warning, and so I've treated it as a bug.

This PR ensures the block contains the default class names + whatever classes are currently in the HTML, ignoring any custom ones in the block itself.

The unit tests have been beefed up to cope with several edge case situations

Fixes #8131

Note that I don't fully understand the context of this change, and I may totally have misunderstood the code. The change keeps the existing unit tests running while fixing the additional cases of removing classes. I'm not sure if this is the purpose of the code, so the fix may be misplaced.

## How has this been tested?

Existing unit tests work, and additional unit tests have been added. Manual verification will show the problem in different situations:

- Add a custom class to a block without a default class and then remove it. To test, manually add a class to a paragraph block:
  `<p class="test">paragraph</p>`
  And then remove the class to trigger an invalid block warning
- Add a custom class to a block with a default class and then remove the class - explained above
- Add several custom classes to a block and remove one of them. To test, manually add several classes to a quote block:
  `<blockquote class="wp-block-quote a b c"><p>fdsfsdfsdd</p></blockquote>`
  Then remove class `b` to trigger an invalid block warning. A variation of above, but worth testing

## Types of changes

This is a bug fix that changes some core block HTML code and so could potentially be a breaking fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
