### PR TITLE
[Fix] File Block center align behavior

### DIFF
--- a/core-blocks/file/edit.js
+++ b/core-blocks/file/edit.js
@@ -189,7 +189,7 @@ class FileEdit extends Component {
 					</Toolbar>
 				</BlockControls>
 				<div className={ classes }>
-					<div>
+					<div className={ `${ className }__content-wrapper` }>
 						<RichText
 							wrapperClassName={ `${ className }__textlink` }
 							tagName="div" // must be block-level or else cursor disappears

--- a/core-blocks/file/editor.scss
+++ b/core-blocks/file/editor.scss
@@ -4,12 +4,12 @@
 	align-items: center;
 	margin-bottom: 0;
 
-	> div {
-		flex-grow: 1;
-	}
-
 	&.is-transient {
 		@include loading_fade;
+	}
+
+	&__content-wrapper {
+		flex-grow: 1;
 	}
 
 	&__textlink {

--- a/core-blocks/file/editor.scss
+++ b/core-blocks/file/editor.scss
@@ -4,6 +4,10 @@
 	align-items: center;
 	margin-bottom: 0;
 
+	> div {
+		flex-grow: 1;
+	}
+
 	&.is-transient {
 		@include loading_fade;
 	}


### PR DESCRIPTION
## Description
This PR addresses #8296 which reports the un-responsive alignment behavior of the file block in the editor when it is set to center align.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added a "File" block and added a file from the media library.
3. Set the block alignment to "center".
4. Made sure that the block is center aligned in the editor.

This was tested in WP 4.9.7, Gutenberg 3.3.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-8296](https://user-images.githubusercontent.com/20284937/43410491-e1d29ae4-9448-11e8-8d3a-99d77ad6b922.gif)

## Types of changes
This PR just adds a bit CSS to the block flexbox element's file child `div`, so that it grows up to the remaining space in the container.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
