### PR TITLE
PrePublishPanel: suggest tags and postformat

### DIFF
--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -16,7 +16,7 @@ import { withInstanceId, compose } from '@wordpress/compose';
  */
 import PostFormatCheck from './check';
 
-const POST_FORMATS = [
+export const POST_FORMATS = [
 	{ id: 'aside', caption: __( 'Aside' ) },
 	{ id: 'gallery', caption: __( 'Gallery' ) },
 	{ id: 'link', caption: __( 'Link' ) },

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -13,12 +13,17 @@ import PostFormat from '../post-format';
 const MaybePostFormatPanel = ( { currentPostFormat, suggestedPostFormat } ) => suggestedPostFormat &&
 	suggestedPostFormat !== currentPostFormat &&
 	<PanelBody initialOpen={ false } title={ [
-		<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
-		__( 'Tip:' ),
+		<Dashicon
+			key={ 'dashicon-lightbulb' }
+			icon={ 'lightbulb' }
+			className={ 'post-publish-panel__tip' }
+			size={ 18 }
+		/>,
 		<span className="editor-post-publish-panel__link" key="label">{
-			__( 'Choose a fitting post format' )
+			__( 'Add a post format' )
 		}</span>,
 	] } >
+		<p>Post formats are used to display different types of content differently.</p>
 		<PostFormat />
 	</PanelBody>;
 

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -32,7 +32,7 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => <PanelBody ini
 	}</span>,
 ] } >
 	<p>Your theme will be able to use them to display content differently.</p>
-	<p>It looks like you may want to use the <PostFormatSuggested suggestion={ suggestion } onUpdatePostFormat={ onUpdatePostFormat } /> post format type for this post.</p>
+	<p>It looks like you may want to use the <PostFormatSuggested suggestion={ suggestion } onUpdatePostFormat={ onUpdatePostFormat } /> format for this post.</p>
 </PanelBody>;
 
 export default compose(

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -16,7 +16,7 @@ import { Button, PanelBody } from '@wordpress/components';
  */
 import { POST_FORMATS } from '../post-format';
 
-const PostFormatSuggested = ( { suggestedPostFormat, suggestionText, onUpdatePostFormat } ) => (
+const PostFormatSuggestion = ( { suggestedPostFormat, suggestionText, onUpdatePostFormat } ) => (
 	<Button isLink onClick={ () => onUpdatePostFormat( suggestedPostFormat ) }>
 		{ suggestionText }
 	</Button>
@@ -38,7 +38,7 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
 				{ __( 'Your theme uses post formats to highlight different kinds of content, like images or videos. Apply a post format to see this special styling.' ) }
 			</p>
 			<p>
-				<PostFormatSuggested
+				<PostFormatSuggestion
 					onUpdatePostFormat={ onUpdatePostFormat }
 					suggestedPostFormat={ suggestion.id }
 					suggestionText={ sprintf(

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { withSelect } from '@wordpress/data';
+import { Dashicon, PanelBody } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import PostFormat from '../post-format';
+
+const MaybePostFormatPanel = ( { currentPostFormat, suggestedPostFormat } ) => suggestedPostFormat &&
+	suggestedPostFormat !== currentPostFormat &&
+	<PanelBody initialOpen={ true } title={ [
+		<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
+		__( 'Tip:' ),
+		<span className="editor-post-publish-panel__link" key="label">{
+			__( 'Choose a fitting post format' )
+		}</span>,
+	] } >
+		<PostFormat />
+	</PanelBody>;
+
+export default withSelect(
+	( select ) => {
+		const { getEditedPostAttribute, getSuggestedPostFormat } = select( 'core/editor' );
+		return {
+			suggestedPostFormat: getSuggestedPostFormat(),
+			currentPostFormat: getEditedPostAttribute( 'format' ),
+		};
+	}
+)( MaybePostFormatPanel );

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -31,7 +31,7 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => <PanelBody ini
 		__( 'Add a post format' )
 	}</span>,
 ] } >
-	<p>Post formats are used to display different types of content differently.</p>
+	<p>Your theme will be able to use them to display content differently.</p>
 	<p>It looks like you may want to use the <PostFormatSuggested suggestion={ suggestion } onUpdatePostFormat={ onUpdatePostFormat } /> post format type for this post.</p>
 </PanelBody>;
 

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -31,8 +31,12 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => <PanelBody ini
 		__( 'Add a post format' )
 	}</span>,
 ] } >
