### PR TITLE
Respect Posts Page

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -111,6 +111,10 @@ function is_gutenberg_page() {
 		return false;
 	}
 
+	if ( get_the_ID() == get_option( 'page_for_posts' ) && empty( $post->post_content ) ) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -111,10 +111,6 @@ function is_gutenberg_page() {
 		return false;
 	}
 
-	if ( get_the_ID() == get_option( 'page_for_posts' ) && empty( $post->post_content ) ) {
-		return false;
-	}
-
 	return true;
 }
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -269,7 +269,8 @@ function gutenberg_can_edit_post( $post ) {
 		return false;
 	}
 
-	if ( $post->ID == get_option( 'page_for_posts' ) && empty( $post->post_content ) ) {
+	// Disable the editor if on the blog page and there is no content.
+	if ( absint( get_option( 'page_for_posts' ) ) === $post->ID && empty( $post->post_content ) ) {
 		return false;
 	}
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -269,6 +269,10 @@ function gutenberg_can_edit_post( $post ) {
 		return false;
 	}
 
+	if ( $post->ID == get_option( 'page_for_posts' ) && empty( $post->post_content ) ) {
+		return false;
+	}
+
 	if ( ! gutenberg_can_edit_post_type( $post->post_type ) ) {
 		return false;
 	}

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -75,6 +75,20 @@ class Admin_Test extends WP_UnitTestCase {
 
 		wp_set_current_user( self::$editor_user_id );
 		$this->assertTrue( gutenberg_can_edit_post( $generic_post_id ) );
+
+		$blog_page_without_content = self::factory()->post->create( array(
+			'post_title'   => 'Blog',
+			'post_content' => '',
+		) );
+		update_option( 'page_for_posts', $blog_page_without_content );
+		$this->assertFalse( gutenberg_can_edit_post( $blog_page_without_content ) );
+
+		$blog_page_with_content = self::factory()->post->create( array(
+			'post_title'   => 'Blog',
+			'post_content' => 'Hello World!',
+		) );
+		update_option( 'page_for_posts', $blog_page_with_content );
+		$this->assertTrue( gutenberg_can_edit_post( $blog_page_with_content ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Ensure that Gutenberg is disabled when on the assigned blog page in WordPress. Provides feature parity as per functionality from https://github.com/WordPress/WordPress/blob/master/wp-admin/edit-form-advanced.php#L73).

Fixes https://github.com/WordPress/gutenberg/issues/3659

## How has this been tested?

Tested manually as follows:

1. From 'Settings' > 'Reading' in the admin, make sure you configure the 'Your homepage displays' section to have a 'Posts page' configured. (The posts page should have no content on it)
2. Visit the posts page edit screen in the WordPress admin.
3. The blog page should not utilize Gutenberg and should show a "You are currently editing the page that shows your latest posts." message.

Added unit tests to ensure the gutenberg_can_edit_post() function returns false when attempting to edit the posts page if it does not have content and returns true when it does have content.

## Screenshots
![edit_page_ _gutenberg_ _wordpress](https://user-images.githubusercontent.com/890951/43345390-5d76bd14-91bb-11e8-8619-6dbe9c62f8d0.png)

## Types of changes
Bug fix - adds a check to the `gutenberg_can_edit_post()` function and returns false if it is the posts page and has no content. 

## Checklist:
- [ ✓] My code is tested.
- [✓ ] My code follows the WordPress code style.
- [ ✓] My code follows the accessibility standards.
- [✓ ] My code has proper inline documentation.
