### PR TITLE
Docs: Extend guidelines for managing packages and publishing them to npm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ npx nvm install
 npx nvm use
 ```
 
-You should also have the latest release of <a href="https://npmjs.org">npm installed</a>, npm is a separate project from Node.js and is updated frequently. If you've just installed Node.js which includes a version of npm within the installation you most likely will need to also update your npm install. To update npm, type this into your terminal: `npm install npm@latest -g`
+You should also have the latest release of [npm installed][npm]. npm is a separate project from Node.js and is updated frequently. If you've just installed Node.js which includes a version of npm within the installation you most likely will need to also update your npm installation. To update npm, type this into your terminal: `npm install npm@latest -g`
 
 To test the plugin, or to contribute to it, you can clone this repository and build the plugin files using Node. How you do that depends on whether you're developing locally or uploading the plugin to a remote host.
 
@@ -111,7 +111,7 @@ Gutenberg contains both PHP and JavaScript code, and encourages testing and code
 
 ## Managing packages
 
-This repository uses [lerna](https://lernajs.io) to manage Gutenberg modules and publish them as packages to `npm`. 
+This repository uses [lerna] to manage Gutenberg modules and publish them as packages to [npm]. 
 
 ### Creating new package
 
@@ -197,7 +197,7 @@ If you have the ability to publish packages, you _must_ have [2FA enabled](https
 
 #### Before releasing
 
-Confirm that you're logged into `npm`, by running `npm whoami`. If you're not logged in, run `npm adduser` to login.
+Confirm that you're logged into [npm], by running `npm whoami`. If you're not logged in, run `npm adduser` to login.
 
 If you're publishing a new package, ensure that its `package.json` file contains the correct `publishConfig` settings:
 
@@ -221,7 +221,7 @@ NPM_CONFIG_OTP=123456 npm run publish:dev
 
 Lerna will ask you which version number you want to choose for each package. For a `dev` release, you'll more likely want to choose the "prerelease" option. Repeat the same for all the outdated packages and confirm your version updates.
 
-Lerna will then publish to `npm`, commit the `package.json` changes and create the git tags.
+Lerna will then publish to [npm], commit the `package.json` changes and create the git tags.
 
 #### Production release
 
@@ -260,3 +260,6 @@ A Global Translation Editor (GTE) or Project Translation Editor (PTE) with suita
 Language packs are automatically generated once 95% of the plugin's strings are translated and approved for a locale.
 
 The eventual inclusion of Gutenberg into WordPress core means that more than 51% of WordPress installations running a translated WordPress installation will have Gutenberg's translated strings compiled into the core language pack as well.
+
+[lerna]: https://lernajs.io/
+[npm]: https://www.npmjs.com/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,7 @@ When creating a new package you need to provide at least the following:
 		},
 		"main": "build/index.js",
 		"module": "build-module/index.js",
+		"react-native": "src/index",
 		"dependencies": {
 			"@babel/runtime-corejs2": "7.0.0-beta.56"
 		},

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ When creating a new package you need to provide at least the following:
 	- Usage example.
 	- `Code is Poetry` logo.
 	
-### Managing packages
+### Maintaining changelogs
 
 It isn't easy task to maintain dozens of npm packages. That's why we decided to introduce `CHANGELOG.md` files for all packages to simplify the release process.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,8 @@ If you're publishing a new package, ensure that its `package.json` file contains
 	}
 ```
 
+You can double check it by executing `npm run lint-pkg-json` command.
+
 ### Development release
 
 Run the following command to release a dev version of the outdated packages, replacing "123456" with your 2FA code. Make sure you're using a freshly generated 2FA code, rather than one that's about to timeout. This is a little cumbersome, but helps to prevent the release process from dying mid-deploy.
@@ -147,7 +149,12 @@ To release a production version for the outdated packages, run the following com
 NPM_CONFIG_OTP=123456 npm run publish:prod
 ```
 
-Choose the correct version (minor, major or patch) and confirm your choices and let Lerna do its magic.
+Choose the correct version (`major`, `minor` or `patch`) according to the following guidelines:
+- Major version X (X.y.z | X > 0) should be bumped on any backwards-incompatible change. This will usually occur at the final removal of the feature. The deprecation should be fully backwards-compatible and, if it is not, it should warrant a separate major version bump.
+- Minor version Y (x.Y.z | x > 0) update should be selected when you add functionality in a backwards-compatible manner. It must be incremented if any public API functionality is marked as deprecated.
+- Patch version Z (x.y.Z | x > 0) should be incremented when you make backwards-compatible bug fixes.
+
+When in doubt, refer to [Semantic Versioning specification](https://semver.org/). Confirm all your choices and let Lerna do its magic.
 
 ## How Designers Can Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,25 +147,26 @@ When creating a new package you need to provide at least the following:
 		}
 	}
 	```
