### PR TITLE
Fix the UrlInput component after the search API introduction

### DIFF
--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -165,10 +165,10 @@ class URLInput extends Component {
 				break;
 			}
 			case ENTER: {
-				if ( this.state.selectedSuggestion ) {
+				if ( this.state.selectedSuggestion !== null ) {
 					event.stopPropagation();
 					const post = this.state.posts[ this.state.selectedSuggestion ];
-					this.selectLink( post.link );
+					this.selectLink( post.url );
 				}
 			}
 		}
@@ -227,7 +227,7 @@ class URLInput extends Component {
 									className={ classnames( 'editor-url-input__suggestion', {
 										'is-selected': index === selectedSuggestion,
 									} ) }
-									onClick={ () => this.selectLink( post.link ) }
+									onClick={ () => this.selectLink( post.url ) }
 									aria-selected={ index === selectedSuggestion }
 								>
 									{ decodeEntities( post.title ) || __( '(no title)' ) }


### PR DESCRIPTION
A new endpoint to search accross CPT's was introduced in #7894 and used in the UrlInput component. We missed updating the `link` attribute references to `url` attributes used in this new endpoint which was breaking post/pages selections from the dropdown.

This PR also fixes another bug where we'd select the post/page using `Enter`. If the suggestion is the first element in the dropdown, it was not selected because `0` is falsy :)

**Testing instructions**

 - Try add links to pages and posts
 - The URL of the selected posts/pages should be used.
 - Try also using keyboard to validate your selection.
