### PR TITLE
Sort strikethrough after link

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -36,16 +36,16 @@ const FORMATTING_CONTROLS = [
 		format: 'italic',
 	},
 	{
-		icon: 'editor-strikethrough',
-		title: __( 'Strikethrough' ),
-		shortcut: displayShortcut.access( 'd' ),
-		format: 'strikethrough',
-	},
-	{
 		icon: 'admin-links',
 		title: __( 'Link' ),
 		shortcut: displayShortcut.primary( 'k' ),
 		format: 'link',
+	},
+	{
+		icon: 'editor-strikethrough',
+		title: __( 'Strikethrough' ),
+		shortcut: displayShortcut.access( 'd' ),
+		format: 'strikethrough',
 	},
 ];
 


### PR DESCRIPTION
This is a tiny PR to sort the "Strikethrough" button after the link.

One of the... perhaps this is unwritten and should be written down somewhere... one of the design principles of the block toolbar is that it starts with block related commands (like switcher), then _block level_ (i.e. actions that apply to the whole block, like textalign applies for the whole paragraph), and finally _inline level actions_ last. In the latter, it is sorted by presumed order of importance, and in this case, I would like to argue that Link is more important than Strikethrough.

One side effect of this is that one day when we can make the toolbar better handle nested contexts or small screens, we can "pop off" buttons into an overflow menu as the toolbar has to scale. If/when that happens, it's important that buttons are also sorted in order of importance.

<img width="746" alt="screen shot 2018-08-09 at 09 19 53" src="https://user-images.githubusercontent.com/1204802/43884248-e11846ac-9bb5-11e8-8888-9f2e05c2671f.png">