-	It assumes that code is goind to be located in `src` folder and will be transpiled with `Babel`.
+	This assumes that your code is located in the `src` folder and will be transpiled with `Babel`.
 2. `.npmrc` file which disables creating `package-lock.json` file for the package:
 	```
 	package-lock=false
 	```
 3. `README.md` file containing at least:
-	- Package name.
-	- Package description.
-	- Installation details.
-	- Usage example.
-	- `Code is Poetry` logo.
+	- Package name
+	- Package description
+	- Installation details
+	- Usage example
+	- `Code is Poetry` logo (`<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>`)
 	
 ### Maintaining changelogs
 
-It isn't easy task to maintain dozens of npm packages. That's why we decided to introduce `CHANGELOG.md` files for all packages to simplify the release process.
+Maintaining dozens of npm packages is difficult–it can be tough to keep track of changes. That's why we use `CHANGELOG.md` files for each package to simplify the release process. All packages should follow the [Semantic Versioning (`semver`) specification](https://semver.org/).
 
-The developer who proposes a change (pull request) is responsible to choose the correct version increment (`major`, `minor` or `patch`) according to the following guidelines:
-- Major version X (X.y.z | X > 0) should be bumped on any backwards-incompatible change. This will usually occur at the final stage of deprecating and the removal of a feature. The deprecation should be fully backwards-compatible and, if it is not, it should warrant a separate major version bump.
-- Minor version Y (x.Y.z | x > 0) update should be selected when you add functionality in a backwards-compatible manner. It must be incremented if any public API functionality is marked as deprecated.
+The developer who proposes a change (pull request) is responsible to choose the correct version increment (`major`, `minor`, or `patch`) according to the following guidelines:
+
+- Major version X (X.y.z | X > 0) should be changed with any backwards-incompatible/"breaking" change. This will usually occur at the final stage of deprecating and removing of a feature.
+- Minor version Y (x.Y.z | x > 0) should be changed when you add functionality or change functionality in a backwards-compatible manner. It must be incremented if any public API functionality is marked as deprecated.
 - Patch version Z (x.y.Z | x > 0) should be incremented when you make backwards-compatible bug fixes.
 
 When in doubt, refer to [Semantic Versioning specification](https://semver.org/).
@@ -175,15 +176,15 @@ _Example:_
 ```md
 ## v1.2.2 (Unreleased)
 
-#### Bug Fix
+### Bug Fix
 
 - ...
 - ...
 ```
 
-- If you need to add something considered a bug fix, you add the item to `Bug Fix`section and leave the version as 1.2.2.
+- If you need to add something considered a bug fix, you add the item to `Bug Fix` section and leave the version as 1.2.2.
 - If it's a new feature you add the item to `New Feature` section and change version to 1.3.0.
-- If it's a breaking change you want to introduce, you add the item to `Breaking Change` section and bump the version to 2.0.0.
+- If it's a breaking change you want to introduce, add the item to `Breaking Change` section and bump the version to 2.0.0.
 
 The version bump is only necessary if one of the following applies:
  - There are no other unreleased changes.
@@ -191,13 +192,13 @@ The version bump is only necessary if one of the following applies:
 
 ### Releasing packages
 
-Lerna automatically releases all the outdated packages. To check which packages are outdated and will be released, type `npm run publish:check`.
+Lerna automatically releases all outdated packages. To check which packages are outdated and will be released, type `npm run publish:check`.
 
-If you have the ability to publish packages, you _must_ have [2FA enabled](https://docs.npmjs.com/getting-started/using-two-factor-authentication) on your npmjs.com account.
+If you have the ability to publish packages, you _must_ have [2FA enabled](https://docs.npmjs.com/getting-started/using-two-factor-authentication) on your [npm account][npm].
 
 #### Before releasing
 
-Confirm that you're logged into [npm], by running `npm whoami`. If you're not logged in, run `npm adduser` to login.
+Confirm that you're logged in to [npm], by running `npm whoami`. If you're not logged in, run `npm adduser` to login.
 
 If you're publishing a new package, ensure that its `package.json` file contains the correct `publishConfig` settings:
 
@@ -209,11 +210,11 @@ If you're publishing a new package, ensure that its `package.json` file contains
 }
 ```
 
-You can double check it by executing `npm run lint-pkg-json` command.
+You can check your package configs by running `npm run lint-pkg-json`.
 
 #### Development release
 
-Run the following command to release a dev version of the outdated packages, replacing "123456" with your 2FA code. Make sure you're using a freshly generated 2FA code, rather than one that's about to timeout. This is a little cumbersome, but helps to prevent the release process from dying mid-deploy.
+Run the following command to release a dev version of the outdated packages, replacing `123456` with your 2FA code. Make sure you're using a freshly generated 2FA code, rather than one that's about to timeout. This is a little cumbersome, but helps to prevent the release process from dying mid-deploy.
 
 ```bash
 NPM_CONFIG_OTP=123456 npm run publish:dev
@@ -225,7 +226,7 @@ Lerna will then publish to [npm], commit the `package.json` changes and create t
 
 #### Production release
 
-To release a production version for the outdated packages, run the following command, replacing "123456" with your (freshly generated, as above) 2FA code:
+To release a production version for the outdated packages, run the following command, replacing `123456` with your (freshly generated, as above) 2FA code:
 
 ```bash
 NPM_CONFIG_OTP=123456 npm run publish:prod

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ When creating a new package you need to provide at least the following:
 	
 ### Maintaining changelogs
 
-Maintaining dozens of npm packages is difficult–it can be tough to keep track of changes. That's why we use `CHANGELOG.md` files for each package to simplify the release process. All packages should follow the [Semantic Versioning (`semver`) specification](https://semver.org/).
+Maintaining dozens of npm packages is difficult—it can be tough to keep track of changes. That's why we use `CHANGELOG.md` files for each package to simplify the release process. All packages should follow the [Semantic Versioning (`semver`) specification](https://semver.org/).
 
 The developer who proposes a change (pull request) is responsible to choose the correct version increment (`major`, `minor`, or `patch`) according to the following guidelines:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,9 +202,11 @@ Confirm that you're logged into `npm`, by running `npm whoami`. If you're not lo
 If you're publishing a new package, ensure that its `package.json` file contains the correct `publishConfig` settings:
 
 ```json
+{
 	"publishConfig": {
 		"access": "public"
 	}
+}
 ```
 
 You can double check it by executing `npm run lint-pkg-json` command.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,10 +161,10 @@ When creating a new package you need to provide at least the following:
 	
 ### Maintaining changelogs
 
-It isn't easy task to maintain dozens of npm packages. That's why we decided to introduce `CHANGELOG.md` files for all packages to simplify the release process.
+It isn't easy task to maintain dozens of npm packages. That's why we choose to introduce `CHANGELOG.md` files for all packages to simplify the release process.
 
-The developer who proposes a change (pull request) is responsible to choose the correct version increment (`major`, `minor` or `patch`) according to the following guidelines:
-- Major version X (X.y.z | X > 0) should be bumped on any backwards-incompatible change. This will usually occur at the final removal of the feature. The deprecation should be fully backwards-compatible and, if it is not, it should warrant a separate major version bump.
+The developer who proposes a change (pull request) is responsible to determine the correct version increment (`major`, `minor` or `patch`) according to the following guidelines:
+- Major version X (X.y.z | X > 0) should be bumped on any backwards-incompatible change. This will usually occur at the final stage of deprecating and the removal of a feature. The deprecation should be fully backwards-compatible and, if it is not, it should warrant a separate major version bump.
 - Minor version Y (x.Y.z | x > 0) update should be selected when you add functionality in a backwards-compatible manner. It must be incremented if any public API functionality is marked as deprecated.
 - Patch version Z (x.y.Z | x > 0) should be incremented when you make backwards-compatible bug fixes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,36 @@ When creating a new package you need to provide at least the following:
 	- Installation details.
 	- Usage example.
 	- `Code is Poetry` logo.
+	
+### Managing packages
 
+It isn't easy task to maintain dozens of npm packages. That's why we decided to introduce `CHANGELOG.md` files for all packages to simplify the release process.
+
+The developer who proposes a change (pull request) is responsible to choose the correct version increment (`major`, `minor` or `patch`) according to the following guidelines:
+- Major version X (X.y.z | X > 0) should be bumped on any backwards-incompatible change. This will usually occur at the final removal of the feature. The deprecation should be fully backwards-compatible and, if it is not, it should warrant a separate major version bump.
+- Minor version Y (x.Y.z | x > 0) update should be selected when you add functionality in a backwards-compatible manner. It must be incremented if any public API functionality is marked as deprecated.
+- Patch version Z (x.y.Z | x > 0) should be incremented when you make backwards-compatible bug fixes.
+
+When in doubt, refer to [Semantic Versioning specification](https://semver.org/).
+
+_Example:_
+
+```md
+## v1.2.2 (Unreleased)
+
+#### Bug Fix
+
+- ...
+- ...
+```
+
+- If you need to add something considered a bug fix, you add the item to `Bug Fix`section and leave the version as 1.2.2.
+- If it's a new feature you add the item to `New Feature` section and change version to 1.3.0.
+- If it's a breaking change you want to introduce, you add the item to `Breaking Change` section and bump the version to 2.0.0.
+
+The version bump is only necessary if one of the following applies:
+ - There are no other unreleased changes.
+ - The type of change you're introducing is incompatible (more severe) than the other unreleased changes.
 
 ### Releasing packages
 
@@ -200,12 +229,7 @@ To release a production version for the outdated packages, run the following com
 NPM_CONFIG_OTP=123456 npm run publish:prod
 ```
 
-Choose the correct version (`major`, `minor` or `patch`) according to the following guidelines:
-- Major version X (X.y.z | X > 0) should be bumped on any backwards-incompatible change. This will usually occur at the final removal of the feature. The deprecation should be fully backwards-compatible and, if it is not, it should warrant a separate major version bump.
-- Minor version Y (x.Y.z | x > 0) update should be selected when you add functionality in a backwards-compatible manner. It must be incremented if any public API functionality is marked as deprecated.
-- Patch version Z (x.y.Z | x > 0) should be incremented when you make backwards-compatible bug fixes.
-
-When in doubt, refer to [Semantic Versioning specification](https://semver.org/). Confirm all your choices and let Lerna do its magic.
+Choose the correct version based on `CHANGELOG.md` files, confirm your choices and let Lerna do its magic.
 
 ## How Designers Can Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,7 @@ _Example:_
 - If you need to add something considered a bug fix, you add the item to `Bug Fix` section and leave the version as 1.2.2.
 - If it's a new feature you add the item to `New Feature` section and change version to 1.3.0.
 - If it's a breaking change you want to introduce, add the item to `Breaking Change` section and bump the version to 2.0.0.
+- If you struggle to classify a change as one of the above, then it might be not necessary to include it.
 
 The version bump is only necessary if one of the following applies:
  - There are no other unreleased changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,9 +161,9 @@ When creating a new package you need to provide at least the following:
 	
 ### Maintaining changelogs
 
-It isn't easy task to maintain dozens of npm packages. That's why we choose to introduce `CHANGELOG.md` files for all packages to simplify the release process.
+It isn't easy task to maintain dozens of npm packages. That's why we decided to introduce `CHANGELOG.md` files for all packages to simplify the release process.
 
-The developer who proposes a change (pull request) is responsible to determine the correct version increment (`major`, `minor` or `patch`) according to the following guidelines:
+The developer who proposes a change (pull request) is responsible to choose the correct version increment (`major`, `minor` or `patch`) according to the following guidelines:
 - Major version X (X.y.z | X > 0) should be bumped on any backwards-incompatible change. This will usually occur at the final stage of deprecating and the removal of a feature. The deprecation should be fully backwards-compatible and, if it is not, it should warrant a separate major version bump.
 - Minor version Y (x.Y.z | x > 0) update should be selected when you add functionality in a backwards-compatible manner. It must be incremented if any public API functionality is marked as deprecated.
 - Patch version Z (x.y.Z | x > 0) should be incremented when you make backwards-compatible bug fixes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,13 +109,63 @@ The workflow is documented in greater detail in the [repository management](./do
 
 Gutenberg contains both PHP and JavaScript code, and encourages testing and code style linting for both. It also incorporates end-to-end testing using [Google Puppeteer](https://developers.google.com/web/tools/puppeteer/). You can find out more details in [Testing Overview document](./docs/reference/testing-overview.md).
 
-## Releasing packages
+## Managing packages
 
-This repository uses [lerna](https://lernajs.io) to manage Gutenberg modules and publish them as packages to `npm`. Lerna automatically releases all the outdated packages. To check which packages are outdated and will be released, type `npm run publish:check`.
+This repository uses [lerna](https://lernajs.io) to manage Gutenberg modules and publish them as packages to `npm`. 
+
+### Creating new package
+
+When creating a new package you need to provide at least the following:
+
+1. `package.json` based on the template:
+	```json
+	{
+		"name": "@wordpress/package-name",
+		"version": "1.0.0-beta.0",
+		"description": "Package description.",
+		"author": "The WordPress Contributors",
+		"license": "GPL-2.0-or-later",
+		"keywords": [
+			"wordpress"
+		],
+		"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/package-name/README.md",
+		"repository": {
+			"type": "git",
+			"url": "https://github.com/WordPress/gutenberg.git"
+		},
+		"bugs": {
+			"url": "https://github.com/WordPress/gutenberg/issues"
+		},
+		"main": "build/index.js",
+		"module": "build-module/index.js",
+		"dependencies": {
+			"@babel/runtime-corejs2": "7.0.0-beta.56"
+		},
+		"publishConfig": {
+			"access": "public"
+		}
+	}
+	```
+	It assumes that code is goind to be located in `src` folder and will be transpiled with `Babel`.
+2. `.npmrc` file which disables creating `package-lock.json` file for the package:
+	```
+	package-lock=false
+	```
+3. `README.md` file containing at least:
+	- Package name.
+	- Package description.
+	- Installation details.
+	- Usage example.
+	- `Code is Poetry` logo.
+
+
+### Releasing packages
+
+Lerna automatically releases all the outdated packages. To check which packages are outdated and will be released, type `npm run publish:check`.
 
 If you have the ability to publish packages, you _must_ have [2FA enabled](https://docs.npmjs.com/getting-started/using-two-factor-authentication) on your npmjs.com account.
 
-### Before releasing
+#### Before releasing
 
 Confirm that you're logged into `npm`, by running `npm whoami`. If you're not logged in, run `npm adduser` to login.
 
@@ -129,7 +179,7 @@ If you're publishing a new package, ensure that its `package.json` file contains
 
 You can double check it by executing `npm run lint-pkg-json` command.
 
-### Development release
+#### Development release
 
 Run the following command to release a dev version of the outdated packages, replacing "123456" with your 2FA code. Make sure you're using a freshly generated 2FA code, rather than one that's about to timeout. This is a little cumbersome, but helps to prevent the release process from dying mid-deploy.
 
@@ -141,7 +191,7 @@ Lerna will ask you which version number you want to choose for each package. For
 
 Lerna will then publish to `npm`, commit the `package.json` changes and create the git tags.
 
-### Production release
+#### Production release
 
 To release a production version for the outdated packages, run the following command, replacing "123456" with your (freshly generated, as above) 2FA code:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gutenberg
 [![Build Status](https://img.shields.io/travis/WordPress/gutenberg/master.svg)](https://travis-ci.org/WordPress/gutenberg)
 [![Coverage](https://img.shields.io/codecov/c/github/WordPress/gutenberg/master.svg)](https://codecov.io/gh/WordPress/gutenberg)
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
 Printing since 1440.
 

--- a/docs/reference/repository-management.md
+++ b/docs/reference/repository-management.md
@@ -123,7 +123,7 @@ A pull request can generally be merged once it is:
 - In compliance with all relevant code review criteria.
 - Covered by sufficient tests, as necessary.
 - Vetted against all potential edge cases.
-- Changelog entries were introduced.
+- Changelog entries were properly added.
 - Reviewed by someone other than the original author.
 
 The final pull request merge decision is made by the **@wordpress/gutenberg-core** team.

--- a/docs/reference/repository-management.md
+++ b/docs/reference/repository-management.md
@@ -123,6 +123,7 @@ A pull request can generally be merged once it is:
 - In compliance with all relevant code review criteria.
 - Covered by sufficient tests, as necessary.
 - Vetted against all potential edge cases.
+- Changelog entries were introduced.
 - Reviewed by someone other than the original author.
 
 The final pull request merge decision is made by the **@wordpress/gutenberg-core** team.


### PR DESCRIPTION
## Description

As discussed during the [JavaScript weekly chat](https://make.wordpress.org/core/2018/08/07/javascript-chat-summary-august-7/) earlier this week, I opened pull request to extend our guidelines for managing and publishing npm packages with Lerna.

### TODO
* [x] creating new packages
* [x] Babel dependencies
* [x] maintaining changelogs