### PR TITLE
Pass title attribute when uploading an image

### DIFF
--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -159,6 +159,7 @@ function createMediaFromFile( file, additionalData ) {
 	// Create upload payload
 	const data = new window.FormData();
 	data.append( 'file', file, file.name || file.type.replace( '/', '.' ) );
+	data.append( 'title', file.name ? file.name.replace( /\.[^.]+$/, '' ) : file.type.replace( '/', '.' ) );
 	forEach( additionalData, ( ( value, key ) => data.append( key, value ) ) );
 	return apiFetch( {
 		path: '/wp/v2/media',


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/8902 by passing along an image title during the upload.

## How has this been tested?
Steps to test:

1. Upload a new image to the GB image block called `image name.png`.
2. Notice the title is now `image-name`.
3. Apply patch and upload a new image called `another image.png`.
4. Notice the title is now correctly `another image`.

## Screenshots <!-- if applicable -->
Before: http://cld.wthms.co/QJgKc8
After: http://cld.wthms.co/N2IhcF

## Types of changes
The title will be the file's name (ex `file name.jpg`) if it exists, except with the extension and period removed. If the file name does not exist (an edge case shown in the line above), then it will pass `image/png` for example, except a period substituted for the slash as done on line 161.

The regex for removing the extension is the same used in WP core https://github.com/WordPress/WordPress/blob/aab929b8d619bde14495a97cdc1eb7bdf1f1d487/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php#L143 and https://github.com/WordPress/WordPress/blob/acd3f4cb10675c35b7532f123bc4ddb871d35ff1/wp-admin/includes/media.php#L436

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
