### PR TITLE
Fix shared block deprecation

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -21,6 +21,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.utils.mediaUpload` has been removed. Please use `wp.editor.mediaUpload` instead.
  - `wp.utils.preloadImage` has been removed.
  - `supports.wideAlign` has been removed from the Block API. Please use `supports.alignWide` instead.
+ - `fetchSharedBlocks`, `receiveSharedBlocks`, `saveSharedBlock`, `deleteSharedBlock`, `updateSharedBlockTitle`, and `convertBlockToShared` has been removed. Please use `fetchReusableBlocks`, `receiveReusableBlocks`, `saveReusableBlock`, `deleteReusableBlock`, `updateReusableBlockTitle`, or `convertBlockToReusable` instead.
 
 ## 3.5.0
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -815,8 +815,8 @@ export function updateSharedBlockTitle( id, title ) {
 	return updateReusableBlockTitle( id, title );
 }
 
-export function convertBlockToSaved( clientId ) {
-	deprecated( 'convertBlockToSaved', {
+export function convertBlockToShared( clientId ) {
+	deprecated( 'convertBlockToShared', {
 		alternative: 'convertBlockToReusable',
 		version: '3.6',
 		plugin: 'Gutenberg',


### PR DESCRIPTION
Fixes some mistakes in https://github.com/WordPress/gutenberg/pull/8123.

- `convertBlockToShared` which was added for backwards compatibility was accidentally named `convertBlockToSaved`.
- Deprecation notes weren't added to `deprecated.md`.