### PR TITLE
IE11: Fix The metaboxes area position (overlapping the content)

### DIFF
--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -86,7 +86,14 @@
 	-webkit-overflow-scrolling: touch;
 
 	.edit-post-visual-editor {
-		flex-basis: 100%;
+		flex-grow: 1;
+
+		// In IE11 flex-basis: 100% cause a bug where the metaboxes area overlap with the content area.
+		// Resetting the `auto` makes it behave properly.
+		flex-basis: auto;
+		@supports (position: sticky) {
+			flex-basis: 100%;
+		}
 	}
 
 	.edit-post-layout__metaboxes {

--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -89,8 +89,8 @@
 		flex-grow: 1;
 
 		// In IE11 flex-basis: 100% cause a bug where the metaboxes area overlap with the content area.
-		// Resetting the `auto` makes it behave properly.
-		flex-basis: auto;
+		// But it works as expected without it.
+		// The flex-basis is needed for the other browsers to make sure the content area is full-height.
 		@supports (position: sticky) {
 			flex-basis: 100%;
 		}


### PR DESCRIPTION
closes #5503

In IE11 the `flex-basis` property doesn't work properly. Fortunately, resetting its value to `auto` makes behave exactly like we want it to.

**Testing instructions**

 - Add a metabox 
 - If the content of your post is short, you should be able to click the blank area between the metaboxes and the content to type
 - If the content is long, the page scrolls but the content area don't overlap with the metabox area.