### PR TITLE
Fix awkward capitalisation in demo post content; fixes #8590.

### DIFF
--- a/post-content.php
+++ b/post-content.php
@@ -19,7 +19,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":2} -->
-<h2><?php _e( 'A Picture is worth a Thousand Words', 'gutenberg' ); ?></h2>
+<h2><?php _e( 'A Picture is Worth a Thousand Words', 'gutenberg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
This is a suuuuuuper simple fix that corrects some funky capitalisation in the Try Gutenberg callout's demo post content. May or may not be noticed by anyone who isn't a typo-finding magpie.

### Before:
<img width="613" alt="screenshot 2018-08-06 13 11 23" src="https://user-images.githubusercontent.com/376315/43716560-766be696-997c-11e8-95d9-e6dcc6710fbd.png">

### After:
<img width="604" alt="screenshot 2018-08-06 13 27 46" src="https://user-images.githubusercontent.com/376315/43716580-8549eabe-997c-11e8-8880-e21721feef62.png">
