### PR TITLE
URLInput: Pass the the search result object to props.onChange

### DIFF
--- a/packages/editor/src/components/url-input/README.md
+++ b/packages/editor/src/components/url-input/README.md
@@ -1,0 +1,100 @@
+# `URLInput`
+
+Render a URL input that allows users to search for and select a post or enter any arbitrary URL.
+
+## Properties
+
+### `value: String`
+
+*Required.* This should be set to the attribute (or component state) property used to store the URL.
+
+### `onChange( url: String, post: Object ): Function`
+
+*Required.* Called when the value changes. The second parameter defaults to an empty object unless the user selects a post from the suggestions dropdown. In those cases the `post` parameter will look like this:
+
+```json
+{
+  "id": 1,
+  "subtype": "page",
+  "title": "Sample Page",
+  "type": "post",
+  "url": "https://example.com/sample-page/",
+  "_links": {
+    "self": [ { embeddable: true, href: "https://example.com/wp-json/wp/v2/pages/1" } ],
+    "about": [ { href: "https://example.com/wp-json/wp/v2/types/page" } ],
+    "collection": [ { href: "https://example.com/wp-json/gutenberg/v1/search" } ]
+  }
+}
+```
+
+### `autoFocus: Boolean`
+
+*Optional.* By default, the input will gain focus when it is rendered as typically it is used in combination with a `Popover`. If you are rendering the component all the time set this to `false`.
+
+## Example
+
+{% codetabs %}
+{% ES5 %}
+```js
+wp.blocks.registerBlockType( /* ... */, {
+	// ...
+
+	attributes: {
+		url: {
+			type: 'string'
+		},
+    text: {
+      type: 'string'
+    }
+	},
+
+	edit: function( props ) {
+		return wp.element.createElement( wp.editor.URLInput, {
+			className: props.className,
+			value: props.attributes.url,
+			onChange: function( url, post ) {
+				props.setAttributes( { url: url, text: post.title || 'Click here' } );
+			}
+		} );
+	},
+
+	save: function( props ) {
+		return wp.element.createElement( 'a', {
+			href: props.attributes.url,
+		}, props.attributes.text );
+	}
+} );
+```
+{% ESNext %}
+```js
+const { registerBlockType } = wp.blocks;
+const { RichText } = wp.editor;
+
+registerBlockType( /* ... */, {
+	// ...
+
+	attributes: {
+		url: {
+			type: 'string',
+		},
+    text: {
+      type: 'string',
+    },
+	},
+
+	edit( { className, attributes, setAttributes } ) {
+		return (
+			<URLInput
+				className={ className }
+				value={ attributes.url }
+				onChange={ ( url, post ) => setAttributes( { url, text: post.title || 'Click here' } ) }
+			/>
+		);
+	},
+
+	save( { attributes } ) {
+		return <a href={ attributes.url }>{ attributes.text }</a>;
+	}
+} );
+```
+{% end %}

