### PR TITLE
Element: Create dummy context components for type switch

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -42,33 +42,13 @@ import {
  * Internal dependencies
  */
 import {
+	createContext,
 	Fragment,
 	StrictMode,
 } from './react';
 import RawHTML from './raw-html';
 
-/**
- * Boolean reflecting whether the current environment supports Symbol.
- *
- * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
- *
- * @type {boolean}
- */
-const HAS_SYMBOL = typeof Symbol === 'function' && Symbol.for;
-
-/**
- * Internal React symbol representing Provider type.
- *
- * @type {Symbol}
- */
-const REACT_PROVIDER_TYPE = HAS_SYMBOL ? Symbol.for( 'react.provider' ) : 0xeacd;
-
-/**
- * Internal React symbol representing context (Consumer) type.
- *
- * @type {Symbol}
- */
-const REACT_CONTEXT_TYPE = HAS_SYMBOL ? Symbol.for( 'react.context' ) : 0xeace;
+const { Provider, Consumer } = createContext();
 
 /**
  * Valid attribute types.
@@ -513,16 +493,11 @@ export function renderElement( element, context, legacyContext = {} ) {
 			return renderElement( type( props, legacyContext ), context, legacyContext );
 	}
 
-	// React polyfills the symbol constants REACT_PROVIDER_TYPE and REACT_CONTEXT_TYPE
-	// using the 0xeacd and 0xeace numbers in IE11.
-	// See https://github.com/facebook/react/blob/master/packages/shared/ReactSymbols.js
 	switch ( type && type.$$typeof ) {
-		case REACT_PROVIDER_TYPE:
-		case 0xeacd:
+		case Provider.$$typeof:
 			return renderChildren( props.children, props.value, legacyContext );
 
-		case REACT_CONTEXT_TYPE:
-		case 0xeace:
+		case Consumer.$$typeof:
 			return renderElement( props.children( context || type._currentValue ), context, legacyContext );
 	}
 


### PR DESCRIPTION
Related: #8967

This pull request seeks to refactor the serialize behavior of `@wordpress/element` to reference `$$typeof` property of dummy `Provider` and `Consumer` components when serializing context. 

**Testing instructions:**

Verify there are no regressions in the issue described in #8967.

Ensure unit tests pass:

```
npm run test-unit
```