### PR TITLE
[Enhancement] Introduce left and right float alignment options to latest posts block

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -125,7 +125,6 @@ class LatestPostsEdit extends Component {
 						onChange={ ( nextAlign ) => {
 							setAttributes( { align: nextAlign } );
 						} }
-						controls={ [ 'center', 'wide', 'full' ] }
 					/>
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>


### PR DESCRIPTION
## Description
This PR closes #8777 which request the availability of left and right float alignment options in the Latest Posts block, making it consistent like the Archive, Latest Comments, and Categories blocks.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the Latest Post block.
3. Made sure the left and right alignment options are available and functional.

This was tested in WP 4.9.8, Gutenberg 3.5.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-8777](https://user-images.githubusercontent.com/20284937/43947387-c5cbe06c-9ca9-11e8-9441-4153fb859b9f.png)

## Types of changes
This PR just omits the `controls` property in the block alignment toolbar of the Latest Posts block, which specified the `center`, `wide`, and `full` alignments, excluding the `left` and `right` ones.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
