### PR TITLE
Expand drop zone to fill the entire block

### DIFF
--- a/packages/editor/src/components/block-drop-zone/style.scss
+++ b/packages/editor/src/components/block-drop-zone/style.scss
@@ -8,12 +8,14 @@
 	}
 
 	&.is-close-to-bottom {
+		background: none;
 		border-bottom: 3px solid theme(primary);
 	}
 
 	&.is-close-to-top,
 	&.is-appender.is-close-to-top,
 	&.is-appender.is-close-to-bottom {
+		background: none;
 		border-top: 3px solid theme(primary);
 		border-bottom: none;
 	}

--- a/packages/editor/src/components/block-drop-zone/style.scss
+++ b/packages/editor/src/components/block-drop-zone/style.scss
@@ -8,14 +8,12 @@
 	}
 
 	&.is-close-to-bottom {
-		background: none;
 		border-bottom: 3px solid theme(primary);
 	}
 
 	&.is-close-to-top,
 	&.is-appender.is-close-to-top,
 	&.is-appender.is-close-to-bottom {
-		background: none;
 		border-top: 3px solid theme(primary);
 		border-bottom: none;
 	}

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -519,9 +519,9 @@
 
 	// Dropzones
 	.editor-block-drop-zone {
-		top: -4px;
-		bottom: -3px;
-		margin: 0 $block-padding;
+		top: 0;
+		bottom: -1px;
+		margin: 0 -$block-padding;
 	}
 
 	// Hide appender shortcuts in nested blocks


### PR DESCRIPTION
## Description
1. The background for the drop zone has been restored, this fixes #8115 
2. Tweaked some values for the dropzone to make it cover the whole block. See screenshots below.

## How has this been tested?
This has been tested by dropping an image into a paragraph block.
The testing environment was the docker container included with this repository.
Tested dropping an image onto the other block types and all worked okay.

## Screenshots
Before:
https://imgur.com/Kf1h664

After:
https://imgur.com/XBbBOuD

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->