### PR TITLE
List: Convert single paragraph into one item per line

### DIFF
--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -19,6 +19,11 @@ import {
 	RichText,
 } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import splitOnLineBreak from './split-on-line-break';
+
 const listContentSchema = {
 	...getPhrasingContentSchema(),
 	ul: {},
@@ -73,8 +78,15 @@ export const settings = {
 				isMultiBlock: true,
 				blocks: [ 'core/paragraph' ],
 				transform: ( blockAttributes ) => {
-					const items = blockAttributes.map( ( { content } ) => content );
+					let items = blockAttributes.map( ( { content } ) => content );
 					const hasItems = ! items.every( isEmpty );
+
+					// Look for line breaks if converting a single paragraph,
+					// then treat each line as a list item.
+					if ( hasItems && items.length === 1 ) {
+						items = splitOnLineBreak( items[ 0 ] );
+					}
+
 					return createBlock( 'core/list', {
 						values: hasItems ? items.map( ( content, index ) => <li key={ index }>{ content }</li> ) : [],
 					} );

--- a/packages/block-library/src/list/split-on-line-break.js
+++ b/packages/block-library/src/list/split-on-line-break.js
@@ -6,9 +6,13 @@ import { last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { children as childrenApi } from '@wordpress/blocks';
+import {
+	children as childrenAPI,
+	node as nodeAPI,
+} from '@wordpress/blocks';
 
-const { getChildrenArray, isChildOfType } = childrenApi;
+const { getChildrenArray } = childrenAPI;
+const { isNodeOfType } = nodeAPI;
 
 /**
  * Split the content of a paragraph on line breaks ('<br>') into sets of
@@ -18,27 +22,27 @@ const { getChildrenArray, isChildOfType } = childrenApi;
  *
  * @see WPBlockChildren
  *
- * @param {WPBlockChildren} children Rich-text content
- * @return {Array<WPBlockChildren>} Array of rich-text content
+ * @param {WPBlockChildren} children Block children
+ * @return {Array<WPBlockChildren>} Array of block children
  */
 export default function splitOnLineBreak( children ) {
-	return getChildrenArray( children ).reduce( ( acc, child, i ) => {
-		// Skip if child is a line break
-		if ( isChildOfType( child, 'br' ) ) {
+	return getChildrenArray( children ).reduce( ( acc, node, i ) => {
+		// Skip if node is a line break
+		if ( isNodeOfType( node, 'br' ) ) {
 			return acc;
 		}
 
 		// If we've just skipped a line break, append the
-		// next child as a new item.
+		// next node as a new item.
 		const prevFragment = i > 0 && children[ i - 1 ];
-		if ( isChildOfType( prevFragment, 'br' ) ) {
-			return [ ...acc, [ child ] ];
+		if ( isNodeOfType( prevFragment, 'br' ) ) {
+			return [ ...acc, [ node ] ];
 		}
 
-		// Otherwise, append child to last item.
+		// Otherwise, append node to last item.
 		return [
 			...acc.slice( 0, acc.length - 1 ),
-			[ ...last( acc ), child ],
+			[ ...last( acc ), node ],
 		];
 	}, [ [] ] );
 }

--- a/packages/block-library/src/list/split-on-line-break.js
+++ b/packages/block-library/src/list/split-on-line-break.js
@@ -11,8 +11,8 @@ import { last } from 'lodash';
  * array of strings and element-like objects (e.g. `{ type: strong, props: {
  * children: […] } }`).
  *
- * @param {Array}    fragments Rich-text content
- * @return {Array}   Array of rich-text content
+ * @param {WPBlockChildren} fragments Rich-text content
+ * @return {Array<WPBlockChildren>} Array of rich-text content
  */
 export default function splitOnLineBreak( fragments ) {
 	return fragments.reduce( ( acc, fragment, i, arr ) => {

--- a/packages/block-library/src/list/split-on-line-break.js
+++ b/packages/block-library/src/list/split-on-line-break.js
@@ -15,7 +15,7 @@ import { last } from 'lodash';
  * @return {Array<WPBlockChildren>} Array of rich-text content
  */
 export default function splitOnLineBreak( fragments ) {
-	return fragments.reduce( ( acc, fragment, i, arr ) => {
+	return fragments.reduce( ( acc, fragment, i ) => {
 		// Skip if fragment is a line break
 		if ( fragment && fragment.type === 'br' ) {
 			return acc;
@@ -23,7 +23,7 @@ export default function splitOnLineBreak( fragments ) {
 
 		// If we've just skipped a line break, append the
 		// next fragment as a new item.
-		const prevFragment = i > 0 && arr[ i - 1 ];
+		const prevFragment = i > 0 && fragments[ i - 1 ];
 		if ( prevFragment && prevFragment.type === 'br' ) {
 			return [ ...acc, [ fragment ] ];
 		}

--- a/packages/block-library/src/list/split-on-line-break.js
+++ b/packages/block-library/src/list/split-on-line-break.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
+ * Split the content of a paragraph on line breaks ('<br>') into sets of
+ * content, each representing a list item.
+ *
+ * The term "content" refers to a rich-text description in the form of a mixed
+ * array of strings and element-like objects (e.g. `{ type: strong, props: {
+ * children: […] } }`).
+ *
+ * @param {Array}    fragments Rich-text content
+ * @return {Array}   Array of rich-text content
+ */
+export default function splitOnLineBreak( fragments ) {
+	return fragments.reduce( ( acc, fragment, i, arr ) => {
+		// Skip if fragment is a line break
+		if ( fragment && fragment.type === 'br' ) {
+			return acc;
+		}
+
+		// If we've just skipped a line break, append the
+		// next fragment as a new item.
+		const prevFragment = i > 0 && arr[ i - 1 ];
+		if ( prevFragment && prevFragment.type === 'br' ) {
+			return [ ...acc, [ fragment ] ];
+		}
+
+		// Otherwise, append fragment to last item.
+		return [
+			...acc.slice( 0, acc.length - 1 ),
+			[ ...last( acc ), fragment ],
+		];
+	}, [ [] ] );
+}

--- a/packages/block-library/src/list/split-on-line-break.js
+++ b/packages/block-library/src/list/split-on-line-break.js
@@ -4,34 +4,41 @@
 import { last } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { children as childrenApi } from '@wordpress/blocks';
+
+const { getChildrenArray, isChildOfType } = childrenApi;
+
+/**
  * Split the content of a paragraph on line breaks ('<br>') into sets of
  * content, each representing a list item.
  *
- * The term "content" refers to a rich-text description in the form of a mixed
- * array of strings and element-like objects (e.g. `{ type: strong, props: {
- * children: […] } }`).
+ * The term "content" refers to a rich-text description of block children.
  *
- * @param {WPBlockChildren} fragments Rich-text content
+ * @see WPBlockChildren
+ *
+ * @param {WPBlockChildren} children Rich-text content
  * @return {Array<WPBlockChildren>} Array of rich-text content
  */
-export default function splitOnLineBreak( fragments ) {
-	return fragments.reduce( ( acc, fragment, i ) => {
-		// Skip if fragment is a line break
-		if ( fragment && fragment.type === 'br' ) {
+export default function splitOnLineBreak( children ) {
+	return getChildrenArray( children ).reduce( ( acc, child, i ) => {
+		// Skip if child is a line break
+		if ( isChildOfType( child, 'br' ) ) {
 			return acc;
 		}
 
 		// If we've just skipped a line break, append the
-		// next fragment as a new item.
-		const prevFragment = i > 0 && fragments[ i - 1 ];
-		if ( prevFragment && prevFragment.type === 'br' ) {
-			return [ ...acc, [ fragment ] ];
+		// next child as a new item.
+		const prevFragment = i > 0 && children[ i - 1 ];
+		if ( isChildOfType( prevFragment, 'br' ) ) {
+			return [ ...acc, [ child ] ];
 		}
 
-		// Otherwise, append fragment to last item.
+		// Otherwise, append child to last item.
 		return [
 			...acc.slice( 0, acc.length - 1 ),
-			[ ...last( acc ), fragment ],
+			[ ...last( acc ), child ],
 		];
 	}, [ [] ] );
 }

--- a/packages/block-library/src/list/test/split-on-line-break.js
+++ b/packages/block-library/src/list/test/split-on-line-break.js
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+import splitOnLineBreak from '../split-on-line-break';
+
+describe( 'split-on-line-break', () => {
+	it( 'should handle an empty set', () => {
+		expect( splitOnLineBreak( [] ) ).toEqual( [ [] ] );
+	} );
+
+	it( 'should handle a set with no line breaks', () => {
+		expect( splitOnLineBreak( [
+			'I like',
+			{ type: 'strong', props: {
+				children: [ 'bold' ],
+			} },
+			'text',
+		] ) ).toEqual( [
+			[
+				'I like',
+				{ type: 'strong', props: {
+					children: [ 'bold' ],
+				} },
+				'text',
+			],
+		] );
+	} );
+
+	it( 'should handle a set with line breaks', () => {
+		expect( splitOnLineBreak( [
+			'One line',
+			{ type: 'br', props: {
+				children: [],
+			} },
+			{ type: 'strong', props: {
+				children: [ 'Another' ],
+			} },
+			'line',
+		] ) ).toEqual( [
+			[
+				'One line',
+			],
+			[
+				{ type: 'strong', props: {
+					children: [ 'Another' ],
+				} },
+				'line',
+			],
+		] );
+	} );
+} );

--- a/packages/blocks/src/api/children.js
+++ b/packages/blocks/src/api/children.js
@@ -16,18 +16,18 @@ import * as node from './node';
 /**
  * A representation of a block's rich text value.
  *
- * @typedef {WPBlockChild[]} WPBlockChildren
+ * @typedef {WPBlockNode[]} WPBlockChildren
  */
 
 /**
- * Given a block node, returns a serialize-capable WordPress element.
+ * Given block children, returns a serialize-capable WordPress element.
  *
- * @param {WPBlockChildren} children Block node to convert.
+ * @param {WPBlockChildren} children Block children object to convert.
  *
  * @return {WPElement} A serialize-capable element.
  */
 export function getSerializeCapableElement( children ) {
-	// The fact that a block node is compatible with the element serializer is
+	// The fact that block children are compatible with the element serializer is
 	// merely an implementation detail that currently serves to be true, but
 	// should not be mistaken as being a guarantee on the external API. The
 	// public API only offers guarantees to work with strings (toHTML) and DOM
@@ -36,12 +36,18 @@ export function getSerializeCapableElement( children ) {
 	return children;
 }
 
+/**
+ * Given block children, returns an array of block nodes.
+ *
+ * @param {WPBlockChildren} children Block children object to convert.
+ *
+ * @return {Array<WPBlockNode>} An array of individual block nodes.
+ */
 function getChildrenArray( children ) {
+	// The fact that block children are compatible with the element serializer
+	// is merely an implementation detail that currently serves to be true, but
+	// should not be mistaken as being a guarantee on the external API.
 	return children;
-}
-
-function isChildOfType( child, type ) {
-	return child && child.type === type;
 }
 
 /**
@@ -135,7 +141,6 @@ export function matcher( selector ) {
 export default {
 	concat,
 	getChildrenArray,
-	isChildOfType,
 	fromDOM,
 	toHTML,
 	matcher,

--- a/packages/blocks/src/api/children.js
+++ b/packages/blocks/src/api/children.js
@@ -36,6 +36,14 @@ export function getSerializeCapableElement( children ) {
 	return children;
 }
 
+function getChildrenArray( children ) {
+	return children;
+}
+
+function isChildOfType( child, type ) {
+	return child && child.type === type;
+}
+
 /**
  * Given two or more block nodes, returns a new block node representing a
  * concatenation of its values.
@@ -126,6 +134,8 @@ export function matcher( selector ) {
 
 export default {
 	concat,
+	getChildrenArray,
+	isChildOfType,
 	fromDOM,
 	toHTML,
 	matcher,

--- a/packages/blocks/src/api/node.js
+++ b/packages/blocks/src/api/node.js
@@ -20,6 +20,19 @@ const { TEXT_NODE, ELEMENT_NODE } = window.Node;
  */
 
 /**
+ * Given a single node and a node type (e.g. `'br'`), returns true if the node
+ * corresponds to that type, false otherwise.
+ *
+ * @param {WPBlockNode} node Block node to test
+ * @param {string} type      Node to type to test against.
+ *
+ * @return {boolean} Whether node is of intended type.
+ */
+function isNodeOfType( node, type ) {
+	return node && node.type === type;
+}
+
+/**
  * Given an object implementing the NamedNodeMap interface, returns a plain
  * object equivalent value of name, value key-value pairs.
  *
@@ -106,6 +119,7 @@ export function matcher( selector ) {
 }
 
 export default {
+	isNodeOfType,
 	fromDOM,
 	toHTML,
 	matcher,


### PR DESCRIPTION
## Description

When converting a single paragraph (i.e., when not in multi-block selection) to a list, look for line breaks (`<br>`) in the paragraph and yield one list item per paragraph line.

## How has this been tested?
Test case, and manual testing. See screenshot. Make sure that:
- Converting a single paragraph with line breaks yields multiple items in a new list.
- Converting a single paragraph with no line breaks works as before.
- Converting multiple paragraphs works as before.

## Screenshots

![gutenberg-single-paragraph-to-multi-item-list](https://user-images.githubusercontent.com/150562/44342117-df5dc100-a481-11e8-8b49-86bcd9cdf686.gif)

## Types of changes
- I wrote `splitOnLineBreak` as a single file inside the List block's source directory to make it easier to test.
- I didn't place it in a utils module because I don't necessarily want this to be a public module to manipulate rich text.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
