### PR TITLE
Fix the heading level buttons in IE11

### DIFF
--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -67,8 +67,9 @@ div.components-toolbar {
 
 	& > svg {
 		padding: 5px;
-		box-sizing: content-box;
 		border-radius: $radius-round-rectangle;
+		height: 30px;
+		width: 30px;
 	}
 
 	// Subscript for numbered icon buttons, like headings
@@ -81,9 +82,10 @@ div.components-toolbar {
 		font-family: $default-font;
 		font-size: $default-font-size;
 		font-weight: 600;
+		line-height: 12px;
 		position: absolute;
-		right: 8px;
-		bottom: 8px;
+		right: 7px;
+		bottom: 9px;
 	}
 
 	// Assign hover style to child element, not the button itself

--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -74,7 +74,7 @@ div.components-toolbar {
 
 	// Subscript for numbered icon buttons, like headings
 	&[data-subscript] svg {
-		padding: 4px 8px 4px 0;
+		padding: 5px 10px 5px 0;
 	}
 
 	&[data-subscript]::after {
@@ -84,8 +84,8 @@ div.components-toolbar {
 		font-weight: 600;
 		line-height: 12px;
 		position: absolute;
-		right: 7px;
-		bottom: 9px;
+		right: 8px;
+		bottom: 10px;
 	}
 
 	// Assign hover style to child element, not the button itself

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -826,7 +826,7 @@
 
 	// Position toolbar below the block on mobile.
 	position: absolute;
-	bottom: $block-toolbar-height - $block-padding;
+	bottom: $block-toolbar-height - $block-padding - 1px;
 	left: 0;
 	right: 0;
 

--- a/packages/editor/src/components/block-toolbar/style.scss
+++ b/packages/editor/src/components/block-toolbar/style.scss
@@ -1,5 +1,5 @@
 .editor-block-toolbar {
-	display: inline-flex;
+	display: flex;
 	flex-grow: 1;
 	width: 100%;
 	overflow: auto; // Allow horizontal scrolling on mobile.


### PR DESCRIPTION
closes #8656

Fix the heading button levels in IE11

 - The `box-sizing: content-box` is not working as expected in iE11, I used fixed sizes instead.
 - The line height of the `:after` element was different between browsers, I fixed it to make sure the "numbers" show up at the right position

