### PR TITLE
Avoid using elt.remove because it's unavailable in ie11

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -382,7 +382,7 @@ function gutenberg_replace_default_add_new_button() {
 			newbutton += '<a href="' + classicUrl + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span><span class="page-title-action" style="display:none;"></span>';
 
 			button.insertAdjacentHTML( 'afterend', newbutton );
-			button.remove();
+			button.parentNode.removeChild( button );
 
 			var expander = document.getElementById( 'split-page-title-action' ).getElementsByClassName( 'expander' ).item( 0 );
 			var dropdown = expander.parentNode.querySelector( '.dropdown' );


### PR DESCRIPTION
fixes #8377

**Testing instructions**

 - Open the post list page in IE11
 - The button to switch editors should show up properly.