### PR TITLE
Add a warning to the Classic Editor when the post contains blocks

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -237,7 +237,12 @@ function gutenberg_warn_classic_about_blocks() {
 					<?php
 					if ( $revisions_link ) {
 						?>
-							<p><?php printf( __( 'You can also <a href="%s">browse previous revisions</a> and restore a version of the page before it was edited in Gutenberg.', 'gutenberg' ), esc_url( $revisions_link ) ); ?></p>
+							<p>
+							<?php
+								/* translators: link to the post revisions page */
+								printf( __( 'You can also <a href="%s">browse previous revisions</a> and restore a version of the page before it was edited in Gutenberg.', 'gutenberg' ), esc_url( $revisions_link ) );
+							?>
+							</p>
 						<?php
 					} else {
 						?>

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -173,10 +173,11 @@ function gutenberg_warn_classic_about_blocks() {
 		return;
 	}
 
-	$gutenberg_edit_link = $classic_edit_link = get_edit_post_link( $post->ID, 'raw' );
+	$gutenberg_edit_link = get_edit_post_link( $post->ID, 'raw' );
 
+	$classic_edit_link = $gutenberg_edit_link;
 	$classic_edit_link = add_query_arg( array(
-		'classic-editor' => '',
+		'classic-editor'     => '',
 		'hide-block-warning' => '',
 	), $classic_edit_link );
 
@@ -186,17 +187,12 @@ function gutenberg_warn_classic_about_blocks() {
 
 		// If there's only one revision, that won't help.
 		if ( count( $revisions ) > 1 ) {
-			reset( $revisions ); // Reset pointer for key()
+			reset( $revisions ); // Reset pointer for key().
 			$revisions_link = get_edit_post_link( key( $revisions ) );
 		}
 	}
-
 	?>
 		<style type="text/css">
-			/*
-			 * Styles copied from wp-admin/css/edit.css
-			 */
-
 			#blocks-in-post-dialog .notification-dialog {
 				width: 500px;
 				margin-left: -250px;
@@ -212,38 +208,33 @@ function gutenberg_warn_classic_about_blocks() {
 			#blocks-in-post-dialog .wp-tab-first {
 				outline: 0;
 			}
-
-
 		</style>
+
 		<div id="blocks-in-post-dialog" class="notification-dialog-wrap">
 			<div class="notification-dialog-background"></div>
 			<div class="notification-dialog">
 				<div class="blocks-in-post-message">
-					<p class="wp-tab-first" tabindex="0">
-						<?php
-							_e( 'This post was previously edited in the Gutenberg. While you can continue and edit in the Classic Editor, you may lose data or formatting from the Gutenberg version of this page.', 'gutenberg' );
-						?>
-					</p>
+					<p class="wp-tab-first" tabindex="0"><?php _e( 'This post was previously edited in the Gutenberg. While you can continue and edit in the Classic Editor, you may lose data or formatting from the Gutenberg version of this page.', 'gutenberg' ); ?></p>
 					<?php
-						if ( $revisions_link ) {
-							?>
-								<p><?php _e( 'To continue anyway, click the "Edit in Classic Editor" button. You can also find an earlier revision to edit by clicking the "Browse Revisions" button. Otherwise, press "Edit in Gutenberg" to keep this post in Gutenberg.', 'gutenberg' ); ?></p>
-							<?php
-						} else {
-							?>
-								<p><strong><?php _e( "Because this post doesn't have revisions, you won't be able to restore an earlier version of your content.", 'gutenberg' ); ?></strong></p>
-								<p><?php _e( 'To continue anyway, click the "Edit in Classic Editor" button. Otherwise, press "Edit in Gutenberg" to continue to Gutenberg, preserving your content and formatting.', 'gutenberg' ); ?></p>
-							<?php
-						}
+					if ( $revisions_link ) {
+						?>
+							<p><?php _e( 'To continue anyway, click the "Edit in Classic Editor" button. You can also find an earlier revision to edit by clicking the "Browse Revisions" button. Otherwise, press "Edit in Gutenberg" to keep this post in Gutenberg.', 'gutenberg' ); ?></p>
+						<?php
+					} else {
+						?>
+							<p><strong><?php _e( "Because this post doesn't have revisions, you won't be able to restore an earlier version of your content.", 'gutenberg' ); ?></strong></p>
+							<p><?php _e( 'To continue anyway, click the "Edit in Classic Editor" button. Otherwise, press "Edit in Gutenberg" to continue to Gutenberg, preserving your content and formatting.', 'gutenberg' ); ?></p>
+						<?php
+					}
 					?>
 					<p>
 						<a class="button" href="<?php echo esc_url( $classic_edit_link ); ?>"><?php _e( 'Edit in Classic Editor', 'gutenberg' ); ?></a>
 						<?php
-							if ( $revisions_link ) {
-								?>
-									<a class="button" href="<?php echo esc_url( $revisions_link ); ?>"><?php _e( 'Browse Revisions', 'gutenberg' ); ?></a>
-								<?php
-							}
+						if ( $revisions_link ) {
+							?>
+								<a class="button" href="<?php echo esc_url( $revisions_link ); ?>"><?php _e( 'Browse Revisions', 'gutenberg' ); ?></a>
+							<?php
+						}
 						?>
 						<a class="button button-primary" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Edit in Gutenberg', 'gutenberg' ); ?></a>
 					</p>

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -148,12 +148,13 @@ function gutenberg_wpautop( $content ) {
 remove_filter( 'the_content', 'wpautop' );
 add_filter( 'the_content', 'gutenberg_wpautop', 8 );
 
+
 /**
- * Adds a warning to the Classic Editor when trying to edit a post containing blocks.
+ * Check if we need to load the block warning in the Classic Editor.
  *
  * @since 3.4.0
  */
-function gutenberg_warn_classic_about_blocks() {
+function gutenberg_check_if_classic_needs_warning_about_blocks() {
 	global $pagenow;
 
 	if ( ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) || ! isset( $_REQUEST['classic-editor'] ) ) {
@@ -173,7 +174,19 @@ function gutenberg_warn_classic_about_blocks() {
 		return;
 	}
 
-	wp_enqueue_script( 'wp-santize' );
+	wp_enqueue_script( 'wp-sanitize' );
+
+	add_action( 'admin_footer', 'gutenberg_warn_classic_about_blocks' );
+}
+add_action( 'admin_enqueue_scripts', 'gutenberg_check_if_classic_needs_warning_about_blocks' );
+
+/**
+ * Adds a warning to the Classic Editor when trying to edit a post containing blocks.
+ *
+ * @since 3.4.0
+ */
+function gutenberg_warn_classic_about_blocks() {
+	$post = get_post();
 
 	$gutenberg_edit_link = get_edit_post_link( $post->ID, 'raw' );
 
@@ -309,4 +322,3 @@ function gutenberg_warn_classic_about_blocks() {
 		</script>
 	<?php
 }
-add_action( 'admin_footer', 'gutenberg_warn_classic_about_blocks' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -233,7 +233,7 @@ function gutenberg_warn_classic_about_blocks() {
 			<div class="notification-dialog-background"></div>
 			<div class="notification-dialog">
 				<div class="blocks-in-post-message">
-					<h1><?php _e( 'Heads up!' ); ?></h1>
+					<h1><?php _e( 'Heads up!', 'gutenberg' ); ?></h1>
 					<p><?php _e( 'This post was previously edited in Gutenberg. You can continue in the Classic Editor, but you may lose data and formatting.', 'gutenberg' ); ?></p>
 					<?php
 					if ( $revisions_link ) {
@@ -242,17 +242,17 @@ function gutenberg_warn_classic_about_blocks() {
 						<?php
 					} else {
 						?>
-							<p><strong><?php _e( "Because this post does not have revisions, you will not be able to revert any changes you make in the Classic Editor.", 'gutenberg' ); ?></strong></p>
+							<p><strong><?php _e( 'Because this post does not have revisions, you will not be able to revert any changes you make in the Classic Editor.', 'gutenberg' ); ?></strong></p>
 						<?php
 					}
 					?>
 					<p>
-					<a class="button button-primary blocks-in-post-gutenberg-button" title="<?php esc_attr_e( 'Open this post in the Gutenberg block editor' ); ?>" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Gutenberg', 'gutenberg' ); ?></a>
-					<a class="button" title="<?php esc_attr_e( 'Open this post in the classic editor' ); ?>" href="<?php echo esc_url( $classic_edit_link ); ?>"><?php _e( 'Classic Editor', 'gutenberg' ); ?></a>
+					<a class="button button-primary blocks-in-post-gutenberg-button" title="<?php esc_attr_e( 'Open this post in the Gutenberg block editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Gutenberg', 'gutenberg' ); ?></a>
+					<a class="button" title="<?php esc_attr_e( 'Open this post in the classic editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $classic_edit_link ); ?>"><?php _e( 'Classic Editor', 'gutenberg' ); ?></a>
 						<?php
 						if ( $revisions_link ) {
 							?>
-								<a class="button" title="<?php esc_attr_e( 'Open the revisions browser' ); ?>" href="<?php echo esc_url( $revisions_link ); ?>"><?php _e( 'Revisions', 'gutenberg' ); ?></a>
+								<a class="button" title="<?php esc_attr_e( 'Open the revisions browser', 'gutenberg' ); ?>" href="<?php echo esc_url( $revisions_link ); ?>"><?php _e( 'Revisions', 'gutenberg' ); ?></a>
 							<?php
 						}
 						?>

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -233,12 +233,11 @@ function gutenberg_warn_classic_about_blocks() {
 			<div class="notification-dialog-background"></div>
 			<div class="notification-dialog">
 				<div class="blocks-in-post-message">
-					<h1><?php _e( 'Heads up!', 'gutenberg' ); ?></h1>
 					<p><?php _e( 'This post was previously edited in Gutenberg. You can continue in the Classic Editor, but you may lose data and formatting.', 'gutenberg' ); ?></p>
 					<?php
 					if ( $revisions_link ) {
 						?>
-							<p><?php _e( 'You can also browse your previous revisions and restore a version of the page before it was edited in Gutenberg.', 'gutenberg' ); ?></p>
+							<p><?php printf( __( 'You can also <a href="%s">browse previous revisions</a> and restore a version of the page before it was edited in Gutenberg.', 'gutenberg' ), esc_url( $revisions_link ) ); ?></p>
 						<?php
 					} else {
 						?>
@@ -247,15 +246,8 @@ function gutenberg_warn_classic_about_blocks() {
 					}
 					?>
 					<p>
-					<a class="button button-primary blocks-in-post-gutenberg-button" title="<?php esc_attr_e( 'Open this post in the Gutenberg block editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Gutenberg', 'gutenberg' ); ?></a>
-					<a class="button" title="<?php esc_attr_e( 'Open this post in the classic editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $classic_edit_link ); ?>"><?php _e( 'Classic Editor', 'gutenberg' ); ?></a>
-						<?php
-						if ( $revisions_link ) {
-							?>
-								<a class="button" title="<?php esc_attr_e( 'Open the revisions browser', 'gutenberg' ); ?>" href="<?php echo esc_url( $revisions_link ); ?>"><?php _e( 'Revisions', 'gutenberg' ); ?></a>
-							<?php
-						}
-						?>
+						<a class="button button-primary blocks-in-post-gutenberg-button" title="<?php esc_attr_e( 'Open this post in the Gutenberg block editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Edit in Gutenberg', 'gutenberg' ); ?></a>
+						<a class="button" title="<?php esc_attr_e( 'Open this post in the classic editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $classic_edit_link ); ?>"><?php _e( 'Edit in Classic Editor', 'gutenberg' ); ?></a>
 					</p>
 				</div>
 			</div>

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -161,10 +161,6 @@ function gutenberg_check_if_classic_needs_warning_about_blocks() {
 		return;
 	}
 
-	if ( isset( $_REQUEST['hide-block-warning'] ) ) {
-		return;
-	}
-
 	$post = get_post();
 	if ( ! $post ) {
 		return;
@@ -174,6 +170,8 @@ function gutenberg_check_if_classic_needs_warning_about_blocks() {
 		return;
 	}
 
+	// Enqueue the JS we're going to need in the dialog.
+	wp_enqueue_script( 'wp-a11y' );
 	wp_enqueue_script( 'wp-sanitize' );
 
 	add_action( 'admin_footer', 'gutenberg_warn_classic_about_blocks' );
@@ -208,12 +206,8 @@ function gutenberg_warn_classic_about_blocks() {
 	}
 	?>
 		<style type="text/css">
-			#blocks-in-post-dialog .blocks-in-post-message {
-				margin: 25px;
-			}
-
-			#blocks-in-post-dialog .post-locked-message a.button {
-				margin-right: 10px;
+			#blocks-in-post-dialog .notification-dialog {
+				padding: 25px;
 			}
 
 			@media only screen and (max-height: 480px), screen and (max-width: 450px) {
@@ -250,11 +244,11 @@ function gutenberg_warn_classic_about_blocks() {
 						<?php
 					}
 					?>
-					<p>
-						<a class="button button-primary blocks-in-post-gutenberg-button" title="<?php esc_attr_e( 'Open this post in the Gutenberg block editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Edit in Gutenberg', 'gutenberg' ); ?></a>
-						<a class="button" title="<?php esc_attr_e( 'Open this post in the classic editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $classic_edit_link ); ?>"><?php _e( 'Edit in Classic Editor', 'gutenberg' ); ?></a>
-					</p>
 				</div>
+				<p>
+					<a class="button button-primary blocks-in-post-gutenberg-button" title="<?php esc_attr_e( 'Open this post in the Gutenberg block editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Edit in Gutenberg', 'gutenberg' ); ?></a>
+					<button class="button blocks-in-post-classic-button" title="<?php esc_attr_e( 'Close this dialog, and edit the post in the classic editor', 'gutenberg' ); ?>"><?php _e( 'Continue to Classic Editor', 'gutenberg' ); ?></button>
+				</p>
 			</div>
 		</div>
 
@@ -287,6 +281,7 @@ function gutenberg_warn_classic_about_blocks() {
 
 					// Attach event handlers.
 					dialog.warningTabbables.on( 'keydown', dialog.constrainTabbing );
+					dialog.warning.on( 'click', '.blocks-in-post-classic-button', dialog.dismissWarning );
 
 					// Make screen readers announce the warning message after a short delay (necessary for some screen readers).
 					setTimeout( function() {
@@ -311,6 +306,13 @@ function gutenberg_warn_classic_about_blocks() {
 						lastTabbable.focus();
 						event.preventDefault();
 					}
+				};
+
+				dialog.dismissWarning = function() {
+					// Hide modal.
+					dialog.warning.remove();
+					$( '#wpwrap' ).removeAttr( 'aria-hidden' );
+					$( 'body' ).removeClass( 'modal-open' );
 				};
 
 				$( document ).ready( dialog.init );


### PR DESCRIPTION
## Description

The Classic Editor can do funky things to block markup, so it's nice to warn people before they try to edit block-based posts in the Classic Editor.

Fixes #8213.

## Screenshots

<img width="1279" alt="screen shot of the warning on desktop" src="https://user-images.githubusercontent.com/352291/43394584-94c39c1c-943e-11e8-82e7-29cf8660039a.png">

<img width="1279" alt="screen shot of the warning on mobile" src="https://user-images.githubusercontent.com/352291/43394589-98574784-943e-11e8-84b3-1616b07d9fe7.png">