-	<p>Your theme will be able to use them to display content differently.</p>
-	<p>It looks like you may want to use the <PostFormatSuggested suggestion={ suggestion } onUpdatePostFormat={ onUpdatePostFormat } /> format for this post.</p>
+	<p> { __( 'Your theme will be able to use them to display content differently.' ) } </p>
+	<p>
+		{ __( 'It looks like this post could use the following format type: ' ) }
+		<PostFormatSuggested suggestion={ suggestion } onUpdatePostFormat={ onUpdatePostFormat } />
+		.
+	</p>
 </PanelBody>;
 
 export default compose(

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -9,7 +9,7 @@ import { find, get, includes, union } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { ifCondition, compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Button, Dashicon, PanelBody } from '@wordpress/components';
+import { Button, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -21,12 +21,6 @@ const PostFormatSuggested = ( { suggestion, onUpdatePostFormat } ) => <Button is
 </Button>;
 
 const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => <PanelBody initialOpen={ false } title={ [
-	<Dashicon
-		key={ 'dashicon-lightbulb' }
-		icon={ 'lightbulb' }
-		className={ 'post-publish-panel__tip' }
-		size={ 18 }
-	/>,
 	<span className="editor-post-publish-panel__link" key="label">{
 		__( 'Add a post format' )
 	}</span>,

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -35,7 +35,7 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
 	return (
 		<PanelBody initialOpen={ false } title={ panelBodyTitle } >
 			<p>
-				{ __( 'Your theme uses post formats to highlight different kinds of content like images or videos. Apply one to see this special styling' ) }
+				{ __( 'Your theme uses post formats to highlight different kinds of content, like images or videos. Apply a post format to see this special styling.' ) }
 			</p>
 			<p>
 				<PostFormatSuggested

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, includes, union } from 'lodash';
+import { find, get, includes } from 'lodash';
 
 /**
  * WordPress dependencies.
@@ -35,7 +35,7 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
 	return (
 		<PanelBody initialOpen={ false } title={ panelBodyTitle } >
 			<p>
-				{ __( 'Your theme uses Post Formats. These offer styling tweaks that highlight different kinds of content–like images or videos.' ) }
+				{ __( 'Your theme uses Post Formats, styling tweaks that highlight different kinds of content like images or videos.' ) }
 			</p>
 			<p>
 				<PostFormatSuggested

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -6,7 +6,7 @@ import { find, get, includes, union } from 'lodash';
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { ifCondition, compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Button, PanelBody } from '@wordpress/components';
@@ -16,23 +16,40 @@ import { Button, PanelBody } from '@wordpress/components';
  */
 import { POST_FORMATS } from '../post-format';
 
-const PostFormatSuggested = ( { suggestion, onUpdatePostFormat } ) => <Button isLink onClick={ () => onUpdatePostFormat( suggestion.id ) }>
-	{ suggestion.caption }
-</Button>;
+const PostFormatSuggested = ( { suggestion, suggestionText, onUpdatePostFormat } ) => (
+	<Button isLink onClick={ () => onUpdatePostFormat( suggestion.id ) }>
+		{ suggestionText }
+	</Button>
+);
 
-const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => <PanelBody initialOpen={ false } title={ [
-	__( 'Tip:' ),
-	<span className="editor-post-publish-panel__link" key="label">{
-		__( 'Add a post format' )
-	}</span>,
-] } >
-	<p> { __( 'Your theme uses post formats -- styling tweaks that complement different kinds of content.' ) } </p>
-	<p>
-		{ __( 'The ' ) }
-		<PostFormatSuggested suggestion={ suggestion } onUpdatePostFormat={ onUpdatePostFormat } />
-		{ __( ' format would be great for this post.' ) }
-	</p>
-</PanelBody>;
+const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
+	const panelBodyTitle = [
+		__( 'Tip:' ),
+		(
+			<span className="editor-post-publish-panel__link" key="label">
+				{ __( 'Add a post format' ) }
+			</span>
+		),
+	];
+
+	return (
+		<PanelBody initialOpen={ false } title={ panelBodyTitle } >
+			<p>
+				{ __( 'Your theme uses Post Formats. These offer styling tweaks that highlight different kinds of content–like images or videos.' ) }
+			</p>
+			<p>
+				<PostFormatSuggested
+					onUpdatePostFormat={ onUpdatePostFormat }
+					suggestion={ suggestion }
+					suggestionText={ sprintf(
+						__( 'Convert to "%1$s" format.' ),
+						suggestion.caption
+					) }
+				/>
+			</p>
+		</PanelBody>
+	);
+};
 
 export default compose(
 	withSelect( ( select ) => {

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -1,17 +1,26 @@
 /**
+ * External dependencies
+ */
+import { find, get, includes, union } from 'lodash';
+
+/**
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
 import { ifCondition, compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
-import { Dashicon, PanelBody } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { Button, Dashicon, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
-import PostFormat from '../post-format';
+import { POST_FORMATS } from '../post-format';
 
-const PostFormatPanel = ( ) =>	<PanelBody initialOpen={ false } title={ [
+const PostFormatSuggested = ( { suggestion, onUpdatePostFormat } ) => <Button isLink onClick={ () => onUpdatePostFormat( suggestion.id ) }>
+	{ suggestion.caption }
+</Button>;
+
+const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => <PanelBody initialOpen={ false } title={ [
 	<Dashicon
 		key={ 'dashicon-lightbulb' }
 		icon={ 'lightbulb' }
@@ -23,16 +32,30 @@ const PostFormatPanel = ( ) =>	<PanelBody initialOpen={ false } title={ [
 	}</span>,
 ] } >
 	<p>Post formats are used to display different types of content differently.</p>
-	<PostFormat />
+	<p>It looks like you may want to use the <PostFormatSuggested suggestion={ suggestion } onUpdatePostFormat={ onUpdatePostFormat } /> post format type for this post.</p>
 </PanelBody>;
 
 export default compose(
 	withSelect( ( select ) => {
 		const { getEditedPostAttribute, getSuggestedPostFormat } = select( 'core/editor' );
+		const suggestedPostFormat = getSuggestedPostFormat();
+		const currentPostFormat = getEditedPostAttribute( 'format' );
+		const themeSupports = select( 'core' ).getThemeSupports();
+		// Ensure current format is always in the set.
+		// The current format may not be a format supported by the theme.
+		const supportedFormats = union( [ currentPostFormat ], get( themeSupports, [ 'formats' ], [] ) );
+		const formats = POST_FORMATS.filter( ( format ) => includes( supportedFormats, format.id ) );
+		const suggestion = find( formats, ( format ) => format.id === suggestedPostFormat );
 		return {
-			suggestedPostFormat: getSuggestedPostFormat(),
-			currentPostFormat: getEditedPostAttribute( 'format' ),
+			currentPostFormat,
+			suggestedPostFormat,
+			suggestion,
 		};
 	} ),
+	withDispatch( ( dispatch ) => ( {
+		onUpdatePostFormat( postFormat ) {
+			dispatch( 'core/editor' ).editPost( { format: postFormat } );
+		},
+	} ) ),
 	ifCondition( ( { suggestedPostFormat, currentPostFormat } ) => suggestedPostFormat && suggestedPostFormat !== currentPostFormat ),
 )( PostFormatPanel );

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -26,11 +26,11 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => <PanelBody ini
 		__( 'Add a post format' )
 	}</span>,
 ] } >
-	<p> { __( 'Your theme will be able to use them to display content differently.' ) } </p>
+	<p> { __( 'Your theme uses post formats -- styling tweaks that complement different kinds of content.' ) } </p>
 	<p>
-		{ __( 'It looks like this post could use the following format type: ' ) }
+		{ __( 'The ' ) }
 		<PostFormatSuggested suggestion={ suggestion } onUpdatePostFormat={ onUpdatePostFormat } />
-		.
+		{ __( ' format would be great for this post.' ) }
 	</p>
 </PanelBody>;
 

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -16,8 +16,8 @@ import { Button, PanelBody } from '@wordpress/components';
  */
 import { POST_FORMATS } from '../post-format';
 
-const PostFormatSuggested = ( { suggestion, suggestionText, onUpdatePostFormat } ) => (
-	<Button isLink onClick={ () => onUpdatePostFormat( suggestion.id ) }>
+const PostFormatSuggested = ( { suggestedPostFormat, suggestionText, onUpdatePostFormat } ) => (
+	<Button isLink onClick={ () => onUpdatePostFormat( suggestedPostFormat ) }>
 		{ suggestionText }
 	</Button>
 );
@@ -40,7 +40,7 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
 			<p>
 				<PostFormatSuggested
 					onUpdatePostFormat={ onUpdatePostFormat }
-					suggestion={ suggestion }
+					suggestedPostFormat={ suggestion.id }
 					suggestionText={ sprintf(
 						__( 'Convert to "%1$s" format.' ),
 						suggestion.caption
@@ -64,7 +64,6 @@ export default compose(
 		const suggestion = find( formats, ( format ) => format.id === suggestedPostFormat );
 		return {
 			currentPostFormat,
-			suggestedPostFormat,
 			suggestion,
 		};
 	} ),
@@ -73,5 +72,5 @@ export default compose(
 			dispatch( 'core/editor' ).editPost( { format: postFormat } );
 		},
 	} ) ),
-	ifCondition( ( { suggestedPostFormat, currentPostFormat } ) => suggestedPostFormat && suggestedPostFormat !== currentPostFormat ),
+	ifCondition( ( { suggestion, currentPostFormat } ) => suggestion && suggestion.id !== currentPostFormat ),
 )( PostFormatPanel );

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -21,6 +21,7 @@ const PostFormatSuggested = ( { suggestion, onUpdatePostFormat } ) => <Button is
 </Button>;
 
 const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => <PanelBody initialOpen={ false } title={ [
+	__( 'Tip:' ),
 	<span className="editor-post-publish-panel__link" key="label">{
 		__( 'Add a post format' )
 	}</span>,

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { ifCondition, compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { Dashicon, PanelBody } from '@wordpress/components';
 
@@ -10,29 +11,28 @@ import { Dashicon, PanelBody } from '@wordpress/components';
  */
 import PostFormat from '../post-format';
 
-const MaybePostFormatPanel = ( { currentPostFormat, suggestedPostFormat } ) => suggestedPostFormat &&
-	suggestedPostFormat !== currentPostFormat &&
-	<PanelBody initialOpen={ false } title={ [
-		<Dashicon
-			key={ 'dashicon-lightbulb' }
-			icon={ 'lightbulb' }
-			className={ 'post-publish-panel__tip' }
-			size={ 18 }
-		/>,
-		<span className="editor-post-publish-panel__link" key="label">{
-			__( 'Add a post format' )
-		}</span>,
-	] } >
-		<p>Post formats are used to display different types of content differently.</p>
-		<PostFormat />
-	</PanelBody>;
+const PostFormatPanel = ( ) =>	<PanelBody initialOpen={ false } title={ [
+	<Dashicon
+		key={ 'dashicon-lightbulb' }
+		icon={ 'lightbulb' }
+		className={ 'post-publish-panel__tip' }
+		size={ 18 }
+	/>,
+	<span className="editor-post-publish-panel__link" key="label">{
+		__( 'Add a post format' )
+	}</span>,
+] } >
+	<p>Post formats are used to display different types of content differently.</p>
+	<PostFormat />
+</PanelBody>;
 
-export default withSelect(
-	( select ) => {
+export default compose(
+	withSelect( ( select ) => {
 		const { getEditedPostAttribute, getSuggestedPostFormat } = select( 'core/editor' );
 		return {
 			suggestedPostFormat: getSuggestedPostFormat(),
 			currentPostFormat: getEditedPostAttribute( 'format' ),
 		};
-	}
-)( MaybePostFormatPanel );
+	} ),
+	ifCondition( ( { suggestedPostFormat, currentPostFormat } ) => suggestedPostFormat && suggestedPostFormat !== currentPostFormat ),
+)( PostFormatPanel );

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -51,20 +51,18 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
 	);
 };
 
+const getSuggestion = ( supportedFormats, suggestedPostFormat ) => {
+	const formats = POST_FORMATS.filter( ( format ) => includes( supportedFormats, format.id ) );
+	return find( formats, ( format ) => format.id === suggestedPostFormat );
+};
+
 export default compose(
 	withSelect( ( select ) => {
 		const { getEditedPostAttribute, getSuggestedPostFormat } = select( 'core/editor' );
-		const suggestedPostFormat = getSuggestedPostFormat();
-		const currentPostFormat = getEditedPostAttribute( 'format' );
-		const themeSupports = select( 'core' ).getThemeSupports();
-		// Ensure current format is always in the set.
-		// The current format may not be a format supported by the theme.
-		const supportedFormats = union( [ currentPostFormat ], get( themeSupports, [ 'formats' ], [] ) );
-		const formats = POST_FORMATS.filter( ( format ) => includes( supportedFormats, format.id ) );
-		const suggestion = find( formats, ( format ) => format.id === suggestedPostFormat );
+		const supportedFormats = get( select( 'core' ).getThemeSupports(), [ 'formats' ], [] );
 		return {
-			currentPostFormat,
-			suggestion,
+			currentPostFormat: getEditedPostAttribute( 'format' ),
+			suggestion: getSuggestion( supportedFormats, getSuggestedPostFormat() ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -12,7 +12,7 @@ import PostFormat from '../post-format';
 
 const MaybePostFormatPanel = ( { currentPostFormat, suggestedPostFormat } ) => suggestedPostFormat &&
 	suggestedPostFormat !== currentPostFormat &&
-	<PanelBody initialOpen={ true } title={ [
+	<PanelBody initialOpen={ false } title={ [
 		<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
 		__( 'Tip:' ),
 		<span className="editor-post-publish-panel__link" key="label">{

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -24,10 +24,10 @@ const PostFormatSuggested = ( { suggestedPostFormat, suggestionText, onUpdatePos
 
 const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
 	const panelBodyTitle = [
-		__( 'Tip:' ),
+		__( 'Suggestion:' ),
 		(
 			<span className="editor-post-publish-panel__link" key="label">
-				{ __( 'Add a post format' ) }
+				{ __( 'Use a post format' ) }
 			</span>
 		),
 	];
@@ -35,14 +35,14 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
 	return (
 		<PanelBody initialOpen={ false } title={ panelBodyTitle } >
 			<p>
-				{ __( 'Your theme uses Post Formats, styling tweaks that highlight different kinds of content like images or videos.' ) }
+				{ __( 'Your theme uses post formats to highlight different kinds of content like images or videos. Apply one to see this special styling' ) }
 			</p>
 			<p>
 				<PostFormatSuggested
 					onUpdatePostFormat={ onUpdatePostFormat }
 					suggestedPostFormat={ suggestion.id }
 					suggestionText={ sprintf(
-						__( 'Convert to "%1$s" format.' ),
+						__( 'Apply the "%1$s" format.' ),
 						suggestion.caption
 					) }
 				/>

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -15,7 +15,7 @@ const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
 		__( 'Add tags to your post' )
 	}</span>,
 ] }>
-	<p> { __( 'This will help readers find your posts.' ) } </p>
+	<p> { __( "Enter a few words that describe your post's subject to help interested readers find it." ) } </p>
 	<FlatTermSelector slug={ 'post_tag' } />
 </PanelBody>;
 

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -28,9 +28,7 @@ class MaybeTagsPanel extends Component {
 	}
 
 	render() {
-		const { isPostTypeSupported } = this.props;
-		const { hadTags } = this.state;
-		if ( ! isPostTypeSupported || hadTags ) {
+		if ( this.state.hadTags ) {
 			return null;
 		}
 		return ( <TagsPanel /> );
@@ -40,12 +38,12 @@ class MaybeTagsPanel extends Component {
 export default compose(
 	withSelect( ( select ) => {
 		const postType = select( 'core/editor' ).getCurrentPostType();
-		const tags = select( 'core' ).getTaxonomy( 'post_tag' );
-		const terms = tags ? select( 'core/editor' ).getEditedPostAttribute( tags.rest_base ) : [];
+		const tagsTaxonomy = select( 'core' ).getTaxonomy( 'post_tag' );
 		return {
-			hasTags: tags && terms && terms.length > 0,
-			isPostTypeSupported: tags && tags.types.some( ( type ) => type === postType ),
+			areTagsFetched: tagsTaxonomy !== undefined,
+			isPostTypeSupported: tagsTaxonomy && tagsTaxonomy.types.some( ( type ) => type === postType ),
+			hasTags: tagsTaxonomy ? select( 'core/editor' ).getEditedPostAttribute( tagsTaxonomy.rest_base ).length > 0 : false,
 		};
 	} ),
-	ifCondition( ( { hasTags } ) => hasTags !== undefined ),
+	ifCondition( ( { areTagsFetched, isPostTypeSupported } ) => isPostTypeSupported && areTagsFetched ),
 )( MaybeTagsPanel );

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -20,7 +20,7 @@ const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
 		__( 'Add tags to your post' )
 	}</span>,
 ] }>
-	<p>Add a few tags to your posts so your readers will be able to find your posts more easily.</p>
+	<p>Your readers will be able to find your posts more easily.</p>
 	<FlatTermSelector slug={ 'post_tag' } />
 </PanelBody>;
 

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -29,7 +29,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		const postType = select( 'core/editor' ).getCurrentPostType();
 		const tags = select( 'core' ).getTaxonomy( 'post_tag' );
-		const terms = select( 'core/editor' ).getEditedPostAttribute( tags.rest_base );
+		const terms = tags ? select( 'core/editor' ).getEditedPostAttribute( tags.rest_base ) : [];
 		return {
 			hasTags: tags && terms && terms.length > 0,
 			isPostTypeSupported: tags && tags.types.some( ( type ) => type === postType ),

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -2,11 +2,13 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 import { Dashicon, PanelBody } from '@wordpress/components';
 
 import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
-const MaybeTagsPanel = () => <PanelBody initialOpen={ true } title={ [
+const TagsPanel = () => <PanelBody initialOpen={ true } title={ [
 	<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
 	__( 'Tip:' ),
 	<span className="editor-post-publish-panel__link" key="label">{
@@ -16,4 +18,19 @@ const MaybeTagsPanel = () => <PanelBody initialOpen={ true } title={ [
 	<FlatTermSelector slug={ 'post_tag' } />
 </PanelBody>;
 
-export default MaybeTagsPanel;
+const MaybeTagsPanel = ( { hasTags } ) => {
+	if ( ! hasTags ) {
+		return null;
+	}
+	return ( <TagsPanel /> );
+};
+
+export default compose( [
+	withSelect( ( select ) => {
+		const postType = select( 'core/editor' ).getCurrentPostType();
+		const tags = select( 'core' ).getTaxonomy( 'post_tag' );
+		return {
+			hasTags: tags && tags.types.some( ( type ) => type === postType ),
+		};
+	} ),
+] )( MaybeTagsPanel );

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -10,6 +10,7 @@ import { PanelBody } from '@wordpress/components';
 import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
 const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
+	__( 'Tip:' ),
 	<span className="editor-post-publish-panel__link" key="label">{
 		__( 'Add tags to your post' )
 	}</span>,

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -33,16 +33,26 @@ class MaybeTagsPanel extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			hadTags: props.hasTags,
+			hadTagsWhenOpeningThePanel: props.hasTags,
 		};
 	}
 
+	/*
+	 * We only want to show the tag panel if the post didn't have
+	 * any tags when the user hit the Publish button.
+	 *
+	 * We can't use the prop.hasTags because it'll change to true
+	 * if the user adds a new tag within the pre-publish panel.
+	 * This would force a re-render and a new prop.hasTags check,
+	 * hiding this panel and keeping the user from adding
+	 * more than one tag.
+	 */
 	render() {
-		if ( this.state.hadTags ) {
-			return null;
+		if ( ! this.state.hadTagsWhenOpeningThePanel ) {
+			return <TagsPanel />;
 		}
 
-		return <TagsPanel />;
+		return null;
 	}
 }
 

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -20,7 +20,7 @@ const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
 		__( 'Add tags to your post' )
 	}</span>,
 ] }>
-	<p>Your readers will be able to find your posts more easily.</p>
+	<p> { __( 'Your readers will be able to find your posts more easily.' ) } </p>
 	<FlatTermSelector slug={ 'post_tag' } />
 </PanelBody>;
 

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -5,17 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { Dashicon, PanelBody } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 
 import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
 const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
-	<Dashicon
-		key={ 'dashicon-lightbulb' }
-		icon={ 'lightbulb' }
-		className={ 'post-publish-panel__tip' }
-		size={ 18 }
-	/>,
 	<span className="editor-post-publish-panel__link" key="label">{
 		__( 'Add tags to your post' )
 	}</span>,

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -10,12 +10,17 @@ import { Dashicon, PanelBody } from '@wordpress/components';
 import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
 const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
-	<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
-	__( 'Tip:' ),
+	<Dashicon
+		key={ 'dashicon-lightbulb' }
+		icon={ 'lightbulb' }
+		className={ 'post-publish-panel__tip' }
+		size={ 18 }
+	/>,
 	<span className="editor-post-publish-panel__link" key="label">{
 		__( 'Add tags to your post' )
 	}</span>,
 ] }>
+	<p>Add a few tags to your posts so your readers will be able to find your posts more easily.</p>
 	<FlatTermSelector slug={ 'post_tag' } />
 </PanelBody>;
 

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -18,8 +18,8 @@ const TagsPanel = () => <PanelBody initialOpen={ true } title={ [
 	<FlatTermSelector slug={ 'post_tag' } />
 </PanelBody>;
 
-const MaybeTagsPanel = ( { hasTags } ) => {
-	if ( ! hasTags ) {
+const MaybeTagsPanel = ( { isPostTypeSupported, hasTags } ) => {
+	if ( ! isPostTypeSupported || hasTags ) {
 		return null;
 	}
 	return ( <TagsPanel /> );
@@ -29,8 +29,10 @@ export default compose( [
 	withSelect( ( select ) => {
 		const postType = select( 'core/editor' ).getCurrentPostType();
 		const tags = select( 'core' ).getTaxonomy( 'post_tag' );
+		const terms = select( 'core/editor' ).getEditedPostAttribute( tags.rest_base );
 		return {
-			hasTags: tags && tags.types.some( ( type ) => type === postType ),
+			hasTags: tags && terms && terms.length > 0,
+			isPostTypeSupported: tags && tags.types.some( ( type ) => type === postType ),
 		};
 	} ),
 ] )( MaybeTagsPanel );

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -9,15 +9,25 @@ import { PanelBody } from '@wordpress/components';
 
 import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
-const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
-	__( 'Tip:' ),
-	<span className="editor-post-publish-panel__link" key="label">{
-		__( 'Add tags to your post' )
-	}</span>,
-] }>
-	<p> { __( "Enter a few words that describe your post's subject to help interested readers find it." ) } </p>
-	<FlatTermSelector slug={ 'post_tag' } />
-</PanelBody>;
+const TagsPanel = () => {
+	const panelBodyTitle = [
+		__( 'Tip:' ),
+		(
+			<span className="editor-post-publish-panel__link" key="label">
+				{ __( 'Add tags to your post' ) }
+			</span>
+		),
+	];
+
+	return (
+		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
+			<p>
+				{ __( 'Enter a few words that describe your post’s subject. This will help interested readers find it.' ) }
+			</p>
+			<FlatTermSelector slug={ 'post_tag' } />
+		</PanelBody>
+	);
+};
 
 class MaybeTagsPanel extends Component {
 	constructor( props ) {
@@ -31,7 +41,8 @@ class MaybeTagsPanel extends Component {
 		if ( this.state.hadTags ) {
 			return null;
 		}
-		return ( <TagsPanel /> );
+
+		return <TagsPanel />;
 	}
 }
 

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { Dashicon, PanelBody } from '@wordpress/components';
@@ -18,12 +19,47 @@ const TagsPanel = () => <PanelBody initialOpen={ true } title={ [
 	<FlatTermSelector slug={ 'post_tag' } />
 </PanelBody>;
 
-const MaybeTagsPanel = ( { isPostTypeSupported, hasTags } ) => {
-	if ( ! isPostTypeSupported || hasTags ) {
+class MaybeTagsPanel extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			hadTags: props.hasTags,
+		};
+	}
+
+	/*
+	 * We use state.hadTags to track whether the post had tags when this
+	 * component was first mounted.
+	 *
+	 * We can't rely on the props.hasTags value to do this check
+	 * because when the user adds a tag to a post that didn't have one,
+	 * the props.hasTags is going to change from false to true,
+	 * forcing a re-render of this component and hiding it when it was previosly shown.
+	 *
+	 * We take advantage of the fact that the props.hasTags value is undefined
+	 * if tags weren't fetched yet, otherwise it will be true of false.
+	 *
+	 */
+	static getDerivedStateFromProps( props, state ) {
+		const { hadTags: currentHadTags } = state;
+		const { hasTags } = props;
+		if ( currentHadTags === undefined && hasTags !== undefined ) {
+			return {
+				hadTags: hasTags,
+			};
+		}
 		return null;
 	}
-	return ( <TagsPanel /> );
-};
+
+	render() {
+		const { isPostTypeSupported } = this.props;
+		const { hadTags } = this.state;
+		if ( ! isPostTypeSupported || hadTags ) {
+			return null;
+		}
+		return ( <TagsPanel /> );
+	}
+}
 
 export default compose( [
 	withSelect( ( select ) => {

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Dashicon, PanelBody } from '@wordpress/components';
+
+import FlatTermSelector from '../post-taxonomies/flat-term-selector';
+
+const MaybeTagsPanel = () => <PanelBody initialOpen={ true } title={ [
+	<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
+	__( 'Tip:' ),
+	<span className="editor-post-publish-panel__link" key="label">{
+		__( 'Add tags to your post' )
+	}</span>,
+] }>
+	<FlatTermSelector slug={ 'post_tag' } />
+</PanelBody>;
+
+export default MaybeTagsPanel;

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
+import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { Dashicon, PanelBody } from '@wordpress/components';
 
@@ -27,30 +27,6 @@ class MaybeTagsPanel extends Component {
 		};
 	}
 
-	/*
-	 * We use state.hadTags to track whether the post had tags when this
-	 * component was first mounted.
-	 *
-	 * We can't rely on the props.hasTags value to do this check
-	 * because when the user adds a tag to a post that didn't have one,
-	 * the props.hasTags is going to change from false to true,
-	 * forcing a re-render of this component and hiding it when it was previosly shown.
-	 *
-	 * We take advantage of the fact that the props.hasTags value is undefined
-	 * if tags weren't fetched yet, otherwise it will be true of false.
-	 *
-	 */
-	static getDerivedStateFromProps( props, state ) {
-		const { hadTags: currentHadTags } = state;
-		const { hasTags } = props;
-		if ( currentHadTags === undefined && hasTags !== undefined ) {
-			return {
-				hadTags: hasTags,
-			};
-		}
-		return null;
-	}
-
 	render() {
 		const { isPostTypeSupported } = this.props;
 		const { hadTags } = this.state;
@@ -61,7 +37,7 @@ class MaybeTagsPanel extends Component {
 	}
 }
 
-export default compose( [
+export default compose(
 	withSelect( ( select ) => {
 		const postType = select( 'core/editor' ).getCurrentPostType();
 		const tags = select( 'core' ).getTaxonomy( 'post_tag' );
@@ -71,4 +47,5 @@ export default compose( [
 			isPostTypeSupported: tags && tags.types.some( ( type ) => type === postType ),
 		};
 	} ),
-] )( MaybeTagsPanel );
+	ifCondition( ( { hasTags } ) => hasTags !== undefined ),
+)( MaybeTagsPanel );

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -14,7 +14,7 @@ const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
 		__( 'Add tags to your post' )
 	}</span>,
 ] }>
-	<p> { __( 'Your readers will be able to find your posts more easily.' ) } </p>
+	<p> { __( 'This will help readers find your posts.' ) } </p>
 	<FlatTermSelector slug={ 'post_tag' } />
 </PanelBody>;
 

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -11,10 +11,10 @@ import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
 const TagsPanel = () => {
 	const panelBodyTitle = [
-		__( 'Tip:' ),
+		__( 'Suggestion:' ),
 		(
 			<span className="editor-post-publish-panel__link" key="label">
-				{ __( 'Add tags to your post' ) }
+				{ __( 'Add tags' ) }
 			</span>
 		),
 	];
@@ -22,7 +22,7 @@ const TagsPanel = () => {
 	return (
 		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
 			<p>
-				{ __( 'Enter a few words that describe your post’s subject. This will help interested readers find it.' ) }
+				{ __( 'Tags help users and search engines navigate your site and find your content. Add a few keywords to describe your post.' ) }
 			</p>
 			<FlatTermSelector slug={ 'post_tag' } />
 		</PanelBody>

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -9,7 +9,7 @@ import { Dashicon, PanelBody } from '@wordpress/components';
 
 import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
-const TagsPanel = () => <PanelBody initialOpen={ true } title={ [
+const TagsPanel = () => <PanelBody initialOpen={ false } title={ [
 	<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
 	__( 'Tip:' ),
 	<span className="editor-post-publish-panel__link" key="label">{

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -53,7 +53,7 @@ export default compose(
 		return {
 			areTagsFetched: tagsTaxonomy !== undefined,
 			isPostTypeSupported: tagsTaxonomy && tagsTaxonomy.types.some( ( type ) => type === postType ),
-			hasTags: tagsTaxonomy ? select( 'core/editor' ).getEditedPostAttribute( tagsTaxonomy.rest_base ).length > 0 : false,
+			hasTags: tagsTaxonomy && select( 'core/editor' ).getEditedPostAttribute( tagsTaxonomy.rest_base ).length,
 		};
 	} ),
 	ifCondition( ( { areTagsFetched, isPostTypeSupported } ) => isPostTypeSupported && areTagsFetched ),

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -19,6 +19,7 @@ import PostVisibilityLabel from '../post-visibility/label';
 import PostSchedule from '../post-schedule';
 import PostScheduleLabel from '../post-schedule/label';
 import MaybeTagsPanel from './maybe-tags-panel';
+import MaybePostFormatPanel from './maybe-post-format-panel';
 
 function PostPublishPanelPrepublish( {
 	hasPublishAction,
@@ -42,6 +43,7 @@ function PostPublishPanelPrepublish( {
 					] }>
 						<PostSchedule />
 					</PanelBody>
+					<MaybePostFormatPanel />
 					<MaybeTagsPanel />
 					{ children }
 				</Fragment>

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { Dashicon, PanelBody } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -18,7 +18,7 @@ import PostVisibility from '../post-visibility';
 import PostVisibilityLabel from '../post-visibility/label';
 import PostSchedule from '../post-schedule';
 import PostScheduleLabel from '../post-schedule/label';
-import FlatTermSelector from '../post-taxonomies/flat-term-selector';
+import MaybeTagsPanel from './maybe-tags-panel';
 
 function PostPublishPanelPrepublish( {
 	hasPublishAction,
@@ -42,15 +42,7 @@ function PostPublishPanelPrepublish( {
 					] }>
 						<PostSchedule />
 					</PanelBody>
-					<PanelBody initialOpen={ true } title={ [
-						<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
-						__( 'Tip:' ),
-						<span className="editor-post-publish-panel__link" key="label">{
-							__( 'Add tags to your post' )
-						}</span>,
-					] }>
-						<FlatTermSelector slug={ 'post_tag' } />
-					</PanelBody>
+					<MaybeTagsPanel />
 					{ children }
 				</Fragment>
 			) }

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { PanelBody } from '@wordpress/components';
+import { Dashicon, PanelBody } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -18,6 +18,7 @@ import PostVisibility from '../post-visibility';
 import PostVisibilityLabel from '../post-visibility/label';
 import PostSchedule from '../post-schedule';
 import PostScheduleLabel from '../post-schedule/label';
+import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
 function PostPublishPanelPrepublish( {
 	hasPublishAction,
@@ -40,6 +41,15 @@ function PostPublishPanelPrepublish( {
 						<span className="editor-post-publish-panel__link" key="label"><PostScheduleLabel /></span>,
 					] }>
 						<PostSchedule />
+					</PanelBody>
+					<PanelBody initialOpen={ true } title={ [
+						<Dashicon key={ 'dashicon-lightbulb' } icon={ 'lightbulb' } />,
+						__( 'Tip:' ),
+						<span className="editor-post-publish-panel__link" key="label">{
+							__( 'Add tags to your post' )
+						}</span>,
+					] }>
+						<FlatTermSelector slug={ 'post_tag' } />
 					</PanelBody>
 					{ children }
 				</Fragment>

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -107,3 +107,7 @@
 .post-publish-panel__postpublish-header {
 	font-weight: 500;
 }
+
+.post-publish-panel__tip {
+	color: $alert-yellow;
+}


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/7426

This PR aims to include the Tags and the PostFormat components in the pre-publish panel:

* Tags component is shown only if the user hasn't tagged the post yet.
* PostFormat is shown if the suggested PostFormat is different from the current one.

### How to test

* Create a new post.
* Add a block image (doesn't need to have any actual image).
* Click Publish. 
* The expected behavior is that the pre-publish panel includes both the Tags and the PostFormat components to prompt the user to add them. Both should be collapsed. See:

| Closed | Opened |
| --- | --- |
| ![pre-publish-panel-copy-long-closed](https://user-images.githubusercontent.com/583546/43855589-6768d142-9b46-11e8-9954-6637279302c5.png) | ![pre-publish-panel-copy-toffumatt](https://user-images.githubusercontent.com/583546/43885487-4ec1f02e-9bb9-11e8-8536-15dc4916b983.png) |

Test variations of the above: with the document sidebar closed (as this is when tags are fetched), with tags and `image` as the current post format, etc. The suggested post format is shown below the current post format, if there is any suggestion - typing `wp.data.select('core/editor').getSuggestedPostFormat()` in the console will give you the same result (or `null` if none is to be suggested).

### TODO

- [x] Make text translatable.
- [x] Try a more conversational post format suggestion (see https://github.com/WordPress/gutenberg/issues/7426#issuecomment-403977765)
- [x] Not shown conditions:
  - [x] Post already has some tag applied.
  - [x] It's a page, not a post (more generally, if the post type allows tags).
- [x] Fix: 
  - [x] Don't crash if tags weren't fetched yet.
  - [x] Panel is hidden after adding one tag in the pre-publish panel.

### Open questions 

- [x] Should we suggest only tags or any available taxonomy? We're going to go with tags as a starter.
