### PR TITLE
Expand date filter select box width

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -73,10 +73,10 @@ body.gutenberg-editor-page {
 	ul#adminmenu > li.current > a.current::after {
 		border-right-color: $white;
 	}
-	
+
 	.media-frame select.attachment-filters:last-of-type {
-	    	width: auto;
-	    	max-width: 100%;
+		width: auto;
+		max-width: 100%;
 	}
 }
 

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -73,6 +73,11 @@ body.gutenberg-editor-page {
 	ul#adminmenu > li.current > a.current::after {
 		border-right-color: $white;
 	}
+	
+	.media-frame select.attachment-filters:last-of-type {
+	    	width: auto;
+	    	max-width: 100%;
+	}
 }
 
 .gutenberg {


### PR DESCRIPTION
Widens the "All Dates" select box in the "Add Media" modal window, so that the full placeholder text is shown. Fix for #2202

## Description
Added width: auto; and max-width: 100%; to edit-post/assets/stylesheets/main.scss

## How has this been tested?
Browser tested in Chrome 67.0.3396.99 and FF 61.0.1, Windows 10

## Screenshots
**Before changes**
![gutenberg-2202-before](https://user-images.githubusercontent.com/34601694/43481680-a0571f36-94d4-11e8-8106-905c376a190a.PNG)

**After changes**
![gutenberg-2202-after](https://user-images.githubusercontent.com/34601694/43481679-9ffa914e-94d4-11e8-9683-c1828c72a095.PNG)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
