### PR TITLE
Fix issues with drag and drop over text

### DIFF
--- a/packages/components/src/drop-zone/style.scss
+++ b/packages/components/src/drop-zone/style.scss
@@ -16,14 +16,10 @@
 		visibility: visible;
 		transition: 0.3s opacity, 0.3s background-color;
 	}
-}
 
-// Only show the upload instructions on placeholders and galleries.
-.components-placeholder,
-.wp-block-gallery {
-	.components-drop-zone.components-drop-zone.is-dragging-over-element {
+	&.is-dragging-over-element {
 		background-color: rgba($blue-dark-900, 0.8);
-	
+
 		.components-drop-zone__content {
 			display: block;
 		}

--- a/packages/components/src/drop-zone/style.scss
+++ b/packages/components/src/drop-zone/style.scss
@@ -16,15 +16,16 @@
 		visibility: visible;
 		transition: 0.3s opacity, 0.3s background-color;
 	}
+}
 
-	&.is-dragging-over-element {
-
+// Only show the upload instructions on placeholders and galleries.
+.components-placeholder,
+.wp-block-gallery {
+	.components-drop-zone.components-drop-zone.is-dragging-over-element {
+		background-color: rgba($blue-dark-900, 0.8);
+	
 		.components-drop-zone__content {
 			display: block;
-		}
-
-		&.is-dragging-file {
-			background-color: rgba($blue-dark-900, 0.8);
 		}
 	}
 }

--- a/packages/editor/src/components/block-drop-zone/style.scss
+++ b/packages/editor/src/components/block-drop-zone/style.scss
@@ -3,7 +3,8 @@
 	border: none;
 	border-radius: 0;
 
-	.components-drop-zone__content {
+	.components-drop-zone__content,
+	&.is-dragging-over-element .components-drop-zone__content {
 		display: none;
 	}
 
@@ -18,12 +19,5 @@
 		background: none;
 		border-top: 3px solid theme(primary);
 		border-bottom: none;
-	}
-
-	&.is-dragging-html,
-	&.is-dragging-default {
-		.components-drop-zone__content {
-			display: none;
-		}
 	}
 }


### PR DESCRIPTION
This PR is a followup to #8752, and fixes #8115.

It is the situation in `master` right now that every single block has instructional overlay text when dragging files from the desktop over it. This also means very short paragraphs, separators, lots of different blocks that can neither fit the upload message, nor can really _accept_ any uploads. That last part is key, because we also have a different upload indicator — the blue horizontal line. This indicator shows _where the block you're about to drop will be inserted_. Because you can drop an image file on top of a paragraph, but it will show up either _before_ the paragraph, or _after_ the paragraph, not _inside_ it.

Therefore, the upload message should not be present on top of every single block. In fact it should be present only on placeholders and galleries, where dropping a file on the block itself really _does_ insert the dropped file there.

GIF of behavior:

![dragondrop](https://user-images.githubusercontent.com/1204802/44254550-6b15ea00-a203-11e8-857e-f3b7c1c9b318.gif)

GIF of current behavior in `master`:

![master](https://user-images.githubusercontent.com/1204802/44254601-91d42080-a203-11e8-9d46-1163a9252696.gif)

Note that this PR uses CSS to accomplish the above, which basically makes a whitelist of which blocks to show this message of. This doesn't seem ideal, and it also seems wasteful to include the actual text of the upload message even in paragraph blocks where they shouldn't be shown. @youknowriad any idea how to do this in a better way? 

Basically the desired behavior is that _for every block where the blue line shows up, we don't want the message_, whereas for every block where the blue line _doesn't_ show up, we want just the message. 