### PR TITLE
Move MoreMenu-specific styling away from Popover CSS

### DIFF
--- a/edit-post/components/header/more-menu/index.js
+++ b/edit-post/components/header/more-menu/index.js
@@ -3,6 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { IconButton, Dropdown, MenuGroup } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import KeyboardShortcutsHelpMenuItem from '../keyboard-shortcuts-help-menu-item'
 const MoreMenu = () => (
 	<Dropdown
 		className="edit-post-more-menu"
+		contentClassName="edit-post-more-menu__content"
 		position="bottom left"
 		renderToggle={ ( { isOpen, onToggle } ) => (
 			<IconButton
@@ -27,7 +29,7 @@ const MoreMenu = () => (
 			/>
 		) }
 		renderContent={ ( { onClose } ) => (
-			<div className="edit-post-more-menu__content">
+			<Fragment>
 				<ModeSwitcher onSelect={ onClose } />
 				<MenuGroup
 					label={ __( 'Settings' ) }
@@ -43,7 +45,7 @@ const MoreMenu = () => (
 				>
 					<KeyboardShortcutsHelpMenuItem onSelect={ onClose } />
 				</MenuGroup>
-			</div>
+			</Fragment>
 		) }
 	/>
 );

--- a/edit-post/components/header/more-menu/style.scss
+++ b/edit-post/components/header/more-menu/style.scss
@@ -20,7 +20,15 @@
 	}
 }
 
-.edit-post-more-menu__content {
+.edit-post-more-menu__content .components-popover__content {
+	min-width: 260px;
+
+	// Let the menu scale to fit items.
+	@include break-mobile() {
+		width: auto;
+		max-width: $break-mobile;
+	}
+
 	.components-menu-group:not(:last-child),
 	> div:not(:last-child) .components-menu-group {
 		border-bottom: $border-width solid $light-gray-500;

--- a/edit-post/components/header/more-menu/test/__snapshots__/index.js.snap
+++ b/edit-post/components/header/more-menu/test/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`MoreMenu should match snapshot 1`] = `
 <MoreMenu>
   <Dropdown
     className="edit-post-more-menu"
+    contentClassName="edit-post-more-menu__content"
     position="bottom left"
     renderContent={[Function]}
     renderToggle={[Function]}

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -151,13 +151,6 @@ $arrow-size: 8px;
 		position: absolute;
 		height: auto;
 		overflow-y: auto;
-
-		// Let the menu scale to fit items.
-		min-width: 260px;
-		@include break-mobile() {
-			width: auto;
-			max-width: $break-mobile;
-		}
 	}
 
 	.components-popover:not(.is-mobile).is-top & {


### PR DESCRIPTION
This PR was graciously written by @noisysocks, to fix a regression I introduced in https://github.com/WordPress/gutenberg/pull/8756. It was done, and Robert was opening the PR as I came online without enough coffee and thought the fix should be slightly different to what Robert was proposing. As is so often the case, he was right all along. My thanks to Robert for fixing this.

In #8756, the change was made to the popover component in order to let all menus using this component grow and shrink as necessary. However with the addition of a whitespace rule, this only really made sense for _menu items_ inside popovers, not all _popovers_. This PR moves things around to be where they're supposed to be.

Roberts original text:

Moves CSS rules that are specific to styling the MoreMenu component out
of the Popover CSS file and into the MoreMenu's CSS file. This fixes
DotTips from appearing too narrow, and should prevent other components
that use Popover from being inadvertently styled differently.