### PR TITLE
Remove unused terms, taxonomies and categories code

### DIFF
--- a/docs/data/data-core.md
+++ b/docs/data/data-core.md
@@ -2,54 +2,6 @@
 
 ## Selectors 
 
-### getTerms
-
-Returns all the available terms for the given taxonomy.
-
-*Parameters*
-
- * state: Data state.
- * taxonomy: Taxonomy name.
-
-### getCategories
-
-Returns all the available categories.
-
-*Parameters*
-
- * state: Data state.
-
-*Returns*
-
-Categories list.
-
-### isRequestingTerms
-
-Returns true if a request is in progress for terms data of a given taxonomy,
-or false otherwise.
-
-*Parameters*
-
- * state: Data state.
- * taxonomy: Taxonomy name.
-
-*Returns*
-
-Whether a request is in progress for taxonomy's terms.
-
-### isRequestingCategories
-
-Returns true if a request is in progress for categories data, or false
-otherwise.
-
-*Parameters*
-
- * state: Data state.
-
-*Returns*
-
-Whether a request is in progress for categories.
-
 ### getAuthors
 
 Returns all available authors.
@@ -117,16 +69,6 @@ Return theme supports data in the index.
 Index data.
 
 ## Actions
-
-### receiveTerms
-
-Returns an action object used in signalling that terms have been received
-for a given taxonomy.
-
-*Parameters*
-
- * taxonomy: Taxonomy name.
- * terms: Terms received.
 
 ### receiveUserQuery
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -3,6 +3,11 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 ## 3.7.0
 
  - `wp.components.withAPIData` has been removed. Please use the Core Data module or `wp.apiFetch` directly instead.
+ - `wp.data.dispatch("core").receiveTerms` has been deprecated. Please use `wp.data.dispatch("core").receiveEntityRecords` instead.
+ - `getCategories` resolvers has been deprecated. Please use `getEntityRecords` resolver instead.
+ - `wp.data.select("core").getTerms` has been deprecated. Please use `wp.data.select("core").getEntityRecords` instead.
+ - `wp.data.select("core").getCategories` has been deprecated. Please use `wp.data.select("core").getEntityRecords` instead.
+ - `wp.data.select("core").isRequestingTerms` has been deprecated. Please use `wp.data.select("core").getEntitiesByKind` instead.
 
 ## 3.6.0
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -14,33 +14,24 @@ npm install @wordpress/core-data --save
 
 ## Example
 
