### PR TITLE
Add inline comment that explains a stopPropagation()

### DIFF
--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -25,7 +25,11 @@ export function DotTip( {
 			focusOnMount="container"
 			role="dialog"
 			aria-label={ __( 'Gutenberg tips' ) }
-			onClick={ ( event ) => event.stopPropagation() }
+			onClick={ ( event ) => {
+				// Tips are often nested within buttons. We stop propagation so that clicking
+				// on a tip doesn't result in the button being clicked.
+				event.stopPropagation();
+			} }
 		>
 			<p>{ children }</p>
 			<p>


### PR DESCRIPTION
Attempts to explain a call to `event.stopPropagation()` using an inline comment.

Fixes https://github.com/WordPress/gutenberg/pull/6631#discussion_r206548911.