### PR TITLE
Add a delay to the blue outline + block type label on hover

### DIFF
--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -7,6 +7,15 @@
 	}
 }
 
+@keyframes outline-fade-in {
+	from {
+		outline: $border-width solid $dark-opacity-light-500;
+	}
+	to {
+		outline: $border-width solid theme(outlines);
+	}
+}
+
 @mixin animate_fade {
 	animation: animate_fade 0.1s ease-out;
 	animation-fill-mode: forwards;
@@ -26,8 +35,13 @@
 	animation: slide_in_right 0.1s forwards;
 }
 
-@mixin fade_in($speed: 0.2s) {
-	animation: fade-in $speed ease-out;
+@mixin fade_in($speed: 0.2s, $delay: 0s) {
+	animation: fade-in $speed ease-out $delay;
+	animation-fill-mode: forwards;
+}
+
+@mixin outline_fade_in($speed: 0.2s, $delay: 0s) {
+	animation: outline-fade-in $speed ease-out $delay;
 	animation-fill-mode: forwards;
 }
 

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -195,7 +195,6 @@
 			content: "";
 			position: absolute;
 			outline: $border-width solid transparent;
-			transition: outline 0.1s linear;
 			pointer-events: none;
 
 			// Show wider padding for top level blocks.
@@ -233,7 +232,8 @@
 
 	// Hover style
 	&.is-hovered > .editor-block-list__block-edit::before {
-		outline: $border-width solid theme(outlines);
+		@include outline_fade_in(0.1s, 1s);
+		outline: $border-width solid $dark-opacity-light-500;
 	}
 }
 
@@ -983,7 +983,8 @@
 
 		// Animate in
 		.editor-block-list__block:hover & {
-			@include fade_in(0.1s);
+			opacity: 0;
+			@include fade_in(0.1s, 1s);
 		}
 	}
 }

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -47,7 +47,8 @@
 	}
 
 	.editor-post-title__input:hover {
-		border-color: theme(outlines);
+		@include outline_fade_in(0.1s, 1s);
+		outline: $border-width solid $dark-opacity-light-500;
 	}
 }
 


### PR DESCRIPTION
## Description

Currently, if you move your mouse around a Gutenberg document, each block will quickly present you with a dark blue outline and text label:

<img width="649" alt="screen shot 2018-08-10 at 10 15 55 am" src="https://user-images.githubusercontent.com/1202812/43962717-62d12206-9c86-11e8-9fe5-3ad5be8cdd56.png">

As noted in #8524, this can get jarring when you're just casually moving your mouse around the document. Additionally, I've wondered if that text label is a case of Gutenberg going to a little too far to answer a question the user hasn’t asked yet: "What type of block is this?" 

Small, prominent UI elements like these contribute to an overall "heaviness" in the UI of Gutenberg. Especially when they're repeated on every block — these bits of UI add up quickly. 

I'd propose adding a slight delay to the blue border + breadcrumb. This PR shows the user a light gray outline immediately, but transitions to the dark blue outline + label if the pointer lingers for a bit longer. This accomplishes a few things: 

- Eliminates the "flashing" of heavy UI when a user moves their mouse through their document.
- Helps lighten the editing experience by lessening the appearance of a repetitive, heavy UI element. 
- Shows the label only when a user has made a more deliberate action (a slightly longer hover)

It does that without sacrificing discoverability of the label — the delay is short enough that the user is likely to trigger it during normal usage. They'll still know it exists. 

## How has this been tested?

Mac OS 10.13.6, in Chrome 68.0.3440.106 + Firefox 61.0.2
iOS 11.4, in Safari (This PR has no effect on iOS, but I checked to be safe. 🙂)

## Screenshots

Current: 

![current-outline-label](https://user-images.githubusercontent.com/1202812/43962566-0a2e40de-9c86-11e8-9829-e68230f852f3.gif)

Proposed:

![outline-label](https://user-images.githubusercontent.com/1202812/43962587-1dcd4482-9c86-11e8-8c09-95f185f7debc.gif)