### PR TITLE
fix/paragraph-component-drop-cap 

### DIFF
--- a/core-blocks/paragraph/style.scss
+++ b/core-blocks/paragraph/style.scss
@@ -22,11 +22,12 @@ p {
 	&.has-drop-cap:not( :focus ):first-letter {
 		float: left;
 		font-size: 8.4em;
-		line-height: 0.68;
+		line-height: 0.8;
 		font-weight: 100;
 		margin: .05em .1em 0 0;
 		text-transform: uppercase;
 		font-style: normal;
+		overflow: hidden;
 	}
 }
 

--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -2,6 +2,7 @@
 .editor-rich-text {
 	// This is needed to position the formatting toolbar.
 	position: relative;
+	overflow:hidden; 
 }
 
 .editor-rich-text__tinymce {


### PR DESCRIPTION
## Description
Fix to visual issue for paragraph component with enabled drop cap mode
Steps to reproduce issue:

Click Add Block button
Select block Paragraph and add it
Go to Block properties -> Drop Cap (enable)
Type some text like 'Test'
Drop Cap is out of editor lines

## How has this been tested?
Manually tested using FF and Chrome developer tools
Environment:
Chrome - Version 67.0.3396.99 (Official Build) (64-bit)
Firefox 57.0 (64-bit)

## Screenshots <!-- if applicable -->
![43288383-542f229a-9130-11e8-985b-577f1a9ca3a9](https://user-images.githubusercontent.com/7103128/43472194-8e24056a-94f5-11e8-8e36-dffde5905c8d.png)


## Types of changes
CSS Style

