### PR TITLE
TinyMCE: Remove container assignment hack

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -138,10 +138,6 @@ export default class TinyMCE extends Component {
 			return;
 		}
 
-		// This hack prevents TinyMCE from trying to remove the container node
-		// while cleaning for destroy, since removal is handled by React. It
-		// does so by substituting the container to be removed.
-		this.editor.container = document.createDocumentFragment();
 		this.editor.destroy();
 		delete this.editor;
 	}

--- a/test/e2e/specs/__snapshots__/rich-text.test.js.snap
+++ b/test/e2e/specs/__snapshots__/rich-text.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`adding blocks Should handle change in tag name gracefully 1`] = `
+"<!-- wp:heading {\\"level\\":3} -->
+<h3></h3>
+<!-- /wp:heading -->"
+`;

--- a/test/e2e/specs/rich-text.test.js
+++ b/test/e2e/specs/rich-text.test.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import '../support/bootstrap';
+import {
+	newPost,
+	newDesktopBrowserPage,
+	getEditedPostContent,
+	insertBlock,
+} from '../support/utils';
+
+describe( 'adding blocks', () => {
+	beforeEach( async () => {
+		await newDesktopBrowserPage();
+		await newPost();
+	} );
+
+	it( 'Should handle change in tag name gracefully', async () => {
+		// Regression test: The heading block changes the tag name of its
+		// RichText element. Historically this has been prone to breakage,
+		// specifically in destroying / reinitializing the TinyMCE instance.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/3091
+		await insertBlock( 'Heading' );
+		await page.click( '[aria-label="Heading 3"]' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Related: #3091
Related: #3093

This pull request seeks to remove a workaround introduced to the TinyMCE component, targeted at resolving an error which could occur when a block changed the tag name of its rendered RichText (#3091). This has [since been resolved in TinyMCE](https://github.com/WordPress/gutenberg/issues/3091#issuecomment-338457755) and therefore the workaround is no longer necessary. An end-to-end test has been implemented to protect against the original regression.

**Testing instructions:**

Verify that switching levels of the Heading block does not produce an error.

Ensure that end-to-end tests pass:

```
npm run test-e2e
```