### PR TITLE
chore: setup conventional commits with Lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,14 @@
 {
 	"command": {
 		"publish": {
+			"allowBranch": "master",
+			"conventionalCommits": true,
 			"message": "chore(release): publish"
 		}
 	},
 	"ignoreChanges": [
+		"**/*.md",
+		"**/__mocks__/**",
 		"**/benchmark/*.js",
 		"**/test/**"
 	],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,15 +1817,15 @@
 			}
 		},
 		"@lerna/add": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.0.0-beta.21.tgz",
-			"integrity": "sha512-IPRCgioIuPacBS938p1DaB0glqUp32FXDBpwxePUyg/LydpDuxalqW6lDuGO5YhDDCfMcN8CT/nx+An2IB5mUw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.0.0-rc.0.tgz",
+			"integrity": "sha512-PZ/dn4UlA/7sd848LHE2TLXIkOzLDk8Uw/Gz6OwXfxXpng/w6mXcyjaScniT3HzLbzw5fP150+im5mL6BQv9JQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/bootstrap": "^3.0.0-beta.21",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/filter-options": "^3.0.0-beta.18",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/bootstrap": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/filter-options": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"dedent": "^0.7.0",
 				"npm-package-arg": "^6.0.0",
 				"p-map": "^1.2.0",
@@ -1834,33 +1834,33 @@
 			}
 		},
 		"@lerna/batch-packages": {
-			"version": "3.0.0-beta.18",
-			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.0.0-beta.18.tgz",
-			"integrity": "sha512-ZFbKNQkp0vy2M1JGNMj6wX08E3Vv5mlA+QtScwOR2DGV2nG2HK5F7HcVICOi1BW9bjvHKjfU+e8aebTCWizllA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.0.0-rc.0.tgz",
+			"integrity": "sha512-2FZs545THLHSWZ96xKT5wWFOdIt1UIKnc+Z2IIXCgmhT//fcqEcHFSgq42VxgoELgE4rM7jE2s6wgMatiJwRGg==",
 			"dev": true,
 			"requires": {
-				"@lerna/package-graph": "^3.0.0-beta.18",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/package-graph": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/bootstrap": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.0.0-beta.21.tgz",
-			"integrity": "sha512-UmLCrE9poTZ6F3itY/0tiJaTMTO88lQMjYOnNtmmj9nnmdXcfu6qAmmY062YpbYWbgHZd5gJ2/5rinl4EM19fA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.0.0-rc.0.tgz",
+			"integrity": "sha512-69mXMWjXA8R6ldDmSntFIIZTNAgEu1lOUP7DilL4OY55z01ln5fOtG/c65PQBm4mjm5ejh1kJVWiDT8MbCRslQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "^3.0.0-beta.18",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/filter-options": "^3.0.0-beta.18",
-				"@lerna/npm-conf": "^3.0.0-beta.19",
-				"@lerna/npm-install": "^3.0.0-beta.21",
-				"@lerna/rimraf-dir": "^3.0.0-beta.21",
-				"@lerna/run-lifecycle": "^3.0.0-beta.0",
-				"@lerna/run-parallel-batches": "^3.0.0-beta.0",
-				"@lerna/symlink-binary": "^3.0.0-beta.17",
-				"@lerna/symlink-dependencies": "^3.0.0-beta.17",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/batch-packages": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/filter-options": "^3.0.0-rc.0",
+				"@lerna/npm-conf": "^3.0.0-rc.0",
+				"@lerna/npm-install": "^3.0.0-rc.0",
+				"@lerna/rimraf-dir": "^3.0.0-rc.0",
+				"@lerna/run-lifecycle": "^3.0.0-rc.0",
+				"@lerna/run-parallel-batches": "^3.0.0-rc.0",
+				"@lerna/symlink-binary": "^3.0.0-rc.0",
+				"@lerna/symlink-dependencies": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"dedent": "^0.7.0",
 				"get-port": "^3.2.0",
 				"multimatch": "^2.1.0",
@@ -1875,22 +1875,22 @@
 			}
 		},
 		"@lerna/changed": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.0.0-beta.21.tgz",
-			"integrity": "sha512-qb7EkSNKMZjKayE4aiGZsSH9Ys/TOEWm4I9C/lv4vWjOhqYzpG0g56pH2s+m38Lk9iqj/Q9Dk1mn/8W+siVrDg==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.0.0-rc.0.tgz",
+			"integrity": "sha512-DY2Id3Y1jifIdZ8uNymUijUgkVRFg64IUHMTb1sm0g/Nd+n++kLo9oqxRTUfuBkW3e1HTUuMkd3ZygU5UBtz6g==",
 			"dev": true,
 			"requires": {
-				"@lerna/collect-updates": "^3.0.0-beta.21",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/output": "^3.0.0-beta.0",
-				"@lerna/publish": "^3.0.0-beta.21",
+				"@lerna/collect-updates": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/output": "^3.0.0-rc.0",
+				"@lerna/publish": "^3.0.0-rc.0",
 				"chalk": "^2.3.1"
 			}
 		},
 		"@lerna/child-process": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.0.0-beta.21.tgz",
-			"integrity": "sha512-9FO1UFujjOUAepwdW+Fe4fKm6zPlGI58LiwOg5X69VIBvVxxXU++RpKQGL+Xdj5/Q6p7+oMnpivWIlPyODqsUQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.0.0-rc.0.tgz",
+			"integrity": "sha512-5LhCU8isfJFj+5V5cJ+wcRR+VkNIbb3rSjm4VVclnD05ZfaY1HmfhBu3VjYt0SulhZKWJEnNBvjG88wgTay1vQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.1",
@@ -1929,55 +1929,107 @@
 			}
 		},
 		"@lerna/clean": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.0.0-beta.21.tgz",
