### PR TITLE
Rich Text: Indicate which text will be turned into a link

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -3,12 +3,13 @@
  */
 import classnames from 'classnames';
 import {
-	isEqual,
-	forEach,
-	merge,
-	identity,
-	find,
 	defer,
+	difference,
+	find,
+	forEach,
+	identity,
+	isEqual,
+	merge,
 	noop,
 } from 'lodash';
 import 'element-closest';
@@ -59,15 +60,25 @@ const { Node, getSelection } = window;
  */
 const TINYMCE_ZWSP = '\uFEFF';
 
-export function getFormatProperties( formatName, parents ) {
+export function getFormatValue( formatName, parents ) {
 	switch ( formatName ) {
 		case 'link' : {
-			const anchor = find( parents, ( node ) => node.nodeName.toLowerCase() === 'a' );
-			return !! anchor ? { value: anchor.getAttribute( 'href' ) || '', target: anchor.getAttribute( 'target' ) || '', node: anchor } : {};
+			const anchor = find( parents, ( node ) => node.nodeName === 'A' );
+			if ( anchor ) {
+				if ( anchor.hasAttribute( 'data-wp-placeholder' ) ) {
+					return { isAdding: true };
+				}
+				return {
+					isActive: true,
+					value: anchor.getAttribute( 'href' ) || '',
+					target: anchor.getAttribute( 'target' ) || '',
+					node: anchor,
+				};
+			}
 		}
-		default:
-			return {};
 	}
+
+	return { isActive: true };
 }
 
 const DEFAULT_FORMATS = [ 'bold', 'italic', 'strikethrough', 'link', 'code' ];
@@ -385,7 +396,6 @@ export class RichText extends Component {
 	/**
 	 * Handles any case where the content of the TinyMCE instance has changed.
 	 */
-
 	onChange() {
 		this.savedContent = this.getContent();
 		this.props.onChange( this.savedContent );
@@ -699,13 +709,12 @@ export class RichText extends Component {
 			return;
 		}
 
+		// Remove *non-selected* placeholder links when the selection is changed.
+		this.removePlaceholderLinks( parents );
+
 		const formatNames = this.props.formattingControls;
 		const formats = this.editor.formatter.matchAll( formatNames ).reduce( ( accFormats, activeFormat ) => {
-			accFormats[ activeFormat ] = {
-				isActive: true,
-				...getFormatProperties( activeFormat, parents ),
-			};
-
+			accFormats[ activeFormat ] = getFormatValue( activeFormat, parents );
 			return accFormats;
 		}, {} );
 
@@ -776,6 +785,27 @@ export class RichText extends Component {
 				console.error( 'Formatters passed via `formatters` prop will only be registered once. Formatters can be enabled/disabled via the `formattingControls` prop.' );
 			}
 		}
+
+		// When the block is unselected, remove placeholder links and hide the formatting toolbar.
+		if ( ! this.props.isSelected && prevProps.isSelected ) {
+			this.removePlaceholderLinks();
+			this.setState( { formats: {} } );
+		}
+	}
+
+	/**
+	 * Removes any placeholder links from the editor DOM. Placeholder links are
+	 * used when adding a link to indicate which text will become a link.
+	 *
+	 * @param {HTMLElement[]=} linksToKeep If specified, these links will *not*
+	 *                                     be removed. Useful for keeping the
+	 *                                     currently selected link as is.
+	 */
+	removePlaceholderLinks( linksToKeep = [] ) {
+		const placeholderLinks = this.editor.$( 'a[data-wp-placeholder]' ).toArray();
+		for ( const placeholderLink of difference( placeholderLinks, linksToKeep ) ) {
+			this.editor.dom.remove( placeholderLink, /* keepChildren: */ true );
+		}
 	}
 
 	/**
@@ -809,37 +839,59 @@ export class RichText extends Component {
 
 	changeFormats( formats ) {
 		forEach( formats, ( formatValue, format ) => {
+			const isActive = this.isFormatActive( format );
+
 			if ( format === 'link' ) {
-				if ( !! formatValue ) {
-					if ( formatValue.isAdding ) {
-						return;
-					}
-
-					const { value: href, target } = formatValue;
-
-					if ( ! this.isFormatActive( 'link' ) && this.editor.selection.isCollapsed() ) {
-						// When no link or text is selected, insert a link with the URL as its text
-						const anchorHTML = this.editor.dom.createHTML(
-							'a',
-							{ href, target },
-							this.editor.dom.encode( href )
-						);
-						this.editor.insertContent( anchorHTML );
-					} else {
-						// Use built-in TinyMCE command turn the selection into a link. This takes
-						// care of deleting any existing links within the selection
-						this.editor.execCommand( 'mceInsertLink', false, { href, target } );
-					}
-				} else {
+				// Remove the selected link when `formats.link` is set to a falsey value.
+				if ( ! formatValue ) {
 					this.editor.execCommand( 'Unlink' );
+					return;
 				}
-			} else {
-				const isActive = this.isFormatActive( format );
-				if ( isActive && ! formatValue ) {
-					this.removeFormat( format );
-				} else if ( ! isActive && formatValue ) {
-					this.applyFormat( format );
+
+				const { isAdding, value: href, target } = formatValue;
+				const isSelectionCollapsed = this.editor.selection.isCollapsed();
+
+				// Bail early if the link is still being added. <RichText> will ask the user
+				// for a URL and then update `formats.link`.
+				if ( isAdding ) {
+					// Create a placeholder <a> so that there's something to indicate which
+					// text will become a link. Placeholder links are stripped from
+					// getContent() and removed when the selection changes.
+					if ( ! isSelectionCollapsed ) {
+						this.editor.formatter.apply( format, {
+							href: '#',
+							'data-wp-placeholder': true,
+							'data-mce-bogus': true,
+						} );
+					}
+					return;
 				}
+
+				// When no link or text is selected, use the URL as the link's text.
+				if ( isSelectionCollapsed && ! isActive ) {
+					this.editor.insertContent( this.editor.dom.createHTML(
+						'a',
+						{ href, target },
+						this.editor.dom.encode( href )
+					) );
+					return;
+				}
+
+				// Use built-in TinyMCE command turn the selection into a link. This takes
+				// care of deleting any existing links within the current selection.
+				this.editor.execCommand( 'mceInsertLink', false, {
+					href,
+					target,
+					'data-wp-placeholder': null,
+					'data-mce-bogus': null,
+				} );
+				return;
+			}
+
+			if ( isActive && ! formatValue ) {
+				this.removeFormat( format );
+			} else if ( ! isActive && formatValue ) {
+				this.applyFormat( format );
 			}
 		} );
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -61,20 +61,18 @@ const { Node, getSelection } = window;
 const TINYMCE_ZWSP = '\uFEFF';
 
 export function getFormatValue( formatName, parents ) {
-	switch ( formatName ) {
-		case 'link' : {
-			const anchor = find( parents, ( node ) => node.nodeName === 'A' );
-			if ( anchor ) {
-				if ( anchor.hasAttribute( 'data-wp-placeholder' ) ) {
-					return { isAdding: true };
-				}
-				return {
-					isActive: true,
-					value: anchor.getAttribute( 'href' ) || '',
-					target: anchor.getAttribute( 'target' ) || '',
-					node: anchor,
-				};
+	if ( formatName === 'link' ) {
+		const anchor = find( parents, ( node ) => node.nodeName === 'A' );
+		if ( anchor ) {
+			if ( anchor.hasAttribute( 'data-wp-placeholder' ) ) {
+				return { isAdding: true };
 			}
+			return {
+				isActive: true,
+				value: anchor.getAttribute( 'href' ) || '',
+				target: anchor.getAttribute( 'target' ) || '',
+				node: anchor,
+			};
 		}
 	}
 

--- a/test/e2e/specs/__snapshots__/links.test.js.snap
+++ b/test/e2e/specs/__snapshots__/links.test.js.snap
@@ -1,30 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Managing links Creating a link by selecting text and clicking the Link UI 1`] = `
+exports[`Links can be created by selecting text and clicking Link 1`] = `
 "<!-- wp:paragraph -->
 <p>This is <a href=\\"https://wordpress.org/gutenberg\\">Gutenberg</a></p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Managing links Creating a link by selecting text and using keyboard shortcuts 1`] = `
+exports[`Links can be created by selecting text and using keyboard shortcuts 1`] = `
 "<!-- wp:paragraph -->
 <p>This is <a href=\\"https://wordpress.org/gutenberg\\">Gutenberg</a></p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Managing links Creating a link without any text selected 1`] = `
+exports[`Links can be created without any text selected 1`] = `
 "<!-- wp:paragraph -->
 <p>This is Gutenberg: <a href=\\"https://wordpress.org/gutenberg\\">https://wordpress.org/gutenberg</a></p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Managing links Editing a link 1`] = `
+exports[`Links can be edited 1`] = `
 "<!-- wp:paragraph -->
 <p>This is <a href=\\"https://wordpress.org/gutenberg/handbook\\">Gutenberg</a></p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Managing links Removing a link 1`] = `
+exports[`Links can be removed 1`] = `
 "<!-- wp:paragraph -->
 <p>This is Gutenberg</p>
 <!-- /wp:paragraph -->"

--- a/test/e2e/specs/__snapshots__/managing-links.test.js.snap
+++ b/test/e2e/specs/__snapshots__/managing-links.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Managing links Creating a link by selecting text and clicking the Link UI 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <a href=\\"https://wordpress.org/gutenberg\\">Gutenberg</a></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Managing links Creating a link by selecting text and using keyboard shortcuts 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <a href=\\"https://wordpress.org/gutenberg\\">Gutenberg</a></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Managing links Creating a link without any text selected 1`] = `
+"<!-- wp:paragraph -->
+<p>This is Gutenberg: <a href=\\"https://wordpress.org/gutenberg\\">https://wordpress.org/gutenberg</a></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Managing links Editing a link 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <a href=\\"https://wordpress.org/gutenberg/handbook\\">Gutenberg</a></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Managing links Removing a link 1`] = `
+"<!-- wp:paragraph -->
+<p>This is Gutenberg</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -16,12 +16,12 @@ import {
  */
 const SELECT_WORD_MODIFIER_KEYS = process.platform === 'darwin' ? [ 'Shift', 'Alt' ] : [ 'Shift', 'Control' ];
 
-describe( 'Managing links', () => {
+describe( 'Links', () => {
 	beforeEach( async () => {
 		await newPost();
 	} );
 
-	it( 'Creating a link by selecting text and clicking the Link UI', async () => {
+	it( 'can be created by selecting text and clicking Link', async () => {
 		// Create a block with some text
 		await clickBlockAppender();
 		await page.keyboard.type( 'This is Gutenberg' );
@@ -48,7 +48,7 @@ describe( 'Managing links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'Creating a link by selecting text and using keyboard shortcuts', async () => {
+	it( 'can be created by selecting text and using keyboard shortcuts', async () => {
 		// Create a block with some text
 		await clickBlockAppender();
 		await page.keyboard.type( 'This is Gutenberg' );
@@ -75,7 +75,7 @@ describe( 'Managing links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'Creating a link without any text selected', async () => {
+	it( 'can be created without any text selected', async () => {
 		// Create a block with some text
 		await clickBlockAppender();
 		await page.keyboard.type( 'This is Gutenberg: ' );
@@ -100,7 +100,7 @@ describe( 'Managing links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'Creating a link and then cancelling', async () => {
+	it( 'is not created when we click away from the link input', async () => {
 		// Create a block with some text
 		await clickBlockAppender();
 		await page.keyboard.type( 'This is Gutenberg' );
@@ -148,7 +148,7 @@ describe( 'Managing links', () => {
 		await page.click( 'a[href="https://wordpress.org/gutenberg"]' );
 	};
 
-	it( 'Editing a link', async () => {
+	it( 'can be edited', async () => {
 		await createAndReselectLink();
 
 		// Click on the Edit button
@@ -164,7 +164,7 @@ describe( 'Managing links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'Removing a link', async () => {
+	it( 'can be removed', async () => {
 		await createAndReselectLink();
 
 		// Click on the Unlink button
@@ -187,7 +187,7 @@ describe( 'Managing links', () => {
 		}
 	};
 
-	it( 'Pressing Left and Esc in Link Dialog in "Fixed to Toolbar" mode', async () => {
+	it( 'allows Left to be pressed during creation in "Fixed to Toolbar" mode', async () => {
 		await setFixedToolbar( true );
 
 		await clickBlockAppender();
@@ -205,7 +205,7 @@ describe( 'Managing links', () => {
 		expect( modal ).toBeNull();
 	} );
 
-	it( 'Pressing Left and Esc in Link Dialog in "Docked Toolbar" mode', async () => {
+	it( 'allows Left to be pressed during creation in "Docked Toolbar" mode', async () => {
 		await setFixedToolbar( false );
 
 		await clickBlockAppender();

--- a/test/e2e/specs/managing-links.test.js
+++ b/test/e2e/specs/managing-links.test.js
@@ -2,13 +2,176 @@
  * Internal dependencies
  */
 import {
+	META_KEY,
 	clickBlockAppender,
+	getEditedPostContent,
 	newPost,
+	pressWithModifier,
 } from '../support/utils';
+
+/**
+ * The modifier keys needed to invoke a 'select the next word' keyboard shortcut.
+ *
+ * @type {string}
+ */
+const SELECT_WORD_MODIFIER_KEYS = process.platform === 'darwin' ? [ 'Shift', 'Alt' ] : [ 'Shift', 'Control' ];
 
 describe( 'Managing links', () => {
 	beforeEach( async () => {
 		await newPost();
+	} );
+
+	it( 'Creating a link by selecting text and clicking the Link UI', async () => {
+		// Create a block with some text
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg' );
+
+		// Select some text
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+
+		// Click on the Link button
+		await page.click( 'button[aria-label="Link"]' );
+
+		// A placeholder link should have been inserted
+		expect( await page.$( 'a[data-wp-placeholder]' ) ).not.toBeNull();
+
+		// Type a URL
+		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+
+		// Click on the Apply button
+		await page.click( 'button[aria-label="Apply"]' );
+
+		// There should no longer be a placeholder link
+		expect( await page.$( 'a[data-wp-placeholder]' ) ).toBeNull();
+
+		// The link should have been inserted
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'Creating a link by selecting text and using keyboard shortcuts', async () => {
+		// Create a block with some text
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg' );
+
+		// Select some text
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+
+		// Press Cmd+K to insert a link
+		await pressWithModifier( META_KEY, 'K' );
+
+		// A placeholder link should have been inserted
+		expect( await page.$( 'a[data-wp-placeholder]' ) ).not.toBeNull();
+
+		// Type a URL
+		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+
+		// Press Enter to apply the link
+		await page.keyboard.press( 'Enter' );
+
+		// There should no longer be a placeholder link
+		expect( await page.$( 'a[data-wp-placeholder]' ) ).toBeNull();
+
+		// The link should have been inserted
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'Creating a link without any text selected', async () => {
+		// Create a block with some text
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg: ' );
+
+		// Press Cmd+K to insert a link
+		await pressWithModifier( META_KEY, 'K' );
+
+		// Trigger isTyping = false
+		await page.mouse.move( 200, 300, { steps: 10 } );
+		await page.mouse.move( 250, 350, { steps: 10 } );
+
+		// A placeholder link should not have been inserted
+		expect( await page.$( 'a[data-wp-placeholder]' ) ).toBeNull();
+
+		// Type a URL
+		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+
+		// Press Enter to apply the link
+		await page.keyboard.press( 'Enter' );
+
+		// A link with the URL as its text should have been inserted
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'Creating a link and then cancelling', async () => {
+		// Create a block with some text
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg' );
+
+		// Select some text
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+
+		// Click on the Link button
+		await page.click( 'button[aria-label="Link"]' );
+
+		// Type a URL
+		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+
+		// Click somewhere else - it doesn't really matter where
+		await page.click( '.editor-post-title' );
+
+		// A placeholder link should not have been inserted
+		expect( await page.$( 'a[data-wp-placeholder]' ) ).toBeNull();
+	} );
+
+	const createAndReselectLink = async () => {
+		// Create a block with some text
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg' );
+
+		// Select some text
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+
+		// Click on the Link button
+		await page.click( 'button[aria-label="Link"]' );
+
+		// Wait for the URL field to auto-focus
+		await page.waitForFunction( () => !! document.activeElement.closest( '.editor-url-input' ) );
+
+		// Type a URL
+		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+
+		// Click on the Apply button
+		await page.click( 'button[aria-label="Apply"]' );
+
+		// Click somewhere else - it doesn't really matter where
+		await page.click( '.editor-post-title' );
+
+		// Select the link again
+		await page.click( 'a[href="https://wordpress.org/gutenberg"]' );
+	};
+
+	it( 'Editing a link', async () => {
+		await createAndReselectLink();
+
+		// Click on the Edit button
+		await page.click( 'button[aria-label="Edit"]' );
+
+		// Change the URL
+		await page.keyboard.type( '/handbook' );
+
+		// Click on the Apply button
+		await page.click( 'button[aria-label="Apply"]' );
+
+		// The link should have been updated
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'Removing a link', async () => {
+		await createAndReselectLink();
+
+		// Click on the Unlink button
+		await page.click( 'button[aria-label="Unlink"]' );
+
+		// The link should have been removed
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	const setFixedToolbar = async ( b ) => {


### PR DESCRIPTION
Fixes #6156. Supersedes https://github.com/WordPress/gutenberg/pull/4909.

When inserting a link, the text selection disappears when the focus changes into the `URLInput` text field. This makes it hard to tell which text will be turned into a link.

The Classic Editor solves this by inserting a placeholder `<a>` element, which is the approach that I'm borrowing here.

The placeholder `<a>` is removed when the selection changes or when the block is deselected. We set `data-mce-bogus` on the placeholder `<a>` so that [it doesn't ever get serialised into post content](https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/rich-text/format.js#L60).

![links](https://user-images.githubusercontent.com/612155/43940982-8f22f7b0-9cb5-11e8-95c8-c2e5c961b9cd.gif)

**To test:**

I've included E2E tests for most basic link interactions, so look for the ✅!

It's worthwhile manually testing that no undo levels are created when placeholder links are created and destroyed. To do this:

1. Add a `console.log( 'undo level created' )` to `RichText::onCreateUndoLevel()`
1. Select some text
2. Press the _Link_ button in the formatting toolbar
3. Verify that the selected text looks like a link and that no undo level was created
4. Click on something else
3. Verify that there's no longer a link and that no undo level was created
4. Create a link for real this time
5. Verify that a link appears and that an undo level was created