### PR TITLE
toAsyncIterable: remove Promise.resolve call that's already done by the JS runtime

### DIFF
--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -104,13 +104,8 @@ export function toAsyncIterable( object ) {
 			object = [ object ];
 		}
 
-		for ( let maybeAction of object ) {
-			// ...of Promises.
-			if ( ! ( maybeAction instanceof Promise ) ) {
-				maybeAction = Promise.resolve( maybeAction );
-			}
-
-			yield await maybeAction;
+		for ( const maybeAction of object ) {
+			yield maybeAction;
 		}
 	}() );
 }


### PR DESCRIPTION
When `await`-ing something or `yield`-ing something from an async generator, one doesn't need to call `Promise.resolve` to cast it to a Promise. The language runtime and all library functions already to that for us. Examples:

Library functions that accept promises always accept other values, too:
```js
Promise.all( [ 1, 2, new Promise( r => setTimeout( () => r( 3 ), 1000 ) ) ] )
```
This resolves to `[ 1, 2, 3 ]` after 1 second. The `1` and `2` values are wrapped with `Promise.resolve` automatically.

`await` also accepts both promises and non-promises:
```js
const a = await 1; // `a` is assigned `1` in the next microtask tick
const b = await new Promise( r => setTimeout( () => r( 2 ), 1000 ) ); // waits a second
return a + b; // returns (promise of) `3` from the async function
```

and finally, async generator can yield non-promise values and yet the resulting iterator will always return promises:
```js
async function* agen() { yield 1; yield 2; }
const it = agen();
it.next().then( x => console.log( 'should be 1:', x.value ) );
it.next().then( x => console.log( 'should be 2:', x.value ) );
```

Every well-designed API that accepts promises should behave this way. See the [W3C guide on writing promise-using specs](https://www.w3.org/2001/tag/doc/promises-guide#accepting-promises).

This patch also fixes a bug: if the thing passed to `toAsyncIterable` is an array of thenables that are not instances of the native `Promise`, e.g., Bluebird promises or objects from some polyfill, the resulting async iterable will "follow" the values of these thenables:
```js
const iterable = [ thenableThatResolvesTo( 1 ), thenableThatResolvesTo( 2 ) ];
for await ( const i of toAsyncIterable( iterable ) ) {
  console.log( i );
}
```
**Before:** `console.log` prints some objects with a `then` method
**After:** `console.log` prints values `1` and `2`

**Idea for a followup PR:**
The `toAsyncIterable` function does more redundant work that's already done by the `for await` loop. For example, `for await` accepts a synchronous iterable or iterator:
```js
// the array is a synchronous iterable, the loop casts it to async and the loop body
// is executed as three separate microtasks with independent call stacks
for await ( const i of [ 1, 2, 3 ] )

// the iterated thing is a sync iterator, casted to async
function* syncGen() { yield 1; yield 2; yield 3; }
for await ( const i of syncGen() )
```

Therefore, any array, map, or sync iterator is already a valid **async iterable**, although it's not an **async iterator**. What does the `toAsyncIterable` function want to return? The name suggests that it wants to return async iterable, but the unit tests test for async iterator, which is a subset.