### PR TITLE
Adds support for matching blocks with diacritics using lodash.deburr

### DIFF
--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -58,8 +58,9 @@ export const searchItems = ( items, searchTerm ) => {
 };
 
 /**
- * Converts the search term into a normalized term, removing diacritics
- * and whitespace.
+ * Converts the search term into a normalized term, removing diacritics,
+ * leading & trailing whitespace. The term is also converted to
+ * lowercase.
  *
  * @param {string} term The search term to normalize
  * @return {string} The normalized search term

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -59,11 +59,11 @@ export const searchItems = ( items, searchTerm ) => {
 
 /**
  * Converts the search term into a normalized term, removing diacritics,
- * leading & trailing whitespace. The term is also converted to
- * lowercase.
+ * leading & trailing whitespace. The term is also converted to lowercase.
  *
- * @param {string} term The search term to normalize
- * @return {string} The normalized search term
+ * @param {string} term The search term to normalize.
+ *
+ * @return {string} The normalized search term.
  */
 export const normalizeTerm = ( term ) => {
 	term = deburr( term );

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -13,6 +13,7 @@ import {
 	sortBy,
 	without,
 	includes,
+	deburr,
 } from 'lodash';
 import scrollIntoView from 'dom-scroll-into-view';
 
@@ -48,12 +49,27 @@ const MAX_SUGGESTED_ITEMS = 9;
  * @return {Array}             Filtered item list.
  */
 export const searchItems = ( items, searchTerm ) => {
-	const normalizedSearchTerm = searchTerm.toLowerCase().trim();
-	const matchSearch = ( string ) => string.toLowerCase().indexOf( normalizedSearchTerm ) !== -1;
+	const normalizedSearchTerm = normalizeTerm( searchTerm );
+	const matchSearch = ( string ) => normalizeTerm( string ).indexOf( normalizedSearchTerm ) !== -1;
 
 	return items.filter( ( item ) =>
 		matchSearch( item.title ) || some( item.keywords, matchSearch )
 	);
+};
+
+/**
+ * Converts the search term into a normalized term, removing diacritics
+ * and whitespace.
+ *
+ * @param {string} term		The search term to normalize
+ * @return {string}				The normalized search term
+ */
+export const normalizeTerm = ( term ) => {
+	term = deburr( term );
+	term = term.toLowerCase();
+	term = term.trim();
+
+	return term;
 };
 
 export class InserterMenu extends Component {

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -61,8 +61,8 @@ export const searchItems = ( items, searchTerm ) => {
  * Converts the search term into a normalized term, removing diacritics
  * and whitespace.
  *
- * @param {string} term		The search term to normalize
- * @return {string}				The normalized search term
+ * @param {string} term The search term to normalize
+ * @return {string} The normalized search term
  */
 export const normalizeTerm = ( term ) => {
 	term = deburr( term );

--- a/packages/editor/src/components/inserter/test/menu.js
+++ b/packages/editor/src/components/inserter/test/menu.js
@@ -8,7 +8,7 @@ import ReactDOM from 'react-dom';
 /**
  * Internal dependencies
  */
-import { InserterMenu, searchItems } from '../menu';
+import { InserterMenu, searchItems, normalizeTerm } from '../menu';
 
 const textItem = {
 	id: 'core/text-block',
@@ -335,6 +335,26 @@ describe( 'searchItems', () => {
 	it( 'should search items using the keywords', () => {
 		expect( searchItems( items, 'GOOGL' ) ).toEqual(
 			[ youtubeItem ]
+		);
+	} );
+} );
+
+describe( 'normalizeTerm', () => {
+	it( 'should remove diacritics', () => {
+		expect( normalizeTerm( 'média' ) ).toEqual(
+			'media'
+		);
+	} );
+
+	it( 'should trim whitespace', () => {
+		expect( normalizeTerm( '  média  ' ) ).toEqual(
+			'media'
+		);
+	} );
+
+	it( 'should convert to lowercase', () => {
+		expect( normalizeTerm( '  Média  ' ) ).toEqual(
+			'media'
 		);
 	} );
 } );


### PR DESCRIPTION
## Description

Fixes #6387.

This PR updates the Gutenberg Block Inserter Menu to allow searching for terms that contain diacritics. 

## How has this been tested?

- I added unit tests for the normalizeTerm function and run the test suite successfully.
- I created a new sample block called 'Example Média Block'. And was able to match on this block in the inserter after my change.

## Types of changes

New feature

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards.standards
- [x] My code has proper inline documentation.
