### PR TITLE
Filters for PanelBody component, and for PostExcerptForm editor component

### DIFF
--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -37,10 +38,12 @@ class PanelBody extends Component {
 	}
 
 	render() {
-		const { title, children, opened, className, icon } = this.props;
+		const { title: rawTitle, children, opened, className, icon } = this.props;
 		const isOpened = opened === undefined ? this.state.opened : opened;
 		const arrow = `arrow-${ isOpened ? 'up' : 'down' }`;
 		const classes = classnames( 'components-panel__body', className, { 'is-opened': isOpened } );
+
+		const title = applyFilters( 'components.panel.body.title', rawTitle );
 
 		return (
 			<div className={ classes }>

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -7,6 +7,7 @@ import { shallow, mount } from 'enzyme';
  * Internal dependencies
  */
 import PanelBody from '../body';
+import { addFilter } from '@wordpress/hooks';
 
 jest.mock( '../../button' );
 
@@ -55,6 +56,13 @@ describe( 'PanelBody', () => {
 			expect( panelBody.instance().props.children ).toBe( 'Some Text' );
 			// Text should be empty even though props.children is set.
 			expect( panelBody.text() ).toBe( '' );
+		} );
+
+		it( 'should obey filter for the panel title', () => {
+			addFilter( 'components.panel.body.title', 'test', () => 'Filtered Title' );
+			const panelBody = shallow( <PanelBody title="Some Text" children="Child Text" /> );
+			const button = panelBody.find( 'Button' );
+			expect( button.childAt( 1 ).text() ).toBe( 'Filtered Title' );
 		} );
 	} );
 

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -58,7 +58,7 @@ describe( 'PanelBody', () => {
 			expect( panelBody.text() ).toBe( '' );
 		} );
 
-		it( 'should obey filter for the panel title', () => {
+		it( 'should allow filtering of the panel title', () => {
 			addFilter( 'components.panel.body.title', 'test', () => 'Filtered Title' );
 			const panelBody = shallow( <PanelBody title="Some Text" children="Child Text" /> );
 			const button = panelBody.find( 'Button' );

--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -5,21 +5,30 @@ import { __ } from '@wordpress/i18n';
 import { ExternalLink, TextareaControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { applyFilters } from '@wordpress/hooks';
 
 function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	return (
 		<div className="editor-post-excerpt">
 			<TextareaControl
-				label={ __( 'Write an excerpt (optional)' ) }
+				label={ PostExcerptLabel( __( 'Write an excerpt (optional)' ) ) }
 				className="editor-post-excerpt__textarea"
 				onChange={ ( value ) => onUpdateExcerpt( value ) }
 				value={ excerpt }
 			/>
 			<ExternalLink href="https://codex.wordpress.org/Excerpt">
-				{ __( 'Learn more about manual excerpts' ) }
+				{ PostExcerptLinkText( __( 'Learn more about manual excerpts' ) ) }
 			</ExternalLink>
 		</div>
 	);
+}
+
+function PostExcerptLabel( label ) {
+	return applyFilters( 'editor.post-excerpt.label', label );
+}
+
+function PostExcerptLinkText( text ) {
+	return applyFilters( 'editor.post-excerpt.link-text', text );
 }
 
 export default compose( [

--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -23,10 +23,22 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	);
 }
 
+/**
+ * Wrapper function to filter the label property passed to the post excerpt Textareacontrol.
+ *
+ * @param {string} label The default label to be filtered.
+ * @return {string} The filtered string.
+ */
 function PostExcerptLabel( label ) {
 	return applyFilters( 'editor.post-excerpt.label', label );
 }
 
+/**
+ * Wrapper function to filter the internal text of the codex link in the post excerpt.
+ *
+ * @param {string} text The default text to be filtered.
+ * @return {string} The filtered string.
+ */
 function PostExcerptLinkText( text ) {
 	return applyFilters( 'editor.post-excerpt.link-text', text );
 }

--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -7,7 +7,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
 
-function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
+export function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	return (
 		<div className="editor-post-excerpt">
 			<TextareaControl

--- a/packages/editor/src/components/post-excerpt/test/index.js
+++ b/packages/editor/src/components/post-excerpt/test/index.js
@@ -14,7 +14,7 @@ describe( 'PostExcerpt', () => {
 		addFilter( 'editor.post-excerpt.label', 'test', () => 'Filtered Label' );
 		const wrapper = shallow( <PostExcerpt /> );
 		const control = wrapper.childAt( 0 );
-		expect( control.prop( 'label') ).toBe( 'Filtered Label' );
+		expect( control.prop( 'label' ) ).toBe( 'Filtered Label' );
 	} );
 
 	it( 'should allow filtering of the excerpt link text', () => {

--- a/packages/editor/src/components/post-excerpt/test/index.js
+++ b/packages/editor/src/components/post-excerpt/test/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostExcerpt } from '../';
+import { addFilter } from '@wordpress/hooks';
+
+describe( 'PostExcerpt', () => {
+	it( 'should allow filtering of the excerpt label', () => {
+		addFilter( 'editor.post-excerpt.label', 'test', () => 'Filtered Label' );
+		const wrapper = shallow( <PostExcerpt /> );
+		const control = wrapper.childAt( 0 );
+		expect( control.prop( 'label') ).toBe( 'Filtered Label' );
+	} );
+
+	it( 'should allow filtering of the excerpt link text', () => {
+		addFilter( 'editor.post-excerpt.link-text', 'test', () => 'Filtered Link Text' );
+		const excerpt = shallow( <PostExcerpt /> );
+		const link = excerpt.childAt( 1 );
+		expect( link.text() ).toBe( 'Filtered Link Text' );
+	} );
+} );


### PR DESCRIPTION
## Description
This pull request makes the title of a `PanelBody` component filterable using `wp.hooks`. It also makes the internal label and text link of the `PostExcerptForm` component filterable by similar means.

## How has this been tested?
I have verified this pull request passes the existing unit testing suite. I have tested it functionally using a small plugin that does the following:

```javascript
wp.hooks.addFilter( 'components.panel.body.title', 'gutenberg-dek', function( title ) {
	if ( 'Excerpt' === title ) {
		return 'Dek';
	}
	return title;
} );

wp.hooks.addFilter( 'editor.post-excerpt.label', 'gutenberg-dek', function( label ) {
	return 'Write a custom dek (optional)';
} );

wp.hooks.addFilter( 'editor.post-excerpt.link-text', 'gutenberg-dek', function ( text ) {
	return 'Learn more about custom deks.';
} );
```

## Types of changes
This is a new feature which does not break any existing implementation or functionality.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
