### PR TITLE
Blocks: Render Button RichText as div

### DIFF
--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -83,7 +83,6 @@ class ButtonEdit extends Component {
 			<Fragment>
 				<span className={ className } title={ title } ref={ this.bindRef }>
 					<RichText
-						tagName="span"
 						placeholder={ __( 'Add text…' ) }
 						value={ text }
 						onChange={ ( value ) => setAttributes( { text: value } ) }

--- a/core-blocks/button/test/__snapshots__/index.js.snap
+++ b/core-blocks/button/test/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`core/button block edit matches snapshot 1`] = `
           <div
             class="components-autocomplete"
           >
-            <span
+            <div
               aria-autocomplete="list"
               aria-expanded="false"
               aria-label="Add text…"
@@ -24,11 +24,11 @@ exports[`core/button block edit matches snapshot 1`] = `
               data-is-placeholder-visible="true"
               role="textbox"
             />
-            <span
+            <div
               class="editor-rich-text__tinymce wp-block-button__link"
             >
               Add text…
-            </span>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes (one of two) #8440 

This pull request seeks to resolve an issue where removing all text from a Button block by backspace would cause subsequent text changes to not be accurately reflected.

It's expected that this is a broader issue with TinyMCE compatibility of inline elements as the root container of a text field (see also https://github.com/tinymce/tinymce/issues/4488). This may be something we want to avoid altogether, instead applying equivalent inline behaviors by styling. As implemented in the Button component, the default `div` visually appears identical and resolves the issue described in #8440.

Since I've also noticed issues with the Quote block's use of the `cite` element, I may propose that we consider avoiding inline elements for _all_ instances of RichText. I will create a separate issue for this if agreeable.

**Testing instructions:**

Repeat steps to reproduce from https://github.com/WordPress/gutenberg/issues/8440#issuecomment-410285930 , verifying that all text changes are respected. It should also behave differently in that the Placeholder will be shown again when all text is removed by Backspace.

Verify there are no styling regressions in the display of the Button block in the editor.