### PR TITLE
Set babel dependencies to fixed version and added core-js2 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2986,14 +2986,14 @@
 		"@wordpress/a11y": {
 			"version": "file:packages/a11y",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/dom-ready": "file:packages/dom-ready"
 			}
 		},
 		"@wordpress/api-fetch": {
 			"version": "file:packages/api-fetch",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n"
 			}
@@ -3001,21 +3001,21 @@
 		"@wordpress/autop": {
 			"version": "file:packages/autop",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "file:packages/babel-plugin-import-jsx-pragma",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/babel-plugin-makepot": {
 			"version": "file:packages/babel-plugin-makepot",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.10"
 			}
@@ -3024,12 +3024,12 @@
 			"version": "file:packages/babel-preset-default",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.52",
-				"@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.52",
-				"@babel/plugin-transform-react-jsx": "^7.0.0-beta.52",
-				"@babel/plugin-transform-runtime": "^7.0.0-beta.52",
-				"@babel/preset-env": "^7.0.0-beta.52",
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.56",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.56",
+				"@babel/plugin-transform-react-jsx": "7.0.0-beta.56",
+				"@babel/plugin-transform-runtime": "7.0.0-beta.56",
+				"@babel/preset-env": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"babel-core": "^7.0.0-bridge.0"
 			}
