### PR TITLE
Audio Block: Avoid scrollbars when shown full-width

### DIFF
--- a/core-blocks/audio/editor.scss
+++ b/core-blocks/audio/editor.scss
@@ -1,3 +1,7 @@
+.wp-block-audio {
+	margin: 0;
+}
+
 .wp-block-audio audio {
 	width: 100%;
 }


### PR DESCRIPTION
It looks like figures have margin by default which causes scrollbars if their content is 100% in full-width. This could be solved in several ways, so let me know what you think.

closes #8717

**Testing instructions**

 - Add an audio block
 - Make it full width
 - No scrollbars.