### PR TITLE
Port heading block to mobile

### DIFF
--- a/core-blocks/heading/edit.native.js
+++ b/core-blocks/heading/edit.native.js
@@ -22,13 +22,10 @@ class HeadingEdit extends Component {
 		const {
 			attributes,
 			setAttributes,
-			style,
 			className,
 		} = this.props;
 
 		const {
-			align,
-			content,
 			level,
 			placeholder,
 		} = attributes;
@@ -44,8 +41,12 @@ class HeadingEdit extends Component {
 					style={ {
 						minHeight: Math.max( minHeight, typeof attributes.aztecHeight === 'undefined' ? 0 : attributes.aztecHeight ),
 					} }
-					onChange={ ( value ) => { setAttributes( value ); } }
-					onContentSizeChange={ ( event ) => { setAttributes( { aztecHeight: event.aztecHeight } ); } }
+					onChange={ ( value ) => {
+						setAttributes( value );
+					} }
+					onContentSizeChange={ ( event ) => {
+						setAttributes( { aztecHeight: event.aztecHeight } );
+					} }
 					className={ className }
 					placeholder={ placeholder || __( 'Write heading…' ) }
 				/>

--- a/core-blocks/heading/edit.native.js
+++ b/core-blocks/heading/edit.native.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { RichText } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+const minHeight = 50;
+
+class HeadingEdit extends Component {
+	render() {
+		const {
+			attributes,
+			setAttributes,
+			style,
+			className,
+		} = this.props;
+
+		const {
+			align,
+			content,
+			level,
+			placeholder,
+		} = attributes;
+
+		const tagName = 'h' + level;
+
+		return (
+			<View>
+				<RichText
+					wrapperClassName="wp-block-heading"
+					tagName={ tagName }
+					content={ { contentTree: attributes.content, eventCount: attributes.eventCount } }
+					style={ {
+						minHeight: Math.max( minHeight, typeof attributes.aztecHeight === 'undefined' ? 0 : attributes.aztecHeight ),
+					} }
+					onChange={ ( value ) => { setAttributes( value ); } }
+					onContentSizeChange={ ( event ) => { setAttributes( { aztecHeight: event.aztecHeight } ); } }
+					className={ className }
+					placeholder={ placeholder || __( 'Write heading…' ) }
+				/>
+			</View>
+		);
+	}
+}
+export default HeadingEdit;

--- a/core-blocks/heading/edit.native.js
+++ b/core-blocks/heading/edit.native.js
@@ -22,7 +22,6 @@ class HeadingEdit extends Component {
 		const {
 			attributes,
 			setAttributes,
-			className,
 		} = this.props;
 
 		const {
@@ -35,7 +34,6 @@ class HeadingEdit extends Component {
 		return (
 			<View>
 				<RichText
-					wrapperClassName="wp-block-heading"
 					tagName={ tagName }
 					content={ { contentTree: attributes.content, eventCount: attributes.eventCount } }
 					style={ {
@@ -47,7 +45,6 @@ class HeadingEdit extends Component {
 					onContentSizeChange={ ( event ) => {
 						setAttributes( { aztecHeight: event.aztecHeight } );
 					} }
-					className={ className }
 					placeholder={ placeholder || __( 'Write heading…' ) }
 				/>
 			</View>

--- a/core-blocks/index.native.js
+++ b/core-blocks/index.native.js
@@ -9,12 +9,14 @@ import {
  * Internal dependencies
  */
 import * as code from './code';
+import * as heading from './heading';
 import * as more from './more';
 import * as paragraph from './paragraph';
 
 export const registerCoreBlocks = () => {
 	[
 		paragraph,
+		heading,
 		code,
 		more,
 	].forEach( ( { name, settings } ) => {

--- a/core-blocks/paragraph/edit.native.js
+++ b/core-blocks/paragraph/edit.native.js
@@ -28,6 +28,7 @@ class ParagraphEdit extends Component {
 		return (
 			<View>
 				<RichText
+					tagName="p"
 					content={ { contentTree: attributes.content, eventCount: attributes.eventCount } }
 					style={ {
 						...style,

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -30,8 +30,10 @@ export class RichText extends Component {
 		this.lastEventCount = event.nativeEvent.eventCount;
 		// The following method just cleans up any <p> tags produced by aztec and replaces them with a br tag
 		// This should be removed on a later version when aztec doesn't return the top tag of the text being edited
-		const contentWithoutP = event.nativeEvent.text.replace( /<p>/gi, '' ).replace( /<\/p>/gi, '<br>' );
-		this.lastContent = contentWithoutP;
+		const openingTagRegexp = RegExp('^<' + this.props.tagName + '>', 'gi');
+		const closingTagRegexp = RegExp('</' + this.props.tagName + '>$', 'gi');
+		const contentWithoutRootTag = event.nativeEvent.text.replace( openingTagRegexp, '' ).replace( closingTagRegexp, '' );
+		this.lastContent = contentWithoutRootTag;
 
 		this.currentTimer = setTimeout( function() {
 			this.props.onChange( {
@@ -68,12 +70,14 @@ export class RichText extends Component {
 	}
 
 	render() {
-		// Save back to HTML from React tree
-		const html = renderToString( this.props.content.contentTree );
 		const {
+			tagName,
 			style,
 			eventCount,
 		} = this.props;
+
+		// Save back to HTML from React tree
+		const html = '<' + tagName + '>' + renderToString( this.props.content.contentTree ) + '</' + tagName + '>';
 
 		return (
 			<RCTAztecView
@@ -86,6 +90,10 @@ export class RichText extends Component {
 			/>
 		);
 	}
+}
+
+RichText.defaultProps = {
+	tagName: 'p',
 }
 
 const RichTextContainer = compose( [

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -92,10 +92,6 @@ export class RichText extends Component {
 	}
 }
 
-RichText.defaultProps = {
-	tagName: 'p',
-};
-
 const RichTextContainer = compose( [
 	withInstanceId,
 ] )( RichText );

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -30,8 +30,8 @@ export class RichText extends Component {
 		this.lastEventCount = event.nativeEvent.eventCount;
 		// The following method just cleans up any <p> tags produced by aztec and replaces them with a br tag
 		// This should be removed on a later version when aztec doesn't return the top tag of the text being edited
-		const openingTagRegexp = RegExp('^<' + this.props.tagName + '>', 'gi');
-		const closingTagRegexp = RegExp('</' + this.props.tagName + '>$', 'gi');
+		const openingTagRegexp = RegExp( '^<' + this.props.tagName + '>', 'gi' );
+		const closingTagRegexp = RegExp( '</' + this.props.tagName + '>$', 'gi' );
 		const contentWithoutRootTag = event.nativeEvent.text.replace( openingTagRegexp, '' ).replace( closingTagRegexp, '' );
 		this.lastContent = contentWithoutRootTag;
 
@@ -94,7 +94,7 @@ export class RichText extends Component {
 
 RichText.defaultProps = {
 	tagName: 'p',
-}
+};
 
 const RichTextContainer = compose( [
 	withInstanceId,


### PR DESCRIPTION
## Description

This adds a native implementation for the heading block.
Currently it skips the toolbar and inspector.

## How has this been tested?

Check out https://github.com/wordpress-mobile/gutenberg-mobile/pull/98 and test there that you can see and edit a heading block.

## Types of changes

- Native version of `core-blocks/heading/edit`
- Include `heading` in the list of registered native blocks
- Make the native `RichText` wrapping tag implementation more generic and introduce the `tagName` property

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->