--- a/packages/editor/src/components/url-input/README.md
+++ b/packages/editor/src/components/url-input/README.md
@@ -27,6 +27,8 @@ Render a URL input button that pops up an input to search for and select a post 
 }
 ```
 
+This prop is passed directly to the `URLInput` component.
+
 ## Example
 
 {% codetabs %}
@@ -96,7 +98,7 @@ registerBlockType( /* ... */, {
 
 # `URLInput`
 
-Renders the URL input normally wrapped by `URLInputButton`.
+Renders the URL input field used by the `URLInputButton` component. It can be used directly to display the input field in different ways such as in a `Popover` or inline.
 
 ## Properties
 
@@ -106,11 +108,28 @@ Renders the URL input normally wrapped by `URLInputButton`.
 
 ### `onChange( url: String, ?post: Object ): Function`
 
-*Required.* Called when the value changes. This is the same as the `onChange` prop described above for `URLInputButton`.
+*Required.* Called when the value changes. The second parameter is `null` unless the user selects a post from the suggestions dropdown. In those cases the `post` parameter will look like this:
+
+```json
+{
+  "id": 1,
+  "subtype": "page",
+  "title": "Sample Page",
+  "type": "post",
+  "url": "https://example.com/sample-page/",
+  "_links": {
+    "self": [ { "embeddable": true, "href": "https://example.com/wp-json/wp/v2/pages/1" } ],
+    "about": [ { "href": "https://example.com/wp-json/wp/v2/types/page" } ],
+    "collection": [ { "href": "https://example.com/wp-json/gutenberg/v1/search" } ]
+  }
+}
+```
 
 ### `autoFocus: Boolean`
 
-*Optional.* By default, the input will gain focus when it is rendered as typically it is used in combination with a `Popover` in `URLInputBUtton`. If you are rendering the component all the time set this to `false`.
+*Optional.* By default, the input will gain focus when it is rendered, as typically it is displayed conditionally. For example when clicking on `URLInputButton` or editing a block.
+
+If you are not conditionally rendering this component set this property to `false`.
 
 ## Example
 

--- a/packages/editor/src/components/url-input/README.md
+++ b/packages/editor/src/components/url-input/README.md
@@ -8,9 +8,9 @@ Render a URL input button that pops up an input to search for and select a post 
 
 *Required.* This should be set to the attribute (or component state) property used to store the URL.
 
-### `onChange( url: String, post: Object ): Function`
+### `onChange( url: String, ?post: Object ): Function`
 
-*Required.* Called when the value changes. The second parameter defaults to an empty object unless the user selects a post from the suggestions dropdown. In those cases the `post` parameter will look like this:
+*Required.* Called when the value changes. The second parameter is `null` unless the user selects a post from the suggestions dropdown. In those cases the `post` parameter will look like this:
 
 ```json
 {
@@ -49,7 +49,7 @@ wp.blocks.registerBlockType( /* ... */, {
 			className: props.className,
 			url: props.attributes.url,
 			onChange: function( url, post ) {
-				props.setAttributes( { url: url, text: post.title || 'Click here' } );
+				props.setAttributes( { url: url, text: (post && post.title) || 'Click here' } );
 			}
 		} );
 	},
@@ -82,7 +82,7 @@ registerBlockType( /* ... */, {
 		return (
 			<URLInputButton
 				url={ attributes.url }
-				onChange={ ( url, post ) => setAttributes( { url, text: post.title || 'Click here' } ) }
+				onChange={ ( url, post ) => setAttributes( { url, text: (post && post.title) || 'Click here' } ) }
 			/>
 		);
 	},
@@ -104,7 +104,7 @@ Renders the URL input normally wrapped by `URLInputButton`.
 
 *Required.* This should be set to the attribute (or component state) property used to store the URL.
 
-### `onChange( url: String, post: Object ): Function`
+### `onChange( url: String, ?post: Object ): Function`
 
 *Required.* Called when the value changes. This is the same as the `onChange` prop described above for `URLInputButton`.
 
@@ -134,7 +134,7 @@ wp.blocks.registerBlockType( /* ... */, {
 			className: props.className,
 			value: props.attributes.url,
 			onChange: function( url, post ) {
-				props.setAttributes( { url: url, text: post.title || 'Click here' } );
+				props.setAttributes( { url: url, text: (post && post.title) || 'Click here' } );
 			}
 		} );
 	},
@@ -168,7 +168,7 @@ registerBlockType( /* ... */, {
 			<URLInput
 				className={ className }
 				value={ attributes.url }
-				onChange={ ( url, post ) => setAttributes( { url, text: post.title || 'Click here' } ) }
+				onChange={ ( url, post ) => setAttributes( { url, text: (post && post.title) || 'Click here' } ) }
 			/>
 		);
 	},

