### PR TITLE
Update `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3640,7 +3640,7 @@
 				"@wordpress/jest-preset-default": "file:packages/jest-preset-default",
 				"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
 				"cross-spawn": "^5.1.0",
-				"jest": "^23.3.0",
+				"jest": "^23.4.2",
 				"npm-package-json-lint": "^3.3.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0"

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -14,7 +14,12 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
         "calls": Array [
           Array [],
         ],
-        "results": undefined,
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
       }
     }
     onFocus={
@@ -22,7 +27,12 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
         "calls": Array [
           Array [],
         ],
-        "results": undefined,
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
       }
     }
     onKeyDown={
@@ -30,7 +40,12 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
         "calls": Array [
           Array [],
         ],
-        "results": undefined,
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
       }
     }
     readOnly={true}


### PR DESCRIPTION
## Description

Fixes #8684

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

• Ensured my local Git repo was up to date with no changed files.
```
❯ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
```

• Removed my local `node_modules` folder:
```
❯ rm -i -rf node_modules/
```

• Ran `npm install`
```
❯ npm install
```
• Ran `git status`
```
❯ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   package-lock.json

no changes added to commit (use "git add" and/or "git commit -a")
```

• The `package-lock.json` diff is the same as @aduth notes in #8684 

• Ran `npm test`
```
Test Suites: 1 skipped, 244 passed, 244 of 245 total
Tests:       1 skipped, 2081 passed, 2082 total
Snapshots:   74 passed, 74 total
Time:        72.278s
Ran all test suites.
```


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Build Tools 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
