### PR TITLE
Apply new checkbox CSS to radio buttons and fix border radius

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -206,7 +206,7 @@ body.gutenberg-editor-page {
 	}
 
 	input[type="radio"] {
-		border-radius: 50%;
+		border-radius: $radius-round;
 
 		&::before {
 			margin: 3px 0 0 3px;

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -175,9 +175,9 @@ body.gutenberg-editor-page {
 		}
 	}
 
-	input[type="checkbox"] {
+	input[type="checkbox"],
+	input[type="radio"] {
 		border: $border-width + 1 solid $dark-gray-300;
-		border-radius: $radius-round-rectangle / 2;
 		margin-right: 12px;
 		transition: none;
 
@@ -194,10 +194,23 @@ body.gutenberg-editor-page {
 		&:checked:focus {
 			box-shadow: 0 0 0 2px $dark-gray-500;
 		}
+	}
+
+	input[type="checkbox"] {
+		border-radius: $radius-round-rectangle / 2;
 
 		&::before {
 			margin: -4px 0 0 -5px;
 			color: $white;
+		}
+	}
+
+	input[type="radio"] {
+		border-radius: 50%;
+
+		&::before {
+			margin: 3px 0 0 3px;
+			background-color: $white;
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR applies the new checkbox styles from #8588 to radio buttons, and fixes a regression with the radio input border-radius caused by #8385.

Fixes #8833.

## How has this been tested?
Visual testing

## Screenshots
Before:
![_untitled____ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/43962993-c1f2777e-9c7e-11e8-879e-9cbe4cdb2c88.png)

After:
![_untitled____ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/43962932-91f51ebe-9c7e-11e8-84dd-721e7c20fb49.png)


## Types of changes
Visual, non-breaking CSS changes

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->