### PR TITLE
Fix recents hover style

### DIFF
--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -76,12 +76,13 @@
 		padding: 0;
 	}
 
-	.components-icon-button svg {
-		margin: 4px;
+	.editor-block-icon {
+		margin: auto;
+	}
 
-		&:not(.dashicon) {
-			margin: 2px;
-		}
+	.components-icon-button svg {
+		display: block;
+		margin: auto;
 	}
 }
 


### PR DESCRIPTION
In the appender, the recently used blocks are offset a bit per the latest icon changes. This PR fixes that.

Before:

<img width="256" alt="screen shot 2018-08-17 at 08 37 45" src="https://user-images.githubusercontent.com/1204802/44251783-f68a7d80-a1f9-11e8-9e47-4a1b85909f1c.png">


After:

<img width="262" alt="screen shot 2018-08-17 at 08 44 56" src="https://user-images.githubusercontent.com/1204802/44251772-effc0600-a1f9-11e8-9269-642b9cafe6f6.png">
