### PR TITLE
[WIP] Try/fresh data as data plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -761,6 +761,28 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@fresh-data/framework": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.2.0.tgz",
+			"integrity": "sha512-oOB766DhLU5cD8wn9XXyz3NZq1jlX3gKMbWxBJXrpeRDsVxSRpx13v/9M5dRkLpf1Av4qp1ZCqWGz9st2jiWUg==",
+			"dev": true,
+			"requires": {
+				"postinstall-build": "^5.0.1",
+				"prop-types": "^15.6.2"
+			},
+			"dependencies": {
+				"prop-types": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				}
+			}
+		},
 		"@lerna/add": {
 			"version": "3.0.0-rc.0",
 			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.0.0-rc.0.tgz",
@@ -16371,6 +16393,12 @@
 				}
 			}
 		},
+		"postinstall-build": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.1.tgz",
+			"integrity": "sha1-uRepB5smF42aJK9aXNjLSpkdEbk=",
+			"dev": true
+		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -16876,6 +16904,38 @@
 				"prop-types": "^15.6.0"
 			},
 			"dependencies": {
+				"prop-types": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				}
+			}
+		},
+		"react-redux": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+			"dev": true,
+			"requires": {
+				"hoist-non-react-statics": "^2.5.0",
+				"invariant": "^2.0.0",
+				"lodash": "^4.17.5",
+				"lodash-es": "^4.17.5",
+				"loose-envify": "^1.1.0",
+				"prop-types": "^15.6.0"
+			},
+			"dependencies": {
+				"hoist-non-react-statics": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+					"dev": true
+				},
 				"prop-types": {
 					"version": "15.6.2",
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "7.0.0-beta.56",
+		"@fresh-data/framework": "0.2.0",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
@@ -81,6 +82,7 @@
 		"cross-env": "3.2.4",
 		"cssnano": "4.0.3",
 		"deasync": "0.1.13",
+		"debug": "3.1.0",
 		"deep-freeze": "0.0.1",
 		"doctrine": "2.1.0",
 		"eslint": "4.16.0",
@@ -104,6 +106,7 @@
 		"postcss-loader": "2.1.3",
 		"puppeteer": "1.6.1",
 		"raw-loader": "0.5.1",
+		"react-redux": "5.0.7",
 		"react-test-renderer": "16.4.1",
 		"rimraf": "2.6.2",
 		"rtlcss": "2.4.0",

--- a/packages/data/src/components/with-resources/index.js
+++ b/packages/data/src/components/with-resources/index.js
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import isShallowEqual from '@wordpress/is-shallow-equal';
+import { remountOnPropChange, createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { RegistryConsumer } from '../registry-provider';
+
+/**
+ * Higher-order component used to inject state-derived props using registered
+ * selectors.
+ *
+ * @param {string} apiName Name of api from which resources are needed.
+ * @param {Function} mapSelectorsToProps Function called on every state change,
+ *                                       expected to return object of props to
+ *                                       merge with the component's own props.
+ *
+ * @return {Component} Enhanced component with merged state data props.
+ */
+const withResources = ( apiName, mapSelectorsToProps ) => createHigherOrderComponent( ( WrappedComponent ) => {
+	/**
+	 * Default merge props. A constant value is used as the fallback since it
+	 * can be more efficiently shallow compared in case component is repeatedly
+ 	 * rendered without its own merge props.
+	 *
+	 * @type {Object}
+	 */
+	const DEFAULT_MERGE_PROPS = {};
+
+	const ComponentWithSelectors = remountOnPropChange( 'registry' )( class extends Component {
+		constructor( props ) {
+			super( props );
+
+			this.subscribe();
+
+			this.mergeProps = this.getNextMergeProps( props );
+		}
+
+		/**
+		 * Given a props object, returns the next merge props by mapStateToProps.
+		 *
+		 * @param {Object} props Props to pass as argument to mapStateToProps.
+		 *
+		 * @return {Object} Props to merge into rendered wrapped element.
+		 */
+		getNextMergeProps( props ) {
+			const apiClient = props.registry.getApiClient( apiName );
+			let selectorProps = DEFAULT_MERGE_PROPS;
+
+			apiClient.setComponentData( this, ( selectors ) => {
+				selectorProps = mapSelectorsToProps( selectors, props.ownProps );
+			} );
+
+			return selectorProps;
+		}
+
+		componentDidMount() {
+			this.canRunSelection = true;
+		}
+
+		componentWillUnmount() {
+			this.canRunSelection = false;
+			this.unsubscribe();
+		}
+
+		shouldComponentUpdate( nextProps, nextState ) {
+			const hasPropsChanged = ! isShallowEqual( this.props.ownProps, nextProps.ownProps );
+
+			// Only render if props have changed or merge props have been updated
+			// from the store subscriber.
+			if ( this.state === nextState && ! hasPropsChanged ) {
+				return false;
+			}
+
+			// If merge props change as a result of the incoming props, they
+			// should be reflected as such in the upcoming render.
+			if ( hasPropsChanged ) {
+				const nextMergeProps = this.getNextMergeProps( nextProps );
+				if ( ! isShallowEqual( this.mergeProps, nextMergeProps ) ) {
+					// Side effects are typically discouraged in lifecycle methods, but
+					// this component is heavily used and this is the most performant
+					// code we've found thus far.
+					// Prior efforts to use `getDerivedStateFromProps` have demonstrated
+					// miserable performance.
+					this.mergeProps = nextMergeProps;
+				}
+			}
+
+			return true;
+		}
+
+		subscribe() {
+			const apiClient = this.props.registry.getApiClient( apiName );
+			this.unsubscribe = apiClient.subscribe( () => {
+				if ( ! this.canRunSelection ) {
+					return;
+				}
+
+				const nextMergeProps = this.getNextMergeProps( this.props );
+				if ( isShallowEqual( this.mergeProps, nextMergeProps ) ) {
+					return;
+				}
+
+				this.mergeProps = nextMergeProps;
+
+				// Schedule an update. Merge props are not assigned to state
+				// because derivation of merge props from incoming props occurs
+				// within shouldComponentUpdate, where setState is not allowed.
+				// setState is used here instead of forceUpdate because forceUpdate
+				// bypasses shouldComponentUpdate altogether, which isn't desireable
+				// if both state and props change within the same render.
+				// Unfortunately this requires that next merge props are generated
+				// twice.
+				this.setState( {} );
+			} );
+		}
+
+		render() {
+			return <WrappedComponent { ...this.props.ownProps } { ...this.mergeProps } />;
+		}
+	} );
+
+	return ( ownProps ) => (
+		<RegistryConsumer>
+			{ ( registry ) => (
+				<ComponentWithSelectors
+					ownProps={ ownProps }
+					registry={ registry }
+				/>
+			) }
+		</RegistryConsumer>
+	);
+}, 'withResources' );
+
+export default withResources;

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -10,6 +10,7 @@ import defaultRegistry from './default-registry';
 import * as plugins from './plugins';
 
 export { default as withSelect } from './components/with-select';
+export { default as withResources } from './components/with-resources';
 export { default as withDispatch } from './components/with-dispatch';
 export { default as RegistryProvider } from './components/registry-provider';
 export { createRegistry } from './registry';
@@ -37,9 +38,14 @@ export const select = defaultRegistry.select;
 export const dispatch = defaultRegistry.dispatch;
 export const subscribe = defaultRegistry.subscribe;
 export const registerStore = defaultRegistry.registerStore;
+export const registerApi = defaultRegistry.registerApi;
 export const registerReducer = defaultRegistry.registerReducer;
 export const registerActions = defaultRegistry.registerActions;
 export const registerSelectors = defaultRegistry.registerSelectors;
 export const registerResolvers = defaultRegistry.registerResolvers;
 export const setupPersistence = defaultRegistry.setupPersistence;
 export const use = defaultRegistry.use;
+
+export const SECOND = 1000;
+export const MINUTE = 60 * SECOND;
+export const HOUR = 60 * MINUTE;

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -38,14 +38,9 @@ export const select = defaultRegistry.select;
 export const dispatch = defaultRegistry.dispatch;
 export const subscribe = defaultRegistry.subscribe;
 export const registerStore = defaultRegistry.registerStore;
-export const registerApi = defaultRegistry.registerApi;
 export const registerReducer = defaultRegistry.registerReducer;
 export const registerActions = defaultRegistry.registerActions;
 export const registerSelectors = defaultRegistry.registerSelectors;
 export const registerResolvers = defaultRegistry.registerResolvers;
 export const setupPersistence = defaultRegistry.setupPersistence;
 export const use = defaultRegistry.use;
-
-export const SECOND = 1000;
-export const MINUTE = 60 * SECOND;
-export const HOUR = 60 * MINUTE;

--- a/packages/data/src/plugins/fresh-data/actions.js
+++ b/packages/data/src/plugins/fresh-data/actions.js
@@ -1,0 +1,20 @@
+
+export function dataRequested( api, clientKey, resourceNames, time = new Date() ) {
+	return {
+		type: 'RESOURCES_REQUESTED',
+		api,
+		clientKey,
+		resourceNames,
+		time,
+	};
+}
+
+export function dataReceived( api, clientKey, resources, time = new Date() ) {
+	return {
+		type: 'RESOURCES_RECEIVED',
+		api,
+		clientKey,
+		resources,
+		time,
+	};
+}

--- a/packages/data/src/plugins/fresh-data/index.js
+++ b/packages/data/src/plugins/fresh-data/index.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { FreshDataApi } from '@fresh-data/framework';
+
+/**
+ * Internal dependencies
+ */
+import * as actions from './actions';
+import reducer from './reducer';
+
+export const SECOND = 1000;
+export const MINUTE = 60 * SECOND;
+export const HOUR = 60 * MINUTE;
+
+/**
+ * Fresh data API.
+ *
+ * @property {Methods}    methods      Functions that correspond to API verbs like
+ *                                     "GET" or "POST" and used by operations.
+ * @property {Operations} operations   Functions to handle operations on the
+ *                                     api, such as "read", or "update".
+ * @property {Selectors}  selectors    Selector functions which can require
+ *                                     resources and return their current values.
+ * @property {Mutations}  mutations    Mutation functions that map to operations and
+ *                                     designed to be used by the application.
+ *
+ * @typedef {WPFreshDataApiSpec}
+ */
+
+/**
+ * Fresh data store options.
+ *
+ * @property {WPFreshDataAPI} apiSpec A fresh-data API Specification.
+ *
+ * @typedef {WPFreshDataStoreOptions}
+ */
+
+/**
+ * Creates a fresh-data api client for use in @wordpress/data.
+ *
+ * @param {Object} apiSpec The api specification for the client.
+ * @param {Object} dispatchActions `dataRequested` and `dataReceived` action creators
+ *                                      wrapped in a dispatch function.
+ *
+ * @return {Object} An ApiClient ready to be used.
+ */
+export function createApiClient( apiSpec, dispatchActions ) {
+	if ( ! apiSpec.methods ) {
+		throw new TypeError( 'apiSpec must specify methods' );
+	}
+	if ( ! apiSpec.operations ) {
+		throw new TypeError( 'apiSpec must specify operations' );
+	}
+
+	// TODO: Remove ApiClass after fresh-data 0.3.0 is released.
+	class ApiClass extends FreshDataApi {
+		constructor() {
+			super();
+			this.methods = apiSpec.methods;
+			this.operations = apiSpec.operations;
+			this.mutations = apiSpec.mutations;
+			this.selectors = apiSpec.selectors || {};
+		}
+	}
+
+	const api = new ApiClass();
+	api.setDataHandlers( dispatchActions );
+	return api.createClient( 'client' );
+}
+
+/**
+ * Registers a fresh-data api.
+ *
+ * @param {WPDataRegistry}           registry    Data registry.
+ * @param {string}                   reducerKey  Name of reducerKey and api instance.
+ * @param {WPFreshDataStoreOptions}  options     Options given to registerStore.
+ *
+ * @return {Object} The api client created.
+ */
+export function registerApiClient( registry, reducerKey, options ) {
+	const { apiSpec } = options;
+
+	const store = registry.registerReducer( reducerKey, reducer, options.persist );
+	registry.registerActions( reducerKey, actions );
+
+	const dispatchActions = registry.dispatch( reducerKey );
+	const apiClient = createApiClient( apiSpec, dispatchActions );
+
+	// Subscribe to the store directly so we don't get all the global events
+	store.subscribe( () => {
+		const state = store.getState() || {};
+		const clientState = state.client || {}; // TODO: Remove this after fresh-data 0.3.0
+		apiClient.setState( clientState );
+	} );
+
+	return { store, apiClient };
+}
+
+/**
+ * Data plugin to map api data to component requirements.
+ *
+ * @param {WPDataRegistry} registry Data registry.
+ *
+ * @return {WPDataPlugin} Data plugin.
+ */
+export default function( registry ) {
+	const apisByReducerKey = {};
+
+	return {
+		registerStore( reducerKey, options ) {
+			if ( options.apiSpec ) {
+				const { store, apiClient } = registerApiClient( registry, reducerKey, options );
+				apisByReducerKey[ reducerKey ] = apiClient;
+				return store;
+			}
+			return registry.registerStore( reducerKey, options );
+		},
+		getApiClient( reducerKey ) {
+			return apisByReducerKey[ reducerKey ] || null;
+		},
+	};
+}

--- a/packages/data/src/plugins/fresh-data/reducer.js
+++ b/packages/data/src/plugins/fresh-data/reducer.js
@@ -1,0 +1,50 @@
+
+export function reduceRequested( state, action ) {
+	const { resourceNames, time } = action;
+	const apiState = state || {};
+	const clientState = apiState.client || {};
+	const existingResources = clientState.resources || {};
+
+	const resources = resourceNames.reduce( ( newResources, resourceName ) => {
+		const existingResource = existingResources[ resourceName ];
+		newResources[ resourceName ] = { ...existingResource, lastRequested: time };
+		return newResources;
+	}, existingResources );
+
+	return { ...state, client: { resources: resources } };
+}
+
+export function reduceReceived( state = {}, action ) {
+	const { resources, time } = action;
+	const apiState = state || {};
+	const clientState = apiState.client || {};
+	const existingResources = clientState.resources || {};
+
+	const updatedResources = Object.keys( resources ).reduce( ( newResources, resourceName ) => {
+		const existingResource = existingResources[ resourceName ];
+		const resource = action.resources[ resourceName ];
+		if ( resource.data ) {
+			resource.lastReceived = time;
+		}
+		if ( resource.error ) {
+			resource.lastError = time;
+		}
+		newResources[ resourceName ] = { ...existingResource, ...resource };
+		return newResources;
+	}, existingResources );
+
+	return { ...state, client: { resources: updatedResources } };
+}
+
+const reducer = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case 'RESOURCES_REQUESTED':
+			return reduceRequested( state, action );
+		case 'RESOURCES_RECEIVED':
+			return reduceReceived( state, action );
+		default:
+			return state;
+	}
+};
+
+export default reducer;

