### PR TITLE
Remove jQuery dependency from @wordpress/api-fetch

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -139,7 +139,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-api-fetch',
 		gutenberg_url( 'build/api-fetch/index.js' ),
-		array( 'wp-i18n' ),
+		array( 'wp-hooks', 'wp-i18n' ),
 		filemtime( gutenberg_dir_path() . 'build/api-fetch/index.js' ),
 		true
 	);

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1095,9 +1095,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	global $wp_scripts;
 
-	// Add "wp-hooks" as dependency of "heartbeat"
+	// Add "wp-hooks" as dependency of "heartbeat".
 	$heartbeat_script = $wp_scripts->query( 'heartbeat', 'registered' );
-	if ( $heartbeat_script && !in_array( 'wp-hooks', $heartbeat_script->deps ) ) {
+	if ( $heartbeat_script && ! in_array( 'wp-hooks', $heartbeat_script->deps ) ) {
 		$heartbeat_script->deps[] = 'wp-hooks';
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -167,6 +167,12 @@ function gutenberg_register_scripts_and_styles() {
 		),
 		'after'
 	);
+	wp_add_inline_script(
+		'wp-api-fetch',
+		'jQuery( document ).on( 'heartbeat-tick', function ( event, response ) { wp.hooks.doAction( 'heartbeat.tick', response ); } );',
+		'after'
+	);
+
 
 	wp_register_script(
 		'wp-deprecated',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -169,10 +169,9 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_add_inline_script(
 		'wp-api-fetch',
-		'jQuery( document ).on( 'heartbeat-tick', function ( event, response ) { wp.hooks.doAction( 'heartbeat.tick', response ); } );',
+		'jQuery( document ).on( "heartbeat-tick", function ( event, response ) { wp.hooks.doAction( "heartbeat.tick", response ) } );',
 		'after'
 	);
-
 
 	wp_register_script(
 		'wp-deprecated',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2994,8 +2994,8 @@
 			"version": "file:packages/api-fetch",
 			"requires": {
 				"@babel/runtime": "^7.0.0-beta.52",
-				"@wordpress/i18n": "file:packages/i18n",
-				"jquery": "^3.3.1"
+				"@wordpress/hooks": "file:packages/hooks",
+				"@wordpress/i18n": "file:packages/i18n"
 			}
 		},
 		"@wordpress/autop": {

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/i18n": "file:../i18n",
-		"jquery": "^3.3.1"
+		"@wordpress/hooks": "file:../hooks"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -21,8 +21,8 @@
 	"module": "build-module/index.js",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52",
-		"@wordpress/i18n": "file:../i18n",
-		"@wordpress/hooks": "file:../hooks"
+		"@wordpress/hooks": "file:../hooks",
+		"@wordpress/i18n": "file:../i18n"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/api-fetch/src/middlewares/nonce.js
+++ b/packages/api-fetch/src/middlewares/nonce.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import jQuery from 'jquery';
+import { addAction } from '@wordpress/hooks';
 
 const createNonceMiddleware = ( nonce ) => ( options, next ) => {
 	let usedNonce = nonce;
@@ -11,7 +11,7 @@ const createNonceMiddleware = ( nonce ) => ( options, next ) => {
 	 * Configure heartbeat to refresh the wp-api nonce, keeping the editor
 	 * authorization intact.
 	 */
-	jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
+	addAction( 'heartbeat.tick', '@wordpress/api-fetch/createNonceMiddleware', ( response ) => {
 		if ( response[ 'rest-nonce' ] ) {
 			usedNonce = response[ 'rest-nonce' ];
 		}

--- a/packages/api-fetch/src/middlewares/nonce.js
+++ b/packages/api-fetch/src/middlewares/nonce.js
@@ -11,7 +11,7 @@ const createNonceMiddleware = ( nonce ) => ( options, next ) => {
 	 * Configure heartbeat to refresh the wp-api nonce, keeping the editor
 	 * authorization intact.
 	 */
-	addAction( 'heartbeat.tick', 'api-fetch/createNonceMiddleware', ( response ) => {
+	addAction( 'heartbeat.tick', 'core/api-fetch/create-nonce-middleware', ( response ) => {
 		if ( response[ 'rest-nonce' ] ) {
 			usedNonce = response[ 'rest-nonce' ];
 		}

--- a/packages/api-fetch/src/middlewares/nonce.js
+++ b/packages/api-fetch/src/middlewares/nonce.js
@@ -11,7 +11,7 @@ const createNonceMiddleware = ( nonce ) => ( options, next ) => {
 	 * Configure heartbeat to refresh the wp-api nonce, keeping the editor
 	 * authorization intact.
 	 */
-	addAction( 'heartbeat.tick', '@wordpress/api-fetch/createNonceMiddleware', ( response ) => {
+	addAction( 'heartbeat.tick', 'api-fetch/createNonceMiddleware', ( response ) => {
 		if ( response[ 'rest-nonce' ] ) {
 			usedNonce = response[ 'rest-nonce' ];
 		}


### PR DESCRIPTION
This removes the `jQuery` dependency from the `@wordpress/api-fetch` package.

The nonce middleware relies now on `@wordpress/hooks` for listening to the heartbeat ticks events.