### PR TITLE
IE11: Fix default appender placeholder

### DIFF
--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -2,7 +2,6 @@
 	position: relative;
 	padding: 50px 0;
 
-	input[type="text"].editor-default-block-appender__content, // The default appender should match a single paragraph. Needs specificity.
 	&,
 	& p {
 		font-family: $editor-font;

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -1,5 +1,7 @@
 .editor-default-block-appender {
 	input[type="text"].editor-default-block-appender__content { // needs specificity
+		font-family: $editor-font;
+		font-size: $editor-font-size; // It should match the default paragraph size
 		border: none;
 		background: none;
 		box-shadow: none;


### PR DESCRIPTION
closes #8654 

 It looks like the line-height for inputs in IE11 is causing issues like this: The placeholder getting clipped on the bottom.

**Testing instructions**

 - Make sure the "Write Store" placeholder shows up properly in different browsers.