--- a/packages/editor/src/components/url-input/README.md
+++ b/packages/editor/src/components/url-input/README.md
@@ -20,9 +20,9 @@ Render a URL input that allows users to search for and select a post or enter an
   "type": "post",
   "url": "https://example.com/sample-page/",
   "_links": {
-    "self": [ { embeddable: true, href: "https://example.com/wp-json/wp/v2/pages/1" } ],
-    "about": [ { href: "https://example.com/wp-json/wp/v2/types/page" } ],
-    "collection": [ { href: "https://example.com/wp-json/gutenberg/v1/search" } ]
+    "self": [ { "embeddable": true, "href": "https://example.com/wp-json/wp/v2/pages/1" } ],
+    "about": [ { "href": "https://example.com/wp-json/wp/v2/types/page" } ],
+    "collection": [ { "href": "https://example.com/wp-json/gutenberg/v1/search" } ]
   }
 }
 ```

--- a/packages/editor/src/components/url-input/README.md
+++ b/packages/editor/src/components/url-input/README.md
@@ -1,10 +1,10 @@
-# `URLInput`
+# `URLInputButton`
 
-Render a URL input that allows users to search for and select a post or enter any arbitrary URL.
+Render a URL input button that pops up an input to search for and select a post or enter any arbitrary URL.
 
 ## Properties
 
-### `value: String`
+### `url: String`
 
 *Required.* This should be set to the attribute (or component state) property used to store the URL.
 
@@ -49,6 +49,91 @@ wp.blocks.registerBlockType( /* ... */, {
 	},
 
 	edit: function( props ) {
+		return wp.element.createElement( wp.editor.URLInputButton, {
+			className: props.className,
+			url: props.attributes.url,
+			onChange: function( url, post ) {
+				props.setAttributes( { url: url, text: post.title || 'Click here' } );
+			}
+		} );
+	},
+
+	save: function( props ) {
+		return wp.element.createElement( 'a', {
+			href: props.attributes.url,
+		}, props.attributes.text );
+	}
+} );
+```
+{% ESNext %}
+```js
+const { registerBlockType } = wp.blocks;
+const { URLInputButton } = wp.editor;
+
+registerBlockType( /* ... */, {
+	// ...
+
+	attributes: {
+		url: {
+			type: 'string',
+		},
+		text: {
+			type: 'string',
+		},
+	},
+
+	edit( { className, attributes, setAttributes } ) {
+		return (
+			<URLInputButton
+				url={ attributes.url }
+				onChange={ ( url, post ) => setAttributes( { url, text: post.title || 'Click here' } ) }
+			/>
+		);
+	},
+
+	save( { attributes } ) {
+		return <a href={ attributes.url }>{ attributes.text }</a>;
+	}
+} );
+```
+{% end %}
+
+# `URLInput`
+
+Renders the URL input normally wrapped by `URLInputButton`.
+
+## Properties
+
+### `value: String`
+
+*Required.* This should be set to the attribute (or component state) property used to store the URL.
+
+### `onChange( url: String, post: Object ): Function`
+
+*Required.* Called when the value changes. This is the same as the `onChange` prop described above for `URLInputButton`.
+
+### `autoFocus: Boolean`
+
+*Optional.* By default, the input will gain focus when it is rendered as typically it is used in combination with a `Popover` in `URLInputBUtton`. If you are rendering the component all the time set this to `false`.
+
+## Example
+
+{% codetabs %}
+{% ES5 %}
+```js
+wp.blocks.registerBlockType( /* ... */, {
+	// ...
+
+	attributes: {
+		url: {
+			type: 'string'
+		},
+		text: {
+			type: 'string'
+		}
+	},
+
+	edit: function( props ) {
 		return wp.element.createElement( wp.editor.URLInput, {
 			className: props.className,
 			value: props.attributes.url,
@@ -68,7 +153,7 @@ wp.blocks.registerBlockType( /* ... */, {
 {% ESNext %}
 ```js
 const { registerBlockType } = wp.blocks;
