### PR TITLE
Automatically create a link when selected text is a URL

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -68,6 +68,7 @@ function computeDerivedState( props ) {
 		settingsVisible: false,
 		opensInNewWindow: !! props.formats.link && !! props.formats.link.target,
 		linkValue: '',
+		isEditingLink: false,
 	};
 }
 
@@ -151,8 +152,7 @@ class FormatToolbar extends Component {
 
 	editLink( event ) {
 		event.preventDefault();
-		this.props.onChange( { link: { ...this.props.formats.link, isAdding: true } } );
-		this.setState( { linkValue: this.props.formats.link.value } );
+		this.setState( { linkValue: this.props.formats.link.value, isEditingLink: true } );
 	}
 
 	submitLink( event ) {
@@ -165,7 +165,7 @@ class FormatToolbar extends Component {
 			value,
 		} } );
 
-		this.setState( { linkValue: value } );
+		this.setState( { linkValue: value, isEditingLink: false } );
 		if ( ! this.props.formats.link.value ) {
 			this.props.speak( __( 'Link added.' ), 'assertive' );
 		}
@@ -177,7 +177,7 @@ class FormatToolbar extends Component {
 
 	render() {
 		const { formats, enabledControls = DEFAULT_CONTROLS, customControls = [], selectedNodeId } = this.props;
-		const { linkValue, settingsVisible, opensInNewWindow } = this.state;
+		const { linkValue, settingsVisible, opensInNewWindow, isEditingLink } = this.state;
 		const isAddingLink = formats.link && formats.link.isAdding;
 
 		const toolbarControls = FORMATTING_CONTROLS.concat( customControls )
@@ -202,6 +202,13 @@ class FormatToolbar extends Component {
 				};
 			} );
 
