### PR TITLE
Add JSDoc comment to Popover's focus() method

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -100,6 +100,13 @@ class Popover extends Component {
 		this.rafHandle = window.requestAnimationFrame( () => this.computePopoverPosition() );
 	}
 
+	/**
+	 * Calling `refresh()` will force the Popover to recalculate its size and
+	 * position. This is useful when a DOM change causes the anchor node to change
+	 * position.
+	 *
+	 * @return {void}
+	 */
 	refresh() {
 		const popoverSize = this.updatePopoverSize();
 		this.computePopoverPosition( popoverSize );


### PR DESCRIPTION
The public focus() method has documentation in the Popover component's README file, but it would be useful to have it in a JSDoc comment as well.

Fixes https://github.com/WordPress/gutenberg/pull/7219#discussion_r206157497.