### PR TITLE
Meta boxes absent when script enqueued in head depends on `wp-edit-post`

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -324,10 +324,13 @@ function the_gutenberg_metaboxes() {
 	 * editor instance. If a cleaner solution can be imagined, please change
 	 * this, and try to get this data to load directly into the editor settings.
 	 */
-	wp_add_inline_script(
-		'wp-edit-post',
-		'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
-	);
+	$script = 'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );';
+
+	wp_add_inline_script( 'wp-edit-post', $script );
+
+	if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
+		printf( "<script type='text/javascript'>\n%s\n</script>\n", trim( implode( "\n", $script ), "\n" ) );
+	}
 
 	// Reset meta box data.
 	$wp_meta_boxes = $_original_meta_boxes;

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -335,7 +335,7 @@ function the_gutenberg_metaboxes() {
 	 * @see https://github.com/WordPress/gutenberg/issues/6963
 	 */
 	if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
-		printf( "<script type='text/javascript'>\n%s\n</script>\n", trim( implode( "\n", $script ), "\n" ) );
+		printf( "<script type='text/javascript'>\n%s\n</script>\n", trim( $script ) );
 	}
 
 	// Reset meta box data.

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -328,6 +328,12 @@ function the_gutenberg_metaboxes() {
 
 	wp_add_inline_script( 'wp-edit-post', $script );
 
+	/**
+	 * When `wp-edit-post` is output in the `<head>`, the inline script needs to be manually printed. Otherwise,
+	 * metaboxes will not display because inline scripts for `wp-edit-post` will not be printed again after this point.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/issues/6963
+	 */
 	if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
 		printf( "<script type='text/javascript'>\n%s\n</script>\n", trim( implode( "\n", $script ), "\n" ) );
 	}


### PR DESCRIPTION
Manually print inline metabox initialization JavaScript when the `wp-edit-post` script is printed in the `<head>`.

Currently, metaboxes do not display when any registered script is dependent on the `wp-edit-post` script and output in the page's `<head>` tag (causing the `wp-edit-post` script to also be printed in the `<head>`. This is because the head scripts and styles are being printed before the inline script is added to `wp-edit-post`, and WordPress cannot print what is not yet registered.

The plugin will now check if the `wp-edit-post` script is `done` and manually output the inline script to ensure metaboxes are properly initialized and displayed.

I played around with `WP_Scripts()->print_inline_script( 'wp-edit-post' )`, but there is no way to print a single inline script attached to a registered script. This causes _every_ inline script to be re-printed and breaks the app. I could not find a function that exists in core to print a one-off inline script not attached to specific registered script. The needed part of `WP_Scripts()->print_inline_script()` is only one line, so I have copied that into the plugin.

## How has this been tested?
To test, follow the steps detailed in #6963 to reproduce the issue. Then apply the changes in this branch to verify it fixes the issue.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.

Fixes #6963.