### PR TITLE
Refactor template select field to use SelectControl

### DIFF
--- a/packages/editor/src/components/page-attributes/template.js
+++ b/packages/editor/src/components/page-attributes/template.js
@@ -7,29 +7,27 @@ import { isEmpty, map } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { SelectControl } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-export function PageTemplate( { availableTemplates, selectedTemplate, instanceId, onUpdate } ) {
+export function PageTemplate( { availableTemplates, selectedTemplate, onUpdate } ) {
 	if ( isEmpty( availableTemplates ) ) {
 		return null;
 	}
-	const selectId = `template-selector-${ instanceId }`;
-	const onEventUpdate = ( event ) => onUpdate( event.target.value );
 	return (
-		<div className="editor-page-attributes__template">
-			<label htmlFor={ selectId }>{ __( 'Template:' ) }</label>
-			<select
-				id={ selectId }
-				value={ selectedTemplate }
-				onBlur={ onEventUpdate }
-				onChange={ onEventUpdate }
-			>
-				{ map( availableTemplates, ( templateName, templateSlug ) => (
-					<option key={ templateSlug } value={ templateSlug }>{ templateName }</option>
-				) ) }
-			</select>
-		</div>
+		<SelectControl
+			label={ __( 'Template:' ) }
+			value={ selectedTemplate }
+			onChange={ ( value ) => onUpdate( value ) }
+			className="editor-page-attributes__template"
+			options={
+				map( availableTemplates, ( templateName, templateSlug ) => ( {
+					value: templateSlug,
+					label: templateName,
+				} ) )
+			}
+		/>
 	);
 }
 
@@ -47,5 +45,4 @@ export default compose(
 			dispatch( 'core/editor' ).editPost( { template: templateSlug || '' } );
 		},
 	} ) ),
-	withInstanceId,
 )( PageTemplate );

--- a/packages/editor/src/components/page-attributes/template.js
+++ b/packages/editor/src/components/page-attributes/template.js
@@ -19,7 +19,7 @@ export function PageTemplate( { availableTemplates, selectedTemplate, onUpdate }
 		<SelectControl
 			label={ __( 'Template:' ) }
 			value={ selectedTemplate }
-			onChange={ ( value ) => onUpdate( value ) }
+			onChange={ onUpdate }
 			className="editor-page-attributes__template"
 			options={
 				map( availableTemplates, ( templateName, templateSlug ) => ( {


### PR DESCRIPTION
## Description
This fixes #8985 by refactoring the template select field to use `SelectControl` instead of an inline `<select>`. This applies the appropriate classes and such so the spacing is correct.

## How has this been tested?
Visually in browser, ran automated tests, Travis passes

## Screenshots

Before:
![edit_page_ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/44109335-c6f5329e-9fca-11e8-9f12-7b3cdf696c4e.png)

After:
![edit_page_ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/44108088-512b6388-9fc7-11e8-9a45-783a81597d54.png)

## Types of changes
Replaces `<select>` with `<SelectControl>`.

My main concern is that previously this select also had an `onBlur` handler, but there isn't an `onBlur` option on `<SelectControl>` so I removed it. This might be a huge mistake! In my testing it didn't seem to cause any issues, but it is worth noting.

I also removed the use of `withInstanceId` because that's natively supported in `SelectControl`, but again this could be a giant mistake.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
