### PR TITLE
Fix 'Prevent duplicate DotTips from appearing' feedback

### DIFF
--- a/packages/nux/src/store/actions.js
+++ b/packages/nux/src/store/actions.js
@@ -14,7 +14,7 @@ export function triggerGuide( tipIds ) {
 }
 
 /**
- * Returns an action object that, when dispathed, associates an instance of the
+ * Returns an action object that, when dispatched, associates an instance of the
  * DotTip component with a tip. This is usually done when the component mounts.
  * Tracking this lets us only show one DotTip at a time per tip.
  *

--- a/packages/nux/src/store/reducer.js
+++ b/packages/nux/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { union, without } from 'lodash';
+import { uniq, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -41,11 +41,13 @@ export function guides( state = [], action ) {
  */
 export function tipInstanceIds( state = {}, action ) {
 	switch ( action.type ) {
-		case 'REGISTER_TIP_INSTANCE':
+		case 'REGISTER_TIP_INSTANCE': {
+			const existingInstanceIds = state[ action.tipId ] || [];
 			return {
 				...state,
-				[ action.tipId ]: union( state[ action.tipId ] || [], [ action.instanceId ] ),
+				[ action.tipId ]: uniq( [ ...existingInstanceIds, action.instanceId ] ),
 			};
+		}
 
 		case 'UNREGISTER_TIP_INSTANCE':
 			return {


### PR DESCRIPTION
Just addressing some feedback that was left on https://github.com/WordPress/gutenberg/pull/8642.