### PR TITLE
Fix components styles import

### DIFF
--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -8,11 +8,6 @@ import classnames from 'classnames';
  */
 import { createElement, forwardRef } from '@wordpress/element';
 
-/**
- * Internal dependencies
- */
-import './style.scss';
-
 export function Button( props, ref ) {
 	const {
 		href,

--- a/packages/components/src/color-indicator/index.js
+++ b/packages/components/src/color-indicator/index.js
@@ -3,11 +3,6 @@
  */
 import classnames from 'classnames';
 
-/**
- * Internal dependencies
- */
-import './style.scss';
-
 const ColorIndicator = ( { className, colorValue, ...props } ) => (
 	<span
 		className={ classnames( 'component-color-indicator', className ) }

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -3,6 +3,7 @@
 @import './button-group/style.scss';
 @import './button/style.scss';
 @import './checkbox-control/style.scss';
+@import './color-indicator/style.scss';
 @import './color-palette/style.scss';
 @import './dashicon/style.scss';
 @import './date-time/style.scss';


### PR DESCRIPTION
#7924 added a new `ColorIndicator` component that was importing the styles in the wrong file. This PR moves the import to `packages/components/src/style.scss`.

This also removes a style import that is not needed in the Button component (added in #7883)

Note that changes done in #7924 and #7883 have not been published to npm yet.