### PR TITLE
Try uncollapsing margins on the columns block.

### DIFF
--- a/core-blocks/columns/editor.scss
+++ b/core-blocks/columns/editor.scss
@@ -41,8 +41,8 @@
 	margin-bottom: 0;
 
 	// This uncollapses margins on this parent container.
-	padding-top: 1px;
-	padding-bottom: 1px;
+	padding-top: 0.1px;
+	padding-bottom: 0.1px;
 }
 
 .wp-block-columns {

--- a/core-blocks/columns/editor.scss
+++ b/core-blocks/columns/editor.scss
@@ -32,12 +32,17 @@
 	}
 }
 
-// Flex container margins do not collapse: https://www.w3.org/TR/css-flexbox-1/#flex-containers.
+// This block has flex container children. Flex container margins do not collapse: https://www.w3.org/TR/css-flexbox-1/#flex-containers.
 // Therefore, let's at least not add any additional margins here.
+// The goal is for the editor to look more like the front-end.
 .editor-block-list__layout .editor-block-list__block[data-type="core/columns"] > .editor-block-list__block-edit,
 .editor-block-list__layout .editor-block-list__block[data-type="core/column"] > .editor-block-list__block-edit {
 	margin-top: 0;
 	margin-bottom: 0;
+
+	// This uncollapses margins on this parent container.
+	padding-top: 1px;
+	padding-bottom: 1px;
 }
 
 .wp-block-columns {


### PR DESCRIPTION
This is a first stab at fixing #7766.

It does not address it fully, I believe further work is necessary, including that of #7694. However this should at least improve the collapsing of the parent container.

In the following screenshots, I've selected all blocks, as this highlights using transparency and overlay effects, the _boundaries_ and how they overlap. Here's what's in `master`:

<img width="699" alt="before" src="https://user-images.githubusercontent.com/1204802/43386750-e95b5800-93e4-11e8-8a86-9abef8cc53a5.png">

Here's with this PR applied:

<img width="682" alt="after" src="https://user-images.githubusercontent.com/1204802/43386767-f44a3ed4-93e4-11e8-9760-6bde0050ae98.png">

As you can see, there are zeroed out margins on the first and last container children inside the columns block. This is there to make the columns block flow more directly with the surrounding content, but this can be revisited, and as noted, #7694 might help here.

Noting that if we were to _remove_ zeroed out margins on the first and last container children, here's what it would look like:

<img width="687" alt="no collapsing margins" src="https://user-images.githubusercontent.com/1204802/43386853-258e3fe0-93e5-11e8-835d-935b03cc0635.png">
