### PR TITLE
Data: Add RegistryConsumer export

### DIFF
--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -11,7 +11,7 @@ import * as plugins from './plugins';
 
 export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
-export { default as RegistryProvider } from './components/registry-provider';
+export { default as RegistryProvider, RegistryConsumer } from './components/registry-provider';
 export { createRegistry } from './registry';
 export {
 	withRehydration,


### PR DESCRIPTION
## Description

The plugin code relies on the RegistryProvider to be able to add
functionality to the registry. `withSelect` uses the RegistryConsumer,
but code outside of `@wordpress/data` can't access this modified
registry at all (even though it can create it!).
This solves the incongruence by simply exporting RegistryConsumer as
well.

## How has this been tested?

It's just an export so adding a test doesn't really make sense.
However, I have tested the export by using it here: https://github.com/woocommerce/wc-admin/pull/301

## Types of changes
This isn't really a new feature and not quite a bug fix, but more an enhancement or correction.
It is not a breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
