### PR TITLE
Fix Custom HTML error when block is empty

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -145,7 +145,7 @@ class Sandbox extends Component {
 				if ( 'DIV' === potentialIframe.tagName || 'SPAN' === potentialIframe.tagName ) {
 						potentialIframe = potentialIframe.children[0];
 					}
-				if ( 'IFRAME' === potentialIframe.tagName ) {
+				if ( potentialIframe && 'IFRAME' === potentialIframe.tagName ) {
 					if ( potentialIframe.width ) {
 						iframe = potentialIframe;
 						aspectRatio = potentialIframe.width / potentialIframe.height;


### PR DESCRIPTION
## Description
Fix Custom HTML block error when block is empty and Preview button is clicked.

Closes: #7277 

## How has this been tested?
This has been tested with "npm test" and manually on Chrome and Firefox

## Types of changes
Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
