### PR TITLE
Framework: Remove client-side document title updates

### DIFF
--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -14,7 +14,6 @@ import {
 	UnsavedChangesWarning,
 	EditorNotices,
 	PostPublishPanel,
-	DocumentTitle,
 	PreserveScrollInReorder,
 } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -69,7 +68,6 @@ function Layout( {
 	};
 	return (
 		<div className={ className }>
-			<DocumentTitle />
 			<BrowserURL />
 			<UnsavedChangesWarning forceIsDirty={ () => {
 				return some( metaBoxes, ( metaBox, location ) => {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -175,6 +175,8 @@ function gutenberg_pre_init() {
  * @return bool   Whether Gutenberg was initialized.
  */
 function gutenberg_init( $return, $post ) {
+	global $title, $post_type;
+
 	if ( true === $return && current_filter() === 'replace_editor' ) {
 		return $return;
 	}
@@ -186,6 +188,16 @@ function gutenberg_init( $return, $post ) {
 	add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );
 	add_filter( 'screen_options_show_screen', '__return_false' );
 	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
+
+	$post_type_object = get_post_type_object( $post_type );
+	/**
+	 * Always force <title> to 'Edit Post' (or equivalent)
+	 * because it needs to be in a generic state for both
+	 * post-new.php and post.php?post=<id>.
+	 */
+	if ( ! empty( $post_type_object ) ) {
+		$title = $post_type_object->labels->edit_item;
+	}
 
 	/**
 	 * Remove the emoji script as it is incompatible with both React and any

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -190,6 +190,7 @@ function gutenberg_init( $return, $post ) {
 	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
 
 	$post_type_object = get_post_type_object( $post_type );
+
 	/*
 	 * Always force <title> to 'Edit Post' (or equivalent)
 	 * because it needs to be in a generic state for both

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -190,7 +190,7 @@ function gutenberg_init( $return, $post ) {
 	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
 
 	$post_type_object = get_post_type_object( $post_type );
-	/**
+	/*
 	 * Always force <title> to 'Edit Post' (or equivalent)
 	 * because it needs to be in a generic state for both
 	 * post-new.php and post.php?post=<id>.
@@ -199,7 +199,7 @@ function gutenberg_init( $return, $post ) {
 		$title = $post_type_object->labels->edit_item;
 	}
 
-	/**
+	/*
 	 * Remove the emoji script as it is incompatible with both React and any
 	 * contenteditable fields.
 	 */

--- a/packages/editor/src/components/document-title/index.js
+++ b/packages/editor/src/components/document-title/index.js
@@ -2,30 +2,16 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 class DocumentTitle extends Component {
 	constructor( props ) {
 		super( props );
-		this.originalDocumentTitle = document.title;
-	}
 
-	componentDidMount() {
-		this.setDocumentTitle( this.props.title );
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.title !== this.props.title ) {
-			this.setDocumentTitle( this.props.title );
-		}
-	}
-
-	componentWillUnmount() {
-		document.title = this.originalDocumentTitle;
-	}
-
-	setDocumentTitle( title ) {
-		document.title = title + ' | ' + this.originalDocumentTitle;
+		deprecated( 'DocumentTitle component', {
+			version: '3.8',
+			plugin: 'Gutenberg',
+		} );
 	}
 
 	render() {
@@ -33,6 +19,4 @@ class DocumentTitle extends Component {
 	}
 }
 
-export default withSelect( ( select ) => ( {
-	title: select( 'core/editor' ).getDocumentTitle(),
-} ) )( DocumentTitle );
+export default DocumentTitle;

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -108,6 +108,11 @@ export function isEditedPostDirty( state ) {
  * @return {boolean} Whether new post and unsaved values exist.
  */
 export function isCleanNewPost( state ) {
+	deprecated( 'isCleanNewPost selector', {
+		version: '3.8',
+		plugin: 'Gutenberg',
+	} );
+
 	return ! isEditedPostDirty( state ) && isEditedPostNew( state );
 }
 
@@ -436,11 +441,17 @@ export function isEditedPostBeingScheduled( state ) {
  * @return {string} Document title.
  */
 export function getDocumentTitle( state ) {
+	deprecated( 'getDocumentTitle selector', {
+		version: '3.8',
+		plugin: 'Gutenberg',
+	} );
+
 	let title = getEditedPostAttribute( state, 'title' );
 
 	if ( ! title || ! title.trim() ) {
 		title = isCleanNewPost( state ) ? __( 'New post' ) : __( '(Untitled)' );
 	}
+
 	return title;
 }
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -300,6 +300,9 @@ describe( 'selectors', () => {
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( true );
+			expect( console ).toHaveWarnedWith(
+				'isCleanNewPost selector is deprecated and will be removed from Gutenberg in 3.8.'
+			);
 		} );
 
 		it( 'should return false when the post is not dirty but the post has been saved', () => {
@@ -317,6 +320,9 @@ describe( 'selectors', () => {
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( false );
+			expect( console ).toHaveWarnedWith(
+				'isCleanNewPost selector is deprecated and will be removed from Gutenberg in 3.8.'
+			);
 		} );
 
 		it( 'should return false when the post is dirty but the post has not been saved', () => {
@@ -334,6 +340,9 @@ describe( 'selectors', () => {
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( false );
+			expect( console ).toHaveWarnedWith(
+				'isCleanNewPost selector is deprecated and will be removed from Gutenberg in 3.8.'
+			);
 		} );
 	} );
 
@@ -601,6 +610,9 @@ describe( 'selectors', () => {
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( 'The Title' );
+			expect( console ).toHaveWarnedWith(
+				'getDocumentTitle selector is deprecated and will be removed from Gutenberg in 3.8.'
+			);
 		} );
 
 		it( 'should return current title for edited existing post', () => {
@@ -622,6 +634,9 @@ describe( 'selectors', () => {
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( 'Modified Title' );
+			expect( console ).toHaveWarnedWith(
+				'getDocumentTitle selector is deprecated and will be removed from Gutenberg in 3.8.'
+			);
 		} );
 
 		it( 'should return new post title when new post is clean', () => {
@@ -645,6 +660,9 @@ describe( 'selectors', () => {
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( __( 'New post' ) );
+			expect( console ).toHaveWarnedWith(
+				'getDocumentTitle selector is deprecated and will be removed from Gutenberg in 3.8.'
+			);
 		} );
 
 		it( 'should return untitled title', () => {
@@ -668,6 +686,9 @@ describe( 'selectors', () => {
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( __( '(Untitled)' ) );
+			expect( console ).toHaveWarnedWith(
+				'getDocumentTitle selector is deprecated and will be removed from Gutenberg in 3.8.'
+			);
 		} );
 	} );
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -6,7 +6,6 @@ import { filter, property, without } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { moment } from '@wordpress/date';
 
@@ -21,14 +20,12 @@ const {
 	hasEditorRedo,
 	isEditedPostNew,
 	isEditedPostDirty,
-	isCleanNewPost,
 	getCurrentPost,
 	getCurrentPostId,
 	getCurrentPostLastRevisionId,
 	getCurrentPostRevisionsCount,
 	getCurrentPostType,
 	getPostEdits,
-	getDocumentTitle,
 	getEditedPostVisibility,
 	isCurrentPostPending,
 	isCurrentPostPublished,
@@ -284,68 +281,6 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isCleanNewPost', () => {
-		it( 'should return true when the post is not dirty and has not been saved before', () => {
-			const state = {
-				editor: {
-					isDirty: false,
-				},
-				currentPost: {
-					id: 1,
-					status: 'auto-draft',
-				},
-				saving: {
-					requesting: false,
-				},
-			};
-
-			expect( isCleanNewPost( state ) ).toBe( true );
-			expect( console ).toHaveWarnedWith(
-				'isCleanNewPost selector is deprecated and will be removed from Gutenberg in 3.8.'
-			);
-		} );
-
-		it( 'should return false when the post is not dirty but the post has been saved', () => {
-			const state = {
-				editor: {
-					isDirty: false,
-				},
-				currentPost: {
-					id: 1,
-					status: 'draft',
-				},
-				saving: {
-					requesting: false,
-				},
-			};
-
-			expect( isCleanNewPost( state ) ).toBe( false );
-			expect( console ).toHaveWarnedWith(
-				'isCleanNewPost selector is deprecated and will be removed from Gutenberg in 3.8.'
-			);
-		} );
-
-		it( 'should return false when the post is dirty but the post has not been saved', () => {
-			const state = {
-				editor: {
-					isDirty: true,
-				},
-				currentPost: {
-					id: 1,
-					status: 'auto-draft',
-				},
-				saving: {
-					requesting: false,
-				},
-			};
-
-			expect( isCleanNewPost( state ) ).toBe( false );
-			expect( console ).toHaveWarnedWith(
-				'isCleanNewPost selector is deprecated and will be removed from Gutenberg in 3.8.'
-			);
-		} );
-	} );
-
 	describe( 'getCurrentPost', () => {
 		it( 'should return the current post', () => {
 			const state = {
@@ -586,109 +521,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPostEdits( state ) ).toEqual( { title: 'terga' } );
-		} );
-	} );
-
-	describe( 'getDocumentTitle', () => {
-		it( 'should return current title unedited existing post', () => {
-			const state = {
-				currentPost: {
-					id: 123,
-					title: 'The Title',
-				},
-				editor: {
-					present: {
-						edits: {},
-						blocksByClientId: {},
-						blockOrder: {},
-					},
-					isDirty: false,
-				},
-				saving: {
-					requesting: false,
-				},
-			};
-
-			expect( getDocumentTitle( state ) ).toBe( 'The Title' );
-			expect( console ).toHaveWarnedWith(
-				'getDocumentTitle selector is deprecated and will be removed from Gutenberg in 3.8.'
-			);
-		} );
-
-		it( 'should return current title for edited existing post', () => {
-			const state = {
-				currentPost: {
-					id: 123,
-					title: 'The Title',
-				},
-				editor: {
-					present: {
-						edits: {
-							title: 'Modified Title',
-						},
-					},
-				},
-				saving: {
-					requesting: false,
-				},
-			};
-
-			expect( getDocumentTitle( state ) ).toBe( 'Modified Title' );
-			expect( console ).toHaveWarnedWith(
-				'getDocumentTitle selector is deprecated and will be removed from Gutenberg in 3.8.'
-			);
-		} );
-
-		it( 'should return new post title when new post is clean', () => {
-			const state = {
-				currentPost: {
-					id: 1,
-					status: 'auto-draft',
-					title: '',
-				},
-				editor: {
-					present: {
-						edits: {},
-						blocksByClientId: {},
-						blockOrder: {},
-					},
-					isDirty: false,
-				},
-				saving: {
-					requesting: false,
-				},
-			};
-
-			expect( getDocumentTitle( state ) ).toBe( __( 'New post' ) );
-			expect( console ).toHaveWarnedWith(
-				'getDocumentTitle selector is deprecated and will be removed from Gutenberg in 3.8.'
-			);
-		} );
-
-		it( 'should return untitled title', () => {
-			const state = {
-				currentPost: {
-					id: 123,
-					status: 'draft',
-					title: '',
-				},
-				editor: {
-					present: {
-						edits: {},
-						blocksByClientId: {},
-						blockOrder: {},
-					},
-					isDirty: true,
-				},
-				saving: {
-					requesting: false,
-				},
-			};
-
-			expect( getDocumentTitle( state ) ).toBe( __( '(Untitled)' ) );
-			expect( console ).toHaveWarnedWith(
-				'getDocumentTitle selector is deprecated and will be removed from Gutenberg in 3.8.'
-			);
 		} );
 	} );
 


### PR DESCRIPTION
Closes #3702

This pull request seeks to deprecate the `DocumentTitle` component and remove its current usage in the editor. This component exists to update the browser tab title on changes to the post's title. With these changes, the title rendered by the server will be used, and will not be manipulated client-side.

**Testing instructions:**

Verify that there are no title changes which occur client-side.

Ensure the title from the server is correct "Edit Post ‹ Site Title — WordPress"