### PR TITLE
Use @babel/runtime-corejs2 for babel-plugin-makepot

### DIFF
--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -25,7 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
+		"@babel/runtime-corejs2": "^7.0.0-beta.56",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10"
 	},


### PR DESCRIPTION
This is necessary because the runtime plugin has been split into two separate runtime modules. The required `@babel/runtime/core-js/object/keys` will no longer be found once users update to beta.56, or start a project fresh, as I just did.

On fresh installs, using the `@babel/runtime: "^7.0.0-beta.52"` requirement the following error is encountered:
` Cannot find module '@babel/runtime/core-js/object/keys'`

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
