### PR TITLE
Allow access to the WordPress installation if DOCKER_ENV=localwpdev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ languages/gutenberg.pot
 phpcs.xml
 yarn.lock
 docker-compose.override.yml
+/wordpress

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,11 @@ Then, run a setup script to check if docker and node are configured properly and
 ./bin/setup-local-env.sh
 ``` 
 
+If you're developing themes, or core WordPress functionality alongside Gutenberg, you can access the WordPress files in `wordpress/` by running the following command instead:
+```
+DOCKER_ENV=localwpdev ./bin/setup-local-env.sh
+```
+
 If everything was successful, you'll see the following ascii art:
 ```
 Welcome to...

--- a/bin/bootstrap-env.sh
+++ b/bin/bootstrap-env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+WP_VERSION=${WP_VERSION-latest}
+DOCKER=${DOCKER-false}
+DOCKER_ENV=${DOCKER_ENV-ci}
+DOCKER_COMPOSE_FILE_OPTIONS="-f docker-compose.yml"
+
+if [ "$DOCKER_ENV" == "localwpdev" ]; then
+	DOCKER_COMPOSE_FILE_OPTIONS="${DOCKER_COMPOSE_FILE_OPTIONS} -f docker-compose-localdev.yml"
+fi

--- a/bin/install-docker.sh
+++ b/bin/install-docker.sh
@@ -3,7 +3,7 @@
 # Exit if any command fails.
 set -e
 
-WP_VERSION=${WP_VERSION-latest}
+. "$(dirname "$0")/bootstrap-env.sh"
 
 # Include useful functions.
 . "$(dirname "$0")/includes.sh"
@@ -22,15 +22,15 @@ fi
 
 # Stop existing containers.
 echo -e $(status_message "Stopping Docker containers...")
-docker-compose down --remove-orphans >/dev/null 2>&1
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS down --remove-orphans >/dev/null 2>&1
 
 # Download image updates.
 echo -e $(status_message "Downloading Docker image updates...")
-docker-compose pull
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS pull
 
 # Launch the containers.
 echo -e $(status_message "Starting Docker containers...")
-docker-compose up -d >/dev/null
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS up -d >/dev/null
 
 # Set up WordPress Development site.
 # Note: we don't bother installing the test site right now, because that's
@@ -39,8 +39,8 @@ docker-compose up -d >/dev/null
 
 # Install the PHPUnit test scaffolding.
 echo -e $(status_message "Installing PHPUnit test scaffolding...")
-docker-compose run --rm wordpress_phpunit /app/bin/install-wp-tests.sh wordpress_test root example mysql $WP_VERSION false > /dev/null
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm wordpress_phpunit /app/bin/install-wp-tests.sh wordpress_test root example mysql $WP_VERSION false > /dev/null
 
 # Install Composer. This is only used to run WordPress Coding Standards checks.
 echo -e $(status_message "Installing and updating Composer modules...")
-docker-compose run --rm composer install
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm composer install

--- a/bin/install-wordpress.sh
+++ b/bin/install-wordpress.sh
@@ -6,11 +6,13 @@ set -e
 # Gutenberg script includes.
 . "$(dirname "$0")/includes.sh"
 
+# Set up environment variables
+. "$(dirname "$0")/bootstrap-env.sh"
+
 # These are the containers and values for the development site.
 CLI='cli'
 CONTAINER='wordpress'
 SITE_TITLE='Gutenberg Dev'
-WP_VERSION=${WP_VERSION-latest}
 
 # If we're installing/re-installing the test site, change the containers used.
 if [ "$1" == '--e2e_tests' ]; then
@@ -20,7 +22,7 @@ if [ "$1" == '--e2e_tests' ]; then
 
 	if ! docker ps | grep -q $CONTAINER; then
 		echo -e $(error_message "WordPress e2e tests run in their own Docker container, but that container wasn't found.")
-		echo "Please restart your Docker containers by running 'docker-compose down && docker-compose up -d' or"
+		echo "Please restart your Docker containers by running 'docker-compose $DOCKER_COMPOSE_FILE_OPTIONS down && docker-compose $DOCKER_COMPOSE_FILE_OPTIONS up -d' or"
 		echo "by running './bin/setup-local-env.sh' again."
 		echo ""
 		exit 1
@@ -28,7 +30,7 @@ if [ "$1" == '--e2e_tests' ]; then
 fi
 
 # Get the host port for the WordPress container.
-HOST_PORT=$(docker-compose port $CONTAINER 80 | awk -F : '{printf $2}')
+HOST_PORT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS port $CONTAINER 80 | awk -F : '{printf $2}')
 
 # Wait until the Docker containers are running and the WordPress site is
 # responding to requests.
@@ -43,27 +45,27 @@ echo ''
 # dirty up the tests.
 if [ "$1" == '--e2e_tests' ]; then
 	echo -e $(status_message "Resetting test database...")
-	docker-compose run --rm $CLI db reset --yes >/dev/null
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CLI db reset --yes >/dev/null
 fi
 
 # Install WordPress.
 echo -e $(status_message "Installing WordPress...")
 # The `-u 33` flag tells Docker to run the command as a particular user and
 # prevents permissions errors. See: https://github.com/WordPress/gutenberg/pull/8427#issuecomment-410232369
-docker-compose run --rm -u 33 $CLI core install --title="$SITE_TITLE" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:$HOST_PORT >/dev/null
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI core install --title="$SITE_TITLE" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:$HOST_PORT >/dev/null
 
 if [ "$WP_VERSION" == "latest" ]; then
 	# Check for WordPress updates, to make sure we're running the very latest version.
