### PR TITLE
Bring the preview tab to the front when clicking the preview button.

### DIFF
--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -68,6 +68,11 @@ export class PostPreviewButton extends Component {
 			this.previewWindow = window.open( '', this.getWindowTarget() );
 		}
 
+		// Ask the browser to bring the preview tab to the front
+		// This can work or not depending on the browser's user preferences
+		// https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus
+		this.previewWindow.focus();
+
 		// If there are no changes to autosave, we cannot perform the save, but
 		// if there is an existing preview link (e.g. previous published post
 		// autosave), it should be reused as the popup destination.

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -87,6 +87,7 @@ describe( 'PostPreviewButton', () => {
 						write: jest.fn(),
 						close: jest.fn(),
 					},
+					focus: () => {},
 				};
 			} );
 


### PR DESCRIPTION
**Testing instructions**

 - Try clicking the preview button, the preview tab should be brought to the front
 - Same if you click multiple times
 - Same if you click after making edits while the preview tab is open