### PR TITLE
Add warning for missing blocks

### DIFF
--- a/core-blocks/index.js
+++ b/core-blocks/index.js
@@ -42,6 +42,7 @@ import * as spacer from './spacer';
 import * as subhead from './subhead';
 import * as table from './table';
 import * as textColumns from './text-columns';
+import * as unknown from './unknown';
 import * as verse from './verse';
 import * as video from './video';
 
@@ -84,6 +85,7 @@ export const registerCoreBlocks = () => {
 		subhead,
 		table,
 		textColumns,
+		unknown,
 		verse,
 		video,
 	].forEach( ( { name, settings } ) => {
@@ -91,5 +93,5 @@ export const registerCoreBlocks = () => {
 	} );
 
 	setDefaultBlockName( paragraph.name );
-	setUnknownTypeHandlerName( freeform.name );
+	setUnknownTypeHandlerName( unknown.name );
 };

--- a/core-blocks/unknown/editor.scss
+++ b/core-blocks/unknown/editor.scss
@@ -1,0 +1,5 @@
+.editor-block-list__block[data-type="core/unknown"] {
+	.editor-warning {
+		position: static;
+	}
+}

--- a/core-blocks/unknown/index.js
+++ b/core-blocks/unknown/index.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import UnknownBlockWarning from './unknown-block-warning';
+import './editor.scss';
+
+export const name = 'core/unknown';
+
+export const settings = {
+	name,
+	category: 'common',
+	title: __( 'Missing Block' ),
+
+	supports: {
+		inserter: false,
+		html: false,
+		preserveOriginalContent: true,
+	},
+
+	attributes: {},
+
+	edit: UnknownBlockWarning,
+	save: () => '',
+};

--- a/core-blocks/unknown/unknown-block-warning.js
+++ b/core-blocks/unknown/unknown-block-warning.js
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { getBlockType, createBlock } from '@wordpress/blocks';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { Warning } from '@wordpress/editor';
+
+export const name = 'core/unknown';
+
+export function UnknownBlockWarning( { block, convertToHTML } ) {
+	const hasContent = !! block.originalUndelimitedContent;
+	const hasHTMLBlock = getBlockType( 'core/html' );
+
+	const actions = [];
+	let messageHTML;
+	if ( hasContent && hasHTMLBlock ) {
+		actions.push(
+			<Button key="convert" onClick={ convertToHTML } isLarge isPrimary>
+				{ __( 'Keep as HTML' ) }
+			</Button>
+		);
+		messageHTML = sprintf(
+			__( 'Your site doesn\'t include support for the <code>%s</code> block. You can leave the block intact, convert it to HTML, or remove it entirely.' ),
+			block.originalName
+		);
+	} else {
+		messageHTML = sprintf(
+			__( 'Your site doesn\'t include support for the <code>%s</code> block. You can leave the block intact or remove it entirely.' ),
+			block.originalName
+		);
+	}
+
+	return (
+		<Warning actions={ actions }>
+			<span dangerouslySetInnerHTML={ { __html: messageHTML } } />
+		</Warning>
+	);
+}
+
+export default compose( [
+	withSelect( ( select, { clientId } ) => {
+		const { getBlock } = select( 'core/editor' );
+		return {
+			block: getBlock( clientId ),
+		};
+	} ),
+	withDispatch( ( dispatch, { block } ) => {
+		const { replaceBlock } = dispatch( 'core/editor' );
+		return {
+			convertToHTML() {
+				replaceBlock( block.clientId, createBlock( 'core/html', {
+					content: block.originalUndelimitedContent,
+				} ) );
+			},
+		};
+	} ),
+] )( UnknownBlockWarning );
+

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -445,6 +445,13 @@ inserter: false,
 multiple: false,
 ```
 
+- `preserveOriginalContent` (default `false`): This flag is for fallback blocks and indicates whether the original block content should be saved instead of the fallback block's `save` output.
+
+```js
+// If this is the fallback block, preserve the original block content when saving.
+preserveOriginalContent: true,
+```
+
 ## Edit and Save
 
 The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](../docs/block-api/block-edit-save.md).

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -294,7 +294,7 @@ export function createBlockWithFallback( blockNode ) {
 	attributes = attributes || {};
 
 	// Trim content to avoid creation of intermediary freeform segments.
-	innerHTML = innerHTML.trim();
+	const originalUndelimitedContent = innerHTML = innerHTML.trim();
 
 	// Use type from block content, otherwise find unknown handler.
 	name = name || getUnknownTypeHandlerName();
@@ -341,11 +341,16 @@ export function createBlockWithFallback( blockNode ) {
 		innerBlocks
 	);
 
-	// Block validation assumes an idempotent operation from source block to serialized block
-	// provided there are no changes in attributes. The validation procedure thus compares the
-	// provided source value with the serialized output before there are any modifications to
-	// the block. When both match, the block is marked as valid.
-	if ( name !== fallbackBlock ) {
+	if ( name === fallbackBlock ) {
+		// Keep original name and attributes so they can be preserved in fallback serialization.
+		block.originalName = blockNode.blockName;
+		block.originalAttributes = attributes;
+		block.originalUndelimitedContent = originalUndelimitedContent;
+	} else {
+		// Block validation assumes an idempotent operation from source block to serialized block
+		// provided there are no changes in attributes. The validation procedure thus compares the
+		// provided source value with the serialized output before there are any modifications to
+		// the block. When both match, the block is marked as valid.
 		block.isValid = isValidBlock( innerHTML, blockType, block.attributes );
 	}
 


### PR DESCRIPTION
## Description
This PR adds a dedicated fallback block to handle the cases where a block in our content no longer exists.

Fixes #7811.

## How has this been tested?
Manually tested using local custom blocks, deactivating and reactivating the plugin. I observed the missing blocks fallback when the custom block plugin was deactivated, and I observed the original block type once I reactivated the plugin.

The plan is to add automated tests as well.

## Screenshots <!-- if applicable -->

![missing-blocks-ui](https://user-images.githubusercontent.com/530877/43308382-454e8a12-9136-11e8-8896-169f1750472a.gif)

## Types of changes
* Adds a `core/unknown` block to use instead of `core/freeform` for fallback.
* The parser now saves the original block name and attributes when a block is missing and is loaded by the fallback block instead.
* When the fallback block supports `preserveOriginalContent`, the serializer preserves its original content.

### Remaining

* [ ] Get copy reviewed and corrected.
* [ ] Write unit tests.
* [ ] Update or fixes for existing tests .
* [ ] Determine how to preserve nested content or defer until after the Try Gutenberg release.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
