### PR TITLE
New filter to disable Gutenberg on a post-level

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -278,6 +278,16 @@ function gutenberg_can_edit_post( $post ) {
 		return false;
 	}
 
+	/**
+	 * Filter to allow plugins to enable/disable Gutenberg for particular posts.
+	 *
+	 * @param bool    $can_edit Whether the post can be edited or not.
+	 * @param WP_Post $post     The post being checked.
+	 */
+	if ( ! apply_filters( 'gutenberg_can_edit_post', true, $post ) ) {
+		return false;
+	}
+
 	return current_user_can( 'edit_post', $post->ID );
 }
 


### PR DESCRIPTION
## Description
This fixes #8346.

Added a new filter `gutenberg_can_edit_post` to disable Gutenberg on a post-level.

## How has this been tested?
Added this filter and tested it using a post ID.

Gutenberg was disabled for the post ID I'd entered.

## Types of changes
Adds a new filter to disable Gutenberg on a post-level. This can be useful when trying to roll Gutenberg out in a post-by-post or template-by-template manner.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
