### PR TITLE
Packages: Make usage of `core-data` explicit

### DIFF
--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -4,6 +4,7 @@
 import '@wordpress/core-data';
 import '@wordpress/editor';
 import '@wordpress/nux';
+import '@wordpress/viewport';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -1,6 +1,9 @@
 /**
  * WordPress dependencies
  */
+import '@wordpress/core-data';
+import '@wordpress/editor';
+import '@wordpress/nux';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,7 +2011,6 @@
 			"version": "file:packages/block-library",
 			"requires": {
 				"@babel/runtime": "^7.0.0-beta.52",
-				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/blocks": "file:packages/blocks",

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -1,6 +1,6 @@
-# Core Blocks
+# Block library
 
-Core Blocks for the WordPress editor.
+Block library for the WordPress editor.
 
 ## Installation
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/block-library",
 	"version": "1.0.0",
-	"description": "Core Blocks of the WordPress editor.",
+	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
@@ -20,8 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0-beta.52",
-		"@wordpress/api-fetch": "file:../api-fetch",
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/blocks": "file:../blocks",

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import '@wordpress/core-data';
 import {
 	registerBlockType,
 	setDefaultBlockName,

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -1,3 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
 import './store';
 import './hooks';
 

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
+import '@wordpress/blocks';
 import '@wordpress/core-data';
+import '@wordpress/nux';
+import '@wordpress/viewport';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## Description

This PR tries to make usage of `@wordpress/core-data` more explicit. When evaluating #8354 and trying to update all blocks to not have direct API calls I figured out that:
- we no longer reference `@wordpress/api-fetch` in the code but we still list it as dependency
- `@wordpress/core-data` isn't initialized for `@wordpress/block-library` and `@wordpress/editor` which might create some issues when using packages outside of WordPress

I also included the change which changes the description of `@wordpress/block-library` package which we missed last week.

