### PR TITLE
Polish permalink UI and make it responsive

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -129,6 +129,7 @@ body.gutenberg-editor-page {
 // Override core input styles to provide styles consistent with Gutenberg.
 // Upstream ticket for redesigned input and styles in general: https://core.trac.wordpress.org/ticket/44749
 // Upstream ticket for redesigned checkbox: https://core.trac.wordpress.org/ticket/35596
+.editor-post-permalink,
 .edit-post-sidebar,
 .editor-post-publish-panel,
 .editor-block-list__block,

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -784,10 +784,12 @@
 		// Matches the whole empty space between two blocks.
 		height: $block-padding * 2;
 		bottom: auto;
+
+		// Go edge to edge on mobile.
 		left: 0;
 		right: 0;
 
-		// Stack with block borders beyond mobile.
+		// Beyond mobile, make sure the toolbar overlaps the hover style.
 		@include break-small() {
 			left: -$border-width;
 			right: -$border-width;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -198,9 +198,9 @@
 			transition: outline 0.1s linear;
 			pointer-events: none;
 
-			// Show wider padding for top level blocks.
-			right: -$parent-block-padding;
-			left: -$parent-block-padding;
+			// Go edge tp edge on mobile.
+			right: -$block-padding;
+			left: -$block-padding;
 			top: -$block-padding;
 			bottom: -$block-padding;
 
@@ -780,11 +780,18 @@
 	> .editor-block-list__insertion-point {
 		position: absolute;
 		top: -$block-padding - $block-spacing / 2;
-		// Matches the whole empty space between two blocks
+
+		// Matches the whole empty space between two blocks.
 		height: $block-padding * 2;
 		bottom: auto;
-		left: -$border-width;
-		right: -$border-width;
+		left: 0;
+		right: 0;
+
+		// Stack with block borders beyond mobile.
+		@include break-small() {
+			left: -$border-width;
+			right: -$border-width;
+		}
 	}
 
 	&[data-align="full"] > .editor-block-list__insertion-point {
@@ -854,8 +861,8 @@
 	}
 
 	// Make block toolbar full width on mobile.
-	margin-left: -$border-width;
-	margin-right: -$border-width;
+	margin-left: 0;
+	margin-right: 0;
 
 	@include break-small() {
 		margin-left: -$parent-block-padding - $parent-block-padding - $border-width;
@@ -962,8 +969,12 @@
 	z-index: z-index(".editor-block-list__breadcrumb");
 
 	// Position in the top right of the border.
-	right: -$block-parent-side-ui-clearance;
+	right: 0;
 	top: -$block-padding - $border-width;
+
+	@include break-small() {
+		right: -$block-parent-side-ui-clearance;
+	}
 
 	// Nested
 	.editor-block-list__block-edit & {

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -198,7 +198,7 @@
 			transition: outline 0.1s linear;
 			pointer-events: none;
 
-			// Go edge tp edge on mobile.
+			// Go edge-to-edge on mobile.
 			right: -$block-padding;
 			left: -$block-padding;
 			top: -$block-padding;

--- a/packages/editor/src/components/post-permalink/editor.js
+++ b/packages/editor/src/components/post-permalink/editor.js
@@ -49,7 +49,7 @@ class PostPermalinkEditor extends Component {
 				className="editor-post-permalink-editor"
 				onSubmit={ this.onSavePermalink }
 			>
-				<span>
+				<span className="editor-post-permalink-editor__container">
 					<span className="editor-post-permalink-editor__prefix">
 						{ prefix }
 					</span>

--- a/packages/editor/src/components/post-permalink/editor.js
+++ b/packages/editor/src/components/post-permalink/editor.js
@@ -49,7 +49,7 @@ class PostPermalinkEditor extends Component {
 				className="editor-post-permalink-editor"
 				onSubmit={ this.onSavePermalink }
 			>
-				<span className="editor-post-permalink-editor__container">
+				<span className="editor-post-permalink__editor-container">
 					<span className="editor-post-permalink-editor__prefix">
 						{ prefix }
 					</span>

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -70,9 +70,10 @@
 	text-overflow: ellipsis;
 }
 
-.editor-post-permalink-editor__edit {
+.editor-post-permalink input[type="text"].editor-post-permalink-editor__edit {
 	min-width: 20%;
-	margin: 0 5px;
+	margin: 0 3px;
+	padding: 2px 4px;
 }
 
 .editor-post-permalink-editor__suffix {

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -55,7 +55,7 @@
 	display: inline-flex;
 	align-items: center;
 
-	.editor-post-permalink-editor__container {
+	.editor-post-permalink__editor-container {
 		flex: 0 1 100%;
 		display: flex;
 		overflow: hidden; // This enables serious flex shrinking.

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -91,7 +91,7 @@
 }
 
 .editor-post-permalink input[type="text"].editor-post-permalink-editor__edit {
-	// Input fields are created with inherent widths. 
+	// Input fields are created with inherent widths.
 	// By supplying both a (any) width and a min-width, we allow it to scale in a flex container.
 	min-width: 10%;
 	width: 100%;

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -55,9 +55,29 @@
 	display: inline-flex;
 	align-items: center;
 
+	.editor-post-permalink-editor__container {
+		flex: 0 1 100%;
+		display: flex;
+		overflow: hidden; // This enables serious flex shrinking.
+		padding: $border-width 0; // Necessary for the overflow to not crop the focus style.
+
+		.editor-post-permalink-editor__prefix {
+			flex: 1 1 auto;
+
+			@include break-small {
+				flex: 1 0 auto;
+			}
+		}
+
+		.editor-post-permalink-editor__edit {
+			flex: 1 1 100%;
+		}
+	}
+
 	// Higher specificity required to override core margin styles.
 	.editor-post-permalink-editor__save {
 		margin-left: auto;
+		flex: 0 1 auto;
 	}
 }
 
@@ -71,12 +91,16 @@
 }
 
 .editor-post-permalink input[type="text"].editor-post-permalink-editor__edit {
-	min-width: 20%;
+	// Input fields are born with inherent widths. 
+	// By supplying both a (any) width and a min-width, we allow it to scale in a flex container.
+	min-width: 10%;
+	width: 100%;
 	margin: 0 3px;
 	padding: 2px 4px;
 }
 
 .editor-post-permalink-editor__suffix {
 	color: $dark-gray-300;
-	margin-right: 10px;
+	margin-right: 6px;
+	flex: 0 0 0%;
 }

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -91,7 +91,7 @@
 }
 
 .editor-post-permalink input[type="text"].editor-post-permalink-editor__edit {
-	// Input fields are born with inherent widths. 
+	// Input fields are created with inherent widths. 
 	// By supplying both a (any) width and a min-width, we allow it to scale in a flex container.
 	min-width: 10%;
 	width: 100%;


### PR DESCRIPTION
This PR fixes three things:

1. It fixes an issue where the focus style of the editable slug in the permalink editor did not have the new focus styles.
2. It fixes a regression with a horizontal scrollbar on the middle breakpoint.
3. It fixes the permalink editor so it scales to mobile.

GIFs:

![focus](https://user-images.githubusercontent.com/1204802/44141765-6f342146-a07e-11e8-86cc-2c43dd2ac7b3.gif)

![responsive](https://user-images.githubusercontent.com/1204802/44141772-7151c172-a07e-11e8-96c8-793f12f82351.gif)

To test, please verify that permalink editing works on all breakpoints. Please also test the demo content to see that the hover styles of various blocks at various breakpoints did not regress as part of the horizontal scrollbar fix. 

This addresses feedback in https://github.com/WordPress/gutenberg/pull/6480#issuecomment-411393551.