### PR TITLE
Fix unhandled error dialog styling

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -1029,3 +1029,23 @@
 		}
 	}
 }
+
+.editor-block-list__block .editor-warning {
+	z-index: z-index(".editor-warning");
+	position: absolute;
+	top: -$block-padding - $border-width;
+	right: -$parent-block-padding - $border-width;
+	left: -$parent-block-padding - $border-width;
+
+	// Position for nested blocks
+	.editor-block-list__block & {
+		right: -$block-padding - $border-width;
+		left: -$block-padding - $border-width;
+	}
+
+	// Bigger padding on mobile where blocks are edge to edge.
+	padding: 10px $parent-block-padding;
+	@include break-small() {
+		padding: 10px $block-padding;
+	}
+}

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -50,6 +50,7 @@ class ErrorBoundary extends Component {
 
 		return (
 			<Warning
+				className="editor-error-boundary"
 				actions={ [
 					<Button key="recovery" onClick={ this.reboot } isLarge>
 						{ __( 'Attempt Recovery' ) }

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -1,0 +1,8 @@
+.editor-error-boundary {
+	max-width: $content-width;
+	margin: auto;
+	max-width: 780px;
+	padding: 20px;
+	margin-top: 60px;
+	box-shadow: $shadow-modal;
+}

--- a/packages/editor/src/components/warning/index.js
+++ b/packages/editor/src/components/warning/index.js
@@ -1,11 +1,16 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Children } from '@wordpress/element';
 
-function Warning( { actions, children } ) {
+function Warning( { className, actions, children } ) {
 	return (
-		<div className="editor-warning">
+		<div className={ classnames( className, 'editor-warning' ) }>
 			<div className="editor-warning__contents">
 				<p className="editor-warning__message">{ children }</p>
 

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -1,16 +1,4 @@
-.editor-block-list__block .editor-warning {
-	z-index: z-index(".editor-warning");
-	position: absolute;
-	top: -$block-padding - $border-width;
-	right: -$parent-block-padding - $border-width;
-	left: -$parent-block-padding - $border-width;
-
-	// Position for nested blocks
-	.editor-block-list__block & {
-		right: -$block-padding - $border-width;
-		left: -$block-padding - $border-width;
-	}
-
+.editor-warning {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -18,18 +6,12 @@
 	background-color: $white;
 	border: $border-width solid $light-gray-500;
 	text-align: left;
-
-	// Bigger padding on mobile where blocks are edge to edge.
-	padding: $block-padding $parent-block-padding 0 $parent-block-padding;
-	@include break-small() {
-		padding: $block-padding $block-padding 0 $block-padding;
-	}
+	padding: 20px;
 
 	.editor-warning__message {
 		line-height: $default-line-height;
 		font-family: $default-font;
 		font-size: $default-font-size;
-		margin: 0 0 $block-padding 0;
 	}
 
 	.editor-warning__contents {
@@ -43,7 +25,6 @@
 
 	.editor-warning__actions {
 		display: flex;
-		margin: 0 0 $block-padding 0;
 	}
 
 	.editor-warning__action {

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -14,6 +14,7 @@
 @import "./components/contrast-checker/style.scss";
 @import "./components/default-block-appender/style.scss";
 @import "./components/document-outline/style.scss";
+@import "./components/error-boundary/style.scss";
 @import "./components/inner-blocks/style.scss";
 @import "./components/inserter-with-shortcuts/style.scss";
 @import "./components/inserter/style.scss";


### PR DESCRIPTION
closes #8677

This doesn't restore the old styling entirely but it fixes it by moving all the opiniated styles out of the generic Warning components, that way the block warnings are customized in the block context, and the global warning in the global context.

<img width="1680" alt="screen shot 2018-08-10 at 14 45 39" src="https://user-images.githubusercontent.com/272444/43961572-3ce95500-9cad-11e8-8e89-9e0f077d63c1.png">

<img width="794" alt="screen shot 2018-08-10 at 14 54 57" src="https://user-images.githubusercontent.com/272444/43961626-686c3f80-9cad-11e8-9252-9ed5ec28a5d6.png">

