### PR TITLE
Docs: Add user input dynamic block info

### DIFF
--- a/docs/blocks/creating-dynamic-blocks.md
+++ b/docs/blocks/creating-dynamic-blocks.md
@@ -179,7 +179,7 @@ The PHP code is the same as above and is automatically handled through the WP RE
 
 ## Rendering block markup with PHP
 
-Dynamic blocks can be used in order to control the markup of your block with PHP. This is useful as if you decide to change your blocks markup, you won't have to go back and re-save all the posts which use that block, in order for your blocks markup change to be reflected on all posts.
+Dynamic blocks can be used in order to control the markup of your block with PHP. This is useful as if you decide to change your block's markup, you won't have to go back and re-save all the posts which use that block, in order for your block's markup change to be reflected on all posts.
 
 {% ESNext %}
 ```js

--- a/docs/blocks/creating-dynamic-blocks.md
+++ b/docs/blocks/creating-dynamic-blocks.md
@@ -176,3 +176,107 @@ registerBlockType( 'my-plugin/latest-post', {
 {% end %}
 
 The PHP code is the same as above and is automatically handled through the WP REST API.
+
+## Rendering block markup with PHP
+
+Dynamic blocks can be used in order to control the markup of your block with PHP. This is useful as if you decide to change your blocks markup, you won't have to go back and re-save all the posts which use that block, in order for your blocks markup change to be reflected on all posts.
+
+{% ESNext %}
+```js
+// grab the translation stuff.
+const { __ } = wp.i18n;
+
+// grab the register block type component.
+const { registerBlockType } = wp.blocks;
+
+// grab the richtext editor component.
+const { RichText } = wp.editor;
+
+// register our block type.
+registerBlockType(
+    'my-block-namespace/my-block',
+    {
+        title: __( 'My Dynamic Block', 'my-block-namespace'),
+        description: __( 'A simple richtext field in a dynamic block.', 'my-block-namespace'),
+        icon: 'megaphone',        
+        category: 'widgets',
+        // setup our attributes - just 1 richtext field named message.
+        // no need to declare selector or source as we are using php to render the block.
+        attributes: {
+            message: {
+                type: 'array',
+            },
+        },
+        edit: props => {
+            const { attributes: { message }, className, setAttributes } = props;
+            const onChangeMessage = message => { setAttributes( { message } ) };
+            return (
+                <div className={ className }>
+                    <RichText
+                        tagName="div"
+                        multiline="p" // when you press enter in the editor, it will create a new paragraph.
+                        placeholder={ __( 'Add your custom message', 'my-block-namespace' ) }
+                        onChange={ onChangeMessage }
+                        value={ message }
+                    />
+                </div>
+            );
+        },
+        save( { attributes } ) {
+            return (
+                <RichText.Content
+                    value={ attributes.message }
+                />
+            );
+        },
+} );
+```
+In the example above, the block attributes (in this case the message rich text field) get passed to the save function. As we are going to use PHP to render the front-end, we don't provide any markup here but we simply return the content of the rich text field using `RichText.Content`, the value of which is the value of the `message` entered into the editor (`attributes.message`).
+
+Then to use PHP to output this on the front-end we need to register the block type in PHP like so and define a callback.
+
+```php
+<?php
+/**
+ * Register the dynamic block.
+ *
+ * Registers our block on the server side and defines its render callback.
+ * The render callback is the function used to output this on the front-end.
+ *
+ * @since 2.1.0
+ *
+ * @return void
+ */
+function my_register_dynamic_block() {
+
+	// Only load if Gutenberg is available.
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
+
+	// Hook server side rendering into render callback
+	register_block_type(
+		'my-block-namespace/my-block',
+		array(
+			'render_callback' => 'my_render_dynamic_block',
+		)
+	);
+
+}
+
+add_action( 'plugins_loaded', 'my_register_dynamic_block', 10, 2 );
+
+/**
+ * Server rendering for our dynamic rich text block.
+ *
+ * @param  array $attributes An array of block attributes.
+ * @param  string $content    The is the contents of the message field from the editor as a string.
+ * @return string             The HTML to output for our block including the content from the editor.
+ */
+function my_render_dynamic_block( $attributes, $content ) {
+
+	// we can now return the rich text fields content with whatever markup we like.
+	return '<div class="my-richtext-block">' . $content . '</div>';
+
+}
+```


### PR DESCRIPTION
This addition attempts to explain how to create a dynamic block that takes user input in the editor (in this example in the form of a rich text input) and then uses PHP to output this on the front-end. The benefit here is that the blocks markup can change without needing to update each of the posts using that block.

I found this page lacking in how to do this as it focused on dynamic blocks that carry out a query in PHP for the content rather than output the takes user input from the block itself. Hopefully it will help others.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
