### PR TITLE
Fix code block style regression.

### DIFF
--- a/packages/block-library/src/code/editor.scss
+++ b/packages/block-library/src/code/editor.scss
@@ -2,9 +2,10 @@
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
 	color: $dark-gray-800;
-	padding: 0.8em 1.6em;
-	border: $border-width solid $light-gray-500;
-	border-radius: 4px;
+
+	&:focus {
+		box-shadow: none;
+	}
 }
 
 // We should extract this to a separate components-toolbar

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -2,7 +2,7 @@
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
 	color: $dark-gray-800;
-	padding: 0.8em 1.6em;
+	padding: 0.8em 1em;
 	border: 1px solid $light-gray-500;
 	border-radius: 4px;
 }


### PR DESCRIPTION
The recent input field changes regressed the style of the code block. This fixes them again, and adjusts the padding to be less rectangular.

Screenshot, now:

<img width="699" alt="screen shot 2018-08-15 at 12 35 33" src="https://user-images.githubusercontent.com/1204802/44144455-e302d80c-a087-11e8-99eb-0fe8e83cd71c.png">
