### PR TITLE
Bug fixes for full/wide image alignments.

### DIFF
--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -172,7 +172,7 @@ class ImageEdit extends Component {
 
 	updateAlignment( nextAlign ) {
 		const extraUpdatedAttributes = [ 'wide', 'full' ].indexOf( nextAlign ) !== -1 ?
-			{ width: undefined, height: undefined } :
+			{ width: undefined, height: undefined, url: this.props.image.source_url } :
 			{};
 		this.props.setAttributes( { ...extraUpdatedAttributes, align: nextAlign } );
 	}

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -172,7 +172,7 @@ class ImageEdit extends Component {
 
 	updateAlignment( nextAlign ) {
 		const extraUpdatedAttributes = [ 'wide', 'full' ].indexOf( nextAlign ) !== -1 ?
-			{ width: undefined, height: undefined, url: this.props.image ? this.props.image.source_url : this.props.attributes.url } :
+			{ width: undefined, height: undefined } :
 			{};
 		this.props.setAttributes( { ...extraUpdatedAttributes, align: nextAlign } );
 	}
@@ -277,7 +277,7 @@ class ImageEdit extends Component {
 						onChange={ this.updateAlt }
 						help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) }
 					/>
-					{ ! isEmpty( availableSizes ) && isResizable && (
+					{ ! isEmpty( availableSizes ) && (
 						<SelectControl
 							label={ __( 'Image Size' ) }
 							value={ url }

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -277,7 +277,7 @@ class ImageEdit extends Component {
 						onChange={ this.updateAlt }
 						help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) }
 					/>
-					{ ! isEmpty( availableSizes ) && (
+					{ ! isEmpty( availableSizes ) && isResizable && (
 						<SelectControl
 							label={ __( 'Image Size' ) }
 							value={ url }
@@ -288,59 +288,61 @@ class ImageEdit extends Component {
 							onChange={ this.updateImageURL }
 						/>
 					) }
-					<div className="core-blocks-image__dimensions">
-						<p className="core-blocks-image__dimensions__row">
-							{ __( 'Image Dimensions' ) }
-						</p>
-						<div className="core-blocks-image__dimensions__row">
-							<TextControl
-								type="number"
-								className="core-blocks-image__dimensions__width"
-								label={ __( 'Width' ) }
-								value={ width !== undefined ? width : '' }
-								placeholder={ imageWidth }
-								min={ 1 }
-								onChange={ this.updateWidth }
-							/>
-							<TextControl
-								type="number"
-								className="core-blocks-image__dimensions__height"
-								label={ __( 'Height' ) }
-								value={ height !== undefined ? height : '' }
-								placeholder={ imageHeight }
-								min={ 1 }
-								onChange={ this.updateHeight }
-							/>
-						</div>
-						<div className="core-blocks-image__dimensions__row">
-							<ButtonGroup aria-label={ __( 'Image Size' ) }>
-								{ [ 25, 50, 75, 100 ].map( ( scale ) => {
-									const scaledWidth = Math.round( imageWidth * ( scale / 100 ) );
-									const scaledHeight = Math.round( imageHeight * ( scale / 100 ) );
+					{ isResizable && (
+						<div className="core-blocks-image__dimensions">
+							<p className="core-blocks-image__dimensions__row">
+								{ __( 'Image Dimensions' ) }
+							</p>
+							<div className="core-blocks-image__dimensions__row">
+								<TextControl
+									type="number"
+									className="core-blocks-image__dimensions__width"
+									label={ __( 'Width' ) }
+									value={ width !== undefined ? width : '' }
+									placeholder={ imageWidth }
+									min={ 1 }
+									onChange={ this.updateWidth }
+								/>
+								<TextControl
+									type="number"
+									className="core-blocks-image__dimensions__height"
+									label={ __( 'Height' ) }
+									value={ height !== undefined ? height : '' }
+									placeholder={ imageHeight }
+									min={ 1 }
+									onChange={ this.updateHeight }
+								/>
+							</div>
+							<div className="core-blocks-image__dimensions__row">
+								<ButtonGroup aria-label={ __( 'Image Size' ) }>
+									{ [ 25, 50, 75, 100 ].map( ( scale ) => {
+										const scaledWidth = Math.round( imageWidth * ( scale / 100 ) );
+										const scaledHeight = Math.round( imageHeight * ( scale / 100 ) );
 
-									const isCurrent = width === scaledWidth && height === scaledHeight;
+										const isCurrent = width === scaledWidth && height === scaledHeight;
 
-									return (
-										<Button
-											key={ scale }
-											isSmall
-											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
-											onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
-										>
-											{ scale }%
-										</Button>
-									);
-								} ) }
-							</ButtonGroup>
-							<Button
-								isSmall
-								onClick={ this.updateDimensions() }
-							>
-								{ __( 'Reset' ) }
-							</Button>
+										return (
+											<Button
+												key={ scale }
+												isSmall
+												isPrimary={ isCurrent }
+												aria-pressed={ isCurrent }
+												onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
+											>
+												{ scale }%
+											</Button>
+										);
+									} ) }
+								</ButtonGroup>
+								<Button
+									isSmall
+									onClick={ this.updateDimensions() }
+								>
+									{ __( 'Reset' ) }
+								</Button>
+							</div>
 						</div>
-					</div>
+					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Link Settings' ) }>
 					<SelectControl
@@ -382,9 +384,12 @@ class ImageEdit extends Component {
 
 							if ( ! isResizable || ! imageWidthWithinContainer ) {
 								return (
-									<div style={ { width, height } }>
-										{ img }
-									</div>
+									<Fragment>
+										{ getInspectorControls( imageWidth, imageHeight ) }
+										<div style={ { width, height } }>
+											{ img }
+										</div>
+									</Fragment>
 								);
 							}
 

--- a/core-blocks/image/edit.js
+++ b/core-blocks/image/edit.js
@@ -172,7 +172,7 @@ class ImageEdit extends Component {
 
 	updateAlignment( nextAlign ) {
 		const extraUpdatedAttributes = [ 'wide', 'full' ].indexOf( nextAlign ) !== -1 ?
-			{ width: undefined, height: undefined, url: this.props.image.source_url } :
+			{ width: undefined, height: undefined, url: this.props.image ? this.props.image.source_url : this.props.attributes.url } :
 			{};
 		this.props.setAttributes( { ...extraUpdatedAttributes, align: nextAlign } );
 	}


### PR DESCRIPTION
## Description
This addresses two image size issues that currently exist with wide/full aligned images using the core/image block:

1. Once an image block is set to wide/full alignments, the inspector controls for adding alternate text or link settings are no longer available.

Commit dbe4042 fixes this issue by including inspector controls even when an image is not resizable (i.e., it's a wide/full aligned image), but conditionally only shows the inspector controls that are related to size settings when an image is, in fact, resizable.

2. If the image size has been manually set to a smaller size (i.e., medium) before changing the alignment to wide/full, the image will continue using the smaller image file as the source url, resulting in blurry, stretched images.

Commit 8651faa addresses this issue by resetting the `url` attribute of the image during `updateAlignment()` to the full size image whenever we're changing the alignment to wide or full.


## How has this been tested?

1. Set an image block to wide or full alignment and see that the alternative text and link settings inspector controls are now displayed.
2. Insert an image, set it to "medium" size, change alignment to "full" and see that the image is not blurry, and is using the full size URL.
3. Run all jest tests after making the changes.

## Screenshots <!-- if applicable -->

## Types of changes

Bug fixes (see above).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
