### PR TITLE
Remove title attributes from the Classic Editor warning

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -247,8 +247,8 @@ function gutenberg_warn_classic_about_blocks() {
 					?>
 				</div>
 				<p>
-					<a class="button button-primary blocks-in-post-gutenberg-button" title="<?php esc_attr_e( 'Open this post in the Gutenberg block editor', 'gutenberg' ); ?>" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Edit in Gutenberg', 'gutenberg' ); ?></a>
-					<button class="button blocks-in-post-classic-button" title="<?php esc_attr_e( 'Close this dialog, and edit the post in the classic editor', 'gutenberg' ); ?>"><?php _e( 'Continue to Classic Editor', 'gutenberg' ); ?></button>
+					<a class="button button-primary blocks-in-post-gutenberg-button" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Edit in Gutenberg', 'gutenberg' ); ?></a>
+					<button type="button" class="button blocks-in-post-classic-button"><?php _e( 'Continue to Classic Editor', 'gutenberg' ); ?></button>
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
## Description

Title attributes are not available to keyboard users, and may not be announced by screen readers depending on user settings. For more details please refer to https://core.trac.wordpress.org/ticket/24766

See also https://core.trac.wordpress.org/query?keywords=~title-attribute

This PR removes two title attributes used on the buttons in the Classic Editor warning introduced in #8247. As a best practice, it also adds a `type="button"` attribute to a button. As said, the information in the title attributes is not available to all users and adds little to nothing to the info already provided via the button text. 

"Edit in Gutenberg"
vs.
"Open this post in the Gutenberg block editor"

"Continue to Classic Editor"
vs.
"Close this dialog, and edit the post in the classic editor"

Fixes #8315 