### PR TITLE
[Fix] Make sure Latest Posts alignment class behaviour

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -47,7 +47,11 @@ function render_block_core_latest_posts( $attributes ) {
 		$list_items_markup .= "</li>\n";
 	}
 
-	$class = "wp-block-latest-posts align{$attributes['align']}";
+	$class = 'wp-block-latest-posts';
+	if ( isset( $attributes['align'] ) ) {
+		$class .= ' align' . $attributes['align'];
+	}
+
 	if ( isset( $attributes['postLayout'] ) && 'grid' === $attributes['postLayout'] ) {
 		$class .= ' is-grid';
 	}
@@ -99,7 +103,6 @@ function register_block_core_latest_posts() {
 			),
 			'align'           => array(
 				'type'    => 'string',
-				'default' => 'center',
 			),
 			'order'           => array(
 				'type'    => 'string',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -102,7 +102,7 @@ function register_block_core_latest_posts() {
 				'default' => 3,
 			),
 			'align'           => array(
-				'type'    => 'string',
+				'type' => 'string',
 			),
 			'order'           => array(
 				'type'    => 'string',


### PR DESCRIPTION
## Description
This PR closes #7911 which reports the incorrect behavior of the alignment classes in the Latest Posts block, where it applies alignment classes even if no alignment was selected. It also gets rids of the behavior where the center alignment is selected by default.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the Latest Post block.
3. Selected the center alignment option in the block toolbar.
4. Deselected the center alignment option in the block toolbar.
5. Published the post and made sure no alignment classes are added to the block, as the alignment was deselected.

This was tested in WP 4.9.8, Gutenberg 3.5.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-7911-min](https://user-images.githubusercontent.com/20284937/43970280-e7859e88-9cee-11e8-88cd-cb4ecd6c145f.gif)

## Types of changes
This PR introduces a conditional before applying the alignment classes to make sure an alignment is selected in the first place. It also removes the `default` property from the `align` attribute, so that the center alignment isn't selected and applied by default.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
