### PR TITLE
Tags: Fix the tags input in IE11

### DIFF
--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -33,6 +33,7 @@
 		margin: 2px 0 2px 8px;
 		padding: 0;
 		line-height: 24px;
+		height: 24px;
 		background: inherit;
 		border: 0;
 		font-size: $default-font-size;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -32,8 +32,7 @@
 		max-width: 100%;
 		margin: 2px 0 2px 8px;
 		padding: 0;
-		line-height: 24px;
-		height: 24px;
+		min-height: 24px;
 		background: inherit;
 		border: 0;
 		font-size: $default-font-size;


### PR DESCRIPTION
closes #8653

**Testing instructions**

 - Check that the tags input's placeholder is not cropped in IE11