### PR TITLE
Use standard label for Alt Text input

### DIFF
--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -272,7 +272,7 @@ class ImageEdit extends Component {
 			<InspectorControls>
 				<PanelBody title={ __( 'Image Settings' ) }>
 					<TextareaControl
-						label={ __( 'Textual Alternative' ) }
+						label={ __( 'Alt Text (Alternative Text)' ) }
 						value={ alt }
 						onChange={ this.updateAlt }
 						help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) }


### PR DESCRIPTION
### Before:
<img width="272" alt="screenshot 2018-07-30 13 45 16" src="https://user-images.githubusercontent.com/376315/43398051-d09d45b6-93fe-11e8-9ade-010acb93a7d3.png">

### After:
<img width="271" alt="screenshot 2018-07-30 13 44 29" src="https://user-images.githubusercontent.com/376315/43398033-bde19db4-93fe-11e8-9c6d-bdeac5e67557.png">

I've used the most common phrasing I could find from a quick Google survey of phrasings here, in the hopes that will be it as clear as possible for people.
Fixes #8063.

## Types of changes
Minor label change bug-fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
