### PR TITLE
Try alternate fix for Classic toolbar

### DIFF
--- a/core-blocks/freeform/editor.scss
+++ b/core-blocks/freeform/editor.scss
@@ -1,7 +1,5 @@
 .wp-block-freeform.core-blocks-rich-text__tinymce {
 	overflow: hidden;
-	margin: -4px;
-	padding: 4px;
 
 	p,
 	li {
@@ -140,11 +138,11 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 
 .freeform-toolbar {
 	width: auto;
-	margin: #{ -$block-padding } #{ -$parent-block-padding };
-	margin-bottom: $block-padding;
+	margin: 0 #{ -$parent-block-padding };
 	position: sticky;
 	z-index: z-index( '.freeform-toolbar' );
-	top: 0;
+	top: $block-padding;
+	transform: translateY( -$block-padding );
 }
 
 .freeform-toolbar:empty {


### PR DESCRIPTION
This is an alternative to #8308, which doesn't rely on uncollapsing margins.

What it does is position the classic toolbar using translate, which is the same way every other toolbar is positioned. This fixes the issue and cleans up the CSS.

GIF:

![alternate fix](https://user-images.githubusercontent.com/1204802/43442955-db24547e-949f-11e8-944b-ef562237c069.gif)

This fixes #7918, which regressed in #7365.