### PR TITLE
Framework: Remove deprecations slated for 3.4 removal

### DIFF
--- a/core-blocks/freeform/edit.js
+++ b/core-blocks/freeform/edit.js
@@ -51,13 +51,13 @@ export default class FreeformEdit extends Component {
 
 	componentWillUnmount() {
 		window.addEventListener( 'DOMContentLoaded', this.initialize );
-		wp.oldEditor.remove( `editor-${ this.props.id }` );
+		wp.oldEditor.remove( `editor-${ this.props.clientId }` );
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { id, attributes: { content } } = this.props;
+		const { clientId, attributes: { content } } = this.props;
 
-		const editor = window.tinymce.get( `editor-${ id }` );
+		const editor = window.tinymce.get( `editor-${ clientId }` );
 
 		if ( prevProps.attributes.content !== content ) {
 			editor.setContent( content || '' );
@@ -65,14 +65,14 @@ export default class FreeformEdit extends Component {
 	}
 
 	initialize() {
-		const { id } = this.props;
+		const { clientId } = this.props;
 		const { settings } = window.wpEditorL10n.tinymce;
-		wp.oldEditor.initialize( `editor-${ id }`, {
+		wp.oldEditor.initialize( `editor-${ clientId }`, {
 			tinymce: {
 				...settings,
 				inline: true,
 				content_css: false,
-				fixed_toolbar_container: `#toolbar-${ id }`,
+				fixed_toolbar_container: `#toolbar-${ clientId }`,
 				setup: this.onSetup,
 			},
 		} );
@@ -150,7 +150,7 @@ export default class FreeformEdit extends Component {
 	}
 
 	render() {
-		const { id } = this.props;
+		const { clientId } = this.props;
 
 		// Disable reason: the toolbar itself is non-interactive, but must capture
 		// events from the KeyboardShortcuts component to stop their propagation.
@@ -161,7 +161,7 @@ export default class FreeformEdit extends Component {
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 			<div
 				key="toolbar"
-				id={ `toolbar-${ id }` }
+				id={ `toolbar-${ clientId }` }
 				ref={ ( ref ) => this.ref = ref }
 				className="freeform-toolbar"
 				onClick={ this.focus }
@@ -170,7 +170,7 @@ export default class FreeformEdit extends Component {
 			/>,
 			<div
 				key="editor"
-				id={ `editor-${ id }` }
+				id={ `editor-${ clientId }` }
 				className="wp-block-freeform core-blocks-rich-text__tinymce"
 			/>,
 		];

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -67,13 +67,6 @@ export function initializeEditor( id, postType, postId, settings, overridePost )
 		hint: 'If paragraphs using this classes are opened in the editor new classes are automatically applied the post just needs to be saved. This is a global warning, shown regardless of whether the classes are used in the current post.',
 	} );
 
-	deprecated( 'block `id` prop in `edit` function', {
-		version: '3.4',
-		alternative: 'block `clientId` prop',
-		plugin: 'Gutenberg',
-		hint: 'This is a global warning, shown regardless of whether blocks exist using the deprecated prop.',
-	} );
-
 	registerCoreBlocks();
 
 	dispatch( 'core/nux' ).triggerGuide( [

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -241,7 +241,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-utils',
 		gutenberg_url( 'build/utils/index.js' ),
-		array( 'lodash', 'wp-api-fetch', 'wp-deprecated', 'wp-html-entities', 'wp-i18n', 'wp-keycodes', 'wp-editor' ),
+		array( 'lodash', 'wp-api-fetch', 'wp-deprecated', 'wp-html-entities', 'wp-i18n', 'wp-editor' ),
 		filemtime( gutenberg_dir_path() . 'build/utils/index.js' ),
 		true
 	);
@@ -1206,31 +1206,12 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
 	$align_wide              = get_theme_support( 'align-wide' );
-	$color_palette           = (array) get_theme_support( 'editor-color-palette' );
+	$color_palette           = current( (array) get_theme_support( 'editor-color-palette' ) );
 	$font_sizes              = current( (array) get_theme_support( 'editor-font-sizes' ) );
-
-	// Backcompat for Color Palette set as multiple parameters.
-	if ( isset( $color_palette[0] ) && ( is_string( $color_palette[0] ) || isset( $color_palette[0]['color'] ) ) ) {
-		_doing_it_wrong(
-			'add_theme_support()',
-			__( 'Setting colors using multiple parameters is deprecated. Please pass a single parameter with an array of colors. See https://wordpress.org/gutenberg/handbook/extensibility/theme-support/ for details.', 'gutenberg' ),
-			'3.4.0'
-		);
-	} else {
-		$color_palette = current( $color_palette );
-	}
 
 	// Backcompat for Color Palette set through `gutenberg` array.
 	if ( empty( $color_palette ) && ! empty( $gutenberg_theme_support[0]['colors'] ) ) {
 		$color_palette = $gutenberg_theme_support[0]['colors'];
-	}
-
-	if ( ! empty( $gutenberg_theme_support ) ) {
-		_doing_it_wrong(
-			'add_theme_support()',
-			__( 'Adding theme support using the `gutenberg` array is deprecated. See https://wordpress.org/gutenberg/handbook/extensibility/theme-support/ for details.', 'gutenberg' ),
-			'3.4.0'
-		);
 	}
 
 	/**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1209,11 +1209,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$color_palette           = current( (array) get_theme_support( 'editor-color-palette' ) );
 	$font_sizes              = current( (array) get_theme_support( 'editor-font-sizes' ) );
 
-	// Backcompat for Color Palette set through `gutenberg` array.
-	if ( empty( $color_palette ) && ! empty( $gutenberg_theme_support[0]['colors'] ) ) {
-		$color_palette = $gutenberg_theme_support[0]['colors'];
-	}
-
 	/**
 	 * Filters the allowed block types for the editor, defaulting to true (all
 	 * block types supported).
@@ -1261,7 +1256,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	}
 
 	if ( false !== $color_palette ) {
-		$editor_settings['colors'] = editor_color_palette_slugs( $color_palette );
+		$editor_settings['colors'] = $color_palette;
 	}
 
 	if ( ! empty( $font_sizes ) ) {
@@ -1313,35 +1308,4 @@ JS;
 	 * @since 0.4.0
 	 */
 	do_action( 'enqueue_block_editor_assets' );
-}
-
-/**
- * This helper function ensures, that every item in $color_palette has a slug.
- *
- * @access public
- * @param array $color_palette The color palette registered with theme_support.
- * @return array $new_color_palette The color palette with slugs added where needed
- */
-function editor_color_palette_slugs( $color_palette ) {
-	$new_color_palette = array();
-	$is_doing_it_wrong = false;
-
-	foreach ( $color_palette as $color ) {
-		if ( ! isset( $color['slug'] ) ) {
-			$color['slug']     = esc_js( $color['name'] );
-			$is_doing_it_wrong = true;
-		}
-
-		$new_color_palette[] = $color;
-	}
-
-	if ( $is_doing_it_wrong ) {
-		_doing_it_wrong(
-			'add_theme_support()',
-			__( 'Each color in the "editor-color-palette" should have a slug defined.', 'gutenberg' ),
-			'3.2.0'
-		);
-	}
-
-	return $new_color_palette;
 }

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -9,7 +9,6 @@ import { flow, castArray, mapValues, omit, stubFalse } from 'lodash';
  */
 import { autop } from '@wordpress/autop';
 import { applyFilters } from '@wordpress/hooks';
-import deprecated from '@wordpress/deprecated';
 import { parse as grammarParse } from '@wordpress/block-serialization-spec-parser';
 
 /**
@@ -19,7 +18,7 @@ import { getBlockType, getUnknownTypeHandlerName } from './registration';
 import { createBlock } from './factory';
 import { isValidBlock } from './validation';
 import { getCommentDelimitedContent } from './serializer';
-import { attr, prop, html, text, query, node, children } from './matchers';
+import { attr, html, text, query, node, children } from './matchers';
 
 /**
  * Higher-order hpq matcher which enhances an attribute matcher to return true
@@ -105,14 +104,6 @@ export function matcherFromSource( sourceConfig ) {
 			}
 
 			return matcher;
-		case 'property':
-			deprecated( '`property` source', {
-				version: '3.4',
-				alternative: 'equivalent `text`, `html`, or `attribute` source, or comment attribute',
-				plugin: 'Gutenberg',
-			} );
-
-			return prop( sourceConfig.selector, sourceConfig.property );
 		case 'html':
 			return html( sourceConfig.selector );
 		case 'text':

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -57,8 +57,6 @@ By default, the *first tabblable element* in the popover will receive focus when
 
 Set this prop to `false` to disable focus changing entirely. This should only be set when an appropriately accessible substitute behavior exists.
 
-**Deprecation notice:** Before Gutenberg 3.2 this value was `Boolean` and the value `true` was equivalent to `"firstElement"`. This behaviour is deprecated and will cause a console warning message.
-
 - Type: `String` or `Boolean`
 - Required: No
 - Default: `"firstElement"`

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -8,7 +8,6 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
-import deprecated from '@wordpress/deprecated';
 import { focus } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
 
@@ -108,21 +107,11 @@ class Popover extends Component {
 	focus() {
 		const { focusOnMount } = this.props;
 
-		if ( focusOnMount === true ) {
-			deprecated( 'focusOnMount={ true }', {
-				version: '3.4',
-				alternative: 'focusOnMount="firstElement"',
-				plugin: 'Gutenberg',
-			} );
-		}
-
 		if ( ! focusOnMount || ! this.contentNode.current ) {
 			return;
 		}
 
-		// Boolean values for focusOnMount deprecated in 3.2–remove
-		// `focusOnMount === true` check in 3.4.
-		if ( focusOnMount === 'firstElement' || focusOnMount === true ) {
+		if ( focusOnMount === 'firstElement' ) {
 			// Find first tabbable node within content and shift focus, falling
 			// back to the popover panel itself.
 			const firstTabbable = focus.tabbable.find( this.contentNode.current )[ 0 ];

--- a/packages/editor/src/components/block-edit/edit.js
+++ b/packages/editor/src/components/block-edit/edit.js
@@ -28,14 +28,7 @@ export const Edit = ( props ) => {
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
 
-	// TODO: `id` prop is to be removed in 3.5 "UID" deprecation.
-	return (
-		<Component
-			{ ...props }
-			id={ props.clientId }
-			className={ className }
-		/>
-	);
+	return <Component { ...props } className={ className } />;
 };
 
 export default withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/editor/src/components/block-settings-menu/block-remove-button.js
+++ b/packages/editor/src/components/block-settings-menu/block-remove-button.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, flow, noop, some } from 'lodash';
+import { castArray, flow, noop, some, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -25,7 +25,7 @@ export function BlockRemoveButton( { onRemove, onClick = noop, isLocked, role, .
 			icon="trash"
 			label={ label }
 			role={ role }
-			{ ...props }
+			{ ...omit( props, 'clientIds' ) }
 		>
 			{ label }
 		</IconButton>

--- a/packages/editor/src/components/colors/utils.js
+++ b/packages/editor/src/components/colors/utils.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { find, kebabCase } from 'lodash';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Returns the color value based on an array of named colors and the definedColor or the customColor value.
@@ -16,14 +15,7 @@ import deprecated from '@wordpress/deprecated';
  */
 export const getColorValue = ( colors, definedColor, customColor ) => {
 	if ( definedColor ) {
-		let colorObj = find( colors, { slug: definedColor } );
-
-		if ( typeof colorObj === 'undefined' && typeof ( colorObj = find( colors, { name: definedColor } ) ) !== 'undefined' ) {
-			deprecated( 'Using color objects without slugs', {
-				version: '3.4',
-				hint: 'You might want to re-select the color if you have saved in previous versions. The frontend is unaffected by this deprecation.',
-			} );
-		}
+		const colorObj = find( colors, { slug: definedColor } );
 
 		return colorObj && colorObj.color;
 	}

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -23,7 +23,7 @@ export { default as RichTextProvider } from './rich-text/provider';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
 export { default as URLInput, UrlInput } from './url-input';
-export { default as URLInputButton, UrlInputButton } from './url-input/button';
+export { default as URLInputButton } from './url-input/button';
 
 // Post Related Components
 export { default as AutosaveMonitor } from './autosave-monitor';

--- a/packages/editor/src/components/url-input/button.js
+++ b/packages/editor/src/components/url-input/button.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -73,19 +72,6 @@ class URLInputButton extends Component {
 				}
 			</div>
 		);
-	}
-}
-
-export class UrlInputButton extends URLInputButton {
-	constructor() {
-		super( ...arguments );
-
-		deprecated( 'wp.editor.UrlInputButton', {
-			alternative: 'wp.editor.URLInputButton',
-			plugin: 'Gutenberg',
-			version: 'v3.4',
-			hint: 'The component has been renamed.',
-		} );
 	}
 }
 

--- a/utils/deprecated.js
+++ b/utils/deprecated.js
@@ -6,7 +6,6 @@ import { groupBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import * as keycodesSource from '@wordpress/keycodes';
 import { decodeEntities as decodeEntitiesSource } from '@wordpress/html-entities';
 import deprecated from '@wordpress/deprecated';
 
@@ -47,24 +46,3 @@ export function decodeEntities( html ) {
 	} );
 	return decodeEntitiesSource( html );
 }
-
-// keycodes
-const wrapKeycodeFunction = ( source, functionName ) => ( ...args ) => {
-	deprecated( `wp.utils.keycodes.${ functionName }`, {
-		version: '3.4',
-		alternative: `wp.keycodes.${ functionName }`,
-		plugin: 'Gutenberg',
-	} );
-	return source( ...args );
-};
-
-const keycodes = { ...keycodesSource, rawShortcut: {}, displayShortcut: {}, isKeyboardEvent: {} };
-const modifiers = [ 'primary', 'primaryShift', 'secondary', 'access' ];
-keycodes.isMacOS = wrapKeycodeFunction( keycodes.isMacOS, 'isMacOS' );
-modifiers.forEach( ( modifier ) => {
-	keycodes.rawShortcut[ modifier ] = wrapKeycodeFunction( keycodesSource.rawShortcut[ modifier ], 'rawShortcut.' + modifier );
-	keycodes.displayShortcut[ modifier ] = wrapKeycodeFunction( keycodesSource.displayShortcut[ modifier ], 'displayShortcut.' + modifier );
-	keycodes.isKeyboardEvent[ modifier ] = wrapKeycodeFunction( keycodesSource.isKeyboardEvent[ modifier ], 'isKeyboardEvent.' + modifier );
-} );
-
-export { keycodes };


### PR DESCRIPTION
This PR removes deprecations scheduled to be removed in the upcoming 3.4.0 release.

* `focusOnMount` prop in the `Popover` component has been changed from Boolean-only to an enum-style property that accepts "`firstElement`", "`container`", or `false`. Please convert any `<Popover focusOnMount />` usage to `<Popover focusOnMount="firstElement" />`.
* `wp.utils.keycodes` utilities are removed. Please use `wp.keycodes` instead.
* Block `id` prop in `edit` function removed. Please use block `clientId` prop instead.
* `property` source removed. Please use equivalent `text`, `html`, or `attribute` source, or comment attribute instead.

Source: https://wordpress.org/gutenberg/handbook/reference/deprecated/#3-4-0

