### PR TITLE
Packages: Redux Routine: Add Babel runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2484,7 +2484,7 @@
 			"dev": true,
 			"requires": {
 				"@wordpress/jest-console": "file:packages/jest-console",
-				"babel-jest": "^23.2.0",
+				"babel-jest": "^23.4.2",
 				"enzyme": "^3.3.0",
 				"enzyme-adapter-react-16": "^1.1.1",
 				"jest-enzyme": "^6.0.2"
@@ -2544,7 +2544,7 @@
 		"@wordpress/redux-routine": {
 			"version": "file:packages/redux-routine",
 			"requires": {
-				"@babel/runtime": "^7.0.0-beta.52"
+				"@babel/runtime-corejs2": "7.0.0-beta.56"
 			},
 			"dependencies": {
 				"js-tokens": {
@@ -3424,9 +3424,9 @@
 			}
 		},
 		"babel-jest": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.4.0.tgz",
-			"integrity": "sha1-IsNMOS4hdvakw2eZKn/P9p0uhVc=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.4.2.tgz",
+			"integrity": "sha512-wg1LJ2tzsafXqPFVgAsYsMCVD5U7kwJZAvbZIxVm27iOewsQw1BR7VZifDlMTEWVo3wasoPPyMdKXWCsfFPr3Q==",
 			"dev": true,
 			"requires": {
 				"babel-plugin-istanbul": "^4.1.6",
@@ -10210,13 +10210,13 @@
 			"integrity": "sha1-elSbvZ/+FYWwzQoZHiAwVb7ldLQ="
 		},
 		"jest": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-23.4.0.tgz",
-			"integrity": "sha1-685j9lKcJ8ZG2AxhCGbwMG9m3L8=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-23.4.2.tgz",
+			"integrity": "sha512-w10HGpVFWT1oN8B2coxeiMEsZoggkDaw3i26xHGLU+rsR+LYkBk8qpZCgi+1cD1S6ttPjZDL8E8M99lmNhgTeA==",
 			"dev": true,
 			"requires": {
 				"import-local": "^1.0.0",
-				"jest-cli": "^23.4.0"
+				"jest-cli": "^23.4.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -10264,9 +10264,9 @@
 					}
 				},
 				"jest-cli": {
-					"version": "23.4.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.4.0.tgz",
-					"integrity": "sha1-0f3R28Qdaa6L1D0AcM4jmI6s2G8=",
+					"version": "23.4.2",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.4.2.tgz",
+					"integrity": "sha512-vaDzy0wRWrgSfz4ZImCqD2gtZqCSoEWp60y3USvGDxA2b4K0rGj2voru6a5scJFjDx5GCiNWKpz2E8IdWDVjdw==",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
@@ -10280,17 +10280,17 @@
 						"istanbul-lib-coverage": "^1.2.0",
 						"istanbul-lib-instrument": "^1.10.1",
 						"istanbul-lib-source-maps": "^1.2.4",
-						"jest-changed-files": "^23.4.0",
-						"jest-config": "^23.4.0",
+						"jest-changed-files": "^23.4.2",
+						"jest-config": "^23.4.2",
 						"jest-environment-jsdom": "^23.4.0",
 						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^23.4.0",
+						"jest-haste-map": "^23.4.1",
 						"jest-message-util": "^23.4.0",
 						"jest-regex-util": "^23.3.0",
-						"jest-resolve-dependencies": "^23.4.0",
-						"jest-runner": "^23.4.0",
-						"jest-runtime": "^23.4.0",
-						"jest-snapshot": "^23.4.0",
+						"jest-resolve-dependencies": "^23.4.2",
+						"jest-runner": "^23.4.2",
+						"jest-runtime": "^23.4.2",
+						"jest-snapshot": "^23.4.2",
 						"jest-util": "^23.4.0",
 						"jest-validate": "^23.4.0",
 						"jest-watcher": "^23.4.0",
@@ -10421,30 +10421,30 @@
 			}
 		},
 		"jest-changed-files": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.0.tgz",