@@ -3037,7 +3037,7 @@
 		"@wordpress/blob": {
 			"version": "file:packages/blob",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/block-serialization-spec-parser": {
@@ -3046,7 +3046,7 @@
 		"@wordpress/blocks": {
 			"version": "file:packages/blocks",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-spec-parser": "file:packages/block-serialization-spec-parser",
@@ -3075,7 +3075,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/compose": "file:packages/compose",
@@ -3369,7 +3369,7 @@
 		"@wordpress/compose": {
 			"version": "file:packages/compose",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10"
@@ -3378,7 +3378,7 @@
 		"@wordpress/core-data": {
 			"version": "file:packages/core-data",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/url": "file:packages/url",
@@ -3391,14 +3391,14 @@
 			"version": "file:packages/custom-templated-path-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"@wordpress/data": {
 			"version": "file:packages/data",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
@@ -3417,7 +3417,7 @@
 		"@wordpress/date": {
 			"version": "file:packages/date",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.16"
 			}
@@ -3425,13 +3425,13 @@
 		"@wordpress/deprecated": {
 			"version": "file:packages/deprecated",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/dom": {
 			"version": "file:packages/dom",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"element-closest": "^2.0.2",
 				"lodash": "^4.17.10"
 			}
@@ -3439,13 +3439,13 @@
 		"@wordpress/dom-ready": {
 			"version": "file:packages/dom-ready",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/editor": {
 			"version": "file:packages/editor",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blob": "file:packages/blob",
@@ -3486,7 +3486,7 @@
 		"@wordpress/element": {
 			"version": "file:packages/element",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10",
@@ -3507,19 +3507,19 @@
 		"@wordpress/hooks": {
 			"version": "file:packages/hooks",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/html-entities": {
 			"version": "file:packages/html-entities",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/i18n": {
 			"version": "file:packages/i18n",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"gettext-parser": "^1.3.1",
 				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
@@ -3529,14 +3529,14 @@
 		"@wordpress/is-shallow-equal": {
 			"version": "file:packages/is-shallow-equal",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/jest-console": {
 			"version": "file:packages/jest-console",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"jest-matcher-utils": "^22.4.3",
 				"lodash": "^4.17.10"
 			}
@@ -3555,7 +3555,7 @@
 		"@wordpress/keycodes": {
 			"version": "file:packages/keycodes",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -3563,7 +3563,7 @@
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"lodash": "^4.17.10",
 				"webpack-sources": "^1.1.0"
 			}
@@ -3575,7 +3575,7 @@
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
@@ -3588,7 +3588,7 @@
 		"@wordpress/plugins": {
 			"version": "file:packages/plugins",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
@@ -3599,7 +3599,7 @@
 			"version": "file:packages/postcss-themes",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"postcss": "^6.0.16"
 			}
 		},
@@ -3709,21 +3709,21 @@
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@wordpress/url": {
 			"version": "file:packages/url",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"qs": "^6.5.2s"
 			}
 		},
 		"@wordpress/viewport": {
 			"version": "file:packages/viewport",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
@@ -3733,7 +3733,7 @@
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52",
+				"@babel/runtime": "7.0.0-beta.56",
 				"lodash": "^4.17.10"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,1145 +5,268 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.52.tgz",
-			"integrity": "sha1-GSSDv6DR5GfBAVccIQKcy3SvKAE=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
+			"integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.52"
+				"@babel/highlight": "7.0.0-beta.56"
 			}
 		},
 		"@babel/core": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.52.tgz",
-			"integrity": "sha1-8nqaRo+M+chgqryl9ghPpS+8blU=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.56.tgz",
+			"integrity": "sha512-IsytpdHZqo5pgJj4FTcpEMKmfXK9TdvThLZo4yUOjbuVZCy8NAwoeBnojvKCNf+139L7xNIIosp3RVA0cMkbOg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.52",
-				"@babel/generator": "7.0.0-beta.52",
-				"@babel/helpers": "7.0.0-beta.52",
-				"@babel/parser": "7.0.0-beta.52",
-				"@babel/template": "7.0.0-beta.52",
-				"@babel/traverse": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52",
+				"@babel/code-frame": "7.0.0-beta.56",
+				"@babel/generator": "7.0.0-beta.56",
+				"@babel/helpers": "7.0.0-beta.56",
+				"@babel/parser": "7.0.0-beta.56",
+				"@babel/template": "7.0.0-beta.56",
+				"@babel/traverse": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56",
 				"convert-source-map": "^1.1.0",
 				"debug": "^3.1.0",
 				"json5": "^0.5.0",
-				"lodash": "^4.17.5",
-				"micromatch": "^3.1.10",
+				"lodash": "^4.17.10",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.52.tgz",
-			"integrity": "sha1-JpaPEvrYGM2XTISbKGtDfh6MzZE=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
+			"integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52",
+				"@babel/types": "7.0.0-beta.56",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
 				"trim-right": "^1.0.1"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.53.tgz",
-			"integrity": "sha1-WZYGKDdcvu+WoH7f4co4t1bwGqg=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.56.tgz",
+			"integrity": "sha512-PaHQ8R489lwBZYz/F81YpKDurIQfKWliNIpHZAysYbnozq8hVyaUx8D5wW6Dplf0lUUQ8Y/I3YKtiNoyg7bLHA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.53.tgz",
-			"integrity": "sha1-RFZwliPX2vqivulPglUD9MDs6Fs=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.56.tgz",
+			"integrity": "sha512-ka5Fe6UB/jRtCWU/emg6fLKqttaVaBCF1zdT06PYs7w8hJPidCcfdVMBoDHfqL3pgLo+hp+LW4Q/99zw/zv0Sw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/helper-explode-assignable-expression": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.53.tgz",
-			"integrity": "sha1-e9fn419EOf03NfAC5hIyGGv5zs8=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.56.tgz",
+			"integrity": "sha512-s7nY9YbY+/6yccMCdI9oqh/rZ9lEoo3EHk/Lt6H2p/t6jyQf0sWqtsbJeHg5j5FzX6ZwYkdX8lTmBBMTrlyf9A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.53",
+				"@babel/types": "7.0.0-beta.56",
 				"esutils": "^2.0.0"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.53.tgz",
-			"integrity": "sha1-ld6Lq9A/nmz08rVkoDhwjBOP/jE=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.56.tgz",
+			"integrity": "sha512-XOv0taD7Elw0CSorktXbbCzdPgH4dZOb8yObk5deEhDbWgJhdwIvd5z8rQpDu712oqDhXm7Z3v+upFsOCg2+nQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-beta.53",
-				"@babel/traverse": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
-					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.5",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
-					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.53",
-						"@babel/template": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
-					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
-					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/generator": "7.0.0-beta.53",
-						"@babel/helper-function-name": "7.0.0-beta.53",
-						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"debug": "^3.1.0",
-						"globals": "^11.1.0",
-						"invariant": "^2.2.0",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/helper-hoist-variables": "7.0.0-beta.56",
+				"@babel/traverse": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.53.tgz",
-			"integrity": "sha1-SOniJlRTeHl1BD76qx7a0jnqlpU=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.56.tgz",
+			"integrity": "sha512-6hWVBpEyeRqvX3cKU7GVjdiYk9SvucpScTwdNpuSvsX8lX1MzuLQ7n9FNrHMU6+ulVNkZV81E7WdABYgXyIfuw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53",
-				"lodash": "^4.17.5"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
-					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.53",
-						"@babel/template": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/helper-function-name": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.53.tgz",
-			"integrity": "sha1-1bytK2tH9ATAruillk3/2TEkc6g=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.56.tgz",
+			"integrity": "sha512-Y3a7HLnwLJEiKe4+XB2AEo6QiCnFsa0ycqg6HBp0lyw4HztSTGt3oyZYO8I5ZhtVCKi/EJXSQuKHLOV98jG/+A==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
-					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.5",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
-					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.53",
-						"@babel/template": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
-					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
-					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/generator": "7.0.0-beta.53",
-						"@babel/helper-function-name": "7.0.0-beta.53",
-						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"debug": "^3.1.0",
-						"globals": "^11.1.0",
-						"invariant": "^2.2.0",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/traverse": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.52.tgz",
-			"integrity": "sha1-qGelj/VxsldysteZsyhmBYVzxFA=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
+			"integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.52",
-				"@babel/template": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/helper-get-function-arity": "7.0.0-beta.56",
+				"@babel/template": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.52.tgz",
-			"integrity": "sha1-HAzaWOC3X0XpLq+9j+GJpO7pK3Q=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
+			"integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.53.tgz",
-			"integrity": "sha1-TCfjuHP6CcWtbpPrQHBMIA+EE3w=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.56.tgz",
+			"integrity": "sha512-PTBa6UfiM7MgeTXOlNjCDiiqtOhqWraHM2GGsZg1M8VkuZRjP1Kag9JNmoppUlsZE5LY3NE+BjJuQ1/mLgcIug==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.53.tgz",
-			"integrity": "sha1-D7Dviy07kD0cO/Qm2kp0V14BnOQ=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.56.tgz",
+			"integrity": "sha512-/TrmPCG1XIENakzenEyiNsbIBSTm10DNWyB/cyKwVljzA18gMivn9YxSMxVAuaC1KyTTmhkeUYibSMF7yF13xw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.53.tgz",
-			"integrity": "sha1-5zXmqjClBLD52Fw4ptRwqfSqgdk=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.56.tgz",
+			"integrity": "sha512-iVWFscU+yIu6DIo5IWkMgVXd74/d3z/ZomwF/QJNGFwFP/lNA282rpjsky56fSxS7oT7wAlXoYoHVCOOaL7tbg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.53",
-				"lodash": "^4.17.5"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/types": "7.0.0-beta.56",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.53.tgz",
-			"integrity": "sha1-e6IUzcyPhiPy0Xl96v8f80mqzhM=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.56.tgz",
+			"integrity": "sha512-jC+blwjVeVx43WWOJHHXYBcHvYw0eHNgZUUXHKkDTLYc0zx8oev3LyciGFiWz29KgCS1K8YYd0t7z8fFXlCTog==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.53",
-				"@babel/helper-simple-access": "7.0.0-beta.53",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.53",
-				"@babel/template": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53",
-				"lodash": "^4.17.5"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
-					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/helper-module-imports": "7.0.0-beta.56",
+				"@babel/helper-simple-access": "7.0.0-beta.56",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.56",
+				"@babel/template": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.53.tgz",
-			"integrity": "sha1-j8eO9MD2n4uzu980zSMsIBIEFMg=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.56.tgz",
+			"integrity": "sha512-T+eZePA6kM+3wHXDPKKFZGHtMJGfK2/xmdk9pVjFHppdg4zwEqGaqLQaOlqfk5ekx2vxO22tmL4Caf2A/MVm0w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.53.tgz",
-			"integrity": "sha1-1kRYY2/8JYtCcUqd2Trrb4uM8+0=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
+			"integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.53.tgz",
-			"integrity": "sha1-bp0hl7Vid54iVWWUaumoXCFbIl4=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.56.tgz",
+			"integrity": "sha512-wtb8bmlc5TF7W7KMd5muS+CVQQu7cNGTdPbI5+8x5w36bN8ytbkun5160hJ2S1r3Tti0FPnrYwz+9W5AGj+d9g==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.5"
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.53.tgz",
-			"integrity": "sha1-uDSnVy3sF2OJ/6x+djV5WGSQySI=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.56.tgz",
+			"integrity": "sha512-uCvdjXeEh/qzvhK61XLP5DADCM0MMxZOVdGIj5In/i9MLt9BD/EAyBmjZN0bc1dD1wJst0qInZyZju0lUUkvNQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.53",
-				"@babel/helper-wrap-function": "7.0.0-beta.53",
-				"@babel/template": "7.0.0-beta.53",
-				"@babel/traverse": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
-					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.5",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
-					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.53",
-						"@babel/template": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
-					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
-					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/generator": "7.0.0-beta.53",
-						"@babel/helper-function-name": "7.0.0-beta.53",
-						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"debug": "^3.1.0",
-						"globals": "^11.1.0",
-						"invariant": "^2.2.0",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.56",
+				"@babel/helper-wrap-function": "7.0.0-beta.56",
+				"@babel/template": "7.0.0-beta.56",
+				"@babel/traverse": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.53.tgz",
-			"integrity": "sha1-M5tb3BAilElbGifFWBMjBuG3vKc=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.56.tgz",
+			"integrity": "sha512-Pv0a8XYWeYLMgzx6BiKYMkBPW7ilDeKmKnPfMD+sCsTRDMZl9DssqnkkSwGxgAeuPwZ9opx18r5EzYPTgt0k4A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "7.0.0-beta.53",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.53",
-				"@babel/traverse": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
-					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.5",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
-					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.53",
-						"@babel/template": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
-					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
-					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/generator": "7.0.0-beta.53",
-						"@babel/helper-function-name": "7.0.0-beta.53",
-						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"debug": "^3.1.0",
-						"globals": "^11.1.0",
-						"invariant": "^2.2.0",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/helper-member-expression-to-functions": "7.0.0-beta.56",
+				"@babel/helper-optimise-call-expression": "7.0.0-beta.56",
+				"@babel/traverse": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.53.tgz",
-			"integrity": "sha1-cvbbmr5C+GgfpvAo79WdgVRHUrM=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.56.tgz",
+			"integrity": "sha512-CIRkGs+/KNWpGJKEUbABeVWTZ1ePskwKwwoR1lVs2qI4cZheS6NvXzLxsFN/uxyc46yn7px/XTxV/zM3rnlQQQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53",
-				"lodash": "^4.17.5"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/template": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.52.tgz",
-			"integrity": "sha1-SqxPMOpjhK82duBLUkZydjLkYN8=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
+			"integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.53.tgz",
-			"integrity": "sha1-q/sr+pQBBCurJXwBkPWtbbjfFdU=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.56.tgz",
+			"integrity": "sha512-WuGMzbpx12M40aHtocM0vs9af/LmdwpXsKBX2T2GqCMueD90MHvQU+148vHScgPbUoWP4lv+dFGZDf0XUc2qJA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.53",
-				"@babel/template": "7.0.0-beta.53",
-				"@babel/traverse": "7.0.0-beta.53",
-				"@babel/types": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
-					"integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.5",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
-					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.53",
-						"@babel/template": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
-					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
-					"integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/generator": "7.0.0-beta.53",
-						"@babel/helper-function-name": "7.0.0-beta.53",
-						"@babel/helper-split-export-declaration": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"debug": "^3.1.0",
-						"globals": "^11.1.0",
-						"invariant": "^2.2.0",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/helper-function-name": "7.0.0-beta.56",
+				"@babel/template": "7.0.0-beta.56",
+				"@babel/traverse": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.52.tgz",
-			"integrity": "sha1-ib7r5OT9ayL111QHFgJ2KUCMSmM=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.56.tgz",
+			"integrity": "sha512-KaNBuVlAGW6sFCEWjliN29dL8K4L/ff8ZUaR/D5ou/JsqOuxLRy34Rf8WXMru3Et2g4Czly6vJeSmaYyf3s0lA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-beta.52",
-				"@babel/traverse": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52"
+				"@babel/template": "7.0.0-beta.56",
+				"@babel/traverse": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.52.tgz",
-			"integrity": "sha1-7ySTFDLwYVXnvDnNuKaze0oos9A=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
+			"integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
@@ -1160,659 +283,473 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.52.tgz",
-			"integrity": "sha1-TpNbYs2b+HK9N7zx9j2C/nsCN6I=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
+			"integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.53.tgz",
-			"integrity": "sha1-XFnvZm0Xwn3LVoa3XsMr622MUNY=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.56.tgz",
+			"integrity": "sha512-2amegw5EfeOJO5un5+A5cZ7cELUKf7fUzdryFdkg3ciGyNA+ISK9x4B57N8Jb5gWXch1xNsOV7tJuaaWeqbJ3g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-remap-async-to-generator": "7.0.0-beta.53",
-				"@babel/plugin-syntax-async-generators": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-remap-async-to-generator": "7.0.0-beta.56",
+				"@babel/plugin-syntax-async-generators": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.53.tgz",
-			"integrity": "sha1-5rXwusUBg48W6PPG00sAs+pANdk=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.56.tgz",
+			"integrity": "sha512-onVk2kI39dzkDP+SzX6eC3nAkq5yemiiZX+AuXAmshOyuz+ZYUu5b+zzXKw0oPFTSnMnlIfJItQCcVzesXcU6A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.53.tgz",
-			"integrity": "sha1-i6DVywtncv66DwxY5u1+oj/S8gI=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.56.tgz",
+			"integrity": "sha512-qLUAi1k8kTiFDUfGkjtdWujo6hTcqCDRw9hvBSxgJ150fRytyCG0pDqmC3KXytSdPPxuAcCCbgB+9CZsGPXkIA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.53.tgz",
-			"integrity": "sha1-YAlUHdmG6OsKkKJRFSMAEQLn3EM=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.56.tgz",
+			"integrity": "sha512-YszvYRt3tgCTJ+qcBSRKpJhlsiM0/BPcehwHgFzyKi0arnRX7jO8iyTZD3VpkVBElTGTbz91G9fSXj/7Y3PdQw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-regex": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-regex": "7.0.0-beta.56",
 				"regexpu-core": "^4.2.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.53.tgz",
-			"integrity": "sha1-gpvvbxUBeentC7lDM58qMSM6qSE=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.56.tgz",
+			"integrity": "sha512-tC8sGd1RridRn0147GUh2rF1WB+8FnP0siTD0ofuqLYJEbOTYn9NF0WD4DNzwwHwOZMBxgHFy8N/B1sNmEC8SQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.53.tgz",
-			"integrity": "sha1-IjzIl3IzOcsiCqghbGVQhv60U5g=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.56.tgz",
+			"integrity": "sha512-QsZbghj9DemNxr6ZX7V1ULukXrb+d3kRAU9ErikMnSCx60tKW5MQCIuSnHjr1l5wU4XlAZT2qclb+RYTTz0rAw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.53.tgz",
-			"integrity": "sha1-nb12jD8QnwKyT7oXNllp+iXrRYw=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.56.tgz",
+			"integrity": "sha512-rDqe3TN5cZaUg4zi3Kzfq5qySS6IcEs19WE7GHlmelgQ1QXy9d/tsPEAWHZTLrG4mjbbEFJZdLvAi+LSGdhJAQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.53.tgz",
-			"integrity": "sha1-pc9szGqrNp/CyleuH0pjs9w4Jes=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.56.tgz",
+			"integrity": "sha512-rpXmUoqQRwV3QaRUIwKTrVh/pzYe1mMmV43TXJNkP3BX4phimxsF+/orJY8MjqZs9QfHwQkfyb+b6BURLY62kA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.53.tgz",
-			"integrity": "sha1-p19fqEl6rBcp0DO/QcJQQWudHgQ=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.56.tgz",
+			"integrity": "sha512-TkpqdTt8ivvNBoawwxwFJSHRAQAWvWRuMyQIJfdrmSGdHVaEJ8xn1MkYuORMOogtpsG+ZncmGRAyCEQeMFBPsA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.53.tgz",
-			"integrity": "sha1-REx2HMQhXJeptVb/WMp7p99dQVM=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.56.tgz",
+			"integrity": "sha512-n34TSk3nFLCnsuC5f2PSb+jdOVXv1UzENnGN/Xu9/epSFVVNLfNR2td0Gx0Rh4CjIef5JZ0tFounyPWWMSh/0Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-remap-async-to-generator": "7.0.0-beta.53"
+				"@babel/helper-module-imports": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-remap-async-to-generator": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.53.tgz",
-			"integrity": "sha1-CkMiGhsMkM1NCfG0a5Wd0khlf3M=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.56.tgz",
+			"integrity": "sha512-rgabVaR9M5c7xyuWFMyPN8vT8QkncF9skgA2/O6seiGX8mgl/WjDMkWi2Sm9PFdPc7WEryKh8Rlu/tgupulwSA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.53.tgz",
-			"integrity": "sha1-nv1uUMofo5jcqnEZYh2j8fu4IbY=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.56.tgz",
+			"integrity": "sha512-hqeciuZPUfsZIhJ6MaB68U3+G5eS12ahidn98oUxyOl+BnS/aN9EhSt877mJPlEBe3oQy35qNwg/HG3rq33O2A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"lodash": "^4.17.5"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.53.tgz",
-			"integrity": "sha1-XcLsMb8emAZqzfDEiHt3RMFL7G4=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.56.tgz",
+			"integrity": "sha512-uq0Nvjlkt5gpF+dlvJ1yOZu8liBfOp3QoA/hrP7LZ6XzmYwZOhIUpUbouvKjgvybWiDmNDGcELeC96CL/mtV5Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.53",
-				"@babel/helper-define-map": "7.0.0-beta.53",
-				"@babel/helper-function-name": "7.0.0-beta.53",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-replace-supers": "7.0.0-beta.53",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.53",
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.56",
+				"@babel/helper-define-map": "7.0.0-beta.56",
+				"@babel/helper-function-name": "7.0.0-beta.56",
+				"@babel/helper-optimise-call-expression": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-replace-supers": "7.0.0-beta.56",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.56",
 				"globals": "^11.1.0"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
-					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.53",
-						"@babel/template": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
-					"integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.53.tgz",
-			"integrity": "sha1-l0fiYIKulO2lMPmNLCBZ6NLbwAU=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.56.tgz",
+			"integrity": "sha512-U0iHc3aEhgJsW5toS4ZjwWp9bV1l+gsJAt4PI/fXA4XK0DVZEZS82Xq3ozHLp5ccWiqJCCEWYAFys2c/ZPKmjA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.53.tgz",
-			"integrity": "sha1-DwrbDhptzTWjZkEBYJ7AYv8SenY=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.56.tgz",
+			"integrity": "sha512-6Jyis4rwPNQ9a8t1PerzymtC0qfgKlI9SOc44xaZfVo2nxzhb09nXrGsjpXywZVepDUWKHXy17XT0ouiQJmrTw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.53.tgz",
-			"integrity": "sha1-TEZHMaRf8Fm36TOsdswFzHBlGkA=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.56.tgz",
+			"integrity": "sha512-nM7ZXzwdDwviGUleCdDrQ4fGXtTkEFg0HHbZ5LD7XlJrN4goJmi6xHBOoZ8iWdTPrzAuDi+FT87RWCHFDcU4xA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-regex": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-regex": "7.0.0-beta.56",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.53.tgz",
-			"integrity": "sha1-D1WZE6v6GCOcpOCPc+7DbF5XuB8=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.56.tgz",
+			"integrity": "sha512-hnMT8itOVeLuLGtuE+SBpaCyLj97nq2LJwu2Ud6O6Nag1iswDp2MMgTYmFPzPF465LuP4cUp5bmjZcOvFkkoHQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.53.tgz",
-			"integrity": "sha1-PiZxeSBMd1GdhBepsZnyUiIejZU=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.56.tgz",
+			"integrity": "sha512-t32wjgnTXwOMDd8cIUSpYu3k31EqrYTJsZf/Dw44RDT6EXJzeTKchMsvwd2n8vf02OzjO0a9/qXF5dKl4cK0HQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.53.tgz",
-			"integrity": "sha1-+gZSFeGFacj3TdUktXIeEdzKlzs=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.56.tgz",
+			"integrity": "sha512-z4sift6xY65vOpFlRyPrcKNgusCV9NZZGOR9Dxt64XUEWnyxpabHZ9mGe0B3mqJbm168cK7sbxruvnyfyrO2fg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.53.tgz",
-			"integrity": "sha1-Kzpbs2TB4cV+zL/iXGv1XygEET4=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.56.tgz",
+			"integrity": "sha512-olcHC1WD2L36/vUl/aw5STpv/+O4C/mUGOytQ2NJn0VPKqeaYCBaEboz+4nnttlvTojaxWzBURTl675YvlPcWw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
-					"integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
-					"integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.53",
-						"@babel/template": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
-					"integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
-					"integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
-					"integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.53",
-						"@babel/parser": "7.0.0-beta.53",
-						"@babel/types": "7.0.0-beta.53",
-						"lodash": "^4.17.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"@babel/helper-function-name": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.53.tgz",
-			"integrity": "sha1-vsTxROmpbvUSHRQwx+vl/QiGV8k=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.56.tgz",
+			"integrity": "sha512-uz7Hcui2qmf1fA8pl5CsLz8KjM3HuUbEws/59G9kaMOrSIMrGSfeN1zsthfFSJDpFQLwq5NZ0+lPIvuOwE61bA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.53.tgz",
-			"integrity": "sha1-WFTXOeZ5IzqId8C0GCaca+t6Miw=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.56.tgz",
+			"integrity": "sha512-qbYJ9Xfi17D6GWzqs6AIKbT5oN5A4ONwxMzqkvr501ft0JognN4Hc5W5UAyCGdNgY/V6+Qdf1t8Opd+zTcS1FA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-module-transforms": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.53.tgz",
-			"integrity": "sha1-68P7ocWmyHQ7kJQD7NPn42gcr6U=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.56.tgz",
+			"integrity": "sha512-48juOe+HB048Km4l7ZzCKptRlfnYGAC5WwPJrDzldHQ8JFFmbrZPoDGPSlDK/3z9JRMldBHioVHvID5WTYPE9g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-simple-access": "7.0.0-beta.53"
+				"@babel/helper-module-transforms": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-simple-access": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.53.tgz",
-			"integrity": "sha1-uA/NnBWXLcaCMhT1JIUnhgu/BY4=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.56.tgz",
+			"integrity": "sha512-tr2KAI4jhBfZLkSIHU4vlS6I1RmFYfMxM49ese+iPryvj1aH7x1VSz2+DEA/Xr+gM4CTXpWk0Xf2r2u260lPEA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-hoist-variables": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.53.tgz",
-			"integrity": "sha1-Kjar5AodpnbkOhwwcVeOJ70tZ50=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.56.tgz",
+			"integrity": "sha512-0ItEhFLodomK7FH2FgK+UAphXd95UKyj3SXcRRhbUifvpfnqv0QFgaffI01iEyFnbxdXKpZqESHZR1fV/w1igw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-module-transforms": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.53.tgz",
-			"integrity": "sha1-m3Sz1TtOhUzw42DwLCpEAwccagE=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.56.tgz",
+			"integrity": "sha512-8r4H92o1LX6xZ3gGCUwrIiMwEoOfUfbflKOzrNQig2ybhX+9thU63m0P7cIU4qgp60mzIDKj2m7bz17s6MCl5g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.53.tgz",
-			"integrity": "sha1-4sTwbts0s9eksnV7oYgp0N8gKcs=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.56.tgz",
+			"integrity": "sha512-GB6OyxC16aIPE7lm13xfUsoP+zoqCn9PaocXzlGbQbotMoQ+qkmv3Ymq/Oy5YQl3kl5xrxX0JKNuOhYUjhG4YQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-replace-supers": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-replace-supers": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.53.tgz",
-			"integrity": "sha1-7+YM7IzsoNGdXG+hrnm8TjMnnVY=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.56.tgz",
+			"integrity": "sha512-zhGeuH/eY3kDVfFCWpyc1pWoIyuTZghqazsqJkUKwJMHoqVZuwEvNmpPi9Hhbn+W+LOFt8MJv5dY+kgfbMlwAQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "7.0.0-beta.53",
-				"@babel/helper-get-function-arity": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
-			},
-			"dependencies": {
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
-					"integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.53"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.53",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
-					"integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/helper-call-delegate": "7.0.0-beta.56",
+				"@babel/helper-get-function-arity": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.53.tgz",
-			"integrity": "sha1-ZYC3v2Zl8UyFgrn8JmygHwDgoEc=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.56.tgz",
+			"integrity": "sha512-xg1l6yyWxxE4NdCIs+d3xx9Q03BmktxI9fIfxKaT0y+UjABg6J1eGCJRBPa1s3X212gkUcEmYPjG6jo4ew40Sw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/plugin-syntax-jsx": "7.0.0-beta.53"
+				"@babel/helper-builder-react-jsx": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/plugin-syntax-jsx": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.53.tgz",
-			"integrity": "sha1-T+u/YISvoMHJ7ISX3mjAaV/p2gs=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.56.tgz",
+			"integrity": "sha512-wSRlSwXSXlpAdAKethZu+JyrnSL1NvLn3VtomlOCqHWhRhjOkjehIBlAe/AmguSn9JTUja0vqBWn1FS8sSnp7Q==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.53.tgz",
-			"integrity": "sha1-TefM/ewGl98PcKRqaCKTcUnI4rU=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.56.tgz",
+			"integrity": "sha512-bzIp/hDJwvN0hiVMlkiwC43N74R49nO+syW2wql8L48Md2z9nfsS0zw3T96oCDBUgGXzOX8uKq9DUKZS9YktTA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-module-imports": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.53.tgz",
-			"integrity": "sha1-38SIG2vXZYoAMew7gWPliPCJjUs=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.56.tgz",
+			"integrity": "sha512-qfN9LTjglikI4N2K/WkZAJQijWQpsQefsC/sXEN6c4/G9n5ZJFyXt23aXXcjibncKbcTrRpmH0nTeMiZK0A+5A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.53.tgz",
-			"integrity": "sha1-g+j2Rsok8cmCKPnxREz2DL1JOLw=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.56.tgz",
+			"integrity": "sha512-C0EUKGVSU5ttbRe+ATn54oR2jdGzGIA8Uo/0jwtMeTU+6lewpTX8nu+M36JZDIcq2sSu7zxfLiRkErb/PX/Q0g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.53.tgz",
-			"integrity": "sha1-D888mUq92Lq1m6l4L+TZ+KVF1uc=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.56.tgz",
+			"integrity": "sha512-VGPxbfefemuJg6/UVXf8WaaU9gIZRr31aLBsjDdYfj41N3W55LSvU+6CxCZ/ID6SfNCcQUEyBtZsWMWvv38Dhw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-regex": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-regex": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.53.tgz",
-			"integrity": "sha1-+msLQXEA0j4tsUwd9HorGzl48dk=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.56.tgz",
+			"integrity": "sha512-VMK/94Mlz24KFg0wc4Y4fAM6FNnx0wnr4A36rMdU54SYM3AEYzQcXtbI4uOCUSGdTOKR5zOiwhNnZFRodi29iA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.53.tgz",
-			"integrity": "sha1-ZarocamqQPYRSDZlcxIJrr1cKis=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.56.tgz",
+			"integrity": "sha512-BnKyH+AUvnVHyl+1Kt40jfr6+0/DUED9huSdirp1DrKwmjlcu4FliGDNcSSKBfawV4covKT7MBjWpE6s+XNk1g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53"
+				"@babel/helper-plugin-utils": "7.0.0-beta.56"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.53.tgz",
-			"integrity": "sha1-CvdOyAGefVnji+ZNt/YikZQv7SU=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.56.tgz",
+			"integrity": "sha512-31lEbd5voBJR8ufUuOaRu/r2dxj53S/fs+VNgPqCqvOw7Ql8AuuinYvJjxbzpZ5GqAWLPX1MKBgJ+gsjomXb6g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/helper-regex": "7.0.0-beta.53",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-regex": "7.0.0-beta.56",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.53.tgz",
-			"integrity": "sha1-KyBL9CZ14WbdpaJ1bEHrvyKbs34=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.56.tgz",
+			"integrity": "sha512-kFjCCUuMr0Y0N1je1QtOd37WXCU3cEnAqjm4GRlbgWlBPcj7A7ZQ40jMfrPeqVUJBbFiqi/UbOK5iLP/K8wdsA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.53",
-				"@babel/helper-plugin-utils": "7.0.0-beta.53",
-				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.53",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.53",
-				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.53",
-				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.53",
-				"@babel/plugin-syntax-async-generators": "7.0.0-beta.53",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.53",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.53",
-				"@babel/plugin-transform-arrow-functions": "7.0.0-beta.53",
-				"@babel/plugin-transform-async-to-generator": "7.0.0-beta.53",
-				"@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.53",
-				"@babel/plugin-transform-block-scoping": "7.0.0-beta.53",
-				"@babel/plugin-transform-classes": "7.0.0-beta.53",
-				"@babel/plugin-transform-computed-properties": "7.0.0-beta.53",
-				"@babel/plugin-transform-destructuring": "7.0.0-beta.53",
-				"@babel/plugin-transform-dotall-regex": "7.0.0-beta.53",
-				"@babel/plugin-transform-duplicate-keys": "7.0.0-beta.53",
-				"@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.53",
-				"@babel/plugin-transform-for-of": "7.0.0-beta.53",
-				"@babel/plugin-transform-function-name": "7.0.0-beta.53",
-				"@babel/plugin-transform-literals": "7.0.0-beta.53",
-				"@babel/plugin-transform-modules-amd": "7.0.0-beta.53",
-				"@babel/plugin-transform-modules-commonjs": "7.0.0-beta.53",
-				"@babel/plugin-transform-modules-systemjs": "7.0.0-beta.53",
-				"@babel/plugin-transform-modules-umd": "7.0.0-beta.53",
-				"@babel/plugin-transform-new-target": "7.0.0-beta.53",
-				"@babel/plugin-transform-object-super": "7.0.0-beta.53",
-				"@babel/plugin-transform-parameters": "7.0.0-beta.53",
-				"@babel/plugin-transform-regenerator": "7.0.0-beta.53",
-				"@babel/plugin-transform-shorthand-properties": "7.0.0-beta.53",
-				"@babel/plugin-transform-spread": "7.0.0-beta.53",
-				"@babel/plugin-transform-sticky-regex": "7.0.0-beta.53",
-				"@babel/plugin-transform-template-literals": "7.0.0-beta.53",
-				"@babel/plugin-transform-typeof-symbol": "7.0.0-beta.53",
-				"@babel/plugin-transform-unicode-regex": "7.0.0-beta.53",
+				"@babel/helper-module-imports": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.56",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.56",
+				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.56",
+				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.56",
+				"@babel/plugin-syntax-async-generators": "7.0.0-beta.56",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.56",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.56",
+				"@babel/plugin-transform-arrow-functions": "7.0.0-beta.56",
+				"@babel/plugin-transform-async-to-generator": "7.0.0-beta.56",
+				"@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.56",
+				"@babel/plugin-transform-block-scoping": "7.0.0-beta.56",
+				"@babel/plugin-transform-classes": "7.0.0-beta.56",
+				"@babel/plugin-transform-computed-properties": "7.0.0-beta.56",
+				"@babel/plugin-transform-destructuring": "7.0.0-beta.56",
+				"@babel/plugin-transform-dotall-regex": "7.0.0-beta.56",
+				"@babel/plugin-transform-duplicate-keys": "7.0.0-beta.56",
+				"@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.56",
+				"@babel/plugin-transform-for-of": "7.0.0-beta.56",
+				"@babel/plugin-transform-function-name": "7.0.0-beta.56",
+				"@babel/plugin-transform-literals": "7.0.0-beta.56",
+				"@babel/plugin-transform-modules-amd": "7.0.0-beta.56",
+				"@babel/plugin-transform-modules-commonjs": "7.0.0-beta.56",
+				"@babel/plugin-transform-modules-systemjs": "7.0.0-beta.56",
+				"@babel/plugin-transform-modules-umd": "7.0.0-beta.56",
+				"@babel/plugin-transform-new-target": "7.0.0-beta.56",
+				"@babel/plugin-transform-object-super": "7.0.0-beta.56",
+				"@babel/plugin-transform-parameters": "7.0.0-beta.56",
+				"@babel/plugin-transform-regenerator": "7.0.0-beta.56",
+				"@babel/plugin-transform-shorthand-properties": "7.0.0-beta.56",
+				"@babel/plugin-transform-spread": "7.0.0-beta.56",
+				"@babel/plugin-transform-sticky-regex": "7.0.0-beta.56",
+				"@babel/plugin-transform-template-literals": "7.0.0-beta.56",
+				"@babel/plugin-transform-typeof-symbol": "7.0.0-beta.56",
+				"@babel/plugin-transform-unicode-regex": "7.0.0-beta.56",
 				"browserslist": "^3.0.0",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
 				"semver": "^5.3.0"
 			}
 		},
-		"@babel/runtime": {
-			"version": "7.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.53.tgz",
-			"integrity": "sha1-nfIq40gjzon3kAYFlLg+5XLixdI=",
+		"@babel/runtime-corejs2": {
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-beta.56.tgz",
+			"integrity": "sha512-LE2R7zTLAgaM54y/XdyAMzHERY1lv1cyQll3IvgN2VrTVxdlUBO7t/cHpc5iwqqHI85/VRNfGtQZdO2PecCIqg==",
 			"requires": {
 				"core-js": "^2.5.7",
 				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"@babel/template": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.52.tgz",
-			"integrity": "sha1-ROGPrDglH1f5JRHWdI8JWrAvmW4=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
+			"integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.52",
-				"@babel/parser": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52",
-				"lodash": "^4.17.5"
+				"@babel/code-frame": "7.0.0-beta.56",
+				"@babel/parser": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.52.tgz",
-			"integrity": "sha1-m4uplPcmTZhHhYrS/uzCc4xeLvM=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
+			"integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.52",
-				"@babel/generator": "7.0.0-beta.52",
-				"@babel/helper-function-name": "7.0.0-beta.52",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.52",
-				"@babel/parser": "7.0.0-beta.52",
-				"@babel/types": "7.0.0-beta.52",
+				"@babel/code-frame": "7.0.0-beta.56",
+				"@babel/generator": "7.0.0-beta.56",
+				"@babel/helper-function-name": "7.0.0-beta.56",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.56",
+				"@babel/parser": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-beta.56",
 				"debug": "^3.1.0",
 				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.17.5"
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-beta.52",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.52.tgz",
-			"integrity": "sha1-o+ViCxU0slOlCrzyIitSDiOxbaI=",
+			"version": "7.0.0-beta.56",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
+			"integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.10",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -2986,14 +1923,14 @@
 		"@wordpress/a11y": {
 			"version": "file:packages/a11y",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/dom-ready": "file:packages/dom-ready"
 			}
 		},
 		"@wordpress/api-fetch": {
 			"version": "file:packages/api-fetch",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n"
 			}
@@ -3001,21 +1938,21 @@
 		"@wordpress/autop": {
 			"version": "file:packages/autop",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "file:packages/babel-plugin-import-jsx-pragma",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/babel-plugin-makepot": {
 			"version": "file:packages/babel-plugin-makepot",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.10"
 			}
@@ -3029,7 +1966,7 @@
 				"@babel/plugin-transform-react-jsx": "7.0.0-beta.56",
 				"@babel/plugin-transform-runtime": "7.0.0-beta.56",
 				"@babel/preset-env": "7.0.0-beta.56",
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"babel-core": "^7.0.0-bridge.0"
 			}
@@ -3037,7 +1974,7 @@
 		"@wordpress/blob": {
 			"version": "file:packages/blob",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/block-serialization-spec-parser": {
@@ -3046,7 +1983,7 @@
 		"@wordpress/blocks": {
 			"version": "file:packages/blocks",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-spec-parser": "file:packages/block-serialization-spec-parser",
@@ -3075,7 +2012,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/compose": "file:packages/compose",
@@ -3369,7 +2306,7 @@
 		"@wordpress/compose": {
 			"version": "file:packages/compose",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10"
@@ -3378,7 +2315,7 @@
 		"@wordpress/core-data": {
 			"version": "file:packages/core-data",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/url": "file:packages/url",
@@ -3391,14 +2328,14 @@
 			"version": "file:packages/custom-templated-path-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"@wordpress/data": {
 			"version": "file:packages/data",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
@@ -3417,7 +2354,7 @@
 		"@wordpress/date": {
 			"version": "file:packages/date",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.16"
 			}
@@ -3425,13 +2362,13 @@
 		"@wordpress/deprecated": {
 			"version": "file:packages/deprecated",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/dom": {
 			"version": "file:packages/dom",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"element-closest": "^2.0.2",
 				"lodash": "^4.17.10"
 			}
@@ -3439,13 +2376,13 @@
 		"@wordpress/dom-ready": {
 			"version": "file:packages/dom-ready",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/editor": {
 			"version": "file:packages/editor",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blob": "file:packages/blob",
@@ -3486,7 +2423,7 @@
 		"@wordpress/element": {
 			"version": "file:packages/element",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10",
@@ -3507,19 +2444,19 @@
 		"@wordpress/hooks": {
 			"version": "file:packages/hooks",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/html-entities": {
 			"version": "file:packages/html-entities",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/i18n": {
 			"version": "file:packages/i18n",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"gettext-parser": "^1.3.1",
 				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
@@ -3529,14 +2466,14 @@
 		"@wordpress/is-shallow-equal": {
 			"version": "file:packages/is-shallow-equal",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			}
 		},
 		"@wordpress/jest-console": {
 			"version": "file:packages/jest-console",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"jest-matcher-utils": "^22.4.3",
 				"lodash": "^4.17.10"
 			}
@@ -3555,7 +2492,7 @@
 		"@wordpress/keycodes": {
 			"version": "file:packages/keycodes",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -3563,7 +2500,7 @@
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"lodash": "^4.17.10",
 				"webpack-sources": "^1.1.0"
 			}
@@ -3575,7 +2512,7 @@
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
@@ -3588,7 +2525,7 @@
 		"@wordpress/plugins": {
 			"version": "file:packages/plugins",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
@@ -3599,7 +2536,7 @@
 			"version": "file:packages/postcss-themes",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"postcss": "^6.0.16"
 			}
 		},
@@ -3709,21 +2646,21 @@
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@wordpress/url": {
 			"version": "file:packages/url",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"qs": "^6.5.2s"
 			}
 		},
 		"@wordpress/viewport": {
 			"version": "file:packages/viewport",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
@@ -3733,7 +2670,7 @@
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.56",
+				"@babel/runtime-corejs2": "7.0.0-beta.56",
 				"lodash": "^4.17.10"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-beta.52",
+		"@babel/core": "7.0.0-beta.56",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/dom-ready": "file:../dom-ready"
 	},
 	"publishConfig": {

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/dom-ready": "file:../dom-ready"
 	},
 	"publishConfig": {

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n"
 	},

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n"
 	},

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -26,7 +26,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"devDependencies": {
 		"@babel/core": "7.0.0-beta.56",

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -26,14 +26,14 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime": "7.0.0-beta.56"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.0.0-beta.52",
-		"@babel/plugin-syntax-jsx": "^7.0.0-beta.52"
+		"@babel/core": "7.0.0-beta.56",
+		"@babel/plugin-syntax-jsx": "7.0.0-beta.56"
 	},
 	"peerDependencies": {
-		"@babel/core": "^7.0.0-beta.52"
+		"@babel/core": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -25,7 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10"
 	},

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -25,16 +25,16 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.0.0-beta.52",
-		"@babel/traverse": "^7.0.0-beta.52"
+		"@babel/core": "7.0.0-beta.56",
+		"@babel/traverse": "7.0.0-beta.56"
 	},
 	"peerDependencies": {
-		"@babel/core": "^7.0.0-beta.52"
+		"@babel/core": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -20,7 +20,7 @@ module.exports = function( api ) {
 				pragma: 'createElement',
 			} ],
 			'@babel/plugin-proposal-async-generator-functions',
-			! isTestEnv && '@babel/plugin-transform-runtime',
+			! isTestEnv && [ '@babel/plugin-transform-runtime', { corejs: 2 } ],
 		].filter( Boolean ),
 	};
 };

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -23,12 +23,12 @@
 	},
 	"main": "index.js",
 	"dependencies": {
-		"@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.52",
-		"@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.52",
-		"@babel/plugin-transform-react-jsx": "^7.0.0-beta.52",
-		"@babel/plugin-transform-runtime": "^7.0.0-beta.52",
-		"@babel/preset-env": "^7.0.0-beta.52",
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.56",
+		"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.56",
+		"@babel/plugin-transform-react-jsx": "7.0.0-beta.56",
+		"@babel/plugin-transform-runtime": "7.0.0-beta.56",
+		"@babel/preset-env": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"babel-core": "^7.0.0-bridge.0"
 	},

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -28,7 +28,7 @@
 		"@babel/plugin-transform-react-jsx": "7.0.0-beta.56",
 		"@babel/plugin-transform-runtime": "7.0.0-beta.56",
 		"@babel/preset-env": "7.0.0-beta.56",
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"babel-core": "^7.0.0-bridge.0"
 	},

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/compose": "file:../compose",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/compose": "file:../compose",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10"

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"@wordpress/url": "file:../url",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"@wordpress/url": "file:../url",

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -24,7 +24,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"escape-string-regexp": "^1.0.5"
 	},
 	"devDependencies": {

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -24,7 +24,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"escape-string-regexp": "^1.0.5"
 	},
 	"devDependencies": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.16"
 	},

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.16"
 	},

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"element-closest": "^2.0.2",
 		"lodash": "^4.17.10"
 	},

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"element-closest": "^2.0.2",
 		"lodash": "^4.17.10"
 	},

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime": "7.0.0-beta.56"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4"

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,7 +22,7 @@
 		"pot-to-php": "./tools/pot-to-php.js"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"gettext-parser": "^1.3.1",
 		"jed": "^1.1.1",
 		"lodash": "^4.17.10",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,7 +22,7 @@
 		"pot-to-php": "./tools/pot-to-php.js"
 	},
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"gettext-parser": "^1.3.1",
 		"jed": "^1.1.1",
 		"lodash": "^4.17.10",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -24,7 +24,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime": "7.0.0-beta.56"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -24,7 +24,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -25,7 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"jest-matcher-utils": "^22.4.3",
 		"lodash": "^4.17.10"
 	},

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -25,7 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"jest-matcher-utils": "^22.4.3",
 		"lodash": "^4.17.10"
 	},

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -23,7 +23,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"lodash": "^4.17.10",
 		"webpack-sources": "^1.1.0"
 	},

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -23,7 +23,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"lodash": "^4.17.10",
 		"webpack-sources": "^1.1.0"
 	},

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -26,7 +26,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"postcss": "^6.0.16"
 	},
 	"publishConfig": {

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -26,7 +26,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"postcss": "^6.0.16"
 	},
 	"publishConfig": {

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"qs": "^6.5.2s"
 	},
 	"publishConfig": {

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"qs": "^6.5.2s"
 	},
 	"publishConfig": {

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-beta.56",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime": "7.0.0-beta.56",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Set babel beta dependencies to a fixed version.

Adds core-js2 support for `@babel/plugin-transform-runtime` in `babel-preset-default` package.

Fixes #8580 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
