### PR TITLE
Publish button: Avoid changing the label of the "publish" button if an auto-save is being performed

### DIFF
--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -16,12 +16,13 @@ export function PublishButtonLabel( {
 	isSaving,
 	isPublishing,
 	hasPublishAction,
+	isAutosaving,
 } ) {
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
-	} else if ( isPublished && isSaving ) {
+	} else if ( isPublished && isSaving && ! isAutosaving ) {
 		return __( 'Updating…' );
-	} else if ( isBeingScheduled && isSaving ) {
+	} else if ( isBeingScheduled && isSaving && ! isAutosaving ) {
 		return __( 'Scheduling…' );
 	}
 
@@ -45,6 +46,7 @@ export default compose( [
 			isPublishingPost,
 			getCurrentPost,
 			getCurrentPostType,
+			isAutosavingPost,
 		} = select( 'core/editor' );
 		return {
 			isPublished: isCurrentPostPublished(),
@@ -53,6 +55,7 @@ export default compose( [
 			isPublishing: isPublishingPost(),
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			postType: getCurrentPostType(),
+			isAutosaving: isAutosavingPost(),
 		};
 	} ),
 ] )( PublishButtonLabel );


### PR DESCRIPTION
closes #7312

In Gutenberg we "disable" publish/save buttons when saves/autosaves is in progress to avoid any unrelated side-effects/race conditions in the state. But this doesn't mean we can't try to make it less ambigious that an autosave is being performed and not a full save.

In this PR, when an autosave is in progress, the label of the publish button doesn't change (it keeps saying "publish" or "update") but it's still is in a "loading" state to clarify that you can't click it at the moment.

Is this the right approach?