### PR TITLE
Fix issue with link dialog.

### DIFF
--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -1,5 +1,5 @@
 // Link input
-$input-padding: 8px;
+$input-padding: 9px 8px;
 $input-size: 230px;
 
 .editor-block-list__block .editor-url-input,
@@ -14,6 +14,9 @@ $input-size: 230px;
 		width: 100%;
 		padding: $input-padding;
 		border: none;
+		border-radius: 0;
+		margin-left: 0;
+		margin-right: 0;
 
 		&::-ms-clear {
 			display: none;
@@ -63,7 +66,7 @@ $input-size: 230px;
 
 	&:focus,
 	&.is-selected {
-		background: color( theme( primary ) shade(15%) );
+		background: color( theme( primary ) shade( 15% ) );
 		color: $white;
 		outline: none;
 	}
@@ -71,7 +74,7 @@ $input-size: 230px;
 
 // Toolbar button
 .components-toolbar > .editor-url-input__button {
-	position: inherit;	// let the dialog position according to parent
+	position: inherit; // Let the dialog position according to parent.
 }
 
 .editor-url-input__button .editor-url-input__back {


### PR DESCRIPTION
The recent focus style changes to text boxes I made introduced a regression in the link dialog box. This PR fixes it:

![screen shot 2018-08-07 at 09 19 52](https://user-images.githubusercontent.com/1204802/43760881-aeb5d2b2-9a23-11e8-87dd-17d3b2ef692a.png)

Note that I meant to also take a look at the specific link dialog box for the image block. But this button appears to have disappeared, is that correct?