+		let linkUIToShow = 'none';
+		if ( isAddingLink || isEditingLink ) {
+			linkUIToShow = 'editing';
+		} else if ( formats.link ) {
+			linkUIToShow = 'previewing';
+		}
+
 		const linkSettings = settingsVisible && (
 			<div className="editor-format-toolbar__link-modal-line editor-format-toolbar__link-settings">
 				<ToggleControl
@@ -215,7 +222,7 @@ class FormatToolbar extends Component {
 			<div className="editor-format-toolbar">
 				<Toolbar controls={ toolbarControls } />
 
-				{ ( isAddingLink || formats.link ) && (
+				{ linkUIToShow !== 'none' && (
 					<Fill name="RichText.Siblings">
 						<PositionedAtSelection className="editor-format-toolbar__link-container">
 							<Popover
@@ -223,9 +230,9 @@ class FormatToolbar extends Component {
 								focusOnMount={ isAddingLink ? 'firstElement' : false }
 								key={ selectedNodeId /* Used to force rerender on change */ }
 							>
-								{ isAddingLink && (
-								// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+								{ linkUIToShow === 'editing' && (
+									// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+									/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 									<form
 										className="editor-format-toolbar__link-modal"
 										onKeyPress={ stopKeyPropagation }
@@ -244,12 +251,12 @@ class FormatToolbar extends Component {
 										</div>
 										{ linkSettings }
 									</form>
-								/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+									/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
 								) }
 
-								{ formats.link && ! isAddingLink && (
-								// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-								/* eslint-disable jsx-a11y/no-static-element-interactions */
+								{ linkUIToShow === 'previewing' && (
+									// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+									/* eslint-disable jsx-a11y/no-static-element-interactions */
 									<div
 										className="editor-format-toolbar__link-modal"
 										onKeyPress={ stopKeyPropagation }
@@ -272,7 +279,7 @@ class FormatToolbar extends Component {
 										</div>
 										{ linkSettings }
 									</div>
-								/* eslint-enable jsx-a11y/no-static-element-interactions */
+									/* eslint-enable jsx-a11y/no-static-element-interactions */
 								) }
 							</Popover>
 						</PositionedAtSelection>

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -13,13 +13,16 @@ npm install @wordpress/url --save
 ## Usage
 
 ```JS
-import { addQueryArgs, prependHTTP } from '@wordpress/url';
+import { isURL, addQueryArgs, prependHTTP } from '@wordpress/url';
+
+// Checks if the argument looks like a URL
+const isURL = isURL( 'https://wordpress.org' ); // true
 
 // Appends arguments to the query string of a given url
-const newUrl = addQueryArgs( 'https://google.com', { q: 'test' } ); // https://google.com/?q=test
+const newURL = addQueryArgs( 'https://google.com', { q: 'test' } ); // https://google.com/?q=test
 
 // Prepends 'http://' to URLs that are probably mean to have them
-const actualUrl = prependHTTP( 'wordpress.org' ); // http://wordpress.org
+const actualURL = prependHTTP( 'wordpress.org' ); // http://wordpress.org
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -3,8 +3,20 @@
  */
 import { parse, stringify } from 'qs';
 
+const URL_REGEXP = /^(?:https?:)?\/\/\S+$/i;
 const EMAIL_REGEXP = /^(mailto:)?[a-z0-9._%+-]+@[a-z0-9][a-z0-9.-]*\.[a-z]{2,63}$/i;
 const USABLE_HREF_REGEXP = /^(?:[a-z]+:|#|\?|\.|\/)/i;
+
+/**
+ * Determines whether the given string looks like a URL.
+ *
+ * @param {string} url The string to scrutinise.
+ *
+ * @return {boolean} Whether or not it looks like a URL.
+ */
+export function isURL( url ) {
+	return URL_REGEXP.test( url );
+}
 
 /**
  * Appends arguments to the query string of the url

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach } from 'lodash';
+import { every } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,9 +18,7 @@ describe( 'isURL', () => {
 			'https://localhost/foo#bar',
 		];
 
-		forEach( urls, ( url ) => {
-			expect( isURL( url ) ).toBe( true );
-		} );
+		expect( every( urls, isURL ) ).toBe( true );
 	} );
 
 	it( 'returns false when given things that don\'t look like a URL', () => {
@@ -32,9 +30,7 @@ describe( 'isURL', () => {
 			'',
 		];
 
-		forEach( urls, ( url ) => {
-			expect( isURL( url ) ).toBe( false );
-		} );
+		expect( every( urls, isURL ) ).toBe( false );
 	} );
 } );
 

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -1,7 +1,42 @@
 /**
- * Internal Dependencies
+ * External dependencies
  */
-import { addQueryArgs, prependHTTP } from '../';
+import { forEach } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { isURL, addQueryArgs, prependHTTP } from '../';
+
+describe( 'isURL', () => {
+	it( 'returns true when given things that look like a URL', () => {
+		const urls = [
+			'http://wordpress.org',
+			'https://wordpress.org',
+			'HTTPS://WORDPRESS.ORG',
+			'https://wordpress.org/foo#bar',
+			'https://localhost/foo#bar',
+		];
+
+		forEach( urls, ( url ) => {
+			expect( isURL( url ) ).toBe( true );
+		} );
+	} );
+
+	it( 'returns false when given things that don\'t look like a URL', () => {
+		const urls = [
+			'HTTP: HyperText Transfer Protocol',
+			'URLs begin with a http:// prefix',
+			'Go here: http://wordpress.org',
+			'http://',
+			'',
+		];
+
+		forEach( urls, ( url ) => {
+			expect( isURL( url ) ).toBe( false );
+		} );
+	} );
+} );
 
 describe( 'addQueryArgs', () => {
 	it( 'should append args to an URL without query string', () => {

--- a/test/e2e/specs/__snapshots__/links.test.js.snap
+++ b/test/e2e/specs/__snapshots__/links.test.js.snap
@@ -12,6 +12,12 @@ exports[`Links can be created by selecting text and using keyboard shortcuts 1`]
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Links can be created instantly when a URL is selected 1`] = `
+"<!-- wp:paragraph -->
+<p>This is Gutenberg: <a href=\\"https://wordpress.org/gutenberg\\">https://wordpress.org/gutenberg</a></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Links can be created without any text selected 1`] = `
 "<!-- wp:paragraph -->
 <p>This is Gutenberg: <a href=\\"https://wordpress.org/gutenberg\\">https://wordpress.org/gutenberg</a></p>

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -100,6 +100,27 @@ describe( 'Links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'can be created instantly when a URL is selected', async () => {
+		// Create a block with some text
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg: https://wordpress.org/gutenberg' );
+
+		// Select the URL
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+
+		// Click on the Link button
+		await page.click( 'button[aria-label="Link"]' );
+
+		// A placeholder link should not have been inserted
+		expect( await page.$( 'a[data-wp-placeholder]' ) ).toBeNull();
+
+		// A link with the selected URL as its href should have been inserted
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'is not created when we click away from the link input', async () => {
 		// Create a block with some text
 		await clickBlockAppender();


### PR DESCRIPTION
Closes #3513. 

When a URL is selected and the Link button is clicked or the Link keyboard shortcut is pressed, a link with that URL set as its `href` should be instantly created.

![auto-link](https://user-images.githubusercontent.com/612155/44248249-c5777080-a22c-11e8-9834-b7facdc8502e.gif)

As part of this, I pulled an existing link regular expression out into its own `isURL` function that lives in the `@wordpress/url` package. Not sure if it's actually a useful helper function, though—happy to go back on this decision.

**To test:**

```
npm run test-e2e
```

Or, for those of us who distrust automation:

1. Highlight a URL
2. Click _Link_ or press <kbd>Cmd</kbd>+<kbd>K</kbd>
3. The selected URL should immediately become a link