-const { RichText } = wp.editor;
+const { URLInput } = wp.editor;
 
 registerBlockType( /* ... */, {
 	// ...

--- a/packages/editor/src/components/url-input/README.md
+++ b/packages/editor/src/components/url-input/README.md
@@ -27,10 +27,6 @@ Render a URL input button that pops up an input to search for and select a post 
 }
 ```
 
-### `autoFocus: Boolean`
-
-*Optional.* By default, the input will gain focus when it is rendered as typically it is used in combination with a `Popover`. If you are rendering the component all the time set this to `false`.
-
 ## Example
 
 {% codetabs %}

--- a/packages/editor/src/components/url-input/README.md
+++ b/packages/editor/src/components/url-input/README.md
@@ -43,9 +43,9 @@ wp.blocks.registerBlockType( /* ... */, {
 		url: {
 			type: 'string'
 		},
-    text: {
-      type: 'string'
-    }
+		text: {
+			type: 'string'
+		}
 	},
 
 	edit: function( props ) {
@@ -77,9 +77,9 @@ registerBlockType( /* ... */, {
 		url: {
 			type: 'string',
 		},
-    text: {
-      type: 'string',
-    },
+		text: {
+			type: 'string',
+		},
 	},
 
 	edit( { className, attributes, setAttributes } ) {

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -131,9 +131,9 @@ class URLInput extends Component {
 		this.suggestionsRequest = request;
 	}
 
-	onChange( event, post = {} ) {
+	onChange( event ) {
 		const inputValue = event.target.value;
-		this.props.onChange( inputValue, post );
+		this.props.onChange( inputValue );
 		this.updateSuggestions( inputValue );
 	}
 

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -131,9 +131,9 @@ class URLInput extends Component {
 		this.suggestionsRequest = request;
 	}
 
-	onChange( event ) {
+	onChange( event, post = {} ) {
 		const inputValue = event.target.value;
-		this.props.onChange( inputValue );
+		this.props.onChange( inputValue, post );
 		this.updateSuggestions( inputValue );
 	}
 
@@ -168,14 +168,14 @@ class URLInput extends Component {
 				if ( this.state.selectedSuggestion !== null ) {
 					event.stopPropagation();
 					const post = this.state.posts[ this.state.selectedSuggestion ];
-					this.selectLink( post.url );
+					this.selectLink( post.url, post );
 				}
 			}
 		}
 	}
 
-	selectLink( link ) {
-		this.props.onChange( link );
+	selectLink( link, post ) {
+		this.props.onChange( link, post );
 		this.setState( {
 			selectedSuggestion: null,
 			showSuggestions: false,
@@ -227,7 +227,7 @@ class URLInput extends Component {
 									className={ classnames( 'editor-url-input__suggestion', {
 										'is-selected': index === selectedSuggestion,
 									} ) }
-									onClick={ () => this.selectLink( post.url ) }
+									onClick={ () => this.selectLink( post.url, post ) }
 									aria-selected={ index === selectedSuggestion }
 								>
 									{ decodeEntities( post.title ) || __( '(no title)' ) }

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -168,14 +168,14 @@ class URLInput extends Component {
 				if ( this.state.selectedSuggestion !== null ) {
 					event.stopPropagation();
 					const post = this.state.posts[ this.state.selectedSuggestion ];
-					this.selectLink( post.url, post );
+					this.selectLink( post );
 				}
 			}
 		}
 	}
 
-	selectLink( link, post ) {
-		this.props.onChange( link, post );
+	selectLink( post ) {
+		this.props.onChange( post.url, post );
 		this.setState( {
 			selectedSuggestion: null,
 			showSuggestions: false,
@@ -227,7 +227,7 @@ class URLInput extends Component {
 									className={ classnames( 'editor-url-input__suggestion', {
 										'is-selected': index === selectedSuggestion,
 									} ) }
-									onClick={ () => this.selectLink( post.url, post ) }
+									onClick={ () => this.selectLink( post ) }
 									aria-selected={ index === selectedSuggestion }
 								>
 									{ decodeEntities( post.title ) || __( '(no title)' ) }


### PR DESCRIPTION
## Description

The `URLInput` component is great however the number of use cases it can support increases a huge amount if it makes the search result object available to the `onChange()` prop as well.

Example use cases:

- Component can be used as a simple post picker
- Retrieving the post title as well to update block attributes eg. link text
- Fetching other / additional post data using the `_links` property of the search result object

## How has this been tested?

I made a copy of the component with the proposed modifications locally and used it as a post picker. I updated not only the URL but was able to set other attributes such as a post title and fetch the post's featured image.

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
