### PR TITLE
[Task] Update RichText usage to avoid inline elements

### DIFF
--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -9,10 +9,6 @@
 }
 
 .wp-block-pullquote {
-	cite {
-		display: block;
-	}
-
 	cite .editor-rich-text__tinymce[data-is-empty="true"]::before {
 		font-size: 14px;
 		font-family: $default-font;

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -70,7 +70,6 @@ export const settings = {
 				/>
 				{ ( citation || isSelected ) && (
 					<RichText
-						tagName="cite"
 						value={ citation }
 						/* translators: the individual or entity quoted */
 						placeholder={ __( 'Write citation…' ) }
@@ -79,6 +78,7 @@ export const settings = {
 								citation: nextCitation,
 							} )
 						}
+						className="wp-block-pullquote__citation"
 					/>
 				) }
 			</blockquote>

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -4,9 +4,11 @@
 	color: $dark-gray-600;
 
 	cite,
-	footer {
+	footer,
+	&__citation {
 		color: $dark-gray-600;
 		text-transform: uppercase;
 		font-size: $default-font-size;
+		font-style: italic;
 	}
 }

--- a/packages/block-library/src/quote/editor.scss
+++ b/packages/block-library/src/quote/editor.scss
@@ -1,8 +1,7 @@
 .wp-block-quote {
 	margin: 0;
 
-	cite {
-		display: block;
+	&__citation {
 		font-size: $default-font-size;
 	}
 }

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -204,7 +204,6 @@ export const settings = {
 					/>
 					{ ( ( citation && citation.length > 0 ) || isSelected ) && (
 						<RichText
-							tagName="cite"
 							value={ citation }
 							onChange={
 								( nextCitation ) => setAttributes( {
@@ -213,6 +212,7 @@ export const settings = {
 							}
 							/* translators: the individual or entity quoted */
 							placeholder={ __( 'Write citation…' ) }
+							className="wp-block-quote__citation"
 						/>
 					) }
 				</blockquote>

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -2,7 +2,8 @@
 	margin: 20px 0;
 
 	cite,
-	footer {
+	footer,
+	&__citation {
 		color: $dark-gray-300;
 		font-size: $default-font-size;
 		margin-top: 1em;


### PR DESCRIPTION
## Description
This PR closes #8773 which reports the incompatibility of inline `RichText` elements and TinyMCE.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added a quote/pull-quote block with some text.
3. Made sure everything is functional and the styling is unchanged even though inline tags (`cite`) are replaced with block-level elements (`div`).

This was tested in WP 4.9.8, Gutenberg 3.4.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-8773-min](https://user-images.githubusercontent.com/20284937/43913038-c2c08c30-9c25-11e8-880a-87fe8cefc2f9.gif)

## Types of changes
This PR omits the `tagName` properties in the citations for the quote and pull-quote blocks so that they convert to using `div` tags instead of `cite`. It also updates styling to make sure the blocks look unchanged.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
