### PR TITLE
Testing: Trigger E2E test failure on console logging

### DIFF
--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -196,6 +196,8 @@ describe( 'Change detection', () => {
 		await page.setOfflineMode( false );
 
 		await assertIsDirty( true );
+
+		expect( console ).toHaveErroredWith( 'Failed to load resource: net::ERR_INTERNET_DISCONNECTED' );
 	} );
 
 	it( 'Should prompt if changes and save is in-flight', async () => {

--- a/test/e2e/support/setup-test-framework.js
+++ b/test/e2e/support/setup-test-framework.js
@@ -27,29 +27,40 @@ async function setupBrowser() {
 	await setViewport( 'large' );
 }
 
+/**
+ * Navigates to the post listing screen and bulk-trashes any posts which exist.
+ *
+ * @return {Promise} Promise resolving once posts have been trashed.
+ */
+async function trashExistingPosts() {
+	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
+	await visitAdmin( 'edit.php' );
+
+	// If this selector doesn't exist there are no posts for us to delete.
+	const bulkSelector = await page.$( '#bulk-action-selector-top' );
+	if ( ! bulkSelector ) {
+		return;
+	}
+
+	// Select all posts.
+	await page.waitForSelector( '#cb-select-all-1' );
+	await page.click( '#cb-select-all-1' );
+	// Select the "bulk actions" > "trash" option.
+	await page.select( '#bulk-action-selector-top', 'trash' );
+	// Submit the form to send all draft/scheduled/published posts to the trash.
+	await page.click( '#doaction' );
+	return page.waitForXPath(
+		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
+	);
+}
+
 // Before every test suite run, delete all content created by the test. This ensures
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
 beforeAll( async () => {
 	enablePageDialogAccept();
 
-	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
-	await visitAdmin( 'edit.php' );
-
-	// If this selector doesn't exist there are no posts for us to delete.
-	const bulkSelector = await page.$( '#bulk-action-selector-top' );
-	if ( bulkSelector ) {
-		// Select all posts.
-		await page.waitForSelector( '#cb-select-all-1' );
-		await page.click( '#cb-select-all-1' );
-		// Select the "bulk actions" > "trash" option.
-		await page.select( '#bulk-action-selector-top', 'trash' );
-		// Submit the form to send all draft/scheduled/published posts to the trash.
-		await page.click( '#doaction' );
-		await page.waitForXPath(
-			'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
-		);
-	}
+	await trashExistingPosts();
 	await setupBrowser();
 } );
 

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -307,11 +307,3 @@ async function acceptPageDialog( dialog ) {
 export function enablePageDialogAccept() {
 	page.on( 'dialog', acceptPageDialog );
 }
-
-/**
- * Disables even listener which accepts a page dialog which
- * may appear when navigating away from Gutenberg.
- */
-export function disablePageDialogAccept() {
-	page.removeListener( 'dialog', acceptPageDialog );
-}


### PR DESCRIPTION
This pull request seeks to enhance end-to-end tests to protect against unexpected console logging. While our use of `jest-puppeteer` will capture and fail tests on `pageerror` events, often we have other errors which occur that either do not crash the page or are captured by the top-level application error handler and handled gracefully. This console monitoring should also help protect against internal use of deprecated functionality.

**Implementation notes:**

One point of stability I introduced here is automated handling of teardown of `page` event bindings. We should probably apply this to `browser` as well, and probably on `afterEach`, to improve isolation between tests and avoid event handler leaking. This should be done separately.

**Testing instructions:**

Verify end-to-end tests pass successfully:

```
npm run test-e2e
```

You can trigger a failure by introducing a `console.error` somewhere which would be covered by E2E tests.