### PR TITLE
Update icons for Paragraph, Heading and Subheading for clarity

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -62,7 +62,7 @@ export const settings = {
 
 	description: __( 'Insert a headline above your post or page content.' ),
 
-	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect width="24" height="24" fill="none" /><path d="M2.5,4v3h5v12h3V7h5V4H2.5z M21.5,9h-9v3h3v7h3v-7h3V9z" /></svg>,
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24" /><g><path d="M18 20h-3v-6H9v6H6V5.01h3V11h6V5.01h3V20z" /></g></svg>,
 
 	category: 'common',
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -74,7 +74,7 @@ export const settings = {
 
 	description: __( 'Add some basic text.' ),
 
-	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><polygon points="21 11.01 3 11 3 13 21 13" /><rect x="3" y="16" width="12" height="2" /><polygon points="21 6 3 6 3 8.01 21 8" /></svg>,
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 5v7H9.5C7.6 12 6 10.4 6 8.5S7.6 5 9.5 5H11m8-2H9.5C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3z" fill="#12181e" /></svg>,
 
 	category: 'common',
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -74,7 +74,7 @@ export const settings = {
 
 	description: __( 'Add some basic text.' ),
 
-	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 5v7H9.5C7.6 12 6 10.4 6 8.5S7.6 5 9.5 5H11m8-2H9.5C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3z" fill="#12181e" /></svg>,
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 5v7H9.5C7.6 12 6 10.4 6 8.5S7.6 5 9.5 5H11m8-2H9.5C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3z" /></svg>,
 
 	category: 'common',
 

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -17,7 +17,7 @@ export const settings = {
 
 	description: __( 'What’s a subhead? Smaller than a headline, bigger than basic text.' ),
 
-	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0z" /><g><path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" /></g></svg>,
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.9 20h-3l.9-5h-4l-.9 5h-3L8.1 7h3l-.9 5h4l.9-5h3l-2.2 13z" /></svg>,
 
 	category: 'common',
 


### PR DESCRIPTION
This PR changes the Paragraph heading to an outline version of the paragraph symbol. This is done to fix the confusion where the text-icon looks confusing next to alignments: https://mobile.twitter.com/webmatros/status/1030816482614235137

By using the Paragraph icon, it shows what the block is.

This PR also adds new icons for Heading and Subheading, a capital H and smallcap italic H respectively. This is inspired by the same reasons as the "P for Paragraph" argument, H for Heading. Subheading was changed additionally because its previous visual language could also be confused with alignments.

![screen shot 2018-08-20 at 09 58 35](https://user-images.githubusercontent.com/1204802/44327860-2cc93680-a460-11e8-92ea-1369967a443e.png)

Edit: Don't mind the icon that says "Broken" — this was me testing a shared block to try and break something ;)