### PR TITLE
Prevent Travis from running when changes are only made to .md files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ cache:
     - $HOME/.npm
 
 before_install:
+  - |
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)' || {
+      echo "Only docs were updated, stopping build process."
+      exit
+    }
   - nvm install && nvm use
   - npm install npm -g
 


### PR DESCRIPTION
This comes from [a discussion](https://wordpress.slack.com/archives/C02QB2JS7/p1533720310000209) with @gziolo in #core-editor. Basically we can skip the full Travis build if the commit range being tested only contains changes to `.md` files. 

Modeled after: https://github.com/facebook/react/pull/2000

In my testing, this shortens the Travis run time on each item in the test list from ~4-6 minutes down to ~1 minute or less for docs only changes. Should help speed up merging non-code PRs. 

Here are some test builds I did from my fork:
[Only change .md file](https://travis-ci.org/earnjam/gutenberg/builds/413732648) - aborts early
[Only change .js file](https://travis-ci.org/earnjam/gutenberg/builds/413733458) - runs normally
[Changes both .md and .js files](https://travis-ci.org/earnjam/gutenberg/builds/413733882) - runs normally