### PR TITLE
Fix Eslint issues found in block-serialization-spec-parser packages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,6 @@ build
 build-module
 coverage
 node_modules
-packages/block-serialization-spec-parser
 test/e2e/test-plugins
 vendor
+packages/block-serialization-spec-parser/index.js

--- a/packages/block-serialization-spec-parser/test/__snapshots__/index.js.snap
+++ b/packages/block-serialization-spec-parser/test/__snapshots__/index.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`block-serialization-spec-parser parse() works properly 1`] = `
+Array [
+  Object {
+    "attrs": null,
+    "blockName": "core/more",
+    "innerBlocks": Array [],
+    "innerHTML": "<!--more-->",
+  },
+]
+`;

--- a/packages/block-serialization-spec-parser/test/index.js
+++ b/packages/block-serialization-spec-parser/test/index.js
@@ -1,23 +1,14 @@
 /**
  * Internal dependencies
  */
-import { parse } from "../";
+import { parse } from '../';
 
-describe("block-serialization-spec-parser", () => {
-	test("parse() works properly", () => {
+describe( 'block-serialization-spec-parser', () => {
+	test( 'parse() works properly', () => {
 		const result = parse(
-			"<!-- wp:core/more --><!--more--><!-- /wp:core/more -->"
+			'<!-- wp:core/more --><!--more--><!-- /wp:core/more -->'
 		);
 
-		expect(result).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "attrs": null,
-    "blockName": "core/more",
-    "innerBlocks": Array [],
-    "innerHTML": "<!--more-->",
-  },
-]
-`);
-	});
-});
+		expect( result ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description
Fixes issue raised by @aduth in [the comment](https://github.com/WordPress/gutenberg/pull/7664#discussion_r210730788):

> Why do we ignore the entire package? Could we just ignore the singular file(s) which are generated? The test file, for example, includes a number of legitimate code style violations.

It turned out that using `toMatchInlineSnapshot` doesn't work quite well for use because it uses `prettier` behind the scenes. We can't really use it with the current setup unless we adopt `calypso-prettier`.

This PR ensures that only generated file is ignored by lint checks and updates existing test suite code to pass Eslint checks.

## How has this been tested?
`npm test`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
