### PR TITLE
Testing: use simpler jest.fn() mocks for api-fetch calls in unit tests

### DIFF
--- a/__mocks__/@wordpress/api-fetch/index.js
+++ b/__mocks__/@wordpress/api-fetch/index.js
@@ -1,6 +1,0 @@
-const apiFetch = jest.fn( () => {
-	return apiFetch.mockReturnValue;
-} );
-apiFetch.mockReturnValue = 'Mock this value by overriding apiFetch.mockReturnValue.';
-
-export default apiFetch;

--- a/packages/components/src/higher-order/with-api-data/test/request.js
+++ b/packages/components/src/higher-order/with-api-data/test/request.js
@@ -14,7 +14,7 @@ import request, {
 	isRequestMethod,
 } from '../request';
 
-jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 describe( 'request', () => {
 	const actualResponse = {
@@ -31,13 +31,7 @@ describe( 'request', () => {
 			delete cache[ key ];
 		}
 
-		apiFetch.mockReturnValue = {
-			// jQuery.Deferred aren't true promises, particularly in their
-			// treatment of resolved arguments. $.ajax will spread resolved
-			// arguments, but this is not valid for Promise (only single).
-			// Instead, we emulate by invoking the callback manually.
-			then: ( callback ) => Promise.resolve( callback( actualResponse ) ),
-		};
+		apiFetch.mockImplementation( () => Promise.resolve( actualResponse ) );
 	} );
 
 	describe( 'getCachedResponse()', () => {

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -9,7 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { getMethodName, defaultEntities, getKindEntities } from '../entities';
 import { addEntities } from '../actions';
 
-jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 describe( 'getMethodName', () => {
 	it( 'should return the right method name for an entity with the root kind', () => {

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -9,7 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { getCategories, getEntityRecord, getEntityRecords } from '../resolvers';
 import { receiveTerms, receiveEntityRecords, addEntities } from '../actions';
 
-jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 describe( 'getCategories', () => {
 	const CATEGORIES = [ { id: 1 } ];

--- a/packages/editor/src/store/effects/test/reusable-blocks.js
+++ b/packages/editor/src/store/effects/test/reusable-blocks.js
@@ -38,6 +38,8 @@ import {
 } from '../../actions';
 import reducer from '../../reducer';
 
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
 describe( 'reusable blocks effects', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/test-block', {


### PR DESCRIPTION
This Tiny PR, simplifies and unifies how we mock `api-fetch` calls by avoiding the global mock and just using `jest.fn` per test.

**Testing instructions**

 - Check that the unit tests are still passing properly.