### PR TITLE
Update Heading icon

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -62,7 +62,7 @@ export const settings = {
 
 	description: __( 'Insert a headline above your post or page content.' ),
 
-	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24" /><g><path d="M18 20h-3v-6H9v6H6V5.01h3V11h6V5.01h3V20z" /></g></svg>,
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 4v3h5.5v12h3V7H19V4z" /><path fill="none" d="M0 0h24v24H0V0z" /></svg>,
 
 	category: 'common',
 

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -17,7 +17,7 @@ export const settings = {
 
 	description: __( 'What’s a subhead? Smaller than a headline, bigger than basic text.' ),
 
-	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.9 20h-3l.9-5h-4l-.9 5h-3L8.1 7h3l-.9 5h4l.9-5h3l-2.2 13z" /></svg>,
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.1 6l-.5 3h4.5L9.4 19h3l1.8-10h4.5l.5-3H7.1z" /></svg>,
 
 	category: 'common',
 


### PR DESCRIPTION
This refines the recent heading icon change in https://github.com/WordPress/gutenberg/pull/9152#issuecomment-414286401, per feedback.

Although it is H for Heading, internationally that first letter is not quite as ubiquitous, whereas T fares a bit better. By changing from an H we are also avoiding the very same issue that we sought to address by bringing back the Paragraph icon, namely that there are going to be icons (for heading levels) right next to the switcher, and if they look too alike that might cause confusion.

Subheading was also updated to the same, still with the same pattern of a smallcap italicized, to show the relationship between heading and subheading.

![screen shot 2018-08-20 at 13 44 07](https://user-images.githubusercontent.com/1204802/44338904-d1a73c00-a47f-11e8-9de8-a07b4232b976.png)

Note that if a better icon idea comes around, we can always update this again, but for now let's make this the baseline to beat. 