-			"integrity": "sha512-OY/PigGfqRAFl430QLfhqL4ktdqgvzqU2MBIGljRi07H09Ux5UO7uhfGy3RaY4Wb+U+Xo91j/zkV3BdPQS1Uaw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.0.0-rc.0.tgz",
+			"integrity": "sha512-rVlvO+bhfU/Q9D6bfg5GaLprKMD5rTRjJEqLONpESx/5Ed+NKgbYRiWafpQrB85m2r3c5dSGEPEc2q2rNG3EPg==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/filter-options": "^3.0.0-beta.18",
-				"@lerna/prompt": "^3.0.0-beta.0",
-				"@lerna/rimraf-dir": "^3.0.0-beta.21",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/filter-options": "^3.0.0-rc.0",
+				"@lerna/prompt": "^3.0.0-rc.0",
+				"@lerna/rimraf-dir": "^3.0.0-rc.0",
 				"p-map": "^1.2.0",
 				"p-map-series": "^1.0.0",
 				"p-waterfall": "^1.0.0"
 			}
 		},
 		"@lerna/cli": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.0.0-beta.21.tgz",
-			"integrity": "sha512-kEki2UDee0JWUQhfCv4qZknAST7C7OdIXb3T+IyOqpEP/MSbpYdGfwlxrkF7ZTVZHn4X0uP2op0fbQ1LRt757A==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.0.0-rc.0.tgz",
+			"integrity": "sha512-MUOrP8BiwjayPZAS3Nww1nlB6j02N4FmJK/f2PhJPMDsXMqm3mn5jBTBvlKbLQZJ/VDro8JbRGUUxCuCQEE+cQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/add": "^3.0.0-beta.21",
-				"@lerna/bootstrap": "^3.0.0-beta.21",
-				"@lerna/changed": "^3.0.0-beta.21",
-				"@lerna/clean": "^3.0.0-beta.21",
-				"@lerna/create": "^3.0.0-beta.21",
-				"@lerna/diff": "^3.0.0-beta.21",
-				"@lerna/exec": "^3.0.0-beta.21",
-				"@lerna/global-options": "^3.0.0-beta.13",
-				"@lerna/import": "^3.0.0-beta.21",
-				"@lerna/init": "^3.0.0-beta.21",
-				"@lerna/link": "^3.0.0-beta.21",
-				"@lerna/list": "^3.0.0-beta.21",
-				"@lerna/publish": "^3.0.0-beta.21",
-				"@lerna/run": "^3.0.0-beta.21",
+				"@lerna/add": "^3.0.0-rc.0",
+				"@lerna/bootstrap": "^3.0.0-rc.0",
+				"@lerna/changed": "^3.0.0-rc.0",
+				"@lerna/clean": "^3.0.0-rc.0",
+				"@lerna/create": "^3.0.0-rc.0",
+				"@lerna/diff": "^3.0.0-rc.0",
+				"@lerna/exec": "^3.0.0-rc.0",
+				"@lerna/global-options": "^3.0.0-rc.0",
+				"@lerna/import": "^3.0.0-rc.0",
+				"@lerna/init": "^3.0.0-rc.0",
+				"@lerna/link": "^3.0.0-rc.0",
+				"@lerna/list": "^3.0.0-rc.0",
+				"@lerna/publish": "^3.0.0-rc.0",
+				"@lerna/run": "^3.0.0-rc.0",
 				"dedent": "^0.7.0",
 				"is-ci": "^1.0.10",
 				"npmlog": "^4.1.2",
-				"yargs": "^11.0.0"
+				"yargs": "^12.0.1"
 			},
 			"dependencies": {
+				"decamelize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+					"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+					"dev": true,
+					"requires": {
+						"xregexp": "4.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+					"dev": true
+				},
 				"yargs": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+					"version": "12.0.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+					"integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
+						"decamelize": "^2.0.0",
+						"find-up": "^3.0.0",
 						"get-caller-file": "^1.0.1",
 						"os-locale": "^2.0.0",
 						"require-directory": "^2.1.1",
@@ -1985,14 +2037,14 @@
 						"set-blocking": "^2.0.0",
 						"string-width": "^2.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^10.1.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "9.0.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -2000,77 +2052,13 @@
 				}
 			}
 		},
-		"@lerna/collect-packages": {
-			"version": "3.0.0-beta.17",
-			"resolved": "https://registry.npmjs.org/@lerna/collect-packages/-/collect-packages-3.0.0-beta.17.tgz",
-			"integrity": "sha512-ADGLVCKlIfGLkNk5iME6H3Wi2HjI5WwlB1MfGEDapv456uifWDZk+hmFbOK3402W+6MQvkCTrw3xeRZyX8mGTQ==",
-			"dev": true,
-			"requires": {
-				"@lerna/package": "^3.0.0-beta.17",
-				"@lerna/validation-error": "^3.0.0-beta.10",
-				"globby": "^8.0.1",
-				"load-json-file": "^4.0.0",
-				"p-map": "^1.2.0"
-			},
-			"dependencies": {
-				"globby": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-					"dev": true,
-					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
-						"fast-glob": "^2.0.2",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				}
-			}
-		},
 		"@lerna/collect-updates": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.0.0-beta.21.tgz",
-			"integrity": "sha512-4vYlELyws068eY35gDGZ7REHbRlYZo7eJKplVWuUEbWK21x0f8HIh4u6TLcG9WITXZ6HXWWdSP8pP7AKqa3I6w==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.0.0-rc.0.tgz",
+			"integrity": "sha512-G1BgTIWc6rSsuMLsgpT+xvrQrSN/a0kC+KqMZ9CbCoImtj0AKvrAm3TeFOsYU9JHBUYfe1HWMIIhUSD4VhXmeg==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
+				"@lerna/child-process": "^3.0.0-rc.0",
 				"minimatch": "^3.0.4",
 				"npmlog": "^4.1.2",
 				"semver": "^5.5.0",
