### PR TITLE
Added audio block creation by dropping

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -16,7 +16,9 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	RichText,
+	editorMediaUpload,
 } from '@wordpress/editor';
+import { getBlobByURL } from '@wordpress/blob';
 
 class AudioEdit extends Component {
 	constructor() {
@@ -29,6 +31,27 @@ class AudioEdit extends Component {
 
 		this.toggleAttribute = this.toggleAttribute.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
+	}
+
+	componentDidMount() {
+		const { attributes, noticeOperations, setAttributes } = this.props;
+		const { id, src = '' } = attributes;
+		if ( ! id && src.indexOf( 'blob:' ) === 0 ) {
+			const file = getBlobByURL( src );
+			if ( file ) {
+				editorMediaUpload( {
+					filesList: [ file ],
+					onFileChange: ( [ { url } ] ) => {
+						setAttributes( { src: url } );
+					},
+					onError: ( message ) => {
+						this.setState( { editing: true } );
+						noticeOperations.createErrorNotice( message );
+					},
+					allowedType: 'audio',
+				} );
+			}
+		}
 	}
 
 	toggleAttribute( attribute ) {

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/editor';
+import { createBlock } from '@wordpress/blocks';
+import { createBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -53,6 +55,27 @@ export const settings = {
 			selector: 'audio',
 			attribute: 'preload',
 		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'files',
+				isMatch( files ) {
+					return files.length === 1 && files[ 0 ].type.indexOf( 'audio/' ) === 0;
+				},
+				transform( files ) {
+					const file = files[ 0 ];
+					// We don't need to upload the media directly here
+					// It's already done as part of the `componentDidMount`
+					// in the audio block
+					const block = createBlock( 'core/audio', {
+						src: createBlobURL( file ),
+					} );
+					return block;
+				},
+			},
+		],
 	},
 
 	supports: {


### PR DESCRIPTION
## Description
Dropping an audio file on an insertion point now creates an Audio Block
instead of a File Block.

Addresses: #8861, #8862, #8863 and #8864 

This was done by adding the corresponding transform for the Audio Block
It supports immediate preview until upload and error handling.

## How has this been tested?
Included tests and manually

## Screenshots <!-- if applicable -->
**Before:**
![dropaudiobefore](https://user-images.githubusercontent.com/3190666/44006113-22cc7e3e-9e44-11e8-840a-59fc36b75d02.gif)

**After:**
![dropaudioafter](https://user-images.githubusercontent.com/3190666/44006104-f190ddba-9e43-11e8-85d8-3c88f41ba05b.gif)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
