### PR TITLE
Edit Post: Reset active sidebar tab on initial load

### DIFF
--- a/docs/data/data-core-edit-post.md
+++ b/docs/data/data-core-edit-post.md
@@ -36,7 +36,14 @@ Whether the plugin sidebar is opened.
 
 ### getActiveGeneralSidebarName
 
-Returns the current active general sidebar name.
+Returns the current active general sidebar name, or null if there is no
+general sidebar active. The active general sidebar is a unique name to
+identify either an editor or plugin sidebar.
+
+Examples:
+
+ - `edit-post/document`
+ - `my-plugin/insert-image-sidebar`
 
 *Parameters*
 

--- a/edit-post/store/defaults.js
+++ b/edit-post/store/defaults.js
@@ -1,6 +1,6 @@
 export const PREFERENCES_DEFAULTS = {
 	editorMode: 'visual',
-	activeGeneralSidebar: 'edit-post/document', // null | 'edit-post/block' | 'edit-post/document' | 'plugin/*'
+	isGeneralSidebarDismissed: false,
 	panels: { 'post-status': true },
 	features: {
 		fixedToolbar: false,

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -14,6 +14,13 @@ import { combineReducers } from '@wordpress/data';
 import { PREFERENCES_DEFAULTS } from './defaults';
 
 /**
+ * The default active general sidebar: The "Document" tab.
+ *
+ * @type {string}
+ */
+export const DEFAULT_ACTIVE_GENERAL_SIDEBAR = 'edit-post/document';
+
+/**
  * Reducer returning the user preferences.
  *
  * @param {Object}  state                           Current state.
@@ -89,13 +96,10 @@ export const preferences = combineReducers( {
  *
  * @return {?string} Updated state.
  */
-export function activeGeneralSidebar( state = null, action ) {
+export function activeGeneralSidebar( state = DEFAULT_ACTIVE_GENERAL_SIDEBAR, action ) {
 	switch ( action.type ) {
 		case 'OPEN_GENERAL_SIDEBAR':
 			return action.name;
-
-		case 'CLOSE_GENERAL_SIDEBAR':
-			return null;
 	}
 
 	return state;

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -16,27 +16,28 @@ import { PREFERENCES_DEFAULTS } from './defaults';
 /**
  * Reducer returning the user preferences.
  *
- * @param {Object}  state                 Current state.
- * @param {string}  state.mode            Current editor mode, either "visual" or "text".
- * @param {boolean} state.isSidebarOpened Whether the sidebar is opened or closed.
- * @param {Object}  state.panels          The state of the different sidebar panels.
- * @param {Object}  action                Dispatched action.
+ * @param {Object}  state                           Current state.
+ * @param {string}  state.mode                      Current editor mode, either
+ *                                                  "visual" or "text".
+ * @param {boolean} state.isGeneralSidebarDismissed Whether general sidebar is
+ *                                                  dismissed. False by default
+ *                                                  or when closing general
+ *                                                  sidebar, true when opening
+ *                                                  sidebar.
+ * @param {boolean} state.isSidebarOpened           Whether the sidebar is
+ *                                                  opened or closed.
+ * @param {Object}  state.panels                    The state of the different
+ *                                                  sidebar panels.
+ * @param {Object}  action                          Dispatched action.
  *
- * @return {string} Updated state.
+ * @return {Object} Updated state.
  */
 export const preferences = combineReducers( {
-	activeGeneralSidebar( state = PREFERENCES_DEFAULTS.activeGeneralSidebar, action ) {
+	isGeneralSidebarDismissed( state = false, action ) {
 		switch ( action.type ) {
 			case 'OPEN_GENERAL_SIDEBAR':
-				return action.name;
-
 			case 'CLOSE_GENERAL_SIDEBAR':
-				return null;
-			case 'SERIALIZE': {
-				if ( state === 'edit-post/block' ) {
-					return PREFERENCES_DEFAULTS.activeGeneralSidebar;
-				}
-			}
+				return action.type === 'CLOSE_GENERAL_SIDEBAR';
 		}
 
 		return state;
@@ -78,6 +79,27 @@ export const preferences = combineReducers( {
 		return state;
 	},
 } );
+
+/**
+ * Reducer returning the next active general sidebar state. The active general
+ * sidebar is a unique name to identify either an editor or plugin sidebar.
+ *
+ * @param {?string} state  Current state.
+ * @param {Object}  action Action object.
+ *
+ * @return {?string} Updated state.
+ */
+export function activeGeneralSidebar( state = null, action ) {
+	switch ( action.type ) {
+		case 'OPEN_GENERAL_SIDEBAR':
+			return action.name;
+
+		case 'CLOSE_GENERAL_SIDEBAR':
+			return null;
+	}
+
+	return state;
+}
 
 export function panel( state = 'document', action ) {
 	switch ( action.type ) {
@@ -192,6 +214,7 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 
 export default combineReducers( {
 	preferences,
+	activeGeneralSidebar,
 	panel,
 	activeModal,
 	publishSidebarActive,

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -60,14 +60,7 @@ export function getActiveGeneralSidebarName( state ) {
 		return null;
 	}
 
-	// If not dismissed and an active sidebar is assigned, used.
-	const { activeGeneralSidebar } = state;
-	if ( activeGeneralSidebar !== null ) {
-		return activeGeneralSidebar;
-	}
-
-	// Default to Document tab.
-	return 'edit-post/document';
+	return state.activeGeneralSidebar;
 }
 
 /**

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -23,7 +23,7 @@ export function getEditorMode( state ) {
  * @return {boolean} Whether the editor sidebar is opened.
  */
 export function isEditorSidebarOpened( state ) {
-	const activeGeneralSidebar = getPreference( state, 'activeGeneralSidebar', null );
+	const activeGeneralSidebar = getActiveGeneralSidebarName( state );
 
 	return includes( [ 'edit-post/document', 'edit-post/block' ], activeGeneralSidebar );
 }
@@ -40,14 +40,34 @@ export function isPluginSidebarOpened( state ) {
 }
 
 /**
- * Returns the current active general sidebar name.
+ * Returns the current active general sidebar name, or null if there is no
+ * general sidebar active. The active general sidebar is a unique name to
+ * identify either an editor or plugin sidebar.
+ *
+ * Examples:
+ *
+ *  - `edit-post/document`
+ *  - `my-plugin/insert-image-sidebar`
  *
  * @param {Object} state Global application state.
  *
  * @return {?string} Active general sidebar name.
  */
 export function getActiveGeneralSidebarName( state ) {
-	return getPreference( state, 'activeGeneralSidebar', null );
+	// Dismissal takes precedent.
+	const isDismissed = getPreference( state, 'isGeneralSidebarDismissed', false );
+	if ( isDismissed ) {
+		return null;
+	}
+
+	// If not dismissed and an active sidebar is assigned, used.
+	const { activeGeneralSidebar } = state;
+	if ( activeGeneralSidebar !== null ) {
+		return activeGeneralSidebar;
+	}
+
+	// Default to Document tab.
+	return 'edit-post/document';
 }
 
 /**

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -7,6 +7,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
+	DEFAULT_ACTIVE_GENERAL_SIDEBAR,
 	preferences,
 	activeGeneralSidebar,
 	activeModal,
@@ -124,6 +125,12 @@ describe( 'state', () => {
 	} );
 
 	describe( 'activeGeneralSidebar', () => {
+		it( 'should default to the default active sidebar', () => {
+			const state = activeGeneralSidebar( undefined, {} );
+
+			expect( state ).toBe( DEFAULT_ACTIVE_GENERAL_SIDEBAR );
+		} );
+
 		it( 'should set the general sidebar', () => {
 			const original = activeGeneralSidebar( undefined, {} );
 			const state = activeGeneralSidebar( original, {
@@ -132,31 +139,6 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toBe( 'edit-post/document' );
-		} );
-
-		it( 'should does not update if sidebar is already set to value', () => {
-			const original = activeGeneralSidebar( undefined, {
-				type: 'OPEN_GENERAL_SIDEBAR',
-				name: 'edit-post/document',
-			} );
-			const state = activeGeneralSidebar( original, {
-				type: 'OPEN_GENERAL_SIDEBAR',
-				name: 'edit-post/document',
-			} );
-
-			expect( original ).toBe( state );
-		} );
-
-		it( 'should unset the general sidebar', () => {
-			const original = activeGeneralSidebar( undefined, {
-				type: 'OPEN_GENERAL_SIDEBAR',
-				name: 'edit-post/document',
-			} );
-			const state = activeGeneralSidebar( original, {
-				type: 'CLOSE_GENERAL_SIDEBAR',
-			} );
-
-			expect( state ).toBe( null );
 		} );
 	} );
 

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -8,6 +8,7 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	preferences,
+	activeGeneralSidebar,
 	activeModal,
 	isSavingMetaBoxes,
 	metaBoxes,
@@ -19,57 +20,25 @@ describe( 'state', () => {
 			const state = preferences( undefined, {} );
 
 			expect( state ).toEqual( {
-				activeGeneralSidebar: 'edit-post/document',
 				editorMode: 'visual',
+				isGeneralSidebarDismissed: false,
 				panels: { 'post-status': true },
 				features: { fixedToolbar: false },
 				pinnedPluginItems: {},
 			} );
 		} );
 
-		it( 'should set the general sidebar', () => {
+		it( 'should set the general sidebar dismissed', () => {
 			const original = deepFreeze( preferences( undefined, {} ) );
 			const state = preferences( original, {
 				type: 'OPEN_GENERAL_SIDEBAR',
 				name: 'edit-post/document',
 			} );
 
-			expect( state.activeGeneralSidebar ).toBe( 'edit-post/document' );
+			expect( state.isGeneralSidebarDismissed ).toBe( false );
 		} );
 
-		it( 'should save activeGeneralSidebar default value when serializing if the value was edit-post/block', () => {
-			const state = preferences( {
-				activeGeneralSidebar: 'edit-post/block',
-				editorMode: 'visual',
-				panels: { 'post-status': true },
-				features: { fixedToolbar: false },
-			}, {
-				type: 'SERIALIZE',
-			} );
-
-			expect( state ).toEqual( {
-				activeGeneralSidebar: 'edit-post/document',
-				editorMode: 'visual',
-				panels: { 'post-status': true },
-				features: { fixedToolbar: false },
-				pinnedPluginItems: {},
-			} );
-		} );
-
-		it( 'should does not update if sidebar is already set to value', () => {
-			const original = deepFreeze( preferences( undefined, {
-				type: 'OPEN_GENERAL_SIDEBAR',
-				name: 'edit-post/document',
-			} ) );
-			const state = preferences( original, {
-				type: 'OPEN_GENERAL_SIDEBAR',
-				name: 'edit-post/document',
-			} );
-
-			expect( original ).toBe( state );
-		} );
-
-		it( 'should unset the general sidebar', () => {
+		it( 'should set the general sidebar undismissed', () => {
 			const original = deepFreeze( preferences( undefined, {
 				type: 'OPEN_GENERAL_SIDEBAR',
 				name: 'edit-post/document',
@@ -78,7 +47,7 @@ describe( 'state', () => {
 				type: 'CLOSE_GENERAL_SIDEBAR',
 			} );
 
-			expect( state.activeGeneralSidebar ).toBe( null );
+			expect( state.isGeneralSidebarDismissed ).toBe( true );
 		} );
 
 		it( 'should set the sidebar panel open flag to true if unset', () => {
@@ -151,6 +120,43 @@ describe( 'state', () => {
 
 				expect( state.pinnedPluginItems[ 'foo/disabled' ] ).toBe( true );
 			} );
+		} );
+	} );
+
+	describe( 'activeGeneralSidebar', () => {
+		it( 'should set the general sidebar', () => {
+			const original = activeGeneralSidebar( undefined, {} );
+			const state = activeGeneralSidebar( original, {
+				type: 'OPEN_GENERAL_SIDEBAR',
+				name: 'edit-post/document',
+			} );
+
+			expect( state ).toBe( 'edit-post/document' );
+		} );
+
+		it( 'should does not update if sidebar is already set to value', () => {
+			const original = activeGeneralSidebar( undefined, {
+				type: 'OPEN_GENERAL_SIDEBAR',
+				name: 'edit-post/document',
+			} );
+			const state = activeGeneralSidebar( original, {
+				type: 'OPEN_GENERAL_SIDEBAR',
+				name: 'edit-post/document',
+			} );
+
+			expect( original ).toBe( state );
+		} );
+
+		it( 'should unset the general sidebar', () => {
+			const original = activeGeneralSidebar( undefined, {
+				type: 'OPEN_GENERAL_SIDEBAR',
+				name: 'edit-post/document',
+			} );
+			const state = activeGeneralSidebar( original, {
+				type: 'CLOSE_GENERAL_SIDEBAR',
+			} );
+
+			expect( state ).toBe( null );
 		} );
 	} );
 

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -166,17 +166,6 @@ describe( 'selectors', () => {
 
 			expect( getActiveGeneralSidebarName( state ) ).toBe( 'edit-post/block' );
 		} );
-
-		it( 'returns default value when no active general sidebar assigned', () => {
-			const state = {
-				preferences: {
-					isGeneralSidebarDismissed: false,
-				},
-				activeGeneralSidebar: null,
-			};
-
-			expect( getActiveGeneralSidebarName( state ) ).toBe( 'edit-post/document' );
-		} );
 	} );
 
 	describe( 'isModalActive', () => {

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -9,6 +9,7 @@ import {
 	isModalActive,
 	isFeatureActive,
 	isPluginSidebarOpened,
+	getActiveGeneralSidebarName,
 	isPluginItemPinned,
 	getMetaBoxes,
 	hasMetaBoxes,
@@ -65,8 +66,20 @@ describe( 'selectors', () => {
 		it( 'should return false when the editor sidebar is not opened', () => {
 			const state = {
 				preferences: {
-					activeGeneralSidebar: null,
+					isGeneralSidebarDismissed: true,
 				},
+				activeGeneralSidebar: null,
+			};
+
+			expect( isEditorSidebarOpened( state ) ).toBe( false );
+		} );
+
+		it( 'should return false when the editor sidebar is assigned but not opened', () => {
+			const state = {
+				preferences: {
+					isGeneralSidebarDismissed: true,
+				},
+				activeGeneralSidebar: 'edit-post/document',
 			};
 
 			expect( isEditorSidebarOpened( state ) ).toBe( false );
@@ -75,8 +88,9 @@ describe( 'selectors', () => {
 		it( 'should return false when the plugin sidebar is opened', () => {
 			const state = {
 				preferences: {
-					activeGeneralSidebar: 'my-plugin/my-sidebar',
+					isGeneralSidebarDismissed: false,
 				},
+				activeGeneralSidebar: 'my-plugin/my-sidebar',
 			};
 
 			expect( isEditorSidebarOpened( state ) ).toBe( false );
@@ -85,8 +99,9 @@ describe( 'selectors', () => {
 		it( 'should return true when the editor sidebar is opened', () => {
 			const state = {
 				preferences: {
-					activeGeneralSidebar: 'edit-post/document',
+					isGeneralSidebarDismissed: false,
 				},
+				activeGeneralSidebar: 'edit-post/document',
 			};
 
 			expect( isEditorSidebarOpened( state ) ).toBe( true );
@@ -97,8 +112,9 @@ describe( 'selectors', () => {
 		it( 'should return false when the plugin sidebar is not opened', () => {
 			const state = {
 				preferences: {
-					activeGeneralSidebar: null,
+					isGeneralSidebarDismissed: true,
 				},
+				activeGeneralSidebar: null,
 			};
 
 			expect( isPluginSidebarOpened( state ) ).toBe( false );
@@ -107,8 +123,9 @@ describe( 'selectors', () => {
 		it( 'should return false when the editor sidebar is opened', () => {
 			const state = {
 				preferences: {
-					activeGeneralSidebar: 'edit-post/document',
+					isGeneralSidebarDismissed: false,
 				},
+				activeGeneralSidebar: 'edit-post/document',
 			};
 
 			expect( isPluginSidebarOpened( state ) ).toBe( false );
@@ -118,11 +135,47 @@ describe( 'selectors', () => {
 			const name = 'plugin-sidebar/my-plugin/my-sidebar';
 			const state = {
 				preferences: {
-					activeGeneralSidebar: name,
+					isGeneralSidebarDismissed: false,
 				},
+				activeGeneralSidebar: name,
 			};
 
 			expect( isPluginSidebarOpened( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'getActiveGeneralSidebarName', () => {
+		it( 'returns null if dismissed', () => {
+			const state = {
+				preferences: {
+					isGeneralSidebarDismissed: true,
+				},
+				activeGeneralSidebar: 'edit-post/block',
+			};
+
+			expect( getActiveGeneralSidebarName( state ) ).toBe( null );
+		} );
+
+		it( 'returns active general sidebar', () => {
+			const state = {
+				preferences: {
+					isGeneralSidebarDismissed: false,
+				},
+				activeGeneralSidebar: 'edit-post/block',
+			};
+
+			expect( getActiveGeneralSidebarName( state ) ).toBe( 'edit-post/block' );
+		} );
+
+		it( 'returns default value when no active general sidebar assigned', () => {
+			const state = {
+				preferences: {
+					isGeneralSidebarDismissed: false,
+				},
+				activeGeneralSidebar: null,
+			};
+
+			expect( getActiveGeneralSidebarName( state ) ).toBe( 'edit-post/document' );
 		} );
 	} );
 

--- a/test/e2e/specs/preferences.test.js
+++ b/test/e2e/specs/preferences.test.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import { newPost } from '../support/utils';
+
+describe( 'preferences', () => {
+	beforeAll( async () => {
+		await newPost();
+	} );
+
+	/**
+	 * Returns a promise which resolves to the text content of the active
+	 * editor sidebar tab, or null if there is no active sidebar tab (closed).
+	 *
+	 * @return {Promise} Promise resolving to active tab.
+	 */
+	async function getActiveSidebarTabText() {
+		try {
+			return await page.$eval(
+				'.edit-post-sidebar__panel-tab.is-active',
+				( node ) => node.textContent
+			);
+		} catch ( error ) {
+			// page.$eval throws when it does not find the selector, which we
+			// can intentionally intercept and consider as there being no
+			// active sidebar tab (no sidebar).
+			return null;
+		}
+	}
+
+	it( 'remembers sidebar dismissal between sessions', async () => {
+		// Open by default.
+		expect( await getActiveSidebarTabText() ).toBe( 'Document' );
+
+		// Change to "Block" tab.
+		await page.click( '.edit-post-sidebar__panel-tab[aria-label="Block settings"]' );
+		expect( await getActiveSidebarTabText() ).toBe( 'Block' );
+
+		// Regression test: Reload resets to document tab.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/6377
+		// See: https://github.com/WordPress/gutenberg/pull/8995
+		await page.reload();
+		expect( await getActiveSidebarTabText() ).toBe( 'Document' );
+
+		// Dismiss
+		await page.click( '.edit-post-sidebar__panel-tabs [aria-label="Close settings"]' );
+		expect( await getActiveSidebarTabText() ).toBe( null );
+
+		// Remember after reload.
+		await page.reload();
+		expect( await getActiveSidebarTabText() ).toBe( null );
+	} );
+} );


### PR DESCRIPTION
Fixes #6377 
Related: #6382

This pull request seeks to resolve a regression which was recently introduced in recent refactoring of state persistence. The `SERIALIZE` action type is no longer used to limit or modify the persisted result.

The changes here, rather than imitate the equivalent, instead change active general sidebar to be a non-persisted state value. However, in implementing this it was discovered that we may want to at least persist whether or not the user chooses to dismiss the sidebar altogether. Thus, there are now two state values: `state.activeGeneralSidebar` (string, not persisted) and `state.preferences.isGeneralSidebarDismissed` (boolean, persisted).

It is not quite the same behavior in that if a plugin sidebar is activated, the sidebar will still be reset to `edit-post/document` on the next session. This is an intentional change.

**Testing instructions:**

Repeat steps to reproduce from #6377, ensuring that sidebar resets between editor sessions.

Ensure unit tests pass:

```
npm run test-unit
```