-	docker-compose run --rm -u 33 $CLI core update >/dev/null
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI core update >/dev/null
 fi
 
 # If the 'wordpress' volume wasn't during the down/up earlier, but the post port has changed, we need to update it.
-CURRENT_URL=$(docker-compose run -T --rm $CLI option get siteurl)
+CURRENT_URL=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm $CLI option get siteurl)
 if [ "$CURRENT_URL" != "http://localhost:$HOST_PORT" ]; then
-	docker-compose run --rm $CLI option update home "http://localhost:$HOST_PORT" >/dev/null
-	docker-compose run --rm $CLI option update siteurl "http://localhost:$HOST_PORT" >/dev/null
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CLI option update home "http://localhost:$HOST_PORT" >/dev/null
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CLI option update siteurl "http://localhost:$HOST_PORT" >/dev/null
 fi
 
 # Activate Gutenberg.
 echo -e $(status_message "Activating Gutenberg...")
-docker-compose run --rm $CLI plugin activate gutenberg >/dev/null
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CLI plugin activate gutenberg >/dev/null

--- a/bin/run-wp-unit-tests.sh
+++ b/bin/run-wp-unit-tests.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+
+# Set up environment variables
+. "$(dirname "$0")/bootstrap-env.sh"
+
 cd "$(dirname "$0")/../"
 
 export PATH="$HOME/.composer/vendor/bin:$PATH"
@@ -29,8 +33,8 @@ fi
 
 echo Running with the following versions:
 if [[ $DOCKER = "true" ]]; then
-	docker-compose run --rm wordpress_phpunit php -v
-	docker-compose run --rm wordpress_phpunit phpunit --version
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm wordpress_phpunit php -v
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm wordpress_phpunit phpunit --version
 else
 	php -v
 	phpunit --version

--- a/bin/setup-local-env.sh
+++ b/bin/setup-local-env.sh
@@ -3,6 +3,9 @@
 # Exit if any command fails
 set -e
 
+# Set up environment variables
+. "$(dirname "$0")/bootstrap-env.sh"
+
 # Include useful functions
 . "$(dirname "$0")/includes.sh"
 
@@ -23,7 +26,7 @@ cd "$(dirname "$0")/.."
                                                 `---'
 EOT
 
-CURRENT_URL=$(docker-compose run -T --rm cli option get siteurl)
+CURRENT_URL=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm cli option get siteurl)
 
 echo -e "\nWelcome to...\n"
 echo -e "\033[95m$GUTENBERG\033[0m"

--- a/docker-compose-localdev.yml
+++ b/docker-compose-localdev.yml
@@ -10,11 +10,3 @@ services:
     image: wordpress:cli
     volumes:
       - ./wordpress:/var/www/html
-
-  wordpress_e2e_tests:
-    volumes:
-      - ./wordpress:/var/www/html
-
-  cli_e2e_tests:
-    volumes:
-      - ./wordpress:/var/www/html

--- a/docker-compose-localdev.yml
+++ b/docker-compose-localdev.yml
@@ -1,0 +1,28 @@
+version: '3.1'
+
+services:
+
+  wordpress:
+    volumes:
+      - ./wordpress:/var/www/html
+      - .:/var/www/html/wp-content/plugins/gutenberg
+      - ./test/e2e/test-plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
+      - ./test/e2e/test-mu-plugins:/var/www/html/wp-content/mu-plugins
+
+  cli:
+    image: wordpress:cli
+    volumes:
+      - ./wordpress:/var/www/html
+      - .:/var/www/html/wp-content/plugins/gutenberg
+
+  wordpress_e2e_tests:
+    volumes:
+      - ./wordpress:/var/www/html
+      - .:/var/www/html/wp-content/plugins/gutenberg
+      - ./test/e2e/test-plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
+      - ./test/e2e/test-mu-plugins:/var/www/html/wp-content/mu-plugins
+
+  cli_e2e_tests:
+    volumes:
+      - ./wordpress:/var/www/html
+      - .:/var/www/html/wp-content/plugins/gutenberg

--- a/docker-compose-localdev.yml
+++ b/docker-compose-localdev.yml
@@ -5,24 +5,16 @@ services:
   wordpress:
     volumes:
       - ./wordpress:/var/www/html
-      - .:/var/www/html/wp-content/plugins/gutenberg
-      - ./test/e2e/test-plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
-      - ./test/e2e/test-mu-plugins:/var/www/html/wp-content/mu-plugins
 
   cli:
     image: wordpress:cli
     volumes:
       - ./wordpress:/var/www/html
-      - .:/var/www/html/wp-content/plugins/gutenberg
 
   wordpress_e2e_tests:
     volumes:
       - ./wordpress:/var/www/html
-      - .:/var/www/html/wp-content/plugins/gutenberg
-      - ./test/e2e/test-plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
-      - ./test/e2e/test-mu-plugins:/var/www/html/wp-content/mu-plugins
 
   cli_e2e_tests:
     volumes:
       - ./wordpress:/var/www/html
-      - .:/var/www/html/wp-content/plugins/gutenberg


### PR DESCRIPTION
## Description

Adds a new docker-compose file that overrides volume settings so that WordPress can be accessed for theme or core dev.

## How has this been tested?

CI should run as normal, `DOCKER_ENV=localwpdev ./bin/setup-local-env.sh` should expose WordPress

