### PR TITLE
Add a filter for the reusable block id

### DIFF
--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -17,14 +17,20 @@ function render_block_core_block( $attributes ) {
 		return '';
 	}
 
+	$post_id = null;
+	if ( get_post() ) {
+		$post_id = get_post()->ID;
+	}
+
 	/**
 	 * Filter to allow plugins to override the reusable block id.
 	 *
 	 * @since 3.5.0
 	 *
-	 * @param int $block_id     The id of the reusable block
+	 * @param int $block_id The id of the reusable block.
+	 * @param int $post_id  The post ID that the reusable block is being embedding in.
 	 */
-	$reusable_block_id = apply_filters( 'reusable_block_id', $attributes['ref'] );
+	$reusable_block_id = apply_filters( 'reusable_block_id', $attributes['ref'], $post_id );
 	$reusable_block    = get_post( $reusable_block_id );
 	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
 		return '';

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -24,7 +24,7 @@ function render_block_core_block( $attributes ) {
 	 *
 	 * @param int $block_id     The id of the reusable block
 	 */
-	$reusable_block_id = apply_filters( 'gutenberg_reusable_block_id', $attributes['ref'] );
+	$reusable_block_id = apply_filters( 'reusable_block_id', $attributes['ref'] );
 	$reusable_block    = get_post( $reusable_block_id );
 	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
 		return '';

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -17,6 +17,13 @@ function render_block_core_block( $attributes ) {
 		return '';
 	}
 
+	/**
+	 * Filter to allow plugins to override the reusable block id.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param int $block_id     The id of the reusable block
+	 */
 	$reusable_block_id = apply_filters( 'gutenberg_reusable_block_id', $attributes['ref'] );
 	$reusable_block    = get_post( $reusable_block_id );
 	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -17,7 +17,8 @@ function render_block_core_block( $attributes ) {
 		return '';
 	}
 
-	$reusable_block = get_post( $attributes['ref'] );
+	$reusable_block_id = apply_filters( 'gutenberg_reusable_block_id', $attributes['ref'] );
+	$reusable_block    = get_post( $reusable_block_id );
 	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
 		return '';
 	}


### PR DESCRIPTION
## Description
Add a filter so that plugins and themes can filter the reusable block id and return a different block.

## Why is this needed.
Plugins may want to display a different reusable block in some situations. Eg. WPML allows you to translate the reusable block. When rendering the page that contains the reusable block WPML can detect the current language and select the appropriate reusable block to display. 

## How has this been tested?
This has been tested with WPML using the follow code example.

```
add_filter( 'gutenberg_reusable_block_id', 'gutenberg_reusable_block_id_filter' );
function gutenberg_reusable_block_id_filter( $block_id ) {
   return icl_object_id( $block_id, 'wp_block', true );
}
```

## Types of changes
Add a new filter

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
