### PR TITLE
Fix paragraph splits on RN

### DIFF
--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -18,6 +18,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0-beta.52",
 		"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -30,8 +30,8 @@ export class RichText extends Component {
 		this.lastEventCount = event.nativeEvent.eventCount;
 		// The following method just cleans up any <p> tags produced by aztec and replaces them with a br tag
 		// This should be removed on a later version when aztec doesn't return the top tag of the text being edited
-		const openingTagRegexp = RegExp( '^<' + this.props.tagName + '>', 'gi' );
-		const closingTagRegexp = RegExp( '</' + this.props.tagName + '>$', 'gi' );
+		const openingTagRegexp = RegExp( '^<' + this.props.tagName + '>', 'gim' );
+		const closingTagRegexp = RegExp( '</' + this.props.tagName + '>$', 'gim' );
 		const contentWithoutRootTag = event.nativeEvent.text.replace( openingTagRegexp, '' ).replace( closingTagRegexp, '' );
 		this.lastContent = contentWithoutRootTag;
 


### PR DESCRIPTION
## Description

This PR fixes a regression where trying to write multiple lines on a paragraph was making the RN example app crash.

## How has this been tested?

Run the RN app on gutenberg mobile, using the branch for this [PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/104),  and make sure that the app does not crash when inserting multiple paragraphs on the paragraph block.

## Screenshots <!-- if applicable -->

## Types of changes

- Bug fix on the RichText block
- Added an entry point on new the block-library package.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