@@ -2078,19 +2066,18 @@
 			}
 		},
 		"@lerna/command": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.0.0-beta.21.tgz",
-			"integrity": "sha512-ijshJe404Kskyey3VQpjZVoEQX8Bx3MbEQTE+PQb7bEzV5zvJJTuHApjcf20bESiKj8DjDoO/bmq0TX8rhSumA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.0.0-rc.0.tgz",
+			"integrity": "sha512-YzQKhQGSaqhnj/UbygmIneQDuhsTGu9rBqbX84Qs8RhKMMAPWurg+k6sCIihHgBz17tknxEvch/SefMNQxqzAA==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/collect-packages": "^3.0.0-beta.17",
-				"@lerna/collect-updates": "^3.0.0-beta.21",
-				"@lerna/filter-packages": "^3.0.0-beta.10",
-				"@lerna/package-graph": "^3.0.0-beta.18",
-				"@lerna/project": "^3.0.0-beta.20",
-				"@lerna/validation-error": "^3.0.0-beta.10",
-				"@lerna/write-log-file": "^3.0.0-beta.0",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/collect-updates": "^3.0.0-rc.0",
+				"@lerna/filter-packages": "^3.0.0-rc.0",
+				"@lerna/package-graph": "^3.0.0-rc.0",
+				"@lerna/project": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
+				"@lerna/write-log-file": "^3.0.0-rc.0",
 				"dedent": "^0.7.0",
 				"execa": "^0.10.0",
 				"lodash": "^4.17.5",
@@ -2128,17 +2115,17 @@
 			}
 		},
 		"@lerna/conventional-commits": {
-			"version": "3.0.0-beta.15",
-			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.0.0-beta.15.tgz",
-			"integrity": "sha512-r74KL1lclM7GJec6DvH7hIVDNYfqYPvK+7ZSRApbNfTEEzH+/IIyPqZnZflczrhWTQCoMWphbQK8zf9QazPcHQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.0.0-rc.0.tgz",
+			"integrity": "sha512-J5RC+pd7kHP8EfqzvZqaXW253IoShdlzl1Jrw17KqPDAfL5CoZoUwxgZv4ur3kSSv+jHZGQeuAcg93OsBgkzPw==",
 			"dev": true,
 			"requires": {
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"conventional-changelog-angular": "^1.6.6",
 				"conventional-changelog-core": "^2.0.5",
 				"conventional-recommended-bump": "^2.0.6",
 				"dedent": "^0.7.0",
-				"fs-extra": "^5.0.0",
+				"fs-extra": "^6.0.1",
 				"get-stream": "^3.0.0",
 				"npm-package-arg": "^6.0.0",
 				"npmlog": "^4.1.2",
@@ -2146,18 +2133,18 @@
 			}
 		},
 		"@lerna/create": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.0.0-beta.21.tgz",
-			"integrity": "sha512-MxjaivJMSIm8VLLCspT6ob9BRus6+DMEizkF0kOiYTVHUh5PI2sCtsw7fa8sIGZQJeU0ELGrvMF4i4VXXFikSQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.0.0-rc.0.tgz",
+			"integrity": "sha512-6GLI+MEKANCAVnuA9pYQX1k+XyyPEBdoPAiSK4lnW2w4E2KSQZxdkI1+9QLv6S2oTrnlrFSxGmqgmmijaZfCGg==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/npm-conf": "^3.0.0-beta.19",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/npm-conf": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"camelcase": "^4.1.0",
 				"dedent": "^0.7.0",
-				"fs-extra": "^5.0.0",
+				"fs-extra": "^6.0.1",
 				"globby": "^8.0.1",
 				"init-package-json": "^1.10.3",
 				"npm-package-arg": "^6.0.0",
