### PR TITLE
Fix the More Block input width

### DIFF
--- a/core-blocks/more/edit.js
+++ b/core-blocks/more/edit.js
@@ -38,7 +38,9 @@ export default class MoreEdit extends Component {
 		const toggleNoTeaser = () => setAttributes( { noTeaser: ! noTeaser } );
 		const { defaultText } = this.state;
 		const value = customText !== undefined ? customText : defaultText;
-		const inputLength = value.length * 3;
+
+		// Set the input width to 3em per character, plus 1em to allow for empty strings.
+		const inputLength = ( value.length * 3 ) + 1;
 
 		return (
 			<Fragment>

--- a/core-blocks/more/edit.js
+++ b/core-blocks/more/edit.js
@@ -38,7 +38,7 @@ export default class MoreEdit extends Component {
 		const toggleNoTeaser = () => setAttributes( { noTeaser: ! noTeaser } );
 		const { defaultText } = this.state;
 		const value = customText !== undefined ? customText : defaultText;
-		const inputLength = value.length + 1;
+		const inputLength = value.length * 3;
 
 		return (
 			<Fragment>

--- a/core-blocks/more/editor.scss
+++ b/core-blocks/more/editor.scss
@@ -24,6 +24,7 @@
 		background: $white;
 		padding: 6px 8px;
 		height: $icon-button-size-small;
+		max-width: 100%;
 
 		&:focus {
 			box-shadow: none;

--- a/core-blocks/more/test/__snapshots__/index.js.snap
+++ b/core-blocks/more/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`core/more block edit matches snapshot 1`] = `
   class="wp-block-more"
 >
   <input
-    size="10"
+    size="28"
     type="text"
     value="Read more"
   />


### PR DESCRIPTION
## Description

The current behaviour of the More block input element is to expand the width based on the length of the current content. Unfortunately, the current calculation (length + 1) doesn't allow for glyphs that are always going to be more than 1em in width.

This PR changes the calculation to be (length * 3), effectively allowing glyphs up to 3em in width to display correctly. While it is technically possible to construct even wider glyphs through the judicious use of modifiers (eg, "﷽"), this is not to my knowledge an actual meaningful character, so is unlikely to be a real use case.

To avoid unsightly overflow issues for super long labels encountered whilst testing, this PR also limits the `max-width` of the input.

Fixes #8750.

## Screenshots

<img width="657" alt="the more block with a Japanese label" src="https://user-images.githubusercontent.com/352291/43880135-75eebf48-9bea-11e8-8e91-6ec98ab4dbbd.png">

<img width="657" alt="the more block with an overflowing label" src="https://user-images.githubusercontent.com/352291/43880138-780669ca-9bea-11e8-95b0-46a37fc10b18.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.