### PR TITLE
Show drop zone background when file is dragged

### DIFF
--- a/packages/components/src/drop-zone/style.scss
+++ b/packages/components/src/drop-zone/style.scss
@@ -24,7 +24,7 @@
 		}
 
 		&.is-dragging-file {
-			background-color: rgba( $blue-dark-900, 0.8 );
+			background-color: rgba($blue-dark-900, 0.8);
 		}
 	}
 }

--- a/packages/components/src/drop-zone/style.scss
+++ b/packages/components/src/drop-zone/style.scss
@@ -18,10 +18,13 @@
 	}
 
 	&.is-dragging-over-element {
-		background-color: rgba($blue-dark-900, 0.8);
 
 		.components-drop-zone__content {
 			display: block;
+		}
+
+		&.is-dragging-file {
+			background-color: rgba( $blue-dark-900, 0.8 );
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR fixes #8115 . The drop zone background is not visible, when it has `is-dragging-over-element` class name, but is overridden by another another selectors `is-close-to-top, is-close-to-bottom` which remove the background. The issue has been introduced the following PR: #6040, which fix the following issue:
#6035. My initial idea was to just remove the background from `is-close-to-top, is-close-to-bottom` classes, but this will bring back the background when a block is dragged over another block. So I decided to use the `is-dragging-file` class, which is added only when a files is dragged over the block.

## How has this been tested?
* I dragged a file over a block and the background was visible.
* I dragged a block over another block. but this time the background was not visible, which was expected.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