@@ -2192,135 +2179,135 @@
 			}
 		},
 		"@lerna/create-symlink": {
-			"version": "3.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.0.0-beta.0.tgz",
-			"integrity": "sha512-i9gm0h3RVM8Mhe+kliWmZmLPcaxOyn8ccOtIqHIUanOB4MrlRsg9xQJtlpsEsG3szCKZ+EqcpM9sknEyoHyt4Q==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.0.0-rc.0.tgz",
+			"integrity": "sha512-wz/C7DB5chTidAOc9+edeg65nJLG1PNO9J/jlAUZOY4G3EPGihLroabIlvbjB5SJ8QKS88ftX+f1pzFZ+nYOdQ==",
 			"dev": true,
 			"requires": {
 				"cmd-shim": "^2.0.2",
-				"fs-extra": "^5.0.0",
+				"fs-extra": "^6.0.1",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/diff": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.0.0-beta.21.tgz",
-			"integrity": "sha512-/i/RrA6kPMGCsnYnsDixZtlzbM8Q21Ov31+UxP9Z4gAFMVbxyi3DmiQH+de9H8fuVVeqpSGg0XAnVN7nML+mIg==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.0.0-rc.0.tgz",
+			"integrity": "sha512-fXeB10qaFeBMucorkV6Q/bJiWayZgGizVsPkuGN1izENd4DBsTxUyh2a6Y3lY5GzCZ33wmuVDe2HdRVHtfrzaQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/exec": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.0.0-beta.21.tgz",
-			"integrity": "sha512-JsGpl98dk2CrQ3iMw2tFk9dbmf2iFDeOmFIHUWxDwXSC+MLiFCl+XZeJ4AY3/OmF2sQev/HtysfnaqULxkYxUQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.0.0-rc.0.tgz",
+			"integrity": "sha512-DYU00HAAoreqNQmLV0+gfH4mXIJKbd1rbrMvQbnfCTZ3nWYiORXQwvwCYbGgmsMarSaJ/T3eTPP6LvsVt7y1aw==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "^3.0.0-beta.18",
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/filter-options": "^3.0.0-beta.18",
-				"@lerna/run-parallel-batches": "^3.0.0-beta.0",
-				"@lerna/validation-error": "^3.0.0-beta.10"
+				"@lerna/batch-packages": "^3.0.0-rc.0",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/filter-options": "^3.0.0-rc.0",
+				"@lerna/run-parallel-batches": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0"
 			}
 		},
 		"@lerna/filter-options": {
-			"version": "3.0.0-beta.18",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.0.0-beta.18.tgz",
-			"integrity": "sha512-2TiOR9+7hTv95CEYEIVxSpBFiU4UM6bi7VYwEgErfc8Q72Do9hx9Q1y1wAf2exdAUW5KYx1U+l2Ho/ovq8XEwQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.0.0-rc.0.tgz",
+			"integrity": "sha512-aqyb0GWEnQgu7eXHpVSpZLedVd3PrI5WK/CfzDlHGqUT8PCJTo9q2562gmEdeCWWfeSvXbezGm0djTC6RwHV1A==",
 			"dev": true,
 			"requires": {
 				"dedent": "^0.7.0"
 			}
 		},
 		"@lerna/filter-packages": {
-			"version": "3.0.0-beta.10",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.0.0-beta.10.tgz",
-			"integrity": "sha512-w8Q+tj5h4N4zPauTIdtgBiTD4pPJrV8kbnerxA2A3gWLbjKjDzn8XD7NJJ7HtNMc1x8M7mgyOdXeBZFu474Jgw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.0.0-rc.0.tgz",
+			"integrity": "sha512-ZVObVh8Nk5d6XS/RAJEdu56KbpqvwJrKruoYnDPFeno/Q6/G1Oi8S/W2NmfEXMBSPaVpYecbGfM4Xu5dLzipNA==",
 			"dev": true,
 			"requires": {
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"multimatch": "^2.1.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/get-npm-exec-opts": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.0.0-beta.21.tgz",
-			"integrity": "sha512-+pIB/6wF0Xfz9+an/EDKC+vsba3UI+6GSkS6HyOfLhjCw6kDDGDC0oPmfJtr0DXavrunvKzYTOEm2cD/okEvkw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.0.0-rc.0.tgz",
+			"integrity": "sha512-n5Oe1LPzyMKGAdYVVDimpuVsWexTCaLlJq9RqXphoijRh5DAB/Mhaw9//5vGrv770m/QNMSceF99SZLI9gyh4g==",
 			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/global-options": {
-			"version": "3.0.0-beta.13",
-			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.0.0-beta.13.tgz",
-			"integrity": "sha512-xQv3fdjMSXImeq424rauW5hfOYDTBZAq4kQn2Wbm0q4or+uznECwkfDUHwOY1RwYu40OkjJ1Wtt7DL+WTHSngQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.0.0-rc.0.tgz",
+			"integrity": "sha512-Sy8KE1cAcGwjxOxiJOHjTxJecLcJhAeQym4Ge3WP1Jnz5mq03o9mb37X0Hmjpv1W9OblbXVxHdmbyC3hxMEHIA==",
 			"dev": true
 		},
 		"@lerna/import": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.0.0-beta.21.tgz",
-			"integrity": "sha512-D9+SqWMOdRvB3/vUlauX7BLy84cQ17tG9wzLIiK79JmxTXwnm7zK51oHQ8B51AE4GT96Ht421YAoOCFEpKAdbA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.0.0-rc.0.tgz",
+			"integrity": "sha512-ZRrusuAScKg29jRrurEi/qJbpol5RWY98nBhOmq08pibVz8cwS1QzyTwQhxaZECHYrKpL/qdLNigKsNi4+jyYw==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/prompt": "^3.0.0-beta.0",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/prompt": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"dedent": "^0.7.0",
-				"fs-extra": "^5.0.0",
+				"fs-extra": "^6.0.1",
 				"p-map-series": "^1.0.0"
 			}
 		},
 		"@lerna/init": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.0.0-beta.21.tgz",
-			"integrity": "sha512-uI4FSNwsBZ3ulBWtJt09z90qfBDTPugyyEoFH5ZpoZ06rdXVoM3i1vbdzPnVGX5qsvIIjNfSu0/zUAw2kM3OJg==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.0.0-rc.0.tgz",
+			"integrity": "sha512-/G4gy5QDNsxVXTEo59YRilcW7hnob31GVPc3omy9AZq8HZYCpj/tAw39mEds7S1wPCx0aotRj+NDf178zj11Mw==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/command": "^3.0.0-beta.21",
-				"fs-extra": "^5.0.0",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"fs-extra": "^6.0.1",
 				"p-map": "^1.2.0",
 				"write-json-file": "^2.3.0"
 			}
 		},
 		"@lerna/link": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.0.0-beta.21.tgz",
-			"integrity": "sha512-thQb6Bq2BI1bFoTw2ADfGRG1DhBRCPteJmQxJZpPrzA6iB9dIFSQb3mXl/piUlF79Cv6Wliwi+3irtM9F5MgPw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.0.0-rc.0.tgz",
+			"integrity": "sha512-Al57Ib56/ojGQ3hcln+DhS5IGWqLv8EElrAmSp0c3t/Ie48VOv9AusQR9nDRIGEn73APu/EG0ILdbylfQBzaKg==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/package-graph": "^3.0.0-beta.18",
-				"@lerna/symlink-dependencies": "^3.0.0-beta.17",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/package-graph": "^3.0.0-rc.0",
+				"@lerna/symlink-dependencies": "^3.0.0-rc.0",
 				"p-map": "^1.2.0",
 				"slash": "^1.0.0"
 			}
 		},
 		"@lerna/list": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.0.0-beta.21.tgz",
