### PR TITLE
Constrain media blocks to content area width in frontend.

### DIFF
--- a/core-blocks/image/style.scss
+++ b/core-blocks/image/style.scss
@@ -1,5 +1,10 @@
 .wp-block-image {
 	width: fit-content;
+    max-width: 100%;
+
+	img {
+	    max-width: 100%;
+	}
 
 	&.aligncenter {
 		display: block;

--- a/core-blocks/image/style.scss
+++ b/core-blocks/image/style.scss
@@ -1,9 +1,9 @@
 .wp-block-image {
 	width: fit-content;
-    max-width: 100%;
+	max-width: 100%;
 
 	img {
-	    max-width: 100%;
+		max-width: 100%;
 	}
 
 	&.aligncenter {

--- a/core-blocks/video/style.scss
+++ b/core-blocks/video/style.scss
@@ -1,4 +1,8 @@
 .wp-block-video {
+	video {
+		max-width: 100%;
+	}
+
 	&.aligncenter {
 		text-align: center;
 	}


### PR DESCRIPTION
As it stands right now, images and videos can potentially overflow the content area if their theme doesn't explicitly tell them not to. This doesn't affect the majority (guess) of newer themes, but is likely an issue with lots of older/non-responsive themes, including twentyten.

Giving a max-width of 100% to the image and video blocks ensures they won't break out of the content area of the site, regardless of whether the theme has styling that prevents overflow.

I tested this in a bunch of themes, both old and new, and it doesn't *seem* to introduce any egregious conflicts, but I may have missed something. I'd appreciate some extra 👀 on it! 

Fixes #8334.

### Before:
![image](https://user-images.githubusercontent.com/376315/43599343-30c9858a-967f-11e8-8bc1-27f258b60e99.png)


### After:
![image](https://user-images.githubusercontent.com/376315/43599253-f049dece-967e-11e8-9964-c08b77c93e7b.png)


