### PR TITLE
Return inner HTML before and after inner blocks when parsing and fix …

### DIFF
--- a/core-blocks/test/fixtures/core__column.parsed.json
+++ b/core-blocks/test/fixtures/core__column.parsed.json
@@ -16,7 +16,9 @@
                 "innerHTML": "\n\t<p>Column One, Paragraph Two</p>\n\t"
             }
         ],
-        "innerHTML": "\n<div class=\"wp-block-column\">\n\t\n\t\n</div>\n"
+        "innerHTML": "\n<div class=\"wp-block-column\">\n\t\n\t\n</div>\n",
+        "innerHTMLBeforeInnerBlocks": "\n<div class=\"wp-block-column\">\n\t",
+        "innerHTMLAfterInnerBlocks": "\n\t\n</div>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__column.rendered.html
+++ b/core-blocks/test/fixtures/core__column.rendered.html
@@ -1,0 +1,10 @@
+
+<div class="wp-block-column">
+	
+	<p>Column One, Paragraph One</p>
+	
+	<p>Column One, Paragraph Two</p>
+	
+	
+</div>
+

--- a/core-blocks/test/fixtures/core__columns.parsed.json
+++ b/core-blocks/test/fixtures/core__columns.parsed.json
@@ -22,7 +22,9 @@
                         "innerHTML": "\n\t\t<p>Column One, Paragraph Two</p>\n\t\t"
                     }
                 ],
-                "innerHTML": "\n\t<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>\n\t"
+                "innerHTML": "\n\t<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>\n\t",
+                "innerHTMLBeforeInnerBlocks": "\n\t<div class=\"wp-block-column\">\n\t\t",
+                "innerHTMLAfterInnerBlocks": "\n\t\t\n\t</div>\n\t"
             },
             {
                 "blockName": "core/column",
@@ -41,10 +43,14 @@
                         "innerHTML": "\n\t\t<p>Column Three, Paragraph One</p>\n\t\t"
                     }
                 ],
-                "innerHTML": "\n\t<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>\n\t"
+                "innerHTML": "\n\t<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>\n\t",
+                "innerHTMLBeforeInnerBlocks": "\n\t<div class=\"wp-block-column\">\n\t\t",
+                "innerHTMLAfterInnerBlocks": "\n\t\t\n\t</div>\n\t"
             }
         ],
-        "innerHTML": "\n<div class=\"wp-block-columns has-3-columns\">\n\t\n\t\n</div>\n"
+        "innerHTML": "\n<div class=\"wp-block-columns has-3-columns\">\n\t\n\t\n</div>\n",
+        "innerHTMLBeforeInnerBlocks": "\n<div class=\"wp-block-columns has-3-columns\">\n\t",
+        "innerHTMLAfterInnerBlocks": "\n\t\n</div>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__columns.rendered.html
+++ b/core-blocks/test/fixtures/core__columns.rendered.html
@@ -1,0 +1,24 @@
+
+<div class="wp-block-columns has-3-columns">
+	
+	<div class="wp-block-column">
+		
+		<p>Column One, Paragraph One</p>
+		
+		<p>Column One, Paragraph Two</p>
+		
+		
+	</div>
+	
+	<div class="wp-block-column">
+		
+		<p>Column Two, Paragraph One</p>
+		
+		<p>Column Three, Paragraph One</p>
+		
+		
+	</div>
+	
+	
+</div>
+

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -108,6 +108,13 @@ function gutenberg_render_block( $block ) {
 		}
 	}
 
