### PR TITLE
Handbook - Fix incorrect example code  for withSelect HOC

### DIFF
--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -19,7 +19,7 @@ Below is an example of a component which simply renders a list of authors:
 ```jsx
 const { withSelect } = wp.data;
 
-function MyAuthorsList( { authors } ) {
+function MyAuthorsListBase( { authors } ) {
 	return (
 		<ul>
 			{ authors.map( ( author ) => (
@@ -29,9 +29,9 @@ function MyAuthorsList( { authors } ) {
 	);
 }
 
-MyAuthorsList = withSelect( ( select ) => ( {
+const MyAuthorsList = withSelect( ( select ) => ( {
 	authors: select( 'core' ).getAuthors(),
-} ) )( MyAuthorsList );
+} ) )( MyAuthorsListBase );
 ```
 
 ## Actions

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -31,7 +31,7 @@ function MyAuthorsList( { authors } ) {
 
 MyAuthorsList = withSelect( ( select ) => ( {
 	authors: select( 'core' ).getAuthors(),
-} ) );
+} ) )( MyAuthorsList );
 ```
 
 ## Actions


### PR DESCRIPTION
## Description
[The docs in the handbook for the @wordpress/core-data package](https://wordpress.org/gutenberg/handbook/packages/packages-core-data/#example) have a small omission in the example code for the `withSelect` HOC.

[The docs in the package readme correctly show how this should be done.](https://github.com/WordPress/gutenberg/tree/master/packages/data#withselect-mapselecttoprops-function--function)

## How has this been tested?
NA - docs only.

## Types of changes
Update documentation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