-			"integrity": "sha512-m++8Tb8vGj/1qtxomT7ic83DTR+8zY248X9XqOyLxlNnPyB/307lmA3Q5VHaTMLQ41d08BKdh0Sv9O++TYWUtA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.0.0-rc.0.tgz",
+			"integrity": "sha512-uQuFeRHhF6ALohRkVY6VxpCyeCHHTEqzt0SNvacTAA+gJX/hadtEYS883KOzmmcFibL4UtljQbdfj+DjrLKfUQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/filter-options": "^3.0.0-beta.18",
-				"@lerna/output": "^3.0.0-beta.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/filter-options": "^3.0.0-rc.0",
+				"@lerna/output": "^3.0.0-rc.0",
 				"chalk": "^2.3.1",
 				"columnify": "^1.5.4"
 			}
 		},
 		"@lerna/npm-conf": {
-			"version": "3.0.0-beta.19",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.0.0-beta.19.tgz",
-			"integrity": "sha512-6E5dx52ZuN9aV4Pe3rED6fccGGuZPznJpCjfSU8QXYvLfbCOkUOEik8+TzvzpD2N301ThtUpQqD+wtaGI8WtNw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.0.0-rc.0.tgz",
+			"integrity": "sha512-zdd/c83UTDGHci1MrW61olXh04cqRvwkA1SZgXYiLo7A87yHlBYwVOu1d7Rl0J6lHG7++8X2odWqzYZkFfeVFA==",
 			"dev": true,
 			"requires": {
 				"config-chain": "^1.1.11",
@@ -2336,25 +2323,25 @@
 			}
 		},
 		"@lerna/npm-dist-tag": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.0.0-beta.21.tgz",
-			"integrity": "sha512-G4RNx07THCsPQuHTXZZntiLCv2WeYdZkFZk/vcR3sHDaYR6JUaIPDIfwK7XGWRtU9uziRkeTnyi7QbJITyd+Xw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.0.0-rc.0.tgz",
+			"integrity": "sha512-Xa5mPmSIsi0N4pNNSBpKeghQ7XskKCVK+pawEvgKAYHph/J9PIfrddVJUU8o3nk2qkqeqikypoS++bwMdVr8Ew==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/get-npm-exec-opts": "^3.0.0-beta.21",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/get-npm-exec-opts": "^3.0.0-rc.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/npm-install": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.0.0-beta.21.tgz",
-			"integrity": "sha512-qYB7ZUWXura0PSBDkXfuyBSJMVPbOiFWuxB0O8fpSFW4o+/HaL137Ayjdr5Nxr6r4r0hlY4liKNYpXxyFAKE4g==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.0.0-rc.0.tgz",
+			"integrity": "sha512-QWvgQ0osTf7e87hc1kKXDcbWPXVCqGUiVnTpjX22+CEiJjUMStWEp4MjLieObgFVLyTtanOZp8VpRqBsPE0HRQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/get-npm-exec-opts": "^3.0.0-beta.21",
-				"fs-extra": "^5.0.0",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/get-npm-exec-opts": "^3.0.0-rc.0",
+				"fs-extra": "^6.0.1",
 				"npm-package-arg": "^6.0.0",
 				"npmlog": "^4.1.2",
 				"signal-exit": "^3.0.2",
@@ -2362,40 +2349,40 @@
 			}
 		},
 		"@lerna/npm-publish": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.0.0-beta.21.tgz",
-			"integrity": "sha512-bgXejqsOZMquDGBmedAjHczun16X/E76BB9uwys02jTSKBqtYggaBii1kGaUVNL5dZ2mPyumj/8+Aps24DwdjA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.0.0-rc.0.tgz",
+			"integrity": "sha512-rP8epG0SsHzqYw9xvwVX6YyAAwPYJAYZvMNxJvyi8fp5KdnD2sTeV/JOrWbQD/RxBxR2WGJxelVRL617KWZMOA==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/get-npm-exec-opts": "^3.0.0-beta.21",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/get-npm-exec-opts": "^3.0.0-rc.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/npm-run-script": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.0.0-beta.21.tgz",
-			"integrity": "sha512-2vmDsVVMEu1tGiF/gGXDW2Axm3ADzsJUn5O0PbrANZvoGEnMHY3dN4m8gDLOBb1B04h3jU8gbXQXUqrmZWvxUA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.0.0-rc.0.tgz",
+			"integrity": "sha512-Hm6KLPpeIyRIdc9MntmaAhuboUyw75DJLJ1MTaLwq/RwZ2kKHYk1Hi/R7yjj8LOyD7A25BTYX0Pd1gHd1lsFVw==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/get-npm-exec-opts": "^3.0.0-beta.21",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/get-npm-exec-opts": "^3.0.0-rc.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/output": {
-			"version": "3.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.0.0-beta.0.tgz",
-			"integrity": "sha512-jfndeh1Bf3bQHLkq7zTEV3dcgV+jIxekBqlhVs7KTZrGc/pXz4v+sqGd2HLByDxMTixELzslzntJIyKJ7RO4GA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.0.0-rc.0.tgz",
+			"integrity": "sha512-zZmQ94nVUfe1CvexarDnrb/Mqt81OcZNuOCvcKFHJiNkr5VSIn2GJuUwtTaVUtoh5uXdJCJvm696Ptsep10BWw==",
 			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/package": {
