### PR TITLE
DOM: Abort selection range set on unset range target

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -266,8 +266,9 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
 		return;
 	}
 
+	container.focus();
+
 	if ( ! container.isContentEditable ) {
-		container.focus();
 		return;
 	}
 
@@ -275,6 +276,12 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
 	// avoids the selection always being `endOffset` of 1 when placed at end,
 	// where `startContainer`, `endContainer` would always be container itself.
 	const rangeTarget = container[ isReverse ? 'lastChild' : 'firstChild' ];
+
+	// If no range target, it implies that the container is empty. Focusing is
+	// sufficient for caret to be placed correctly.
+	if ( ! rangeTarget ) {
+		return;
+	}
 
 	const selection = window.getSelection();
 	const range = document.createRange();
@@ -284,8 +291,6 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
 
 	selection.removeAllRanges();
 	selection.addRange( range );
-
-	container.focus();
 }
 
 /**

--- a/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
@@ -6,6 +6,16 @@ exports[`splitting and merging blocks should delete an empty first line 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`splitting and merging blocks should gracefully handle if placing caret in empty container 1`] = `
+"<!-- wp:paragraph -->
+<p><strong>Foo</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`splitting and merging blocks should merge into inline boundary position 1`] = `
 "<!-- wp:paragraph -->
 <p>Bar</p>

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -101,4 +101,27 @@ describe( 'splitting and merging blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should gracefully handle if placing caret in empty container', async () => {
+		// Regression Test: placeCaretAtHorizontalEdge previously did not
+		// account for contentEditables which have no children.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/8676
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Foo' );
+
+		// The regression appeared to only affect paragraphs created while
+		// within an inline boundary.
+		await page.keyboard.down( 'Shift' );
+		await pressTimes( 'ArrowLeft', 3 );
+		await page.keyboard.up( 'Shift' );
+		await pressWithModifier( 'mod', 'b' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
Fixes #8676

This pull request seeks to resolve an issue where merging two empty paragraph blocks which were created while at the end of an inline boundary would result in an uncaught error.

**Implementation notes:**

We were relying on a bogus node from TinyMCE to be present. Regardless of whether we should be concerned about an inconsistency in the presence of this node, the `placeCaretAtHorizontalEdge` function should be resilient in handling an empty contentEditable.

**Testing instructions:**

Repeat testing instructions from #8676, ensuring that no error is encountered.

Ensure end-to-end tests pass:

```
npm run test-e2e
```