### PR TITLE
Fix the shortcode block UI in IE11

### DIFF
--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -7,20 +7,16 @@
 	font-family: $default-font;
 
 	label {
-		flex-basis: 0;
 		display: flex;
 		align-items: center;
 		margin-right: $item-spacing;
 		white-space: nowrap;
 		font-weight: 600;
+		flex-shrink: 0;
 	}
 
 	.editor-plain-text {
-		/*
-		 * Unit required on zero value to work around IE bug.
-		 * https://github.com/philipwalton/flexbugs#flexbug-4
-		 */
-		flex: 1 0 0%;
+		flex-grow: 1;
 	}
 
 	.dashicon {


### PR DESCRIPTION
Closes #8624

**Testing instructions** (See the issue above)

 - Insert a shortcode block
 - The placeholder should show up properly.