### PR TITLE
API: Replace all withAPIData usage and deprecate the HoC

### DIFF
--- a/core-blocks/latest-posts/edit.js
+++ b/core-blocks/latest-posts/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isUndefined, pickBy } from 'lodash';
+import { isUndefined, pickBy } from 'lodash';
 import moment from 'moment';
 import classnames from 'classnames';
 

--- a/core-blocks/latest-posts/edit.js
+++ b/core-blocks/latest-posts/edit.js
@@ -17,7 +17,6 @@ import {
 	Spinner,
 	ToggleControl,
 	Toolbar,
-	withAPIData,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -26,7 +25,7 @@ import {
 	BlockAlignmentToolbar,
 	BlockControls,
 } from '@wordpress/editor';
-import { addQueryArgs } from '@wordpress/url';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -50,8 +49,7 @@ class LatestPostsEdit extends Component {
 	}
 
 	render() {
-		const latestPosts = this.props.latestPosts.data;
-		const { attributes, categoriesList, setAttributes } = this.props;
+		const { attributes, categoriesList, setAttributes, latestPosts } = this.props;
 		const { displayPostDate, align, postLayout, columns, order, orderBy, categories, postsToShow } = attributes;
 
 		const inspectorControls = (
@@ -60,7 +58,7 @@ class LatestPostsEdit extends Component {
 					<QueryControls
 						{ ...{ order, orderBy } }
 						numberOfItems={ postsToShow }
-						categoriesList={ get( categoriesList, [ 'data' ], {} ) }
+						categoriesList={ categoriesList }
 						selectedCategoryId={ categories }
 						onOrderChange={ ( value ) => setAttributes( { order: value } ) }
 						onOrderByChange={ ( value ) => setAttributes( { orderBy: value } ) }
@@ -158,21 +156,20 @@ class LatestPostsEdit extends Component {
 	}
 }
 
-export default withAPIData( ( props ) => {
+export default withSelect( ( select, props ) => {
 	const { postsToShow, order, orderBy, categories } = props.attributes;
+	const { getEntityRecords } = select( 'core' );
 	const latestPostsQuery = pickBy( {
 		categories,
 		order,
 		orderby: orderBy,
 		per_page: postsToShow,
-		_fields: [ 'date_gmt', 'link', 'title' ],
 	}, ( value ) => ! isUndefined( value ) );
 	const categoriesListQuery = {
 		per_page: 100,
-		_fields: [ 'id', 'name', 'parent' ],
 	};
 	return {
-		latestPosts: addQueryArgs( '/wp/v2/posts', latestPostsQuery ),
-		categoriesList: addQueryArgs( '/wp/v2/categories', categoriesListQuery ),
+		latestPosts: getEntityRecords( 'postType', 'post', latestPostsQuery ),
+		categoriesList: getEntityRecords( 'taxonomy', 'category', categoriesListQuery ),
 	};
 } )( LatestPostsEdit );

--- a/docs/blocks/creating-dynamic-blocks.md
+++ b/docs/blocks/creating-dynamic-blocks.md
@@ -11,29 +11,26 @@ The following code example shows how to create the latest post block dynamic blo
 
 var el = wp.element.createElement,
 	registerBlockType = wp.blocks.registerBlockType,
-	withAPIData = wp.components.withAPIData;
+	withSelect = wp.data.withSelect;
 
 registerBlockType( 'my-plugin/latest-post', {
 	title: 'Latest Post',
 	icon: 'megaphone',
 	category: 'widgets',
 
-	edit: withAPIData( function() {
+	edit: withSelect( function( select ) {
 		return {
-			posts: '/wp/v2/posts?per_page=1'
+			posts: select( 'core' ).getEntityRecords( 'postType', 'post' )
 		};
 	} )( function( props ) {
-		if ( ! props.posts.data ) {
-			return "loading !";
-		}
-		if ( props.posts.data.length === 0 ) {
+		if ( props.posts && props.posts.length === 0 ) {
 			return "No posts";
 		}
 		var className = props.className;
-		var post = props.posts.data[ 0 ];
-		
+		var post = props.posts[ 0 ];
+
 		return el(
-			'a', 
+			'a',
 			{ className: className, href: post.link },
 			post.title.rendered
 		);
@@ -50,26 +47,23 @@ registerBlockType( 'my-plugin/latest-post', {
 // myblock.js
 
 const { registerBlockType } = wp.blocks;
-const { withAPIData } = wp.components;
+const { withSelect } = wp.data;
 
 registerBlockType( 'my-plugin/latest-post', {
 	title: 'Latest Post',
 	icon: 'megaphone',
 	category: 'widgets',
 
-	edit: withAPIData( () => {
+	edit: withSelect( ( select ) => {
 		return {
-			posts: '/wp/v2/posts?per_page=1'
+			posts: select( 'core' ).getEntityRecords( 'postType', 'post' )
 		};
 	} )( ( { posts, className } ) => {
-		if ( ! posts.data ) {
-			return "loading !";
-		}
-		if ( posts.data.length === 0 ) {
+		if ( posts && posts.length === 0 ) {
 			return "No posts";
 		}
-		var post = posts.data[ 0 ];
-		
+		var post = posts[ 0 ];
+
 		return <a className={ className } href={ post.link }>
 			{ post.title.rendered }
 		</a>;
@@ -119,7 +113,7 @@ There are a few things to notice:
 
 ## Live rendering in Gutenberg editor
 
-Gutenberg 2.8 added the [`<ServerSideRender>`](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/server-side-render) block which enables all the rendering to take place on the server using PHP rather than in JavaScript. Server-side render is meant as a fallback; client-side rendering in JavaScript is the preferred implementation. 
+Gutenberg 2.8 added the [`<ServerSideRender>`](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/server-side-render) block which enables all the rendering to take place on the server using PHP rather than in JavaScript. Server-side render is meant as a fallback; client-side rendering in JavaScript is the preferred implementation.
 
 {% codetabs %}
 {% ES5 %}

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,5 +1,9 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 3.7.0
+
+ - `wp.components.withAPIData` has been removed. Please use the Core Data module or `wp.apiFetch` directly instead.
+
 ## 3.6.0
 
  - `wp.editor.editorMediaUpload` has been removed. Please use `wp.editor.mediaUpload` instead.

--- a/packages/components/src/higher-order/with-api-data/index.js
+++ b/packages/components/src/higher-order/with-api-data/index.js
@@ -9,6 +9,7 @@ import { mapValues, reduce, forEach, noop } from 'lodash';
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import isShallowEqual from '@wordpress/is-shallow-equal';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -17,6 +18,12 @@ import request, { getCachedResponse } from './request';
 import { getRoute } from './routes';
 
 export default ( mapPropsToData ) => createHigherOrderComponent( ( WrappedComponent ) => {
+	deprecated( 'wp.components.withAPIData', {
+		version: 3.7,
+		plugin: 'Gutenberg',
+		alternative: 'the Core Data Module or wp.apiFetch directly',
+	} );
+
 	class APIDataComponent extends Component {
 		constructor( props, context ) {
 			super( ...arguments );

--- a/packages/components/src/higher-order/with-api-data/test/index.js
+++ b/packages/components/src/higher-order/with-api-data/test/index.js
@@ -114,6 +114,7 @@ describe( 'withAPIData()', () => {
 			'path',
 		] );
 		expect( getDataProps( wrapper ).revisions.isLoading ).toBe( true );
+		expect( console ).toHaveWarned();
 
 		process.nextTick( () => {
 			expect( getDataProps( wrapper ).revisions.isLoading ).toBe( false );

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -22,6 +22,7 @@ export const defaultEntities = [
 
 export const kinds = [
 	{ name: 'postType', loadEntities: loadPostTypeEntities },
+	{ name: 'taxonomy', loadEntities: loadTaxonomyEntities },
 ];
 
 /**
@@ -35,6 +36,22 @@ async function loadPostTypeEntities() {
 		return {
 			kind: 'postType',
 			baseURL: '/wp/v2/' + postType.rest_base,
+			name,
+		};
+	} );
+}
+
+/**
+ * Returns the list of the taxonomies entities.
+ *
+ * @return {Promise} Entities promise
+ */
+async function loadTaxonomyEntities() {
+	const taxonomies = await apiFetch( { path: '/wp/v2/taxonomies?context=edit' } );
+	return map( taxonomies, ( taxonomy, name ) => {
+		return {
+			kind: 'taxonomy',
+			baseURL: '/wp/v2/' + taxonomy.rest_base,
 			name,
 		};
 	} );


### PR DESCRIPTION
This PR removes the remaining usage of withAPIData from Gutenberg and officially deprecate its usage.

**Testing instructions**

 - Check that The lastest posts block is working properly
 - Check that you can set a parent page when creating pages.

closes #7397
closes #6277
closes #6379
closes #6537