### PR TITLE
Remove unused code in taxonomies panel

### DIFF
--- a/edit-post/components/sidebar/post-taxonomies/index.js
+++ b/edit-post/components/sidebar/post-taxonomies/index.js
@@ -2,18 +2,11 @@
  * WordPress dependencies
  */
 import { PostTaxonomies as PostTaxonomiesForm, PostTaxonomiesCheck } from '@wordpress/editor';
-import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import TaxonomyPanel from './taxonomy-panel';
-
-/**
- * Module Constants
- */
-const PANEL_NAME = 'post-taxonomies';
 
 function PostTaxonomies() {
 	return (
@@ -31,16 +24,4 @@ function PostTaxonomies() {
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			isOpened: select( 'core/edit-post' ).isEditorSidebarPanelOpened( PANEL_NAME ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		onTogglePanel() {
-			return dispatch( 'core/edit-post' ).toggleGeneralSidebarEditorPanel( PANEL_NAME );
-		},
-	} ) ),
-] )( PostTaxonomies );
-
+export default PostTaxonomies;


### PR DESCRIPTION
After merging https://github.com/WordPress/gutenberg/pull/5183 the code that has been removed in this PR is no longer needed.
