### PR TITLE
Polish the checkbox, update switch documentation

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -129,22 +129,22 @@ body.gutenberg-editor-page {
 .editor-block-list__block,
 .components-popover {
 	.input-control, // Upstream name is `.regular-text`.
-	input[type=text],
-	input[type=search],
-	input[type=radio],
-	input[type=tel],
-	input[type=time],
-	input[type=url],
-	input[type=week],
-	input[type=password],
-	input[type=checkbox],
-	input[type=color],
-	input[type=date],
-	input[type=datetime],
-	input[type=datetime-local],
-	input[type=email],
-	input[type=month],
-	input[type=number],
+	input[type="text"],
+	input[type="search"],
+	input[type="radio"],
+	input[type="tel"],
+	input[type="time"],
+	input[type="url"],
+	input[type="week"],
+	input[type="password"],
+	input[type="checkbox"],
+	input[type="color"],
+	input[type="date"],
+	input[type="datetime"],
+	input[type="datetime-local"],
+	input[type="email"],
+	input[type="month"],
+	input[type="number"],
 	select,
 	textarea {
 		margin-top: 0; // These override a "margin: 1px" from core.
@@ -170,7 +170,7 @@ body.gutenberg-editor-page {
 		}
 	}
 
-	input[type=checkbox] {
+	input[type="checkbox"] {
 		border: $border-width + 1 solid $dark-gray-300;
 		border-radius: $radius-round-rectangle / 2;
 		margin-right: 12px;
@@ -182,15 +182,15 @@ body.gutenberg-editor-page {
 		}
 
 		&:checked {
-			background: theme( toggle );
-			border-color: theme( toggle );
+			background: theme(toggle);
+			border-color: theme(toggle);
 		}
 
 		&:checked:focus {
 			box-shadow: 0 0 0 2px $dark-gray-500;
 		}
 
-		&:before {
+		&::before {
 			margin: -4px 0 0 -5px;
 			color: $white;
 		}

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -121,29 +121,29 @@ body.gutenberg-editor-page {
 	}
 }
 
-// Override core input styles to provide ones consistent with Gutenberg
-// @todo submit as upstream patch as well
+// Override core input styles to provide styles consistent with Gutenberg.
+// @todo Submit as upstream patch as well.
 .edit-post-sidebar,
 .editor-post-publish-panel,
 .editor-block-list__block,
 .components-popover {
-	.input-control, // upstream name is .regular-text
-	input[type="text"],
-	input[type="search"],
-	input[type="radio"],
-	input[type="tel"],
-	input[type="time"],
-	input[type="url"],
-	input[type="week"],
-	input[type="password"],
-	input[type="checkbox"],
-	input[type="color"],
-	input[type="date"],
-	input[type="datetime"],
-	input[type="datetime-local"],
-	input[type="email"],
-	input[type="month"],
-	input[type="number"],
+	.input-control, // Upstream name is `.regular-text`.
+	input[type=text],
+	input[type=search],
+	input[type=radio],
+	input[type=tel],
+	input[type=time],
+	input[type=url],
+	input[type=week],
+	input[type=password],
+	input[type=checkbox],
+	input[type=color],
+	input[type=date],
+	input[type=datetime],
+	input[type=datetime-local],
+	input[type=email],
+	input[type=month],
+	input[type=number],
 	select,
 	textarea {
 		margin-top: 0; // These override a "margin: 1px" from core.
@@ -166,6 +166,32 @@ body.gutenberg-editor-page {
 			// Windows High Contrast mode will show this outline
 			outline: 2px solid transparent;
 			outline-offset: 0;
+		}
+	}
+
+	input[type=checkbox] {
+		border: 2px solid $dark-gray-300;
+		border-radius: $radius-round-rectangle / 2;
+		margin-right: 12px;
+		transition: none;
+
+		&:focus {
+			border-color: $dark-gray-300;
+			box-shadow: 0 0 0 1px $dark-gray-300;
+		}
+
+		&:checked {
+			background: theme( toggle );
+			border-color: theme( toggle );
+		}
+
+		&:checked:focus {
+			box-shadow: 0 0 0 2px $dark-gray-500;
+		}
+
+		&:before {
+			margin: -4px 0 0 -5px;
+			color: $white;
 		}
 	}
 }

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -122,7 +122,8 @@ body.gutenberg-editor-page {
 }
 
 // Override core input styles to provide styles consistent with Gutenberg.
-// @todo Submit as upstream patch as well.
+// Upstream ticket for redesigned input and styles in general: https://core.trac.wordpress.org/ticket/44749
+// Upstream ticket for redesigned checkbox: https://core.trac.wordpress.org/ticket/35596
 .edit-post-sidebar,
 .editor-post-publish-panel,
 .editor-block-list__block,
@@ -170,7 +171,7 @@ body.gutenberg-editor-page {
 	}
 
 	input[type=checkbox] {
-		border: 2px solid $dark-gray-300;
+		border: $border-width + 1 solid $dark-gray-300;
 		border-radius: $radius-round-rectangle / 2;
 		margin-right: 12px;
 		transition: none;

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -1,7 +1,3 @@
-.components-base-control {
-	margin: 0 0 1.5em;
-}
-
 .components-base-control__label {
 	display: block;
 	margin-bottom: 5px;

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -1,4 +1,3 @@
 .components-checkbox-control__input[type="checkbox"] {
 	margin-top: 0;
-	margin-right: 6px;
 }

--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -1,20 +1,20 @@
 # FormToggle
 
-The Form Toggle Control (or Switch) is a complement to the Checkbox Control, which is used when the effect is instant and boolean. Like its light switch counterpart that brings light, when you flip this switch something changes instantanously.
+The Form Toggle Control is a switch that should be **used when the effect is boolean and instant**. The Form Toggle Control is a complement to the Checkbox Control.
 
-Use:
+Use Form Toggle when:
 
-- When the effect of the switch is immediately visible to the user. For example when applying a dropcap to text, the actual dropcap is immediately activated.
-- When there are only two states for the switch, on or off.
+- The effect of the switch is immediately visible to the user. For example: when applying a drop-cap to text, the actual drop-cap is immediately activated.
+- There are only two states for the switch: on or off.
 
 Do **not** use:
 
 - When the control is part of a group of other related controls (multiple choice).
 - When the effect of flipping the switch is not instantaneous.
 
-When the Form Toggle compoment is not appropriate, use the Checkbox Control.
+When Form Toggle component is not appropriate, use the Checkbox Control.
 
-Note: it is highly recommended that you pair the switch control with contextual help text, for example `checked ? __( 'Thumbnails are cropped to align.' ) : __( 'Thumbnails are not cropped.' )`.
+Note: it is recommended that you pair the switch control with contextual help text, for example `checked ? __( 'Thumbnails are cropped to align.' ) : __( 'Thumbnails are not cropped.' )`.
 
 ## Usage
 

--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -1,5 +1,21 @@
 # FormToggle
 
+The Form Toggle Control (or Switch) is a complement to the Checkbox Control, which is used when the effect is instant and boolean. Like its light switch counterpart that brings light, when you flip this switch something changes instantanously.
+
+Use:
+
+- When the effect of the switch is immediately visible to the user. For example when applying a dropcap to text, the actual dropcap is immediately activated.
+- When there are only two states for the switch, on or off.
+
+Do **not** use:
+
+- When the control is part of a group of other related controls (multiple choice).
+- When the effect of flipping the switch is not instantaneous.
+
+When the Form Toggle compoment is not appropriate, use the Checkbox Control.
+
+Note: it is highly recommended that you pair the switch control with contextual help text, for example `checked ? __( 'Thumbnails are cropped to align.' ) : __( 'Thumbnails are not cropped.' )`.
+
 ## Usage
 
 ```jsx

--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -3,10 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-function PostComments( { commentStatus = 'open', instanceId, ...props } ) {
+function PostComments( { commentStatus = 'open', ...props } ) {
 	const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
 
 	return (
@@ -27,5 +27,4 @@ export default compose( [
 	withDispatch( ( dispatch ) => ( {
 		editPost: dispatch( 'core/editor' ).editPost,
 	} ) ),
-	withInstanceId,
 ] )( PostComments );

--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -2,24 +2,20 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { FormToggle } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 function PostComments( { commentStatus = 'open', instanceId, ...props } ) {
 	const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
 
-	const commentsToggleId = 'allow-comments-toggle-' + instanceId;
-
-	return [
-		<label key="label" htmlFor={ commentsToggleId }>{ __( 'Allow Comments' ) }</label>,
-		<FormToggle
-			key="toggle"
+	return (
+		<CheckboxControl
+			label={ __( 'Allow Comments' ) }
 			checked={ commentStatus === 'open' }
 			onChange={ onToggleComments }
-			id={ commentsToggleId }
-		/>,
-	];
+		/>
+	);
 }
 
 export default compose( [

--- a/packages/editor/src/components/post-pending-status/index.js
+++ b/packages/editor/src/components/post-pending-status/index.js
@@ -4,14 +4,14 @@
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import PostPendingStatusCheck from './check';
 
-export function PostPendingStatus( { instanceId, status, onUpdateStatus } ) {
+export function PostPendingStatus( { status, onUpdateStatus } ) {
 	const togglePendingStatus = () => {
 		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
 		onUpdateStatus( updatedStatus );
@@ -37,5 +37,4 @@ export default compose(
 			dispatch( 'core/editor' ).editPost( { status } );
 		},
 	} ) ),
-	withInstanceId
 )( PostPendingStatus );

--- a/packages/editor/src/components/post-pending-status/index.js
+++ b/packages/editor/src/components/post-pending-status/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { FormToggle } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 
@@ -12,7 +12,6 @@ import { withInstanceId, compose } from '@wordpress/compose';
 import PostPendingStatusCheck from './check';
 
 export function PostPendingStatus( { instanceId, status, onUpdateStatus } ) {
-	const pendingId = 'pending-toggle-' + instanceId;
 	const togglePendingStatus = () => {
 		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
 		onUpdateStatus( updatedStatus );
@@ -20,9 +19,8 @@ export function PostPendingStatus( { instanceId, status, onUpdateStatus } ) {
 
 	return (
 		<PostPendingStatusCheck>
-			<label htmlFor={ pendingId }>{ __( 'Pending Review' ) }</label>
-			<FormToggle
-				id={ pendingId }
+			<CheckboxControl
+				label={ __( 'Pending Review' ) }
 				checked={ status === 'pending' }
 				onChange={ togglePendingStatus }
 			/>

--- a/packages/editor/src/components/post-pingbacks/index.js
+++ b/packages/editor/src/components/post-pingbacks/index.js
@@ -2,24 +2,20 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { FormToggle } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 
 function PostPingbacks( { pingStatus = 'open', instanceId, ...props } ) {
 	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
 
-	const pingbacksToggleId = 'allow-pingbacks-toggle-' + instanceId;
-
-	return [
-		<label key="label" htmlFor={ pingbacksToggleId }>{ __( 'Allow Pingbacks & Trackbacks' ) }</label>,
-		<FormToggle
-			key="toggle"
+	return (
+		<CheckboxControl
+			label={ __( 'Allow Pingbacks & Trackbacks' ) }
 			checked={ pingStatus === 'open' }
 			onChange={ onTogglePingback }
-			id={ pingbacksToggleId }
-		/>,
-	];
+		/>
+	);
 }
 
 export default compose( [

--- a/packages/editor/src/components/post-pingbacks/index.js
+++ b/packages/editor/src/components/post-pingbacks/index.js
@@ -4,9 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 
-function PostPingbacks( { pingStatus = 'open', instanceId, ...props } ) {
+function PostPingbacks( { pingStatus = 'open', ...props } ) {
 	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
 
 	return (
@@ -27,5 +27,4 @@ export default compose( [
 	withDispatch( ( dispatch ) => ( {
 		editPost: dispatch( 'core/editor' ).editPost,
 	} ) ),
-	withInstanceId,
 ] )( PostPingbacks );

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { FormToggle } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 
@@ -12,16 +12,12 @@ import { withInstanceId, compose } from '@wordpress/compose';
 import PostStickyCheck from './check';
 
 export function PostSticky( { onUpdateSticky, postSticky = false, instanceId } ) {
-	const stickyToggleId = 'post-sticky-toggle-' + instanceId;
-
 	return (
 		<PostStickyCheck>
-			<label htmlFor={ stickyToggleId }>{ __( 'Stick to the Front Page' ) }</label>
-			<FormToggle
-				key="toggle"
+			<CheckboxControl
+				label={ __( 'Stick to the Front Page' ) }
 				checked={ postSticky }
 				onChange={ () => onUpdateSticky( ! postSticky ) }
-				id={ stickyToggleId }
 			/>
 		</PostStickyCheck>
 	);

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -4,14 +4,14 @@
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import PostStickyCheck from './check';
 
-export function PostSticky( { onUpdateSticky, postSticky = false, instanceId } ) {
+export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 	return (
 		<PostStickyCheck>
 			<CheckboxControl
@@ -36,5 +36,4 @@ export default compose( [
 			},
 		};
 	} ),
-	withInstanceId,
 ] )( PostSticky );

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -1,5 +1,5 @@
 .editor-post-taxonomies__hierarchical-terms-choice {
-	margin-bottom: 5px;
+	margin-bottom: 8px;
 }
 
 .editor-post-taxonomies__hierarchical-terms-input[type="checkbox"] {
@@ -7,21 +7,21 @@
 }
 
 .editor-post-taxonomies__hierarchical-terms-subchoices {
-	margin-top: 5px;
+	margin-top: 8px;
 	margin-left: $panel-padding;
 }
 
 .components-button.editor-post-taxonomies__hierarchical-terms-submit,
 .components-button.editor-post-taxonomies__hierarchical-terms-add {
-	margin-top: 10px;
+	margin-top: 12px;
 }
 
 .editor-post-taxonomies__hierarchical-terms-label {
 	display: inline-block;
-	margin-top: 10px;
+	margin-top: 12px;
 }
 
 .editor-post-taxonomies__hierarchical-terms-input {
-	margin-top: 5px;
+	margin-top: 8px;
 	width: 100%;
 }

--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -92,7 +92,7 @@ describe( 'Change detection', () => {
 
 		// Toggle post as sticky (not persisted for autosave).
 		await ensureSidebarOpened();
-		await page.click( '[id^="post-sticky-toggle-"]' );
+		await page.click( '[id="inspector-checkbox-control-0"]' );
 
 		// Force autosave to occur immediately.
 		await Promise.all( [

--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -92,7 +92,9 @@ describe( 'Change detection', () => {
 
 		// Toggle post as sticky (not persisted for autosave).
 		await ensureSidebarOpened();
-		await page.click( '[id="inspector-checkbox-control-0"]' );
+
+		const postStickyToggleButton = ( await page.$x( "//label[contains(text(), 'Stick to the Front Page')]" ) )[ 0 ];
+		await postStickyToggleButton.click( 'button' );
 
 		// Force autosave to occur immediately.
 		await Promise.all( [


### PR DESCRIPTION
The switch has a long history. Before I go into details, here's what this PR does:

- It replaces "Pending Review", "Stick to Front Page", "Allow Comments", and "Allow Pingbacks" from using Switches to using Checkboxes.
- It tweaks the design of the checkbox to have a significantly more visible checked state, and a new more visual focus state.
- It tweaks the documentation for when to use a switch instead of a checkbox.
- It unifies the margins of checkboxes to use our 4/8/12 grid, and adds a little padding.

The Switch is born from mobile, which is increasingly the device of choice for people and long term might become the only choice. It's bigger and more tappable, and implies by its nature that it's a boolean choice. It also has qualities that the checkbox does not embody:

- Like its wall lightswitch counterpart, it’s something you flip and the effect is instant. There used to be darkness, now there’s light.
- It has only a single purpose, and that purpose is boolean. For example you wouldn’t use switches to select multiple categories.

However "Allow Comments" and the three other aforementioned toggles that use switches in master, do not have an instant effect, they require you to hit "Save" before the toggle option is stored. Given the above reasoning, a checkbox is a better choice in those situations.

The toggle is still a good choice in situations where immediate visual feedback is given, like when a dropcap is applied, or when you toggle image croppping for gallery items. In those situations, the pairing of the boolean nature and the larger touch target makes the switch feel more substantial.

With this PR I'm trying to take into account all the past discussions on the topic, and I know there have been many. Lay your thoughts on me.

Screenshots, checking and focus styles:

![styles](https://user-images.githubusercontent.com/1204802/43713195-05b89690-9979-11e8-99a7-432753c7f632.gif)

Relaxed margins:

<img width="273" alt="tweaks" src="https://user-images.githubusercontent.com/1204802/43713227-1f178d30-9979-11e8-8bcf-0e3d47ef5d2e.png">

Instant effect toggles:

![switch](https://user-images.githubusercontent.com/1204802/43713236-27734b40-9979-11e8-834e-8becfcb441c3.gif)
