### PR TITLE
Blocks: Un-collapse Classic block margins

### DIFF
--- a/core-blocks/freeform/editor.scss
+++ b/core-blocks/freeform/editor.scss
@@ -1,8 +1,4 @@
 .wp-block-freeform.core-blocks-rich-text__tinymce {
-	overflow: hidden;
-	margin: -4px;
-	padding: 4px;
-
 	p,
 	li {
 		line-height: $editor-line-height;
@@ -140,11 +136,10 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 
 .freeform-toolbar {
 	width: auto;
-	margin: #{ -$block-padding } #{ -$parent-block-padding };
-	margin-bottom: $block-padding;
-	position: sticky;
+	margin: 0 #{ -$parent-block-padding };
+	position: relative;
 	z-index: z-index( '.freeform-toolbar' );
-	top: 0;
+	top: #{ -1 * $block-padding };
 }
 
 .freeform-toolbar:empty {
@@ -160,12 +155,6 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 		line-height: 37px;
 		padding: $block-padding;
 	}
-}
-
-// Un-collapse freeform block margins.
-.editor-block-list__block[data-type="core/freeform"] > .editor-block-list__block-edit {
-	padding-top: 0.1px;
-	padding-bottom: 0.1px;
 }
 
 // Overwrite inline styles.

--- a/core-blocks/freeform/editor.scss
+++ b/core-blocks/freeform/editor.scss
@@ -162,6 +162,12 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 	}
 }
 
+// Un-collapse freeform block margins.
+.editor-block-list__block[data-type="core/freeform"] > .editor-block-list__block-edit {
+	padding-top: 0.1px;
+	padding-bottom: 0.1px;
+}
+
 // Overwrite inline styles.
 .freeform-toolbar .mce-tinymce-inline,
 .freeform-toolbar .mce-tinymce-inline > div,


### PR DESCRIPTION
Fixes #7918 
Related (regression of): #7365

This pull request seeks to resolve an issue where the Classic block TinyMCE panel is not flush with its block container. It does so by reverting the margin collapsing for the Classic block only, similar to as proposed for the Columns block in #8283.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/43417118-178f1c48-9408-11e8-8031-44b3484a4f9c.png)|![After](https://user-images.githubusercontent.com/1779930/43417104-0cff91a4-9408-11e8-9c17-0817b0c53014.png)

**Testing instructions:**

Repeat steps to reproduce from #7918, verifying that there is no excess gap between the Classic block panel and its block container.