### PR TITLE
Updates docs for templateLock's `insert` option

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -67,7 +67,7 @@ Sometimes the intention might be to lock the template on the UI so that the bloc
 *Options:*
 
 - `all` — prevents all operations. It is not possible to insert new blocks, move existing blocks, or delete blocks.
-- `insert` — prevents inserting new blocks, but allows moving or removing existing blocks.
+- `insert` — prevents inserting or removing blocks, but allows moving existing blocks.
 
 ## Existing Post Types
 

--- a/packages/editor/src/components/inner-blocks/README.md
+++ b/packages/editor/src/components/inner-blocks/README.md
@@ -46,6 +46,7 @@ _Note:_ Because the save step will automatically apply props to the element retu
 * **Type:** `Array<String>`
 
 Allowed blocks prop should contain an array of strings, each string should contain the identifier of a block. When allowedBlocks is set it is only possible to insert blocks part of the set specified in the array.
+
 ```jsx
 const ALLOWED_BLOCKS = [ 'core/image', 'core/paragraph' ];
 ...
@@ -53,6 +54,7 @@ const ALLOWED_BLOCKS = [ 'core/image', 'core/paragraph' ];
     allowedBlocks={ ALLOWED_BLOCKS }
 />
 ```
+
 The previous code block creates an `InnerBlocks` area where only image and paragraph blocks can be inserted.
 
 Child blocks that have marked themselves as compatible are not excluded from the allowed blocks. Even if `allowedBlocks` doesn't specify a child block, a registered child block will still appear on the inserter for this block.
@@ -64,6 +66,7 @@ const ALLOWED_BLOCKS = [];
     allowedBlocks={ ALLOWED_BLOCKS }
 />
 ```
+
 The previous code block restricts all blocks, so only child blocks explicitly registered as compatible with this block can be inserted. If no child blocks are available: it will be impossible to insert any inner blocks.
 
 ### `template`
@@ -86,6 +89,7 @@ const TEMPLATE = [ [ 'core/columns', {}, [
     template={ TEMPLATE }
 />
 ```
+
 The previous example creates an InnerBlocks area containing two columns one with an image and the other with a paragraph.
 
 ### `templateLock`
@@ -97,7 +101,7 @@ Template locking allows locking the `InnerBlocks` area for the current template.
 *Options:*
 
 - `all` — prevents all operations. It is not possible to insert new blocks. Move existing blocks or delete them.
-- `insert` — prevents inserting new blocks, but allows moving or removing existing ones.
+- `insert` — prevents inserting or removing blocks, but allows moving existing ones.
 - `false` — prevents locking from being applied to an `InnerBlocks` area even if a parent block contains locking.
 
 If locking is not set in an `InnerBlocks` area: the locking of the parent `InnerBlocks` area is used.


### PR DESCRIPTION
## Description
`templateLock` now correctly locks deletion (not sure exactly when this happened, but the logic is [correct here](https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/block-settings-menu/index.js#L194)) but the docs weren't updated to reflect this change. This fixes that.

## How has this been tested?
Tested by reading the docs

## Types of changes
Updates documentation

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->