### PR TITLE
Add styles for Spinner component

### DIFF
--- a/block-library/html/test/__snapshots__/index.js.snap
+++ b/block-library/html/test/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`core/html block edit matches snapshot 1`] = `
       class="components-placeholder__fieldset"
     >
       <span
-        class="spinner is-active"
+        class="components-spinner"
       />
     </div>
   </div>

--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -44,3 +44,16 @@
 	animation: editor_region_focus $speed ease-out;
 	animation-fill-mode: forwards;
 }
+
+@keyframes rotation {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+@mixin animate_rotation($speed: 1s) {
+	animation: rotation $speed infinite linear;
+}

--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -69,7 +69,7 @@
 		z-index: z-index(".edit-post-meta-boxes-area.is-loading::before");
 	}
 
-	.spinner {
+	.components-spinner {
 		position: absolute;
 		top: 10px;
 		right: 20px;

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -101,7 +101,7 @@
 	padding: 0;
 }
 
-.blocks-gallery-item .spinner {
+.blocks-gallery-item .components-spinner {
 	position: absolute;
 	top: 50%;
 	left: 50%;

--- a/packages/components/src/spinner/index.js
+++ b/packages/components/src/spinner/index.js
@@ -1,3 +1,1 @@
-const spinner = <span className="spinner is-active" />;
-
-export default () => spinner;
+export default () => <span className="components-spinner" />;

--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -12,7 +12,7 @@
 	&::before {
 		content: "";
 		position: absolute;
-		background-color: white;
+		background-color: #fff;
 		top: 3px;
 		left: 3px;
 		width: 4px;

--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -1,15 +1,6 @@
-@keyframes rotation {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 .components-spinner {
 	display: inline-block;
-	background-color: #808080;
+	background-color: $dark-gray-200;
 	width: 18px;
 	height: 18px;
 	opacity: 0.7;
@@ -27,7 +18,7 @@
 		width: 4px;
 		height: 4px;
 		border-radius: 100%;
-		animation: rotation 1s infinite linear;
 		transform-origin: 6px 6px;
+		@include animate_rotation;
 	}
 }

--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -1,9 +1,9 @@
 @keyframes rotation {
   from {
-    transform: rotate(0deg) translateZ(0);
+    transform: rotate(0deg);
   }
   to {
-    transform: rotate(360deg) translateZ(0);
+    transform: rotate(360deg);
   }
 }
 

--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -12,7 +12,7 @@
 	&::before {
 		content: "";
 		position: absolute;
-		background-color: #fff;
+		background-color: $white;
 		top: 3px;
 		left: 3px;
 		width: 4px;

--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -1,0 +1,33 @@
+@keyframes rotation {
+  from {
+    transform: rotate(0deg) translateZ(0);
+  }
+  to {
+    transform: rotate(360deg) translateZ(0);
+  }
+}
+
+.components-spinner {
+	display: inline-block;
+	background-color: #808080;
+	width: 18px;
+	height: 18px;
+	opacity: 0.7;
+	float: right;
+	margin: 5px 11px 0;
+	border-radius: 100%;
+	position: relative;
+
+	&::before {
+		content: "";
+		position: absolute;
+		background-color: white;
+		top: 3px;
+		left: 3px;
+		width: 4px;
+		height: 4px;
+		border-radius: 100%;
+		animation: rotation 1s infinite linear;
+		transform-origin: 6px 6px;
+	}
+}

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -30,6 +30,7 @@
 @import "./responsive-wrapper/style.scss";
 @import "./scroll-lock/style.scss";
 @import "./select-control/style.scss";
+@import "./spinner/style.scss";
 @import "./text-control/style.scss";
 @import "./textarea-control/style.scss";
 @import "./toggle-control/style.scss";

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -1,7 +1,7 @@
 .editor-post-featured-image {
 	padding: 0;
 
-	.spinner {
+	.components-spinner {
 		margin: 0;
 	}
 

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -4,7 +4,7 @@
 }
 
 .editor-post-publish-panel__content {
-	.spinner {
+	.components-spinner {
 		display: block;
 		float: none;
 		margin: 100px auto 0;

--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -41,7 +41,7 @@ $input-size: 230px;
 
 // Hide suggestions on mobile until we @todo find a better way to show them
 .editor-url-input__suggestions,
-.editor-url-input .spinner {
+.editor-url-input .components-spinner {
 	display: none;
 	@include break-small() {
 		display: inherit;

--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -23,7 +23,7 @@ $input-size: 230px;
 		}
 	}
 
-	.spinner {
+	.components-spinner {
 		position: absolute;
 		right: 0;
 		top: $input-padding;


### PR DESCRIPTION
Closes #8566.

It adds the needed styles by the `Spinner` component, so it is displayed correctly even if the WordPress Core styles are not available.

Note that the spinner provided by the WordPress Core styles uses an image. In order to don't handle any image during the build process, this component renders a spinner using only CSS that should look like the original image.

![aug-10-2018 13-44-35](https://user-images.githubusercontent.com/1233880/43956202-8aca8668-9ca3-11e8-8696-c4e59b57f402.gif)
(Left: Original Image - Right: New CSS only)