### PR TITLE
Use "post" instead of "page" in the warning when the post contains blocks

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -235,7 +235,7 @@ function gutenberg_warn_classic_about_blocks() {
 							<p>
 							<?php
 								/* translators: link to the post revisions page */
-								printf( __( 'You can also <a href="%s">browse previous revisions</a> and restore a version of the page before it was edited in Gutenberg.', 'gutenberg' ), esc_url( $revisions_link ) );
+								printf( __( 'You can also <a href="%s">browse previous revisions</a> and restore a version of the post before it was edited in Gutenberg.', 'gutenberg' ), esc_url( $revisions_link ) );
 							?>
 							</p>
 						<?php


### PR DESCRIPTION
## Description
In #8247, new strings were introduced for warning when there are blocks in the post content. While others refer to "post", one refers to "page". This PR changes that.

## Types of changes
String fix
