### PR TITLE
Update Dashicons component.

### DIFF
--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -6,14 +6,9 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 !!! */
 
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import './style.scss';
 
 export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {

--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -6,9 +6,14 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 !!! */
 
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
 
 export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {
@@ -539,6 +544,12 @@ export default class Dashicon extends Component {
 				break;
 			case 'info':
 				path = 'M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm1 4c0-.55-.45-1-1-1s-1 .45-1 1 .45 1 1 1 1-.45 1-1zm0 9V9H9v6h2z';
+				break;
+			case 'insert-after':
+				path = 'M9 12h2v-2h2V8h-2V6H9v2H7v2h2v2zm1 4c3.9 0 7-3.1 7-7s-3.1-7-7-7-7 3.1-7 7 3.1 7 7 7zm0-12c2.8 0 5 2.2 5 5s-2.2 5-5 5-5-2.2-5-5 2.2-5 5-5zM3 19h14v-2H3v2z';
+				break;
+			case 'insert-before':
+				path = 'M11 8H9v2H7v2h2v2h2v-2h2v-2h-2V8zm-1-4c-3.9 0-7 3.1-7 7s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 12c-2.8 0-5-2.2-5-5s2.2-5 5-5 5 2.2 5 5-2.2 5-5 5zM3 1v2h14V1H3z';
 				break;
 			case 'insert':
 				path = 'M10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7zm1-11H9v3H6v2h3v3h2v-3h3V9h-3V6z';


### PR DESCRIPTION
This adds a few new icons, notably Insert Before and Insert After.

But it also adds any dashicons that have been added to the upstream repo in the mean time.

I see changes have been added in https://github.com/WordPress/gutenberg/commit/6928e41c8afd7daa3a709afdda7eee48218473b7#diff-297ebddffcddddf088a365bab7f0909cR9, but they have not been added upstream.

Are those changes intentional, because if yes let's backport them to the upstream repo, then I can redo this PR. 

I can do the backporting PR, but please remember that the Dashicon component is built using a build process in a separate repo: https://github.com/WordPress/dashicons