-			"version": "3.0.0-beta.17",
-			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.0.0-beta.17.tgz",
-			"integrity": "sha512-eLEbzMcNdCCMZmkG3IsIpAe04bq4unWkF6GaVplvv0UmP7ZmNPkopAJ3Mre5kpz7g6ICF96yjXJ8I3VCPJWELQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.0.0-rc.0.tgz",
+			"integrity": "sha512-4EUnBc04IxganMamjnEfagajLya3nPKfqlorGc5VLoGh5akOZmrCF9qiqB90nYzrJoMt+5QB1lxYD8bxikX0qg==",
 			"dev": true,
 			"requires": {
 				"npm-package-arg": "^6.0.0",
@@ -2403,9 +2390,9 @@
 			}
 		},
 		"@lerna/package-graph": {
-			"version": "3.0.0-beta.18",
-			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.0.0-beta.18.tgz",
-			"integrity": "sha512-7hmli0geLBhKPZylt4osZYXTlx+V7TwlKWjsndobx8DmCfu7l1IM8OLJ1WBBh/pjXIAdo277twX5uUVYunv2/g==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.0.0-rc.0.tgz",
+			"integrity": "sha512-E2MlL0CwDzcDTLPpMhg9+TESRAD/wYLtEu+Mj1R4OZbF2jlSXSZok1g3LW/gzulVd5oq9q+qBdY3SX5b9PCsGQ==",
 			"dev": true,
 			"requires": {
 				"npm-package-arg": "^6.0.0",
@@ -2413,19 +2400,21 @@
 			}
 		},
 		"@lerna/project": {
-			"version": "3.0.0-beta.20",
-			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.0.0-beta.20.tgz",
-			"integrity": "sha512-bS0gD1ReT9l4ZwZXLM4bZBCb1tlJAzVZXJj4RVDgJ1pGt2h4UVMpWJCZqCuYhhiyu6J0v7ntwK3TQH+C3rlqcw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.0.0-rc.0.tgz",
+			"integrity": "sha512-lNego7jYd24jIDGLTcy1mrESEopCblVaZztKhJJntSZdqWZ/tnExjIITfS55CnZyKAXwPVIus6YRfOc24tvuaA==",
 			"dev": true,
 			"requires": {
-				"@lerna/package": "^3.0.0-beta.17",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/package": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"cosmiconfig": "^5.0.2",
 				"dedent": "^0.7.0",
 				"dot-prop": "^4.2.0",
 				"glob-parent": "^3.1.0",
+				"globby": "^8.0.1",
 				"load-json-file": "^4.0.0",
 				"npmlog": "^4.1.2",
+				"p-map": "^1.2.0",
 				"resolve-from": "^4.0.0",
 				"write-json-file": "^2.3.0"
 			},
@@ -2438,6 +2427,21 @@
 					"requires": {
 						"is-glob": "^3.1.0",
 						"path-dirname": "^1.0.0"
+					}
+				},
+				"globby": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"dev": true,
+					"requires": {
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"fast-glob": "^2.0.2",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -2498,9 +2502,9 @@
 			}
 		},
 		"@lerna/prompt": {
-			"version": "3.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.0.0-beta.0.tgz",
-			"integrity": "sha512-hEBT3TiMzJgkxUx7vrvTfCn8ZwYEFy/e/FlFvoDV/MheX4OQ3+cb73mW7ya7J1akJ6jRXUvwmEcZnKXkKQgo/w==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.0.0-rc.0.tgz",
+			"integrity": "sha512-4ABsGTq7/IMh3nX7LfRirJnXt50Yp/Lg837hb/Hp1OXFz1FoXLcbzoIx0QQYyk3q+Gnv2TwSK2M86xoUFIUXnw==",
 			"dev": true,
 			"requires": {
 				"inquirer": "^5.1.0",
@@ -2531,26 +2535,26 @@
 			}
 		},
 		"@lerna/publish": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.0.0-beta.21.tgz",
-			"integrity": "sha512-xsKcWFF8mlRCfmEvPE4G0R84JCmFpmmah/gVsviCLLmhkdoTwDugnp++Ij2ONx5wW+kSYhw7MflcbuygOU8t6w==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.0.0-rc.0.tgz",
+			"integrity": "sha512-bfjRtCzHAGSS5z8QOUw3UeLn4u5CpJTGUkk9y1PPbzdbMWmJhJnEjSw+TN2LaZFVGzQbE8dsLqR5TL149Y7P/Q==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "^3.0.0-beta.18",
-				"@lerna/child-process": "^3.0.0-beta.21",
-				"@lerna/collect-updates": "^3.0.0-beta.21",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/conventional-commits": "^3.0.0-beta.15",
-				"@lerna/npm-conf": "^3.0.0-beta.19",
-				"@lerna/npm-dist-tag": "^3.0.0-beta.21",
-				"@lerna/npm-publish": "^3.0.0-beta.21",
-				"@lerna/output": "^3.0.0-beta.0",
-				"@lerna/prompt": "^3.0.0-beta.0",
-				"@lerna/run-lifecycle": "^3.0.0-beta.0",
-				"@lerna/run-parallel-batches": "^3.0.0-beta.0",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/batch-packages": "^3.0.0-rc.0",
+				"@lerna/child-process": "^3.0.0-rc.0",
+				"@lerna/collect-updates": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/conventional-commits": "^3.0.0-rc.0",
+				"@lerna/npm-dist-tag": "^3.0.0-rc.0",
+				"@lerna/npm-publish": "^3.0.0-rc.0",
+				"@lerna/output": "^3.0.0-rc.0",
+				"@lerna/prompt": "^3.0.0-rc.0",
+				"@lerna/run-lifecycle": "^3.0.0-rc.0",
+				"@lerna/run-parallel-batches": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"chalk": "^2.3.1",
 				"dedent": "^0.7.0",
