### PR TITLE
Updated dependencies: `jest`, `npm-package-json-lint` and `read-pkg-up`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3612,98 +3612,9 @@
 				"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
 				"cross-spawn": "^5.1.0",
 				"jest": "^23.3.0",
-				"npm-package-json-lint": "^3.0.1",
-				"read-pkg-up": "^4.0.0",
+				"npm-package-json-lint": "^3.3.0",
+				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/shortcode": {
@@ -14979,12 +14890,12 @@
 			}
 		},
 		"npm-package-json-lint": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.1.0.tgz",
-			"integrity": "sha1-/ZzSkB6QahmoSBsIUAFOGTyKWYg=",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.3.0.tgz",
+			"integrity": "sha512-Npd7o3qMkNWcBr/2sjNWJPY7N8911+EIdlqwLpfMOMUNGNo230eJTWA0zVc/PzIlviyO4d5o545cc4hLpIn7jg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.0",
+				"ajv": "^6.5.2",
 				"chalk": "^2.4.1",
 				"glob": "^7.1.2",
 				"is-path-inside": "^2.0.0",
@@ -14995,7 +14906,7 @@
 				"plur": "^3.0.1",
 				"semver": "^5.5.0",
 				"strip-json-comments": "^2.0.1",
-				"validator": "^10.2.0"
+				"validator": "^10.5.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -19784,9 +19695,9 @@
 			}
 		},
 		"validator": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-10.4.0.tgz",
-			"integrity": "sha512-Q/wBy3LB1uOyssgNlXSRmaf22NxjvDNZM2MtIQ4jaEOAB61xsh1TQxsq1CgzUMBV1lDrVMogIh8GjG1DYW0zLg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-10.5.0.tgz",
+			"integrity": "sha512-6OOi+eV2mOxCFLq0f2cJDrdB6lrtLXEUxabhNRGjgOLT/l3SSll9J49Cl+LIloUqkWWTPraK/mucEQ3dc2jStQ==",
 			"dev": true
 		},
 		"vendors": {

--- a/package.json
+++ b/package.json
@@ -120,6 +120,13 @@
 	"npmPackageJsonLintConfig": {
 		"extends": "@wordpress/npm-package-json-lint-config",
 		"rules": {
+			"description-format": [
+				"error",
+				{
+					"requireCapitalFirstLetter": true,
+					"requireEndingPeriod": true
+				}
+			],
 			"require-publishConfig": "error",
 			"valid-values-author": [
 				"error",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0 (Unreleased)
+
+- Updated dependencies: `jest`, `npm-package-json-lint` and `read-pkg-up`
+
 ## 2.0.0 (2018-07-12)
 
 - Breaking: Updated code to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -35,9 +35,9 @@
 		"@wordpress/jest-preset-default": "file:../jest-preset-default",
 		"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",
 		"cross-spawn": "^5.1.0",
-		"jest": "^23.3.0",
-		"npm-package-json-lint": "^3.0.1",
-		"read-pkg-up": "^4.0.0",
+		"jest": "^23.4.2",
+		"npm-package-json-lint": "^3.3.0",
+		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## Description

This PR updates `npm-package-json-lint` to the latest version and adds newly introduced rules. Props to @tclindner for making it possible:

> Hey! I just released v3.3.0 of npm-package-json-lint with a new description-format rule. It has two options:
> 
> requireCapitalFirstLetter - Throws an error if the first character in the description isn't capitalized.
> requireEndingPeriod - Throws an error if the description doesn't end with a period.
> Hopefully this works well for your team!

With this change, we can integrate new linting rule which will ensure that `description` inside `package.json` file will have proper formatting.

I took advantage of the fact that we are changing deps and bumped also `jest` which had also minor release.

I also downgraded `read-pkg-up` to avoid having it installed locally in the package. Instead, we can use the older version which is used with other packages. It doesn't break anything and keeps our setup simpler.

## How has this been tested?
`npm test` should cover all tools.
