### PR TITLE
Let Wordpress make images in gallery block responsive / add srcset attribute 

### DIFF
--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -175,7 +175,7 @@ export const settings = {
 							break;
 					}
 
-					const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } />;
+					const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } className={ image.id ? `wp-image-${ image.id }` : null } />;
 
 					return (
 						<li key={ image.id || image.url } className="blocks-gallery-item">
@@ -193,6 +193,41 @@ export const settings = {
 	},
 
 	deprecated: [
+		{
+			attributes: blockAttributes,
+			save( { attributes } ) {
+				const { images, columns = defaultColumnsNumber( attributes ), imageCrop, linkTo } = attributes;
+				return (
+					<ul className={ `columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
+						{ images.map( ( image ) => {
+							let href;
+
+							switch ( linkTo ) {
+								case 'media':
+									href = image.url;
+									break;
+								case 'attachment':
+									href = image.link;
+									break;
+							}
+
+							const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } />;
+
+							return (
+								<li key={ image.id || image.url } className="blocks-gallery-item">
+									<figure>
+										{ href ? <a href={ href }>{ img }</a> : img }
+										{ image.caption && image.caption.length > 0 && (
+											<RichText.Content tagName="figcaption" value={ image.caption } />
+										) }
+									</figure>
+								</li>
+							);
+						} ) }
+					</ul>
+				);
+			},
+		},
 		{
 			attributes: {
 				...blockAttributes,

--- a/test/integration/fixtures/wordpress-out.html
+++ b/test/integration/fixtures/wordpress-out.html
@@ -19,5 +19,5 @@
 <!-- /wp:heading -->
 
 <!-- wp:gallery {"columns":3,"linkTo":"attachment"} -->
-<ul class="wp-block-gallery columns-3 is-cropped"><li class="blocks-gallery-item"><figure><img data-id="1"/></figure></li></ul>
+<ul class="wp-block-gallery columns-3 is-cropped"><li class="blocks-gallery-item"><figure><img data-id="1" class="wp-image-1"/></figure></li></ul>
 <!-- /wp:gallery -->


### PR DESCRIPTION
## Description
Wordpress makes images with a wp-image-ID class responsive using a srcset attribute. This PR adds the needed class to the images in the gallery block. See #4898 for a similar fix for the image block.

Would help for #1450 because the browser should then only download the appropriate image sizes.

Fixes: #5674
Related: #2900 

## How has this been tested?
Upload images, create a gallery and view on the front-end. It should have added srcset attributes.

I've also run `npm test` and `npm run lint`

## Types of changes
My code adds the wp-image-ID class to the images in the gallery block. I also edited the wordpress-out.html test to reflect this change. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
