### PR TITLE
Position caret at end of previous block for any type of block removal

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -324,12 +324,8 @@ export class BlockListBlock extends Component {
 			case BACKSPACE:
 			case DELETE:
 				// Remove block on backspace.
-				const { clientId, onRemove, previousBlockClientId, onSelect } = this.props;
+				const { clientId, onRemove } = this.props;
 				onRemove( clientId );
-
-				if ( previousBlockClientId ) {
-					onSelect( previousBlockClientId, -1 );
-				}
 				event.preventDefault();
 				break;
 		}

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -248,7 +248,7 @@ export default {
 		// Dispatch select block action if the currently selected block
 		// is not already the block we want to be selected.
 		if ( blockClientIdToSelect !== currentSelectedBlock ) {
-			dispatch( selectBlock( blockClientIdToSelect ) );
+			dispatch( selectBlock( blockClientIdToSelect, -1 ) );
 		}
 	},
 };

--- a/test/e2e/specs/__snapshots__/block-deletion.test.js.snap
+++ b/test/e2e/specs/__snapshots__/block-deletion.test.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`block deletion - deleting the third block using backspace in an empty block positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph - caret was here</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting the third block using backspace in an empty block results in two remaining blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting the third block using backspace with block wrapper selection positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph - caret was here</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting the third block using backspace with block wrapper selection results in three remaining blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting the third block using the Remove Block menu item positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph - caret was here</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting the third block using the Remove Block menu item results in two remaining blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting the third block using the Remove Block shortcut positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph - caret was here</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting the third block using the Remove Block shortcut results in two remaining blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting third third and fourth blocks using backspace with multi-block selection positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph - caret was here</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting third third and fourth blocks using backspace with multi-block selection results in two remaining blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting third third and fourth blocks using backspace with multi-block selection results in two remaining blocks 2`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/__snapshots__/block-deletion.test.js.snap
+++ b/test/e2e/specs/__snapshots__/block-deletion.test.js.snap
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`block deletion - deleting the third block using backspace in an empty block positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+exports[`block deletion - deleting the third block using backspace in an empty block results in two remaining blocks and positions the caret at the end of the second block 1`] = `
+"<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block deletion - deleting the third block using backspace in an empty block results in two remaining blocks and positions the caret at the end of the second block 2`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
@@ -10,7 +20,7 @@ exports[`block deletion - deleting the third block using backspace in an empty b
 <!-- /wp:paragraph -->"
 `;
 
-exports[`block deletion - deleting the third block using backspace in an empty block results in two remaining blocks 1`] = `
+exports[`block deletion - deleting the third block using backspace with block wrapper selection results in three remaining blocks and positions the caret at the end of the third block 1`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
@@ -20,7 +30,7 @@ exports[`block deletion - deleting the third block using backspace in an empty b
 <!-- /wp:paragraph -->"
 `;
 
-exports[`block deletion - deleting the third block using backspace with block wrapper selection positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+exports[`block deletion - deleting the third block using backspace with block wrapper selection results in three remaining blocks and positions the caret at the end of the third block 2`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
@@ -30,7 +40,7 @@ exports[`block deletion - deleting the third block using backspace with block wr
 <!-- /wp:paragraph -->"
 `;
 
-exports[`block deletion - deleting the third block using backspace with block wrapper selection results in three remaining blocks 1`] = `
+exports[`block deletion - deleting the third block using the Remove Block menu item results in two remaining blocks and positions the caret at the end of the second block 1`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
@@ -40,7 +50,7 @@ exports[`block deletion - deleting the third block using backspace with block wr
 <!-- /wp:paragraph -->"
 `;
 
-exports[`block deletion - deleting the third block using the Remove Block menu item positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+exports[`block deletion - deleting the third block using the Remove Block menu item results in two remaining blocks and positions the caret at the end of the second block 2`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
@@ -50,7 +60,7 @@ exports[`block deletion - deleting the third block using the Remove Block menu i
 <!-- /wp:paragraph -->"
 `;
 
-exports[`block deletion - deleting the third block using the Remove Block menu item results in two remaining blocks 1`] = `
+exports[`block deletion - deleting the third block using the Remove Block shortcut results in two remaining blocks and positions the caret at the end of the second block 1`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
@@ -60,7 +70,7 @@ exports[`block deletion - deleting the third block using the Remove Block menu i
 <!-- /wp:paragraph -->"
 `;
 
-exports[`block deletion - deleting the third block using the Remove Block shortcut positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+exports[`block deletion - deleting the third block using the Remove Block shortcut results in two remaining blocks and positions the caret at the end of the second block 2`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
@@ -70,7 +80,7 @@ exports[`block deletion - deleting the third block using the Remove Block shortc
 <!-- /wp:paragraph -->"
 `;
 
-exports[`block deletion - deleting the third block using the Remove Block shortcut results in two remaining blocks 1`] = `
+exports[`block deletion - deleting third third and fourth blocks using backspace with multi-block selection results in two remaining blocks and positions the caret at the end of the second block 1`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
@@ -80,32 +90,12 @@ exports[`block deletion - deleting the third block using the Remove Block shortc
 <!-- /wp:paragraph -->"
 `;
 
-exports[`block deletion - deleting third third and fourth blocks using backspace with multi-block selection positions the caret at the end of the second block as evidenced by typing additional text 1`] = `
+exports[`block deletion - deleting third third and fourth blocks using backspace with multi-block selection results in two remaining blocks and positions the caret at the end of the second block 2`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>Second paragraph - caret was here</p>
-<!-- /wp:paragraph -->"
-`;
-
-exports[`block deletion - deleting third third and fourth blocks using backspace with multi-block selection results in two remaining blocks 1`] = `
-"<!-- wp:paragraph -->
-<p>First paragraph</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>Second paragraph</p>
-<!-- /wp:paragraph -->"
-`;
-
-exports[`block deletion - deleting third third and fourth blocks using backspace with multi-block selection results in two remaining blocks 2`] = `
-"<!-- wp:paragraph -->
-<p>First paragraph</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>Second paragraph</p>
 <!-- /wp:paragraph -->"
 `;

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -1,0 +1,116 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	clickOnBlockSettingsMenuItem,
+	getEditedPostContent,
+	newPost,
+	pressWithModifier,
+	PRIMARY_ALT_MODIFIER_KEYS,
+} from '../support/utils';
+
+const addThreeParagraphsToNewPost = async () => {
+	await newPost();
+
+	// Add demo content
+	await clickBlockAppender();
+	await page.keyboard.type( 'First paragraph' );
+	await page.keyboard.press( 'Enter' );
+	await page.keyboard.type( 'Second paragraph' );
+	await page.keyboard.press( 'Enter' );
+};
+
+describe( 'block deletion -', () => {
+	describe( 'deleting the third block using the Remove Block menu item', () => {
+		beforeAll( addThreeParagraphsToNewPost );
+
+		it( 'results in two remaining blocks', async () => {
+			await clickOnBlockSettingsMenuItem( 'Remove Block' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			await page.keyboard.type( ' - caret was here' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'deleting the third block using the Remove Block shortcut', () => {
+		beforeAll( addThreeParagraphsToNewPost );
+
+		it( 'results in two remaining blocks', async () => {
+			await pressWithModifier( PRIMARY_ALT_MODIFIER_KEYS, 'Backspace' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			await page.keyboard.type( ' - caret was here' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'deleting the third block using backspace in an empty block', () => {
+		beforeAll( addThreeParagraphsToNewPost );
+
+		it( 'results in two remaining blocks', async () => {
+			await page.keyboard.press( 'Backspace' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			await page.keyboard.type( ' - caret was here' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'deleting the third block using backspace with block wrapper selection', () => {
+		beforeAll( addThreeParagraphsToNewPost );
+
+		it( 'results in three remaining blocks', async () => {
+			// Add an image block since it's easier to click the wrapper on non-textual blocks.
+			await page.keyboard.type( '/image' );
+			await page.keyboard.press( 'Enter' );
+
+			// Click on something that's not a block.
+			await page.click( '.editor-post-title' );
+
+			// Click on the third (image) block so that its wrapper is selected and backspace to delete it.
+			await page.click( '.editor-block-list__block:nth-child(3)' );
+			await page.keyboard.press( 'Backspace' );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			await page.keyboard.type( ' - caret was here' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'deleting third third and fourth blocks using backspace with multi-block selection', () => {
+		beforeAll( async () => {
+			await addThreeParagraphsToNewPost();
+
+			// Add a third paragraph for this test.
+			await page.keyboard.type( 'Third paragraph' );
+			await page.keyboard.press( 'Enter' );
+		} );
+
+		it( 'results in two remaining blocks', async () => {
+			// Press the up arrow once to select the third and fourth blocks.
+			await pressWithModifier( 'Shift', 'ArrowUp' );
+
+			// Now that the block wrapper is selected, press backspace to delete it.
+			await page.keyboard.press( 'Backspace' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			await page.keyboard.type( ' - caret was here' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+} );

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -3,7 +3,6 @@
  */
 import {
 	clickBlockAppender,
-	clickOnBlockSettingsMenuItem,
 	getEditedPostContent,
 	newPost,
 	pressWithModifier,
@@ -19,6 +18,12 @@ const addThreeParagraphsToNewPost = async () => {
 	await page.keyboard.press( 'Enter' );
 	await page.keyboard.type( 'Second paragraph' );
 	await page.keyboard.press( 'Enter' );
+};
+
+const clickOnBlockSettingsMenuItem = async ( buttonLabel ) => {
+	await expect( page ).toClick( '.editor-block-settings-menu__toggle' );
+	const itemButton = ( await page.$x( `//*[contains(@class, "editor-block-settings-menu__popover")]//button[contains(text(), '${ buttonLabel }')]` ) )[ 0 ];
+	await itemButton.click();
 };
 
 describe( 'block deletion -', () => {

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -7,7 +7,7 @@ import {
 	getEditedPostContent,
 	newPost,
 	pressWithModifier,
-	PRIMARY_ALT_MODIFIER_KEYS,
+	META_KEY,
 } from '../support/utils';
 
 const addThreeParagraphsToNewPost = async () => {
@@ -40,7 +40,7 @@ describe( 'block deletion -', () => {
 		beforeAll( addThreeParagraphsToNewPost );
 
 		it( 'results in two remaining blocks', async () => {
-			await pressWithModifier( PRIMARY_ALT_MODIFIER_KEYS, 'Backspace' );
+			await pressWithModifier( [ 'Alt', META_KEY ], 'Backspace' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -109,8 +109,6 @@ describe( 'block deletion -', () => {
 			// Now that the block wrapper is selected, press backspace to delete it.
 			await page.keyboard.press( 'Backspace' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
-
-			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 
 		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -27,52 +27,43 @@ const clickOnBlockSettingsMenuItem = async ( buttonLabel ) => {
 };
 
 describe( 'block deletion -', () => {
-	describe( 'deleting the third block using the Remove Block menu item', () => {
-		beforeAll( addThreeParagraphsToNewPost );
+	beforeEach( addThreeParagraphsToNewPost );
 
-		it( 'results in two remaining blocks', async () => {
+	describe( 'deleting the third block using the Remove Block menu item', () => {
+		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
 			await clickOnBlockSettingsMenuItem( 'Remove Block' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
-		} );
 
-		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			// Type additional text and assert that caret position is correct by comparing to snapshot.
 			await page.keyboard.type( ' - caret was here' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 	} );
 
 	describe( 'deleting the third block using the Remove Block shortcut', () => {
-		beforeAll( addThreeParagraphsToNewPost );
-
-		it( 'results in two remaining blocks', async () => {
+		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
 			await pressWithModifier( [ 'Alt', META_KEY ], 'Backspace' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
-		} );
 
-		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			// Type additional text and assert that caret position is correct by comparing to snapshot.
 			await page.keyboard.type( ' - caret was here' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 	} );
 
 	describe( 'deleting the third block using backspace in an empty block', () => {
-		beforeAll( addThreeParagraphsToNewPost );
-
-		it( 'results in two remaining blocks', async () => {
+		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
 			await page.keyboard.press( 'Backspace' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
-		} );
 
-		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			// Type additional text and assert that caret position is correct by comparing to snapshot.
 			await page.keyboard.type( ' - caret was here' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 	} );
 
 	describe( 'deleting the third block using backspace with block wrapper selection', () => {
-		beforeAll( addThreeParagraphsToNewPost );
-
-		it( 'results in three remaining blocks', async () => {
+		it( 'results in three remaining blocks and positions the caret at the end of the third block', async () => {
 			// Add an image block since it's easier to click the wrapper on non-textual blocks.
 			await page.keyboard.type( '/image' );
 			await page.keyboard.press( 'Enter' );
@@ -85,33 +76,27 @@ describe( 'block deletion -', () => {
 			await page.keyboard.press( 'Backspace' );
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
-		} );
 
-		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			// Type additional text and assert that caret position is correct by comparing to snapshot.
 			await page.keyboard.type( ' - caret was here' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 	} );
 
 	describe( 'deleting third third and fourth blocks using backspace with multi-block selection', () => {
-		beforeAll( async () => {
-			await addThreeParagraphsToNewPost();
-
+		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
 			// Add a third paragraph for this test.
 			await page.keyboard.type( 'Third paragraph' );
 			await page.keyboard.press( 'Enter' );
-		} );
 
-		it( 'results in two remaining blocks', async () => {
 			// Press the up arrow once to select the third and fourth blocks.
 			await pressWithModifier( 'Shift', 'ArrowUp' );
 
 			// Now that the block wrapper is selected, press backspace to delete it.
 			await page.keyboard.press( 'Backspace' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
-		} );
 
-		it( 'positions the caret at the end of the second block as evidenced by typing additional text', async () => {
+			// Type additional text and assert that caret position is correct by comparing to snapshot.
 			await page.keyboard.type( ' - caret was here' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -42,7 +42,7 @@ describe( 'block deletion -', () => {
 
 	describe( 'deleting the third block using the Remove Block shortcut', () => {
 		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
-			await pressWithModifier( [ 'Alt', META_KEY ], 'Backspace' );
+			await pressWithModifier( [ 'Shift', META_KEY ], 'x' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 
 			// Type additional text and assert that caret position is correct by comparing to snapshot.

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -34,6 +34,24 @@ export const META_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
 export const ACCESS_MODIFIER_KEYS = process.platform === 'darwin' ? [ 'Control', 'Alt' ] : [ 'Shift', 'Alt' ];
 
 /**
+ * Platform-specific modifier for the primary+alt key chord.
+ *
+ * @see pressWithModifier
+ *
+ * @type {string}
+ */
+export const PRIMARY_ALT_MODIFIER_KEYS = process.platform === 'darwin' ? [ 'Alt', 'Meta' ] : [ 'Control', 'Alt' ];
+
+/**
+ * Platform-specific modifier for the primary+shift key chord.
+ *
+ * @see pressWithModifier
+ *
+ * @type {string}
+ */
+export const PRIMARY_SHIFT_MODIFIER_KEYS = process.platform === 'darwin' ? [ 'Shift', 'Meta' ] : [ 'Control', 'Shift' ];
+
+/**
  * Regular expression matching zero-width space characters.
  *
  * @type {RegExp}
@@ -262,12 +280,23 @@ export async function pressWithModifier( modifiers, key ) {
 }
 
 /**
- * Clicks on More Menu item, searchers for the button with the text provided and clicks it.
+ * Clicks on More Menu item, searches for the button with the text provided and clicks it.
  *
  * @param {string} buttonLabel The label to search the button for.
  */
 export async function clickOnMoreMenuItem( buttonLabel ) {
 	await expect( page ).toClick( '.edit-post-more-menu [aria-label="More"]' );
+	const itemButton = ( await page.$x( `//button[contains(text(), '${ buttonLabel }')]` ) )[ 0 ];
+	await itemButton.click( 'button' );
+}
+
+/**
+ * Clicks on Block Settings Menu item, searches for the button with the text provided and clicks it.
+ *
+ * @param {string} buttonLabel The label to search the button for.
+ */
+export async function clickOnBlockSettingsMenuItem( buttonLabel ) {
+	await expect( page ).toClick( '.editor-block-settings-menu__toggle' );
 	const itemButton = ( await page.$x( `//button[contains(text(), '${ buttonLabel }')]` ) )[ 0 ];
 	await itemButton.click( 'button' );
 }

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -298,7 +298,7 @@ export async function clickOnMoreMenuItem( buttonLabel ) {
 export async function clickOnBlockSettingsMenuItem( buttonLabel ) {
 	await expect( page ).toClick( '.editor-block-settings-menu__toggle' );
 	const itemButton = ( await page.$x( `//*[contains(@class, "editor-block-settings-menu__popover")]//button[contains(text(), '${ buttonLabel }')]` ) )[ 0 ];
-	await itemButton.click( 'button' );
+	await itemButton.click();
 }
 
 /**

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -34,24 +34,6 @@ export const META_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
 export const ACCESS_MODIFIER_KEYS = process.platform === 'darwin' ? [ 'Control', 'Alt' ] : [ 'Shift', 'Alt' ];
 
 /**
- * Platform-specific modifier for the primary+alt key chord.
- *
- * @see pressWithModifier
- *
- * @type {string}
- */
-export const PRIMARY_ALT_MODIFIER_KEYS = process.platform === 'darwin' ? [ 'Alt', 'Meta' ] : [ 'Control', 'Alt' ];
-
-/**
- * Platform-specific modifier for the primary+shift key chord.
- *
- * @see pressWithModifier
- *
- * @type {string}
- */
-export const PRIMARY_SHIFT_MODIFIER_KEYS = process.platform === 'darwin' ? [ 'Shift', 'Meta' ] : [ 'Control', 'Shift' ];
-
-/**
  * Regular expression matching zero-width space characters.
  *
  * @type {RegExp}

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -297,7 +297,7 @@ export async function clickOnMoreMenuItem( buttonLabel ) {
  */
 export async function clickOnBlockSettingsMenuItem( buttonLabel ) {
 	await expect( page ).toClick( '.editor-block-settings-menu__toggle' );
-	const itemButton = ( await page.$x( `//button[contains(text(), '${ buttonLabel }')]` ) )[ 0 ];
+	const itemButton = ( await page.$x( `//*[contains(@class, "editor-block-settings-menu__popover")]//button[contains(text(), '${ buttonLabel }')]` ) )[ 0 ];
 	await itemButton.click( 'button' );
 }
 

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -273,17 +273,6 @@ export async function clickOnMoreMenuItem( buttonLabel ) {
 }
 
 /**
- * Clicks on Block Settings Menu item, searches for the button with the text provided and clicks it.
- *
- * @param {string} buttonLabel The label to search the button for.
- */
-export async function clickOnBlockSettingsMenuItem( buttonLabel ) {
-	await expect( page ).toClick( '.editor-block-settings-menu__toggle' );
-	const itemButton = ( await page.$x( `//*[contains(@class, "editor-block-settings-menu__popover")]//button[contains(text(), '${ buttonLabel }')]` ) )[ 0 ];
-	await itemButton.click();
-}
-
-/**
  * Publishes the post, resolving once the request is complete (once a notice
  * is displayed).
  *

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -206,7 +206,8 @@ export async function ensureSidebarOpened() {
  * Clicks the default block appender.
  */
 export async function clickBlockAppender() {
-	await expect( page ).toClick( '.editor-default-block-appender__content' );
+	await page.waitForSelector( '.editor-default-block-appender__content' );
+	await page.click( '.editor-default-block-appender__content' );
 	await waitForRichTextInitialization();
 }
 

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -206,7 +206,6 @@ export async function ensureSidebarOpened() {
  * Clicks the default block appender.
  */
 export async function clickBlockAppender() {
-	await page.waitForSelector( '.editor-default-block-appender__content' );
 	await page.click( '.editor-default-block-appender__content' );
 	await waitForRichTextInitialization();
 }


### PR DESCRIPTION
## Description
As pointed out on #8805 - when removing a block (using either the keyboard shortcut or block settings menu), the caret ends up at the beginning of a preceding paragraph block. It feels natural that the cursor should instead be at the end of the block.

This ticket features a couple of simple changes to improve the situation, placing the cursor by default at the end of the the next selected block in the REMOVE_BLOCKS effect.

Some duplicated code is also removed.

There still seem to be a few cases where the flow is not quite right:
- deleting blocks using DELETE key still selects previous block (#8965)
- deleting blocks so that the first block is the selected block behaves inconsistently - sometimes the selections is the end, sometimes the start (#8963)

These issues still exist in master, so will create separate issues.

## How has this been tested?
- Test removing block(s) using block settings keyboard shortcut (event handled by BlockSettingsMenu)
- Test removing block(s) using block settings menu (event handled by BlockSettingsMenu)
- Test removing a multi-block selection using delete/backspace (event handled by EditorGlobalKeyboardShortcuts)
- Test removing a non-RichText block like the Image Block using delete/backspace (event handled by BlockListBlock

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
