### PR TITLE
Data Module: Correctly handle per_page=-1 in the queried data state

### DIFF
--- a/edit-post/hooks/components/media-upload/index.js
+++ b/edit-post/hooks/components/media-upload/index.js
@@ -67,7 +67,7 @@ const getAttachmentsCollection = ( ids ) => {
 	return wp.media.query( {
 		order: 'ASC',
 		orderby: 'post__in',
-		perPage: -1,
+		per_page: -1,
 		post__in: ids,
 		query: true,
 		type: 'image',

--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -47,8 +47,10 @@ export function getQueryParts( query ) {
 
 		switch ( key ) {
 			case 'page':
-			case 'perPage':
 				parts[ key ] = Number( value );
+				break;
+			case 'per_page':
+				parts.perPage = Number( value );
 				break;
 
 			default:

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -28,6 +28,7 @@ const queriedItemsCacheByState = new WeakMap();
  */
 function getQueriedItemsUncached( state, query ) {
 	const { stableKey, page, perPage } = getQueryParts( query );
+
 	if ( ! state.queries[ stableKey ] ) {
 		return null;
 	}
@@ -37,8 +38,8 @@ function getQueriedItemsUncached( state, query ) {
 		return null;
 	}
 
-	const startOffset = ( page - 1 ) * perPage;
-	const endOffset = Math.min(
+	const startOffset = perPage === -1 ? 0 : ( page - 1 ) * perPage;
+	const endOffset = perPage === -1 ? itemIds.length : Math.min(
 		startOffset + perPage,
 		itemIds.length
 	);

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -5,7 +5,7 @@ import { getQueryParts } from '../get-query-parts';
 
 describe( 'getQueryParts', () => {
 	it( 'parses out pagination data', () => {
-		const parts = getQueryParts( { page: 2, perPage: 2 } );
+		const parts = getQueryParts( { page: 2, per_page: 2 } );
 
 		expect( parts ).toEqual( {
 			page: 2,
@@ -37,13 +37,23 @@ describe( 'getQueryParts', () => {
 	} );
 
 	it( 'encodes stable string key with page data normalized to number', () => {
-		const first = getQueryParts( { b: 2, page: 1, perPage: 10 } );
-		const second = getQueryParts( { b: 2, page: '1', perPage: '10' } );
+		const first = getQueryParts( { b: 2, page: 1, per_page: 10 } );
+		const second = getQueryParts( { b: 2, page: '1', per_page: '10' } );
 
 		expect( first ).toEqual( second );
 		expect( first ).toEqual( {
 			page: 1,
 			perPage: 10,
+			stableKey: 'b=2',
+		} );
+	} );
+
+	it( 'returns -1 for unlimited queries', () => {
+		const parts = getQueryParts( { b: 2, page: 1, per_page: -1 } );
+
+		expect( parts ).toEqual( {
+			page: 1,
+			perPage: -1,
 			stableKey: 'b=2',
 		} );
 	} );

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -106,7 +106,7 @@ describe( 'reducer', () => {
 		} );
 		const state = reducer( original, {
 			type: 'RECEIVE_ITEMS',
-			query: { s: 'a', page: 1, perPage: 3 },
+			query: { s: 'a', page: 1, per_page: 3 },
 			items: [
 				{ id: 1, name: 'abc' },
 			],


### PR DESCRIPTION
closes #8848

This PR fixes an issue where we were requestion all the data (per_page=-1) but receiving only 10 in the selector.

There are actually two bug fixes here:

 - We were expecting the query to contain a `perPage` argument while it's in reality `per_page`
 - The "unlimited" pagination flag was not being handled properly in the selector and we were always returning 10 elements.

**Testing instructions**

 - Create more than 10 pages
 - Check that the page parent selector shows all the pages properly.