### PR TITLE
Fix wide toolbar regression.

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -447,7 +447,7 @@
 
 		// Beyond the mobile breakpoint, wide images stretch outside of the column.
 		// To center the toolbar, we make it inline-flex so the toolbar is not full-wide.
-		@include break-mobile () {
+		@include break-small () {
 			.editor-block-toolbar {
 				display: inline-flex;
 			}

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -444,6 +444,14 @@
 				display: block;
 			}
 		}
+
+		// Beyond the mobile breakpoint, wide images stretch outside of the column.
+		// To center the toolbar, we make it inline-flex so the toolbar is not full-wide.
+		@include break-mobile () {
+			.editor-block-toolbar {
+				display: inline-flex;
+			}
+		}
 	}
 
 	// Wide

--- a/packages/editor/src/components/block-toolbar/style.scss
+++ b/packages/editor/src/components/block-toolbar/style.scss
@@ -1,7 +1,5 @@
 .editor-block-toolbar {
-	// Should be inline-flex so it isn't full-wide. 
-	// We leverage this to center the toolbar on wide and full-wide images.
-	display: inline-flex;
+	display: flex;
 	flex-grow: 1;
 	width: 100%;
 	overflow: auto; // Allow horizontal scrolling on mobile.

--- a/packages/editor/src/components/block-toolbar/style.scss
+++ b/packages/editor/src/components/block-toolbar/style.scss
@@ -1,5 +1,7 @@
 .editor-block-toolbar {
-	display: flex;
+	// Should be inline-flex so it isn't full-wide. 
+	// We leverage this to center the toolbar on wide and full-wide images.
+	display: inline-flex;
 	flex-grow: 1;
 	width: 100%;
 	overflow: auto; // Allow horizontal scrolling on mobile.


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/WordPress/gutenberg/pull/8840/files#diff-1f76ee5adc19638316fea06f655caa9aR2, which caused the block toolbar to not be centered on wide and fullwide blocks.

In master:

![screen shot 2018-08-17 at 13 35 39](https://user-images.githubusercontent.com/1204802/44264478-184c2a80-a223-11e8-9503-f4385eac9701.png)

After this PR:

![screen shot 2018-08-17 at 13 34 56](https://user-images.githubusercontent.com/1204802/44264486-1bdfb180-a223-11e8-8d62-2e941bd5a8a5.png)
