### PR TITLE
Release font-size for code.

### DIFF
--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -38,7 +38,7 @@
 		color: $dark-gray-800;
 		background: $light-gray-200;
 		font-family: $editor-html-font;
-		font-size: inherit;
+		font-size: inherit; // This is necessary to override upstream CSS.
 
 		.is-multi-selected & {
 			background: darken($blue-medium-highlight, 15%);

--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -38,7 +38,7 @@
 		color: $dark-gray-800;
 		background: $light-gray-200;
 		font-family: $editor-html-font;
-		font-size: 14px;
+		font-size: inherit;
 
 		.is-multi-selected & {
 			background: darken($blue-medium-highlight, 15%);


### PR DESCRIPTION
This addresses feedback in this comment https://github.com/WordPress/gutenberg/pull/710/files/3096d0bebe5d64142a84511b954d89ea6599e4f3#r208286450

Previously, the font size for any element in the `code` tag was fixed to 14px. Now it's released, free, and can be any size the parent container suggests to it.

<img width="650" alt="screen shot 2018-08-13 at 11 27 50" src="https://user-images.githubusercontent.com/1204802/44023959-398dfe92-9eec-11e8-8d6e-e91a9ff06db8.png">


Note that the `inherit` is necessary here to override code from upstream.