### PR TITLE
Pad menus

### DIFF
--- a/packages/components/src/menu-group/style.scss
+++ b/packages/components/src/menu-group/style.scss
@@ -1,9 +1,9 @@
 .components-menu-group {
 	width: 100%;
-	padding: 10px;
+	padding: $item-spacing - $border-width;
 }
 
 .components-menu-group__label {
-	margin-bottom: 10px;
+	margin-bottom: $item-spacing;
 	color: $dark-gray-300;
 }

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -139,18 +139,18 @@ export class BlockSettingsMenu extends Component {
 								</MenuItem>
 							) }
 							{ count === 1 && (
+								<BlockModeToggle
+									clientId={ firstBlockClientId }
+									onToggle={ onClose }
+								/>
+							) }
+							{ count === 1 && (
 								<ReusableBlockConvertButton
 									clientId={ firstBlockClientId }
 									onToggle={ onClose }
 								/>
 							) }
 							<_BlockSettingsMenuPluginsExtension.Slot fillProps={ { clientIds, onClose } } />
-							{ count === 1 && (
-								<BlockModeToggle
-									clientId={ firstBlockClientId }
-									onToggle={ onClose }
-								/>
-							) }
 							<div className="editor-block-settings-menu__separator" />
 							{ count === 1 && (
 								<ReusableBlockDeleteButton

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -119,12 +119,6 @@ export class BlockSettingsMenu extends Component {
 						<NavigableMenu className="editor-block-settings-menu__content">
 							<_BlockSettingsMenuFirstItem.Slot fillProps={ { onClose } } />
 							{ count === 1 && (
-								<BlockModeToggle
-									clientId={ firstBlockClientId }
-									onToggle={ onClose }
-								/>
-							) }
-							{ count === 1 && (
 								<BlockUnknownConvertButton
 									clientId={ firstBlockClientId }
 								/>
@@ -151,6 +145,12 @@ export class BlockSettingsMenu extends Component {
 								/>
 							) }
 							<_BlockSettingsMenuPluginsExtension.Slot fillProps={ { clientIds, onClose } } />
+							{ count === 1 && (
+								<BlockModeToggle
+									clientId={ firstBlockClientId }
+									onToggle={ onClose }
+								/>
+							) }
 							<div className="editor-block-settings-menu__separator" />
 							{ count === 1 && (
 								<ReusableBlockDeleteButton

--- a/packages/editor/src/components/block-settings-menu/style.scss
+++ b/packages/editor/src/components/block-settings-menu/style.scss
@@ -62,11 +62,14 @@
 
 	.editor-block-settings-menu__content {
 		width: 100%;
+		padding: $item-spacing - $border-width;
 	}
 
 	.editor-block-settings-menu__separator {
 		margin-top: $item-spacing;
 		margin-bottom: $item-spacing;
+		margin-left: -$item-spacing + $border-width;
+		margin-right: -$item-spacing + $border-width;
 		border-top: $border-width solid $light-gray-500;
 
 		// Check if the separator is the last child in the node and if so, hide itself


### PR DESCRIPTION
This adds padding to the block more menu. At first glance this will look like much, but in fact it simply makes it the same padding as that of every other popover.

This starts work on an aspect of #7433. 

Screenshots:

<img width="341" alt="screen shot 2018-08-09 at 09 57 08" src="https://user-images.githubusercontent.com/1204802/43886033-cf3afdc6-9bba-11e8-80ee-bd313f87c0e9.png">

<img width="309" alt="screen shot 2018-08-09 at 09 57 12" src="https://user-images.githubusercontent.com/1204802/43886035-d05ab6d8-9bba-11e8-97ef-7e1c2f6965c6.png">
