### PR TITLE
Fixing styling for post visibility component

### DIFF
--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -75,7 +75,7 @@ export class PostVisibility extends Component {
 		};
 
 		return [
-			<fieldset key="visibility-selector">
+			<fieldset key="visibility-selector" className="editor-post-visibility">
 				<legend className="editor-post-visibility__dialog-legend">
 					{ __( 'Post Visibility' ) }
 				</legend>

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -1,0 +1,17 @@
+.edit-post-post-visibility__dialog {
+	.editor-post-visibility__dialog-legend {
+		font-weight: 600;
+		margin-bottom: 1em;
+		margin-top: 0.5em;
+	}
+	.editor-post-visibility__dialog-label {
+		font-weight: 600;
+	}
+	.editor-post-visibility__dialog-info {
+		margin-top: 0;
+		margin-left: 28px;
+	}
+	.editor-post-visibility__dialog-password-input {
+		margin-left: 28px;
+	}
+}

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -31,6 +31,7 @@
 @import "./components/post-saved-state/style.scss";
 @import "./components/post-taxonomies/style.scss";
 @import "./components/post-text-editor/style.scss";
+@import "./components/post-visibility/style.scss";
 @import "./components/post-title/style.scss";
 @import "./components/post-trash/style.scss";
 @import "./components/rich-text/core-tokens/image/style.scss";


### PR DESCRIPTION
## Description
Adding a Sass stylesheet for the post visibility component in the sidebar.

## How has this been tested?
No functionality has been changed. No new tests needed

## Screenshot

![screen shot 2018-08-19 at 01 51 56](https://user-images.githubusercontent.com/191583/44304101-9b1fd300-a352-11e8-8230-1c1fabcf6621.png)

## Types of changes
Visual/cosmetic changes only.

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
