### PR TITLE
Add components examples in README.md files - Part 1

### DIFF
--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -110,54 +110,54 @@ Whether to apply debouncing for the autocompleter. Set to true to enable debounc
 The following is a contrived completer for fresh fruit.
 
 ```jsx
-class FreshFruitAutocomplete extends React.Component {
-	render() {
-		const autocompleters = [
-			{
-				name: 'fruit',
-				// The prefix that triggers this completer
-				triggerPrefix: '~',
-				// The option data
-				options: [
-					{ visual: '🍎', name: 'Apple', id: 1 },
-					{ visual: '🍊', name: 'Orange', id: 2 },
-					{ visual: '🍇', name: 'Grapes', id: 3 },
-				],
-				// Returns a label for an option like "🍊 Orange"
-				getOptionLabel: option => (
-					<span>
-						<span className="icon" >{ option.visual }</span>{ option.name }
-					</span>
-				),
-				// Declares that options should be matched by their name
-				getOptionKeywords: option => [ option.name ],
-				// Declares that the Grapes option is disabled
-				isOptionDisabled: option => option.name === 'Grapes',
-				// Declares completions should be inserted as abbreviations
-				getOptionCompletion: option => (
-					<abbr title={ option.name }>{ option.visual }</abbr>
-				),
-			}
-		];
+import { Autocomplete } from '@wordpress/components';
+
+function FreshFruitAutocomplete() {
+	const autocompleters = [
+		{
+			name: 'fruit',
+			// The prefix that triggers this completer
+			triggerPrefix: '~',
+			// The option data
+			options: [
+				{ visual: '🍎', name: 'Apple', id: 1 },
+				{ visual: '🍊', name: 'Orange', id: 2 },
+				{ visual: '🍇', name: 'Grapes', id: 3 },
+			],
+			// Returns a label for an option like "🍊 Orange"
+			getOptionLabel: option => (
+				<span>
+					<span className="icon" >{ option.visual }</span>{ option.name }
+				</span>
+			),
+			// Declares that options should be matched by their name
+			getOptionKeywords: option => [ option.name ],
+			// Declares that the Grapes option is disabled
+			isOptionDisabled: option => option.name === 'Grapes',
+			// Declares completions should be inserted as abbreviations
+			getOptionCompletion: option => (
+				<abbr title={ option.name }>{ option.visual }</abbr>
+			),
+		}
+	];
 		
-		return (
-			<div>
-				<Autocomplete completers={ autocompleters }>
-					{ ( { isExpanded, listBoxId, activeId } ) => (
-						<div
-							contentEditable
-							suppressContentEditableWarning
-							aria-autocomplete="list"
-							aria-expanded={ isExpanded }
-							aria-owns={ listBoxId }
-							aria-activedescendant={ activeId }
-						>
-						</div>
-					) }
-				</Autocomplete>
-				<p>Type ~ for triggering the autocomplete.</p>
-			</div>
-		);
-	}
+	return (
+		<div>
+			<Autocomplete completers={ autocompleters }>
+				{ ( { isExpanded, listBoxId, activeId } ) => (
+					<div
+						contentEditable
+						suppressContentEditableWarning
+						aria-autocomplete="list"
+						aria-expanded={ isExpanded }
+						aria-owns={ listBoxId }
+						aria-activedescendant={ activeId }
+					>
+					</div>
+				) }
+			</Autocomplete>
+			<p>Type ~ for triggering the autocomplete.</p>
+		</div>
+	);
 };
 ```

--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -1,5 +1,4 @@
-Autocomplete
-============
+# Autocomplete
 
 This component is used to provide autocompletion support for a child input component.
 

--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -105,33 +105,59 @@ Whether to apply debouncing for the autocompleter. Set to true to enable debounc
 - Type: `Boolean`
 - Required: No
 
