### PR TITLE
MediaPlaceholder multiple and gallery properties

### DIFF
--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -127,7 +127,7 @@ class MediaPlaceholder extends Component {
 					{ __( 'Upload' ) }
 				</FormFileUpload>
 				<MediaUpload
-					gallery={ multiple && type === "image" }
+					gallery={ multiple && type === 'image' }
 					multiple={ multiple }
 					onSelect={ onSelect }
 					type={ type }

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -127,7 +127,8 @@ class MediaPlaceholder extends Component {
 					{ __( 'Upload' ) }
 				</FormFileUpload>
 				<MediaUpload
-					gallery={ multiple && type != "audio" }
+					gallery={ multiple && type === "image" }
+					playlist={ multiple && type === "audio" }
 					multiple={ multiple }
 					onSelect={ onSelect }
 					type={ type }

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -127,7 +127,7 @@ class MediaPlaceholder extends Component {
 					{ __( 'Upload' ) }
 				</FormFileUpload>
 				<MediaUpload
-					gallery={ multiple }
+					gallery={ multiple && type != "audio" }
 					multiple={ multiple }
 					onSelect={ onSelect }
 					type={ type }

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -128,7 +128,6 @@ class MediaPlaceholder extends Component {
 				</FormFileUpload>
 				<MediaUpload
 					gallery={ multiple && type === "image" }
-					playlist={ multiple && type === "audio" }
 					multiple={ multiple }
 					onSelect={ onSelect }
 					type={ type }


### PR DESCRIPTION
The `gallery` property should be set to `true` only after checking that the selected `type` of media is not `audio`.

## Description
The MediaPlaceholder component can be used to select multiple files also with audio files. In addition to being counterintuitive, forcing `gallery` to be `true` only based on the `multiple` property does not allow to work with audio files. In fact, when `type` is set to `"audio"` and `multiple` is `true`, the MediaUpload component only shows images

## Additional Information
In addition to the proposed change, it could be possible to add another line as follows:

```
playlist={ multiple && type === "audio" }
```

This could be done when a playlist block is finally added to Gutenberg.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
