### PR TITLE
Restore min-width to popover.

### DIFF
--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -151,6 +151,7 @@ $arrow-size: 8px;
 		position: absolute;
 		height: auto;
 		overflow-y: auto;
+		min-width: 260px;
 	}
 
 	.components-popover:not(.is-mobile).is-top & {


### PR DESCRIPTION
This fixes a regression introduced as part of https://github.com/WordPress/gutenberg/pull/8756. Basically we removed the min-width so as to let the content itself expand the popover. But alas an empty textfield, like the URL input field, did not expand the popover as it should. We could look at adding the min-width to the URL input field instead, this should expand the popover, but given the fallout this min-width removal has caused already, it's probably good to keep it in place as a baseline.

Screenshot of this being fixed:

![screen shot 2018-08-17 at 14 20 41](https://user-images.githubusercontent.com/1204802/44266012-3e74c900-a229-11e8-901a-7288173f31da.png)
