### PR TITLE
Add new Insert Before/After menu items and shortcuts

### DIFF
--- a/edit-post/components/keyboard-shortcut-help-modal/config.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/config.js
@@ -9,7 +9,7 @@ const {
 	primary,
 	// Shift+Cmd+<key> on a mac, Ctrl+Shift+<key> elsewhere
 	primaryShift,
-	// Alt+Cmd+<key> on a mac, Ctrl+Alt+<key> elsewhere
+	// Option+Cmd+<key> on a mac, Ctrl+Alt+<key> elsewhere
 	primaryAlt,
 	// Shift+Alt+Cmd+<key> on a mac, Ctrl+Shift+Akt+<key> elsewhere
 	secondary,
@@ -90,6 +90,14 @@ const blockShortcuts = {
 		{
 			keyCombination: primaryAlt( 'backspace' ),
 			description: __( 'Remove the selected block(s).' ),
+		},
+		{
+			keyCombination: primaryAlt( 't' ),
+			description: __( 'Insert a new block before the selected block(s).' ),
+		},
+		{
+			keyCombination: primaryAlt( 'y' ),
+			description: __( 'Insert a new block after the selected block(s).' ),
 		},
 		{
 			keyCombination: '/',

--- a/edit-post/components/keyboard-shortcut-help-modal/config.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/config.js
@@ -5,15 +5,15 @@ import { displayShortcutList } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 
 const {
-	// Cmd+<key> on a mac, Ctrl+<key> elsewhere
+	// Cmd+<key> on a mac, Ctrl+<key> elsewhere.
 	primary,
-	// Shift+Cmd+<key> on a mac, Ctrl+Shift+<key> elsewhere
+	// Shift+Cmd+<key> on a mac, Ctrl+Shift+<key> elsewhere.
 	primaryShift,
-	// Option+Cmd+<key> on a mac, Ctrl+Alt+<key> elsewhere
+	// Option+Cmd+<key> on a mac, Ctrl+Alt+<key> elsewhere.
 	primaryAlt,
-	// Shift+Alt+Cmd+<key> on a mac, Ctrl+Shift+Akt+<key> elsewhere
+	// Shift+Alt+Cmd+<key> on a mac, Ctrl+Shift+Akt+<key> elsewhere.
 	secondary,
-	// Ctrl+Alt+<key> on a mac, Shift+Alt+<key> elsewhere
+	// Ctrl+Alt+<key> on a mac, Shift+Alt+<key> elsewhere.
 	access,
 	ctrl,
 	ctrlShift,

--- a/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -171,6 +171,26 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
             ],
           },
           Object {
+            "description": "Insert a new block before the selected block(s).",
+            "keyCombination": Array [
+              "Ctrl",
+              "+",
+              "Alt",
+              "+",
+              "T",
+            ],
+          },
+          Object {
+            "description": "Insert a new block after the selected block(s).",
+            "keyCombination": Array [
+              "Ctrl",
+              "+",
+              "Alt",
+              "+",
+              "Y",
+            ],
+          },
+          Object {
             "description": "Change the block type after adding a new paragraph.",
             "keyCombination": "/",
           },

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -283,13 +283,19 @@ export default compose( [
 				}
 			},
 			onRemove() {
-				removeBlocks( clientIds );
+				if ( ! isLocked ) {
+					removeBlocks( clientIds );
+				}
 			},
 			onInsertBefore() {
-				insertDefaultBlock( {}, rootClientId, firstSelectedIndex );
+				if ( ! isLocked ) {
+					insertDefaultBlock( {}, rootClientId, firstSelectedIndex );
+				}
 			},
 			onInsertAfter() {
-				insertDefaultBlock( {}, rootClientId, lastSelectedIndex + 1 );
+				if ( ! isLocked ) {
+					insertDefaultBlock( {}, rootClientId, lastSelectedIndex + 1 );
+				}
 			},
 			onSelect( clientId ) {
 				selectBlock( clientId );

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -40,6 +40,14 @@ const shortcuts = {
 		raw: rawShortcut.primaryAlt( 'backspace' ),
 		display: displayShortcut.primaryAlt( 'bksp' ),
 	},
+	insertBefore: {
+		raw: rawShortcut.primaryAlt( 'b' ),
+		display: displayShortcut.primaryShift( 'b' ),
+	},
+	insertAfter: {
+		raw: rawShortcut.primaryAlt( 'a' ),
+		display: displayShortcut.primaryAlt( 'a' ),
+	},
 };
 
 export class BlockSettingsMenu extends Component {
@@ -94,6 +102,11 @@ export class BlockSettingsMenu extends Component {
 						// Does not clash with any known browser/native shortcuts, but preventDefault
 						// is used to prevent any obscure unknown shortcuts from triggering
 						[ shortcuts.removeBlock.raw ]: flow( preventDefault, onRemove ),
+
+						// There are no known clashes for these shortcuts, but prevent obscure unknown
+						// behaviour using preventDefault.
+						[ shortcuts.insertBefore.raw ]: flow( preventDefault, onInsertBefore ),
+						[ shortcuts.insertAfter.raw ]: flow( preventDefault, onInsertAfter ),
 					} }
 				/>
 				<Dropdown
@@ -152,6 +165,7 @@ export class BlockSettingsMenu extends Component {
 								className="editor-block-settings-menu__control"
 								onClick={ onInsertBefore }
 								icon="insert-before"
+								shortcut={ shortcuts.insertBefore.display }
 							>
 								{ __( 'Insert Before' ) }
 							</MenuItem>
@@ -159,6 +173,7 @@ export class BlockSettingsMenu extends Component {
 								className="editor-block-settings-menu__control"
 								onClick={ onInsertAfter }
 								icon="insert-after"
+								shortcut={ shortcuts.insertAfter.display }
 							>
 								{ __( 'Insert After' ) }
 							</MenuItem>

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -8,7 +8,7 @@ import { castArray, first, last, every, flow } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { IconButton, Dropdown, NavigableMenu, MenuItem, KeyboardShortcuts } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -163,22 +163,26 @@ export class BlockSettingsMenu extends Component {
 									{ __( 'Duplicate' ) }
 								</MenuItem>
 							) }
-							<MenuItem
-								className="editor-block-settings-menu__control"
-								onClick={ onInsertBefore }
-								icon="insert-before"
-								shortcut={ shortcuts.insertBefore.display }
-							>
-								{ __( 'Insert Before' ) }
-							</MenuItem>
-							<MenuItem
-								className="editor-block-settings-menu__control"
-								onClick={ onInsertAfter }
-								icon="insert-after"
-								shortcut={ shortcuts.insertAfter.display }
-							>
-								{ __( 'Insert After' ) }
-							</MenuItem>
+							{ ! isLocked && (
+								<Fragment>
+									<MenuItem
+										className="editor-block-settings-menu__control"
+										onClick={ onInsertBefore }
+										icon="insert-before"
+										shortcut={ shortcuts.insertBefore.display }
+									>
+										{ __( 'Insert Before' ) }
+									</MenuItem>
+									<MenuItem
+										className="editor-block-settings-menu__control"
+										onClick={ onInsertAfter }
+										icon="insert-after"
+										shortcut={ shortcuts.insertAfter.display }
+									>
+										{ __( 'Insert After' ) }
+									</MenuItem>
+								</Fragment>
+							) }
 							{ count === 1 && (
 								<BlockModeToggle
 									clientId={ firstBlockClientId }

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -103,9 +103,11 @@ export class BlockSettingsMenu extends Component {
 						// is used to prevent any obscure unknown shortcuts from triggering
 						[ shortcuts.removeBlock.raw ]: flow( preventDefault, onRemove ),
 
-						// There are no known clashes for these shortcuts, but prevent obscure unknown
-						// behaviour using preventDefault.
+						// Prevent 'view recently closed tabs' in Opera using preventDefault.
 						[ shortcuts.insertBefore.raw ]: flow( preventDefault, onInsertBefore ),
+
+						// Does not clash with any known browser/native shortcuts, but preventDefault
+						// is used to prevent any obscure unknown shortcuts from triggering
 						[ shortcuts.insertAfter.raw ]: flow( preventDefault, onInsertAfter ),
 					} }
 				/>

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -72,6 +72,8 @@ export class BlockSettingsMenu extends Component {
 			isHidden,
 			onDuplicate,
 			onRemove,
+			onInsertBefore,
+			onInsertAfter,
 			canDuplicate,
 			isLocked,
 		} = this.props;
@@ -146,6 +148,20 @@ export class BlockSettingsMenu extends Component {
 									{ __( 'Duplicate' ) }
 								</MenuItem>
 							) }
+							<MenuItem
+								className="editor-block-settings-menu__control"
+								onClick={ onInsertBefore }
+								icon="insert-before"
+							>
+								{ __( 'Insert Before' ) }
+							</MenuItem>
+							<MenuItem
+								className="editor-block-settings-menu__control"
+								onClick={ onInsertAfter }
+								icon="insert-after"
+							>
+								{ __( 'Insert After' ) }
+							</MenuItem>
 							{ count === 1 && (
 								<BlockModeToggle
 									clientId={ firstBlockClientId }
@@ -199,15 +215,32 @@ export default compose( [
 		} );
 
 		return {
-			index: getBlockIndex( last( castArray( clientIds ) ), rootClientId ),
+			firstSelectedIndex: getBlockIndex( first( castArray( clientIds ) ), rootClientId ),
+			lastSelectedIndex: getBlockIndex( last( castArray( clientIds ) ), rootClientId ),
 			isLocked: !! getTemplateLock( rootClientId ),
 			blocks,
 			canDuplicate,
 			shortcuts,
 		};
 	} ),
-	withDispatch( ( dispatch, { clientIds, rootClientId, blocks, index, isLocked, canDuplicate } ) => {
-		const { insertBlocks, multiSelect, removeBlocks, selectBlock } = dispatch( 'core/editor' );
+	withDispatch( ( dispatch, props ) => {
+		const {
+			clientIds,
+			rootClientId,
+			blocks,
+			firstSelectedIndex,
+			lastSelectedIndex,
+			isLocked,
+			canDuplicate,
+		} = props;
+
+		const {
+			insertBlocks,
+			multiSelect,
+			removeBlocks,
+			selectBlock,
+			insertDefaultBlock,
+		} = dispatch( 'core/editor' );
 
 		return {
 			onDuplicate() {
@@ -218,7 +251,7 @@ export default compose( [
 				const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
 				insertBlocks(
 					clonedBlocks,
-					index + 1,
+					lastSelectedIndex + 1,
 					rootClientId
 				);
 				if ( clonedBlocks.length > 1 ) {
@@ -230,6 +263,12 @@ export default compose( [
 			},
 			onRemove() {
 				removeBlocks( clientIds );
+			},
+			onInsertBefore() {
+				insertDefaultBlock( {}, rootClientId, firstSelectedIndex );
+			},
+			onInsertAfter() {
+				insertDefaultBlock( {}, rootClientId, lastSelectedIndex + 1 );
 			},
 			onSelect( clientId ) {
 				selectBlock( clientId );

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -100,14 +100,14 @@ export class BlockSettingsMenu extends Component {
 						[ shortcuts.duplicate.raw ]: flow( preventDefault, onDuplicate ),
 
 						// Does not clash with any known browser/native shortcuts, but preventDefault
-						// is used to prevent any obscure unknown shortcuts from triggering
+						// is used to prevent any obscure unknown shortcuts from triggering.
 						[ shortcuts.removeBlock.raw ]: flow( preventDefault, onRemove ),
 
 						// Prevent 'view recently closed tabs' in Opera using preventDefault.
 						[ shortcuts.insertBefore.raw ]: flow( preventDefault, onInsertBefore ),
 
 						// Does not clash with any known browser/native shortcuts, but preventDefault
-						// is used to prevent any obscure unknown shortcuts from triggering
+						// is used to prevent any obscure unknown shortcuts from triggering.
 						[ shortcuts.insertAfter.raw ]: flow( preventDefault, onInsertAfter ),
 					} }
 				/>
@@ -140,7 +140,6 @@ export class BlockSettingsMenu extends Component {
 						);
 					} }
 					renderContent={ ( { onClose } ) => (
-						// Should this just use a DropdownMenu instead of a DropDown ?
 						<NavigableMenu className="editor-block-settings-menu__content">
 							<_BlockSettingsMenuFirstItem.Slot fillProps={ { onClose } } />
 							{ count === 1 && (

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -41,12 +41,12 @@ const shortcuts = {
 		display: displayShortcut.primaryAlt( 'bksp' ),
 	},
 	insertBefore: {
-		raw: rawShortcut.primaryAlt( 'b' ),
-		display: displayShortcut.primaryShift( 'b' ),
+		raw: rawShortcut.primaryAlt( 't' ),
+		display: displayShortcut.primaryAlt( 't' ),
 	},
 	insertAfter: {
-		raw: rawShortcut.primaryAlt( 'a' ),
-		display: displayShortcut.primaryAlt( 'a' ),
+		raw: rawShortcut.primaryAlt( 'y' ),
+		display: displayShortcut.primaryAlt( 'y' ),
 	},
 };
 


### PR DESCRIPTION
## Description
Closes #7297

Adds the following keyboard shortcuts for those actions:
- <kbd>Option</kbd>+<kbd>Cmd</kbd>+<kbd>T</kbd> (Mac) / <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd> - Insert Before
- <kbd>Option</kbd>+<kbd>Cmd</kbd>+<kbd>Y</kbd> (Mac) / <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Y</kbd> - Insert After

## How has this been tested?
- Tested use of MenuItem and shortcut across browsers on Mac (Chrome, Safari, Firefox, Opera)
- Tested use of MenuItem and shortcut across browsers on Windows (Chrome, IE11, Edge, Firefox, Opera)
- Tested with a block that uses InnerBlocks with a template lock

## Screenshots <!-- if applicable -->
**MenuItems**
![screen shot 2018-08-13 at 4 33 36 pm](https://user-images.githubusercontent.com/677833/44021434-683edc54-9f17-11e8-9c91-fe0f8c1e0eb1.png)

**Shortcut Help**
![screen shot 2018-08-13 at 4 33 01 pm](https://user-images.githubusercontent.com/677833/44021471-7a31a806-9f17-11e8-81ec-38213dfbeefb.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
