### PR TITLE
Fix block validation: wrap in exception handler for malformed HTML

### DIFF
--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -454,6 +454,16 @@ describe( 'validation', () => {
 			expect( console ).toHaveWarned();
 			expect( isEquivalent ).toBe( false );
 		} );
+
+		it( 'should return false if supplied two sets of malformed HTML', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div>fsdfsdfsd<p>fdsfsdfsdd</pfd fd fd></div>',
+				'<blockquote>fsdfsdfsd<p>fdsfsdfsdd</p a></blockquote>',
+			);
+
+			expect( console ).toHaveWarned();
+			expect( isEquivalent ).toBe( false );
+		} );
 	} );
 
 	describe( 'isValidBlock()', () => {

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -445,6 +445,15 @@ describe( 'validation', () => {
 			expect( isEquivalent ).toBe( true );
 		} );
 
+		it( 'should return true when comparing empty strings', () => {
+			const isEquivalent = isEquivalentHTML(
+				'',
+				'',
+			);
+
+			expect( isEquivalent ).toBe( true );
+		} );
+
 		it( 'should return false if supplied malformed HTML', () => {
 			const isEquivalent = isEquivalentHTML(
 				'<blockquote class="wp-block-quote">fsdfsdfsd<p>fdsfsdfsdd</pfd fd fd></blockquote>',

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -444,6 +444,16 @@ describe( 'validation', () => {
 
 			expect( isEquivalent ).toBe( true );
 		} );
+
+		it( 'should return false if supplied malformed HTML', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<blockquote class="wp-block-quote">fsdfsdfsd<p>fdsfsdfsdd</pfd fd fd></blockquote>',
+				'<blockquote class="wp-block-quote">fsdfsdfsd<p>fdsfsdfsdd</p></blockquote>',
+			);
+
+			expect( console ).toHaveWarned();
+			expect( isEquivalent ).toBe( false );
+		} );
 	} );
 
 	describe( 'isValidBlock()', () => {

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -385,7 +385,7 @@ export function getNextNonWhitespaceToken( tokens ) {
  *
  * @param {string} html HTML string to tokenize.
  *
- * @return {Object[]|boolean} Array of valid tokenized HTML elements, or null on error
+ * @return {Object[]|null} Array of valid tokenized HTML elements, or null on error
  */
 function getHTMLTokens( html ) {
 	try {

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -380,10 +380,12 @@ export function getNextNonWhitespaceToken( tokens ) {
 }
 
 /**
- * Tokenize some HTML, with exception handling
- * @param {string} html Actual HTML string.
+ * Tokenize an HTML string, gracefully handling any errors thrown during
+ * underlying tokenization.
  *
- * @return {Array} Array of valid tokenized HTML elements
+ * @param {string} html HTML string to tokenize.
+ *
+ * @return {Object[]} Array of valid tokenized HTML elements.
  */
 function getHTMLTokens( html ) {
 	try {

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -385,7 +385,7 @@ export function getNextNonWhitespaceToken( tokens ) {
  *
  * @param {string} html HTML string to tokenize.
  *
- * @return {Object[]|boolean} Array of valid tokenized HTML elements, or false
+ * @return {Object[]|boolean} Array of valid tokenized HTML elements, or null on error
  */
 function getHTMLTokens( html ) {
 	try {
@@ -394,7 +394,7 @@ function getHTMLTokens( html ) {
 		log.warning( 'Malformed HTML detected: %s', html );
 	}
 
-	return false;
+	return null;
 }
 
 /**
@@ -412,7 +412,7 @@ export function isEquivalentHTML( actual, expected ) {
 	const [ actualTokens, expectedTokens ] = [ actual, expected ].map( getHTMLTokens );
 
 	// If either is malformed then stop comparing - the strings are not equivalent
-	if ( actualTokens === false || expectedTokens === false ) {
+	if ( ! actualTokens || ! expectedTokens ) {
 		return false;
 	}
 

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -380,6 +380,22 @@ export function getNextNonWhitespaceToken( tokens ) {
 }
 
 /**
+ * Tokenize some HTML, with exception handling
+ * @param {string} html Actual HTML string.
+ *
+ * @return {Array} Array of valid tokenized HTML elements
+ */
+function getHTMLTokens( html ) {
+	try {
+		return tokenize( html );
+	} catch ( e ) {
+		log.warning( 'Malformed HTML detected: %s', html );
+	}
+
+	return [];
+}
+
+/**
  * Returns true if there is given HTML strings are effectively equivalent, or
  * false otherwise.
  *
@@ -390,7 +406,7 @@ export function getNextNonWhitespaceToken( tokens ) {
  */
 export function isEquivalentHTML( actual, expected ) {
 	// Tokenize input content and reserialized save content
-	const [ actualTokens, expectedTokens ] = [ actual, expected ].map( tokenize );
+	const [ actualTokens, expectedTokens ] = [ actual, expected ].map( getHTMLTokens );
 
 	let actualToken, expectedToken;
 	while ( ( actualToken = getNextNonWhitespaceToken( actualTokens ) ) ) {

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -385,7 +385,7 @@ export function getNextNonWhitespaceToken( tokens ) {
  *
  * @param {string} html HTML string to tokenize.
  *
- * @return {Object[]} Array of valid tokenized HTML elements.
+ * @return {Object[]|boolean} Array of valid tokenized HTML elements, or false
  */
 function getHTMLTokens( html ) {
 	try {
@@ -394,12 +394,13 @@ function getHTMLTokens( html ) {
 		log.warning( 'Malformed HTML detected: %s', html );
 	}
 
-	return [];
+	return false;
 }
 
 /**
- * Returns true if there is given HTML strings are effectively equivalent, or
- * false otherwise.
+ * Returns true if the given HTML strings are effectively equivalent, or
+ * false otherwise. Invalid HTML is not considered equivalent, even if the
+ * strings directly match.
  *
  * @param {string} actual Actual HTML string.
  * @param {string} expected Expected HTML string.
@@ -409,6 +410,11 @@ function getHTMLTokens( html ) {
 export function isEquivalentHTML( actual, expected ) {
 	// Tokenize input content and reserialized save content
 	const [ actualTokens, expectedTokens ] = [ actual, expected ].map( getHTMLTokens );
+
+	// If either is malformed then stop comparing - the strings are not equivalent
+	if ( actualTokens === false || expectedTokens === false ) {
+		return false;
+	}
 
 	let actualToken, expectedToken;
 	while ( ( actualToken = getNextNonWhitespaceToken( actualTokens ) ) ) {


### PR DESCRIPTION
If you paste malformed HTML into a block the HTML tokenizer can break.

The underlying bug is in the `simple-html-tokenizer` package. Ideally it will be fixed there, but in the meantime (and also to protect against other unknown errors) this PR wraps the tokenizer in an exception handler.

The fixed behaviour is that the block will show an invalid block warning message, allowing it to be cleaned up in a controlled way.

As far as I can tell this is the only place in Gutenberg where `simple-html-tokenizer` is used and so I haven't tried to generally wrap the library.

## How has this been tested?

An additional unit test has been added which tests the breakage. You can manually verify the problem by:
- Open developer console
- Add a quote block
- Edit HTML of the quote block and replace the content with `<blockquote class="wp-block-quote">fsdfsdfsd<p>fdsfsdfsdd</pfd fd fd></blockquote>`
- Look in developer console for this error:
![error](https://user-images.githubusercontent.com/1277682/43411455-1a543bec-9422-11e8-8617-0af6f0a47f0b.jpg)
- Verify that after applying this PR the error is no longer shown and an invalid block warning is shown

## Types of changes

Non breaking bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
