### PR TITLE
Blocks: Fix excess whitespace in block style class name (new package: TokenList)

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -462,6 +462,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/token-list",
+		"slug": "packages-token-list",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/token-list/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/url",
 		"slug": "packages-url",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/url/README.md",

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -134,6 +134,13 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/is-shallow-equal/index.js' ),
 		true
 	);
+	wp_register_script(
+		'wp-token-list',
+		gutenberg_url( 'build/token-list/index.js' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/token-list/index.js' ),
+		true
+	);
 
 	// Editor Scripts.
 	wp_register_script(
@@ -515,6 +522,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-keycodes',
 			'wp-nux',
 			'wp-tinymce',
+			'wp-token-list',
 			'wp-url',
 			'wp-viewport',
 			'wp-wordcount',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -137,7 +137,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-token-list',
 		gutenberg_url( 'build/token-list/index.js' ),
-		array(),
+		array( 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/token-list/index.js' ),
 		true
 	);

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/nux": "file:../nux",
+		"@wordpress/token-list": "file:../token-list",
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/wordcount": "file:../wordcount",

--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -52,14 +52,13 @@ export function getActiveStyle( styles, className ) {
  * @return {string} The updated className.
  */
 export function replaceActiveStyle( className, activeStyle, newStyle ) {
-	const newStyleName = 'is-style-' + newStyle.name;
-
 	const list = new TokenList( className );
+
 	if ( activeStyle ) {
-		list.replace( 'is-style-' + activeStyle.name, newStyleName );
-	} else {
-		list.add( newStyleName );
+		list.remove( 'is-style-' + activeStyle.name );
 	}
+
+	list.add( 'is-style-' + newStyle.name );
 
 	return list.value;
 }

--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, compact, get } from 'lodash';
+import { find, get } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -11,6 +11,7 @@ import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { getBlockType } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
+import TokenList from '@wordpress/token-list';
 
 /**
  * Internal dependencies
@@ -26,23 +27,19 @@ import { BlockPreviewContent } from '../block-preview';
  * @return {Object?} The active style.
  */
 export function getActiveStyle( styles, className ) {
-	let activeStyle;
-	className
-		.split( ' ' )
-		.map( ( current ) => current.trim() )
-		.filter( ( current ) => current.indexOf( 'is-style-' ) === 0 )
-		.forEach( ( current ) => {
-			if ( activeStyle ) {
-				return;
-			}
-			const potentialStyleName = current.substring( 9 );
-			activeStyle = find( styles, ( style ) => style.name === potentialStyleName );
-		} );
-	if ( ! activeStyle ) {
-		activeStyle = find( styles, ( style ) => style.isDefault );
+	for ( const style of new TokenList( className ).values() ) {
+		if ( style.indexOf( 'is-style-' ) === -1 ) {
+			continue;
+		}
+
+		const potentialStyleName = style.substring( 9 );
+		const activeStyle = find( styles, { name: potentialStyleName } );
+		if ( activeStyle ) {
+			return activeStyle;
+		}
 	}
 
-	return activeStyle;
+	return find( styles, 'isDefault' );
 }
 
 /**
@@ -55,22 +52,16 @@ export function getActiveStyle( styles, className ) {
  * @return {string} The updated className.
  */
 export function replaceActiveStyle( className, activeStyle, newStyle ) {
-	let added = false;
-	let updatedClassName = compact( className
-		.split( ' ' )
-		.map( ( current ) => {
-			const trimmed = current.trim();
-			if ( activeStyle && trimmed === 'is-style-' + activeStyle.name ) {
-				added = true;
-				return newStyle.isDefault ? null : 'is-style-' + newStyle.name;
-			}
-			return trimmed;
-		} ) ).join( ' ' );
-	if ( ! added && ! newStyle.isDefault ) {
-		updatedClassName = updatedClassName + ' is-style-' + newStyle.name;
+	const newStyleName = 'is-style-' + newStyle.name;
+
+	const list = new TokenList( className );
+	if ( activeStyle ) {
+		list.replace( 'is-style-' + activeStyle.name, newStyleName );
+	} else {
+		list.add( newStyleName );
 	}
 
-	return updatedClassName;
+	return list.value;
 }
 
 function BlockStyles( {

--- a/packages/editor/src/components/block-styles/test/index.js
+++ b/packages/editor/src/components/block-styles/test/index.js
@@ -64,6 +64,15 @@ describe( 'replaceActiveStyle', () => {
 			.toBe( 'is-style-small' );
 	} );
 
+	it( 'Should add the new style if no active style (unassigned default)', () => {
+		const activeStyle = { name: 'default' };
+		const newStyle = { name: 'small' };
+		const className = '';
+
+		expect( replaceActiveStyle( className, activeStyle, newStyle ) )
+			.toBe( 'is-style-small' );
+	} );
+
 	it( 'Should replace the previous active style', () => {
 		const activeStyle = { name: 'large' };
 		const newStyle = { name: 'small' };

--- a/packages/editor/src/components/block-styles/test/index.js
+++ b/packages/editor/src/components/block-styles/test/index.js
@@ -55,6 +55,15 @@ describe( 'replaceActiveStyle', () => {
 			.toBe( 'custom-class is-style-small' );
 	} );
 
+	it( 'Should add the new style if no active style (no existing class)', () => {
+		const activeStyle = undefined;
+		const newStyle = { name: 'small' };
+		const className = '';
+
+		expect( replaceActiveStyle( className, activeStyle, newStyle ) )
+			.toBe( 'is-style-small' );
+	} );
+
 	it( 'Should replace the previous active style', () => {
 		const activeStyle = { name: 'large' };
 		const newStyle = { name: 'small' };

--- a/packages/token-list/.npmrc
+++ b/packages/token-list/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/token-list/CHANGELOG.md
+++ b/packages/token-list/CHANGELOG.md
@@ -1,0 +1,3 @@
+## v1.0.0 (Unreleased)
+
+- Initial release

--- a/packages/token-list/README.md
+++ b/packages/token-list/README.md
@@ -1,0 +1,47 @@
+# Token List
+
+Constructable, plain JavaScript [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) implementation, supporting non-browser runtimes.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/token-list
+```
+
+## Usage
+
+Construct a new token list, optionally with an initial value. A value with an interface matching DOMTokenList is returned.
+
+```js
+import TokenList from '@wordpress/token-list';
+
+const tokens = new TokenList( 'abc def' );
+tokens.add( 'ghi' );
+tokens.remove( 'def' );
+tokens.replace( 'abc', 'xyz' );
+console.log( tokens.value );
+// "xyz ghi"
+```
+
+All [methods of DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList#Methods) are implemented.
+
+Note the following implementation divergences from the [specification](https://dom.spec.whatwg.org/#domtokenlist):
+
+- `TokenList#supports` will always return true, regardless of the token passed.
+- `TokenList#add` and `TokenList#remove` will simply disregard the empty string argument or whitespace of a token argument, rather than [throwing an error](https://dom.spec.whatwg.org/#dom-domtokenlist-add).
+- An item cannot be referenced by its index as a property. Use `TokenList#item` instead.
+
+## Browser Support
+
+While it could be used in one's implementation, this is not intended to serve as a polyfill for `Element#classList` or other instances of `DOMTokenList`.
+
+The implementation of the `DOMTokenList` interface provided through `@wordpress/token-list` is broadly compatible in environments supporting ES5 (IE8 and newer). That being said, due to its internal implementation leveraging arrays for `TokenList#entries`, `TokenList#forEach`, `TokenList#keys`, and `TokenList#values`, you may need to assure that these functions are supported or polyfilled if you intend to use them.
+
+- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/entries#Browser_compatibility
+- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/values#Browser_compatibility
+
+TokenList's own internal implementation of the `DOMTokenList` interface does not leverage any of these functions, so it is not necessary to polyfill them for basic usage.
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -19,7 +19,7 @@
 	"module": "build-module/index.js",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.0.0-beta.56",
-		"lodash-es": "^4.17.10"
+		"lodash": "^4.17.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@wordpress/token-list",
+	"version": "1.0.0",
+	"description": "Constructable, plain JavaScript DOMTokenList implementation, supporting non-browser runtimes.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"domtokenlist"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/token-list/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"dependencies": {
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"lodash-es": "^4.17.10"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/token-list/src/index.js
+++ b/packages/token-list/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniq, compact, without } from 'lodash-es';
+import { uniq, compact, without } from 'lodash';
 
 /**
  * A set of tokens.

--- a/packages/token-list/src/index.js
+++ b/packages/token-list/src/index.js
@@ -1,0 +1,172 @@
+/**
+ * External dependencies
+ */
+import { uniq, compact, without } from 'lodash-es';
+
+/**
+ * A set of tokens.
+ *
+ * @link https://dom.spec.whatwg.org/#domtokenlist
+ */
+export default class TokenList {
+	/**
+	 * Constructs a new instance of TokenList.
+	 *
+	 * @param {string} initialValue Initial value to assign.
+	 */
+	constructor( initialValue = '' ) {
+		this.value = initialValue;
+
+		[ 'entries', 'forEach', 'keys', 'values' ].forEach( ( fn ) => {
+			this[ fn ] = ( function() {
+				return this._valueAsArray[ fn ]( ...arguments );
+			} ).bind( this );
+		} );
+	}
+
+	/**
+	 * Returns the associated set as string.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-value
+	 *
+	 * @return {string} Token set as string.
+	 */
+	get value() {
+		return this._currentValue;
+	}
+
+	/**
+	 * Replaces the associated set with a new string value.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-value
+	 *
+	 * @param {string} value New token set as string.
+	 */
+	set value( value ) {
+		value = String( value );
+		this._valueAsArray = uniq( compact( value.split( /\s+/g ) ) );
+		this._currentValue = this._valueAsArray.join( ' ' );
+	}
+
+	/**
+	 * Returns the number of tokens.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-length
+	 *
+	 * @return {number} Number of tokens.
+	 */
+	get length() {
+		return this._valueAsArray.length;
+	}
+
+	/**
+	 * Returns the token with index `index`.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-item
+	 *
+	 * @param {number} index Index at which to return token.
+	 *
+	 * @return {?string} Token at index.
+	 */
+	item( index ) {
+		return this._valueAsArray[ index ];
+	}
+
+	/**
+	 * Returns true if `token` is present, and false otherwise.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-contains
+	 *
+	 * @param {string} item Token to test.
+	 *
+	 * @return {boolean} Whether token is present.
+	 */
+	contains( item ) {
+		return this._valueAsArray.indexOf( item ) !== -1;
+	}
+
+	/**
+	 * Adds all arguments passed, except those already present.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-add
+	 *
+	 * @param {...string} items Items to add.
+	 */
+	add( ...items ) {
+		this.value += ' ' + items.join( ' ' );
+	}
+
+	/**
+	 * Removes arguments passed, if they are present.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-remove
+	 *
+	 * @param {...string} items Items to remove.
+	 */
+	remove( ...items ) {
+		this.value = without( this._valueAsArray, ...items ).join( ' ' );
+	}
+
+	/**
+	 * If `force` is not given, "toggles" `token`, removing it if it’s present
+	 * and adding it if it’s not present. If `force` is true, adds token (same
+	 * as add()). If force is false, removes token (same as remove()). Returns
+	 * true if `token` is now present, and false otherwise.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-toggle
+	 *
+	 * @param {string}   token Token to toggle.
+	 * @param {?boolean} force Presence to force.
+	 *
+	 * @return {boolean} Whether token is present after toggle.
+	 */
+	toggle( token, force ) {
+		if ( undefined === force ) {
+			force = ! this.contains( token );
+		}
+
+		if ( force ) {
+			this.add( token );
+		} else {
+			this.remove( token );
+		}
+
+		return force;
+	}
+
+	/**
+	 * Replaces `token` with `newToken`. Returns true if `token` was replaced
+	 * with `newToken`, and false otherwise.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-replace
+	 *
+	 * @param {string} token    Token to replace with `newToken`.
+	 * @param {string} newToken Token to use in place of `token`.
+	 *
+	 * @return {boolean} Whether replacement occurred.
+	 */
+	replace( token, newToken ) {
+		if ( ! this.contains( token ) ) {
+			return false;
+		}
+
+		this.remove( token );
+		this.add( newToken );
+
+		return true;
+	}
+
+	/**
+	 * Returns true if `token` is in the associated attribute’s supported
+	 * tokens. Returns false otherwise.
+	 *
+	 * Always returns `true` in this implementation.
+	 *
+	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-supports
+	 *
+	 * @return {boolean} Whether token is supported.
+	 */
+	supports() {
+		return true;
+	}
+}

--- a/packages/token-list/src/test/index.js
+++ b/packages/token-list/src/test/index.js
@@ -1,0 +1,221 @@
+/**
+ * Internal dependencies
+ */
+import TokenList from '../';
+
+describe( 'token-list', () => {
+	describe( 'constructor', () => {
+		it( 'should instantiate instance with no initial value', () => {
+			const list = new TokenList();
+
+			expect( list.value ).toBe( '' );
+			expect( list ).toHaveLength( 0 );
+		} );
+
+		it( 'should instantiate instance with empty initial value', () => {
+			const list = new TokenList( '' );
+
+			expect( list.value ).toBe( '' );
+			expect( list ).toHaveLength( 0 );
+		} );
+
+		it( 'should instantiate instance with initial value', () => {
+			const list = new TokenList( 'abc   ' );
+
+			expect( list.value ).toBe( 'abc' );
+			expect( list ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'value', () => {
+		it( 'sets to stringified value', () => {
+			const list = new TokenList();
+			list.value = undefined;
+
+			expect( list.value ).toBe( 'undefined' );
+		} );
+	} );
+
+	describe( 'item', () => {
+		it( 'should return undefined if item at index does not exist', () => {
+			const list = new TokenList();
+
+			expect( list.item( 0 ) ).toBeUndefined();
+		} );
+
+		it( 'should return item at index', () => {
+			const list = new TokenList( 'abc' );
+
+			expect( list.item( 0 ) ).toBe( 'abc' );
+		} );
+	} );
+
+	describe( 'contains', () => {
+		it( 'should return false if token does not exist', () => {
+			const list = new TokenList();
+
+			expect( list.contains( 'abc' ) ).toBe( false );
+		} );
+
+		it( 'should return true if token exists', () => {
+			const list = new TokenList( 'abc' );
+
+			expect( list.contains( 'abc' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'add', () => {
+		it( 'does nothing if token already exists', () => {
+			const list = new TokenList( 'abc' );
+			const returnValue = list.add( 'abc' );
+
+			expect( list.value ).toBe( 'abc' );
+			expect( list ).toHaveLength( 1 );
+			expect( returnValue ).toBeUndefined();
+		} );
+
+		it( 'does nothing if token already exists (whitespace variation)', () => {
+			const list = new TokenList( 'abc   ' );
+			const returnValue = list.add( '' );
+
+			expect( list.value ).toBe( 'abc' );
+			expect( list ).toHaveLength( 1 );
+			expect( returnValue ).toBeUndefined();
+		} );
+
+		it( 'does not add an empty token', () => {
+			const list = new TokenList( 'abc' );
+			const returnValue = list.add( '' );
+
+			expect( list.value ).toBe( 'abc' );
+			expect( list ).toHaveLength( 1 );
+			expect( returnValue ).toBeUndefined();
+		} );
+
+		it( 'adds token to empty initial value', () => {
+			const list = new TokenList();
+			const returnValue = list.add( 'abc' );
+
+			expect( list.value ).toBe( 'abc' );
+			expect( list ).toHaveLength( 1 );
+			expect( returnValue ).toBeUndefined();
+		} );
+
+		it( 'adds token to non-empty initial value', () => {
+			const list = new TokenList( 'abc' );
+			const returnValue = list.add( 'def' );
+
+			expect( list.value ).toBe( 'abc def' );
+			expect( list ).toHaveLength( 2 );
+			expect( returnValue ).toBeUndefined();
+		} );
+
+		it( 'adds multiple tokens, uniquely', () => {
+			const list = new TokenList( 'abc' );
+			const returnValue = list.add( 'abc', 'def', 'ghi' );
+
+			expect( list.value ).toBe( 'abc def ghi' );
+			expect( list ).toHaveLength( 3 );
+			expect( returnValue ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'remove', () => {
+		it( 'does nothing if token does not exist', () => {
+			const list = new TokenList( 'abc' );
+			const returnValue = list.remove( 'def' );
+
+			expect( list.value ).toBe( 'abc' );
+			expect( list ).toHaveLength( 1 );
+			expect( returnValue ).toBeUndefined();
+		} );
+
+		it( 'removes token', () => {
+			const list = new TokenList( 'abc def' );
+			const returnValue = list.remove( 'def' );
+
+			expect( list.value ).toBe( 'abc' );
+			expect( list ).toHaveLength( 1 );
+			expect( returnValue ).toBeUndefined();
+		} );
+
+		it( 'removes multiple tokens', () => {
+			const list = new TokenList( 'abc def' );
+			const returnValue = list.remove( 'abc', 'def' );
+
+			expect( list.value ).toBe( '' );
+			expect( list ).toHaveLength( 0 );
+			expect( returnValue ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'replace', () => {
+		it( 'does nothing if token does not exist', () => {
+			const list = new TokenList( 'abc' );
+			const returnValue = list.replace( 'def', 'ghi' );
+
+			expect( list.value ).toBe( 'abc' );
+			expect( list ).toHaveLength( 1 );
+			expect( returnValue ).toBe( false );
+		} );
+
+		it( 'removes token', () => {
+			const list = new TokenList( 'abc def' );
+			const returnValue = list.replace( 'def', 'ghi' );
+
+			expect( list.value ).toBe( 'abc ghi' );
+			expect( list ).toHaveLength( 2 );
+			expect( returnValue ).toBe( true );
+		} );
+	} );
+
+	describe( 'supports', () => {
+		it( 'returns true', () => {
+			const list = new TokenList( 'abc def' );
+
+			expect( list.supports( 'does-not-matter' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'toggle', () => {
+		describe( 'without force', () => {
+			it( 'toggles off', () => {
+				const list = new TokenList( 'abc' );
+				const returnValue = list.toggle( 'abc' );
+
+				expect( list.value ).toBe( '' );
+				expect( list ).toHaveLength( 0 );
+				expect( returnValue ).toBe( false );
+			} );
+
+			it( 'toggles on', () => {
+				const list = new TokenList();
+				const returnValue = list.toggle( 'abc' );
+
+				expect( list.value ).toBe( 'abc' );
+				expect( list ).toHaveLength( 1 );
+				expect( returnValue ).toBe( true );
+			} );
+		} );
+
+		describe( 'with force', () => {
+			it( 'toggles off', () => {
+				const list = new TokenList( 'abc' );
+				const returnValue = list.toggle( 'abc', false );
+
+				expect( list.value ).toBe( '' );
+				expect( list ).toHaveLength( 0 );
+				expect( returnValue ).toBe( false );
+			} );
+
+			it( 'toggles on', () => {
+				const list = new TokenList( 'abc' );
+				const returnValue = list.toggle( 'abc', true );
+
+				expect( list.value ).toBe( 'abc' );
+				expect( list ).toHaveLength( 1 );
+				expect( returnValue ).toBe( true );
+			} );
+		} );
+	} );
+} );

--- a/test/e2e/specs/__snapshots__/style-variation.test.js.snap
+++ b/test/e2e/specs/__snapshots__/style-variation.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`adding blocks Should switch the style of the quote block 1`] = `
-"<!-- wp:quote {\\"className\\":\\" is-style-large\\"} -->
-<blockquote class=\\"wp-block-quote  is-style-large\\"><p>Quote content</p></blockquote>
+"<!-- wp:quote {\\"className\\":\\"is-style-large\\"} -->
+<blockquote class=\\"wp-block-quote is-style-large\\"><p>Quote content</p></blockquote>
 <!-- /wp:quote -->"
 `;

--- a/test/unit/jest.config.json
+++ b/test/unit/jest.config.json
@@ -23,5 +23,8 @@
 	"testPathIgnorePatterns": [
 		"/node_modules/",
 		"/test/e2e"
+	],
+	"transformIgnorePatterns": [
+		"node_modules/(?!(lodash-es)/)"
 	]
 }

--- a/test/unit/jest.config.json
+++ b/test/unit/jest.config.json
@@ -23,8 +23,5 @@
 	"testPathIgnorePatterns": [
 		"/node_modules/",
 		"/test/e2e"
-	],
-	"transformIgnorePatterns": [
-		"node_modules/(?!(lodash-es)/)"
 	]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,6 +107,7 @@ const gutenbergPackages = [
 	'plugins',
 	'redux-routine',
 	'shortcode',
+	'token-list',
 	'url',
 	'viewport',
 	'wordcount',


### PR DESCRIPTION
This pull request seeks to resolve an issue where assigning a block style can introduce unnecessary whitespace to its `className`. In doing so, it implements a new package, `@wordpress/token-list`, intended to imitate the interface of [`DOMTokenList`](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) while being constructable and not requiring a DOM. `DOMTokenList` is the interface used by [`Element#classList`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList), which is an easier mechanism for working with (adding, removing, replacing) class names.

**Testing instructions:**

Ensure unit tests pass:

```
npm test
```

Verify that changing the "Quote" block style to "Large" has no leading or trailing whitespace in its assigned class name.