+				"fs-extra": "^6.0.1",
 				"minimatch": "^3.0.4",
 				"npmlog": "^4.1.2",
 				"p-finally": "^1.0.0",
@@ -2564,58 +2568,59 @@
 			}
 		},
 		"@lerna/resolve-symlink": {
-			"version": "3.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.0.0-beta.0.tgz",
-			"integrity": "sha512-eF2iqrQWcgGFKCSGGPm23+6WD+8hChGGEa2uHebo3UHGGbzXVnyMKHYC9Z8WK7mzt8k+s1BiwC0YYtqHcOFDvg==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.0.0-rc.0.tgz",
+			"integrity": "sha512-EBRD/65aTCyZMqWzAM7Ac1zqtZBkTE5AHzzIViQaB5el3j7ThBzzWwYuiBNWibNGTMObLQMrp+65yCbew5H+aA==",
 			"dev": true,
 			"requires": {
-				"fs-extra": "^5.0.0",
+				"fs-extra": "^6.0.1",
 				"npmlog": "^4.1.2",
 				"read-cmd-shim": "^1.0.1"
 			}
 		},
 		"@lerna/rimraf-dir": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.0.0-beta.21.tgz",
-			"integrity": "sha512-fHluLhYnQuaCoSd/PxhVMy095vETH47iw0V0RhwbYBNdrdsMI6zQoDNr+uSzuVawGIkQku1HuNt/olmMLYf6fg==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.0.0-rc.0.tgz",
+			"integrity": "sha512-aFPX1hMOBL+5AU5xI9SZ2xKTAlnk93+tIw1ZJGWMMc4dzxNs/sT3WeUUH4v1TOYzMqWM3AnLQza3O4OY/xb2hg==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "^3.0.0-beta.21",
+				"@lerna/child-process": "^3.0.0-rc.0",
 				"npmlog": "^4.1.2",
 				"path-exists": "^3.0.0",
 				"rimraf": "^2.6.2"
 			}
 		},
 		"@lerna/run": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.0.0-beta.21.tgz",
