### PR TITLE
Color palette: clear the floating link that clears color

### DIFF
--- a/packages/editor/src/components/color-palette/control.scss
+++ b/packages/editor/src/components/color-palette/control.scss
@@ -1,4 +1,4 @@
 .editor-color-palette-control__color-palette {
+	display: inline-block;
 	margin-top: 0.6rem;
-	margin-bottom: 1.4rem;
 }


### PR DESCRIPTION
## Description

This PR seeks to solve a layout issue with the color palette: the last element in the palette is the Clear link that resets the color, and it's floated, thus causing some collapsing in the container since it's not cleared. This PR solves the layout issue and the dimensions of the container are correctly rendered. With this clear, the bottom margin is no longer necessary.

<!-- Please describe what you have changed or added -->

## How has this been tested?
Can be inspected using Dev Tools

## Screenshots <!-- if applicable -->

### Before

<img width="285" alt="captura de pantalla 2018-08-11 a la s 01 53 48" src="https://user-images.githubusercontent.com/1041600/43993947-45780cf2-9d6b-11e8-8a7c-1da7f7c5f144.png">

### After

<img width="288" alt="captura de pantalla 2018-08-11 a la s 01 53 23" src="https://user-images.githubusercontent.com/1041600/43993949-496ca746-9d6b-11e8-8096-7a7b526629ce.png">

Note that the overflowing color dialog is not affected by this change 👍
<img width="276" alt="captura de pantalla 2018-08-11 a la s 13 45 45" src="https://user-images.githubusercontent.com/1041600/43994049-ed58a412-9d6c-11e8-9b98-dd7a5db43684.png">

## Types of changes
Sets the display for the color swatches and Clear link container to `inline-block` to properly clear the float without affecting its inner elements.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->