### PR TITLE
Copy: use sentence case for all texts in tooltips

### DIFF
--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -119,7 +119,7 @@ export class BlockSettingsMenu extends Component {
 							'is-opened': isOpen,
 							'is-visible': isFocused || isOpen || ! isHidden,
 						} );
-						const label = isOpen ? __( 'Hide Options' ) : __( 'More Options' );
+						const label = isOpen ? __( 'Hide options' ) : __( 'More options' );
 
 						return (
 							<IconButton

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -81,7 +81,7 @@ class PostPublishPanel extends Component {
 						aria-expanded={ true }
 						onClick={ onClose }
 						icon="no-alt"
-						label={ __( 'Close Publish Panel' ) }
+						label={ __( 'Close Publish panel' ) }
 					/>
 				</div>
 				<div className="editor-post-publish-panel__content">

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -81,7 +81,7 @@ class PostPublishPanel extends Component {
 						aria-expanded={ true }
 						onClick={ onClose }
 						icon="no-alt"
-						label={ __( 'Close Publish panel' ) }
+						label={ __( 'Close panel' ) }
 					/>
 				</div>
 				<div className="editor-post-publish-panel__content">

--- a/packages/editor/src/components/table-of-contents/index.js
+++ b/packages/editor/src/components/table-of-contents/index.js
@@ -21,7 +21,7 @@ function TableOfContents( { hasBlocks } ) {
 					onClick={ onToggle }
 					icon="info-outline"
 					aria-expanded={ isOpen }
-					label={ __( 'Content Structure' ) }
+					label={ __( 'Content structure' ) }
 					disabled={ ! hasBlocks }
 				/>
 			) }

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -21,56 +21,56 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	alignWide: false,
 	colors: [
 		{
-			name: __( 'pale pink' ),
+			name: __( 'Pale pink' ),
 			slug: 'pale-pink',
 			color: '#f78da7',
 		},
-		{	name: __( 'vivid red' ),
+		{	name: __( 'Vivid red' ),
 			slug: 'vivid-red',
 			color: '#cf2e2e',
 		},
 		{
-			name: __( 'luminous vivid orange' ),
+			name: __( 'Luminous vivid orange' ),
 			slug: 'luminous-vivid-orange',
 			color: '#ff6900',
 		},
 		{
-			name: __( 'luminous vivid amber' ),
+			name: __( 'Luminous vivid amber' ),
 			slug: 'luminous-vivid-amber',
 			color: '#fcb900',
 		},
 		{
-			name: __( 'light green cyan' ),
+			name: __( 'Light green cyan' ),
 			slug: 'light-green-cyan',
 			color: '#7bdcb5',
 		},
 		{
-			name: __( 'vivid green cyan' ),
+			name: __( 'Vivid green cyan' ),
 			slug: 'vivid-green-cyan',
 			color: '#00d084',
 		},
 		{
-			name: __( 'pale cyan blue' ),
+			name: __( 'Pale cyan blue' ),
 			slug: 'pale-cyan-blue',
 			color: '#8ed1fc',
 		},
 		{
-			name: __( 'vivid cyan blue' ),
+			name: __( 'Vivid cyan blue' ),
 			slug: 'vivid-cyan-blue',
 			color: '#0693e3',
 		},
 		{
-			name: __( 'very light gray' ),
+			name: __( 'Very light gray' ),
 			slug: 'very-light-gray',
 			color: '#eeeeee',
 		},
 		{
-			name: __( 'cyan bluish gray' ),
+			name: __( 'Cyan bluish gray' ),
 			slug: 'cyan-bluish-gray',
 			color: '#abb8c3',
 		},
 		{
-			name: __( 'very dark gray' ),
+			name: __( 'Very dark gray' ),
 			slug: 'very-dark-gray',
 			color: '#313131',
 		},
@@ -78,25 +78,25 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 
 	fontSizes: [
 		{
-			name: __( 'small' ),
+			name: __( 'Small' ),
 			shortName: __( 'S' ),
 			size: 14,
 			slug: 'small',
 		},
 		{
-			name: __( 'regular' ),
+			name: __( 'Regular' ),
 			shortName: __( 'M' ),
 			size: 16,
 			slug: 'regular',
 		},
 		{
-			name: __( 'large' ),
+			name: __( 'Large' ),
 			shortName: __( 'L' ),
 			size: 36,
 			slug: 'large',
 		},
 		{
-			name: __( 'larger' ),
+			name: __( 'Larger' ),
 			shortName: __( 'XL' ),
 			size: 48,
 			slug: 'larger',

--- a/test/e2e/specs/editor-modes.test.js
+++ b/test/e2e/specs/editor-modes.test.js
@@ -16,8 +16,8 @@ describe( 'Editing modes (visual/HTML)', () => {
 		expect( visualBlock ).toHaveLength( 1 );
 
 		// Change editing mode from "Visual" to "HTML".
-		await page.waitForSelector( 'button[aria-label="More Options"]' );
-		await page.click( 'button[aria-label="More Options"]' );
+		await page.waitForSelector( 'button[aria-label="More options"]' );
+		await page.click( 'button[aria-label="More options"]' );
 		let changeModeButton = await page.waitForXPath( '//button[text()="Edit as HTML"]' );
 		await changeModeButton.click();
 
@@ -26,8 +26,8 @@ describe( 'Editing modes (visual/HTML)', () => {
 		expect( htmlBlock ).toHaveLength( 1 );
 
 		// Change editing mode from "HTML" back to "Visual".
-		await page.waitForSelector( 'button[aria-label="More Options"]' );
-		await page.click( 'button[aria-label="More Options"]' );
+		await page.waitForSelector( 'button[aria-label="More options"]' );
+		await page.click( 'button[aria-label="More options"]' );
 		changeModeButton = await page.waitForXPath( '//button[text()="Edit visually"]' );
 		await changeModeButton.click();
 
@@ -38,8 +38,8 @@ describe( 'Editing modes (visual/HTML)', () => {
 
 	it( 'should display sidebar in HTML mode', async () => {
 		// Change editing mode from "Visual" to "HTML".
-		await page.waitForSelector( 'button[aria-label="More Options"]' );
-		await page.click( 'button[aria-label="More Options"]' );
+		await page.waitForSelector( 'button[aria-label="More options"]' );
+		await page.click( 'button[aria-label="More options"]' );
 		const changeModeButton = await page.waitForXPath( '//button[text()="Edit as HTML"]' );
 		await changeModeButton.click();
 
@@ -51,8 +51,8 @@ describe( 'Editing modes (visual/HTML)', () => {
 
 	it( 'should update HTML in HTML mode when sidebar is used', async () => {
 		// Change editing mode from "Visual" to "HTML".
-		await page.waitForSelector( 'button[aria-label="More Options"]' );
-		await page.click( 'button[aria-label="More Options"]' );
+		await page.waitForSelector( 'button[aria-label="More options"]' );
+		await page.click( 'button[aria-label="More options"]' );
 		const changeModeButton = await page.waitForXPath( '//button[text()="Edit as HTML"]' );
 		await changeModeButton.click();
 

--- a/test/e2e/specs/reusable-blocks.test.js
+++ b/test/e2e/specs/reusable-blocks.test.js
@@ -38,8 +38,8 @@ describe( 'Reusable Blocks', () => {
 		await page.mouse.move( 250, 350, { steps: 10 } );
 
 		// Convert block to a reusable block
-		await page.waitForSelector( 'button[aria-label="More Options"]' );
-		await page.click( 'button[aria-label="More Options"]' );
+		await page.waitForSelector( 'button[aria-label="More options"]' );
+		await page.click( 'button[aria-label="More options"]' );
 		const convertButton = await page.waitForXPath( '//button[text()="Add to Reusable Blocks"]' );
 		await convertButton.click();
 
@@ -85,8 +85,8 @@ describe( 'Reusable Blocks', () => {
 		await page.mouse.move( 250, 350, { steps: 10 } );
 
 		// Convert block to a reusable block
-		await page.waitForSelector( 'button[aria-label="More Options"]' );
-		await page.click( 'button[aria-label="More Options"]' );
+		await page.waitForSelector( 'button[aria-label="More options"]' );
+		await page.click( 'button[aria-label="More options"]' );
 		const convertButton = await page.waitForXPath( '//button[text()="Add to Reusable Blocks"]' );
 		await convertButton.click();
 
@@ -160,7 +160,7 @@ describe( 'Reusable Blocks', () => {
 		await insertBlock( 'Surprised greeting block' );
 
 		// Convert block to a regular block
-		await page.click( 'button[aria-label="More Options"]' );
+		await page.click( 'button[aria-label="More options"]' );
 		const convertButton = await page.waitForXPath(
 			'//button[text()="Convert to Regular Block"]'
 		);
@@ -183,7 +183,7 @@ describe( 'Reusable Blocks', () => {
 		await insertBlock( 'Surprised greeting block' );
 
 		// Delete the block and accept the confirmation dialog
-		await page.click( 'button[aria-label="More Options"]' );
+		await page.click( 'button[aria-label="More options"]' );
 		const convertButton = await page.waitForXPath( '//button[text()="Remove from Reusable Blocks"]' );
 		await Promise.all( [ waitForAndAcceptDialog(), convertButton.click() ] );
 


### PR DESCRIPTION
Fixes #8888 

## Description
This PR seeks to unify the title style in the copy used in all black tooltips by using sentence case as pointed in https://github.com/WordPress/gutenberg/issues/8888#issuecomment-412470409 

## How has this been tested?
Checking each tooltip copy in the UI.

## Screenshots <!-- if applicable -->

<img width="157" alt="captura de pantalla 2018-08-13 a la s 12 20 10" src="https://user-images.githubusercontent.com/1041600/44041796-0375c8e0-9ef5-11e8-888e-f9a503c9f3ef.png">
<img width="124" alt="captura de pantalla 2018-08-13 a la s 12 20 24" src="https://user-images.githubusercontent.com/1041600/44041797-03a12ff8-9ef5-11e8-897e-e8671e887332.png">
<img width="92" alt="captura de pantalla 2018-08-14 a la s 15 17 07" src="https://user-images.githubusercontent.com/1041600/44110142-53de0c6c-9fd5-11e8-9c63-20296ae4302c.png">
<img width="93" alt="captura de pantalla 2018-08-13 a la s 12 21 03" src="https://user-images.githubusercontent.com/1041600/44041799-03cdc7c0-9ef5-11e8-8606-cb9ad2c5fde8.png">

The last one shows only one color but all color names have been updated.

## Types of changes
Updates the text for tooltips.
Removes 'Publish' from 'Close Publish panel'

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->