### PR TITLE
Gallery: Add alternate caption style

### DIFF
--- a/core-blocks/gallery/edit.js
+++ b/core-blocks/gallery/edit.js
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import { filter, pick } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -53,6 +54,7 @@ class GalleryEdit extends Component {
 		this.setLinkTo = this.setLinkTo.bind( this );
 		this.setColumnsNumber = this.setColumnsNumber.bind( this );
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
+		this.toggleCaptionStyle = this.toggleCaptionStyle.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.addFiles = this.addFiles.bind( this );
@@ -107,6 +109,16 @@ class GalleryEdit extends Component {
 		return checked ? __( 'Thumbnails are cropped to align.' ) : __( 'Thumbnails are not cropped.' );
 	}
 
+	toggleCaptionStyle() {
+		this.props.setAttributes( {
+			captionStyle: this.props.attributes.captionStyle === 'underneath' ? 'overlay' : 'underneath',
+		} );
+	}
+
+	getCaptionStyleHelp( checked ) {
+		return checked ? __( 'Captions are placed below images.' ) : __( 'Captions are not placed inside images.' );
+	}
+
 	setImageAttributes( index, attributes ) {
 		const { attributes: { images }, setAttributes } = this.props;
 		if ( ! images[ index ] ) {
@@ -155,7 +167,14 @@ class GalleryEdit extends Component {
 
 	render() {
 		const { attributes, isSelected, className, noticeOperations, noticeUI } = this.props;
-		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
+		const {
+			images,
+			columns = defaultColumnsNumber( attributes ),
+			align,
+			imageCrop,
+			captionStyle,
+			linkTo,
+		} = attributes;
 
 		const dropZone = (
 			<DropZone
@@ -209,6 +228,16 @@ class GalleryEdit extends Component {
 			);
 		}
 
+		const classes = classnames(
+			className,
+			`align${ align }`,
+			`columns-${ columns }`,
+			{
+				'is-cropped': imageCrop,
+				'has-captions-underneath': captionStyle === 'underneath',
+			},
+		);
+
 		return (
 			<Fragment>
 				{ controls }
@@ -227,6 +256,12 @@ class GalleryEdit extends Component {
 							onChange={ this.toggleImageCrop }
 							help={ this.getImageCropHelp }
 						/>
+						<ToggleControl
+							label={ __( 'Display Captions Below Images' ) }
+							checked={ captionStyle === 'underneath' }
+							onChange={ this.toggleCaptionStyle }
+							help={ this.getCaptionStyleHelp }
+						/>
 						<SelectControl
 							label={ __( 'Link to' ) }
 							value={ linkTo }
@@ -236,7 +271,7 @@ class GalleryEdit extends Component {
 					</PanelBody>
 				</InspectorControls>
 				{ noticeUI }
-				<ul className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
+				<ul className={ classes }>
 					{ dropZone }
 					{ images.map( ( img, index ) => (
 						<li className="blocks-gallery-item" key={ img.id || img.url }>

--- a/core-blocks/gallery/editor.scss
+++ b/core-blocks/gallery/editor.scss
@@ -15,7 +15,6 @@
 }
 
 .blocks-gallery-item {
-
 	.is-selected {
 		outline: 4px solid theme( primary );
 		outline-offset: -4px;
@@ -26,31 +25,13 @@
 	}
 
 	.editor-rich-text {
-		position: absolute;
 		width: 100%;
 		max-height: 100%;
-		overflow-y: auto;
 	}
 
 	.editor-rich-text figcaption:not( [data-is-placeholder-visible="true"] ) {
 		position: relative;
 		overflow: hidden;
-	}
-
-	.is-selected .editor-rich-text {
-		width: calc( 100% - 8px );
-		left: 4px;
-		margin-top: -4px;
-
-		// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
-		.editor-rich-text__inline-toolbar {
-			top: 0;
-		}
-
-		// Make extra space for the inline toolbar.
-		.editor-rich-text__tinymce {
-			padding-top: 48px;
-		}
 	}
 
 	.components-form-file-upload,
@@ -75,6 +56,29 @@
 		&:hover,
 		&:focus {
 			border: 1px solid #999;
+		}
+	}
+}
+
+.wp-block-gallery:not( .has-captions-underneath ) .blocks-gallery-item {
+	.editor-rich-text {
+		position: absolute;
+		overflow-y: auto;
+	}
+
+	.is-selected .editor-rich-text {
+		width: calc( 100% - 8px );
+		left: 4px;
+		margin-top: -4px;
+
+		// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
+		.editor-rich-text__inline-toolbar {
+			top: 0;
+		}
+
+		// Make extra space for the inline toolbar.
+		.editor-rich-text__tinymce {
+			padding-top: 48px;
 		}
 	}
 }

--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { filter, every } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -58,6 +59,10 @@ const blockAttributes = {
 	imageCrop: {
 		type: 'boolean',
 		default: true,
+	},
+	captionStyle: {
+		type: 'string',
+		default: 'overlay',
 	},
 	linkTo: {
 		type: 'string',
@@ -160,9 +165,24 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { images, columns = defaultColumnsNumber( attributes ), imageCrop, linkTo } = attributes;
+		const {
+			images,
+			columns = defaultColumnsNumber( attributes ),
+			imageCrop,
+			captionStyle,
+			linkTo,
+		} = attributes;
+
+		const classes = classnames(
+			`columns-${ columns }`,
+			{
+				'is-cropped': imageCrop,
+				'has-captions-underneath': captionStyle === 'underneath',
+			},
+		);
+
 		return (
-			<ul className={ `columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
+			<ul className={ classes } >
 				{ images.map( ( image ) => {
 					let href;
 

--- a/core-blocks/gallery/style.scss
+++ b/core-blocks/gallery/style.scss
@@ -19,7 +19,8 @@
 			margin: 0;
 			height: 100%;
 			display: flex;
-			align-items: flex-end;
+			justify-content: flex-end;
+			flex-direction: column;
 		}
 
 		img {
@@ -29,15 +30,10 @@
 		}
 
 		figcaption {
-			position: absolute;
 			width: 100%;
-			max-height: 100%;
-			overflow: auto;
-			padding: 40px 10px 5px;
-			color: $white;
+			color: $dark-gray-100;
 			text-align: center;
 			font-size: $default-font-size;
-			background: linear-gradient( 0deg, rgba( $color: $black, $alpha: 0.7 ) 0, rgba($color: $black, $alpha: 0.3) 60%, transparent );
 	
 			img {
 				display: inline;
@@ -93,5 +89,19 @@
 	&.alignright {
 		max-width: $content-width / 2;
 		width: 100%;
+	}
+}
+
+.wp-block-gallery:not( .has-captions-underneath ) {
+	.blocks-gallery-image,
+	.blocks-gallery-item {
+		figcaption {
+			position: absolute;
+			max-height: 100%;
+			overflow: auto;
+			padding: 40px 10px 5px;
+			color: $white;
+			background: linear-gradient( 0deg, rgba( $color: $black, $alpha: 0.7 ) 0, rgba( $color: $black, $alpha: 0.3 ) 60%, transparent );
+		}
 	}
 }

--- a/core-blocks/test/fixtures/core__gallery.json
+++ b/core-blocks/test/fixtures/core__gallery.json
@@ -17,6 +17,7 @@
                 }
             ],
             "imageCrop": true,
+            "captionStyle": "overlay",
             "linkTo": "none"
         },
         "innerBlocks": [],

--- a/core-blocks/test/fixtures/core__gallery__columns.json
+++ b/core-blocks/test/fixtures/core__gallery__columns.json
@@ -18,6 +18,7 @@
             ],
             "columns": 1,
             "imageCrop": true,
+            "captionStyle": "overlay",
             "linkTo": "none"
         },
         "innerBlocks": [],


### PR DESCRIPTION
## Description
Fixes #8030.

Adds an option to show gallery captions underneath each image instead of overlaid on top of each image.

## How has this been tested?
1. Insert a gallery block. Ensure there's a good selection of images with varied aspect ratios
2. Ensure that the gallery looks and works good in the editor and on the frontend
3. Toggle on _Display Captions Below Images_
2. Ensure that the block looks and works good in the editor and on the frontend

## Screenshots <!-- if applicable -->
<img width="661" alt="screen shot 2018-08-01 at 14 11 05" src="https://user-images.githubusercontent.com/612155/43500662-119074a2-9595-11e8-88b0-9189a6a5708b.png">