### PR TITLE
Packages: Generate source maps and read those from the webpack build

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -123,10 +123,14 @@ function buildFileFor( file, silent, environment ) {
 	const buildDir = BUILD_DIR[ environment ];
 	const destPath = getBuildPath( file, buildDir );
 	const babelOptions = getBabelConfig( environment );
+	babelOptions.sourceMaps = true;
+	babelOptions.sourceFileName = file;
 
 	mkdirp.sync( path.dirname( destPath ) );
-	const transformed = babel.transformFileSync( file, babelOptions ).code;
-	fs.writeFileSync( destPath, transformed );
+	const transformed = babel.transformFileSync( file, babelOptions );
+	fs.writeFileSync( destPath + '.map', JSON.stringify( transformed.map ) );
+	fs.writeFileSync( destPath, transformed.code + '\n//# sourceMappingURL=' + path.basename( destPath ) + '.map' );
+
 	if ( ! silent ) {
 		process.stdout.write(
 			chalk.green( '  \u2022 ' ) +

--- a/package-lock.json
+++ b/package-lock.json
@@ -18503,6 +18503,37 @@
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 			"dev": true
 		},
+		"source-map-loader": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
+			"integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
+			"dev": true,
+			"requires": {
+				"async": "^2.5.0",
+				"loader-utils": "~0.2.2",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "0.2.17",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"dev": true,
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0",
+						"object-assign": "^4.0.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"rimraf": "2.6.2",
 		"rtlcss": "2.4.0",
 		"sass-loader": "6.0.7",
+		"source-map-loader": "0.2.3",
 		"sprintf-js": "1.1.1",
 		"style-loader": "0.20.3",
 		"symlink-or-copy": "1.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -165,6 +165,11 @@ const config = {
 		rules: [
 			{
 				test: /\.js$/,
+				use: [ 'source-map-loader' ],
+				enforce: 'pre',
+			},
+			{
+				test: /\.js$/,
 				exclude: [
 					/block-serialization-spec-parser/,
 					/is-shallow-equal/,


### PR DESCRIPTION
This PR fixes sourcemaps to allow debugging code while working on Gutenberg itself. It does so in two steps:

 1- Generate source maps for each file built using babel in the packages folder
 2- Configure webpack to preload source maps for its input files.