### PR TITLE
Fix the block styles in IE11

### DIFF
--- a/packages/editor/src/components/block-styles/style.scss
+++ b/packages/editor/src/components/block-styles/style.scss
@@ -1,12 +1,12 @@
 .editor-block-styles {
 	display: flex;
 	flex-wrap: wrap;
-	padding: $item-spacing / 2;
+	justify-content: space-between;
 }
 
 .editor-block-styles__item {
-	margin: $item-spacing / 2;
-	width: calc(50% - #{ $item-spacing });
+	width: calc(50% - #{ $item-spacing / 2 });
+	margin: ($item-spacing / 2) 0;
 	flex-shrink: 0;
 	cursor: pointer;
 	overflow: hidden;

--- a/packages/editor/src/components/block-styles/style.scss
+++ b/packages/editor/src/components/block-styles/style.scss
@@ -1,10 +1,13 @@
 .editor-block-styles {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-gap: $item-spacing;
+	display: flex;
+	flex-wrap: wrap;
+	padding: $item-spacing / 2;
 }
 
 .editor-block-styles__item {
+	margin: $item-spacing / 2;
+	width: calc(50% - #{ $item-spacing });
+	flex-shrink: 0;
 	cursor: pointer;
 	overflow: hidden;
 

--- a/packages/editor/src/components/block-switcher/style.scss
+++ b/packages/editor/src/components/block-switcher/style.scss
@@ -61,7 +61,7 @@
 
 .editor-block-switcher__popover:not(.is-mobile) > .components-popover__content {
 	// Reset overflow to allow showing the preview on the left once an item is hovered.
-	overflow-y: initial;
+	overflow-y: visible;
 }
 
 .editor-block-switcher__popover .editor-block-styles {

--- a/packages/editor/src/components/inserter/style.scss
+++ b/packages/editor/src/components/inserter/style.scss
@@ -18,7 +18,7 @@ $block-inserter-search-height: 38px;
 
 .editor-inserter__popover:not(.is-mobile) > .components-popover__content {
 	@include break-medium {
-		overflow-y: initial;
+		overflow-y: visible;
 		height: $block-inserter-content-height + $block-inserter-tabs-height + $block-inserter-search-height;
 	}
 }


### PR DESCRIPTION
closes #8623 

This PR fixes some style issues in the block style variations and the inserter:

 - Grid layout was not working in IE11, this uses flexbox to solve the issue (two styles per row)
 - `overflow-y: initial` was not working in IE11 causing the "flipping" effect when you hover block styles or shared blocks in the inserter.

**Testing instructions**

 - Ensure you can preview block styles and shared blocks
 - Ensure the block styles show properly (2 per row)