### PR TITLE
Saving: Open preview window before setting URL

### DIFF
--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -55,14 +55,10 @@ export class PostPreviewButton extends Component {
 	}
 
 	/**
-	 * Handles a click event to open a popup window and prevent default click
-	 * behavior if the post is either autosaveable or has a previously assigned
-	 * preview link to be shown in the popup window target. Triggers autosave
-	 * if post is autosaveable.
-	 *
-	 * @param {MouseEvent} event Click event from preview button click.
+	 * Opens a popup window, navigating user to a preview of the current post.
+	 * Triggers autosave if post is autosaveable.
 	 */
-	openPreviewWindow( event ) {
+	openPreviewWindow() {
 		const { isAutosaveable, previewLink, currentPostLink } = this.props;
 
 		// If there are no changes to autosave, we cannot perform the save, but
@@ -79,7 +75,6 @@ export class PostPreviewButton extends Component {
 		// Open a popup, BUT: Set it to a blank page until save completes. This
 		// is necessary because popups can only be opened in response to user
 		// interaction (click), but we must still wait for the post to save.
-		event.preventDefault();
 		this.previewWindow = window.open(
 			isAutosaveable ? 'about:blank' : previewLink,
 			this.getWindowTarget()

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -76,7 +76,6 @@ describe( 'PostPreviewButton', () => {
 	describe( 'openPreviewWindow()', () => {
 		function assertForPreview( props, expectedPreviewURL, isExpectingSave ) {
 			const autosave = jest.fn();
-			const preventDefault = jest.fn();
 			const windowOpen = window.open;
 			window.open = jest.fn( () => {
 				return {
@@ -95,16 +94,11 @@ describe( 'PostPreviewButton', () => {
 				/>
 			);
 
-			wrapper.simulate( 'click', { preventDefault } );
+			wrapper.simulate( 'click' );
 
 			if ( expectedPreviewURL ) {
-				if ( expectedPreviewURL !== props.currentPostLink ) {
-					expect( preventDefault ).toHaveBeenCalled();
-				}
-
 				expect( window.open ).toHaveBeenCalledWith( expectedPreviewURL, 'wp-preview-1' );
 			} else {
-				expect( preventDefault ).not.toHaveBeenCalled();
 				expect( window.open ).not.toHaveBeenCalled();
 			}
 

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -76,9 +76,13 @@ describe( 'PostPreviewButton', () => {
 	describe( 'openPreviewWindow()', () => {
 		function assertForPreview( props, expectedPreviewURL, isExpectingSave ) {
 			const autosave = jest.fn();
+			const setLocation = jest.fn();
 			const windowOpen = window.open;
 			window.open = jest.fn( () => {
 				return {
+					set location( url ) {
+						setLocation( url );
+					},
 					document: {
 						write: jest.fn(),
 						close: jest.fn(),
@@ -96,10 +100,12 @@ describe( 'PostPreviewButton', () => {
 
 			wrapper.simulate( 'click' );
 
+			expect( window.open ).toHaveBeenCalledWith( '', 'wp-preview-1' );
+
 			if ( expectedPreviewURL ) {
-				expect( window.open ).toHaveBeenCalledWith( expectedPreviewURL, 'wp-preview-1' );
+				expect( setLocation ).toHaveBeenCalledWith( expectedPreviewURL );
 			} else {
-				expect( window.open ).not.toHaveBeenCalled();
+				expect( setLocation ).not.toHaveBeenCalled();
 			}
 
 			window.open = windowOpen;
@@ -125,14 +131,14 @@ describe( 'PostPreviewButton', () => {
 			assertForPreview( {
 				isAutosaveable: true,
 				previewLink: 'https://wordpress.org/?p=1&preview=true',
-			}, 'about:blank', true );
+			}, null, true );
 		} );
 
 		it( 'should save for autosaveable post without preview link', () => {
 			assertForPreview( {
 				isAutosaveable: true,
 				previewLink: undefined,
-			}, 'about:blank', true );
+			}, null, true );
 		} );
 
 		it( 'should not save but open a popup window if not autosaveable but preview link available', () => {

--- a/test/e2e/specs/preview.test.js
+++ b/test/e2e/specs/preview.test.js
@@ -23,85 +23,8 @@ describe( 'Preview', () => {
 		await newPost();
 	} );
 
-	let lastPreviewPage;
-
-	/**
-	 * Clicks the preview button and returns the generated preview window page,
-	 * either the newly created tab or the redirected existing target. This is
-	 * required because Chromium infuriatingly disregards same target name in
-	 * specific undetermined circumstances, else our efforts to reuse the same
-	 * popup have been fruitless and exhausting. It is worth exploring further,
-	 * perhaps considering factors such as origin of the interstitial page (the
-	 * about:blank placeholder screen), or whether the preview link default
-	 * behavior is used / prevented by the display of the popup window of the
-	 * same target name. Resolves only once the preview page has finished
-	 * loading.
-	 *
-	 * @return {Promise} Promise resolving with focused, loaded preview page.
-	 */
-	async function getOpenedPreviewPage() {
-		const eventHandlers = [];
-
-		page.click( '.editor-post-preview' );
-
-		const race = [
-			new Promise( ( resolve ) => {
-				async function onBrowserTabOpened( target ) {
-					const targetPage = await target.page();
-					resolve( targetPage );
-				}
-				browser.once( 'targetcreated', onBrowserTabOpened );
-				eventHandlers.push( [ browser, 'targetcreated', onBrowserTabOpened ] );
-			} ),
-		];
-
-		if ( lastPreviewPage ) {
-			race.push( new Promise( async ( resolve ) => {
-				function onLastPreviewPageLoaded() {
-					resolve( lastPreviewPage );
-				}
-
-				lastPreviewPage.once( 'load', onLastPreviewPageLoaded );
-				eventHandlers.push( [ lastPreviewPage, 'load', onLastPreviewPageLoaded ] );
-			} ) );
-		}
-
-		// The preview page is whichever of the two resolves first:
-		//  - A new tab has opened.
-		//  - An existing tab is reused and navigates.
-		const previewPage = await Promise.race( race );
-
-		// Since there may be lingering event handlers from whichever of the
-		// race candidates had lost, remove all handlers.
-		eventHandlers.forEach( ( [ target, event, handler ] ) => {
-			target.removeListener( event, handler );
-		} );
-
-		// If a new preview tab is opened and there was a previous one, close
-		// the previous tab.
-		if ( lastPreviewPage && lastPreviewPage !== previewPage ) {
-			await lastPreviewPage.close();
-		}
-
-		lastPreviewPage = previewPage;
-
-		// Allow preview to generate if interstitial is visible.
-		const isGeneratingPreview = await previewPage.evaluate( () => (
-			!! document.querySelector( '.editor-post-preview-button__interstitial-message' )
-		) );
-
-		if ( isGeneratingPreview ) {
-			await previewPage.waitForNavigation();
-		}
-
-		await previewPage.bringToFront();
-
-		return previewPage;
-	}
-
 	it( 'Should open a preview window for a new post', async () => {
 		const editorPage = page;
-		let previewPage;
 
 		// Disabled until content present.
 		const isPreviewDisabled = await page.$$eval(
@@ -112,7 +35,15 @@ describe( 'Preview', () => {
 
 		await editorPage.type( '.editor-post-title__input', 'Hello World' );
 
-		previewPage = await getOpenedPreviewPage();
+		await page.click( '.editor-post-preview' );
+
+		const previewPage = await new Promise( ( resolve ) => {
+			async function onBrowserTabOpened( target ) {
+				const targetPage = await target.page();
+				resolve( targetPage );
+			}
+			browser.once( 'targetcreated', onBrowserTabOpened );
+		} );
 
 		// When autosave completes for a new post, the URL of the editor should
 		// update to include the ID. Use this to assert on preview URL.
@@ -130,7 +61,8 @@ describe( 'Preview', () => {
 		// Return to editor to change title.
 		await editorPage.bringToFront();
 		await editorPage.type( '.editor-post-title__input', '!' );
-		previewPage = await getOpenedPreviewPage();
+		await page.click( '.editor-post-preview' );
+		await previewPage.waitForNavigation();
 
 		// Title in preview should match updated input.
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
@@ -139,7 +71,8 @@ describe( 'Preview', () => {
 		// Pressing preview without changes should bring same preview window to
 		// front and reload, but should not show interstitial.
 		await editorPage.bringToFront();
-		previewPage = await getOpenedPreviewPage();
+		await page.click( '.editor-post-preview' );
+		await previewPage.waitForNavigation();
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
 		expect( previewTitle ).toBe( 'Hello World!' );
 
@@ -152,15 +85,15 @@ describe( 'Preview', () => {
 			page.click( '.editor-post-publish-panel__header button' ),
 		] );
 		expectedPreviewURL = await editorPage.$eval( '.notice-success a', ( node ) => node.href );
-		previewPage = await getOpenedPreviewPage();
+		await page.click( '.editor-post-preview' );
+		await previewPage.waitForNavigation();
 		expect( previewPage.url() ).toBe( expectedPreviewURL );
 
 		// Return to editor to change title.
 		await editorPage.bringToFront();
 		await editorPage.type( '.editor-post-title__input', ' And more.' );
-
-		// Published preview should reuse same popup frame.
-		previewPage = await getOpenedPreviewPage();
+		await page.click( '.editor-post-preview' );
+		await previewPage.waitForNavigation();
 
 		// Title in preview should match updated input.
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
@@ -178,7 +111,8 @@ describe( 'Preview', () => {
 		//
 		// See: https://github.com/WordPress/gutenberg/issues/7561
 		await editorPage.bringToFront();
-		previewPage = await getOpenedPreviewPage();
+		await page.click( '.editor-post-preview' );
+		await previewPage.waitForNavigation();
 
 		// Title in preview should match updated input.
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );

--- a/test/e2e/specs/preview.test.js
+++ b/test/e2e/specs/preview.test.js
@@ -23,6 +23,21 @@ describe( 'Preview', () => {
 		await newPost();
 	} );
 
+	/**
+	 * Given a Puppeteer Page instance for a preview window, clicks Preview and
+	 * awaits the window navigation.
+	 *
+	 * @param {puppeteer.Page} previewPage Page on which to await navigation.
+	 *
+	 * @return {Promise} Promise resolving once navigation completes.
+	 */
+	function waitForPreviewNavigation( previewPage ) {
+		return Promise.all( [
+			previewPage.waitForNavigation(),
+			page.click( '.editor-post-preview' ),
+		] );
+	}
+
 	it( 'Should open a preview window for a new post', async () => {
 		const editorPage = page;
 
@@ -61,8 +76,7 @@ describe( 'Preview', () => {
 		// Return to editor to change title.
 		await editorPage.bringToFront();
 		await editorPage.type( '.editor-post-title__input', '!' );
-		await page.click( '.editor-post-preview' );
-		await previewPage.waitForNavigation();
+		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
@@ -71,8 +85,7 @@ describe( 'Preview', () => {
 		// Pressing preview without changes should bring same preview window to
 		// front and reload, but should not show interstitial.
 		await editorPage.bringToFront();
-		await page.click( '.editor-post-preview' );
-		await previewPage.waitForNavigation();
+		await waitForPreviewNavigation( previewPage );
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
 		expect( previewTitle ).toBe( 'Hello World!' );
 
@@ -85,15 +98,13 @@ describe( 'Preview', () => {
 			page.click( '.editor-post-publish-panel__header button' ),
 		] );
 		expectedPreviewURL = await editorPage.$eval( '.notice-success a', ( node ) => node.href );
-		await page.click( '.editor-post-preview' );
-		await previewPage.waitForNavigation();
+		await waitForPreviewNavigation( previewPage );
 		expect( previewPage.url() ).toBe( expectedPreviewURL );
 
 		// Return to editor to change title.
 		await editorPage.bringToFront();
 		await editorPage.type( '.editor-post-title__input', ' And more.' );
-		await page.click( '.editor-post-preview' );
-		await previewPage.waitForNavigation();
+		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
@@ -111,8 +122,7 @@ describe( 'Preview', () => {
 		//
 		// See: https://github.com/WordPress/gutenberg/issues/7561
 		await editorPage.bringToFront();
-		await page.click( '.editor-post-preview' );
-		await previewPage.waitForNavigation();
+		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );


### PR DESCRIPTION
Fixes #8318 
Fixes #6956

This pull request seeks to resolve an issue where previewing can cause a new tab to be created, even when an existing preview tab exists to be reused. This also enables the related end-to-end test to be simplified to avoid needing to accommodate both cases where a tab is reused or a new one is created. It is hoped that this simplification will remedy intermittent failures in the end-to-end test suite.

**Implementation notes:**

If I'm being honest, I'm not entirely clear what it is about this specific flow of logic that resolves the issue. It may be one of:

- Using `''` empty string instead of `about:blank` avoids cross-origin conflicts which might cause a separate window tab to be created
  - The [empty string is documented](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) as an explicitly handled "blank page" behavior
- Opening the window to a blank page before setting its location explicitly

**Testing instructions:**

Ensure preview end-to-end tests pass (notably in Travis CI).

```
npm run test-e2e test/e2e/specs/preview.test.js
```

Ensure PostPreviewButton unit tests pass:

```
npm run test-unit packages/editor/src/components/post-preview-button/test/index.js
```

Verify that Preview button will open a tab if one does not already exist, or reuse an existing open tab.

_Caveat:_ While the open tab will be reused, it's not guaranteed it will be given focus. This is consistent with Classic Editor behavior and, to my knowledge, it is not possible to force focus on the opened tab.