### PR TITLE
Block warning: allow re-editing of HTML

### DIFF
--- a/packages/editor/src/components/block-list/block-html.js
+++ b/packages/editor/src/components/block-list/block-html.js
@@ -46,6 +46,11 @@ export class BlockHTML extends Component {
 		if ( ! html ) {
 			this.setState( { html: content } );
 		}
+
+		if ( ! isValid ) {
+			// An error was detected so flip the block back to visual mode so we see the invalid block warning
+			this.props.onToggleMode( this.props.clientId );
+		}
 	}
 
 	onChange( event ) {
@@ -72,6 +77,9 @@ export default compose( [
 	withDispatch( ( dispatch ) => ( {
 		onChange( clientId, attributes, originalContent, isValid ) {
 			dispatch( 'core/editor' ).updateBlock( clientId, { attributes, originalContent, isValid } );
+		},
+		onToggleMode( clientId ) {
+			dispatch( 'core/editor' ).toggleBlockMode( clientId );
 		},
 	} ) ),
 ] )( BlockHTML );

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -461,12 +461,15 @@ export class BlockListBlock extends Component {
 						( isPartOfMultiSelection && isFirstMultiSelected ) ||
 						! isPartOfMultiSelection;
 
+					// We allow an invalid block to be re-edited in HTML mode
+					const isValidOrHtmlMode = isValid || mode === 'html';
+
 					// The wp-block className is important for editor styles.
 					// Generate the wrapper class names handling the different states of the block.
 					const wrapperClassName = classnames(
 						'wp-block editor-block-list__block',
 						{
-							'has-warning': ! isValid || !! error || isUnregisteredBlock,
+							'has-warning': ! isValidOrHtmlMode || !! error || isUnregisteredBlock,
 							'is-selected': shouldAppearSelected,
 							'is-multi-selected': isPartOfMultiSelection,
 							'is-hovered': shouldAppearHovered,
@@ -608,10 +611,10 @@ export class BlockListBlock extends Component {
 								>
 									<BlockCrashBoundary onError={ this.onBlockError }>
 										{ isValid && blockEdit }
-										{ isValid && mode === 'html' && (
+										{ mode === 'html' && (
 											<BlockHtml clientId={ clientId } />
 										) }
-										{ ! isValid && [
+										{ ! isValidOrHtmlMode && [
 											<BlockInvalidWarning
 												key="invalid-warning"
 												clientId={ clientId }

--- a/packages/editor/src/components/block-list/test/block-html.js
+++ b/packages/editor/src/components/block-list/test/block-html.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -79,7 +80,7 @@ describe( 'BlockHTML', () => {
 				content: 'test-block',
 				isValid: true,
 			} );
-			const wrapper = shallow( <BlockHTML block={ block } onChange={ onChange } /> );
+			const wrapper = shallow( <BlockHTML block={ block } onChange={ onChange } onToggleMode={ noop } /> );
 
 			wrapper.instance().onChange( { target: { value: '<p>update' } } );
 			wrapper.instance().onBlur();

--- a/packages/editor/src/components/block-list/test/block.js
+++ b/packages/editor/src/components/block-list/test/block.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	registerBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { BlockListBlock } from '../block';
+import BlockInvalidWarning from '../block-invalid-warning';
+import BlockEdit from '../../block-edit';
+import BlockHtml from '../block-html';
+
+describe( 'BlockListBlock', () => {
+	beforeAll( () => {
+		registerBlockType( 'core/test-block', {
+			category: 'common',
+			title: 'Test',
+			attributes: {},
+			edit: () => {},
+			save: () => {},
+		} );
+	} );
+
+	describe( 'Invalid Block', () => {
+		it( 'valid block is shown without warning and with visual editor in visual mode', () => {
+			const block = createBlock( 'core/test-block' );
+			const wrapper = shallow( <BlockListBlock block={ block } mode="visual" /> );
+
+			expect( wrapper.hasClass( 'has-warning' ) ).toBe( false );
+			expect( wrapper.find( BlockInvalidWarning ).exists() ).toBe( false );
+			expect( wrapper.find( BlockEdit ).exists() ).toBe( true );
+		} );
+
+		it( 'valid block is shown without warning and with html editor in html mode', () => {
+			const block = createBlock( 'core/test-block' );
+			const wrapper = shallow( <BlockListBlock block={ block } mode="html" /> );
+
+			expect( wrapper.hasClass( 'has-warning' ) ).toBe( false );
+			expect( wrapper.find( BlockInvalidWarning ).exists() ).toBe( false );
+			expect( wrapper.find( BlockHtml ).exists() ).toBe( true );
+		} );
+
+		it( 'invalid block is shown with warning and without visual editor when in visual mode', () => {
+			const block = { ... createBlock( 'core/test-block' ), isValid: false };
+			const wrapper = shallow( <BlockListBlock block={ block } mode="visual" /> );
+
+			expect( wrapper.hasClass( 'has-warning' ) ).toBe( true );
+			expect( wrapper.find( BlockInvalidWarning ).exists() ).toBe( true );
+			expect( wrapper.find( BlockEdit ).exists() ).toBe( false );
+		} );
+
+		it( 'invalid block is shown without warning and with html editor when in html mode', () => {
+			const block = { ... createBlock( 'core/test-block' ), isValid: false };
+			const wrapper = shallow( <BlockListBlock block={ block } mode="html" /> );
+
+			expect( wrapper.hasClass( 'has-warning' ) ).toBe( false );
+			expect( wrapper.find( BlockInvalidWarning ).exists() ).toBe( false );
+			expect( wrapper.find( BlockHtml ).exists() ).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
If a block is flagged as invalid then allow it to be re-edited in HTML mode so the content can be fixed. This allows a quicker route to fixing an invalid block if you happen to make a mistake in the HTML.

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44266787-c8219800-a223-11e8-9b57-f76394aa3556.jpg)

Leads to:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44266801-d40d5a00-a223-11e8-82bd-ad4de24ef638.jpg)

Note that selecting 'edit visually' while in HTML will re-trigger the invalid warning if the problem has not been fixed.

This fixes the issue of the 'edit as HTML' / 'edit visually' block options being available but having no effect in #7743

## How has this been tested?
Additional unit test has been added to verify that a block can be re-edited in HTML mode.

To manually test:
- Add a paragraph block, edit as HTML, and remove the trailing `</p>` - tab out of the editor to trigger an invalid block warning
- From the block menu select 'Edit as HTML'
- Verify that the invalid block warning is removed and the HTML editor is shown with the invalid HTML content
- Verify that selecting 'Edit visually' from the block menu triggers the invalid block warning again

## Types of changes
Potentially breaking feature.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
