### PR TITLE
Fix our custom element serializer in IE11

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -512,11 +512,17 @@ export function renderElement( element, context, legacyContext = {} ) {
 
 			return renderElement( type( props, legacyContext ), context, legacyContext );
 	}
+
+	// React polyfills the symbol constants REACT_PROVIDER_TYPE and REACT_CONTEXT_TYPE
+	// using the 0xeacd and 0xeace numbers in IE11.
+	// See https://github.com/facebook/react/blob/master/packages/shared/ReactSymbols.js
 	switch ( type && type.$$typeof ) {
 		case REACT_PROVIDER_TYPE:
+		case 0xeacd:
 			return renderChildren( props.children, props.value, legacyContext );
 
 		case REACT_CONTEXT_TYPE:
+		case 0xeace:
 			return renderElement( props.children( context || type._currentValue ), context, legacyContext );
 	}
 


### PR DESCRIPTION
In IE11, React don't use the constants for its element types because of the lack of support for `Symbol`s. Which means in our element serializer we need to check against those numbers React uses as types.

This fixes an issue where RichText content was not saved in IE11

**Testing instructions**

 - Create a paragraph in IE11 and type something in it
 - Save and refresh the page
 - The content should still be there.