-			"integrity": "sha1-8bME+YwjWvXZox7FJCYsXk3jxv8=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
+			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
 			"dev": true,
 			"requires": {
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.0.tgz",
-			"integrity": "sha1-ecz41oqg5I+eO+uBuDqlh1xj+j8=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.2.tgz",
+			"integrity": "sha512-CDJGO4H+7P+T6khaSHEjTxqVaIlmQMEFAyJFOVrAQeM+Xn12iZ+YY8Pluk1RDxi8Jqj9DoE09PHQzASCGePGtg==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
-				"babel-jest": "^23.4.0",
+				"babel-jest": "^23.4.2",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
 				"jest-environment-jsdom": "^23.4.0",
 				"jest-environment-node": "^23.4.0",
 				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^23.4.0",
+				"jest-jasmine2": "^23.4.2",
 				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.4.0",
+				"jest-resolve": "^23.4.1",
 				"jest-util": "^23.4.0",
 				"jest-validate": "^23.4.0",
 				"pretty-format": "^23.2.0"
@@ -10846,9 +10846,9 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.4.0.tgz",
-			"integrity": "sha1-8qDqpBr3Zs1RAebCkf3GQ1yT7hw=",
+			"version": "23.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.4.1.tgz",
+			"integrity": "sha512-PGQxOEGAfRbTyJkmZeOKkVSs+KVeWgG625p89KUuq+sIIchY5P8iPIIc+Hw2tJJPBzahU3qopw1kF/qyhDdNBw==",
 			"dev": true,
 			"requires": {
 				"fb-watchman": "^2.0.0",
@@ -10937,11 +10937,12 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.0.tgz",
-			"integrity": "sha1-F85Tn+YI74mNaYZRgUSs8nC+yo8=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz",
+			"integrity": "sha512-MUoqn41XHMQe5u8QvRTH2HahpBNzImnnjS3pV/T7LvrCM6f2zfGdi1Pm+bRbFMLJROqR8VlK8HmsenL2WjrUIQ==",
 			"dev": true,
 			"requires": {
+				"babel-traverse": "^6.0.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
 				"expect": "^23.4.0",
@@ -10950,7 +10951,7 @@
 				"jest-each": "^23.4.0",
 				"jest-matcher-utils": "^23.2.0",
 				"jest-message-util": "^23.4.0",
-				"jest-snapshot": "^23.4.0",
+				"jest-snapshot": "^23.4.2",
 				"jest-util": "^23.4.0",
 				"pretty-format": "^23.2.0"
 			},
@@ -11221,9 +11222,9 @@
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.0.tgz",
-			"integrity": "sha1-tAYdvNY5G15EXV/YTJ2tX/H/VmI=",
+			"version": "23.4.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.1.tgz",
+			"integrity": "sha512-VNk4YRNR5gsHhNS0Lp46/DzTT11e+ecbUC61ikE593cKbtdrhrMO+zXkOJaE8YDD5sHxH9W6OfssNn4FkZBzZQ==",
 			"dev": true,
 			"requires": {
 				"browser-resolve": "^1.11.3",
@@ -11232,30 +11233,30 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.0.tgz",
-			"integrity": "sha1-5z785wJipuK/UmPQsjAJoJhnhiA=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.2.tgz",
+			"integrity": "sha512-JUrU1/1mQAf0eKwKT4+RRnaqcw0UcRzRE38vyO+YnqoXUVidf646iuaKE+NG7E6Gb0+EVPOJ6TgqkaTPdQz78A==",
 			"dev": true,
 			"requires": {
 				"jest-regex-util": "^23.3.0",
-				"jest-snapshot": "^23.4.0"
+				"jest-snapshot": "^23.4.2"
 			}
 		},
 		"jest-runner": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.4.0.tgz",
-			"integrity": "sha1-GFmyEaJk6lpDt6MCLhGZBnxN/lc=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.4.2.tgz",
+			"integrity": "sha512-o+aEdDE7/Gyp8fLYEEf5B8aOUguz76AYcAMl5pueucey2Q50O8uUIXJ7zvt8O6OEJDztR3Kb+osMoh8MVIqgTw==",
 			"dev": true,
 			"requires": {
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.4.0",
+				"jest-config": "^23.4.2",
 				"jest-docblock": "^23.2.0",
-				"jest-haste-map": "^23.4.0",
-				"jest-jasmine2": "^23.4.0",
+				"jest-haste-map": "^23.4.1",
+				"jest-jasmine2": "^23.4.2",
 				"jest-leak-detector": "^23.2.0",
 				"jest-message-util": "^23.4.0",
-				"jest-runtime": "^23.4.0",
+				"jest-runtime": "^23.4.2",
 				"jest-util": "^23.4.0",
 				"jest-worker": "^23.2.0",
 				"source-map-support": "^0.5.6",
@@ -11384,9 +11385,9 @@
 			}
 		},
 		"jest-runtime": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.4.0.tgz",
-			"integrity": "sha1-ww72Gd71h7k7rUpJONqazLmTa00=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.4.2.tgz",
+			"integrity": "sha512-qaUDOi7tcdDe3MH5g5ycEslTpx0voPZvzIYbKjvWxCzCL2JEemLM+7IEe0BeLi2v5wvb/uh3dkb2wQI67uPtCw==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
@@ -11396,12 +11397,12 @@
 				"exit": "^0.1.2",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.4.0",
-				"jest-haste-map": "^23.4.0",
+				"jest-config": "^23.4.2",
+				"jest-haste-map": "^23.4.1",
 				"jest-message-util": "^23.4.0",
 				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.4.0",
-				"jest-snapshot": "^23.4.0",
+				"jest-resolve": "^23.4.1",
+				"jest-snapshot": "^23.4.2",
 				"jest-util": "^23.4.0",
 				"jest-validate": "^23.4.0",
 				"micromatch": "^2.3.11",
@@ -11603,18 +11604,17 @@
 			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.0.tgz",
-			"integrity": "sha1-dGPQNXyr3+HGOZTV4y9wfRAz1hY=",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",
+			"integrity": "sha512-rCBxIURDlVEW1gJgJSpo8l2F2gFwp9U7Yb3CmcABUpmQ8NASpb6LJkEvtcQifAYSi22OL44TSuanq1G6x1GJwg==",
 			"dev": true,
 			"requires": {
-				"babel-traverse": "^6.0.0",
 				"babel-types": "^6.0.0",
 				"chalk": "^2.0.1",
 				"jest-diff": "^23.2.0",
 				"jest-matcher-utils": "^23.2.0",
 				"jest-message-util": "^23.4.0",
-				"jest-resolve": "^23.4.0",
+				"jest-resolve": "^23.4.1",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"pretty-format": "^23.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,6 +2543,9 @@
 		},
 		"@wordpress/redux-routine": {
 			"version": "file:packages/redux-routine",
+			"requires": {
+				"@babel/runtime": "^7.0.0-beta.52"
+			},
 			"dependencies": {
 				"js-tokens": {
 					"version": "4.0.0",

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -14,12 +14,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
         "calls": Array [
           Array [],
         ],
-        "results": Array [
-          Object {
-            "isThrow": false,
-            "value": undefined,
-          },
-        ],
+        "results": undefined,
       }
     }
     onFocus={
@@ -27,12 +22,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
         "calls": Array [
           Array [],
         ],
-        "results": Array [
-          Object {
-            "isThrow": false,
-            "value": undefined,
-          },
-        ],
+        "results": undefined,
       }
     }
     onKeyDown={
@@ -40,12 +30,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
         "calls": Array [
           Array [],
         ],
-        "results": Array [
-          Object {
-            "isThrow": false,
-            "value": undefined,
-          },
-        ],
+        "results": undefined,
       }
     }
     readOnly={true}

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -27,7 +27,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"@wordpress/jest-console": "file:../jest-console",
-		"babel-jest": "^23.2.0",
+		"babel-jest": "^23.4.2",
 		"enzyme": "^3.3.0",
 		"enzyme-adapter-react-16": "^1.1.1",
 		"jest-enzyme": "^6.0.2"

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/redux-routine",
-	"version": "1.0.0",
+	"version": "1.0.0-beta.0",
 	"description": "Redux middleware for generator coroutines.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -21,7 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52"
+		"@babel/runtime-corejs2": "7.0.0-beta.56"
 	},
 	"devDependencies": {
 		"redux": "^4.0.0"

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -20,7 +20,9 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"dependencies": {},
+	"dependencies": {
+		"@babel/runtime": "^7.0.0-beta.52"
+	},
 	"devDependencies": {
 		"redux": "^4.0.0"
 	},


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/8096#discussion_r208244881

This pull request seeks to add `@babel/runtime` as a dependency of the `@wordpress/redux-routine` package, since its transpiled output includes a module dependency on this package. 

This may need to be reconciled with updates to use fixed version dependency proposed in #8586.

**Testing instructions:**

Verify `npm install`