### PR TITLE
Fix canvas jumb when navigation regions

### DIFF
--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -117,15 +117,16 @@
 }
 
 .edit-post-toggle-publish-panel {
-	display: block;
-	position: relative;
-	float: right;
-	top: -9999em;
+	position: absolute;
+	bottom: 0;
+	right: 0;
 	z-index: z-index(".edit-post-toggle-publish-panel");
-	padding: 20px 0 0 0;
 	width: $sidebar-width;
+	height: 0;
+	overflow: hidden;
 	&:focus-within {
-		top: 0;
+		height: auto;
+		padding: 20px 0 0 0;
 	}
 
 	.edit-post-toggle-publish-panel__button {


### PR DESCRIPTION
closes #9006 

This PR simplifies the styling of the "Toggle publish panel" aria region to avoid content jumps.

**Testing instructions**

 - Write a long post (requires scrolling)
 - Navigate regions using `Alt + Shift + N`
 - The content shouldn't jump/scroll when focusing the "Open publish panel" region.