### PR TITLE
Initialize the Autosaves controller, even if revisions are disabled

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -41,10 +41,9 @@ function gutenberg_register_rest_routes() {
 			continue;
 		}
 
-		if ( post_type_supports( $post_type->name, 'revisions' ) ) {
-			$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type->name );
-			$autosaves_controller->register_routes();
-		}
+		// Initialize the Autosaves controller.
+		$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type->name );
+		$autosaves_controller->register_routes();
 	}
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/8536
Fixes #7442
Fixes #7348

Revisions are not required to support autosaves - see https://codex.wordpress.org/Revisions#Revision_Options

## How has this been tested?
I verified the endpoint shows up even with revisions disabled for a post type.

## Types of changes
Removed the check for revision post type support when loading the autosaves controller.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
