### PR TITLE
IE11 flexbox fix for keyboard shortcuts help

### DIFF
--- a/edit-post/components/keyboard-shortcut-help-modal/style.scss
+++ b/edit-post/components/keyboard-shortcut-help-modal/style.scss
@@ -26,16 +26,18 @@
 	}
 
 	&__shortcut-term {
-		flex: 1;
 		order: 1;
-		text-align: right;
 		font-weight: bold;
 		margin: 0 0 0 1rem;
 	}
 
 	&__shortcut-description {
+		flex: 1;
 		order: 0;
 		margin: 0;
+
+		// IE 11 flex item fix - ensure the item does not collapse
+		flex-basis: auto;
 	}
 
 	&__shortcut-key-combination {


### PR DESCRIPTION
## Description
I must have made a mistake when I originally merged the keyboard shortcuts help modal, as there are IE11 flex issues 🤦‍♂️. This branch fixes things.

- Moves the `flex:1` to the correct flex item (the description)
- Removes no longer needed `text-align`
- Adds `flex-basis: 1` as an IE11 fix to stop the description collapsing.

## How has this been tested?
- Tested the changes on IE11, edge, chrome, firefox, safari and opera.

## Screenshots <!-- if applicable -->
Here's how it looks now in IE:
![keyboardshortcuts-ie11](https://user-images.githubusercontent.com/677833/44336269-8efa5980-a4a9-11e8-871b-8bd3226017cc.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