-			"integrity": "sha512-RhyXznUi0xcHj3PbeW0M1Dm5wH5z+oEUVLDyJJE+eqYjQiDfctYo9U4IgFw6wom/mPTUbE3j4BxAyR1U/ynuSg==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.0.0-rc.0.tgz",
+			"integrity": "sha512-biLKshDBwQ7n3XLihV5QvrlOBJ1isnRJC8xC8FeUbH3x1FRX15Ogg+8/GiGG7vaM6kdE4j0ebrW8HPUEh5L4cw==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "^3.0.0-beta.18",
-				"@lerna/command": "^3.0.0-beta.21",
-				"@lerna/filter-options": "^3.0.0-beta.18",
-				"@lerna/npm-run-script": "^3.0.0-beta.21",
-				"@lerna/output": "^3.0.0-beta.0",
-				"@lerna/run-parallel-batches": "^3.0.0-beta.0",
-				"@lerna/validation-error": "^3.0.0-beta.10",
+				"@lerna/batch-packages": "^3.0.0-rc.0",
+				"@lerna/command": "^3.0.0-rc.0",
+				"@lerna/filter-options": "^3.0.0-rc.0",
+				"@lerna/npm-run-script": "^3.0.0-rc.0",
+				"@lerna/output": "^3.0.0-rc.0",
+				"@lerna/run-parallel-batches": "^3.0.0-rc.0",
+				"@lerna/validation-error": "^3.0.0-rc.0",
 				"p-map": "^1.2.0"
 			}
 		},
 		"@lerna/run-lifecycle": {
-			"version": "3.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.0.0-beta.0.tgz",
-			"integrity": "sha512-QAmgToyNTKpPeyPm3lE6FEaTf58x3Rm5hHgzCA+e8kYeJ3XkopDfOcLJlpW0YA1pST5EbNGUipvS8P8zI1Va3Q==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.0.0-rc.0.tgz",
+			"integrity": "sha512-/cofDJ5qzAgC99+VYxO602k1wBetv79NYOXUoju3R8xPrCXGJYoBN+/NhrPdj/CciZd9lSsx016M6FcScsaO1Q==",
 			"dev": true,
 			"requires": {
+				"@lerna/npm-conf": "^3.0.0-rc.0",
 				"npm-lifecycle": "^2.0.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/run-parallel-batches": {
-			"version": "3.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0-beta.0.tgz",
-			"integrity": "sha512-G8reoAaDwpF9mYhVfnxCUYm63RVXaTdT8zWHxnIamtdMhH1vPq+goUzLgCTAZuDO8c51H1SHu8XK/4agGwoP+A==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0-rc.0.tgz",
+			"integrity": "sha512-MpXiDRo02ZHazis3sDqzhmFuMxEEPKv+mmPpzLElkCDO4LHVZYvwa3ib3ezhWwt+FUFPP4u/8w2A4cFO2PbmVQ==",
 			"dev": true,
 			"requires": {
 				"p-map": "^1.2.0",
@@ -2623,14 +2628,14 @@
 			}
 		},
 		"@lerna/symlink-binary": {
-			"version": "3.0.0-beta.17",
-			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.0.0-beta.17.tgz",
-			"integrity": "sha512-OlDHER9NboPnrcC5LLRNW1yFhCrOPtr551yccTqaa2TQ0GNcfirztcgKsrWRJeiaH0nxs1Rwi4ZQmOk/sYB+sw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.0.0-rc.0.tgz",
+			"integrity": "sha512-aFmZmvjNApa7i4SCrq//j7kg7E6mO3U7dzE4J28biFen2Ey1fmxObf1jiv6b24T92D/WztiBGSSTXbFR41yAsw==",
 			"dev": true,
 			"requires": {
-				"@lerna/create-symlink": "^3.0.0-beta.0",
-				"@lerna/package": "^3.0.0-beta.17",
-				"fs-extra": "^5.0.0",
+				"@lerna/create-symlink": "^3.0.0-rc.0",
+				"@lerna/package": "^3.0.0-rc.0",
+				"fs-extra": "^6.0.1",
 				"p-map": "^1.2.0",
 				"read-pkg": "^3.0.0"
 			},
@@ -2683,33 +2688,33 @@
 			}
 		},
 		"@lerna/symlink-dependencies": {
-			"version": "3.0.0-beta.17",
-			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.0.0-beta.17.tgz",
-			"integrity": "sha512-gawfpPH85rFXJCWrPJLHhnsloQr+wx6sjZK6aS9CwmWJAnsp9RAF6xODwG4C2kuHr4OsQCpIInhR7fCiVzGMLQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.0.0-rc.0.tgz",
+			"integrity": "sha512-dk7V95ToYw1nfn7ydkGQAn0RWyye9n05vPSCQzME+OP0nL7PcsSY+0umatsRP104VMX0yTmML129Zg5xpYDSAw==",
 			"dev": true,
 			"requires": {
-				"@lerna/create-symlink": "^3.0.0-beta.0",
-				"@lerna/resolve-symlink": "^3.0.0-beta.0",
-				"@lerna/symlink-binary": "^3.0.0-beta.17",
-				"fs-extra": "^5.0.0",
+				"@lerna/create-symlink": "^3.0.0-rc.0",
+				"@lerna/resolve-symlink": "^3.0.0-rc.0",
+				"@lerna/symlink-binary": "^3.0.0-rc.0",
+				"fs-extra": "^6.0.1",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
 				"p-map-series": "^1.0.0"
 			}
 		},
 		"@lerna/validation-error": {
-			"version": "3.0.0-beta.10",
-			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.0.0-beta.10.tgz",
-			"integrity": "sha512-Ff7DPJzlgO7DIRp5812SxdWOWPJsF8kbhuEe79gcqyNJYxD+03tGnXDQcXt4zr9d8Np8Kmcl65xGhQDIH1q8lQ==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.0.0-rc.0.tgz",
+			"integrity": "sha512-VuYvUC2DUjVq/DG7r52wWKmq1G0doGPB5eq7Uozi4QIIRWj2op1l6yCSogb3H2UKPn/5NrMOV4jztwQBnSJu0w==",
 			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/write-log-file": {
-			"version": "3.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.0.0-beta.0.tgz",
-			"integrity": "sha512-2KJ2Zw4t8uHg827ihAmDpbWfuN6/5Yow5qWrw86Ip1ihMQ+CGMLqx5FDotlHLmOM7Io+xD5wh8yWOD+iDjKDPw==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.0.0-rc.0.tgz",
+			"integrity": "sha512-LHQPRY/1eWyq7ly+4A412FT9uzGKHDSGHkLYVro8r6mToPB/6eHdntJFRGOYNzKM5eax6RgrzBImEhs3F9FWSQ==",
 			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2",
@@ -9051,9 +9056,9 @@
 			}
 		},
 		"fs-extra": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-			"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+			"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -13311,12 +13316,12 @@
 			"dev": true
 		},
 		"lerna": {
-			"version": "3.0.0-beta.21",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.0.0-beta.21.tgz",
-			"integrity": "sha512-dSMbr+Zho9zBR8UyHB+8NLu0dwjzkJ3l0nU8W8v+Aoe5bD1rSsXwUpVX7rwJNTXAqe474BmpAjrmV0gcFjEAXA==",
+			"version": "3.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.0.0-rc.0.tgz",
+			"integrity": "sha512-fj5Ku6vGgJAzdnpXWE3Stlgnex9ZfaHBQvMQzts13qZ57cJNCzEq5AQPVOOFWE6qqqiABLQfE5T2+Yg/IEqWNQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/cli": "^3.0.0-beta.21",
+				"@lerna/cli": "^3.0.0-rc.0",
 				"import-local": "^1.0.0",
 				"npmlog": "^4.1.2"
 			}
@@ -21034,6 +21039,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xregexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
 			"dev": true
 		},
 		"xtend": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"espree": "3.5.4",
 		"extract-text-webpack-plugin": "4.0.0-beta.0",
 		"glob": "7.1.2",
-		"lerna": "3.0.0-beta.21",
+		"lerna": "3.0.0-rc.0",
 		"mkdirp": "0.5.1",
 		"node-sass": "4.9.2",
 		"path-type": "3.0.0",


### PR DESCRIPTION
## Description
This PR tries to enabled conventional commits with Lerna which would allows us to automatically regenerate `CHANGELOG.md` files every time we publish packages to npm. This might also simplify creating Gutenberg changelog for release similar to what we did in #8278.

It's based on Lerna repository configuration and the following article: https://michaljanaszek.com/blog/lerna-conventional-commits.

It is blocked by a known bug in Lerna itself: https://github.com/lerna/lerna/issues/1532:
> With a lerna setup with `version: independent` and `conventionalCommits: true` for the publish command in `lerna.json`: when publishing a new release with lerna publish lerna takes all previous commits into account and adds all commits again into `CHANGELOG.md` for this release and also raises the version respecting all previous commits.

## TODO

* [ ] Update [Repository management](https://github.com/WordPress/gutenberg/blob/master/docs/reference/repository-management.md#merging-pull-requests)'s section about merging PRs to include details how to properly word title and description based on [Angular](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) (unless we want to create our own convention but that requires some coding.

## How has this been tested?
Can you actually test without publishing? I guess, NO.