-### Examples
+## Usage
 
 The following is a contrived completer for fresh fruit.
 
 ```jsx
-const fruitCompleter = {
-	name: 'fruit',
-	// The prefix that triggers this completer
-	triggerPrefix: '~',
-	// The option data
-	options: [
-		{ visual: '🍎', name: 'Apple' },
-		{ visual: '🍊', name: 'Orange' },
-		{ visual: '🍇', name: 'Grapes' },
-	],
-	// Returns a label for an option like "🍊 Orange"
-	getOptionLabel: option => [
-		<span class="icon">{ option.visual }</span>,
-		option.name
-	],
-	// Declares that options should be matched by their name
-	getOptionKeywords: option => [ option.name ],
-	// Declares that the Grapes option is disabled
-	isOptionDisabled: option => option.name === 'Grapes',
-	// Declares completions should be inserted as abbreviations
-	getOptionCompletion: option => (
-		<abbr title={ option.name }>{ option.visual }</abbr>
-	),
+class FreshFruitAutocomplete extends React.Component {
+	render() {
+		const autocompleters = [
+			{
+				name: 'fruit',
+				// The prefix that triggers this completer
+				triggerPrefix: '~',
+				// The option data
+				options: [
+					{ visual: '🍎', name: 'Apple', id: 1 },
+					{ visual: '🍊', name: 'Orange', id: 2 },
+					{ visual: '🍇', name: 'Grapes', id: 3 },
+				],
+				// Returns a label for an option like "🍊 Orange"
+				getOptionLabel: option => (
+					<span>
+						<span className="icon" >{ option.visual }</span>{ option.name }
+					</span>
+				),
+				// Declares that options should be matched by their name
+				getOptionKeywords: option => [ option.name ],
+				// Declares that the Grapes option is disabled
+				isOptionDisabled: option => option.name === 'Grapes',
+				// Declares completions should be inserted as abbreviations
+				getOptionCompletion: option => (
+					<abbr title={ option.name }>{ option.visual }</abbr>
+				),
+			}
+		];
+		
+		return (
+			<div>
+				<Autocomplete completers={ autocompleters }>
+					{ ( { isExpanded, listBoxId, activeId } ) => (
+						<div
+							contentEditable
+							suppressContentEditableWarning
+							aria-autocomplete="list"
+							aria-expanded={ isExpanded }
+							aria-owns={ listBoxId }
+							aria-activedescendant={ activeId }
+						>
+						</div>
+					) }
+				</Autocomplete>
+				<p>Type ~ for triggering the autocomplete.</p>
+			</div>
+		);
+	}
 };
 ```

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -8,17 +8,19 @@ BaseControl component is used to generate labels and help text for components ha
 
 Render a BaseControl for a textarea input:
 ```jsx
-	<BaseControl
-		id="textarea-1" 
-		label="Text"
-		help="Enter some text"
-	>
-        <textarea
-            id="textarea-1"
-            onChange={ onChangeValue }
-            value={ value }
-        />
-    </BaseControl>
+function MyBaseControl() {
+	return (
+		<BaseControl
+			id="textarea-1"
+			label="Text"
+			help="Enter some text"
+		>
+			<textarea
+				id="textarea-1"
+			/>
+		</BaseControl>
+    );
+}
 ```
 
 ## Props

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -1,5 +1,5 @@
 BaseControl
-=======
+===========
 
 BaseControl component is used to generate labels and help text for components handling user inputs.
 
@@ -8,6 +8,8 @@ BaseControl component is used to generate labels and help text for components ha
 
 Render a BaseControl for a textarea input:
 ```jsx
+import { BaseControl } from '@wordpress/components';
+
 function MyBaseControl() {
 	return (
 		<BaseControl

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -1,5 +1,4 @@
-BaseControl
-===========
+# BaseControl
 
 BaseControl component is used to generate labels and help text for components handling user inputs.
 

--- a/packages/components/src/button-group/README.md
+++ b/packages/components/src/button-group/README.md
@@ -4,6 +4,8 @@ ButtonGroup
 ## Usage
 
 ```jsx
