### PR TITLE
Packages: Redux Routine: Remove fake timers from tests

### DIFF
--- a/packages/redux-routine/src/test/index.js
+++ b/packages/redux-routine/src/test/index.js
@@ -8,8 +8,6 @@ import { createStore, applyMiddleware } from 'redux';
  */
 import createMiddleware from '../';
 
-jest.useFakeTimers();
-
 describe( 'createMiddleware', () => {
 	function createStoreWithMiddleware( middleware ) {
 		const reducer = ( state = null, action ) => action.nextState || state;


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/8096#discussion_r208245061

This pull request seeks to remove an explicit call to `jest.useFakeTimers` from within the tests for Redux Routine. Fake timers are enabled by default for all packagers.

**Testing instructions:**

Verify unit tests pass:

```
npm run test
```