### PR TITLE
Adds export getBlockTypes to be used in react native

### DIFF
--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -14,6 +14,7 @@ export {
 export {
 	registerBlockType,
 	getBlockType,
+	getBlockTypes,
 	hasBlockSupport,
 } from './registration';
 export { getPhrasingContentSchema } from './raw-handling';


### PR DESCRIPTION
## Description

This PR just adds `getBlockTypes` to the exported functions from `./registration` to the React Native side of things. Should not affect Gutenberg (web) at all.

