### PR TITLE
Popover: Expose refresh method from Dropdown component

### DIFF
--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,6 +15,8 @@ class Dropdown extends Component {
 		this.close = this.close.bind( this );
 		this.clickOutside = this.clickOutside.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
+		this.refresh = this.refresh.bind( this );
+		this.popoverRef = createRef();
 		this.state = {
 			isOpen: false,
 		};
@@ -38,6 +40,17 @@ class Dropdown extends Component {
 
 	bindContainer( ref ) {
 		this.container = ref;
+	}
+
+	/**
+	 * When contents change height due to user interaction,
+	 * `refresh` can be called to re-render Popover with correct
+	 * attributes which allow scroll, if need be.
+	 */
+	refresh() {
+		if ( this.popoverRef.current ) {
+			this.popoverRef.current.refresh();
+		}
 	}
 
 	toggle() {
@@ -76,6 +89,7 @@ class Dropdown extends Component {
 				{ isOpen && (
 					<Popover
 						className={ contentClassName }
+						ref={ this.popoverRef }
 						position={ position }
 						onClose={ this.close }
 						onClickOutside={ this.clickOutside }

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -36,6 +36,7 @@ class Popover extends Component {
 		super( ...arguments );
 
 		this.focus = this.focus.bind( this );
+		this.refresh = this.refresh.bind( this );
 		this.getAnchorRect = this.getAnchorRect.bind( this );
 		this.updatePopoverSize = this.updatePopoverSize.bind( this );
 		this.computePopoverPosition = this.computePopoverPosition.bind( this );


### PR DESCRIPTION
## Description
This PR exposes the `refresh` method on Popover class and applies a `ref` to the Popover within the Dropdown component so that `refresh` method can be accessed.

## Why?
When the contents of the Dropdown component change height due to user interaction inside the Dropdown, the Popover element will not re-calculate the height of the content and the scrollable areas are not accessible. 

This code allows an app using Dropdown to call the Popover's `refresh` method to force a recalculation of content height.

## How has this been tested?
Rendering an instance of the Dropdown component, I can log to the console `this.popoverRef.current` and see the class method `refresh` available.

Corresponding wc-admin issue, https://github.com/woocommerce/wc-admin/issues/252

## Screenshots

I'm not sure why some borders look weird in this gif, but you can see the dropdown panel extend beyond the screen after switching to the Custom tab. The PR allows the dropdown to recalculate height and allow the content to be scrollable

![scroll](https://user-images.githubusercontent.com/1922453/44013574-4f170442-9f1a-11e8-89de-9dc81009b5c3.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue) : This PR exposes a class method that was already there.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
