### PR TITLE
Don't register rewrite rules for the wp_blocks post type

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -390,6 +390,7 @@ function gutenberg_register_post_types() {
 			'singular_name' => 'Block',
 		),
 		'public'                => false,
+		'rewrite'               => false,
 		'show_in_rest'          => true,
 		'rest_base'             => 'blocks',
 		'rest_controller_class' => 'WP_REST_Blocks_Controller',


### PR DESCRIPTION
## Description
Sets rewrite to false so rewrite rules aren't generated for shared/reusable blocks (the `wp_block` post type).

Fixes #8233.

## How has this been tested?
Tested with the `wp rewrite list` CLI command and then creating a shared/reusable block and inserting it into another page.

## Types of changes
Bug fix; removes unused rewrite rules for shared/reusable blocks

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->