### PR TITLE
Let the menu grow

### DIFF
--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -41,6 +41,9 @@
 		// !important allows icons from plugins to be overriden and given a dark-gray fill
 		fill: $dark-gray-900 !important;
 	}
+
+	// Don't wrap text.
+	white-space: nowrap;
 }
 
 .components-menu-item__shortcut {
@@ -48,4 +51,5 @@
 	margin-right: 0;
 	margin-left: auto;
 	align-self: center;
+	padding-left: 8px;
 }

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -42,7 +42,7 @@
 		fill: $dark-gray-900 !important;
 	}
 
-	// Don't wrap text.
+	// Don't wrap text until viewport is beyond the mobile breakpoint.
 	@include break-mobile() {
 		.components-popover:not(.is-mobile) & {
 			white-space: nowrap;

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -43,7 +43,11 @@
 	}
 
 	// Don't wrap text.
-	white-space: nowrap;
+	@include break-mobile() {
+		.components-popover:not(.is-mobile) & {
+			white-space: nowrap;
+		}
+	}
 }
 
 .components-menu-item__shortcut {

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -153,9 +153,11 @@ $arrow-size: 8px;
 		overflow-y: auto;
 
 		// Let the menu scale to fit items.
-		width: auto;
-		min-width: 260px;
-		max-width: $break-mobile;
+		@include break-mobile() {
+			width: auto;
+			min-width: 260px;
+			max-width: $break-mobile;
+		}
 	}
 
 	.components-popover:not(.is-mobile).is-top & {

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -149,9 +149,13 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile) & {
 		position: absolute;
-		min-width: 260px;
 		height: auto;
 		overflow-y: auto;
+
+		// Let the menu scale to fit items.
+		width: auto;
+		min-width: 260px;
+		max-width: $break-mobile;
 	}
 
 	.components-popover:not(.is-mobile).is-top & {

--- a/packages/editor/src/components/block-switcher/style.scss
+++ b/packages/editor/src/components/block-switcher/style.scss
@@ -30,9 +30,11 @@
 	}
 }
 
-.editor-block-switcher__popover .components-popover__content {
-	width: 300px;
+.components-popover:not(.is-mobile).editor-block-switcher__popover .components-popover__content {
+	min-width: 320px;
+}
 
+.editor-block-switcher__popover .components-popover__content {
 	@include break-medium {
 		position: relative;
 


### PR DESCRIPTION
This PR lets the menu grow to accommodate long text. Already now in Spanish, the "Code Editor" wraps having to fit both the spanish label and keyboard shortcut. As we add more keyboard shortcuts as well as hints, we need to let the menu grow to accommodate that, up to the mobile breakpoint in width.

This PR accomplishes that using auto widths, nowrap whitespace, and a little Nacin' Spacin' thrown in for code cleanup while I was there.

Screenshots:

<img width="363" alt="screen shot 2018-08-09 at 09 37 39" src="https://user-images.githubusercontent.com/1204802/43885117-4422e0c0-9bb8-11e8-9fc3-780bfb88023b.png">

<img width="405" alt="screen shot 2018-08-09 at 09 38 17" src="https://user-images.githubusercontent.com/1204802/43885122-45d23aa6-9bb8-11e8-87b5-8184bf67cb39.png">

Affects #7433

To test, verify that there are no regressions with any menus/popover content, including the switcher and the library.