### PR TITLE
Ensure meta box functions are available in Gutenberg context

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -193,6 +193,12 @@ function gutenberg_init( $return, $post ) {
 	 */
 	remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 
+	/*
+	 * Ensure meta box functions are available to third-party code;
+	 * includes/meta-boxes is typically loaded from edit-form-advanced.php.
+	 */
+	require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
+
 	require_once ABSPATH . 'wp-admin/admin-header.php';
 	the_gutenberg_project();
 


### PR DESCRIPTION
## Description

Loads `wp-admin/includes/meta-boxes.php` inside of `gutenberg_init()` to ensure functions like `post_thumbnail_meta_box()` are available to third-party code. `wp-admin/includes/meta-boxes.php` is normally loaded in `edit-form-advanced.php`, but Gutenberg doesn't execute that far because of the `replace_editor` filter.

Fixes #7789

## How has this been tested?

See reproduction steps in #7789. With this pull request, the warnings are resolved and the meta boxes load as expected.

## Screenshots

Before:

<img width="895" alt="image" src="https://user-images.githubusercontent.com/36432/43972801-77295c1a-9c8a-11e8-9750-eacfe6f8c8d3.png">

After:

<img width="922" alt="image" src="https://user-images.githubusercontent.com/36432/43972787-69eca944-9c8a-11e8-951b-2829ae350ee8.png">


## Types of changes

Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
