### PR TITLE
Packages: update api-fetch package documentation

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -58,7 +58,7 @@ apiFetch.use( apiFetch.createNonceMiddleware( nonce ) );
 import apiFetch from '@wordpress/api-fetch';
 
 const rootURL = "http://my-wordpress-site/wp-json/";
-apiFetch.use( apiFetch.createRootURLMiddleware( nonce ) );
+apiFetch.use( apiFetch.createRootURLMiddleware( rootURL ) );
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
Add a minor fix for the `api-fetch` middleware documentation related to overriding the API root URL.