+	if ( isset( $block['innerBlocks'] )  && count( $block['innerBlocks'] ) ) {
+		$raw_content = $block['innerHTMLBeforeInnerBlocks'];
+		foreach ( $block['innerBlocks'] as $inner_block ) {
+			$raw_content .= gutenberg_render_block( $inner_block );
+		}
+		$raw_content .= $block['innerHTMLAfterInnerBlocks'];
+	}
 	if ( $raw_content ) {
 		return $raw_content;
 	}

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -266,14 +266,37 @@ class Gutenberg_PEG_Parser {
         );
         }
     private function peg_f4($s, $children, $e) {
-        list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+	    $innerHTMLBeforeInnerBlocks = array();
+	    $innerHTMLAfterInnerBlocks = array();
+	    $innerBlocks = array();
 
-        return array(
+	    $inner_found = false;
+	    foreach ( $children as $child ) {
+	    	if( is_string( $child ) ) {
+	    		if ( $inner_found ) {
+	    			$innerHTMLAfterInnerBlocks[] = $child;
+			    } else {
+				    $innerHTMLBeforeInnerBlocks[] = $child;
+			    }
+		    } else {
+	    		$innerBlocks[] = $child;
+	    		$inner_found = true;
+		    }
+	    }
+
+
+        $block = array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
           'innerBlocks'  => $innerBlocks,
-          'innerHTML'  => implode( '', $innerHTML ),
+          'innerHTML'  => implode( '', $innerHTMLBeforeInnerBlocks ) . implode( '', $innerHTMLAfterInnerBlocks ),
         );
+
+	    if( $inner_found ) {
+          $block['innerHTMLBeforeInnerBlocks']  = implode( '', $innerHTMLBeforeInnerBlocks );
+          $block['innerHTMLAfterInnerBlocks']  = implode( '', $innerHTMLAfterInnerBlocks );
+	    }
+	    return $block;
         }
     private function peg_f5($blockName, $attrs) {
         return array(

--- a/phpunit/class-render-test.php
+++ b/phpunit/class-render-test.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * gutenberg_render_block tests
+ *
+ * @package Gutenberg
+ */
+
+class Render_Test extends WP_UnitTestCase {
+	protected static $fixtures_dir;
+
+	/**
+	 * @test
+	 * @dataProvider inner_block_files
+	 */
+	public function it_renders_inner_blocks( $blocks_file, $rendered_file ) {
+		self::$fixtures_dir = dirname( dirname( __FILE__ ) ) . '/core-blocks/test/fixtures';
+
+		require_once dirname( dirname( __FILE__ ) ) . '/lib/blocks.php';
+
+		$blocks = json_decode( self::strip_r( file_get_contents( self::$fixtures_dir . $blocks_file ) ), true );
+		$expected = self::strip_r( file_get_contents( self::$fixtures_dir . $rendered_file ) );
+
+		$content = '';
+		foreach ( $blocks as $block ) {
+			$content .= gutenberg_render_block( $block );
+		}
+
+		$this->assertEquals( $expected, $content );
+
+	}
+
+	function strip_r( $input ) {
+		return str_replace( "\r", '', $input );
+	}
+
+	public function inner_block_files() {
+		return array(
+			array( '/core__column.parsed.json', '/core__column.rendered.html' ),
+			array( '/core__columns.parsed.json', '/core__columns.rendered.html' ),
+		);
+	}
+
+}


### PR DESCRIPTION


## Description
Fix rendering of inner blocks - https://github.com/WordPress/gutenberg/issues/8214

`gutenberg_render_block` does not render inner blocks

**To Reproduce**
Use Gutenberg editor to add 2 columns. You end up with something like this

```
<!-- wp:columns -->
<div class="wp-block-columns has-2-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>This is a column</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>This is the other column</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

Use `gutenberg_parse_blocks` and then `gutenberg_render_block` to re-generate the content.
```
$blocks = gutenberg_parse_blocks( $content );

$new_content = '';
foreach( $blocks as $block ) {
   $new_content .= gutenberg_render_block( $block );
}
```
**Expected behaviour**
`$new_content` should be the same as `$content` but it's not. The inner blocks of columns is not rendered.


## How has this been tested?
This code has been tested as described above.

This has been covered by PHP Unit class Test_Render.

## Types of changes
Introduced new `innerHTMLBeforeInnerBlocks` and `innerHTMLAfterInnerBlocks` to block parser. This data is set only when there are inner blocks. 
Updated `gutenberg_render_block` to use this data to properly render the inner blocks.
Added tests to cover this.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
