### PR TITLE
Use @wordpress/compose instead of  @wordpress/components

### DIFF
--- a/packages/compose/src/with-state/README.md
+++ b/packages/compose/src/with-state/README.md
@@ -11,7 +11,7 @@ Wrapping a component with `withState` provides state as props to the wrapped com
 /**
  * WordPress dependencies
  */
-import { withState } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
 function MyCounter( { count, setState } ) {
 	return (


### PR DESCRIPTION

## Description
These docs show deprecated usage of `withState` HOC


## Types of changes
Update the docs to use the new package name.