+import { Button, ButtonGroup } from '@wordpress/components';
+
 function MyButtonGroup() {
 	return (
 		<ButtonGroup>

--- a/packages/components/src/button-group/README.md
+++ b/packages/components/src/button-group/README.md
@@ -1,5 +1,4 @@
-ButtonGroup
-===========
+# ButtonGroup
 
 ## Usage
 

--- a/packages/components/src/button-group/README.md
+++ b/packages/components/src/button-group/README.md
@@ -4,7 +4,7 @@ ButtonGroup
 ## Usage
 
 ```jsx
-function Example() {
+function MyButtonGroup() {
 	return (
 		<ButtonGroup>
 			<Button isPrimary>Button 1</Button>

--- a/packages/components/src/button-group/README.md
+++ b/packages/components/src/button-group/README.md
@@ -1,7 +1,7 @@
 ButtonGroup
 ===========
 
-## Example
+## Usage
 
 ```jsx
 function Example() {

--- a/packages/components/src/button-group/README.md
+++ b/packages/components/src/button-group/README.md
@@ -1,0 +1,15 @@
+ButtonGroup
+===========
+
+## Example
+
+```jsx
+function Example() {
+	return (
+		<ButtonGroup>
+			<Button isPrimary>Button 1</Button>
+			<Button isPrimary>Button 2</Button>
+		</ButtonGroup>
+	);
+}
+```

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -14,7 +14,7 @@ Renders a button with default style.
  */
 import { Button } from "@wordpress/components";
 
-export default function ClickMeButton() {
+function Example() {
 	return (
 		<Button isDefault>
 			Click me!

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -9,12 +9,9 @@ The presence of a `href` prop determines whether an `anchor` element is rendered
 Renders a button with default style.
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { Button } from "@wordpress/components";
 
-function Example() {
+function MyButton() {
 	return (
 		<Button isDefault>
 			Click me!

--- a/packages/components/src/checkbox-control/README.md
+++ b/packages/components/src/checkbox-control/README.md
@@ -8,13 +8,16 @@ CheckboxControl component is used to generate a checkbox input field.
 
 Render an is author checkbox:
 ```jsx
-    <CheckboxControl
-        heading="User"
-        label="Is author"
-        help="Is the user a author or not?"
-        checked={ checked }
-        onChange={ onChange }
-    />
+function MyCheckboxControl() {
+	return (
+		<CheckboxControl
+			heading="User"
+			label="Is author"
+			help="Is the user a author or not?"
+			onChange={ () => {} }
+		/>
+	);
+}
 ```
 
 ## Props

--- a/packages/components/src/checkbox-control/README.md
+++ b/packages/components/src/checkbox-control/README.md
@@ -8,17 +8,19 @@ CheckboxControl component is used to generate a checkbox input field.
 Render an is author checkbox:
 ```jsx
 import { CheckboxControl } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
-function MyCheckboxControl() {
-	return (
-		<CheckboxControl
-			heading="User"
-			label="Is author"
-			help="Is the user a author or not?"
-			onChange={ () => {} }
-		/>
-	);
-}
+withState( {
+	isChecked: true,
+} )( ( { isChecked, setState } ) => ( 
+	<CheckboxControl
+		heading="User"
+		label="Is author"
+		help="Is the user a author or not?"
+		checked={ isChecked }
+		onChange={ ( isChecked ) => { setState( { isChecked } ) } }
+	/>
+) )
 ```
 
 ## Props

--- a/packages/components/src/checkbox-control/README.md
+++ b/packages/components/src/checkbox-control/README.md
@@ -1,5 +1,4 @@
-CheckboxControl
-=======
+# CheckboxControl
 
 CheckboxControl component is used to generate a checkbox input field.
 

--- a/packages/components/src/checkbox-control/README.md
+++ b/packages/components/src/checkbox-control/README.md
@@ -8,6 +8,8 @@ CheckboxControl component is used to generate a checkbox input field.
 
 Render an is author checkbox:
 ```jsx
+import { CheckboxControl } from '@wordpress/components';
+
 function MyCheckboxControl() {
 	return (
 		<CheckboxControl

--- a/packages/components/src/clipboard-button/README.md
+++ b/packages/components/src/clipboard-button/README.md
@@ -4,25 +4,19 @@ ClipboardButton
 ## Usage
 
 ```jsx
-class MyClipboardButton extends React.Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			hasCopied: false,
-		};
-	}
+import { ClipboardButton } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
-	render() {		
-		return (
-			<ClipboardButton
-				isPrimary
-				text="WordPress"
-				onCopy={ () => this.setState( { hasCopied: true } ) }
-				onFinishCopy={ () => this.setState( { hasCopied: false } ) }
-			>
-				{ this.state.hasCopied ? 'Copied!' : 'Copy Text' }
-			</ClipboardButton>
-		);
-	}
-}
+withState( {
+	hasCopied: false,
+} )( ( { hasCopied, setState } ) => ( 
+	<ClipboardButton
+		isPrimary
+		text="WordPress"
+		onCopy={ () => setState( { hasCopied: true } ) }
+		onFinishCopy={ () => setState( { hasCopied: false } ) }
+	>
+		{ hasCopied ? 'Copied!' : 'Copy Text' }
+	</ClipboardButton>
+) )
 ```

--- a/packages/components/src/clipboard-button/README.md
+++ b/packages/components/src/clipboard-button/README.md
@@ -1,0 +1,28 @@
+ClipboardButton
+===============
+
+## Usage
+
+```jsx
+class MyClipboardButton extends React.Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			hasCopied: false,
+		};
+	}
+
+	render() {		
+		return (
+			<ClipboardButton
+				isPrimary
+				text="WordPress"
+				onCopy={ () => this.setState( { hasCopied: true } ) }
+				onFinishCopy={ () => this.setState( { hasCopied: false } ) }
+			>
+				{ this.state.hasCopied ? 'Copied!' : 'Copy Text' }
+			</ClipboardButton>
+		);
+	}
+}
+```

--- a/packages/components/src/clipboard-button/README.md
+++ b/packages/components/src/clipboard-button/README.md
@@ -11,7 +11,7 @@ withState( {
 } )( ( { hasCopied, setState } ) => ( 
 	<ClipboardButton
 		isPrimary
-		text="WordPress"
+		text="Text to be copied."
 		onCopy={ () => setState( { hasCopied: true } ) }
 		onFinishCopy={ () => setState( { hasCopied: false } ) }
 	>

--- a/packages/components/src/clipboard-button/README.md
+++ b/packages/components/src/clipboard-button/README.md
@@ -1,5 +1,4 @@
-ClipboardButton
-===============
+# ClipboardButton
 
 ## Usage
 

--- a/packages/components/src/color-indicator/README.md
+++ b/packages/components/src/color-indicator/README.md
@@ -1,0 +1,13 @@
+ColorIndicator
+==============
+## Usage
+
+```jsx
+import { ColorIndicator } from '@wordpress/components';
+
+function MyColorIndicator() {
+	return (
+		<ColorIndicator colorValue="#f00" />
+	);
+}
+```

--- a/packages/components/src/color-indicator/README.md
+++ b/packages/components/src/color-indicator/README.md
@@ -1,5 +1,5 @@
-ColorIndicator
-==============
+# ColorIndicator
+
 ## Usage
 
 ```jsx

--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -1,0 +1,22 @@
+ColorPalette
+============
+
+## Usage
+```jsx
+import { ColorPalette } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
+
+withState( {
+	color: '#f00',
+} )( ( { color, setState } ) => { 
+	const colors = [ { name: 'red', color: '#f00' }, { name: 'white', color: '#fff' }, { name: 'blue', color: '#00f' } ];
+	
+	return ( 
+		<ColorPalette 
+			colors={ colors } 
+			value={ color }
+			onChange={ color => setState( { color } ) } 
+		/>
+	) 
+} )
+```

--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -1,5 +1,4 @@
-ColorPalette
-============
+# ColorPalette
 
 ## Usage
 ```jsx

--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -8,7 +8,11 @@ import { withState } from '@wordpress/compose';
 withState( {
 	color: '#f00',
 } )( ( { color, setState } ) => { 
-	const colors = [ { name: 'red', color: '#f00' }, { name: 'white', color: '#fff' }, { name: 'blue', color: '#00f' } ];
+	const colors = [ 
+		{ name: 'red', color: '#f00' }, 
+		{ name: 'white', color: '#fff' }, 
+		{ name: 'blue', color: '#00f' }, 
+	];
 	
 	return ( 
 		<ColorPalette 

--- a/packages/components/src/dashicon/README.md
+++ b/packages/components/src/dashicon/README.md
@@ -1,7 +1,7 @@
 Dashicon
-===========
+========
 
-## Example
+## Usage
 
 ```jsx
 function Example() {

--- a/packages/components/src/dashicon/README.md
+++ b/packages/components/src/dashicon/README.md
@@ -4,6 +4,8 @@ Dashicon
 ## Usage
 
 ```jsx
+import { Dashicon } from '@wordpress/components';
+
 function MyDashicons() {
 	return (
 		<div>

--- a/packages/components/src/dashicon/README.md
+++ b/packages/components/src/dashicon/README.md
@@ -1,0 +1,16 @@
+Dashicon
+===========
+
+## Example
+
+```jsx
+function Example() {
+	return (
+		<div>
+			<Dashicon icon="admin-home" />
+			<Dashicon icon="products" />
+			<Dashicon icon="wordpress" />
+		</div>
+	);
+}
+```

--- a/packages/components/src/dashicon/README.md
+++ b/packages/components/src/dashicon/README.md
@@ -1,5 +1,4 @@
-Dashicon
-========
+# Dashicon
 
 ## Usage
 

--- a/packages/components/src/dashicon/README.md
+++ b/packages/components/src/dashicon/README.md
@@ -4,7 +4,7 @@ Dashicon
 ## Usage
 
 ```jsx
-function Example() {
+function MyDashicons() {
 	return (
 		<div>
 			<Dashicon icon="admin-home" />

--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -1,5 +1,4 @@
-DateTimePicker
-=======
+# DateTimePicker
 
 DateTimePicker is a React component to render a calendar and clock for selecting a date and time. The calendar and clock components can be accessed individually using the `DatePicker` and `TimePicker` components respectively.
 

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -8,28 +8,40 @@ Disabled is a component which disables descendant tabbable elements and prevents
 Assuming you have a form component, you can disable all form inputs by wrapping the form with `<Disabled>`.
 
 ```jsx
-const DisableToggleForm = withState( {
-	isDisabled: true,
-} )( ( { isDisabled, setState } ) => {
-	let form = <form><input /></form>;
+class ToggleDisable extends React.Component {
 
-	if ( isDisabled ) {
-		form = <Disabled>{ form }</Disabled>;
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			isDisabled: false,
+		};
+		this.toggleDisabled = this.toggleDisabled.bind( this );
 	}
 
-	const toggleDisabled = setState( ( state ) => ( {
-		isDisabled: ! state.isDisabled,
-	} ) );
+	toggleDisabled() {
+		this.setState( state => ( {
+			isDisabled: ! state.isDisabled,
+		} ) );
+	};
 
-	return (
-		<div>
-			{ form }
-			<button onClick={ toggleDisabled }>
-				Toggle Disabled
-			</button>
-		</div>
-	);
-} )
+	render() {
+		const { isDisabled } = this.state;
+		
+		let input = <TextControl label="Input" />;
+		if ( isDisabled ) {
+			input = <Disabled>{ input }</Disabled>;
+		}
+		
+		return (
+			<div>
+				{ input }
+				<Button isPrimary onClick={ this.toggleDisabled }>
+					Toggle Disabled
+				</Button>
+			</div>
+		);
+	}
+}
 ```
 
 A component can detect if it has been wrapped in a `<Disabled>` by accessing its [context](https://reactjs.org/docs/context.html) using `Disabled.Consumer`.

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -26,7 +26,7 @@ withState( {
 	return (
 		<div>
 			{ input }
-			<Button  isPrimary onClick={ toggleDisabled }>
+			<Button isPrimary onClick={ toggleDisabled }>
 				Toggle Disabled
 			</Button>
 		</div>

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -9,7 +9,6 @@ Assuming you have a form component, you can disable all form inputs by wrapping 
 
 ```jsx
 class ToggleDisable extends React.Component {
-
 	constructor() {
 		super( ...arguments );
 		this.state = {
@@ -27,7 +26,7 @@ class ToggleDisable extends React.Component {
 	render() {
 		const { isDisabled } = this.state;
 		
-		let input = <TextControl label="Input" />;
+		let input = <TextControl label="Input" onChange={ () => {} } />;
 		if ( isDisabled ) {
 			input = <Disabled>{ input }</Disabled>;
 		}

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -1,5 +1,4 @@
-Disabled
-========
+# Disabled
 
 Disabled is a component which disables descendant tabbable elements and prevents pointer interaction.
 

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -8,39 +8,30 @@ Disabled is a component which disables descendant tabbable elements and prevents
 Assuming you have a form component, you can disable all form inputs by wrapping the form with `<Disabled>`.
 
 ```jsx
-class ToggleDisable extends React.Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			isDisabled: false,
-		};
-		this.toggleDisabled = this.toggleDisabled.bind( this );
-	}
+import { Button, Disabled, TextControl } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
-	toggleDisabled() {
-		this.setState( state => ( {
-			isDisabled: ! state.isDisabled,
-		} ) );
+withState( {
+	isDisabled: true,
+} )( ( { isDisabled, setState } ) => { 
+	let input = <TextControl label="Input" onChange={ () => {} } />;
+	if ( isDisabled ) {
+		input = <Disabled>{ input }</Disabled>;
+	}
+	
+	const toggleDisabled = () => {
+		setState( state => ( { isDisabled: ! state.isDisabled } ) );
 	};
-
-	render() {
-		const { isDisabled } = this.state;
-		
-		let input = <TextControl label="Input" onChange={ () => {} } />;
-		if ( isDisabled ) {
-			input = <Disabled>{ input }</Disabled>;
-		}
-		
-		return (
-			<div>
-				{ input }
-				<Button isPrimary onClick={ this.toggleDisabled }>
-					Toggle Disabled
-				</Button>
-			</div>
-		);
-	}
-}
+	
+	return (
+		<div>
+			{ input }
+			<Button  isPrimary onClick={ toggleDisabled }>
+				Toggle Disabled
+			</Button>
+		</div>
+	);
+} )
 ```
 
 A component can detect if it has been wrapped in a `<Disabled>` by accessing its [context](https://reactjs.org/docs/context.html) using `Disabled.Consumer`.

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -19,7 +19,7 @@ withState( {
 	}
 	
 	const toggleDisabled = () => {
-		setState( state => ( { isDisabled: ! state.isDisabled } ) );
+		setState( ( state ) => ( { isDisabled: ! state.isDisabled } ) );
 	};
 	
 	return (

--- a/packages/components/src/draggable/README.md
+++ b/packages/components/src/draggable/README.md
@@ -35,3 +35,24 @@ The function called when dragging ends.
 - Type: `Function`
 - Required: No
 - Default: `noop`
+
+## Usage
+
+```jsx
+function DraggablePanel() {
+	return (
+		<div id="draggable-panel">
+			<Panel header="Draggable panel" >
+				<PanelBody>
+					<Draggable
+						elementId="draggable-panel"
+						transferData={ { } }
+					>
+						<Dashicon icon="move" />
+					</Draggable>
+				</PanelBody>
+			</Panel>
+		</div>
+	);
+}
+```

--- a/packages/components/src/draggable/README.md
+++ b/packages/components/src/draggable/README.md
@@ -39,6 +39,8 @@ The function called when dragging ends.
 ## Usage
 
 ```jsx
+import { Dashicon, Draggable, Panel, PanelBody } from '@wordpress/components';
+
 function DraggablePanel() {
 	return (
 		<div id="draggable-panel">

--- a/packages/components/src/drop-zone/README.md
+++ b/packages/components/src/drop-zone/README.md
@@ -5,13 +5,18 @@
 ## Usage
 
 ```jsx
-import { DropZoneProvider, DropZone } from '@wordpress/components';
+import { DropZoneProvider, DropZone, Panel } from '@wordpress/components';
 
 function MyComponent() {
 	return (
 		<DropZoneProvider>
 			<div>
-				<DropZone onDrop={ () => console.log( 'do something' ) } />
+				Drop something here
+				<DropZone 
+					onFilesDrop={ () => console.log( 'do something' ) }
+					onHTMLDrop={ () => console.log( 'do something' ) }
+					onDrop={ () => console.log( 'do something' ) } 
+				/>
 			</div>
 		</DropZoneProvider>
 	);

--- a/packages/components/src/drop-zone/README.md
+++ b/packages/components/src/drop-zone/README.md
@@ -5,22 +5,23 @@
 ## Usage
 
 ```jsx
-import { DropZoneProvider, DropZone, Panel } from '@wordpress/components';
+import { DropZoneProvider, DropZone } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
-function MyComponent() {
-	return (
-		<DropZoneProvider>
-			<div>
-				Drop something here
-				<DropZone 
-					onFilesDrop={ () => console.log( 'do something' ) }
-					onHTMLDrop={ () => console.log( 'do something' ) }
-					onDrop={ () => console.log( 'do something' ) } 
-				/>
-			</div>
-		</DropZoneProvider>
-	);
-}
+withState( {
+	hasDropped: false,
+} )( ( { hasDropped, setState } ) => (
+	<DropZoneProvider>
+		<div>
+			{ hasDropped ? 'Dropped!' : 'Drop something here' }
+			<DropZone 
+				onFilesDrop={ () => setState( { hasDropped: true } ) }
+				onHTMLDrop={ () => setState( { hasDropped: true } )  }
+				onDrop={ () => setState( { hasDropped: true } ) } 
+			/>
+		</div>
+	</DropZoneProvider>
+) );
 ```
 
 ## Props

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -10,7 +10,7 @@ Render a Dropdown Menu with a set of controls:
 ```jsx
 import { DropdownMenu } from '@wordpress/components';
 
-function DirectionMenu( { onMove } ) {
+function DirectionMenu() {
 	return (
 		<DropdownMenu
 			icon="move"
@@ -19,22 +19,22 @@ function DirectionMenu( { onMove } ) {
 				{
 					title: 'Up',
 					icon: 'arrow-up-alt',
-					onClick: () => onMove( 'up' )
+					onClick: () => console.log( 'up' )
 				},
 				{
 					title: 'Right',
 					icon: 'arrow-right-alt',
-					onClick: () => onMove( 'right' )
+					onClick: () => console.log( 'right' )
 				},
 				{
 					title: 'Down',
 					icon: 'arrow-down-alt',
-					onClick: () => onMove( 'down' )
+					onClick: () => console.log( 'down' )
 				},
 				{
 					title: 'Left',
 					icon: 'arrow-left-alt',
-					onClick: () => onMove( 'left' )
+					onClick: () => console.log( 'left' )
 				},
 			] }
 		/>

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -1,5 +1,4 @@
-Dropdown Menu
-=============
+# Dropdown Menu
 
 Dropdown Menu is a React component to render an expandable menu of buttons. It is similar in purpose to a `<select>` element, with the distinction that it does not maintain a value. Instead, each option behaves as an action button.
 

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -1,5 +1,4 @@
-Dropdown
-========
+# Dropdown
 
 Dropdown is a React component to render a button that opens a floating content modal when clicked.
 This components takes care of updating the state of the dropdown menu (opened/closed), handles closing the menu when clicking outside

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -9,7 +9,7 @@ and uses render props to render the button and the content.
 
 
 ```jsx
-import { Dropdown } from '@wordpress/components';
+import { Button, Dropdown } from '@wordpress/components';
 
 function MyDropdownMenu() {
 	return (
@@ -18,9 +18,9 @@ function MyDropdownMenu() {
 			contentClassName="my-popover-content-classname"
 			position="bottom right"
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<button onClick={ onToggle } aria-expanded={ isOpen }>
+				<Button isPrimary onClick={ onToggle } aria-expanded={ isOpen }>
 					Toggle Popover!
-				</button>
+				</Button>
 			) }
 			renderContent={ () => (
 				<div>

--- a/packages/components/src/external-link/README.md
+++ b/packages/components/src/external-link/README.md
@@ -7,7 +7,7 @@ import { ExternalLink } from '@wordpress/components';
 
 function MyExternalLink() {
 	return (
-		<ExternalLink href="https://wordpress.com">WordPress.com</ExternalLink>
+		<ExternalLink href="https://wordpress.org">WordPress.org</ExternalLink>
 	);
 }
 ```

--- a/packages/components/src/external-link/README.md
+++ b/packages/components/src/external-link/README.md
@@ -1,5 +1,4 @@
-ExternalLink
-============
+# ExternalLink
 
 ## Usage
 

--- a/packages/components/src/external-link/README.md
+++ b/packages/components/src/external-link/README.md
@@ -1,0 +1,14 @@
+ExternalLink
+============
+
+## Usage
+
+```jsx
+import { ExternalLink } from '@wordpress/components';
+
+function MyExternalLink() {
+	return (
+		<ExternalLink href="https://wordpress.com">WordPress.com</ExternalLink>
+	);
+}
+```

--- a/packages/components/src/focusable-iframe/README.md
+++ b/packages/components/src/focusable-iframe/README.md
@@ -13,7 +13,7 @@ function MyIframe() {
 	return (
 		<FocusableIframe
 			src="/"
-			onFocus={ () => console.log('iframe is focused') }
+			onFocus={ () => console.log( 'iframe is focused' ) }
 		/>
 	);
 }

--- a/packages/components/src/focusable-iframe/README.md
+++ b/packages/components/src/focusable-iframe/README.md
@@ -1,5 +1,4 @@
-Focusable Iframe
-================
+# Focusable Iframe
 
 `<FocusableIframe />` is a component rendering an `iframe` element enhanced to support focus events. By default, it is not possible to detect when an iframe is focused or clicked within. This enhanced component uses a technique which checks whether the target of a window `blur` event is the iframe, inferring that this has resulted in the focus of the iframe. It dispatches an emulated [`FocusEvent`](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent) on the iframe element with event bubbling, so a parent component binding its own `onFocus` event will account for focus transitioning within the iframe.
 

--- a/packages/components/src/focusable-iframe/README.md
+++ b/packages/components/src/focusable-iframe/README.md
@@ -13,8 +13,8 @@ import { FocusableIframe } from '@wordpress/components';
 function MyIframe() {
 	return (
 		<FocusableIframe
-			src="https://example.com"
-			onFocus={ /* ... */ }
+			src="/"
+			onFocus={ () => console.log('iframe is focused') }
 		/>
 	);
 }

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -8,21 +8,26 @@ The component renders a series of buttons that allow the user to select predefin
 
 
 ```jsx
-import { Dropdown } from '@wordpress/components';
+import { FontSizePicker } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
-function MyFontSizePicker() {
-	return (
-		<FontSizePicker
-			fontSizes={ [
-				{ shortName: 'S', size: 12 },
-				{ shortName: 'M', size: 16 }
-			] }
-			fallbackFontSize={ fallbackFontSize }
+withState( {
+	fontSize: 16,
+} )( ( { fontSize, setState } ) => { 
+	const fontSizes = [
+		{ shortName: 'S', size: 12 },
+		{ shortName: 'M', size: 16 }
+	];
+	const fallbackFontSize = 16;
+	
+	return ( 
+		<FontSizePicker 
+			fontSizes={ fontSizes } 
 			value={ fontSize }
-			onChange={ this.setFontSize }
+			onChange={ fontSize => setState( { fontSize } ) } 
 		/>
-	);
-}
+	) 
+} )
 ```
 
 ## Props

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -1,5 +1,4 @@
-FontSizePicker
-========
+# FontSizePicker
 
 FontSizePicker is a React component that renders a UI that allows users to select a font size.
 The component renders a series of buttons that allow the user to select predefined (common) font sizes and contains a range slider that enables the user to select custom font sizes (by choosing the value.

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -25,8 +25,8 @@ withState( {
 			value={ fontSize }
 			onChange={ fontSize => setState( { fontSize } ) } 
 		/>
-	) 
-} )
+	); 
+} );
 ```
 
 ## Props

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -23,6 +23,7 @@ withState( {
 		<FontSizePicker 
 			fontSizes={ fontSizes } 
 			value={ fontSize }
+			fallbackFontSize={ fallbackFontSize }
 			onChange={ fontSize => setState( { fontSize } ) } 
 		/>
 	); 

--- a/packages/components/src/form-file-upload/README.md
+++ b/packages/components/src/form-file-upload/README.md
@@ -1,0 +1,19 @@
+FormFileUpload
+==============
+
+## Usage
+
+```jsx
+import { FormFileUpload } from '@wordpress/components';
+
+function MyFormFileUpload() {
+	return (
+		<FormFileUpload
+			accept="image/*"
+			onChange={ () => console.log('new image') }
+		>
+			Upload
+		</FormFileUpload>
+	);
+}
+```

--- a/packages/components/src/form-file-upload/README.md
+++ b/packages/components/src/form-file-upload/README.md
@@ -1,5 +1,4 @@
-FormFileUpload
-==============
+# FormFileUpload
 
 ## Usage
 

--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -1,5 +1,4 @@
-FormToggle
-==========
+# FormToggle
 
 ## Usage
 

--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -1,0 +1,18 @@
+FormToggle
+==========
+
+## Usage
+
+```jsx
+import { FormToggle } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
+
+withState( {
+	checked: true,
+} )( ( { checked, setState } ) => (
+	<FormToggle 
+		checked={ checked }
+		onChange={ () => setState( state => ( { checked: ! state.checked } ) ) } 
+	/>
+) )
+```

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -59,7 +59,7 @@ import { withState } from '@wordpress/compose';
 
 withState( {
 	tokens: [],
-	suggestions: ['Africa', 'America', 'Antarctica', 'Asia', 'Europe', 'Oceania'],
+	suggestions: [ 'Africa', 'America', 'Antarctica', 'Asia', 'Europe', 'Oceania' ],
 } )( ( { tokens, suggestions, setState } ) => ( 
 	<FormTokenField 
 		value={ tokens } 

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -7,7 +7,7 @@ Up to one hundred suggestions that match what the user has typed so far will be 
 
 The `value` property is handled in a manner similar to controlled form components. See [Forms](http://facebook.github.io/react/docs/forms.html) in the React Documentation for more information.
 
-### Keyboard Accessibility
+## Keyboard Accessibility
 
 - `left arrow` - if input field is empty, move insertion point before previous token
 - `right arrow` - if input field is empty, move insertion point after next token
@@ -16,7 +16,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `tab` / `enter` - if suggestion selected, insert suggestion as a new token; otherwise, insert value typed into input as new token
 - `comma` - insert value typed into input as new token
 
-### Properties
+## Properties
 
 - `value` - An array of strings or objects to display as tokens in the field. If objects are present in the array, they **must** have a property of `value`. Here is an example object that could be passed in as a value:
 
@@ -52,21 +52,21 @@ The `value` property is handled in a manner similar to controlled form component
 - `disabled` - When true, tokens are not able to be added or removed.
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
 
-### Example
+## Usage
 
 ```jsx
-class extends Component {
-	render() {
-		return (
-			<FormTokenField
-				value={ this.state.tokens }
-				onChange={ this.onTokensChange }
-				suggestions={ this.state.suggestions } />
-		);
-	}
+import { FormTokenField } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
-	onTokensChange( value ) {
-		this.setState( { tokens: value } );
-	}
-}
+withState( {
+	tokens: [],
+	suggestions: ['Africa', 'America', 'Antarctica', 'Asia', 'Europe', 'Oceania'],
+} )( ( { tokens, suggestions, setState } ) => ( 
+	<FormTokenField 
+		value={ tokens } 
+		suggestions={ suggestions } 
+		onChange={ tokens => setState( { tokens } ) }
+		placeholder="Type a continent"
+	/>
+) )
 ```

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -1,5 +1,4 @@
-Form Token Field
-===========
+# Form Token Field
 
 A `FormTokenField` is a field similar to the tags and categories fields in the interim editor chrome, or the "to" field in Mail on OS X. Tokens can be entered by typing them or selecting them from a list of suggested tokens.
 

--- a/packages/components/src/icon-button/README.md
+++ b/packages/components/src/icon-button/README.md
@@ -1,5 +1,4 @@
-IconButton
-==========
+# IconButton
 
 ## Usage
 

--- a/packages/components/src/icon-button/README.md
+++ b/packages/components/src/icon-button/README.md
@@ -1,0 +1,17 @@
+IconButton
+==========
+
+## Usage
+
+```jsx
+import { IconButton } from '@wordpress/components';
+
+function MyIconButton() {
+	return (
+		<IconButton
+			icon="ellipsis"
+			label="More"
+		/>
+	);
+}
+```

--- a/packages/components/src/keyboard-shortcuts/README.md
+++ b/packages/components/src/keyboard-shortcuts/README.md
@@ -12,30 +12,25 @@ It uses the [Mousetrap](https://craig.is/killing/mice) library to implement keyb
 Render `<KeyboardShortcuts />` with a `shortcuts` prop object:
 
 ```jsx
-class SelectAllDetection extends Component {
-	constructor() {
-		super( ...arguments );
+import { KeyboardShortcuts } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
-		this.setAllSelected = this.setAllSelected.bind( this );
-
-		this.state = { isAllSelected: false };
-	}
-
-	setAllSelected() {
-		this.setState( { isAllSelected: true } );
-	}
-
-	render() {
-		return (
-			<div>
-				<KeyboardShortcuts shortcuts={ {
-					'mod+a': this.setAllSelected,
-				} } />
-				Combination pressed? { isAllSelected ? 'Yes' : 'No' }
-			</div>
-		);
-	}
-}
+withState( {
+	isAllSelected: false,
+} )( ( { isAllSelected, setState } ) => { 
+	const selectAll = () => {
+		setState( { isAllSelected: true } )
+	};
+	
+	return (
+		<div>
+			<KeyboardShortcuts shortcuts={ {
+				'mod+a': selectAll,
+			} } />
+			[cmd/ctrl + A] Combination pressed? { isAllSelected ? 'Yes' : 'No' }
+		</div>
+	) 
+} )
 ```
 
 ## Props

--- a/packages/components/src/keyboard-shortcuts/README.md
+++ b/packages/components/src/keyboard-shortcuts/README.md
@@ -1,5 +1,4 @@
-Keyboard Shortcuts
-==================
+# Keyboard Shortcuts
 
 `<KeyboardShortcuts />` is a component which handles keyboard sequences during the lifetime of the rendering element.
 

--- a/packages/components/src/menu-group/README.md
+++ b/packages/components/src/menu-group/README.md
@@ -1,5 +1,4 @@
-MenuGroup
-=========
+# MenuGroup
 
 ## Usage
 

--- a/packages/components/src/menu-group/README.md
+++ b/packages/components/src/menu-group/README.md
@@ -1,0 +1,17 @@
+MenuGroup
+=========
+
+## Usage
+
+```jsx
+import { MenuGroup } from '@wordpress/components';
+
+function MyMenuGroup() {
+	return (
+		<MenuGroup label="Settings">
+			<div>Setting 1</div>
+			<div>Setting 2</div>
+		</MenuGroup>
+	);
+}
+```

--- a/packages/components/src/menu-group/README.md
+++ b/packages/components/src/menu-group/README.md
@@ -3,13 +3,13 @@
 ## Usage
 
 ```jsx
-import { MenuGroup } from '@wordpress/components';
+import { MenuGroup, MenuItem } from '@wordpress/components';
 
 function MyMenuGroup() {
 	return (
 		<MenuGroup label="Settings">
-			<div>Setting 1</div>
-			<div>Setting 2</div>
+			<MenuItem>Setting 1</MenuItem>
+			<MenuItem>Setting 2</MenuItem>
 		</MenuGroup>
 	);
 }

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -1,5 +1,4 @@
-MenuItem
-========
+# MenuItem
 
 ## Usage
 

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -1,0 +1,21 @@
+MenuItem
+========
+
+## Usage
+
+```jsx
+import { MenuItem } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
+
+withState( {
+	isActive: true,
+} )( ( { isActive, setState } ) => (
+	<MenuItem
+		icon={ isActive ? 'yes' : 'no' }
+		isSelected={ isActive }
+		onClick={ () => setState( state => ( { isActive: ! state.isActive } ) ) }
+	>
+		Toggle
+	</MenuItem>
+) )
+```

--- a/packages/components/src/menu-items-choice/README.md
+++ b/packages/components/src/menu-items-choice/README.md
@@ -1,5 +1,4 @@
-MenuItemsChoice
-===============
+# MenuItemsChoice
 
 ## Usage
 

--- a/packages/components/src/menu-items-choice/README.md
+++ b/packages/components/src/menu-items-choice/README.md
@@ -1,0 +1,31 @@
+MenuItemsChoice
+===============
+
+## Usage
+
+```jsx
+import { MenuGroup, MenuItemsChoice } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
+
+withState( {
+	mode: 'visual',
+	choices: [
+		{
+			value: 'visual',
+			label: 'Visual Editor',
+		},
+		{
+			value: 'text',
+			label: 'Code Editor',
+		},
+	],
+} )( ( { mode, choices, setState } ) => (
+	<MenuGroup label="Editor">
+		<MenuItemsChoice
+			choices={ choices }
+			value={ mode }
+			onSelect={ mode => setState( { mode } ) }
+		/>
+	</MenuGroup>
+) )
+```


### PR DESCRIPTION
The aim of this PR is to include *working* examples in the components documentation. 

Based on [this idea](https://github.com/Automattic/wp-calypso/pull/26314#pullrequestreview-140618214) from @gziolo for avoiding to have Gutenberg examples in Calypso.

This task is continued on #8338

### Components (Part 1)
- [x] Autocomplete
- [x] BaseControl
- [x] Button
- [x] ButtonGroup
- [x] CheckboxControl
- [x] ClipboardButton
- [x] ColorIndicator
- [x] ColorPalette
- [x] Dashicon
- [x] DateTime
- [x] Disabled
- [x] Draggable
- [x] DropZone
- [x] DropdownMenu
- [x] Dropdown
- [x] ExternalLink
- [x] FocusableIframe
- [x] FontSizePicker
- [x] FormFileUpload
- [x] FormToggle
- [x] FormTokenField
- [x] IconButton
- [x] KeyboardShortcuts
- [x] MenuGroup
- [x] MenuItem
- [x] MenuItemsChoice