### PR TITLE
Color palette: make the Clear link consistent with buttons in other settings

### DIFF
--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -84,7 +84,9 @@ export default function ColorPalette( { colors, disableCustomColors = false, val
 				className="components-color-palette__clear"
 				type="button"
 				onClick={ () => onChange( undefined ) }
-				isLink
+				isButton
+				isSmall
+				isDefault
 			>
 				{ __( 'Clear' ) }
 			</Button>

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -127,7 +127,9 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
   </div>
   <Button
     className="components-color-palette__clear"
-    isLink={true}
+    isButton={true}
+    isDefault={true}
+    isSmall={true}
     onClick={[Function]}
     type="button"
   >
@@ -211,7 +213,9 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   />
   <Button
     className="components-color-palette__clear"
-    isLink={true}
+    isButton={true}
+    isDefault={true}
+    isSmall={true}
     onClick={[Function]}
     type="button"
   >


### PR DESCRIPTION
This PR updates the Clear link in the color palette to make it consistent with similar actionable elements found in other panels like the Reset buttons in Text Settings:

<img width="267" alt="captura de pantalla 2018-08-11 a la s 13 38 17" src="https://user-images.githubusercontent.com/1041600/43994157-9984951a-9d6e-11e8-8b37-6d3d65dfd63e.png">

or the Image Settings panel:

<img width="269" alt="captura de pantalla 2018-08-11 a la s 13 38 10" src="https://user-images.githubusercontent.com/1041600/43994158-9bf5efc4-9d6e-11e8-987b-16f72142c3c3.png">

## Description
This PR converts the link into a small default button.

## How has this been tested?
Tested manually

## Screenshots <!-- if applicable -->

### Before

<img width="277" alt="captura de pantalla 2018-08-11 a la s 13 40 20" src="https://user-images.githubusercontent.com/1041600/43994168-def5e4f0-9d6e-11e8-9682-8419ecfbdff0.png">

### After

<img width="278" alt="captura de pantalla 2018-08-11 a la s 13 40 04" src="https://user-images.githubusercontent.com/1041600/43994171-e3018a7c-9d6e-11e8-9b73-05a655b7d358.png">

## Types of changes
Several attributes are set for the Button component so it's rendered as a small button.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
