### PR TITLE
Fix to allow publishing pages

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -60,10 +60,11 @@ export default compose(
 	withSelect( ( select ) => {
 		const postType = select( 'core/editor' ).getCurrentPostType();
 		const tagsTaxonomy = select( 'core' ).getTaxonomy( 'post_tag' );
+		const tags = select( 'core/editor' ).getEditedPostAttribute( tagsTaxonomy.rest_base );
 		return {
 			areTagsFetched: tagsTaxonomy !== undefined,
 			isPostTypeSupported: tagsTaxonomy && tagsTaxonomy.types.some( ( type ) => type === postType ),
-			hasTags: tagsTaxonomy && select( 'core/editor' ).getEditedPostAttribute( tagsTaxonomy.rest_base ).length,
+			hasTags: tags && tags.length,
 		};
 	} ),
 	ifCondition( ( { areTagsFetched, isPostTypeSupported } ) => isPostTypeSupported && areTagsFetched ),


### PR DESCRIPTION
How to reproduce the bug:

- Add a new page
- Try to publish it

Expected behavior is that the pre-publish panel would be opened. Instead, I've got: 

![error-publish-page](https://user-images.githubusercontent.com/583546/44264448-f94d9880-a222-11e8-83c5-dc8b47a1f20b.png)