--- a/packages/data/src/plugins/index.js
+++ b/packages/data/src/plugins/index.js
@@ -1,2 +1,3 @@
 export { default as controls } from './controls';
+export { default as freshData } from './fresh-data';
 export { default as persistence } from './persistence';

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -380,6 +380,7 @@ export function createRegistry( storeConfigs = {} ) {
 				super();
 				this.methods = options.methods;
 				this.operations = options.operations;
+				this.mutations = options.mutations;
 				this.selectors = options.selectors || {};
 			}
 		}

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -2,13 +2,8 @@
  * External dependencies
  */
 import { createStore } from 'redux';
-import {
-	flowRight,
-	without,
-	mapValues,
-	overEvery,
-	get,
-} from 'lodash';
+import { flowRight, without, mapValues, overEvery, get } from 'lodash';
+import { FreshDataApi } from '@fresh-data/framework';
 
 /**
  * WordPress dependencies
@@ -303,6 +298,113 @@ export function createRegistry( storeConfigs = {} ) {
 		return store;
 	}
 
+	function registerApi( apiName, options ) {
+		if ( ! options.methods ) {
+			throw new TypeError( 'Must specify methods' );
+		}
+		if ( ! options.operations ) {
+			throw new TypeError( 'Must specify operations' );
+		}
+
+		function reduceRequested( state, action ) {
+			const { resourceNames, time } = action;
+			const apiState = state || {};
+			const clientState = apiState.client || {};
+			const existingResources = clientState.resources || {};
+
+			const resources = resourceNames.reduce( ( newResources, resourceName ) => {
+				const existingResource = existingResources[ resourceName ];
+				newResources[ resourceName ] = { ...existingResource, lastRequested: time };
+				return newResources;
+			}, existingResources );
+
+			return { ...state, client: { resources: resources } };
+		}
+
+		function reduceReceived( state = {}, action ) {
+			const { resources, time } = action;
+			const apiState = state || {};
+			const clientState = apiState.client || {};
+			const existingResources = clientState.resources || {};
+
+			const updatedResources = Object.keys( resources ).reduce( ( newResources, resourceName ) => {
+				const existingResource = existingResources[ resourceName ];
+				const resource = action.resources[ resourceName ];
+				if ( resource.data ) {
+					resource.lastReceived = time;
+				}
+				if ( resource.error ) {
+					resource.lastError = time;
+				}
+				newResources[ resourceName ] = { ...existingResource, ...resource };
+				return newResources;
+			}, existingResources );
+
+			return { ...state, client: { resources: updatedResources } };
+		}
+
+		const reducer = ( state = {}, action ) => {
+			switch ( action.type ) {
+				case 'RESOURCES_REQUESTED':
+					return reduceRequested( state, action );
+				case 'RESOURCES_RECEIVED':
+					return reduceReceived( state, action );
+				default:
+					return state;
+			}
+		};
+
+		const actions = {
+			dataRequested( api, clientKey, resourceNames, time = new Date() ) {
+				return {
+					type: 'RESOURCES_REQUESTED',
+					api,
+					clientKey,
+					resourceNames,
+					time,
+				};
+			},
+			dataReceived( api, clientKey, resources, time = new Date() ) {
+				return {
+					type: 'RESOURCES_RECEIVED',
+					api,
+					clientKey,
+					resources,
+					time,
+				};
+			},
+		};
+
+		class ApiClass extends FreshDataApi {
+			constructor() {
+				super();
+				this.methods = options.methods;
+				this.operations = options.operations;
+				this.selectors = options.selectors || {};
+			}
+		}
+
+		registerReducer( apiName, reducer, options.persist );
+		registerActions( apiName, actions );
+
+		const namespace = namespaces[ apiName ];
+		const api = new ApiClass();
+
+		api.setDataHandlers( namespace.actions );
+
+		namespace.api = api;
+		namespace.store.subscribe( () => {
+			const state = namespace.store.getState() || {};
+			api.updateState( state );
+		} );
+	}
+
+	// TODO: Consider removing clientKey from api altogether, as
+	// we can just instantiate another api with the different client key info.
+	function getApiClient( apiName, clientKey = 'client' ) {
+		return namespaces[ apiName ].api.getClient( clientKey );
+	}
+
 	/**
 	 * Subscribe to changes to any data.
 	 *
@@ -379,6 +481,8 @@ export function createRegistry( storeConfigs = {} ) {
 		registerResolvers,
 		registerActions,
 		registerStore,
+		registerApi,
+		getApiClient,
 		subscribe,
 		select,
 		dispatch,


### PR DESCRIPTION
Note: This PR is not yet fully baked and ready to merge. It still needs further discussion.

## Description
This adds [`fresh-data`](https://github.com/Automattic/fresh-data) functionality to `@wordpress/data` through the plugin `use` mechanism to adjust the registry in the following ways:

* Allows `registerStore( reducerKey, options )` to be called with `apiSpec` as an option, which corresponds to the `apiSpec` object in `fresh-data`.
* Adds a `getApiClient( reducerKey )` function to the registry.

This PR also adds a `withResources` HOC which is similar to the `withSelect` HOC. It's different because it needs a mapping to the component which is requiring the resource, and I really want to set the requirements of a component in one single operation, rather than clearing the requirements then re-adding them, which can get messy.

The reasoning behind this addition is to support more advanced asynchronous API data needs like for the WooCommerce API and other applications which are data-heavy.

This adds the following functionality that does not presently exist in `@wordpress/data`:

- Freshness requirements set within the Component HOC.
- No need to fetch data that has been fetched recently by another component (or block).
- Coordinating for the same resource which is needed by multiple components.
- Pagination fetching which is still compatible with individual items of that page.
- Updating of internal state from return values of mutating API calls.
- Fetching multiple resources using a single API call (e.g. using `includes` param with ids).
- Fetching multiple resources in one API call even if they're required by different components.

This mechanism still also supports the same features we know and love with `@wordpress/data` such as:

- Declarative component interface via the HOC.
- Automatic resolving of data and re-rendering after data arrives.
- Registration of multiple flavors of data.
- Custom selectors/mutations.

Implementation details:

This implementation lays out a mapping of connected components and their data requirements. It then reduces those requirements into an actionable list of resources to be fetched. The mapping of components is critical here, because it allows the resource requirements list to be updated in accordance to component lifecycle. For instance, when a component mounts, it requires the data it needs as referenced by its props (e.g. post #25). When it unmounts, those requirements are cleared from the system and no further fetching of that data will occur (unless there's another component requiring it too, of course). It's by this mechanism that duplicate fetches are avoided without resorting to debouncing. Only one part of the code ever fetches data, and it does it in accordance with the complete mapping of all data required for that api.

Further notes:

Through this process, I've discovered some places where `fresh-data` can be simplified without reducing functionality. These changes will also provide closer integration points to the `@wordpress/data` code. I am [working on these changes](https://github.com/Automattic/fresh-data/milestone/2) and intend to update this code to work with them after they are all merged.

Integration:

This functionality is necessary for more complex API applications. However, I'm open to discussion about how best to integrate these changes. Let's have a discussion about it.

Also, with the addition of the plugin mechanism, it should be possible for this code to exist entirely outside of the `@wordpress/data` package if so desired. (with one caveat: `RegistryConsumer` would need to be exported from `@wordpress/data` for the HOC to be possible.)

## How has this been tested?
I created a PR in `wc-admin` which uses `@wordpress/data` as a dependency and implements some WooCommerce API calls: https://github.com/woocommerce/wc-admin/pull/248

See the instructions on that PR for testing.

## Types of changes
- Adds `plugins/fresh-data` to `@wordpress/data` exports.
- When used, the `fresh-data` plugin adds `apiSpec` and `getApiClient` to registry.
- Adds `withResources` HOC.

No breaking changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
