### PR TITLE
Text settings: add a tooltip to the font size selector buttons 

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -15,23 +15,45 @@ import { __ } from '@wordpress/i18n';
 import Button from '../button';
 import ButtonGroup from '../button-group';
 import RangeControl from '../range-control';
+import Tooltip from '../tooltip';
+
+/**
+ * If short and long font size names are available, render using the short name and add the tooltip using the long name.
+ * If only short or long names but not their counterparts are provided, render them using only what is provided.
+ *
+ * @param {string}   label    Font size name, can be long, Small, or short, S.
+ * @param {string}   value    Current font size.
+ * @param {string}   size     Font size that this button sets.
+ * @param {function} onChange Method that sets the font to the specified size.
+ *
+ * @return {Element} Element with name with tooltip.
+ */
+const fontSize = ( label, value, size, onChange ) => {
+	return (
+		<Button
+			key={ size }
+			isLarge
+			isPrimary={ value === size }
+			aria-pressed={ value === size }
+			onClick={ () => onChange( size ) }
+		>
+			{ label }
+		</Button>
+	);
+};
 
 export default function FontSizePicker( { fontSizes = [], fallbackFontSize, value, onChange } ) {
 	return (
 		<Fragment>
 			<div className="components-font-size-picker__buttons">
 				<ButtonGroup aria-label={ __( 'Font Size' ) }>
-					{ map( fontSizes, ( { name, size, shortName } ) => (
-						<Button
-							key={ size }
-							isLarge
-							isPrimary={ value === size }
-							aria-pressed={ value === size }
-							onClick={ () => onChange( size ) }
-						>
-							{ shortName || name }
-						</Button>
-					) ) }
+					{
+						map( fontSizes, ( { name, size, shortName } ) => shortName && name ? (
+							<Tooltip text={ <div className="components-font-size-picker__name">{ name }</div> }>
+								{ fontSize( shortName, value, size, onChange ) }
+							</Tooltip>
+						) : fontSize( shortName || name, value, size, onChange ) )
+					}
 				</ButtonGroup>
 				<Button
 					isLarge

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -10,3 +10,7 @@
 		height: 30px;
 	}
 }
+
+.components-font-size-picker__name::first-letter {
+	text-transform: uppercase;
+}


### PR DESCRIPTION
This PR makes the font size buttons more clear by adding a tooltip when the short identifier, for example `S` or `M`, is used as the button label.

## Description
Adds a tooltip when the short font size name is used as the button label.

## How has this been tested?
Built and manually tested.

## Screenshots <!-- if applicable -->

<img width="187" alt="captura de pantalla 2018-08-11 a la s 20 43 17" src="https://user-images.githubusercontent.com/1041600/43997193-879ff352-9dab-11e8-8360-36bdd2ae6e1d.png">

## Types of changes
Imports Tooltip component and uses it to wrap the Button component for each font size name when the label used is the short font size name.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->