### PR TITLE
Make active pill button look pressed.

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -31,6 +31,9 @@ $z-layers: (
 	".editor-block-settings-remove": 1,
 	".editor-block-mover__control": 1,
 
+	// Active pill button
+	".components-button.is-button {:focus or .is-primary}": 1,
+
 	// Should have lower index than anything else positioned inside the block containers
 	".editor-block-list__block-draggable": 0,
 

--- a/packages/components/src/button-group/style.scss
+++ b/packages/components/src/button-group/style.scss
@@ -16,7 +16,7 @@
 			border-radius: 0 3px 3px 0;
 		}
 
-		// The focused button should be elevated so the focusring isn't cropped,
+		// The focused button should be elevated so the focus ring isn't cropped,
 		// as should the active button, because it has a different border color.
 		&:focus,
 		&.is-primary {

--- a/packages/components/src/button-group/style.scss
+++ b/packages/components/src/button-group/style.scss
@@ -15,5 +15,18 @@
 		&:last-child {
 			border-radius: 0 3px 3px 0;
 		}
+
+		// The focused button should be elevated so the focusring isn't cropped,
+		// as should the active button, because it has a different border color.
+		&:focus,
+		&.is-primary {
+			position: relative;
+			z-index: z-index(".components-button.is-button {:focus or .is-primary}");
+		}
+
+		// The active button should look pressed.
+		&.is-primary {
+			box-shadow: none;
+		}
 	}
 }


### PR DESCRIPTION
This is a small change that makes the activated pill button look pressed. Right now it just looks like a button, and while it is, it's an _active_ button.

Before:

<img width="172" alt="screen shot 2018-08-10 at 10 54 38" src="https://user-images.githubusercontent.com/1204802/43949461-dfe79f3e-9c8d-11e8-8235-58e13aefb55e.png">

After:

<img width="184" alt="screen shot 2018-08-10 at 11 05 36" src="https://user-images.githubusercontent.com/1204802/43949469-e40997c0-9c8d-11e8-8fc0-21f0aa67f7f6.png">

Additionally, it adds a z index to the active or focused state of the button, so borders and focusrings aren't cropped. This is necessary because a negative margin is used to stack borders. 