### PR TITLE
Fix issue with block menu

### DIFF
--- a/packages/editor/src/components/block-settings-menu/style.scss
+++ b/packages/editor/src/components/block-settings-menu/style.scss
@@ -56,10 +56,6 @@
 		margin-left: 2px;
 	}
 
-	.components-popover__content {
-		width: 182px;
-	}
-
 	.editor-block-settings-menu__content {
 		width: 100%;
 		padding: $item-spacing - $border-width;


### PR DESCRIPTION
This PR fixes a regression in the block menu. It had a hardcoded width that wasn't applied at all, probably from past iterations, which was overridden by a min-width of 260px which was then recently removed.

Before:

![screen shot 2018-08-17 at 13 19 03](https://user-images.githubusercontent.com/1204802/44263750-6c094480-a220-11e8-8fbd-0a4c5f78f27e.png)

After:

![screen shot 2018-08-17 at 13 19 38](https://user-images.githubusercontent.com/1204802/44263758-6e6b9e80-a220-11e8-881f-a286cd960c45.png)
