### PR TITLE
Autosaves: Enable saving of revisions for drafts

### DIFF
--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -180,9 +180,13 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		$user_id           = get_current_user_id();
 
 		if ( ( 'draft' === $post->post_status || 'auto-draft' === $post->post_status ) && $post->post_author == $user_id ) {
-			// Draft posts for the same author: autosaving updates the post and does not create a revision.
+			// Draft posts for the same author: autosaving has to override a filter to create a revision.
+			add_filter( 'wp_save_post_block_revision_for_autosave', '__return_false' );
+
 			// Convert the post object to an array and add slashes, wp_update_post expects escaped array.
 			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
+
+			remove_filter( 'wp_save_post_block_revision_for_autosave', '__return_false' );
 		} else {
 			// Non-draft posts: create or update the post autosave.
 			$autosave_id = $this->create_post_autosave( (array) $prepared_post );

--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -181,12 +181,12 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 
 		if ( ( 'draft' === $post->post_status || 'auto-draft' === $post->post_status ) && $post->post_author == $user_id ) {
 			// Draft posts for the same author: autosaving has to override a filter to create a revision.
-			add_filter( 'wp_save_post_block_revision_for_autosave', '__return_false' );
+			add_filter( 'wp_save_post_prevent_revision_for_autosave', '__return_false' );
 
 			// Convert the post object to an array and add slashes, wp_update_post expects escaped array.
 			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
 
-			remove_filter( 'wp_save_post_block_revision_for_autosave', '__return_false' );
+			remove_filter( 'wp_save_post_prevent_revision_for_autosave', '__return_false' );
 		} else {
 			// Non-draft posts: create or update the post autosave.
 			$autosave_id = $this->create_post_autosave( (array) $prepared_post );


### PR DESCRIPTION
## Description

(In progress) Save a revision for drafts when the editor autosaves.

This demonstrates the usage of new filter proposed in https://core.trac.wordpress.org/ticket/44786.

## How has this been tested?

* Apply patch from the core ticket
* Run this branch
* Create a new draft post (or open an existing one)
* Make a change & allow the autosave to complete
* Revision is saved

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality).
Prevent data loss by saving revisions as posts (& supported CPTs) are drafted 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
