### PR TITLE
Allow transitioning status from scheduled to draft

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -41,7 +41,7 @@ export class PostSavedState extends Component {
 	}
 
 	render() {
-		const { isNew, isPublished, isDirty, isSaving, isSaveable, onSave, isAutosaving } = this.props;
+		const { isNew, isScheduled, isPublished, isDirty, isSaving, isSaveable, onSave, isAutosaving } = this.props;
 		const { forceSavedMessage } = this.state;
 		if ( isSaving ) {
 			// TODO: Classes generation should be common across all return
@@ -59,7 +59,7 @@ export class PostSavedState extends Component {
 			);
 		}
 
-		if ( isPublished ) {
+		if ( isPublished || isScheduled ) {
 			return <PostSwitchToDraftButton />;
 		}
 
@@ -94,6 +94,7 @@ export default compose( [
 		const {
 			isEditedPostNew,
 			isCurrentPostPublished,
+			isCurrentPostScheduled,
 			isEditedPostDirty,
 			isSavingPost,
 			isEditedPostSaveable,
@@ -104,6 +105,7 @@ export default compose( [
 			post: getCurrentPost(),
 			isNew: isEditedPostNew(),
 			isPublished: isCurrentPostPublished(),
+			isScheduled: isCurrentPostScheduled(),
 			isDirty: forceIsDirty || isEditedPostDirty(),
 			isSaving: forceIsSaving || isSavingPost(),
 			isSaveable: isEditedPostSaveable(),

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -6,14 +6,20 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-function PostSwitchToDraftButton( { isSaving, isPublished, onClick } ) {
-	if ( ! isPublished ) {
+function PostSwitchToDraftButton( { isSaving, isPublished, isScheduled, onClick } ) {
+	if ( ! isPublished && ! isScheduled ) {
 		return null;
 	}
 
 	const onSwitch = () => {
+		let alertMessage;
+		if ( isPublished ) {
+			alertMessage = __( 'Are you sure you want to unpublish this post?' );
+		} else if ( isScheduled ) {
+			alertMessage = __( 'Are you sure you want to unschedule this post?' );
+		}
 		// eslint-disable-next-line no-alert
-		if ( window.confirm( __( 'Are you sure you want to unpublish this post?' ) ) ) {
+		if ( window.confirm( alertMessage ) ) {
 			onClick();
 		}
 	};
@@ -32,10 +38,11 @@ function PostSwitchToDraftButton( { isSaving, isPublished, onClick } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isSavingPost, isCurrentPostPublished } = select( 'core/editor' );
+		const { isSavingPost, isCurrentPostPublished, isCurrentPostScheduled } = select( 'core/editor' );
 		return {
 			isSaving: isSavingPost(),
 			isPublished: isCurrentPostPublished(),
+			isScheduled: isCurrentPostScheduled(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {


### PR DESCRIPTION
## Description
Modifies the `PostSavedState` component and the `PostSwitchToDraftButton` component to respect scheduled posts. This allows transitioning of posts from `scheduled` to `draft` without publishing first. Fixes #8327

## How has this been tested?
Tested manually:
1. Create a new post 
2. Set the date for sometime in the future.
3. Click Schedule
4. `Switch to Draft` button appears. 
5. Optionally click `Switch to Draft` and get the alert to confirm unscheduling post, same as for unpublishing. 
6. Change date to sometime in the past. `Switch to Draft` button remains as the alternative to `Publish`

## Screenshots
![gutenberg-switch-to-draft](https://user-images.githubusercontent.com/4267290/43480627-d178ee62-94d1-11e8-8275-ea3d410e06f1.gif)

## Types of changes
Bug Fix
New Feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