-Below is an example of a component which simply renders a list of categories:
+Below is an example of a component which simply renders a list of authors:
 
 ```jsx
 const { withSelect } = wp.data;
 
-function MyCategoriesList( { categories, isRequesting } ) {
-	if ( isRequesting ) {
-		return 'Loading…';
-	}
-
+function MyAuthorsList( { authors } ) {
 	return (
 		<ul>
-			{ categories.map( ( category ) => (
-				<li key={ category.id }>{ category.name }</li>
+			{ authors.map( ( author ) => (
+				<li key={ author.id }>{ author.name }</li>
 			) ) }
 		</ul>
 	);
 }
 
-MyCategoriesList = withSelect( ( select ) => {
-	const { getCategories, isRequestingCategories } = select( 'core' );
-
-	return {
-		categories: getCategories(),
-		isRequesting: isRequestingCategories(),
-	};
-} );
+MyAuthorsList = withSelect( ( select ) => ( {
+	authors: select( 'core' ).getAuthors(),
+} ) );
 ```
 
 ## Actions

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { castArray } from 'lodash';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -21,6 +22,11 @@ import {
  * @return {Object} Action object.
  */
 export function receiveTerms( taxonomy, terms ) {
+	deprecated( 'receiveTerms action', {
+		version: '3.6.0',
+		alternative: 'receiveEntityRecords action',
+		plugin: 'Gutenberg',
+	} );
 	return {
 		type: 'RECEIVE_TERMS',
 		taxonomy,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -23,7 +23,7 @@ import {
  */
 export function receiveTerms( taxonomy, terms ) {
 	deprecated( 'wp.data.dispatch("core").receiveTerms', {
-		version: '13.6.0',
+		version: '3.7.0',
 		alternative: 'wp.data.dispatch("core").receiveEntityRecords',
 		plugin: 'Gutenberg',
 	} );

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -22,9 +22,9 @@ import {
  * @return {Object} Action object.
  */
 export function receiveTerms( taxonomy, terms ) {
-	deprecated( 'receiveTerms action', {
-		version: '3.6.0',
-		alternative: 'receiveEntityRecords action',
+	deprecated( 'wp.data.dispatch("core").receiveTerms', {
+		version: '13.6.0',
+		alternative: 'wp.data.dispatch("core").receiveEntityRecords',
 		plugin: 'Gutenberg',
 	} );
 	return {

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -7,7 +7,6 @@ import { keyBy, map, groupBy, flowRight } from 'lodash';
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -197,18 +196,6 @@ export const entities = ( state = {}, action ) => {
 		config: newConfig,
 	};
 };
-
-deprecated( 'terms reducer', {
-	version: '13.6.0',
-	alternative: 'entities reducer',
-	plugin: 'Gutenberg',
-} );
-
-deprecated( 'taxonomies reducer', {
-	version: '13.6.0',
-	alternative: 'entities reducer',
-	plugin: 'Gutenberg',
-} );
 
 export default combineReducers( {
 	terms,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -7,6 +7,7 @@ import { keyBy, map, groupBy, flowRight } from 'lodash';
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -196,6 +197,18 @@ export const entities = ( state = {}, action ) => {
 		config: newConfig,
 	};
 };
+
+deprecated( 'terms reducer', {
+	version: '13.6.0',
+	alternative: 'entities reducer',
+	plugin: 'Gutenberg',
+} );
+
+deprecated( 'taxonomies reducer', {
+	version: '13.6.0',
+	alternative: 'entities reducer',
+	plugin: 'Gutenberg',
+} );
 
 export default combineReducers( {
 	terms,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -27,7 +27,7 @@ import { getKindEntities } from './entities';
  */
 export async function* getCategories() {
 	deprecated( 'getCategories resolver', {
-		version: '3.6.0',
+		version: '3.7.0',
 		alternative: 'getEntityRecords resolver',
 		plugin: 'Gutenberg',
 	} );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -8,6 +8,7 @@ import { find } from 'lodash';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -25,6 +26,11 @@ import { getKindEntities } from './entities';
  * progress.
  */
 export async function* getCategories() {
+	deprecated( 'getCategories resolver', {
+		version: '3.6.0',
+		alternative: 'getEntityRecords resolver',
+		plugin: 'Gutenberg',
+	} );
 	const categories = await apiFetch( { path: '/wp/v2/categories?per_page=-1' } );
 	yield receiveTerms( 'categories', categories );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -39,7 +39,7 @@ function isResolving( selectorName, ...args ) {
  */
 export function getTerms( state, taxonomy ) {
 	deprecated( 'wp.data.select("core").getTerms', {
-		version: '13.6.0',
+		version: '3.7.0',
 		alternative: 'wp.data.select("core").getEntityRecords',
 		plugin: 'Gutenberg',
 	} );
@@ -55,7 +55,7 @@ export function getTerms( state, taxonomy ) {
  */
 export function getCategories( state ) {
 	deprecated( 'wp.data.select("core").getCategories', {
-		version: '13.6.0',
+		version: '3.7.0',
 		alternative: 'wp.data.select("core").getEntityRecords',
 		plugin: 'Gutenberg',
 	} );
@@ -73,7 +73,7 @@ export function getCategories( state ) {
  */
 export function isRequestingTerms( state, taxonomy ) {
 	deprecated( 'wp.data.select("core").isRequestingTerms', {
-		version: '13.6.0',
+		version: '3.7.0',
 		alternative: 'wp.data.select("core").getEntitiesByKind',
 		plugin: 'Gutenberg',
 	} );
@@ -90,7 +90,7 @@ export function isRequestingTerms( state, taxonomy ) {
  */
 export function isRequestingCategories() {
 	deprecated( 'wp.data.select("core").isRequestingCategories', {
-		version: '13.6.0',
+		version: '3.7.0',
 		alternative: 'wp.data.select("core").getEntitiesByKind',
 		plugin: 'Gutenberg',
 	} );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -38,9 +38,9 @@ function isResolving( selectorName, ...args ) {
  * @return {Array} Categories list.
  */
 export function getTerms( state, taxonomy ) {
-	deprecated( 'getTerms selector', {
-		version: '3.6.0',
-		alternative: 'getEntityRecords selector',
+	deprecated( 'wp.data.select("core").getTerms', {
+		version: '13.6.0',
+		alternative: 'wp.data.select("core").getEntityRecords',
 		plugin: 'Gutenberg',
 	} );
 	return state.terms[ taxonomy ];
@@ -54,9 +54,9 @@ export function getTerms( state, taxonomy ) {
  * @return {Array} Categories list.
  */
 export function getCategories( state ) {
-	deprecated( 'getCategories selector', {
-		version: '3.6.0',
-		alternative: 'getEntityRecords selector',
+	deprecated( 'wp.data.select("core").getCategories', {
+		version: '13.6.0',
+		alternative: 'wp.data.select("core").getEntityRecords',
 		plugin: 'Gutenberg',
 	} );
 	return getTerms( state, 'categories' );
@@ -72,9 +72,9 @@ export function getCategories( state ) {
  * @return {boolean} Whether a request is in progress for taxonomy's terms.
  */
 export function isRequestingTerms( state, taxonomy ) {
-	deprecated( 'isRequestingTerms selector', {
-		version: '3.6.0',
-		alternative: 'getEntitiesByKind selector',
+	deprecated( 'wp.data.select("core").isRequestingTerms', {
+		version: '13.6.0',
+		alternative: 'wp.data.select("core").getEntitiesByKind',
 		plugin: 'Gutenberg',
 	} );
 	return isResolving( 'getTerms', taxonomy );
@@ -89,9 +89,9 @@ export function isRequestingTerms( state, taxonomy ) {
  * @return {boolean} Whether a request is in progress for categories.
  */
 export function isRequestingCategories() {
-	deprecated( 'isRequestingCategories selector', {
-		version: '3.6.0',
-		alternative: 'getEntitiesByKind selector',
+	deprecated( 'wp.data.select("core").isRequestingCategories', {
+		version: '13.6.0',
+		alternative: 'wp.data.select("core").getEntitiesByKind',
 		plugin: 'Gutenberg',
 	} );
 	return isResolving( 'getCategories' );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -72,6 +72,11 @@ export function getCategories( state ) {
  * @return {boolean} Whether a request is in progress for taxonomy's terms.
  */
 export function isRequestingTerms( state, taxonomy ) {
+	deprecated( 'isRequestingTerms selector', {
+		version: '3.6.0',
+		alternative: 'getEntitiesByKind selector',
+		plugin: 'Gutenberg',
+	} );
 	return isResolving( 'getTerms', taxonomy );
 }
 
@@ -84,6 +89,11 @@ export function isRequestingTerms( state, taxonomy ) {
  * @return {boolean} Whether a request is in progress for categories.
  */
 export function isRequestingCategories() {
+	deprecated( 'isRequestingCategories selector', {
+		version: '3.6.0',
+		alternative: 'getEntitiesByKind selector',
+		plugin: 'Gutenberg',
+	} );
 	return isResolving( 'getCategories' );
 }
 

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -8,6 +8,7 @@ import { map, find, get, filter } from 'lodash';
  * WordPress dependencies
  */
 import { select } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -37,6 +38,11 @@ function isResolving( selectorName, ...args ) {
  * @return {Array} Categories list.
  */
 export function getTerms( state, taxonomy ) {
+	deprecated( 'getTerms selector', {
+		version: '3.6.0',
+		alternative: 'getEntityRecords selector',
+		plugin: 'Gutenberg',
+	} );
 	return state.terms[ taxonomy ];
 }
 
@@ -48,6 +54,11 @@ export function getTerms( state, taxonomy ) {
  * @return {Array} Categories list.
  */
 export function getCategories( state ) {
+	deprecated( 'getCategories selector', {
+		version: '3.6.0',
+		alternative: 'getEntityRecords selector',
+		plugin: 'Gutenberg',
+	} );
 	return getTerms( state, 'categories' );
 }
 

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -26,6 +26,7 @@ describe( 'getCategories', () => {
 		const fulfillment = getCategories();
 		const received = ( await fulfillment.next() ).value;
 		expect( received ).toEqual( receiveTerms( 'categories', CATEGORIES ) );
+		expect( console ).toHaveWarnedWith( 'getCategories resolver is deprecated and will be removed from Gutenberg in 3.7.0. Please use getEntityRecords resolver instead.' );
 	} );
 } );
 

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -30,6 +30,7 @@ describe( 'getTerms()', () => {
 			},
 		} );
 		expect( getTerms( state, 'categories' ) ).toEqual( [ { id: 1 } ] );
+		expect( console ).toHaveWarnedWith( 'wp.data.select("core").getTerms is deprecated and will be removed from Gutenberg in 3.7.0. Please use wp.data.select("core").getEntityRecords instead.' );
 	} );
 } );
 
@@ -51,6 +52,7 @@ describe( 'isRequestingCategories()', () => {
 	it( 'returns false if never requested', () => {
 		const result = isRequestingCategories();
 		expect( result ).toBe( false );
+		expect( console ).toHaveWarnedWith( 'wp.data.select("core").isRequestingCategories is deprecated and will be removed from Gutenberg in 3.7.0. Please use wp.data.select("core").getEntitiesByKind instead.' );
 	} );
 
 	it( 'returns false if categories resolution finished', () => {


### PR DESCRIPTION
This PR removes code that is no longer used.

### Open Questions

- [x] How should we go with removing this code? Does this need to be signaled anywhere?

### How has this been tested?

- Automatted tests: unit and e2e.
- Manually: tested that working with tags and categories still work (both within the post and in their wp-admin pages).
- Search for uses of these methods within the codebase.
