### PR TITLE
Add `gutenberg_can_edit_post` filter

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -259,21 +259,35 @@ function gutenberg_collect_meta_box_data() {
  * @return bool Whether the post can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post( $post ) {
-	$post = get_post( $post );
+	$post     = get_post( $post );
+	$can_edit = true;
 
 	if ( ! $post ) {
-		return false;
+		$can_edit = false;
 	}
 
-	if ( 'trash' === $post->post_status ) {
-		return false;
+	if ( $can_edit && 'trash' === $post->post_status ) {
+		$can_edit = false;
 	}
 
-	if ( ! gutenberg_can_edit_post_type( $post->post_type ) ) {
-		return false;
+	if ( $can_edit && ! gutenberg_can_edit_post_type( $post->post_type ) ) {
+		$can_edit = false;
 	}
 
-	return current_user_can( 'edit_post', $post->ID );
+	if ( $can_edit && ! current_user_can( 'edit_post', $post->ID ) ) {
+		$can_edit = false;
+	}
+
+	/**
+	 * Filter to allow plugins to enable/disable Gutenberg for particular post.
+	 *
+	 * @since 3.5
+	 *
+	 * @param bool $can_edit Whether the post can be edited or not.
+	 * @param WP_Post $post The post being checked.
+	 */
+	return apply_filters( 'gutenberg_can_edit_post', $can_edit, $post );
+
 }
 
 /**

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -75,6 +75,14 @@ class Admin_Test extends WP_UnitTestCase {
 
 		wp_set_current_user( self::$editor_user_id );
 		$this->assertTrue( gutenberg_can_edit_post( $generic_post_id ) );
+
+		add_filter( 'gutenberg_can_edit_post', '__return_false' );
+		$this->assertFalse( gutenberg_can_edit_post( $generic_post_id ) );
+		remove_filter( 'gutenberg_can_edit_post', '__return_false' );
+
+		add_filter( 'gutenberg_can_edit_post', '__return_true' );
+		$this->assertTrue( gutenberg_can_edit_post( $restless_post_id ) );
+		remove_filter( 'gutenberg_can_edit_post', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Added `gutenberg_can_edit_post` filter and additional unit tests.

Fixes https://github.com/WordPress/gutenberg/issues/5692

## How has this been tested?
Added unit tests to ensure the `gutenberg_can_edit_post` filter returns true or false depending on the callback.

## Types of changes
New feature

## Checklist:
- [✓ ] My code is tested.
- [✓ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [✓ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [✓ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
