### PR TITLE
Remove TinyMCE paste plugin

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -494,7 +494,6 @@ function gutenberg_register_scripts_and_styles() {
 		array(
 			'lodash',
 			'tinymce-latest-lists',
-			'tinymce-latest-paste',
 			'tinymce-latest-table',
 			'wp-a11y',
 			'wp-api-fetch',
@@ -734,11 +733,6 @@ function gutenberg_register_vendor_scripts() {
 	gutenberg_register_vendor_script(
 		'tinymce-latest-lists',
 		'https://unpkg.com/tinymce@' . $tinymce_version . '/plugins/lists/plugin' . $suffix . '.js',
-		array( 'wp-tinymce' )
-	);
-	gutenberg_register_vendor_script(
-		'tinymce-latest-paste',
-		'https://unpkg.com/tinymce@' . $tinymce_version . '/plugins/paste/plugin' . $suffix . '.js',
 		array( 'wp-tinymce' )
 	);
 	gutenberg_register_vendor_script(

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -34,7 +34,7 @@ import {
 /**
  * Browser dependencies
  */
-const { log, warn } = window.console;
+const { console } = window;
 
 export { getPhrasingContentSchema };
 
@@ -50,7 +50,7 @@ function filterInlineHTML( HTML ) {
 	HTML = removeInvalidHTML( HTML, getPhrasingContentSchema(), { inline: true } );
 
 	// Allows us to ask for this information when we get a report.
-	log( 'Processed inline HTML:\n\n', HTML );
+	console.log( 'Processed inline HTML:\n\n', HTML );
 
 	return HTML;
 }
@@ -173,7 +173,7 @@ export default function rawHandler( { HTML = '', plainText = '', mode = 'AUTO', 
 		piece = normaliseBlocks( piece );
 
 		// Allows us to ask for this information when we get a report.
-		log( 'Processed HTML piece:\n\n', piece );
+		console.log( 'Processed HTML piece:\n\n', piece );
 
 		const doc = document.implementation.createHTMLDocument( '' );
 
@@ -183,7 +183,7 @@ export default function rawHandler( { HTML = '', plainText = '', mode = 'AUTO', 
 			const rawTransformation = findTransform( rawTransformations, ( { isMatch } ) => isMatch( node ) );
 
 			if ( ! rawTransformation ) {
-				warn(
+				console.warn(
 					'A block registered a raw transformation schema for `' + node.nodeName + '` but did not match it. ' +
 					'Make sure there is a `selector` or `isMatch` property that can match the schema.\n' +
 					'Sanitized HTML: `' + node.outerHTML + '`'

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -87,9 +87,9 @@ export class RichText extends Component {
 		this.onKeyUp = this.onKeyUp.bind( this );
 		this.changeFormats = this.changeFormats.bind( this );
 		this.onPropagateUndo = this.onPropagateUndo.bind( this );
+		this.onPaste = this.onPaste.bind( this );
 		this.onCreateUndoLevel = this.onCreateUndoLevel.bind( this );
 		this.setFocusedElement = this.setFocusedElement.bind( this );
-		this.onPaste = this.onPaste.bind( this );
 
 		this.state = {
 			formats: {},
@@ -279,8 +279,8 @@ export class RichText extends Component {
 		}
 
 		const content = rawHandler( {
-			HTML: HTML,
-			plainText: this.pastedPlainText,
+			HTML,
+			plainText,
 			mode,
 			tagName: this.props.tagName,
 			canUserUseUnfilteredHTML: this.props.canUserUseUnfilteredHTML,
@@ -868,7 +868,7 @@ export class RichText extends Component {
 								{ ...ariaProps }
 								className={ className }
 								key={ key }
-								onCustomPaste={ this.onPaste }
+								onPaste={ this.onPaste }
 							/>
 							{ isPlaceholderVisible &&
 								<Tagname

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -218,11 +218,12 @@ export class RichText extends Component {
 		let plainText = '';
 		let html = '';
 
+		// IE11 only supports `Text` as an argument for `getData` and will
+		// otherwise throw an invalid argument error, so we try the standard
+		// arguments first, then fallback to `Text` if they fail.
 		try {
 			plainText = clipboardData.getData( 'text/plain' );
 			html = clipboardData.getData( 'text/html' );
-		// IE11 only supports `Text` as an argument for `getData` and will
-		// otherwise throw an invalid argument error.
 		} catch ( error1 ) {
 			try {
 				html = clipboardData.getData( 'Text' );

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -216,16 +216,16 @@ export class RichText extends Component {
 		const { items = [], files = [] } = clipboardData;
 		const item = find( [ ...items, ...files ], ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
 		let plainText = '';
-		let HTML = '';
+		let html = '';
 
 		try {
 			plainText = clipboardData.getData( 'text/plain' );
-			HTML = clipboardData.getData( 'text/html' );
+			html = clipboardData.getData( 'text/html' );
 		// IE11 only supports `Text` as an argument for `getData` and will
 		// otherwise throw an invalid argument error.
 		} catch ( error1 ) {
 			try {
-				HTML = clipboardData.getData( 'Text' );
+				html = clipboardData.getData( 'Text' );
 			} catch ( error2 ) {
 				// Some browsers like UC Browser paste plain text by default and
 				// don't support clipboardData at all, so allow default
@@ -237,12 +237,12 @@ export class RichText extends Component {
 		event.preventDefault();
 
 		// Allows us to ask for this information when we get a report.
-		window.console.log( 'Received HTML:\n\n', HTML );
+		window.console.log( 'Received HTML:\n\n', html );
 		window.console.log( 'Received plain text:\n\n', plainText );
 
 		// Only process file if no HTML is present.
 		// Note: a pasted file may have the URL as plain text.
-		if ( item && ! HTML ) {
+		if ( item && ! html ) {
 			const file = item.getAsFile ? item.getAsFile() : item;
 			const content = rawHandler( {
 				HTML: `<img src="${ createBlobURL( file ) }">`,
@@ -269,7 +269,7 @@ export class RichText extends Component {
 		// There is a selection, check if a URL is pasted.
 		if ( ! this.editor.selection.isCollapsed() ) {
 			const linkRegExp = /^(?:https?:)?\/\/\S+$/i;
-			const pastedText = ( HTML || plainText ).replace( /<[^>]+>/g, '' ).trim();
+			const pastedText = ( html || plainText ).replace( /<[^>]+>/g, '' ).trim();
 
 			// A URL was pasted, turn the selection into a link
 			if ( linkRegExp.test( pastedText ) ) {
@@ -295,7 +295,7 @@ export class RichText extends Component {
 		}
 
 		const content = rawHandler( {
-			HTML,
+			HTML: html,
 			plainText,
 			mode,
 			tagName: this.props.tagName,

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -212,11 +212,23 @@ export class RichText extends Component {
 	 * @param {PasteEvent} event The paste event as triggered by TinyMCE.
 	 */
 	onPaste( event ) {
-		const clipboardData = event.clipboardData || window.clipboardData;
+		const clipboardData = event.clipboardData;
 		const { items = [], files = [] } = clipboardData;
 		const item = find( [ ...items, ...files ], ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
-		const plainText = clipboardData.getData( 'text/plain' );
-		const HTML = clipboardData.getData( 'text/html' );
+		let plainText = '';
+		let HTML = '';
+
+		try {
+			plainText = clipboardData.getData( 'text/plain' );
+			HTML = clipboardData.getData( 'text/html' );
+		// IE11 will throw an invalid argument error.
+		} catch ( e1 ) {
+			try {
+				HTML = clipboardData.getData( 'Text' );
+			} catch ( e2 ) {
+				return;
+			}
+		}
 
 		event.preventDefault();
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -221,11 +221,15 @@ export class RichText extends Component {
 		try {
 			plainText = clipboardData.getData( 'text/plain' );
 			HTML = clipboardData.getData( 'text/html' );
-		// IE11 will throw an invalid argument error.
-		} catch ( e1 ) {
+		// IE11 only supports `Text` as an argument for `getData` and will
+		// otherwise throw an invalid argument error.
+		} catch ( error1 ) {
 			try {
 				HTML = clipboardData.getData( 'Text' );
-			} catch ( e2 ) {
+			} catch ( error2 ) {
+				// Some browsers like UC Browser paste plain text by default and
+				// don't support clipboardData at all, so allow default
+				// behaviour.
 				return;
 			}
 		}

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -212,7 +212,7 @@ export class RichText extends Component {
 	 * @param {PasteEvent} event The paste event as triggered by TinyMCE.
 	 */
 	onPaste( event ) {
-		const { clipboardData } = event;
+		const clipboardData = event.clipboardData || window.clipboardData;
 		const { items = [], files = [] } = clipboardData;
 		const item = find( [ ...items, ...files ], ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
 		const plainText = clipboardData.getData( 'text/plain' );

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, createElement } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 
 /**
@@ -96,6 +96,7 @@ function applyInternetExplorerInputFix( editorNode ) {
 }
 
 const IS_PLACEHOLDER_VISIBLE_ATTR_NAME = 'data-is-placeholder-visible';
+
 export default class TinyMCE extends Component {
 	constructor() {
 		super();
@@ -103,7 +104,28 @@ export default class TinyMCE extends Component {
 	}
 
 	componentDidMount() {
-		this.initialize();
+		const settings = this.props.getSettings( {
+			theme: false,
+			inline: true,
+			toolbar: false,
+			browser_spellcheck: true,
+			entity_encoding: 'raw',
+			convert_urls: false,
+			inline_boundaries_selector: 'a[href],code,b,i,strong,em,del,ins,sup,sub',
+			plugins: [],
+			formats: {
+				strikethrough: { inline: 'del' },
+			},
+		} );
+
+		tinymce.init( {
+			...settings,
+			target: this.editorNode,
+			setup: ( editor ) => {
+				this.editor = editor;
+				this.props.onSetup( editor );
+			},
+		} );
 	}
 
 	shouldComponentUpdate() {
@@ -149,33 +171,6 @@ export default class TinyMCE extends Component {
 		}
 	}
 
-	initialize() {
-		const settings = this.props.getSettings( {
-			theme: false,
-			inline: true,
-			toolbar: false,
-			browser_spellcheck: true,
-			entity_encoding: 'raw',
-			convert_urls: false,
-			inline_boundaries_selector: 'a[href],code,b,i,strong,em,del,ins,sup,sub',
-			plugins: [],
-			formats: {
-				strikethrough: { inline: 'del' },
-			},
-		} );
-
-		settings.plugins.push( 'paste' );
-
-		tinymce.init( {
-			...settings,
-			target: this.editorNode,
-			setup: ( editor ) => {
-				this.editor = editor;
-				this.props.onSetup( editor );
-			},
-		} );
-	}
-
 	bindEditorNode( editorNode ) {
 		this.editorNode = editorNode;
 
@@ -194,32 +189,40 @@ export default class TinyMCE extends Component {
 	}
 
 	render() {
-		const { tagName = 'div', style, defaultValue, className, isPlaceholderVisible, format } = this.props;
+		const { tagName: TagName = 'div', style, defaultValue, className, isPlaceholderVisible, format } = this.props;
 		const ariaProps = pickAriaProps( this.props );
+		const placeholderProps = {
+			[ IS_PLACEHOLDER_VISIBLE_ATTR_NAME ]: isPlaceholderVisible,
+		};
 
 		/*
 		 * The role=textbox and aria-multiline=true must always be used together
 		 * as TinyMCE always behaves like a sort of textarea where text wraps in
 		 * multiple lines. Only the table block editable element is excluded.
 		 */
-		if ( tagName !== 'table' ) {
+		if ( TagName !== 'table' ) {
 			ariaProps.role = 'textbox';
 			ariaProps[ 'aria-multiline' ] = true;
 		}
 
-		// If a default value is provided, render it into the DOM even before
-		// TinyMCE finishes initializing. This avoids a short delay by allowing
-		// us to show and focus the content before it's truly ready to edit.
-
-		return createElement( tagName, {
-			...ariaProps,
-			className: classnames( className, 'editor-rich-text__tinymce' ),
-			contentEditable: true,
-			[ IS_PLACEHOLDER_VISIBLE_ATTR_NAME ]: isPlaceholderVisible,
-			ref: this.bindEditorNode,
-			style,
-			suppressContentEditableWarning: true,
-			dangerouslySetInnerHTML: { __html: valueToString( defaultValue, format ) },
-		} );
+		return (
+			<TagName
+				{ ...ariaProps }
+				{ ...placeholderProps }
+				className={ classnames( className, 'editor-rich-text__tinymce' ) }
+				contentEditable={ true }
+				suppressContentEditableWarning={ true }
+				ref={ this.bindEditorNode }
+				style={ style }
+				dangerouslySetInnerHTML={ {
+					// If a default value is provided, render it into the DOM
+					// even before TinyMCE finishes initializing. This avoids a
+					// short delay by allowing us to show and focus the content
+					// before it's truly ready to edit.
+					__html: valueToString( defaultValue, format ),
+				} }
+				onPaste={ this.props.onCustomPaste }
+			/>
+		);
 	}
 }


### PR DESCRIPTION
## Description

We no longer need the TinyMCE paste plugin because we have our own paste logic in Gutenberg. The only reason why it is still there is to facilitate getting the pasted content. Initially I thought we should copy over the paste bin technique, but it seems all modern browsers support `clipboardData`. I haven't tested IE11 and Android, so I'd be grateful if someone could try this out there. If either browser does not support `clipboardData`, we can add the paste bin for these browsers as a fallback.

## How has this been tested?

Ensure all paste functionality still works.

* Copy HTML from anywhere and paste it in a rich text field.
* Copy plain text from e.g. a text editor and paste it.
* Copy an image from the web and paste it.
* Try paste in different ways:
  * Use the browser menu bar.
  * Use the right-click menu.
  * Use the keyboard shortcut.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->