### PR TITLE
Add remove block keyboard shortcut

### DIFF
--- a/edit-post/components/keyboard-shortcut-help-modal/config.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/config.js
@@ -9,6 +9,8 @@ const {
 	primary,
 	// Shift+Cmd+<key> on a mac, Ctrl+Shift+<key> elsewhere
 	primaryShift,
+	// Alt+Cmd+<key> on a mac, Ctrl+Alt+<key> elsewhere
+	primaryAlt,
 	// Shift+Alt+Cmd+<key> on a mac, Ctrl+Shift+Akt+<key> elsewhere
 	secondary,
 	// Ctrl+Alt+<key> on a mac, Shift+Alt+<key> elsewhere
@@ -84,6 +86,10 @@ const blockShortcuts = {
 		{
 			keyCombination: primaryShift( 'd' ),
 			description: __( 'Duplicate the selected block(s).' ),
+		},
+		{
+			keyCombination: primaryAlt( 'backspace' ),
+			description: __( 'Remove the selected block(s).' ),
 		},
 		{
 			keyCombination: '/',

--- a/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -161,6 +161,16 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
             ],
           },
           Object {
+            "description": "Remove the selected block(s).",
+            "keyCombination": Array [
+              "Ctrl",
+              "+",
+              "Alt",
+              "+",
+              "Backspace",
+            ],
+          },
+          Object {
             "description": "Change the block type after adding a new paragraph.",
             "keyCombination": "/",
           },

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -36,6 +36,10 @@ const shortcuts = {
 		raw: rawShortcut.primaryShift( 'd' ),
 		display: displayShortcut.primaryShift( 'd' ),
 	},
+	removeBlock: {
+		raw: rawShortcut.primaryAlt( 'backspace' ),
+		display: displayShortcut.primaryAlt( 'bksp' ),
+	},
 };
 
 export class BlockSettingsMenu extends Component {
@@ -84,6 +88,10 @@ export class BlockSettingsMenu extends Component {
 						// Prevents bookmark all Tabs shortcut in Chrome when devtools are closed.
 						// Prevents reposition Chrome devtools pane shortcut when devtools are open.
 						[ shortcuts.duplicate.raw ]: flow( preventDefault, onDuplicate ),
+
+						// Does not clash with any known browser/native shortcuts, but preventDefault
+						// is used to prevent any obscure unknown shortcuts from triggering
+						[ shortcuts.removeBlock.raw ]: flow( preventDefault, onRemove ),
 					} }
 				/>
 				<Dropdown
@@ -163,6 +171,7 @@ export class BlockSettingsMenu extends Component {
 									className="editor-block-settings-menu__control"
 									onClick={ onRemove }
 									icon="trash"
+									shortcut={ shortcuts.removeBlock.display }
 								>
 									{ __( 'Remove Block' ) }
 								</MenuItem>

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -397,8 +397,14 @@ export class RichText extends Component {
 			return;
 		}
 
-		const { keyCode } = event;
+		const { keyCode, altKey, metaKey } = event;
 		const isReverse = keyCode === BACKSPACE;
+
+		// User is using the Remove Block shortcut, so allow the event to bubble
+		if ( altKey && metaKey && isReverse ) {
+			return;
+		}
+
 		const { isCollapsed } = getSelection();
 
 		// Only process delete if the key press occurs at uncollapsed edge.

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -23,7 +23,7 @@ import {
 	getScrollContainer,
 } from '@wordpress/dom';
 import { createBlobURL } from '@wordpress/blob';
-import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, rawShortcut } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, rawShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { Slot } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { rawHandler, children } from '@wordpress/blocks';
@@ -397,11 +397,12 @@ export class RichText extends Component {
 			return;
 		}
 
-		const { keyCode, altKey, metaKey } = event;
+		const { keyCode } = event;
 		const isReverse = keyCode === BACKSPACE;
 
 		// User is using the Remove Block shortcut, so allow the event to bubble
-		if ( altKey && metaKey && isReverse ) {
+		// up to the BlockSettingsMenu component
+		if ( isKeyboardEvent.primaryAlt( event, 'Backspace' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description
Related #2980, #8279

- Adds the keyboard shortcut <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Backspace</kbd> / <kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>Backspace</kbd> for removing a block
- Allows that key combination to bubble from RichText's `onDeleteKeyDown` function
- Adds the shortcut to the keyboard shortcut help modal

## How has this been tested?
- Tested on Windows (chrome/edge/IE11/firefox/opera)
- Tested on Mac (chrome/safari/firefox/opera)
- Tested deleting a single block
- Tested deleting multiple blocks

## Screenshots <!-- if applicable -->
**Block Settings Menu:**
![screen shot 2018-08-10 at 11 49 31 am](https://user-images.githubusercontent.com/677833/43937982-bc3791f6-9c93-11e8-8a2d-e3635afd196f.png)

**Shortcuts Help Modal**
![screen shot 2018-08-10 at 11 49 09 am](https://user-images.githubusercontent.com/677833/43937992-c7590e3e-9c93-11e8-942b-93be5d327c5e.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
