### PR TITLE
Fix a Text Selection Exception in Safari

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -442,10 +442,14 @@ export function isTextField( element ) {
 			contentEditable === 'true'
 		);
 	} catch ( error ) {
-		// Safari throws an exception (instead of `undefined`, like
-		// most other browsers) when trying to get selectionStart on
-		// non-text <input> elements that don't have the text
-		// selection API.
+		// Safari throws an exception when trying to get `selectionStart`
+		// on non-text <input> elements (which, understandably, don't
+		// have the text selection API). We catch this via a try/catch
+		// block, as opposed to a more explicit check of the element's
+		// input types, because of Safari's non-standard behavior. This
+		// also means we don't have to worry about the list of input
+		// types that support `selectionStart` changing as the HTML spec
+		// evolves over time.
 		return false;
 	}
 }

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -433,13 +433,21 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
  * @return {boolean} True if the element is an text field, false if not.
  */
 export function isTextField( element ) {
-	const { nodeName, selectionStart, contentEditable } = element;
+	try {
+		const { nodeName, selectionStart, contentEditable } = element;
 
-	return (
-		( nodeName === 'INPUT' && selectionStart !== null ) ||
-		( nodeName === 'TEXTAREA' ) ||
-		contentEditable === 'true'
-	);
+		return (
+			( nodeName === 'INPUT' && selectionStart !== null ) ||
+			( nodeName === 'TEXTAREA' ) ||
+			contentEditable === 'true'
+		);
+	} catch ( error ) {
+		// Safari throws an exception (instead of `undefined`, like
+		// most other browsers) when trying to get selectionStart on
+		// non-text <input> elements that don't have the text
+		// selection API.
+		return false;
+	}
 }
 
 /**


### PR DESCRIPTION
## Description
Wraps the `isTextField` logic inside a try/catch block to handle an exception when trying to get `selectionStart` on a non-text input in Safari.

Also adds an inline comment to explain the reasoning for the try/catch block, for future devs.

Fixes #8254.

(Text Selection Exception is also my new band name.)

## How has this been tested?
Manually in Safari

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->