### PR TITLE
Framework: Fix typo for removing excerpt block stripping

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -252,7 +252,7 @@ function strip_dynamic_blocks_add_filter( $text ) {
 add_filter( 'get_the_excerpt', 'strip_dynamic_blocks_add_filter', 9 ); // Before wp_trim_excerpt().
 
 /**
- * Adds the content filter to strip dynamic blocks from excerpts.
+ * Removes the content filter to strip dynamic blocks from excerpts.
  *
  * It's a bit hacky for now, but once this gets merged into core the function
  * can just be called in `wp_trim_excerpt()`.
@@ -267,4 +267,4 @@ function strip_dynamic_blocks_remove_filter( $text ) {
 
 	return $text;
 }
-add_filter( 'wp_trim_excerpt', 'strip_dynamic_blocks_add_filter', 0 ); // Before all other.
+add_filter( 'wp_trim_excerpt', 'strip_dynamic_blocks_remove_filter', 0 ); // Before all other.


### PR DESCRIPTION
Fixes #9084
Regression introduced in #8984

This pull request seeks to resolve an issue where a filter which was responsible for stripping dynamic blocks from excerpts was never properly removed. The original implementation appears to have intended to temporarily add a filter for excerpts, but due to what I'm attributing to be a typo, it was never removed because it had specified the incorrect function name. Prior to these changes, the `strip_dynamic_blocks_remove_filter` was an unused function.

**Testing instructions:**

Repeat steps to reproduce from #9084, verifying that Latest Posts appears as expected with the Yoast plugin activated.