### PR TITLE
Try: "Focus Mode".

### DIFF
--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -52,12 +52,14 @@ function Layout( {
 	hasActiveMetaboxes,
 	isSaving,
 	isMobileViewport,
+	isFocusMode,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 
 	const className = classnames( 'edit-post-layout', {
 		'is-sidebar-opened': sidebarIsOpened,
 		'has-fixed-toolbar': hasFixedToolbar,
+		'is-focus-mode': isFocusMode,
 	} );
 
 	const publishLandmarkProps = {
@@ -143,6 +145,7 @@ export default compose(
 		metaBoxes: select( 'core/edit-post' ).getMetaBoxes(),
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
+		isFocusMode: select( 'core/edit-post' ).isFocusMode(),
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/edit-post/hooks/more-menu/focus-mode.js
+++ b/edit-post/hooks/more-menu/focus-mode.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { MenuItem } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+
+function FocusModeMenuItem( { isFocusMode, toggleFocusMode } ) {
+	return (
+		<MenuItem
+			icon={ isFocusMode && 'yes' }
+			onClick={ toggleFocusMode }
+		>
+			{ __( 'Focus Mode' ) }
+		</MenuItem>
+	);
+}
+
+export default compose(
+	withSelect( ( select ) => ( {
+		isFocusMode: select( 'core/edit-post' ).isFocusMode(),
+	} ) ),
+	withDispatch( ( dispatch ) => {
+		const { toggleFocusMode } = dispatch( 'core/edit-post' );
+		return {
+			toggleFocusMode: toggleFocusMode,
+		};
+	} ),
+)( FocusModeMenuItem );

--- a/edit-post/hooks/more-menu/index.js
+++ b/edit-post/hooks/more-menu/index.js
@@ -7,8 +7,9 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import CopyContentMenuItem from './copy-content-menu-item';
+import FocusMode from './focus-mode';
 
-const withCopyContentMenuItem = ( menuItems ) => [
+const withCopyMenuItem = ( menuItems ) => [
 	...menuItems,
 	<CopyContentMenuItem key="copy-content-menu-item" />,
 ];
@@ -16,5 +17,16 @@ const withCopyContentMenuItem = ( menuItems ) => [
 addFilter(
 	'editPost.MoreMenu.tools',
 	'core/edit-post/more-menu/withCopyContentMenuItem',
-	withCopyContentMenuItem
+	withCopyMenuItem
+);
+
+const withFocusMode = ( menuItems ) => [
+	...menuItems,
+	<FocusMode key="focus-mode" />,
+];
+
+addFilter(
+	'editPost.MoreMenu.tools',
+	'core/edit-post/more-menu/focusMode',
+	withFocusMode
 );

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -97,6 +97,17 @@ export function toggleGeneralSidebarEditorPanel( panel ) {
 }
 
 /**
+ * Returns an action object used in signalling that the user toggles focus mode.
+ *
+ * @return {Object} Action object
+ */
+export function toggleFocusMode() {
+	return {
+		type: 'TOGGLE_FOCUS_MODE',
+	};
+}
+
+/**
  * Returns an action object used to toggle a feature flag.
  *
  * @param {string} feature Feature name.

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -119,6 +119,14 @@ export function publishSidebarActive( state = false, action ) {
 	return state;
 }
 
+export function focusModeActive( state = false, action ) {
+	switch ( action.type ) {
+		case 'TOGGLE_FOCUS_MODE':
+			return ! state;
+	}
+	return state;
+}
+
 const locations = [
 	'normal',
 	'side',
@@ -195,6 +203,7 @@ export default combineReducers( {
 	panel,
 	activeModal,
 	publishSidebarActive,
+	focusModeActive,
 	metaBoxes,
 	isSavingMetaBoxes,
 } );

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -100,6 +100,17 @@ export function isEditorSidebarPanelOpened( state, panel ) {
 }
 
 /**
+ * Returns true if focus mode is enabled.
+ *
+ * @param {Object} state Global application state
+ *
+ * @return {boolean} Whether focus mode is enabled.
+ */
+export function isFocusMode( state ) {
+	return state.focusModeActive;
+}
+
+/**
  * Returns true if a modal is active, or false otherwise.
  *
  * @param  {Object}  state 	   Global application state.

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -79,7 +79,6 @@
 	cursor: grab;
 }
 
-
 // Allow Drag & Drop when clicking on the empty area of the mover and the settings menu
 .editor-block-list__layout .editor-block-list__block .editor-block-mover,
 .editor-block-list__layout .editor-block-list__block .editor-block-settings-menu {
@@ -1026,6 +1025,49 @@
 		// Don't use this for full-wide blocks, as there's no clearance to accommodate extra area on the side.
 		&[data-align="full"]::before {
 			content: none;
+		}
+	}
+}
+
+// When focus mode is engaged, dim down visibility of non-selected blocks
+.editor-block-list__layout .editor-block-list__block:not(.is-selected):not(.is-typing) {
+	.is-focus-mode & {
+		opacity: 0.2;
+	}
+}
+
+.editor-block-list__layout .editor-block-contextual-toolbar,
+.editor-block-settings-menu,
+.editor-block-mover,
+.editor-block-list__block.is-hovered .editor-block-list__block-edit::before,
+.editor-block-list__breadcrumb,
+.editor-post-permalink {
+	.is-focus-mode & {
+		display: none !important;
+		outline: none !important;
+	}
+}
+
+.is-focus-mode .edit-post-header {
+	.edit-post-header-toolbar {
+		> * {
+			visibility: hidden !important;
+		}
+
+		.editor-inserter,
+		.editor-history__undo,
+		.editor-history__redo,
+		.edit-post-header-toolbar__block-toolbar {
+			visibility: visible !important;
+		}
+	}
+	.edit-post-header__settings {
+		> * {
+			visibility: hidden !important;
+		}
+
+		.edit-post-more-menu {
+			visibility: visible !important;
 		}
 	}
 }


### PR DESCRIPTION
_Not Ready To Merge_

This PR explores introducing a potential "Focus Mode" to the editor. When enabled, the mode would reduce the weight of the visual interface and highlight only the current block that is selected while the rest fade away. Pairing it with the "fix toolbar to header" can offer a compelling setup for those that already know how to navigate an editor.

The aim is to provide a writing experience that can satisfy those that would prefer an environment with the least amount of distractions at the expense of tool clarity. I've been testing this and personally find it a very enjoyable mode to toggle when I just want to write for a bit.

Paired with a robust set of keyboard shortcuts it could be quite nice to use. In this sense, it'd be important to provide an easy keyboard shortcut to toggle the mode on and off.

Video showing it in action: https://cloudup.com/cwaVMa9NygI

![focus-mode-comparison](https://user-images.githubusercontent.com/548849/44032903-e22cc152-9f08-11e8-8f65-da6422dd62f2.png)

---

If we were to add this in, here are a few tasks pending:

- [ ] Figure out where this code should live — `editor`, `edit-post`, as a core extension, editor setting, etc.
- [ ] Add a keyboard shortcut to toggle the mode.
- [ ] Decide whether to selectively fade header controls. Should they appear when the header area is focused?
- [ ] Fix multi-selection.
- [ ] Consider adding focus mode as a top-level icon in the header bar that can be easily toggled. If done as an extension it could just use the pinning mechanism.
- [ ] Persist the setting.
- [ ] Properly decouple CSS in its own file.