### PR TITLE
Always register the autosaves controller

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -41,10 +41,8 @@ function gutenberg_register_rest_routes() {
 			continue;
 		}
 
-		if ( post_type_supports( $post_type->name, 'revisions' ) ) {
-			$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type->name );
-			$autosaves_controller->register_routes();
-		}
+		$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type->name );
+		$autosaves_controller->register_routes();
 	}
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );


### PR DESCRIPTION
## Description

Ensures the autosaves controller is _always_ registered for post types with `show_in_rest=>true`. While revisions can be enabled/disabled on a post type by post type basis, the editor expects that a post type can always be autosaved.

Fixes #7442
Fixes #7348

## How has this been tested?

1. Disable revisions for the Post post type:

```
add_action( 'init', function(){
	remove_post_type_support( 'post', 'revisions' );
});
```

2. In the Gutenberg editor, create a new Post, enter a title, and hit "Preview". You should see the preview of the post display.

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
