### PR TITLE
RichText: Mark onSetup, getSettings as unstable APIs

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,5 +1,10 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 3.9.0
+
+- RichText `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.
+- RichText `onSetup` prop has been removed. The `unstableOnSetup` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.
+
 ## 3.8.0
 
  - `wp.components.withContext` has been removed. Please use `wp.element.createContext` instead. See: https://reactjs.org/docs/context.html.

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -326,8 +326,8 @@ export const settings = {
 					<RichText
 						multiline="li"
 						tagName={ tagName }
-						getSettings={ this.getEditorSettings }
-						onSetup={ this.setupEditor }
+						unstableGetSettings={ this.getEditorSettings }
+						unstableOnSetup={ this.setupEditor }
 						onChange={ this.setNextValues }
 						value={ values }
 						wrapperClassName="block-library-list"

--- a/packages/block-library/src/table/table-block.js
+++ b/packages/block-library/src/table/table-block.js
@@ -97,12 +97,12 @@ export default class TableBlock extends Component {
 				<RichText
 					tagName="table"
 					wrapperClassName={ className }
-					getSettings={ ( settings ) => ( {
+					unstableGetSettings={ ( settings ) => ( {
 						...settings,
 						plugins: ( settings.plugins || [] ).concat( 'table' ),
 						table_tab_navigation: false,
 					} ) }
-					onSetup={ ( editor ) => this.handleSetup( editor, isSelected ) }
+					unstableOnSetup={ ( editor ) => this.handleSetup( editor, isSelected ) }
 					onChange={ onChange }
 					value={ content }
 				/>

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -28,6 +28,7 @@ import { Slot } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { rawHandler, children } from '@wordpress/blocks';
 import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -109,13 +110,31 @@ export class RichText extends Component {
 	 * @return {Object} The settings for this block.
 	 */
 	getSettings( settings ) {
-		return ( this.props.getSettings || identity )( {
+		let { unstableGetSettings: getSettings } = this.props;
+		if ( ! getSettings && typeof this.props.getSettings === 'function' ) {
+			deprecated( 'RichText getSettings prop', {
+				alternative: 'unstableGetSettings',
+				plugin: 'Gutenberg',
+				version: '3.9',
+				hint: 'Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.',
+			} );
+
+			getSettings = this.props.getSettings;
+		}
+
+		settings = {
 			...settings,
 			forced_root_block: this.props.multiline || false,
 			// Allow TinyMCE to keep one undo level for comparing changes.
 			// Prevent it otherwise from accumulating any history.
 			custom_undo_redo_levels: 1,
-		} );
+		};
+
+		if ( getSettings ) {
+			settings = getSettings( settings );
+		}
+
+		return settings;
 	}
 
 	/**
@@ -143,8 +162,20 @@ export class RichText extends Component {
 
 		patterns.apply( this, [ editor ] );
 
-		if ( this.props.onSetup ) {
-			this.props.onSetup( editor );
+		let { unstableOnSetup: onSetup } = this.props;
+		if ( ! onSetup && typeof this.props.onSetup === 'function' ) {
+			deprecated( 'RichText onSetup prop', {
+				alternative: 'unstableOnSetup',
+				plugin: 'Gutenberg',
+				version: '3.9',
+				hint: 'Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.',
+			} );
+
+			onSetup = this.props.onSetup;
+		}
+
+		if ( onSetup ) {
+			onSetup( editor );
 		}
 	}
 

--- a/packages/editor/src/components/rich-text/test/index.js
+++ b/packages/editor/src/components/rich-text/test/index.js
@@ -4,6 +4,11 @@
 import { shallow } from 'enzyme';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import {
@@ -11,6 +16,8 @@ import {
 	getFormatProperties,
 } from '../';
 import { diffAriaProps, pickAriaProps } from '../aria';
+
+jest.mock( '@wordpress/deprecated', () => jest.fn() );
 
 describe( 'getFormatProperties', () => {
 	const formatName = 'link';
@@ -99,10 +106,17 @@ describe( 'RichText', () => {
 				} );
 			} );
 
-			test( 'should be overriden', () => {
+			test( 'should be overriden (deprecated)', () => {
 				const mock = jest.fn().mockImplementation( () => 'mocked' );
 
 				expect( shallow( <RichText value={ value } multiline={ true } getSettings={ mock } /> ).instance().getSettings( settings ) ).toEqual( 'mocked' );
+				expect( deprecated ).toHaveBeenCalled();
+			} );
+
+			test( 'should be overriden', () => {
+				const mock = jest.fn().mockImplementation( () => 'mocked' );
+
+				expect( shallow( <RichText value={ value } multiline={ true } unstableGetSettings={ mock } /> ).instance().getSettings( settings ) ).toEqual( 'mocked' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
This pull request seeks to deprecate the following two props of `RichText`, while still making them available as intentionally-flagged "unstable" equivalent props:

- `getSettings`
   - Now available as `unstableGetSettings`
- `onSetup`
   - Now available as `unstableOnSetup`

These changes follow a similar pattern to that of #7029 (`unstableOnFocus`), where the intent is to discourage use of these props, which are already undocumented. Their existence is undesirable, but necessary in current implementations of core blocks. Until the core blocks can be refactored to avoid them, they are marked as unstable to discourage other developers from considering adoption.

These props are considered undesirable because they pierce the abstraction RichText is intended to serve atop TinyMCE. Respectively they are intended to allow a consumer to override _TinyMCE settings_ or to receive the initialized _TinyMCE instance_.

**Testing instructions:**

Verify that there are no regressions in the behavior of the List and Table blocks.

Then revert a9a6792 in your local copy of the branch to reintroduce the deprecated prop usage. Verify that the blocks still operate as expected, but log a deprecated warning in the process.