### PR TITLE
Fix unrecognised `forwardedRef` prop

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -143,8 +143,8 @@ class Sandbox extends Component {
 				// keeping the correct aspect ratio.
 				var potentialIframe = document.body.children[0];
 				if ( 'DIV' === potentialIframe.tagName || 'SPAN' === potentialIframe.tagName ) {
-						potentialIframe = potentialIframe.children[0];
-					}
+					potentialIframe = potentialIframe.children[0];
+				}
 				if ( potentialIframe && 'IFRAME' === potentialIframe.tagName ) {
 					if ( potentialIframe.width ) {
 						iframe = potentialIframe;

--- a/packages/compose/src/with-global-events/index.js
+++ b/packages/compose/src/with-global-events/index.js
@@ -61,12 +61,12 @@ function withGlobalEvents( eventTypesToHandlers ) {
 			}
 
 			render() {
-				return <WrappedComponent { ...this.props } ref={ this.handleRef } />;
+				return <WrappedComponent { ...this.props.ownProps } ref={ this.handleRef } />;
 			}
 		}
 
 		return forwardRef( ( props, ref ) => {
-			return <Wrapper { ...props } forwardedRef={ ref } />;
+			return <Wrapper ownProps={ props } forwardedRef={ ref } />;
 		} );
 	}, 'withGlobalEvents' );
 }


### PR DESCRIPTION
## Description
Fixes a warning I noticed while testing https://github.com/WordPress/gutenberg/pull/8556. 

`withGlobalEvents` was setting `forwardedRef` on the wrapped component, which caused an `Unrecognised forwardedRef prop` React warning in `FocusableIframe`.

Also corrects some incorrect indentation in some embedded JavaScript.

## How has this been tested?
3. Click to add a new block
4. Select `Custom HTML` block
5. Click `Preview` button

No errors or warnings should appear in the console.