### PR TITLE
TinyMCE: Clean TinyMCE internal DOM state on blur

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -15,7 +15,7 @@ import { BACKSPACE, DELETE } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { diffAriaProps, pickAriaProps } from './aria';
-import { valueToString } from './format';
+import { valueToString, domToFormat } from './format';
 
 /**
  * Determines whether we need a fix to provide `input` events for contenteditable.
@@ -96,10 +96,13 @@ function applyInternetExplorerInputFix( editorNode ) {
 }
 
 const IS_PLACEHOLDER_VISIBLE_ATTR_NAME = 'data-is-placeholder-visible';
+
 export default class TinyMCE extends Component {
 	constructor() {
-		super();
+		super( ...arguments );
+
 		this.bindEditorNode = this.bindEditorNode.bind( this );
+		this.resetDOMState = this.resetDOMState.bind( this );
 	}
 
 	componentDidMount() {
@@ -147,6 +150,15 @@ export default class TinyMCE extends Component {
 		if ( this.editorNode.getAttribute( IS_PLACEHOLDER_VISIBLE_ATTR_NAME ) !== isPlaceholderVisibleString ) {
 			this.editorNode.setAttribute( IS_PLACEHOLDER_VISIBLE_ATTR_NAME, isPlaceholderVisibleString );
 		}
+	}
+
+	resetDOMState() {
+		const cleanFragment = domToFormat( this.editorNode.childNodes, 'dom' );
+		while ( this.editorNode.firstChild ) {
+			this.editorNode.removeChild( this.editorNode.firstChild );
+		}
+
+		this.editorNode.appendChild( cleanFragment );
 	}
 
 	initialize() {
@@ -215,6 +227,7 @@ export default class TinyMCE extends Component {
 			...ariaProps,
 			className: classnames( className, 'editor-rich-text__tinymce' ),
 			contentEditable: true,
+			onBlur: this.resetDOMState,
 			[ IS_PLACEHOLDER_VISIBLE_ATTR_NAME ]: isPlaceholderVisible,
 			ref: this.bindEditorNode,
 			style,

--- a/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/test/e2e/specs/__snapshots__/splitting-merging.test.js.snap
@@ -79,3 +79,13 @@ exports[`splitting and merging blocks should split and merge paragraph blocks us
 <p>BeforeSecond:Second</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`splitting and merging blocks should split without inline formatting 1`] = `
+"<!-- wp:paragraph -->
+<p><strong>Foo</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Bar</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -171,4 +171,17 @@ describe( 'splitting and merging blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should split without inline formatting', async () => {
+		// Regression test: Previously, splitting while at the extent of an
+		// inline boundary and continuing to type would revert caret position
+		// back inside the inline boundary.
+		await insertBlock( 'Paragraph' );
+		await pressWithModifier( META_KEY, 'b' );
+		await page.keyboard.type( 'Foo' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Bar' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -108,9 +108,9 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.type( 'After' );
 
-		// Arrow right from end of first should traverse to second, *BEFORE*
-		// the bolded text. Another press should move within inline boundary.
-		await pressTimes( 'ArrowRight', 2 );
+		// Arrow right from end of first should traverse to second, inside the
+		// bolded text.
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'Inside' );
 
 		// Arrow left from end of beginning of inline boundary should move to
@@ -131,7 +131,8 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'ArrowLeft' );
 
-		// Should be after the inline boundary again.
+		// Should be inside the inline boundary, so navigate out.
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'After' );
 
 		// Finally, ensure that ArrowRight from end of unbolded text moves to


### PR DESCRIPTION
Fixes #8877 

*In Progress:* Still needs unit tests, documentation, and evaluation of whether this is the best approach. Other options include calling `setContent` from `RichText` to just replace the content, though this may be more intensive since it requires TinyMCE to re-parse. There may be room for improvement to refactor shared behaviors between "dom" and "content" formats in `formats.js`. Also not sure we want to expose this as a proper format for RichText.

This pull request seeks to resolve an issue where lingering TinyMCE DOM state when a RichText field is blurred can occasionally cause forced re-focuses.

**Testing instructions:**

Repeat steps to reproduce from #8877, verifying that caret placement occurs as expected.

Ensure end-to-end tests pass:

```
npm run test-e2e
```