### PR TITLE
feat: Hide keyboard shortcuts on mobile screens

### DIFF
--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -51,9 +51,16 @@
 }
 
 .components-menu-item__shortcut {
+	align-self: center;
 	opacity: 0.5;
 	margin-right: 0;
 	margin-left: auto;
-	align-self: center;
 	padding-left: 8px;
+
+	// Hide the keyboard shortcuts on mobile, because they aren't super-useful
+	// for most mobile users.
+	display: none;
+	@include break-mobile() {
+		display: inline;
+	}
 }

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -58,7 +58,8 @@
 	padding-left: 8px;
 
 	// Hide the keyboard shortcuts on mobile, because they aren't super-useful
-	// for most mobile users.
+	// for most mobile users and it frees up screen space for any item
+	// with a long description.
 	display: none;
 	@include break-mobile() {
 		display: inline;

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -153,9 +153,9 @@ $arrow-size: 8px;
 		overflow-y: auto;
 
 		// Let the menu scale to fit items.
+		min-width: 260px;
 		@include break-mobile() {
 			width: auto;
-			min-width: 260px;
 			max-width: $break-mobile;
 		}
 	}


### PR DESCRIPTION
Fix #9050.

## Description
Hide the shortcuts for mobile screens.

## How has this been tested?
Tested locally; works.

## Screenshots
![screen shot 2018-08-16 at 14 31 03](https://user-images.githubusercontent.com/90871/44211903-f76fd080-a161-11e8-8e36-498780731587.png)

## Types of changes
CSS change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->