### PR TITLE
Reusable blocks: Add NUX

### DIFF
--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -69,7 +69,7 @@ class ReusableBlockEditPanel extends Component {
 							<Dashicon icon="controls-repeat" />
 							{ title }
 							<DotTip id="core/editor.reusableBlocks">
-								{ __( 'This is a reusable block. Changes made to this block will appear on every post and page that uses it. It’s a great way to re-use content.' ) }
+								{ __( 'This is a Reusable Block: it adds this exact content anywhere it’s inserted. Use them for text, images, links, or any other kind of content. Update a Reusable Block on one page, and it automatically updates everywhere it appears – a handy time-saver for managing content you need to have in many places on your site.' ) }
 							</DotTip>
 						</b>
 						<Button

--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Dashicon, Button } from '@wordpress/components';
 import { Component, Fragment, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
 import { withInstanceId } from '@wordpress/compose';
+import { DotTip } from '@wordpress/nux';
 
 /**
  * Internal dependencies
@@ -65,7 +66,11 @@ class ReusableBlockEditPanel extends Component {
 				{ ( ! isEditing && ! isSaving ) && (
 					<div className="reusable-block-edit-panel">
 						<b className="reusable-block-edit-panel__info">
+							<Dashicon icon="controls-repeat" />
 							{ title }
+							<DotTip id="core/editor.reusableBlocks">
+								{ __( 'This is a reusable block. Changes made to this block will appear on every post and page that uses it. It’s a great way to re-use content.' ) }
+							</DotTip>
 						</b>
 						<Button
 							ref={ this.editButton }

--- a/core-blocks/block/edit-panel/index.js
+++ b/core-blocks/block/edit-panel/index.js
@@ -65,12 +65,14 @@ class ReusableBlockEditPanel extends Component {
 			<Fragment>
 				{ ( ! isEditing && ! isSaving ) && (
 					<div className="reusable-block-edit-panel">
-						<b className="reusable-block-edit-panel__info">
-							<Dashicon icon="controls-repeat" />
-							{ title }
-							<DotTip id="core/editor.reusableBlocks">
+						<span className="reusable-block-edit-panel__icon">
+							<DotTip id="core/editor.reusableBlocks" position="bottom right">
 								{ __( 'This is a Reusable Block: it adds this exact content anywhere it’s inserted. Use them for text, images, links, or any other kind of content. Update a Reusable Block on one page, and it automatically updates everywhere it appears – a handy time-saver for managing content you need to have in many places on your site.' ) }
 							</DotTip>
+							<Dashicon icon="controls-repeat" />
+						</span>
+						<b className="reusable-block-edit-panel__info">
+							{ title }
 						</b>
 						<Button
 							ref={ this.editButton }

--- a/core-blocks/block/edit-panel/style.scss
+++ b/core-blocks/block/edit-panel/style.scss
@@ -17,15 +17,15 @@
 		padding: 10px $block-padding;
 	}
 
-	.reusable-block-edit-panel__info {
+	.reusable-block-edit-panel__icon {
 		align-items: center;
 		display: flex;
-		margin-right: auto;
-		padding-right: 5px;
+		height: 30px;
+		margin-right: 5px;
+	}
 
-		.dashicon {
-			margin-right: 5px;
-		}
+	.reusable-block-edit-panel__info {
+		margin-right: auto;
 	}
 
 	.reusable-block-edit-panel__label {

--- a/core-blocks/block/edit-panel/style.scss
+++ b/core-blocks/block/edit-panel/style.scss
@@ -17,12 +17,15 @@
 		padding: 10px $block-padding;
 	}
 
-	.reusable-block-edit-panel__spinner {
-		margin: 0 5px;
-	}
-
 	.reusable-block-edit-panel__info {
+		align-items: center;
+		display: flex;
 		margin-right: auto;
+		padding-right: 5px;
+
+		.dashicon {
+			margin-right: 5px;
+		}
 	}
 
 	.reusable-block-edit-panel__label {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -416,3 +416,41 @@ add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_b
 function gutenberg_add_admin_body_class( $classes ) {
 	return "$classes gutenberg-editor-page";
 }
+
+/**
+ * Creates initial Gutenberg content when the plugin first activates. This
+ * consists of the default 'Gutenpride' reusable block.
+ *
+ * @since 3.5.0
+ */
+function gutenberg_install_defaults() {
+	$existing_sample_blocks = get_posts( array(
+		'name'      => 'gutenpride',
+		'post_type' => 'wp_block',
+	) );
+
+	if ( count( $existing_sample_blocks ) ) {
+		return;
+	}
+
+	$sample_block_content = sprintf(
+		"<!-- wp:paragraph {\"className\":\"wp-block-gutenpride\"} -->\n<p class=\"wp-block-gutenpride\">%s</p>\n<!-- /wp:paragraph -->",
+		sprintf(
+			/* translators: %s: a link that opens the Gutenberg product page */
+			__( '❤️ This post proudly created in %s', 'gutenberg' ),
+			sprintf(
+				'<a href="https://wordpress.org/gutenberg/">%s</a>',
+				__( 'Gutenberg', 'gutenberg' )
+			)
+		)
+	);
+
+	wp_insert_post( array(
+		'post_title'   => __( 'Gutenpride', 'gutenberg' ),
+		'post_content' => $sample_block_content,
+		'post_status'  => 'publish',
+		'post_type'    => 'wp_block',
+		'post_name'    => 'gutenpride',
+	) );
+}
+register_activation_hook( __FILE__, 'gutenberg_install_defaults' );

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -8,6 +8,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 
 export function DotTip( {
 	children,
+	position = 'middle right',
 	isVisible,
 	hasNextTip,
 	onDismiss,
@@ -20,7 +21,7 @@ export function DotTip( {
 	return (
 		<Popover
 			className="nux-dot-tip"
-			position="middle right"
+			position={ position }
 			noArrow
 			focusOnMount="container"
 			role="dialog"

--- a/packages/nux/src/components/dot-tip/style.scss
+++ b/packages/nux/src/components/dot-tip/style.scss
@@ -51,10 +51,10 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 	}
 
 	// Position the dot right next to the edge of the button
-	&.is-left {
+	&.is-middle.is-left {
 		margin-left: -$dot-size / 2;
 	}
-	&.is-right {
+	&.is-middle.is-right {
 		margin-left: $dot-size / 2;
 	}
 


### PR DESCRIPTION
This is a slightly experimental attempt to aid with the discovery and understanding of reusable blocks by:

- Shipping Gutenberg with a sample reusable block. This allows users to discover the feature via the inserter which is already a very natural way to discover features in Gutenberg. The sample block is installed when the plugin is activated.
- Adding the reusable block icon that we use elsewhere next to the title of a reusable block. By leaning more heavily on this icon we lessen our reliance on the word _reusable_ which isn't very self-explanatory.
- Adding a tip to reusable blocks. The tip helps explain what a reusable block is in more detail once discovered.

I'm using [Gutenpride](https://github.com/mkaz/gutenpride) as the sample block because _I thought it would be cute™_. We could also go with something more explicit like the default _Hello world!_ post or _Sample Page_ page that is created when WordPress is first installed.

The complete flow for a new user would then be:

1. Open the inserter
2. See _Gutenpride_ in the inserter at the bottom
3. Click on it out of curiosity
4. See the example block appear with a tip explaining what reusable blocks are

![blocks-nux](https://user-images.githubusercontent.com/612155/43565923-f574fbb8-966f-11e8-8c69-8af0c1709529.gif)