### PR TITLE
Introduce strip_dynamic_blocks() for excerpts 

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -91,6 +91,8 @@ function get_dynamic_block_names() {
 /**
  * Retrieve the dynamic blocks regular expression for searching.
  *
+ * @since 3.6.0
+ *
  * @return string
  */
 function get_dynamic_blocks_regex() {
@@ -222,6 +224,8 @@ add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode().
 /**
  * Remove all dynamic blocks from the given content.
  *
+ * @since 3.6.0
+ *
  * @param string $content Content of the current post.
  * @return string
  */
@@ -235,8 +239,9 @@ function strip_dynamic_blocks( $content ) {
  * It's a bit hacky for now, but once this gets merged into core the function
  * can just be called in `wp_trim_excerpt()`.
  *
- * @param string $text Excerpt.
+ * @since 3.6.0
  *
+ * @param string $text Excerpt.
  * @return string
  */
 function strip_dynamic_blocks_add_filter( $text ) {
@@ -251,6 +256,8 @@ add_filter( 'get_the_excerpt', 'strip_dynamic_blocks_add_filter', 9 ); // Before
  *
  * It's a bit hacky for now, but once this gets merged into core the function
  * can just be called in `wp_trim_excerpt()`.
+ *
+ * @since 3.6.0
  *
  * @param string $text Excerpt.
  * @return string

--- a/phpunit/class-blocks-api-test.php
+++ b/phpunit/class-blocks-api-test.php
@@ -10,6 +10,8 @@
  */
 class Blocks_API extends WP_UnitTestCase {
 
+	public static $post_id;
+
 	public $content = '
 <!-- wp:paragraph -->
 <p>paragraph</p>
@@ -33,6 +35,43 @@ class Blocks_API extends WP_UnitTestCase {
 <!-- /wp:spacer -->';
 
 	/**
+	 * Dummy block rendering function.
+	 *
+	 * @return string Block output.
+	 */
+	function render_dummy_block() {
+		return get_the_excerpt( self::$post_id );
+	}
+
+	/**
+	 * Set up.
+	 */
+	function setUp() {
+		parent::setUp();
+
+		self::$post_id = $this->factory()->post->create( array(
+			'post_excerpt' => '', // Empty excerpt, so it has to be generated.
+			'post_content' => '<!-- wp:core/dummy /-->',
+		) );
+
+		register_block_type( 'core/dummy', array(
+			'render_callback' => array( $this, 'render_dummy_block' ),
+		) );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	function tearDown() {
+		parent::tearDown();
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		$registry->unregister( 'core/dummy' );
+
+		wp_delete_post( self::$post_id, true );
+	}
+
+	/**
 	 * Tests strip_dynamic_blocks().
 	 *
 	 * @covers ::strip_dynamic_blocks
@@ -44,5 +83,29 @@ class Blocks_API extends WP_UnitTestCase {
 
 		// Dynamic block with options, embedded in other content.
 		$this->assertEquals( $this->filtered_content, strip_dynamic_blocks( $this->content ) );
+	}
+
+	/**
+	 * Tests that dynamic blocks don't cause an out-of-memory error.
+	 *
+	 * When dynamic blocks happen to generate an excerpt, they can cause an
+	 * infinite loop if that block is part of the post's content.
+	 *
+	 * `wp_trim_excerpt()` applies the `the_content` filter, which has
+	 * `do_blocks` attached to it, trying to render the block which again will
+	 * attempt to return an excerpt of that post.
+	 *
+	 * This infinite loop can be avoided by stripping dynamic blocks before
+	 * `the_content` gets applied, just like shortcodes.
+	 *
+	 * @covers ::strip_dynamic_blocks_add_filter, ::strip_dynamic_blocks_remove_filter
+	 */
+	function test_excerpt_infinite_loop() {
+		$query = new WP_Query( array(
+			'post__in' => array( self::$post_id ),
+		) );
+		$query->the_post();
+
+		$this->assertEmpty( do_blocks( '<!-- wp:core/dummy /-->' ) );
 	}
 }

--- a/phpunit/class-blocks-api-test.php
+++ b/phpunit/class-blocks-api-test.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Blocks API Tests
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Test functions in blocks.php
+ */
+class Blocks_API extends WP_UnitTestCase {
+
+	public $content = <<<CONTENT
+<!-- wp:paragraph -->
+<p>paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:latest-posts {"postsToShow":3,"displayPostDate":true,"order":"asc","orderBy":"title"} /-->
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+CONTENT;
+
+	public $filtered_content = <<<FILTERED_CONTENT
+<!-- wp:paragraph -->
+<p>paragraph</p>
+<!-- /wp:paragraph -->
+
+
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+FILTERED_CONTENT;
+
+	/**
+	 * Tests strip_dynamic_blocks().
+	 *
+	 * @covers ::strip_dynamic_blocks
+	 */
+	function test_strip_dynamic_blocks() {
+		// Simple dynamic block..
+		$content = '<!-- wp:core/block /-->';
+		$this->assertEmpty( strip_dynamic_blocks( $content ) );
+
+		// Dynamic block with options, embedded in other content.
+		$this->assertEquals( $this->filtered_content, strip_dynamic_blocks( $this->content ) );
+	}
+}

--- a/phpunit/class-blocks-api-test.php
+++ b/phpunit/class-blocks-api-test.php
@@ -10,7 +10,7 @@
  */
 class Blocks_API extends WP_UnitTestCase {
 
-	public $content = <<<CONTENT
+	public $content = '
 <!-- wp:paragraph -->
 <p>paragraph</p>
 <!-- /wp:paragraph -->
@@ -19,10 +19,9 @@ class Blocks_API extends WP_UnitTestCase {
 
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-CONTENT;
+<!-- /wp:spacer -->';
 
-	public $filtered_content = <<<FILTERED_CONTENT
+	public $filtered_content = '
 <!-- wp:paragraph -->
 <p>paragraph</p>
 <!-- /wp:paragraph -->
@@ -31,8 +30,7 @@ CONTENT;
 
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-FILTERED_CONTENT;
+<!-- /wp:spacer -->';
 
 	/**
 	 * Tests strip_dynamic_blocks().


### PR DESCRIPTION
## Description
Aims to fix #7268 by adding parity with `strip_shortcodes()` in `wp_trim_excerpt()`.
Aims to fix #5572 by removing dynamic blocks when generating excerpts to avoid infinite loops when dynamic blocks generate excerpts themselves.

## How has this been tested?
I created a dynamic block that generated an excerpt in its callback, embedded it, and tested that it didn't create an out-of-memory error. Also added a small unit test to verify dynamic blocks are stripped.

## Types of changes
* Moves generating dynamic block regex into its own function, similar to `get_shortcode_regex()`.
* Introduces `strip_dynamic_blocks()` function.
* Introduces a unit test for `strip_dynamic_blocks()`.
* Calls `strip_dynamic_blocks()` when generating an excerpt.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
