### PR TITLE
Test: Ensure the full content integration test is run

### DIFF
--- a/test/integration/full-content/full-content.spec.js
+++ b/test/integration/full-content/full-content.spec.js
@@ -102,7 +102,7 @@ describe( 'full post content fixture', () => {
 		unstable__bootstrapServerSideBlockDefinitions( require( './server-registered.json' ) );
 
 		// Load all hooks that modify blocks
-		require( '../../packages/editor/src/hooks' );
+		require( '../../../packages/editor/src/hooks' );
 		registerCoreBlocks();
 	} );
 


### PR DESCRIPTION
This test has been moved to the integration tests folder in https://github.com/WordPress/gutenberg/pull/8287#discussion_r209611557 but it looks like this folder requires `.spec` in the file to actually run the test.

