### PR TITLE
Fix/unit tests code coverage

### DIFF
--- a/packages/jest-preset-default/jest-preset.json
+++ b/packages/jest-preset-default/jest-preset.json
@@ -23,7 +23,7 @@
 	],
 	"timers": "fake",
 	"transform": {
-		"^.+\\.jsx?$": "babel-jest"
+		"^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest"
 	},
 	"verbose": true
 }

--- a/packages/jest-preset-default/jest-preset.json
+++ b/packages/jest-preset-default/jest-preset.json
@@ -3,7 +3,8 @@
 	"coveragePathIgnorePatterns": [
 		"/node_modules/",
 		"<rootDir>/.*/build/",
-		"<rootDir>/.*/build-module/"
+		"<rootDir>/.*/build-module/",
+		"<rootDir>/.*/test/"
 	],
 	"moduleNameMapper": {
 		"\\.(scss|css)$": "<rootDir>/node_modules/@wordpress/jest-preset-default/scripts/style-mock.js"

--- a/test/unit/jest.config.json
+++ b/test/unit/jest.config.json
@@ -8,7 +8,8 @@
 		"/node_modules/",
 		"<rootDir>/.*/build/",
 		"<rootDir>/.*/build-module/",
-		"<rootDir>/packages/.*/benchmark/"
+		"<rootDir>/packages/.*/benchmark/",
+		"<rootDir>/packages/.*/test/"
 	],
 	"moduleNameMapper": {
 		"@wordpress\\/(components|edit-post|core-blocks)$": "$1",


### PR DESCRIPTION
## Description
Small tweaks to unit tests setup. I noticed that subfolders aren't ignored when computing code coverage.

We had also report from @nerrad that published preset doesn't work properly with `babel-jest`. Let's try and use `roodDir` based path to see if that helps. This is how all other paths are built and it seems to be standard in other FB maintained presets. 

## How has this been tested?
`npm run test-unit:coverage`
