### PR TITLE
Add stylelint check to precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,9 @@
 		"*.js": [
 			"eslint"
 		],
+		"*.scss": [
+			"npm run lint-css"
+		],
 		"{docs/{root-manifest.json,tool/*.js},packages/{*/README.md,*/src/{actions,selectors}.js,components/src/*/README.md}}": [
 			"npm run docs:build"
 		]


### PR DESCRIPTION
## Description
Adds a stylelint check to the precommit hook

## How has this been tested?
- Attempted to commit an incorrect scss style, precommit hook correctly disallowed the commit
- Tested that stylelint only runs when scss changes are staged

## Screenshots <!-- if applicable -->
![screen shot 2018-08-10 at 12 12 52 pm](https://user-images.githubusercontent.com/677833/43938560-d3ed97c0-9c96-11e8-9afc-a9aa631c00e5.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
