### PR TITLE
Metaboxes: Trigger tinymce save before saving metaboxes

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { reduce, some } from 'lodash';
+import tinymce from 'tinymce';
 
 /**
  * WordPress dependencies
@@ -44,6 +45,9 @@ const effects = {
 			}
 		} );
 
+		// Saves the wp_editor fields
+		tinymce.triggerSave();
+
 		// Initialize metaboxes state
 		const dataPerLocation = reduce( action.metaBoxes, ( memo, isActive, location ) => {
 			if ( isActive ) {
@@ -73,6 +77,9 @@ const effects = {
 		} );
 	},
 	REQUEST_META_BOX_UPDATES( action, store ) {
+		// Saves the wp_editor fields
+		tinymce.triggerSave();
+
 		const state = store.getState();
 		const dataPerLocation = reduce( getMetaBoxes( state ), ( memo, metabox, location ) => {
 			if ( metabox.isActive ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -555,6 +555,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-i18n',
 			'wp-keycodes',
 			'wp-plugins',
+			'wp-tinymce',
 			'wp-viewport',
 		),
 		filemtime( gutenberg_dir_path() . 'build/edit-post/index.js' ),


### PR DESCRIPTION
closes #7176

The idea is to fix saving `wp_editor`s used in metaboxes.

**Testing instructions**

 - Install ACF free from the repository
 - Add a WYSIWYG field 
 - Try editing and saving the field
 - Reload the page, it should save properly