### PR TITLE
Packages: Change how required built-ins are polyfilled with Babel 7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ When creating a new package you need to provide at least the following:
 		"module": "build-module/index.js",
 		"react-native": "src/index",
 		"dependencies": {
-			"@babel/runtime-corejs2": "7.0.0-rc.2"
+			"@babel/runtime": "^7.0.0"
 		},
 		"publishConfig": {
 			"access": "public"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ When creating a new package you need to provide at least the following:
 		"module": "build-module/index.js",
 		"react-native": "src/index",
 		"dependencies": {
-			"@babel/runtime-corejs2": "7.0.0-beta.56"
+			"@babel/runtime-corejs2": "7.0.0-rc.2"
 		},
 		"publishConfig": {
 			"access": "public"

--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -10,7 +10,16 @@ const babel = require( '@babel/core' );
 const { options: babelDefaultConfig } = babel.loadPartialConfig( {
 	configFile: '@wordpress/babel-preset-default',
 } );
-const plugins = babelDefaultConfig.plugins;
+const plugins = map( babelDefaultConfig.plugins, ( plugin ) => {
+	if ( get( plugin, [ 'file', 'request' ] ) === '@babel/plugin-transform-runtime' ) {
+		return [ '@babel/plugin-transform-runtime', Object.assign(
+			{},
+			plugin.options,
+			{ corejs: false }
+		) ];
+	}
+	return plugin;
+} );
 if ( ! process.env.SKIP_JSX_PRAGMA_TRANSFORM ) {
 	plugins.push( [ '@wordpress/babel-plugin-import-jsx-pragma', {
 		scopeVariable: 'createElement',

--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -37,7 +37,9 @@ const babelConfigs = {
 		{
 			plugins: map(
 				plugins,
-				( plugin ) => overrideOptions( plugin, '@babel/plugin-transform-runtime', { corejs: false } )
+				( plugin ) => overrideOptions( plugin, '@babel/plugin-transform-runtime', {
+					corejs: false,
+				} )
 			),
 			presets: map(
 				babelDefaultConfig.presets,
@@ -62,9 +64,7 @@ const babelConfigs = {
 			presets: map(
 				babelDefaultConfig.presets,
 				( preset ) => overrideOptions( preset, '@babel/preset-env', {
-					targets: {
-						esmodules: true,
-					},
+					modules: false,
 					useBuiltIns: false,
 				} )
 			),

--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -41,7 +41,10 @@ const babelConfigs = {
 			),
 			presets: map(
 				babelDefaultConfig.presets,
-				( preset ) => overrideOptions( preset, '@babel/preset-env', { modules: 'commonjs' } )
+				( preset ) => overrideOptions( preset, '@babel/preset-env', {
+					modules: 'commonjs',
+					useBuiltIns: false,
+				} )
 			),
 		}
 	),
@@ -54,6 +57,15 @@ const babelConfigs = {
 				( plugin ) => overrideOptions( plugin, '@babel/plugin-transform-runtime', {
 					corejs: false,
 					useESModules: true,
+				} )
+			),
+			presets: map(
+				babelDefaultConfig.presets,
+				( preset ) => overrideOptions( preset, '@babel/preset-env', {
+					targets: {
+						esmodules: true,
+					},
+					useBuiltIns: false,
 				} )
 			),
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-			"integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
+			"integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.56"
+				"@babel/highlight": "7.0.0-rc.1"
 			}
 		},
 		"@babel/core": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.56.tgz",
-			"integrity": "sha512-IsytpdHZqo5pgJj4FTcpEMKmfXK9TdvThLZo4yUOjbuVZCy8NAwoeBnojvKCNf+139L7xNIIosp3RVA0cMkbOg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.1.tgz",
+			"integrity": "sha512-CvuSsq+LFs9N4SJG8MnNPI0hnl913HK1OqG3NEfejOKo+JqtVuxpmAFyXIDogX2x668xqFKAW6EQiCIcUHklMg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.56",
-				"@babel/generator": "7.0.0-beta.56",
-				"@babel/helpers": "7.0.0-beta.56",
-				"@babel/parser": "7.0.0-beta.56",
-				"@babel/template": "7.0.0-beta.56",
-				"@babel/traverse": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/code-frame": "7.0.0-rc.1",
+				"@babel/generator": "7.0.0-rc.1",
+				"@babel/helpers": "7.0.0-rc.1",
+				"@babel/parser": "7.0.0-rc.1",
+				"@babel/template": "7.0.0-rc.1",
+				"@babel/traverse": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1",
 				"convert-source-map": "^1.1.0",
 				"debug": "^3.1.0",
 				"json5": "^0.5.0",
@@ -36,12 +36,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
-			"integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.1.tgz",
+			"integrity": "sha512-Ak4n780/coo+L9GZUS7V/IGJilP11t4UoWl0J9cG3jso4KkDGQcqdx4Y6gJAiXng+sDfvzUmvWfM1hZwH82J0A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-rc.1",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
@@ -49,224 +49,224 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.56.tgz",
-			"integrity": "sha512-PaHQ8R489lwBZYz/F81YpKDurIQfKWliNIpHZAysYbnozq8hVyaUx8D5wW6Dplf0lUUQ8Y/I3YKtiNoyg7bLHA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-rc.1.tgz",
+			"integrity": "sha512-GOV2UExs9gAvSrZF4rcgocXXeLJplq2kL2AsCrn6DmGwMUEfo/KB7FhedN3X6cVh0gOqqKkVKXrz3Li1wQ84xQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.56.tgz",
-			"integrity": "sha512-ka5Fe6UB/jRtCWU/emg6fLKqttaVaBCF1zdT06PYs7w8hJPidCcfdVMBoDHfqL3pgLo+hp+LW4Q/99zw/zv0Sw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-rc.1.tgz",
+			"integrity": "sha512-O6/szesBinGoExLl01Qg2vb5FaOfifSilgL5GnCZLz5z3Pg9jRolN6rGzQAOa/K9Y01TAmDf1dC06AKQUv3x8g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/helper-explode-assignable-expression": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.56.tgz",
-			"integrity": "sha512-s7nY9YbY+/6yccMCdI9oqh/rZ9lEoo3EHk/Lt6H2p/t6jyQf0sWqtsbJeHg5j5FzX6ZwYkdX8lTmBBMTrlyf9A==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-rc.1.tgz",
+			"integrity": "sha512-yhZzfcpjoCnZKrJ/ObzpQmaveBictCRoiIciz0FhAY97+J1lx4Zuy+t9ZqGr3pP4U4rV7UOXyuLknbhNkWT0Ew==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-rc.1",
 				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.56.tgz",
-			"integrity": "sha512-XOv0taD7Elw0CSorktXbbCzdPgH4dZOb8yObk5deEhDbWgJhdwIvd5z8rQpDu712oqDhXm7Z3v+upFsOCg2+nQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-rc.1.tgz",
+			"integrity": "sha512-3Z+shHGJTQnc61RCFVrQ3OJRmyL8uk4dWCsP8kT7G4inxv/bs6/zLOipK21VMePGpjUA4tnKxJCevMtp9ko4pw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-beta.56",
-				"@babel/traverse": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/helper-hoist-variables": "7.0.0-rc.1",
+				"@babel/traverse": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.56.tgz",
-			"integrity": "sha512-6hWVBpEyeRqvX3cKU7GVjdiYk9SvucpScTwdNpuSvsX8lX1MzuLQ7n9FNrHMU6+ulVNkZV81E7WdABYgXyIfuw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-rc.1.tgz",
+			"integrity": "sha512-yTn+nj29QrZLCINtgqFLgbrbvz6yM029ox/MpQfSS/JmrQovnEc+o5vrsW/R74QPheOHmF9ruJo58atwuk04Fw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/helper-function-name": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.56.tgz",
-			"integrity": "sha512-Y3a7HLnwLJEiKe4+XB2AEo6QiCnFsa0ycqg6HBp0lyw4HztSTGt3oyZYO8I5ZhtVCKi/EJXSQuKHLOV98jG/+A==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-rc.1.tgz",
+			"integrity": "sha512-hSa+oxKn9bfbc3Ob1U7QJsO++do2Xe8Ft640alRJpEQ3VWy7tL8ZB+2xqo0pgHKo7rITuSxERz72uZji8dTiWg==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/traverse": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-			"integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.1.tgz",
+			"integrity": "sha512-fDbWxdYYbFNzcI5jn3qsPxHI1UCXwvFk0kGytGce/FEBYEPXBqycKknC8Oqiub8DzGtmTcvnqcm/cl/qxzeuiQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.56",
-				"@babel/template": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/helper-get-function-arity": "7.0.0-rc.1",
+				"@babel/template": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-			"integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.1.tgz",
+			"integrity": "sha512-5+ydaIRxT42FSDqvoXIDksCGlW1903xC73HQnQCFF1YuV7VcIf+9M4+tRZulLlYlshw7ILA+4SiYsKoDlC0Irg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.56.tgz",
-			"integrity": "sha512-PTBa6UfiM7MgeTXOlNjCDiiqtOhqWraHM2GGsZg1M8VkuZRjP1Kag9JNmoppUlsZE5LY3NE+BjJuQ1/mLgcIug==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-rc.1.tgz",
+			"integrity": "sha512-ttcilOh9SM9eqVlzwz2Lv7B5Dwyaa8TIhi1DDEPnC3CarpNPXFdeCOoxoV5qjHRD1klAT86gczeU4lJnSDKmgA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.56.tgz",
-			"integrity": "sha512-/TrmPCG1XIENakzenEyiNsbIBSTm10DNWyB/cyKwVljzA18gMivn9YxSMxVAuaC1KyTTmhkeUYibSMF7yF13xw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-rc.1.tgz",
+			"integrity": "sha512-o263plHxPo1TxDDUx7gHuQ96Y8QyLs2n4968KZvo2l/9rkwn2L9kcIsRVjlhpPPKTz4tWe/7ZV50zkeDorrK9g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.56.tgz",
-			"integrity": "sha512-iVWFscU+yIu6DIo5IWkMgVXd74/d3z/ZomwF/QJNGFwFP/lNA282rpjsky56fSxS7oT7wAlXoYoHVCOOaL7tbg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.1.tgz",
+			"integrity": "sha512-eA8RzanjsZw4X2Cqh3WgVG7zwf1wdSUfXvZOH8Azx1rpwE0hzJ276jDZ3gSOJShsxPVvopHa4h+c2WfEUjW4+Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/types": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.56.tgz",
-			"integrity": "sha512-jC+blwjVeVx43WWOJHHXYBcHvYw0eHNgZUUXHKkDTLYc0zx8oev3LyciGFiWz29KgCS1K8YYd0t7z8fFXlCTog==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-rc.1.tgz",
+			"integrity": "sha512-nz7FTFXlQ9UYp/dBjad4ZOu3Q4/1n86ysw9z9pjunqeKFNm+JHq7j5BeocFKIQAwul7QbIkSXiYm5EiteCHjiQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.56",
-				"@babel/helper-simple-access": "7.0.0-beta.56",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.56",
-				"@babel/template": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/helper-module-imports": "7.0.0-rc.1",
+				"@babel/helper-simple-access": "7.0.0-rc.1",
+				"@babel/helper-split-export-declaration": "7.0.0-rc.1",
+				"@babel/template": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.56.tgz",
-			"integrity": "sha512-T+eZePA6kM+3wHXDPKKFZGHtMJGfK2/xmdk9pVjFHppdg4zwEqGaqLQaOlqfk5ekx2vxO22tmL4Caf2A/MVm0w==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-rc.1.tgz",
+			"integrity": "sha512-XOKPnL/AJz8ZyY553FsMAVt9g/mE1+RQfg5/m3X0K4+RqYviPGZlxwe5mGSd8s2kPSB6D6nZRUfvZFtmFIXEvA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-			"integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.1.tgz",
+			"integrity": "sha512-8ZNzqHXDhT/JjnBvrLKu8AL7NhONVIsnrfyQNm3PJNmufIER5kcIa3OxPMGWgNqox2R8WeQ6YYzYTLNXqq4kgQ==",
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.56.tgz",
-			"integrity": "sha512-wtb8bmlc5TF7W7KMd5muS+CVQQu7cNGTdPbI5+8x5w36bN8ytbkun5160hJ2S1r3Tti0FPnrYwz+9W5AGj+d9g==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-rc.1.tgz",
+			"integrity": "sha512-QXnTXVefioGuXlRMn+MnKKUHwhmdXGKnMvFI1tdHioMnBQEbEHGnmp+aYcddLwJ3KAH/hveaSR95BuWwprW+TA==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.56.tgz",
-			"integrity": "sha512-uCvdjXeEh/qzvhK61XLP5DADCM0MMxZOVdGIj5In/i9MLt9BD/EAyBmjZN0bc1dD1wJst0qInZyZju0lUUkvNQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-rc.1.tgz",
+			"integrity": "sha512-skROQSC2fPwmrzAEPT/M7CObnWjJGpdbNLoICZDYHwDiUDe3dk5cQsU9j3tNlBhX14FaC9SjSpCJnSRpXDOWOw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.56",
-				"@babel/helper-wrap-function": "7.0.0-beta.56",
-				"@babel/template": "7.0.0-beta.56",
-				"@babel/traverse": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+				"@babel/helper-wrap-function": "7.0.0-rc.1",
+				"@babel/template": "7.0.0-rc.1",
+				"@babel/traverse": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.56.tgz",
-			"integrity": "sha512-Pv0a8XYWeYLMgzx6BiKYMkBPW7ilDeKmKnPfMD+sCsTRDMZl9DssqnkkSwGxgAeuPwZ9opx18r5EzYPTgt0k4A==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-rc.1.tgz",
+			"integrity": "sha512-mcv+NKCazZfdEw7yBe/xROekR3qlFcy18d//mJTKnZb7xx2qFPjZAafkeIlpvzNHwd/WMTHShC4+3WjOL8FD5g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "7.0.0-beta.56",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.56",
-				"@babel/traverse": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/helper-member-expression-to-functions": "7.0.0-rc.1",
+				"@babel/helper-optimise-call-expression": "7.0.0-rc.1",
+				"@babel/traverse": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.56.tgz",
-			"integrity": "sha512-CIRkGs+/KNWpGJKEUbABeVWTZ1ePskwKwwoR1lVs2qI4cZheS6NvXzLxsFN/uxyc46yn7px/XTxV/zM3rnlQQQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-rc.1.tgz",
+			"integrity": "sha512-mfrHVSG0Dw51ajyL3Ltz+gEYrWAy4+Kl8lb1V/QWR31H7ovha6vNZ4guev/lR4KFu+4hMHogpjh4HB4AShqeMQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/template": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-			"integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.1.tgz",
+			"integrity": "sha512-hz6QmlnaBFYt4ra8DfRLCMgrI7yfwQ13kJtufSO5dVCasxmAng2LeeQiT6H4iN5TpFONcayp5f/2mXqHH/zn/g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.56.tgz",
-			"integrity": "sha512-WuGMzbpx12M40aHtocM0vs9af/LmdwpXsKBX2T2GqCMueD90MHvQU+148vHScgPbUoWP4lv+dFGZDf0XUc2qJA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-rc.1.tgz",
+			"integrity": "sha512-LrqRD4+jEkQGVQsCRi7bPkSmYFAUd3pv9tYAC8nsr9Y0Qfus8oycqxDj60QW4dmigRKBRRbVVLr/0kMI2pk0MA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.56",
-				"@babel/template": "7.0.0-beta.56",
-				"@babel/traverse": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/helper-function-name": "7.0.0-rc.1",
+				"@babel/template": "7.0.0-rc.1",
+				"@babel/traverse": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.56.tgz",
-			"integrity": "sha512-KaNBuVlAGW6sFCEWjliN29dL8K4L/ff8ZUaR/D5ou/JsqOuxLRy34Rf8WXMru3Et2g4Czly6vJeSmaYyf3s0lA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.1.tgz",
+			"integrity": "sha512-4+AkDbZ0Usr7mNH4wGX8fVx4WJzHdrcjRkJy52EIWyBAQEoKqb5HXca1VjejWtnVwaGwW7zk/h6oQ9FQPywQfA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-beta.56",
-				"@babel/traverse": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56"
+				"@babel/template": "7.0.0-rc.1",
+				"@babel/traverse": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-			"integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
+			"integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
@@ -283,421 +283,421 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-			"integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.1.tgz",
+			"integrity": "sha512-rC+bIz2eZnJlacERmJO25UAbXVZttcSxh0Px0gRGinOTzug5tL7+L9urfIdSWlv1ZzP03+f2xkOFLOxZqSsVmQ==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.56.tgz",
-			"integrity": "sha512-2amegw5EfeOJO5un5+A5cZ7cELUKf7fUzdryFdkg3ciGyNA+ISK9x4B57N8Jb5gWXch1xNsOV7tJuaaWeqbJ3g==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-rc.1.tgz",
+			"integrity": "sha512-ewJnWv10AFUh+Yi6axMVQKW8L1pZCm86a44m2biYtXNSyt6FyWgdRloBbR7iCviPkeurfTCVdPS61G/t5cXVkQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-remap-async-to-generator": "7.0.0-beta.56",
-				"@babel/plugin-syntax-async-generators": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-remap-async-to-generator": "7.0.0-rc.1",
+				"@babel/plugin-syntax-async-generators": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.56.tgz",
-			"integrity": "sha512-onVk2kI39dzkDP+SzX6eC3nAkq5yemiiZX+AuXAmshOyuz+ZYUu5b+zzXKw0oPFTSnMnlIfJItQCcVzesXcU6A==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.1.tgz",
+			"integrity": "sha512-J9qLEkxuZrYh/mel9RA5wDrMGE7jQMOMa1XPZMysih4C0mveeQUExbAPyrVSrFQo5BXLcLIc6ccM24G9xPCCXA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.56.tgz",
-			"integrity": "sha512-qLUAi1k8kTiFDUfGkjtdWujo6hTcqCDRw9hvBSxgJ150fRytyCG0pDqmC3KXytSdPPxuAcCCbgB+9CZsGPXkIA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-rc.1.tgz",
+			"integrity": "sha512-mNJULpCOErHPVvnqj2i464uVuWuTTrnJFoT8dYyODCSjHBypdVvEGZx4Rk67etdDMv+iytZTdKDHUXq5JtWCdg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.56.tgz",
-			"integrity": "sha512-YszvYRt3tgCTJ+qcBSRKpJhlsiM0/BPcehwHgFzyKi0arnRX7jO8iyTZD3VpkVBElTGTbz91G9fSXj/7Y3PdQw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-rc.1.tgz",
+			"integrity": "sha512-NrUBXqwxnvrhJDzeJ4yOiPDDpPbjVQsydRELHVqzjy+WAOh/cAT4JOmMrQegU/vOjj62LM8S1Kp8wHpDgskTLQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-regex": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-regex": "7.0.0-rc.1",
 				"regexpu-core": "^4.2.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.56.tgz",
-			"integrity": "sha512-tC8sGd1RridRn0147GUh2rF1WB+8FnP0siTD0ofuqLYJEbOTYn9NF0WD4DNzwwHwOZMBxgHFy8N/B1sNmEC8SQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-rc.1.tgz",
+			"integrity": "sha512-2F5FYc89TCrqE/8+qFlr5jVMTHfkhEOg9JUx+GXI3inW2OfcY+J6bN8EDc8PLz84PHaR8W630YOuh2PveJu3WA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.56.tgz",
-			"integrity": "sha512-QsZbghj9DemNxr6ZX7V1ULukXrb+d3kRAU9ErikMnSCx60tKW5MQCIuSnHjr1l5wU4XlAZT2qclb+RYTTz0rAw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-rc.1.tgz",
+			"integrity": "sha512-n0BcD2LmCrQkDKRhUd7lSiXiRpbo6Z7x77v3FSuevH5oWTFChjX34vHCCOszgVP37NLAxhuf4Jz0KwiPgXnexg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.56.tgz",
-			"integrity": "sha512-rDqe3TN5cZaUg4zi3Kzfq5qySS6IcEs19WE7GHlmelgQ1QXy9d/tsPEAWHZTLrG4mjbbEFJZdLvAi+LSGdhJAQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.1.tgz",
+			"integrity": "sha512-stOESgG+lc68DSFvXrqoH5dW91ZtedDoR40g9wJ1ruLahCdr9X5hVLv/ddf/g/1zzjevq59A1Q+xdUREhEnrvQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.56.tgz",
-			"integrity": "sha512-rpXmUoqQRwV3QaRUIwKTrVh/pzYe1mMmV43TXJNkP3BX4phimxsF+/orJY8MjqZs9QfHwQkfyb+b6BURLY62kA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-rc.1.tgz",
+			"integrity": "sha512-e4dGUnZGhg1LWTvyQ6/m8nKZ9bUrtPwl9M487CEVhTA5lVUvYxASHBCEtkVWPwT16NzcWlFR/PghsHeLFGIw7A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.56.tgz",
-			"integrity": "sha512-TkpqdTt8ivvNBoawwxwFJSHRAQAWvWRuMyQIJfdrmSGdHVaEJ8xn1MkYuORMOogtpsG+ZncmGRAyCEQeMFBPsA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-rc.1.tgz",
+			"integrity": "sha512-9JnWkl+iKmjNgMFrLjfGJQm3f66SJxwaYjdsm49Vpvo9x7ADHMGMZYa5Yto9WNQBlIdtf+fhypwBcz6IPxdyvg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.56.tgz",
-			"integrity": "sha512-n34TSk3nFLCnsuC5f2PSb+jdOVXv1UzENnGN/Xu9/epSFVVNLfNR2td0Gx0Rh4CjIef5JZ0tFounyPWWMSh/0Q==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-rc.1.tgz",
+			"integrity": "sha512-8oE9Frx07ILINop9hOejXgcDVhmt4FuB3ZjXnIMcSMkAuiT3xLrxFMDo1Qo0kf5mty2jLlnOO6tbbH0kiIWxWA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-remap-async-to-generator": "7.0.0-beta.56"
+				"@babel/helper-module-imports": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-remap-async-to-generator": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.56.tgz",
-			"integrity": "sha512-rgabVaR9M5c7xyuWFMyPN8vT8QkncF9skgA2/O6seiGX8mgl/WjDMkWi2Sm9PFdPc7WEryKh8Rlu/tgupulwSA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-rc.1.tgz",
+			"integrity": "sha512-dFEgZqmyWXaVYrFU11IgLX8M1+gK7GSU+CVRv42D7P1FFMNndg1u36jXIa7URExEuTeTUykLM/IWgk5pHWxo6A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.56.tgz",
-			"integrity": "sha512-hqeciuZPUfsZIhJ6MaB68U3+G5eS12ahidn98oUxyOl+BnS/aN9EhSt877mJPlEBe3oQy35qNwg/HG3rq33O2A==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-rc.1.tgz",
+			"integrity": "sha512-9uGwvSqJcmcKPEkLHA7ffrG0lKXTXprupwGjEKDw27OoRWXHdWUmA4VwpuzMrUsYyV+q+P6mgj6TPzoGJA3fAw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.56.tgz",
-			"integrity": "sha512-uq0Nvjlkt5gpF+dlvJ1yOZu8liBfOp3QoA/hrP7LZ6XzmYwZOhIUpUbouvKjgvybWiDmNDGcELeC96CL/mtV5Q==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-rc.1.tgz",
+			"integrity": "sha512-mPXMbQR8zNHMXvaJ71wQ7iPcQLHPv12XjWwvYkDjtsEvknDQ2HWA+UYZGVpZ0bv3jLQIZuwc1kZ6f5vSsavvog==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.56",
-				"@babel/helper-define-map": "7.0.0-beta.56",
-				"@babel/helper-function-name": "7.0.0-beta.56",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-replace-supers": "7.0.0-beta.56",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.56",
+				"@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+				"@babel/helper-define-map": "7.0.0-rc.1",
+				"@babel/helper-function-name": "7.0.0-rc.1",
+				"@babel/helper-optimise-call-expression": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-replace-supers": "7.0.0-rc.1",
+				"@babel/helper-split-export-declaration": "7.0.0-rc.1",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.56.tgz",
-			"integrity": "sha512-U0iHc3aEhgJsW5toS4ZjwWp9bV1l+gsJAt4PI/fXA4XK0DVZEZS82Xq3ozHLp5ccWiqJCCEWYAFys2c/ZPKmjA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-rc.1.tgz",
+			"integrity": "sha512-dfJNqbyF6S8nvFzGc6NthqCqopn1PoY3q2E1KcgrFSgxwYAMOLuhu5eA5iFeXwggp6tIo6OVVXC55/Twsolmow==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.56.tgz",
-			"integrity": "sha512-6Jyis4rwPNQ9a8t1PerzymtC0qfgKlI9SOc44xaZfVo2nxzhb09nXrGsjpXywZVepDUWKHXy17XT0ouiQJmrTw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-rc.1.tgz",
+			"integrity": "sha512-YpuGA3cj5+gRD053nWtogo+3wxc10mNAAyf5syXXCVS/cOWpRjc3qPidzHtPodz+v8TgAwwaXwIz/ghLOojRQw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.56.tgz",
-			"integrity": "sha512-nM7ZXzwdDwviGUleCdDrQ4fGXtTkEFg0HHbZ5LD7XlJrN4goJmi6xHBOoZ8iWdTPrzAuDi+FT87RWCHFDcU4xA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-rc.1.tgz",
+			"integrity": "sha512-6G62wnwVWCjhvmWmWatXHO4wfvWhUL1bJX0MABYIf1bpD5ROFly/HxgWkuMVcTSeIuLzsfsYKSF1CMUI0bykXw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-regex": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-regex": "7.0.0-rc.1",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.56.tgz",
-			"integrity": "sha512-hnMT8itOVeLuLGtuE+SBpaCyLj97nq2LJwu2Ud6O6Nag1iswDp2MMgTYmFPzPF465LuP4cUp5bmjZcOvFkkoHQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-rc.1.tgz",
+			"integrity": "sha512-cWyoUi1izJk5JbWFG07GZrZyZgG+DW4axPKI0MA+lSAxjP8VZwFUhJyjT7R4bGN81KTVv1aprKclQnKxN2R0Lw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.56.tgz",
-			"integrity": "sha512-t32wjgnTXwOMDd8cIUSpYu3k31EqrYTJsZf/Dw44RDT6EXJzeTKchMsvwd2n8vf02OzjO0a9/qXF5dKl4cK0HQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-rc.1.tgz",
+			"integrity": "sha512-5lc0nlX8TPdkHSIX3/3jMtqvvJfzcARcev4qqsaVkXWQ6XNrNnD8ExyTEVgoGhr5Ppz1wA0ymAK8W33uGeKSOg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.56.tgz",
-			"integrity": "sha512-z4sift6xY65vOpFlRyPrcKNgusCV9NZZGOR9Dxt64XUEWnyxpabHZ9mGe0B3mqJbm168cK7sbxruvnyfyrO2fg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-rc.1.tgz",
+			"integrity": "sha512-v09o2ywKHu+b/vkLknjKPV9QXCxuU2cVFxkWhBqcKwl3ERe3clhiab7a/8T9Sc332o4Im6n/LLugKMtpfxqRsQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.56.tgz",
-			"integrity": "sha512-olcHC1WD2L36/vUl/aw5STpv/+O4C/mUGOytQ2NJn0VPKqeaYCBaEboz+4nnttlvTojaxWzBURTl675YvlPcWw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-rc.1.tgz",
+			"integrity": "sha512-MiUORPQo3kvSCYBn/T6kKIfdDKqFAnEsaiRnTz36Y6M/p6NX7br5MgqPumVNgDboYKQ9kzaFNM8YJvWLcjL6SQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-function-name": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.56.tgz",
-			"integrity": "sha512-uz7Hcui2qmf1fA8pl5CsLz8KjM3HuUbEws/59G9kaMOrSIMrGSfeN1zsthfFSJDpFQLwq5NZ0+lPIvuOwE61bA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-rc.1.tgz",
+			"integrity": "sha512-iI468X7shsmB/oIPi8+UfMcOpcQPEsMAz5hDc0H8dKBGUWbPcAlyQpC8CaNDZ7y1/7lK65wtvXs5OGTQd3OsJg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.56.tgz",
-			"integrity": "sha512-qbYJ9Xfi17D6GWzqs6AIKbT5oN5A4ONwxMzqkvr501ft0JognN4Hc5W5UAyCGdNgY/V6+Qdf1t8Opd+zTcS1FA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-rc.1.tgz",
+			"integrity": "sha512-xKIF2ZAFOZRgIhEeW6zuyieyqfjft59NaHvb2C7+N9omdFDVkrx5ZeHVLb8y163a3mUb2MqJg1PLfZXdwvz1EA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-module-transforms": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.56.tgz",
-			"integrity": "sha512-48juOe+HB048Km4l7ZzCKptRlfnYGAC5WwPJrDzldHQ8JFFmbrZPoDGPSlDK/3z9JRMldBHioVHvID5WTYPE9g==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-rc.1.tgz",
+			"integrity": "sha512-G2Y2HwdUVSR+6V1g5q7D6hLm6HQ5f0HJ4TeYzPDIwKj3Ij3djyJ1lrFRtMRxanclcRy/N01sVe0z31m8Dslmzw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-simple-access": "7.0.0-beta.56"
+				"@babel/helper-module-transforms": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-simple-access": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.56.tgz",
-			"integrity": "sha512-tr2KAI4jhBfZLkSIHU4vlS6I1RmFYfMxM49ese+iPryvj1aH7x1VSz2+DEA/Xr+gM4CTXpWk0Xf2r2u260lPEA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-rc.1.tgz",
+			"integrity": "sha512-denli1X4utH2boaedaCv3uDmrmBH0CMioIswTxViNY4M8nti3DV1m7wfKE4kDYq8UrIILLYwxxOsAvGxOS9/Ug==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-hoist-variables": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.56.tgz",
-			"integrity": "sha512-0ItEhFLodomK7FH2FgK+UAphXd95UKyj3SXcRRhbUifvpfnqv0QFgaffI01iEyFnbxdXKpZqESHZR1fV/w1igw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-rc.1.tgz",
+			"integrity": "sha512-wvhxd77dRxyQGSEqfSRfe6dEBDy7Q13MaC1RKLX2H4+SQKZPvGuNr0BS0CEJ3Fm3uSEZ7potTBfRO4YNAygjXg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-module-transforms": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.56.tgz",
-			"integrity": "sha512-8r4H92o1LX6xZ3gGCUwrIiMwEoOfUfbflKOzrNQig2ybhX+9thU63m0P7cIU4qgp60mzIDKj2m7bz17s6MCl5g==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-rc.1.tgz",
+			"integrity": "sha512-mI10u9cgVpTjJllgISn6SmM2H/3X1osvmgT/4sjQjYARGgEfG9khrxtI74IBRhRhtBF9VBgwhah6sYAym+aghw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.56.tgz",
-			"integrity": "sha512-GB6OyxC16aIPE7lm13xfUsoP+zoqCn9PaocXzlGbQbotMoQ+qkmv3Ymq/Oy5YQl3kl5xrxX0JKNuOhYUjhG4YQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-rc.1.tgz",
+			"integrity": "sha512-mwoid0Rx+L55NupRE9xs1JAgFRz0JIYS/JR0aqBlLOQwBY1KrbrAtQfNwHQobwZrP9O24VBRfViMsiYLh/UV4A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-replace-supers": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-replace-supers": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.56.tgz",
-			"integrity": "sha512-zhGeuH/eY3kDVfFCWpyc1pWoIyuTZghqazsqJkUKwJMHoqVZuwEvNmpPi9Hhbn+W+LOFt8MJv5dY+kgfbMlwAQ==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-rc.1.tgz",
+			"integrity": "sha512-PKjm+xf23XvdP0WRj/fIiP3xa5DYOg6qd0150Mpu4JvCIci6vrWvkc+kU9RtwkXLycWRfzdSnnyuSZABxPAP8A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "7.0.0-beta.56",
-				"@babel/helper-get-function-arity": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-call-delegate": "7.0.0-rc.1",
+				"@babel/helper-get-function-arity": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.56.tgz",
-			"integrity": "sha512-xg1l6yyWxxE4NdCIs+d3xx9Q03BmktxI9fIfxKaT0y+UjABg6J1eGCJRBPa1s3X212gkUcEmYPjG6jo4ew40Sw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-rc.1.tgz",
+			"integrity": "sha512-lGSDCkRp8/2JMu0vBeayMLF2xLSiD1n9KZFH+zRSLtrvdNJFhifmzHJ9dYYBcDY7qDQayEpj/Ze9UpyxaU+oSA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/plugin-syntax-jsx": "7.0.0-beta.56"
+				"@babel/helper-builder-react-jsx": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/plugin-syntax-jsx": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.56.tgz",
-			"integrity": "sha512-wSRlSwXSXlpAdAKethZu+JyrnSL1NvLn3VtomlOCqHWhRhjOkjehIBlAe/AmguSn9JTUja0vqBWn1FS8sSnp7Q==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-rc.1.tgz",
+			"integrity": "sha512-a73XZOJGt0Ft8/YbRAUl0Vs1GuPpjB6QVQNYPxWUNXblSiywhkkZxLssHZnao2xTD26kLRfMoXfOtj9FMz5fcw==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.56.tgz",
-			"integrity": "sha512-bzIp/hDJwvN0hiVMlkiwC43N74R49nO+syW2wql8L48Md2z9nfsS0zw3T96oCDBUgGXzOX8uKq9DUKZS9YktTA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-rc.1.tgz",
+			"integrity": "sha512-Tmg0jYdu/Bn0r8iQpQXNmybenq65ci8z/ReMO+IR5CBtnhEYBYtIPxZgvmwZFbggLm1MJ/oRdDRmRl4a/G8QEw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-module-imports": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.56.tgz",
-			"integrity": "sha512-qfN9LTjglikI4N2K/WkZAJQijWQpsQefsC/sXEN6c4/G9n5ZJFyXt23aXXcjibncKbcTrRpmH0nTeMiZK0A+5A==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-rc.1.tgz",
+			"integrity": "sha512-NkUsTSKL8txvPt9vtdkcbJEyiUtcSOAr6ZnAE+Vg4mB0hYI0sWEJCAzl26KDDFgdVSKJSAaenjX5UR3BAF3KaA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.56.tgz",
-			"integrity": "sha512-C0EUKGVSU5ttbRe+ATn54oR2jdGzGIA8Uo/0jwtMeTU+6lewpTX8nu+M36JZDIcq2sSu7zxfLiRkErb/PX/Q0g==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-rc.1.tgz",
+			"integrity": "sha512-/3EkUVVi55i/JCbL2CxXTaoCXCopj3qQMTZ0lvgtpepx1yAMpoHYFBNWLIuQmjG7JhDauOwEdBg8TRsneYRmmw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.56.tgz",
-			"integrity": "sha512-VGPxbfefemuJg6/UVXf8WaaU9gIZRr31aLBsjDdYfj41N3W55LSvU+6CxCZ/ID6SfNCcQUEyBtZsWMWvv38Dhw==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-rc.1.tgz",
+			"integrity": "sha512-sXPFGI3GTtSMxVTDwrRmgwmUcq+l0ovzUZFfAd4YK1zJQ7YQCaCjcmLskuiGM20SoteYserDADg0SrLw+8B8hA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-regex": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-regex": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.56.tgz",
-			"integrity": "sha512-VMK/94Mlz24KFg0wc4Y4fAM6FNnx0wnr4A36rMdU54SYM3AEYzQcXtbI4uOCUSGdTOKR5zOiwhNnZFRodi29iA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-rc.1.tgz",
+			"integrity": "sha512-xq9eSNA65VXbMmVEjKUXB0czP8y/CRs88S8HcwZbJ7XGo4FARUJV3aGQfIPvGUmbkQegsxZx5rlTPlw3NPl+Aw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.56.tgz",
-			"integrity": "sha512-BnKyH+AUvnVHyl+1Kt40jfr6+0/DUED9huSdirp1DrKwmjlcu4FliGDNcSSKBfawV4covKT7MBjWpE6s+XNk1g==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-rc.1.tgz",
+			"integrity": "sha512-wUKNscuv3WOOFy3tGOBeayeOLyZjixjOSvb0QNXrCDRuENhfPaFQjZt/T0UDAZN0mXvAQ7Ksx2pOtXBsyIBxUA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56"
+				"@babel/helper-plugin-utils": "7.0.0-rc.1"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.56.tgz",
-			"integrity": "sha512-31lEbd5voBJR8ufUuOaRu/r2dxj53S/fs+VNgPqCqvOw7Ql8AuuinYvJjxbzpZ5GqAWLPX1MKBgJ+gsjomXb6g==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-rc.1.tgz",
+			"integrity": "sha512-3yz7ehk0VFLqoKVV1GbTdH2sfMtYznhllkBDtnybveM6MeFA5WYCf6iWf+I/vF/8QIMDd1b4359GGWKCI+KuIQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/helper-regex": "7.0.0-beta.56",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-regex": "7.0.0-rc.1",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.56.tgz",
-			"integrity": "sha512-kFjCCUuMr0Y0N1je1QtOd37WXCU3cEnAqjm4GRlbgWlBPcj7A7ZQ40jMfrPeqVUJBbFiqi/UbOK5iLP/K8wdsA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-rc.1.tgz",
+			"integrity": "sha512-c1mn7dKMBnkcS9Se9cuB5K2PAN48I0/mFXIA/ARyu7dHnLxiteSL0wyQukVp4NenKqFlAtPFx5ZtgWEMjaYmbg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.56",
-				"@babel/helper-plugin-utils": "7.0.0-beta.56",
-				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.56",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.56",
-				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.56",
-				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.56",
-				"@babel/plugin-syntax-async-generators": "7.0.0-beta.56",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.56",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.56",
-				"@babel/plugin-transform-arrow-functions": "7.0.0-beta.56",
-				"@babel/plugin-transform-async-to-generator": "7.0.0-beta.56",
-				"@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.56",
-				"@babel/plugin-transform-block-scoping": "7.0.0-beta.56",
-				"@babel/plugin-transform-classes": "7.0.0-beta.56",
-				"@babel/plugin-transform-computed-properties": "7.0.0-beta.56",
-				"@babel/plugin-transform-destructuring": "7.0.0-beta.56",
-				"@babel/plugin-transform-dotall-regex": "7.0.0-beta.56",
-				"@babel/plugin-transform-duplicate-keys": "7.0.0-beta.56",
-				"@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.56",
-				"@babel/plugin-transform-for-of": "7.0.0-beta.56",
-				"@babel/plugin-transform-function-name": "7.0.0-beta.56",
-				"@babel/plugin-transform-literals": "7.0.0-beta.56",
-				"@babel/plugin-transform-modules-amd": "7.0.0-beta.56",
-				"@babel/plugin-transform-modules-commonjs": "7.0.0-beta.56",
-				"@babel/plugin-transform-modules-systemjs": "7.0.0-beta.56",
-				"@babel/plugin-transform-modules-umd": "7.0.0-beta.56",
-				"@babel/plugin-transform-new-target": "7.0.0-beta.56",
-				"@babel/plugin-transform-object-super": "7.0.0-beta.56",
-				"@babel/plugin-transform-parameters": "7.0.0-beta.56",
-				"@babel/plugin-transform-regenerator": "7.0.0-beta.56",
-				"@babel/plugin-transform-shorthand-properties": "7.0.0-beta.56",
-				"@babel/plugin-transform-spread": "7.0.0-beta.56",
-				"@babel/plugin-transform-sticky-regex": "7.0.0-beta.56",
-				"@babel/plugin-transform-template-literals": "7.0.0-beta.56",
-				"@babel/plugin-transform-typeof-symbol": "7.0.0-beta.56",
-				"@babel/plugin-transform-unicode-regex": "7.0.0-beta.56",
+				"@babel/helper-module-imports": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
+				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-rc.1",
+				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-rc.1",
+				"@babel/plugin-syntax-async-generators": "7.0.0-rc.1",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.1",
+				"@babel/plugin-transform-arrow-functions": "7.0.0-rc.1",
+				"@babel/plugin-transform-async-to-generator": "7.0.0-rc.1",
+				"@babel/plugin-transform-block-scoped-functions": "7.0.0-rc.1",
+				"@babel/plugin-transform-block-scoping": "7.0.0-rc.1",
+				"@babel/plugin-transform-classes": "7.0.0-rc.1",
+				"@babel/plugin-transform-computed-properties": "7.0.0-rc.1",
+				"@babel/plugin-transform-destructuring": "7.0.0-rc.1",
+				"@babel/plugin-transform-dotall-regex": "7.0.0-rc.1",
+				"@babel/plugin-transform-duplicate-keys": "7.0.0-rc.1",
+				"@babel/plugin-transform-exponentiation-operator": "7.0.0-rc.1",
+				"@babel/plugin-transform-for-of": "7.0.0-rc.1",
+				"@babel/plugin-transform-function-name": "7.0.0-rc.1",
+				"@babel/plugin-transform-literals": "7.0.0-rc.1",
+				"@babel/plugin-transform-modules-amd": "7.0.0-rc.1",
+				"@babel/plugin-transform-modules-commonjs": "7.0.0-rc.1",
+				"@babel/plugin-transform-modules-systemjs": "7.0.0-rc.1",
+				"@babel/plugin-transform-modules-umd": "7.0.0-rc.1",
+				"@babel/plugin-transform-new-target": "7.0.0-rc.1",
+				"@babel/plugin-transform-object-super": "7.0.0-rc.1",
+				"@babel/plugin-transform-parameters": "7.0.0-rc.1",
+				"@babel/plugin-transform-regenerator": "7.0.0-rc.1",
+				"@babel/plugin-transform-shorthand-properties": "7.0.0-rc.1",
+				"@babel/plugin-transform-spread": "7.0.0-rc.1",
+				"@babel/plugin-transform-sticky-regex": "7.0.0-rc.1",
+				"@babel/plugin-transform-template-literals": "7.0.0-rc.1",
+				"@babel/plugin-transform-typeof-symbol": "7.0.0-rc.1",
+				"@babel/plugin-transform-unicode-regex": "7.0.0-rc.1",
 				"browserslist": "^3.0.0",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
@@ -705,47 +705,48 @@
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-beta.56.tgz",
-			"integrity": "sha512-LE2R7zTLAgaM54y/XdyAMzHERY1lv1cyQll3IvgN2VrTVxdlUBO7t/cHpc5iwqqHI85/VRNfGtQZdO2PecCIqg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-rc.1.tgz",
+			"integrity": "sha512-2QWAvXXu7r0zmgrXExWXnXh7vuarvjgsDB9qL4hN925dSRrrFZWXjiIQ+LB14753shjZkZ+4xLEJrO9hBKGwRA==",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
 				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"@babel/template": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-			"integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.1.tgz",
+			"integrity": "sha512-gPLng2iedNlkaGD0UdwaUByQXK8k4bnaoq2RH5JgR2mqHvh2RyjkDdaMbZFlSss1Iu8+PrXwbIRworTl8iRqbA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.56",
-				"@babel/parser": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/code-frame": "7.0.0-rc.1",
+				"@babel/parser": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
-			"integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.1.tgz",
+			"integrity": "sha512-lNOpJ5xzakg+fCobQQHdeDRYeN54b+bAZpeTYMeeYPAvN+hTldg9/FSNKYEMRs5EWoQ0Yt74gwq98InSORdSDQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.56",
-				"@babel/generator": "7.0.0-beta.56",
-				"@babel/helper-function-name": "7.0.0-beta.56",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.56",
-				"@babel/parser": "7.0.0-beta.56",
-				"@babel/types": "7.0.0-beta.56",
+				"@babel/code-frame": "7.0.0-rc.1",
+				"@babel/generator": "7.0.0-rc.1",
+				"@babel/helper-function-name": "7.0.0-rc.1",
+				"@babel/helper-split-export-declaration": "7.0.0-rc.1",
+				"@babel/parser": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.1",
 				"debug": "^3.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-			"integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.1.tgz",
+			"integrity": "sha512-MBwO1JQKin9BwKTGydrYe4VDJbStCUy35IhJzeZt3FByOdx/q3CYaqMRrH70qVD2RA7+Xk8e3RN0mzKZkYBYuQ==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -1945,14 +1946,14 @@
 		"@wordpress/a11y": {
 			"version": "file:packages/a11y",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/dom-ready": "file:packages/dom-ready"
 			}
 		},
 		"@wordpress/api-fetch": {
 			"version": "file:packages/api-fetch",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n"
 			}
@@ -1960,21 +1961,21 @@
 		"@wordpress/autop": {
 			"version": "file:packages/autop",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime": "7.0.0-rc.1"
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "file:packages/babel-plugin-import-jsx-pragma",
 			"dev": true,
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime": "7.0.0-rc.1"
 			}
 		},
 		"@wordpress/babel-plugin-makepot": {
 			"version": "file:packages/babel-plugin-makepot",
 			"dev": true,
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.10"
 			}
@@ -1983,12 +1984,12 @@
 			"version": "file:packages/babel-preset-default",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.56",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.56",
-				"@babel/plugin-transform-react-jsx": "7.0.0-beta.56",
-				"@babel/plugin-transform-runtime": "7.0.0-beta.56",
-				"@babel/preset-env": "7.0.0-beta.56",
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
+				"@babel/plugin-transform-react-jsx": "7.0.0-rc.1",
+				"@babel/plugin-transform-runtime": "7.0.0-rc.1",
+				"@babel/preset-env": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"babel-core": "^7.0.0-bridge.0"
 			}
@@ -1996,13 +1997,13 @@
 		"@wordpress/blob": {
 			"version": "file:packages/blob",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime": "7.0.0-rc.1"
 			}
 		},
 		"@wordpress/block-library": {
 			"version": "file:packages/block-library",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/blocks": "file:packages/blocks",
@@ -2033,7 +2034,7 @@
 		"@wordpress/blocks": {
 			"version": "file:packages/blocks",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-spec-parser": "file:packages/block-serialization-spec-parser",
@@ -2062,7 +2063,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/compose": "file:packages/compose",
@@ -2364,7 +2365,7 @@
 		"@wordpress/compose": {
 			"version": "file:packages/compose",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10"
@@ -2373,7 +2374,7 @@
 		"@wordpress/core-data": {
 			"version": "file:packages/core-data",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/url": "file:packages/url",
@@ -2386,14 +2387,14 @@
 			"version": "file:packages/custom-templated-path-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"@wordpress/data": {
 			"version": "file:packages/data",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
@@ -2406,7 +2407,7 @@
 		"@wordpress/date": {
 			"version": "file:packages/date",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.16"
 			}
@@ -2414,14 +2415,14 @@
 		"@wordpress/deprecated": {
 			"version": "file:packages/deprecated",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/hooks": "file:packages/hooks"
 			}
 		},
 		"@wordpress/dom": {
 			"version": "file:packages/dom",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"element-closest": "^2.0.2",
 				"lodash": "^4.17.10"
 			}
@@ -2429,13 +2430,13 @@
 		"@wordpress/dom-ready": {
 			"version": "file:packages/dom-ready",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime": "7.0.0-rc.1"
 			}
 		},
 		"@wordpress/editor": {
 			"version": "file:packages/editor",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blob": "file:packages/blob",
@@ -2476,7 +2477,7 @@
 		"@wordpress/element": {
 			"version": "file:packages/element",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"lodash": "^4.17.10",
 				"react": "^16.4.1",
 				"react-dom": "^16.4.1"
@@ -2495,19 +2496,19 @@
 		"@wordpress/hooks": {
 			"version": "file:packages/hooks",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime": "7.0.0-rc.1"
 			}
 		},
 		"@wordpress/html-entities": {
 			"version": "file:packages/html-entities",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime": "7.0.0-rc.1"
 			}
 		},
 		"@wordpress/i18n": {
 			"version": "file:packages/i18n",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"gettext-parser": "^1.3.1",
 				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
@@ -2517,14 +2518,14 @@
 		"@wordpress/is-shallow-equal": {
 			"version": "file:packages/is-shallow-equal",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime": "7.0.0-rc.1"
 			}
 		},
 		"@wordpress/jest-console": {
 			"version": "file:packages/jest-console",
 			"dev": true,
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"jest-matcher-utils": "^22.4.3",
 				"lodash": "^4.17.10"
 			}
@@ -2543,7 +2544,7 @@
 		"@wordpress/keycodes": {
 			"version": "file:packages/keycodes",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -2551,7 +2552,7 @@
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"lodash": "^4.17.10",
 				"webpack-sources": "^1.1.0"
 			}
@@ -2563,7 +2564,7 @@
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
@@ -2576,7 +2577,7 @@
 		"@wordpress/plugins": {
 			"version": "file:packages/plugins",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
@@ -2587,14 +2588,14 @@
 			"version": "file:packages/postcss-themes",
 			"dev": true,
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"postcss": "^6.0.16"
 			}
 		},
 		"@wordpress/redux-routine": {
 			"version": "file:packages/redux-routine",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56"
+				"@babel/runtime": "7.0.0-rc.1"
 			},
 			"dependencies": {
 				"js-tokens": {
@@ -2640,7 +2641,7 @@
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -2654,14 +2655,14 @@
 		"@wordpress/url": {
 			"version": "file:packages/url",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"qs": "^6.5.2s"
 			}
 		},
 		"@wordpress/viewport": {
 			"version": "file:packages/viewport",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
@@ -2671,7 +2672,7 @@
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -5995,7 +5996,8 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2140,389 +2140,6 @@
 				"react-datepicker": "^1.4.1",
 				"rememo": "^3.0.0",
 				"uuid": "^3.1.0"
-			},
-			"dependencies": {
-				"@wordpress/a11y": {
-					"version": "file:packages/a11y",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"@wordpress/dom-ready": "file:packages/dom-ready"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"@wordpress/dom-ready": {
-							"version": "file:packages/dom-ready",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0"
-							},
-							"dependencies": {
-								"@babel/runtime": {
-									"version": "7.0.0",
-									"bundled": true,
-									"requires": {
-										"regenerator-runtime": "^0.12.0"
-									}
-								},
-								"regenerator-runtime": {
-									"version": "0.12.1",
-									"bundled": true
-								}
-							}
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						}
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "file:packages/deprecated",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						}
-					}
-				},
-				"@wordpress/dom": {
-					"version": "file:packages/dom",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"element-closest": "^2.0.2",
-						"lodash": "^4.17.10"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"element-closest": {
-							"version": "2.0.2",
-							"bundled": true
-						},
-						"lodash": {
-							"version": "4.17.10",
-							"bundled": true
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						}
-					}
-				},
-				"@wordpress/element": {
-					"version": "file:packages/element",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"lodash": "^4.17.10",
-						"react": "^16.4.1",
-						"react-dom": "^16.4.1"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"asap": {
-							"version": "2.0.6",
-							"bundled": true
-						},
-						"core-js": {
-							"version": "1.2.7",
-							"bundled": true
-						},
-						"encoding": {
-							"version": "0.1.12",
-							"bundled": true,
-							"requires": {
-								"iconv-lite": "~0.4.13"
-							}
-						},
-						"fbjs": {
-							"version": "0.8.17",
-							"bundled": true,
-							"requires": {
-								"isomorphic-fetch": "^2.1.1",
-								"loose-envify": "^1.0.0",
-								"object-assign": "^4.1.0",
-								"promise": "^7.1.1",
-								"setimmediate": "^1.0.5",
-								"ua-parser-js": "^0.7.18"
-							}
-						},
-						"iconv-lite": {
-							"version": "0.4.24",
-							"bundled": true,
-							"requires": {
-								"safer-buffer": ">= 2.1.2 < 3"
-							}
-						},
-						"is-stream": {
-							"version": "1.1.0",
-							"bundled": true
-						},
-						"isomorphic-fetch": {
-							"version": "2.2.1",
-							"bundled": true,
-							"requires": {
-								"node-fetch": "^1.0.1",
-								"whatwg-fetch": ">=0.10.0"
-							}
-						},
-						"js-tokens": {
-							"version": "4.0.0",
-							"bundled": true
-						},
-						"lodash": {
-							"version": "4.17.10",
-							"bundled": true
-						},
-						"loose-envify": {
-							"version": "1.4.0",
-							"bundled": true,
-							"requires": {
-								"js-tokens": "^3.0.0 || ^4.0.0"
-							}
-						},
-						"node-fetch": {
-							"version": "1.7.3",
-							"bundled": true,
-							"requires": {
-								"encoding": "^0.1.11",
-								"is-stream": "^1.0.1"
-							}
-						},
-						"object-assign": {
-							"version": "4.1.1",
-							"bundled": true
-						},
-						"promise": {
-							"version": "7.3.1",
-							"bundled": true,
-							"requires": {
-								"asap": "~2.0.3"
-							}
-						},
-						"prop-types": {
-							"version": "15.6.2",
-							"bundled": true,
-							"requires": {
-								"loose-envify": "^1.3.1",
-								"object-assign": "^4.1.1"
-							}
-						},
-						"react": {
-							"version": "16.4.2",
-							"bundled": true,
-							"requires": {
-								"fbjs": "^0.8.16",
-								"loose-envify": "^1.1.0",
-								"object-assign": "^4.1.1",
-								"prop-types": "^15.6.0"
-							}
-						},
-						"react-dom": {
-							"version": "16.4.2",
-							"bundled": true,
-							"requires": {
-								"fbjs": "^0.8.16",
-								"loose-envify": "^1.1.0",
-								"object-assign": "^4.1.1",
-								"prop-types": "^15.6.0"
-							}
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						},
-						"safer-buffer": {
-							"version": "2.1.2",
-							"bundled": true
-						},
-						"setimmediate": {
-							"version": "1.0.5",
-							"bundled": true
-						},
-						"ua-parser-js": {
-							"version": "0.7.18",
-							"bundled": true
-						},
-						"whatwg-fetch": {
-							"version": "2.0.4",
-							"bundled": true
-						}
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "file:packages/hooks",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						}
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "file:packages/i18n",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"gettext-parser": "^1.3.1",
-						"jed": "^1.1.1",
-						"lodash": "^4.17.10",
-						"memize": "^1.0.5"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"encoding": {
-							"version": "0.1.12",
-							"bundled": true,
-							"requires": {
-								"iconv-lite": "~0.4.13"
-							}
-						},
-						"gettext-parser": {
-							"version": "1.4.0",
-							"bundled": true,
-							"requires": {
-								"encoding": "^0.1.12",
-								"safe-buffer": "^5.1.1"
-							}
-						},
-						"iconv-lite": {
-							"version": "0.4.24",
-							"bundled": true,
-							"requires": {
-								"safer-buffer": ">= 2.1.2 < 3"
-							}
-						},
-						"jed": {
-							"version": "1.1.1",
-							"bundled": true
-						},
-						"lodash": {
-							"version": "4.17.10",
-							"bundled": true
-						},
-						"memize": {
-							"version": "1.0.5",
-							"bundled": true
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						},
-						"safe-buffer": {
-							"version": "5.1.2",
-							"bundled": true
-						},
-						"safer-buffer": {
-							"version": "2.1.2",
-							"bundled": true
-						}
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "file:packages/is-shallow-equal",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						}
-					}
-				},
-				"@wordpress/keycodes": {
-					"version": "file:packages/keycodes",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"lodash": "^4.17.10"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"lodash": {
-							"version": "4.17.10",
-							"bundled": true
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						}
-					}
-				},
-				"lodash": {
-					"version": "4.17.10",
-					"bundled": true
-				},
-				"prop-types": {
-					"version": "15.6.2",
-					"bundled": true,
-					"requires": {
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
-					}
-				}
 			}
 		},
 		"@wordpress/compose": {
@@ -3371,21 +2988,21 @@
 			"dev": true
 		},
 		"babel-eslint": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.1.tgz",
-			"integrity": "sha512-h3moF6PCTQE06UjMMG+ydZSBvZ4Q7rqPE/5WAUOvUyHYUTqxm8JVhjZRiG1avI/tGVOK4BnZLDQapyLzh8DeKg==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
+			"integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "7.0.0-beta.0",
-				"babel-traverse": "7.0.0-beta.0",
-				"babel-types": "7.0.0-beta.0",
-				"babylon": "7.0.0-beta.22"
+				"@babel/code-frame": "7.0.0-beta.31",
+				"@babel/traverse": "7.0.0-beta.31",
+				"@babel/types": "7.0.0-beta.31",
+				"babylon": "7.0.0-beta.31"
 			},
 			"dependencies": {
-				"babel-code-frame": {
-					"version": "7.0.0-beta.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
-					"integrity": "sha512-/xr1ADm5bnTjjN+xwoXb7lF4v2rnxMzNZzFU7h8SxB+qB6+IqSTOOqVcpaPTUC2Non/MbQxS3OIZnJpQ2X21aQ==",
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.31",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
+					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
@@ -3393,66 +3010,59 @@
 						"js-tokens": "^3.0.0"
 					}
 				},
-				"babel-helper-function-name": {
-					"version": "7.0.0-beta.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz",
-					"integrity": "sha512-DaQccFBBWBEzMdqbKmNXamY0m1yLHJGOdbbEsNoGdJrrU7wAF3wwowtDDPzF0ZT3SqJXPgZW/P2kgBX9moMuAA==",
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.31",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
+					"integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
 					"dev": true,
 					"requires": {
-						"babel-helper-get-function-arity": "7.0.0-beta.0",
-						"babel-template": "7.0.0-beta.0",
-						"babel-traverse": "7.0.0-beta.0",
-						"babel-types": "7.0.0-beta.0"
+						"@babel/helper-get-function-arity": "7.0.0-beta.31",
+						"@babel/template": "7.0.0-beta.31",
+						"@babel/traverse": "7.0.0-beta.31",
+						"@babel/types": "7.0.0-beta.31"
 					}
 				},
-				"babel-helper-get-function-arity": {
-					"version": "7.0.0-beta.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz",
-					"integrity": "sha512-csqAic15/2Vm1951nJxkkL9K8E6ojyNF/eAOjk7pqJlO8kvgrccGNFCV9eDwcGHDPe5AjvJGwVSAcQ5fit9wuA==",
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.31",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
+					"integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
 					"dev": true,
 					"requires": {
-						"babel-types": "7.0.0-beta.0"
+						"@babel/types": "7.0.0-beta.31"
 					}
 				},
-				"babel-messages": {
-					"version": "7.0.0-beta.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-beta.0.tgz",
-					"integrity": "sha512-eXdShsm9ZTh9AQhlIaAn6HR3xWpxCnK9ZwIDA9QyjnwTgMctGxHHflw4b4RJ3/ZjTL0Vrmvm0tQXPkp49mTAUw==",
-					"dev": true
-				},
-				"babel-template": {
-					"version": "7.0.0-beta.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.0.tgz",
-					"integrity": "sha512-tmdH+MmmU0F6Ur8humpevSmFzYKbrN3Oru0g5Qyg4R6+sxjnzZmnvzUbsP0aKMr7tB0Ua6xhEb9arKTOsEMkyA==",
+				"@babel/template": {
+					"version": "7.0.0-beta.31",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
+					"integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
 					"dev": true,
 					"requires": {
-						"babel-traverse": "7.0.0-beta.0",
-						"babel-types": "7.0.0-beta.0",
-						"babylon": "7.0.0-beta.22",
+						"@babel/code-frame": "7.0.0-beta.31",
+						"@babel/types": "7.0.0-beta.31",
+						"babylon": "7.0.0-beta.31",
 						"lodash": "^4.2.0"
 					}
 				},
-				"babel-traverse": {
-					"version": "7.0.0-beta.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
-					"integrity": "sha512-IKzuTqUcQtMRZ0Vv5RjIrGGj33eBKmNTNeRexWSyjPPuAciyNkva1rt7WXPfHfkb+dX7coRAIUhzeTUEzhnwdA==",
+				"@babel/traverse": {
+					"version": "7.0.0-beta.31",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
+					"integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "7.0.0-beta.0",
-						"babel-helper-function-name": "7.0.0-beta.0",
-						"babel-messages": "7.0.0-beta.0",
-						"babel-types": "7.0.0-beta.0",
-						"babylon": "7.0.0-beta.22",
+						"@babel/code-frame": "7.0.0-beta.31",
+						"@babel/helper-function-name": "7.0.0-beta.31",
+						"@babel/types": "7.0.0-beta.31",
+						"babylon": "7.0.0-beta.31",
 						"debug": "^3.0.1",
 						"globals": "^10.0.0",
 						"invariant": "^2.2.0",
 						"lodash": "^4.2.0"
 					}
 				},
-				"babel-types": {
-					"version": "7.0.0-beta.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
-					"integrity": "sha512-rJc2kV9iPJGLlqIY71AM3nPcdkoeLRCDuR07GFgfd3lFl4TsBQq76TxYQQIZ2MONg1HpsqmuoCXr9aZ1Oa4wYw==",
+				"@babel/types": {
+					"version": "7.0.0-beta.31",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
+					"integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -3461,9 +3071,9 @@
 					}
 				},
 				"babylon": {
-					"version": "7.0.0-beta.22",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz",
-					"integrity": "sha512-Yl7iT8QGrS8OfR7p6R12AJexQm+brKwrryai4VWZ7NHUbPoZ5al3+klhvl/14shXZiLa7uK//OIFuZ1/RKHgoA==",
+					"version": "7.0.0-beta.31",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
 					"dev": true
 				},
 				"globals": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
-			"integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-rc.2"
+				"@babel/highlight": "^7.0.0"
 			}
 		},
 		"@babel/core": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.2.tgz",
-			"integrity": "sha512-8VZqKdLMUBfvSDq+V8CWjVBh7y+b2FY+4daFAWN0pgrdgw/UfrEy8afe9CVfppwblROZZVCxGWSSGOBo84rQjg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0.tgz",
+			"integrity": "sha512-nrvxS5u6QUN5gLl1GEakIcmOeoUHT1/gQtdMRq18WFURJ5osn4ppJLVSseMQo4zVWKJfBTF4muIYijXUnKlRLQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-rc.2",
-				"@babel/generator": "7.0.0-rc.2",
-				"@babel/helpers": "7.0.0-rc.2",
-				"@babel/parser": "7.0.0-rc.2",
-				"@babel/template": "7.0.0-rc.2",
-				"@babel/traverse": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2",
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.0.0",
+				"@babel/helpers": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
 				"convert-source-map": "^1.1.0",
 				"debug": "^3.1.0",
 				"json5": "^0.5.0",
@@ -36,12 +36,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.2.tgz",
-			"integrity": "sha512-kD6hlprDaBy17V8qd9uXJbYC5ZYyCggieT+tiGzCwayA7oyT5ynPec3MNkWQHkLyhB7IP2n3c/Ep329jOPQY/g==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
+			"integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2",
+				"@babel/types": "^7.0.0",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
@@ -49,222 +49,222 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-rc.2.tgz",
-			"integrity": "sha512-HukwqtJnDKo4++QL33d1cKwULDENi2YziqG4goiRiILJsVZYdZxEaOho0RYlzsKEvq4A70sbakUMw3bFC3kp3g==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-rc.2.tgz",
-			"integrity": "sha512-xiq0+9lNdVKX8fKIjrcdOgBEHH9JMR9cVYwdPmp1lXORS3zV/QpZAxQVOeOI4oXbdUPx6jfy3tKyrfhLQBXuuA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0.tgz",
+			"integrity": "sha512-9HdU8lrAc4FUZOy+y2w//kUhynSpkGIRYDzJW1oKJx7+v8m6UEAbAd2tSvxirsq2kJTXJZZS6Eo8FnUDUH0ZWw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/helper-explode-assignable-expression": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-rc.2.tgz",
-			"integrity": "sha512-uQGEgtdTB0XVgYpr/OJ52C/4CIPjED7XO8g8R64Am/RSVY0Ah0/H7ae6TbvW+v9eFbVZSvdm8ODb7sdEfMTCAg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
+			"integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2",
+				"@babel/types": "^7.0.0",
 				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-rc.2.tgz",
-			"integrity": "sha512-RbPyt1vkOzeCV0Gowma4aLSs3odq3/MLpxC/Qaki7Wjbq4yyNGsUAgO1J7ZB/YYbB11PX5OesA1OVKw03RLOrg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0.tgz",
+			"integrity": "sha512-HdYG6vr4KgXHK0q1QRZ8guoYCF5rZjIdPlhcVY+j4EBK/FDR+cXRM5/6lQr3NIWDc7dO1KfgjG5rfH6lM89VBw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-rc.2",
-				"@babel/traverse": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-rc.2.tgz",
-			"integrity": "sha512-fquxtu2DZ1QUpoNoCmw/Bqi5IAyLGCvEanP1/rpOZp+MULe6qnULeGVnR5aftIsi9nTC2XPWEqjb8fANmI6x7w==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0.tgz",
+			"integrity": "sha512-acbCxYS9XufWxsBiclmXMK1CFz7en/XSYvHFcbb3Jb8BqjFEBrA46WlIsoSQTRG/eYN60HciUnzdyQxOZhrHfw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2",
+				"@babel/helper-function-name": "^7.0.0",
+				"@babel/types": "^7.0.0",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-rc.2.tgz",
-			"integrity": "sha512-fEmCM0mYCJNuT4hf7EZ3g1K8/CDeo/Ynl1YkKU8HAa6zBo9Kt+4zicFBLgEYDBLogNLPbjBl+0YqR0Fkr5+WJg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0.tgz",
+			"integrity": "sha512-5gLPwdDnYf8GfPsjS+UmZUtYE1jaXTFm1P+ymGobqvXbA0q3ANgpH60+C6zDrRAWXYbQXYvzzQC/r0gJVNNltQ==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.2.tgz",
-			"integrity": "sha512-1frd4Bm/8yfZoAj87tmB6gtQNWtKAzfRzjASVdmsItzq9X13yUlyFLdo6/tNhazftwJO8iIZeadOpi3rNKDXhg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz",
+			"integrity": "sha512-Zo+LGvfYp4rMtz84BLF3bavFTdf8y4rJtMPTe2J+rxYmnDOIeH8le++VFI/pRJU+rQhjqiXxE4LMaIau28Tv1Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-rc.2",
-				"@babel/template": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.2.tgz",
-			"integrity": "sha512-5tjNc0hYngGqBGdjvzN89p92WY6aCntaDv8AadB/xgyUx4VievZwEbz8pc6GKkO6+qfghfZhv1F3+9SC6IA3Eg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-rc.2.tgz",
-			"integrity": "sha512-nxLyQK592UW/IOQA04cnheKVr57bIKVeMRjkZp3yWwRtzlVCNABW2AdlP9WPlF+Db7ATcw4vcrpnrelSi7ivBw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-rc.2.tgz",
-			"integrity": "sha512-8OFFup4az2I+icJL+VPjAIrZZsc7YlS6p8OgC53Nb1JFQ/mvKK8wuHxnNIt63tTIMkBPLRYaZScdij6GpDzCGA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.2.tgz",
-			"integrity": "sha512-4HmUjJ7dwnhhTNOoxOxHe9e24nnzd9VjXNXLcKdw98aRxiFQhBxhOk2t8kX2XMcGVJrFHob5zfVEjgMvnkCmHw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-rc.2.tgz",
-			"integrity": "sha512-tMGTJiSPa3naZNYfhIBF6ma5TfhyWq8PZe5i9ZemreDx4ffToad0MqQ6OW7g0U9S6a3RlZO1639Wc3DQNyvJlw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0.tgz",
+			"integrity": "sha512-QdwmTTlPmT7TZcf30dnqm8pem+o48tVt991xXogE5CQCwqSpWKuzH2E9v8VWeccQ66a6/CmrLZ+bwp66JYeM5A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-rc.2",
-				"@babel/helper-simple-access": "7.0.0-rc.2",
-				"@babel/helper-split-export-declaration": "7.0.0-rc.2",
-				"@babel/template": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2",
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-simple-access": "^7.0.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/types": "^7.0.0",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-rc.2.tgz",
-			"integrity": "sha512-O/rWpfst/rKucph1U0Hy8YDwoHBNwAZJqv7rDOp00S7eMYbU8wDYgG43J+mJcYV+2WV2dqoym6j9QdV4xTvEsw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.2.tgz",
-			"integrity": "sha512-kavwJYTgdd5W12MpfMJMznrfsx3sCl0HMSJ0vsPcbwT9jhF0EmYL1eyfeYbo4pToYmQgPKp+VGtSHQ3wL8N5lQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-rc.2.tgz",
-			"integrity": "sha512-QXqgALeUqvEq0+PjWHyOWz4ZTnSs0rXXgNpwhbkud4nXfl7w7CMtCRPOadRDRjJ2kMpQ47jM0unn7mrUnNmYnA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-rc.2.tgz",
-			"integrity": "sha512-JqxhwM6dK1vCEeGeKqSssjD/yEOo5EophV94lcnutP355UApapzzNnw1hJ08irqYo0nYOqpiMP5uIdBhwxmu5A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0.tgz",
+			"integrity": "sha512-3o4sYLOsK6m0A7t1P0saTanBPmk5MAlxVnp9773Of4L8PMVLukU7loZix5KoJgflxSo2c2ETTzseptc0rQEp7A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-rc.2",
-				"@babel/helper-wrap-function": "7.0.0-rc.2",
-				"@babel/template": "7.0.0-rc.2",
-				"@babel/traverse": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-wrap-function": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-rc.2.tgz",
-			"integrity": "sha512-MdMAYjNacQ3pCMNvAs31Nkp4UZTAE9ahMnJvkqIjgB7YgpNFfRI/8BX97SyWKe4qlNrkVxCE6WrY2s9nJBh7uA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0.tgz",
+			"integrity": "sha512-fsSv7VogxzMSmGch6DwhKHGsciVXo7hbfhBgH9ZrgJMXKMjO7ASQTUfbVL7MU1uCfviyqjucazGK7TWPT9weuQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "7.0.0-rc.2",
-				"@babel/helper-optimise-call-expression": "7.0.0-rc.2",
-				"@babel/traverse": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-rc.2.tgz",
-			"integrity": "sha512-Cw5mRtvW1jdmPWD+oLTUX8XkpyftA8AskpaQzuRkxg7dcjAnmXOUYBsccBZ8vTbrxrRzX5WrdRTwbmtx/Q9uNg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0.tgz",
+			"integrity": "sha512-CNeuX52jbQSq4j1n+R+21xrjbTjsnXa9n1aERbgHRD/p9h4Udkxr1n24yPMQmnTETHdnQDvkVSYWFw/ETAymYg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/template": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.2.tgz",
-			"integrity": "sha512-MBtzTAeZT7MxWETY0JRh5yyIKY4tN/q68BU4/XgzZUaHJ+G74fJUoR7mPO3TbTiwLIEFVBbZQA9AG4yYqe5W2g==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-rc.2.tgz",
-			"integrity": "sha512-uq+7oYjrJCDj2cV9ZpxiWzLeLZFmsM8V4lyfGyOIEsv87biGE+UcOb8R0OHnA8Hkq2CpF73pCj7nm3tdhj8k+g==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0.tgz",
+			"integrity": "sha512-kjprWPDNVPZ/9pyLRXcZBvfjnFwqokmXTPTaC4AV8Ns7WRl7ewSxrB19AWZzQsC/WSPQLOw1ciR8uPYkAM1znA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-rc.2",
-				"@babel/template": "7.0.0-rc.2",
-				"@babel/traverse": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/helper-function-name": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.2.tgz",
-			"integrity": "sha512-X5e6FnKEhS8UtSJfjjkEvY8Mq+W52FES6p55g16gHmVycVrggjwZryQKqK+iMJlus7Dgz6MrrdOtC1SWx4jDDg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0.tgz",
+			"integrity": "sha512-jbvgR8iLZPnyk6m/UqdXYsSxbVtRi7Pd3CzB4OPwPBnmhNG1DWjiiy777NTuoyIcniszK51R40L5pgfXAfHDtw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-rc.2",
-				"@babel/traverse": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
-			"integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
@@ -273,460 +273,494 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.2.tgz",
-			"integrity": "sha512-zDB1QPgQWYwuJty3Ymbx1hq7zbBEbZjTprHOhforvzyQFV86LNh6FS0InjnOUXM6p6QUyONz8KTt/v+MRMd0Hg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz",
+			"integrity": "sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-rc.2.tgz",
-			"integrity": "sha512-t2Cgx5Xwsxn7EBEmmrUWW8g9+12sbYHAPa0kAiiQa/hHTPrxnF9y4Kxsvk2VvAhaFzIFzSNSpq3jJvEQ5K8SWw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0.tgz",
+			"integrity": "sha512-QsXmmjLrFADCcDQAfdQn7tfBRLjpTzRWaDpKpW4ZXW1fahPG4SvjcF1xfvVnXGC662RSExYXL+6DAqbtgqMXeA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-remap-async-to-generator": "7.0.0-rc.2",
-				"@babel/plugin-syntax-async-generators": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.0.0",
+				"@babel/plugin-syntax-async-generators": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0-rc.2.tgz",
-			"integrity": "sha512-VMkSumDfbzHK61VkkIj/+jQBSnW2+iv1Z82aJacgQWF+xiwGmaCr/nrEBjZGi4PuAfFJm9b/35bw3imF3xnzWg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
+			"integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/plugin-syntax-json-strings": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-json-strings": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.2.tgz",
-			"integrity": "sha512-WYF4Pe5qwxWGfbjacz7XCfjlgI6eDyWhCFoWFeAwGVX+43INjKCMt3S+4AzfBYb2wlRh1omzBpUmgGfq1isYUg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+			"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-rc.2.tgz",
-			"integrity": "sha512-s/gOdmc6im0RTIe93FKCCyIFRQy+0BbUQfl7tclpmqU2F9UnjuVBlVqQMyV2HXhlAq5cEoKM5VuVflcndtL1ow==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
+			"integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-rc.2.tgz",
-			"integrity": "sha512-nb6BL9jdAi7t7QV9fGj3ttJwhX4kez2rMiqiVeSAL+NOVfmE4dwkMJ4LliN3gg/ESktsEOQeWXv4rik4q9T9Ug==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
+			"integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-regex": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
 				"regexpu-core": "^4.2.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-rc.2.tgz",
-			"integrity": "sha512-ZG9eCI+3RJVYZL/i794SsW0gFXj75nF+Kk14XvhxyvVAiT7DP1z+iMcNckr0dzZ4pvEymVCVxkU++X1dkgQQow==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
+			"integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0-rc.2.tgz",
-			"integrity": "sha512-CvojPyEfHjkwwHJATQe/x7F3xBuaB3wfVkOAvsnvGiLTnUDx2E1kYPsvPGoEfWgdS1zkLGlwtPH621bS3rYKQQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
+			"integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-rc.2.tgz",
-			"integrity": "sha512-iReV06m3hBc/RyD85vtHNNcYz4wqf0jPUFzUR+yAkzbhupYclHf6Eecse3GMWSNS3sVNMDA/+hCFcgMni41Dwg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
+			"integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.2.tgz",
-			"integrity": "sha512-TcwJSyWkA5ruAuWhJvmj7N9gmiHTGAz44Rqr6Fgkf6fhdlEYcBHRQQvYEKcYyPLLpqgWCqFvfiW7HgfqkCCe3A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
+			"integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-rc.2.tgz",
-			"integrity": "sha512-uZyLBqAFX4142Thord85PcTxD3nTiQE+0BiBL1rHMGc7ln63Auj/EJoWdYa9reb7Bax7OcuwY1lhDbxrgKUYiA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
+			"integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-rc.2.tgz",
-			"integrity": "sha512-wCZZpEfjPBiO7kRLzLLxcaImgHzlrJKjl5pHpTbng+btsCb53hNgE0dm8ph/YRRHv0NdGej0Mo3+kKNJHARjYg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
+			"integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-rc.2.tgz",
-			"integrity": "sha512-NIRF0AbXilqtr8VuTNqhQUgKGeOVu2AosUxJxAQ0e0NaxnNMRWdVTVj4p/Pl1FuSuA5oftDbSGeQYi3VOFktpg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0.tgz",
+			"integrity": "sha512-CiWNhSMZzj1n3uEKUUS/oL+a7Xi8hnPQB6GpC1WfL/ZYvxBLDBn14sHMo5EyOaeArccSonyk5jFIKMRRbrHOnQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-remap-async-to-generator": "7.0.0-rc.2"
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-rc.2.tgz",
-			"integrity": "sha512-l2vetC7pegLd1yhDf0uMQsHpACTqBHqiVB5TaMpiGk7Ixz5qS5R4IXdl2hoSAi6ytAAs7VPRtsWrLqfXgjWYwQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+			"integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-rc.2.tgz",
-			"integrity": "sha512-bJ8717eZ0Y3oY8t5qnCS0f9AQd6aDt5gJiNjqtEYs9OZkwxKfcadnRuIiC49UdfrgbNqVPbXHz/y6ueJiLtheA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
+			"integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "^7.0.0",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-rc.2.tgz",
-			"integrity": "sha512-VGLIza5QhmNBuSQ7wRYl5vSjjb1jdYIJcJsJ7Kgv5QvAasFbjjVAhqiv3/LJae7IJqetjNYN9V+2Bec64399tw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0.tgz",
+			"integrity": "sha512-8LBm7XsHQiNISEmb+ejBiHi1pUihwUf+lrIwyVsXVbQ1vLqgkvhgayK5JnW3WXvQD2rmM0qxFAIyDE5vtMem2A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-rc.2",
-				"@babel/helper-define-map": "7.0.0-rc.2",
-				"@babel/helper-function-name": "7.0.0-rc.2",
-				"@babel/helper-optimise-call-expression": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-replace-supers": "7.0.0-rc.2",
-				"@babel/helper-split-export-declaration": "7.0.0-rc.2",
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-define-map": "^7.0.0",
+				"@babel/helper-function-name": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.0.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-rc.2.tgz",
-			"integrity": "sha512-XZMHsEAM0KRcvEWHIO/5r8kUrPTFlb4oSKf771dlfA7Hfg60YFY8S4UDGmL6Fw5qBn1j0E9pbDoJ5V/MVeU7hA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
+			"integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-rc.2.tgz",
-			"integrity": "sha512-fmtP2ZOtXQGv2ncSZtGzWL/cz5aevgKjvVrdz9t3dPHkyX2CTDBdtJWNds6XLFPkWuN4ayjCbVp7z70Pl98dMg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz",
+			"integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-rc.2.tgz",
-			"integrity": "sha512-BCeZNoleLez7Rg0+iLKK+dqCJDGufKUPISRZr8e6NvSjwwRvovQuNMtdj4Dxww9Xk8zz0e9eKyf2Dt/h9CyECQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
+			"integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-regex": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-rc.2.tgz",
-			"integrity": "sha512-CeEHFlCgeZAb57buALjNFmOYgfblKuQBK2ti09nk2PkhJE3+uf1LbCrLra9sU90lOl474AinQqwkmYyogmkjkw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
+			"integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-rc.2.tgz",
-			"integrity": "sha512-VnotPddF7jLAQK6QgBNNwzhPUsxxullq+BEFaDKi1zvXnNGqOcgJ+fmemrdfGUoZWV82Zv2aRehwswPkxPcK2w==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0.tgz",
+			"integrity": "sha512-Ig74elCuFQ0mvHkWUq5qDCNI3qHWlop5w4TcDxdtJiOk8Egqe2uxDRY9XnXGSlmWClClmnixcoYumyvbAuj4dA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-rc.2.tgz",
-			"integrity": "sha512-6alRFzRGQEYlsYsm/WCOZ3+XND9f+/Pj0wkM4+uWPy7lmYoUHLVESGYJc8wFXjk/diNYzjowrx9JZn6sn6lXNw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
+			"integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-rc.2.tgz",
-			"integrity": "sha512-UmP+TGefcAAakV54Gs1RPwt0WCD1MogSMlWjEjJXUCrjvWlGGUIlcz5YR2bxtvPHBv3anpt9fxS1LZb0fjd2Mw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0.tgz",
+			"integrity": "sha512-mR7JN9vkwsAIot74pSwzn/2Gq4nn2wN0HKtQyJLc1ghAarsymdBMTfh+Q/aeR2N3heXs3URQscTLrKe3yUU7Yw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-function-name": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-rc.2.tgz",
-			"integrity": "sha512-lW0hoPqS4WhYgSQ0ifNk1tHn+e4OateqWXaM7BW7wZEU0dtP+RQ0x4z5Xghc7u82ZA4IwPN7mS1i201I7eT+dw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
+			"integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-rc.2.tgz",
-			"integrity": "sha512-phr4bjRHDvLv3OK4g0NvT998A19kmqZKMrnOFZC5gvIEvdGCa18y9Y2mZPg2Jxi+tKI1lkh248L0puLUsEtwfw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0.tgz",
+			"integrity": "sha512-CtSVpT/0tty/4405qczoIHm41YfFbPChplsmfBwsi3RTq/M9cHgVb3ixI5bqqgdKkqWwSX2sXqejvMKLuTVU+Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-module-transforms": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-rc.2.tgz",
-			"integrity": "sha512-GWwKVT/vqQ9jSXmLPDZXPJkhuJRKyfE+SZkeM8D9EwcZYpy9DLiKFHyLbw5vKW0wHOwovbeD9/0pvPASuT2rAg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0.tgz",
+			"integrity": "sha512-BIcQLgPFCxi7YygtNpz5xj+7HxhOprbCGZKeLW6Kxsn1eHS6sJZMw4MfmqFZagl/v6IVa0AJoMHdDXLVrpd3Aw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-simple-access": "7.0.0-rc.2"
+				"@babel/helper-module-transforms": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-rc.2.tgz",
-			"integrity": "sha512-uIDk/4+OzSSrW9whicWupSfcfDixWUxppUCkPEHBA3UKMNSo7ageneh+35rWKDvZh3f+DrgJxbDfyolFBsr7kg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0.tgz",
+			"integrity": "sha512-8EDKMAsitLkiF/D4Zhe9CHEE2XLh4bfLbb9/Zf3FgXYQOZyZYyg7EAel/aT2A7bHv62jwHf09q2KU/oEexr83g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-rc.2.tgz",
-			"integrity": "sha512-4gnDpcZ8/F9eoYZlQKAvh5wzax3UQFmZEBMKJabl133iTLb0aXkd+yVJGmn7Vu/+Q8wRH4kkH6Kc2pbsvlbnHQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0.tgz",
+			"integrity": "sha512-EMyKpzgugxef+R1diXDwqw/Hmt5ls8VxfI8Gq5Lo8Qp3oKIepkYG4L/mvE2dmZSRalgL9sguoPKbnQ1m96hVFw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-module-transforms": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-rc.2.tgz",
-			"integrity": "sha512-eZR2hgV0rIDAQIYHihqxbGaGNaci7HIOEcpgN207ytlKr0ynw8QFPLGHcu2HNJ3zPF08LltjlfREqttFbdnYzA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
+			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-rc.2.tgz",
-			"integrity": "sha512-VuV9E57/MQLLw5uQ1fiVhyC25gTTa+rNUVz6DEzInIV81VFm1KM0U5/b3FgTqtLMMHp/dFDExqwkHjmvlWpdzw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0.tgz",
+			"integrity": "sha512-BfAiF1l18Xr1shy1NyyQgLiHDvh/S7APiEM5+0wxTsQ+e3fgXO+NA47u4PvppzH0meJS21y0gZHcjnvUAJj8tQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-replace-supers": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-rc.2.tgz",
-			"integrity": "sha512-jjl/rEU3LAHPWdlNokNex0sOZ6ytEw8+f1tvSZCGuSzmqGZbMreLOLB1HFSKRCsu6zsQNYY/in2h11fgQU40yQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0.tgz",
+			"integrity": "sha512-eWngvRBWx0gScot0xa340JzrkA+8HGAk1OaCHDfXAjkrTFkp73Lcf+78s7AStSdRML5nzx5aXpnjN1MfrjkBoA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "7.0.0-rc.2",
-				"@babel/helper-get-function-arity": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-call-delegate": "^7.0.0",
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-rc.2.tgz",
-			"integrity": "sha512-lxGw4nT8AO0QVdmGdWzi35rZxkTp10+igJZXnp37X7BYTWzap/gayBCvchIT21k1noUowgJoeURPoAFCyIk8kQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
+			"integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/plugin-syntax-jsx": "7.0.0-rc.2"
+				"@babel/helper-builder-react-jsx": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-rc.2.tgz",
-			"integrity": "sha512-t4d/kBjxwLgmLWwI/Kz9CnO4z8rsiQ5dS3EYgGRua4VGkczde6m3jpzZx0+7b6iw+frGI12W27V50D5Ruv5juw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-rc.2.tgz",
-			"integrity": "sha512-8zpYlgNvTIaFBmCnWWD5kAqk19vTQYXm6IrE+hZsWuvA4hPdvU6BTJ29R+5iY3NkNkQIq3BHZgc+PkTyv/mm0A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0.tgz",
+			"integrity": "sha512-yECRVxRu25Nsf6IY5v5XrXhcW9ZHomUQiq30VO8H7r3JYPcBJDTcxZmT+6v1O3QKKrDp1Wp40LinGbcd+jlp9A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
 				"resolve": "^1.8.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-rc.2.tgz",
-			"integrity": "sha512-IKkCwaGhfgRTGFrGKCqQmPFm7Z+y4hfzWPgctZNhZFtjPN0Y6B+ixaX7Ey0aFEIq6K+2cAIMiZTJbDflQEb0Fg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
+			"integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-rc.2.tgz",
-			"integrity": "sha512-Xmw5FxsvrxHv94j9i54IfIpbNbaGC4TpokMmMjuqdgeezCEZkCFUolqydhgDKgxCg5pqKDh6oDistJIJ/8RLMA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
+			"integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-rc.2.tgz",
-			"integrity": "sha512-//QPQAuZE6BqOkZNqr2GLfBE0gssKucez91+4wX3f4x0QN9lsMD6fLN5mymnVGWw7FKlM3XuPYEF8syqqJD4Dw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
+			"integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-regex": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-rc.2.tgz",
-			"integrity": "sha512-6ICqvslFDU6S+zggiF73e9chbb1MicgPMFgnjo3QikfKe0aolOfyoKTcBNRRXywnZr+ILUcY44zkF3jI3mr2Fw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
+			"integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-rc.2.tgz",
-			"integrity": "sha512-nL5PV6/VjuBreNsaJm00RzdIuC8ITK1O++WFwlZLOen5CPNSFmpOqP84J088hGk3tU9Iw5x4ETEzYHrf/5/72g==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
+			"integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-rc.2.tgz",
-			"integrity": "sha512-C+28QnIFb8jmw1NegaOtVxnZpBz748h/zsxmAq+uP9J8yGXLA7LtKrFLi00Ky+554BCnqf8Ftp5Fd3NaYpPOOQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
+			"integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/helper-regex": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-rc.2.tgz",
-			"integrity": "sha512-R9Jwm67dPSjlIJmI85hhRsI+JvHCBQLmDwkpo8URCGZ9YxoMgB2Xz3w0fN8x81adIKWZ0/JZaB1m4KWy56qg1g==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0.tgz",
+			"integrity": "sha512-Fnx1wWaWv2w2rl+VHxA9si//Da40941IQ29fKiRejVR7oN1FxSEL8+SyAX/2oKIye2gPvY/GBbJVEKQ/oi43zQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-rc.2",
-				"@babel/helper-plugin-utils": "7.0.0-rc.2",
-				"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.2",
-				"@babel/plugin-proposal-json-strings": "7.0.0-rc.2",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.2",
-				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-rc.2",
-				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-rc.2",
-				"@babel/plugin-syntax-async-generators": "7.0.0-rc.2",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.2",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.2",
-				"@babel/plugin-transform-arrow-functions": "7.0.0-rc.2",
-				"@babel/plugin-transform-async-to-generator": "7.0.0-rc.2",
-				"@babel/plugin-transform-block-scoped-functions": "7.0.0-rc.2",
-				"@babel/plugin-transform-block-scoping": "7.0.0-rc.2",
-				"@babel/plugin-transform-classes": "7.0.0-rc.2",
-				"@babel/plugin-transform-computed-properties": "7.0.0-rc.2",
-				"@babel/plugin-transform-destructuring": "7.0.0-rc.2",
-				"@babel/plugin-transform-dotall-regex": "7.0.0-rc.2",
-				"@babel/plugin-transform-duplicate-keys": "7.0.0-rc.2",
-				"@babel/plugin-transform-exponentiation-operator": "7.0.0-rc.2",
-				"@babel/plugin-transform-for-of": "7.0.0-rc.2",
-				"@babel/plugin-transform-function-name": "7.0.0-rc.2",
-				"@babel/plugin-transform-literals": "7.0.0-rc.2",
-				"@babel/plugin-transform-modules-amd": "7.0.0-rc.2",
-				"@babel/plugin-transform-modules-commonjs": "7.0.0-rc.2",
-				"@babel/plugin-transform-modules-systemjs": "7.0.0-rc.2",
-				"@babel/plugin-transform-modules-umd": "7.0.0-rc.2",
-				"@babel/plugin-transform-new-target": "7.0.0-rc.2",
-				"@babel/plugin-transform-object-super": "7.0.0-rc.2",
-				"@babel/plugin-transform-parameters": "7.0.0-rc.2",
-				"@babel/plugin-transform-regenerator": "7.0.0-rc.2",
-				"@babel/plugin-transform-shorthand-properties": "7.0.0-rc.2",
-				"@babel/plugin-transform-spread": "7.0.0-rc.2",
-				"@babel/plugin-transform-sticky-regex": "7.0.0-rc.2",
-				"@babel/plugin-transform-template-literals": "7.0.0-rc.2",
-				"@babel/plugin-transform-typeof-symbol": "7.0.0-rc.2",
-				"@babel/plugin-transform-unicode-regex": "7.0.0-rc.2",
-				"browserslist": "^3.0.0",
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+				"@babel/plugin-proposal-json-strings": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+				"@babel/plugin-syntax-async-generators": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+				"@babel/plugin-transform-arrow-functions": "^7.0.0",
+				"@babel/plugin-transform-async-to-generator": "^7.0.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoping": "^7.0.0",
+				"@babel/plugin-transform-classes": "^7.0.0",
+				"@babel/plugin-transform-computed-properties": "^7.0.0",
+				"@babel/plugin-transform-destructuring": "^7.0.0",
+				"@babel/plugin-transform-dotall-regex": "^7.0.0",
+				"@babel/plugin-transform-duplicate-keys": "^7.0.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+				"@babel/plugin-transform-for-of": "^7.0.0",
+				"@babel/plugin-transform-function-name": "^7.0.0",
+				"@babel/plugin-transform-literals": "^7.0.0",
+				"@babel/plugin-transform-modules-amd": "^7.0.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.0.0",
+				"@babel/plugin-transform-modules-umd": "^7.0.0",
+				"@babel/plugin-transform-new-target": "^7.0.0",
+				"@babel/plugin-transform-object-super": "^7.0.0",
+				"@babel/plugin-transform-parameters": "^7.0.0",
+				"@babel/plugin-transform-regenerator": "^7.0.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+				"@babel/plugin-transform-spread": "^7.0.0",
+				"@babel/plugin-transform-sticky-regex": "^7.0.0",
+				"@babel/plugin-transform-template-literals": "^7.0.0",
+				"@babel/plugin-transform-typeof-symbol": "^7.0.0",
+				"@babel/plugin-transform-unicode-regex": "^7.0.0",
+				"browserslist": "^4.1.0",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
 				"semver": "^5.3.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.0.tgz",
+					"integrity": "sha512-kQBKB8hnq1SRfSpwHDpM1JNHAyk9fydW8hIDvndR2ijTFKIlBPEvkJkCt8JznOugdm12/YCaRgyq/sqDGz9PwA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000878",
+						"electron-to-chromium": "^1.3.61",
+						"node-releases": "^1.0.0-alpha.11"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000878",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+					"integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.61",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.61.tgz",
+					"integrity": "sha512-XjTdsm6x71Y48lF9EEvGciwXD70b20g0t+3YbrE+0fPFutqV08DSNrZXkoXAp3QuzX7TpL/OW+/VsNoR9GkuNg==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.0.0-alpha.11",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+					"integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
+					"dev": true,
+					"requires": {
+						"semver": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-rc.2.tgz",
-			"integrity": "sha512-QugZtHk0uVHqHmgwNn2f2uOtTwXWPBBZVSH2EFRm9iw1fFmi5fm46ye6NSVSiXT9Ymejh7fKIw3riCv23SNtSQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+			"integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
 			"requires": {
 				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-rc.2.tgz",
-			"integrity": "sha512-WjHH8Zi6h8laPiNjX08rOWUvn3QoeMp4wba8dKwWelQv4812jvoqRtbxqM5ieeRgUmjVVBKXmZf+AzlCyPu27A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0.tgz",
+			"integrity": "sha512-Yww0jXgolNtkhcK+Txo5JN+DjBpNmmAtD7G99HOebhEjBzjnACG09Tip9C8lSOF6PrhA56OeJWeOZduNJaKxBA==",
 			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
@@ -734,37 +768,37 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.2.tgz",
-			"integrity": "sha512-CryGZ01Nko2/g8gkYiiPc7x9ZinrX59/BTWMZV1sDj5cAeia64vhyNnXTcNeim885IdGOdYyia1PNBWKnFxuSw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz",
+			"integrity": "sha512-VLQZik/G5mjYJ6u19U3W2u7eM+rA/NGzH+GtHDFFkLTKLW66OasFrxZ/yK7hkyQcswrmvugFyZpDFRW0DjcjCw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-rc.2",
-				"@babel/parser": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2"
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.2.tgz",
-			"integrity": "sha512-x8y9E+KZHs3Xmy5uiYmr1TtDhOBAZnL9vUtLIt95Pw3jovkY9q2NIwgLzfSlzOU83sQvzAooZWuJ65JERwxx+Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0.tgz",
+			"integrity": "sha512-ka/lwaonJZTlJyn97C4g5FYjPOx+Oxd3ab05hbDr1Mx9aP1FclJ+SUHyLx3Tx40sGmOVJApDxE6puJhd3ld2kw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-rc.2",
-				"@babel/generator": "7.0.0-rc.2",
-				"@babel/helper-function-name": "7.0.0-rc.2",
-				"@babel/helper-split-export-declaration": "7.0.0-rc.2",
-				"@babel/parser": "7.0.0-rc.2",
-				"@babel/types": "7.0.0-rc.2",
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.0.0",
+				"@babel/helper-function-name": "^7.0.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/types": "^7.0.0",
 				"debug": "^3.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.2.tgz",
-			"integrity": "sha512-I2SMGD8bUX7sysOwGM8TcwCoaHiOx2YWZmT9h5oAncsPQ9Wy068yJneCF4vkOGTCzPFIETPDR5i3EIEm5QgMFg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
+			"integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -1964,14 +1998,14 @@
 		"@wordpress/a11y": {
 			"version": "file:packages/a11y",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/dom-ready": "file:packages/dom-ready"
 			}
 		},
 		"@wordpress/api-fetch": {
 			"version": "file:packages/api-fetch",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n"
 			}
@@ -1979,21 +2013,21 @@
 		"@wordpress/autop": {
 			"version": "file:packages/autop",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2"
+				"@babel/runtime": "^7.0.0"
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "file:packages/babel-plugin-import-jsx-pragma",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2"
+				"@babel/runtime": "^7.0.0"
 			}
 		},
 		"@wordpress/babel-plugin-makepot": {
 			"version": "file:packages/babel-plugin-makepot",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.10"
 			}
@@ -2002,12 +2036,12 @@
 			"version": "file:packages/babel-preset-default",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.2",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.2",
-				"@babel/plugin-transform-react-jsx": "7.0.0-rc.2",
-				"@babel/plugin-transform-runtime": "7.0.0-rc.2",
-				"@babel/preset-env": "7.0.0-rc.2",
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-runtime": "^7.0.0",
+				"@babel/preset-env": "^7.0.0",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"babel-core": "^7.0.0-bridge.0"
 			}
@@ -2015,13 +2049,13 @@
 		"@wordpress/blob": {
 			"version": "file:packages/blob",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2"
+				"@babel/runtime": "^7.0.0"
 			}
 		},
 		"@wordpress/block-library": {
 			"version": "file:packages/block-library",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/blocks": "file:packages/blocks",
@@ -2052,7 +2086,7 @@
 		"@wordpress/blocks": {
 			"version": "file:packages/blocks",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-spec-parser": "file:packages/block-serialization-spec-parser",
@@ -2081,7 +2115,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/compose": "file:packages/compose",
@@ -2112,28 +2146,79 @@
 					"version": "file:packages/a11y",
 					"bundled": true,
 					"requires": {
-						"@wordpress/dom-ready": "^1.0.3"
+						"@babel/runtime": "^7.0.0",
+						"@wordpress/dom-ready": "file:packages/dom-ready"
 					},
 					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.0.0",
+							"bundled": true,
+							"requires": {
+								"regenerator-runtime": "^0.12.0"
+							}
+						},
 						"@wordpress/dom-ready": {
-							"version": "1.1.0",
+							"version": "file:packages/dom-ready",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.0.0"
+							},
+							"dependencies": {
+								"@babel/runtime": {
+									"version": "7.0.0",
+									"bundled": true,
+									"requires": {
+										"regenerator-runtime": "^0.12.0"
+									}
+								},
+								"regenerator-runtime": {
+									"version": "0.12.1",
+									"bundled": true
+								}
+							}
+						},
+						"regenerator-runtime": {
+							"version": "0.12.1",
 							"bundled": true
 						}
 					}
 				},
 				"@wordpress/deprecated": {
 					"version": "file:packages/deprecated",
-					"bundled": true
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.0.0"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.0.0",
+							"bundled": true,
+							"requires": {
+								"regenerator-runtime": "^0.12.0"
+							}
+						},
+						"regenerator-runtime": {
+							"version": "0.12.1",
+							"bundled": true
+						}
+					}
 				},
 				"@wordpress/dom": {
 					"version": "file:packages/dom",
 					"bundled": true,
 					"requires": {
+						"@babel/runtime": "^7.0.0",
 						"element-closest": "^2.0.2",
-						"lodash": "^4.17.10",
-						"tinymce": "^4.7.2"
+						"lodash": "^4.17.10"
 					},
 					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.0.0",
+							"bundled": true,
+							"requires": {
+								"regenerator-runtime": "^0.12.0"
+							}
+						},
 						"element-closest": {
 							"version": "2.0.2",
 							"bundled": true
@@ -2142,8 +2227,8 @@
 							"version": "4.17.10",
 							"bundled": true
 						},
-						"tinymce": {
-							"version": "4.8.0",
+						"regenerator-runtime": {
+							"version": "0.12.1",
 							"bundled": true
 						}
 					}
@@ -2152,18 +2237,18 @@
 					"version": "file:packages/element",
 					"bundled": true,
 					"requires": {
+						"@babel/runtime": "^7.0.0",
 						"lodash": "^4.17.10",
 						"react": "^16.4.1",
 						"react-dom": "^16.4.1"
 					},
 					"dependencies": {
-						"@wordpress/deprecated": {
-							"version": "file:packages/deprecated",
-							"bundled": true
-						},
-						"@wordpress/is-shallow-equal": {
-							"version": "file:packages/is-shallow-equal",
-							"bundled": true
+						"@babel/runtime": {
+							"version": "7.0.0",
+							"bundled": true,
+							"requires": {
+								"regenerator-runtime": "^0.12.0"
+							}
 						},
 						"asap": {
 							"version": "2.0.6",
@@ -2193,7 +2278,7 @@
 							}
 						},
 						"iconv-lite": {
-							"version": "0.4.23",
+							"version": "0.4.24",
 							"bundled": true,
 							"requires": {
 								"safer-buffer": ">= 2.1.2 < 3"
@@ -2254,7 +2339,7 @@
 							}
 						},
 						"react": {
-							"version": "16.4.1",
+							"version": "16.4.2",
 							"bundled": true,
 							"requires": {
 								"fbjs": "^0.8.16",
@@ -2264,7 +2349,7 @@
 							}
 						},
 						"react-dom": {
-							"version": "16.4.1",
+							"version": "16.4.2",
 							"bundled": true,
 							"requires": {
 								"fbjs": "^0.8.16",
@@ -2272,6 +2357,10 @@
 								"object-assign": "^4.1.1",
 								"prop-types": "^15.6.0"
 							}
+						},
+						"regenerator-runtime": {
+							"version": "0.12.1",
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -2293,18 +2382,42 @@
 				},
 				"@wordpress/hooks": {
 					"version": "file:packages/hooks",
-					"bundled": true
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.0.0"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.0.0",
+							"bundled": true,
+							"requires": {
+								"regenerator-runtime": "^0.12.0"
+							}
+						},
+						"regenerator-runtime": {
+							"version": "0.12.1",
+							"bundled": true
+						}
+					}
 				},
 				"@wordpress/i18n": {
 					"version": "file:packages/i18n",
 					"bundled": true,
 					"requires": {
+						"@babel/runtime": "^7.0.0",
 						"gettext-parser": "^1.3.1",
 						"jed": "^1.1.1",
-						"lodash": "^4.17.5",
+						"lodash": "^4.17.10",
 						"memize": "^1.0.5"
 					},
 					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.0.0",
+							"bundled": true,
+							"requires": {
+								"regenerator-runtime": "^0.12.0"
+							}
+						},
 						"encoding": {
 							"version": "0.1.12",
 							"bundled": true,
@@ -2321,7 +2434,7 @@
 							}
 						},
 						"iconv-lite": {
-							"version": "0.4.23",
+							"version": "0.4.24",
 							"bundled": true,
 							"requires": {
 								"safer-buffer": ">= 2.1.2 < 3"
@@ -2339,6 +2452,10 @@
 							"version": "1.0.5",
 							"bundled": true
 						},
+						"regenerator-runtime": {
+							"version": "0.12.1",
+							"bundled": true
+						},
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true
@@ -2351,17 +2468,45 @@
 				},
 				"@wordpress/is-shallow-equal": {
 					"version": "file:packages/is-shallow-equal",
-					"bundled": true
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.0.0"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.0.0",
+							"bundled": true,
+							"requires": {
+								"regenerator-runtime": "^0.12.0"
+							}
+						},
+						"regenerator-runtime": {
+							"version": "0.12.1",
+							"bundled": true
+						}
+					}
 				},
 				"@wordpress/keycodes": {
 					"version": "file:packages/keycodes",
 					"bundled": true,
 					"requires": {
+						"@babel/runtime": "^7.0.0",
 						"lodash": "^4.17.10"
 					},
 					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.0.0",
+							"bundled": true,
+							"requires": {
+								"regenerator-runtime": "^0.12.0"
+							}
+						},
 						"lodash": {
 							"version": "4.17.10",
+							"bundled": true
+						},
+						"regenerator-runtime": {
+							"version": "0.12.1",
 							"bundled": true
 						}
 					}
@@ -2383,7 +2528,7 @@
 		"@wordpress/compose": {
 			"version": "file:packages/compose",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10"
@@ -2392,7 +2537,7 @@
 		"@wordpress/core-data": {
 			"version": "file:packages/core-data",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/url": "file:packages/url",
@@ -2405,14 +2550,14 @@
 			"version": "file:packages/custom-templated-path-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"@wordpress/data": {
 			"version": "file:packages/data",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
@@ -2425,7 +2570,7 @@
 		"@wordpress/date": {
 			"version": "file:packages/date",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.16"
 			}
@@ -2433,14 +2578,14 @@
 		"@wordpress/deprecated": {
 			"version": "file:packages/deprecated",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/hooks": "file:packages/hooks"
 			}
 		},
 		"@wordpress/dom": {
 			"version": "file:packages/dom",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"element-closest": "^2.0.2",
 				"lodash": "^4.17.10"
 			}
@@ -2448,13 +2593,13 @@
 		"@wordpress/dom-ready": {
 			"version": "file:packages/dom-ready",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2"
+				"@babel/runtime": "^7.0.0"
 			}
 		},
 		"@wordpress/editor": {
 			"version": "file:packages/editor",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blob": "file:packages/blob",
@@ -2495,7 +2640,7 @@
 		"@wordpress/element": {
 			"version": "file:packages/element",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"lodash": "^4.17.10",
 				"react": "^16.4.1",
 				"react-dom": "^16.4.1"
@@ -2514,19 +2659,19 @@
 		"@wordpress/hooks": {
 			"version": "file:packages/hooks",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2"
+				"@babel/runtime": "^7.0.0"
 			}
 		},
 		"@wordpress/html-entities": {
 			"version": "file:packages/html-entities",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2"
+				"@babel/runtime": "^7.0.0"
 			}
 		},
 		"@wordpress/i18n": {
 			"version": "file:packages/i18n",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"gettext-parser": "^1.3.1",
 				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
@@ -2536,14 +2681,14 @@
 		"@wordpress/is-shallow-equal": {
 			"version": "file:packages/is-shallow-equal",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2"
+				"@babel/runtime": "^7.0.0"
 			}
 		},
 		"@wordpress/jest-console": {
 			"version": "file:packages/jest-console",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"jest-matcher-utils": "^22.4.3",
 				"lodash": "^4.17.10"
 			}
@@ -2562,7 +2707,7 @@
 		"@wordpress/keycodes": {
 			"version": "file:packages/keycodes",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -2570,7 +2715,7 @@
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"lodash": "^4.17.10",
 				"webpack-sources": "^1.1.0"
 			}
@@ -2582,7 +2727,7 @@
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
@@ -2595,7 +2740,7 @@
 		"@wordpress/plugins": {
 			"version": "file:packages/plugins",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
@@ -2606,14 +2751,14 @@
 			"version": "file:packages/postcss-themes",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"postcss": "^6.0.16"
 			}
 		},
 		"@wordpress/redux-routine": {
 			"version": "file:packages/redux-routine",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2"
+				"@babel/runtime": "^7.0.0"
 			},
 			"dependencies": {
 				"js-tokens": {
@@ -2659,28 +2804,28 @@
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@wordpress/token-list": {
 			"version": "file:packages/token-list",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@wordpress/url": {
 			"version": "file:packages/url",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"qs": "^6.5.2s"
 			}
 		},
 		"@wordpress/viewport": {
 			"version": "file:packages/viewport",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
@@ -2690,7 +2835,7 @@
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.2",
+				"@babel/runtime": "^7.0.0",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -3226,21 +3371,21 @@
 			"dev": true
 		},
 		"babel-eslint": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
-			"integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.1.tgz",
+			"integrity": "sha512-h3moF6PCTQE06UjMMG+ydZSBvZ4Q7rqPE/5WAUOvUyHYUTqxm8JVhjZRiG1avI/tGVOK4BnZLDQapyLzh8DeKg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.31",
-				"@babel/traverse": "7.0.0-beta.31",
-				"@babel/types": "7.0.0-beta.31",
-				"babylon": "7.0.0-beta.31"
+				"babel-code-frame": "7.0.0-beta.0",
+				"babel-traverse": "7.0.0-beta.0",
+				"babel-types": "7.0.0-beta.0",
+				"babylon": "7.0.0-beta.22"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
-					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+				"babel-code-frame": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
+					"integrity": "sha512-/xr1ADm5bnTjjN+xwoXb7lF4v2rnxMzNZzFU7h8SxB+qB6+IqSTOOqVcpaPTUC2Non/MbQxS3OIZnJpQ2X21aQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
@@ -3248,59 +3393,66 @@
 						"js-tokens": "^3.0.0"
 					}
 				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
-					"integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
+				"babel-helper-function-name": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz",
+					"integrity": "sha512-DaQccFBBWBEzMdqbKmNXamY0m1yLHJGOdbbEsNoGdJrrU7wAF3wwowtDDPzF0ZT3SqJXPgZW/P2kgBX9moMuAA==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.31",
-						"@babel/template": "7.0.0-beta.31",
-						"@babel/traverse": "7.0.0-beta.31",
-						"@babel/types": "7.0.0-beta.31"
+						"babel-helper-get-function-arity": "7.0.0-beta.0",
+						"babel-template": "7.0.0-beta.0",
+						"babel-traverse": "7.0.0-beta.0",
+						"babel-types": "7.0.0-beta.0"
 					}
 				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
-					"integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
+				"babel-helper-get-function-arity": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz",
+					"integrity": "sha512-csqAic15/2Vm1951nJxkkL9K8E6ojyNF/eAOjk7pqJlO8kvgrccGNFCV9eDwcGHDPe5AjvJGwVSAcQ5fit9wuA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.0.0-beta.31"
+						"babel-types": "7.0.0-beta.0"
 					}
 				},
-				"@babel/template": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
-					"integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
+				"babel-messages": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-beta.0.tgz",
+					"integrity": "sha512-eXdShsm9ZTh9AQhlIaAn6HR3xWpxCnK9ZwIDA9QyjnwTgMctGxHHflw4b4RJ3/ZjTL0Vrmvm0tQXPkp49mTAUw==",
+					"dev": true
+				},
+				"babel-template": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.0.tgz",
+					"integrity": "sha512-tmdH+MmmU0F6Ur8humpevSmFzYKbrN3Oru0g5Qyg4R6+sxjnzZmnvzUbsP0aKMr7tB0Ua6xhEb9arKTOsEMkyA==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "7.0.0-beta.31",
-						"@babel/types": "7.0.0-beta.31",
-						"babylon": "7.0.0-beta.31",
+						"babel-traverse": "7.0.0-beta.0",
+						"babel-types": "7.0.0-beta.0",
+						"babylon": "7.0.0-beta.22",
 						"lodash": "^4.2.0"
 					}
 				},
-				"@babel/traverse": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
-					"integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
+				"babel-traverse": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
+					"integrity": "sha512-IKzuTqUcQtMRZ0Vv5RjIrGGj33eBKmNTNeRexWSyjPPuAciyNkva1rt7WXPfHfkb+dX7coRAIUhzeTUEzhnwdA==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "7.0.0-beta.31",
-						"@babel/helper-function-name": "7.0.0-beta.31",
-						"@babel/types": "7.0.0-beta.31",
-						"babylon": "7.0.0-beta.31",
+						"babel-code-frame": "7.0.0-beta.0",
+						"babel-helper-function-name": "7.0.0-beta.0",
+						"babel-messages": "7.0.0-beta.0",
+						"babel-types": "7.0.0-beta.0",
+						"babylon": "7.0.0-beta.22",
 						"debug": "^3.0.1",
 						"globals": "^10.0.0",
 						"invariant": "^2.2.0",
 						"lodash": "^4.2.0"
 					}
 				},
-				"@babel/types": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
-					"integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
+				"babel-types": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
+					"integrity": "sha512-rJc2kV9iPJGLlqIY71AM3nPcdkoeLRCDuR07GFgfd3lFl4TsBQq76TxYQQIZ2MONg1HpsqmuoCXr9aZ1Oa4wYw==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -3309,9 +3461,9 @@
 					}
 				},
 				"babylon": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+					"version": "7.0.0-beta.22",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz",
+					"integrity": "sha512-Yl7iT8QGrS8OfR7p6R12AJexQm+brKwrryai4VWZ7NHUbPoZ5al3+klhvl/14shXZiLa7uK//OIFuZ1/RKHgoA==",
 					"dev": true
 				},
 				"globals": {
@@ -3523,9 +3675,9 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.0-beta.4.tgz",
-			"integrity": "sha512-fQMCj8jRpF/2CPuVnpFrOb8+8pRuquKqoC+tspy5RWBmL37/2qc104sLLLqpwWltrFzpYb30utPpKc3H6P3ETQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.0.tgz",
+			"integrity": "sha512-lBUGBz411lSfT+8MHPEaqIVQ44odS1D/wxuTMhijqHc9arZR6jhJEaJa0RpZlCSITZoeK6xoDXTaVTrSoFD7IQ==",
 			"dev": true,
 			"requires": {
 				"find-cache-dir": "^1.0.0",
@@ -15526,155 +15678,6 @@
 			"requires": {
 				"@babel/core": "^7.0.0-rc.1",
 				"postcss-styled": ">=0.33.0"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
-					"integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-rc.1"
-					}
-				},
-				"@babel/core": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.1.tgz",
-					"integrity": "sha512-CvuSsq+LFs9N4SJG8MnNPI0hnl913HK1OqG3NEfejOKo+JqtVuxpmAFyXIDogX2x668xqFKAW6EQiCIcUHklMg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-rc.1",
-						"@babel/generator": "7.0.0-rc.1",
-						"@babel/helpers": "7.0.0-rc.1",
-						"@babel/parser": "7.0.0-rc.1",
-						"@babel/template": "7.0.0-rc.1",
-						"@babel/traverse": "7.0.0-rc.1",
-						"@babel/types": "7.0.0-rc.1",
-						"convert-source-map": "^1.1.0",
-						"debug": "^3.1.0",
-						"json5": "^0.5.0",
-						"lodash": "^4.17.10",
-						"resolve": "^1.3.2",
-						"semver": "^5.4.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.1.tgz",
-					"integrity": "sha512-Ak4n780/coo+L9GZUS7V/IGJilP11t4UoWl0J9cG3jso4KkDGQcqdx4Y6gJAiXng+sDfvzUmvWfM1hZwH82J0A==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-rc.1",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.10",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.1.tgz",
-					"integrity": "sha512-fDbWxdYYbFNzcI5jn3qsPxHI1UCXwvFk0kGytGce/FEBYEPXBqycKknC8Oqiub8DzGtmTcvnqcm/cl/qxzeuiQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-rc.1",
-						"@babel/template": "7.0.0-rc.1",
-						"@babel/types": "7.0.0-rc.1"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.1.tgz",
-					"integrity": "sha512-5+ydaIRxT42FSDqvoXIDksCGlW1903xC73HQnQCFF1YuV7VcIf+9M4+tRZulLlYlshw7ILA+4SiYsKoDlC0Irg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-rc.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.1.tgz",
-					"integrity": "sha512-hz6QmlnaBFYt4ra8DfRLCMgrI7yfwQ13kJtufSO5dVCasxmAng2LeeQiT6H4iN5TpFONcayp5f/2mXqHH/zn/g==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-rc.1"
-					}
-				},
-				"@babel/helpers": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.1.tgz",
-					"integrity": "sha512-4+AkDbZ0Usr7mNH4wGX8fVx4WJzHdrcjRkJy52EIWyBAQEoKqb5HXca1VjejWtnVwaGwW7zk/h6oQ9FQPywQfA==",
-					"dev": true,
-					"requires": {
-						"@babel/template": "7.0.0-rc.1",
-						"@babel/traverse": "7.0.0-rc.1",
-						"@babel/types": "7.0.0-rc.1"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
-					"integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.1.tgz",
-					"integrity": "sha512-rC+bIz2eZnJlacERmJO25UAbXVZttcSxh0Px0gRGinOTzug5tL7+L9urfIdSWlv1ZzP03+f2xkOFLOxZqSsVmQ==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.1.tgz",
-					"integrity": "sha512-gPLng2iedNlkaGD0UdwaUByQXK8k4bnaoq2RH5JgR2mqHvh2RyjkDdaMbZFlSss1Iu8+PrXwbIRworTl8iRqbA==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-rc.1",
-						"@babel/parser": "7.0.0-rc.1",
-						"@babel/types": "7.0.0-rc.1",
-						"lodash": "^4.17.10"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.1.tgz",
-					"integrity": "sha512-lNOpJ5xzakg+fCobQQHdeDRYeN54b+bAZpeTYMeeYPAvN+hTldg9/FSNKYEMRs5EWoQ0Yt74gwq98InSORdSDQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-rc.1",
-						"@babel/generator": "7.0.0-rc.1",
-						"@babel/helper-function-name": "7.0.0-rc.1",
-						"@babel/helper-split-export-declaration": "7.0.0-rc.1",
-						"@babel/parser": "7.0.0-rc.1",
-						"@babel/types": "7.0.0-rc.1",
-						"debug": "^3.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.10"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-rc.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.1.tgz",
-					"integrity": "sha512-MBwO1JQKin9BwKTGydrYe4VDJbStCUy35IhJzeZt3FByOdx/q3CYaqMRrH70qVD2RA7+Xk8e3RN0mzKZkYBYuQ==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.10",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
 			}
 		},
 		"postcss-less": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2648,7 +2648,7 @@
 		"@wordpress/token-list": {
 			"version": "file:packages/token-list",
 			"requires": {
-				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@babel/runtime": "7.0.0-rc.1",
 				"lodash": "^4.17.10"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
-			"integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
+			"integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-rc.1"
+				"@babel/highlight": "7.0.0-rc.2"
 			}
 		},
 		"@babel/core": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.1.tgz",
-			"integrity": "sha512-CvuSsq+LFs9N4SJG8MnNPI0hnl913HK1OqG3NEfejOKo+JqtVuxpmAFyXIDogX2x668xqFKAW6EQiCIcUHklMg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.2.tgz",
+			"integrity": "sha512-8VZqKdLMUBfvSDq+V8CWjVBh7y+b2FY+4daFAWN0pgrdgw/UfrEy8afe9CVfppwblROZZVCxGWSSGOBo84rQjg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-rc.1",
-				"@babel/generator": "7.0.0-rc.1",
-				"@babel/helpers": "7.0.0-rc.1",
-				"@babel/parser": "7.0.0-rc.1",
-				"@babel/template": "7.0.0-rc.1",
-				"@babel/traverse": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1",
+				"@babel/code-frame": "7.0.0-rc.2",
+				"@babel/generator": "7.0.0-rc.2",
+				"@babel/helpers": "7.0.0-rc.2",
+				"@babel/parser": "7.0.0-rc.2",
+				"@babel/template": "7.0.0-rc.2",
+				"@babel/traverse": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2",
 				"convert-source-map": "^1.1.0",
 				"debug": "^3.1.0",
 				"json5": "^0.5.0",
@@ -36,12 +36,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.1.tgz",
-			"integrity": "sha512-Ak4n780/coo+L9GZUS7V/IGJilP11t4UoWl0J9cG3jso4KkDGQcqdx4Y6gJAiXng+sDfvzUmvWfM1hZwH82J0A==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.2.tgz",
+			"integrity": "sha512-kD6hlprDaBy17V8qd9uXJbYC5ZYyCggieT+tiGzCwayA7oyT5ynPec3MNkWQHkLyhB7IP2n3c/Ep329jOPQY/g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.2",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
@@ -49,665 +49,684 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-rc.1.tgz",
-			"integrity": "sha512-GOV2UExs9gAvSrZF4rcgocXXeLJplq2kL2AsCrn6DmGwMUEfo/KB7FhedN3X6cVh0gOqqKkVKXrz3Li1wQ84xQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-rc.2.tgz",
+			"integrity": "sha512-HukwqtJnDKo4++QL33d1cKwULDENi2YziqG4goiRiILJsVZYdZxEaOho0RYlzsKEvq4A70sbakUMw3bFC3kp3g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-rc.1.tgz",
-			"integrity": "sha512-O6/szesBinGoExLl01Qg2vb5FaOfifSilgL5GnCZLz5z3Pg9jRolN6rGzQAOa/K9Y01TAmDf1dC06AKQUv3x8g==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-rc.2.tgz",
+			"integrity": "sha512-xiq0+9lNdVKX8fKIjrcdOgBEHH9JMR9cVYwdPmp1lXORS3zV/QpZAxQVOeOI4oXbdUPx6jfy3tKyrfhLQBXuuA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/helper-explode-assignable-expression": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-rc.1.tgz",
-			"integrity": "sha512-yhZzfcpjoCnZKrJ/ObzpQmaveBictCRoiIciz0FhAY97+J1lx4Zuy+t9ZqGr3pP4U4rV7UOXyuLknbhNkWT0Ew==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-rc.2.tgz",
+			"integrity": "sha512-uQGEgtdTB0XVgYpr/OJ52C/4CIPjED7XO8g8R64Am/RSVY0Ah0/H7ae6TbvW+v9eFbVZSvdm8ODb7sdEfMTCAg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1",
+				"@babel/types": "7.0.0-rc.2",
 				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-rc.1.tgz",
-			"integrity": "sha512-3Z+shHGJTQnc61RCFVrQ3OJRmyL8uk4dWCsP8kT7G4inxv/bs6/zLOipK21VMePGpjUA4tnKxJCevMtp9ko4pw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-rc.2.tgz",
+			"integrity": "sha512-RbPyt1vkOzeCV0Gowma4aLSs3odq3/MLpxC/Qaki7Wjbq4yyNGsUAgO1J7ZB/YYbB11PX5OesA1OVKw03RLOrg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-rc.1",
-				"@babel/traverse": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/helper-hoist-variables": "7.0.0-rc.2",
+				"@babel/traverse": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-rc.1.tgz",
-			"integrity": "sha512-yTn+nj29QrZLCINtgqFLgbrbvz6yM029ox/MpQfSS/JmrQovnEc+o5vrsW/R74QPheOHmF9ruJo58atwuk04Fw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-rc.2.tgz",
+			"integrity": "sha512-fquxtu2DZ1QUpoNoCmw/Bqi5IAyLGCvEanP1/rpOZp+MULe6qnULeGVnR5aftIsi9nTC2XPWEqjb8fANmI6x7w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1",
+				"@babel/helper-function-name": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-rc.1.tgz",
-			"integrity": "sha512-hSa+oxKn9bfbc3Ob1U7QJsO++do2Xe8Ft640alRJpEQ3VWy7tL8ZB+2xqo0pgHKo7rITuSxERz72uZji8dTiWg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-rc.2.tgz",
+			"integrity": "sha512-fEmCM0mYCJNuT4hf7EZ3g1K8/CDeo/Ynl1YkKU8HAa6zBo9Kt+4zicFBLgEYDBLogNLPbjBl+0YqR0Fkr5+WJg==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/traverse": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.1.tgz",
-			"integrity": "sha512-fDbWxdYYbFNzcI5jn3qsPxHI1UCXwvFk0kGytGce/FEBYEPXBqycKknC8Oqiub8DzGtmTcvnqcm/cl/qxzeuiQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.2.tgz",
+			"integrity": "sha512-1frd4Bm/8yfZoAj87tmB6gtQNWtKAzfRzjASVdmsItzq9X13yUlyFLdo6/tNhazftwJO8iIZeadOpi3rNKDXhg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-rc.1",
-				"@babel/template": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/helper-get-function-arity": "7.0.0-rc.2",
+				"@babel/template": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.1.tgz",
-			"integrity": "sha512-5+ydaIRxT42FSDqvoXIDksCGlW1903xC73HQnQCFF1YuV7VcIf+9M4+tRZulLlYlshw7ILA+4SiYsKoDlC0Irg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.2.tgz",
+			"integrity": "sha512-5tjNc0hYngGqBGdjvzN89p92WY6aCntaDv8AadB/xgyUx4VievZwEbz8pc6GKkO6+qfghfZhv1F3+9SC6IA3Eg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-rc.1.tgz",
-			"integrity": "sha512-ttcilOh9SM9eqVlzwz2Lv7B5Dwyaa8TIhi1DDEPnC3CarpNPXFdeCOoxoV5qjHRD1klAT86gczeU4lJnSDKmgA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-rc.2.tgz",
+			"integrity": "sha512-nxLyQK592UW/IOQA04cnheKVr57bIKVeMRjkZp3yWwRtzlVCNABW2AdlP9WPlF+Db7ATcw4vcrpnrelSi7ivBw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-rc.1.tgz",
-			"integrity": "sha512-o263plHxPo1TxDDUx7gHuQ96Y8QyLs2n4968KZvo2l/9rkwn2L9kcIsRVjlhpPPKTz4tWe/7ZV50zkeDorrK9g==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-rc.2.tgz",
+			"integrity": "sha512-8OFFup4az2I+icJL+VPjAIrZZsc7YlS6p8OgC53Nb1JFQ/mvKK8wuHxnNIt63tTIMkBPLRYaZScdij6GpDzCGA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.1.tgz",
-			"integrity": "sha512-eA8RzanjsZw4X2Cqh3WgVG7zwf1wdSUfXvZOH8Azx1rpwE0hzJ276jDZ3gSOJShsxPVvopHa4h+c2WfEUjW4+Q==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.2.tgz",
+			"integrity": "sha512-4HmUjJ7dwnhhTNOoxOxHe9e24nnzd9VjXNXLcKdw98aRxiFQhBxhOk2t8kX2XMcGVJrFHob5zfVEjgMvnkCmHw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1",
-				"lodash": "^4.17.10"
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-rc.1.tgz",
-			"integrity": "sha512-nz7FTFXlQ9UYp/dBjad4ZOu3Q4/1n86ysw9z9pjunqeKFNm+JHq7j5BeocFKIQAwul7QbIkSXiYm5EiteCHjiQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-rc.2.tgz",
+			"integrity": "sha512-tMGTJiSPa3naZNYfhIBF6ma5TfhyWq8PZe5i9ZemreDx4ffToad0MqQ6OW7g0U9S6a3RlZO1639Wc3DQNyvJlw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-rc.1",
-				"@babel/helper-simple-access": "7.0.0-rc.1",
-				"@babel/helper-split-export-declaration": "7.0.0-rc.1",
-				"@babel/template": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1",
+				"@babel/helper-module-imports": "7.0.0-rc.2",
+				"@babel/helper-simple-access": "7.0.0-rc.2",
+				"@babel/helper-split-export-declaration": "7.0.0-rc.2",
+				"@babel/template": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-rc.1.tgz",
-			"integrity": "sha512-XOKPnL/AJz8ZyY553FsMAVt9g/mE1+RQfg5/m3X0K4+RqYviPGZlxwe5mGSd8s2kPSB6D6nZRUfvZFtmFIXEvA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-rc.2.tgz",
+			"integrity": "sha512-O/rWpfst/rKucph1U0Hy8YDwoHBNwAZJqv7rDOp00S7eMYbU8wDYgG43J+mJcYV+2WV2dqoym6j9QdV4xTvEsw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.1.tgz",
-			"integrity": "sha512-8ZNzqHXDhT/JjnBvrLKu8AL7NhONVIsnrfyQNm3PJNmufIER5kcIa3OxPMGWgNqox2R8WeQ6YYzYTLNXqq4kgQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.2.tgz",
+			"integrity": "sha512-kavwJYTgdd5W12MpfMJMznrfsx3sCl0HMSJ0vsPcbwT9jhF0EmYL1eyfeYbo4pToYmQgPKp+VGtSHQ3wL8N5lQ==",
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-rc.1.tgz",
-			"integrity": "sha512-QXnTXVefioGuXlRMn+MnKKUHwhmdXGKnMvFI1tdHioMnBQEbEHGnmp+aYcddLwJ3KAH/hveaSR95BuWwprW+TA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-rc.2.tgz",
+			"integrity": "sha512-QXqgALeUqvEq0+PjWHyOWz4ZTnSs0rXXgNpwhbkud4nXfl7w7CMtCRPOadRDRjJ2kMpQ47jM0unn7mrUnNmYnA==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-rc.1.tgz",
-			"integrity": "sha512-skROQSC2fPwmrzAEPT/M7CObnWjJGpdbNLoICZDYHwDiUDe3dk5cQsU9j3tNlBhX14FaC9SjSpCJnSRpXDOWOw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-rc.2.tgz",
+			"integrity": "sha512-JqxhwM6dK1vCEeGeKqSssjD/yEOo5EophV94lcnutP355UApapzzNnw1hJ08irqYo0nYOqpiMP5uIdBhwxmu5A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-rc.1",
-				"@babel/helper-wrap-function": "7.0.0-rc.1",
-				"@babel/template": "7.0.0-rc.1",
-				"@babel/traverse": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/helper-annotate-as-pure": "7.0.0-rc.2",
+				"@babel/helper-wrap-function": "7.0.0-rc.2",
+				"@babel/template": "7.0.0-rc.2",
+				"@babel/traverse": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-rc.1.tgz",
-			"integrity": "sha512-mcv+NKCazZfdEw7yBe/xROekR3qlFcy18d//mJTKnZb7xx2qFPjZAafkeIlpvzNHwd/WMTHShC4+3WjOL8FD5g==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-rc.2.tgz",
+			"integrity": "sha512-MdMAYjNacQ3pCMNvAs31Nkp4UZTAE9ahMnJvkqIjgB7YgpNFfRI/8BX97SyWKe4qlNrkVxCE6WrY2s9nJBh7uA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "7.0.0-rc.1",
-				"@babel/helper-optimise-call-expression": "7.0.0-rc.1",
-				"@babel/traverse": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/helper-member-expression-to-functions": "7.0.0-rc.2",
+				"@babel/helper-optimise-call-expression": "7.0.0-rc.2",
+				"@babel/traverse": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-rc.1.tgz",
-			"integrity": "sha512-mfrHVSG0Dw51ajyL3Ltz+gEYrWAy4+Kl8lb1V/QWR31H7ovha6vNZ4guev/lR4KFu+4hMHogpjh4HB4AShqeMQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-rc.2.tgz",
+			"integrity": "sha512-Cw5mRtvW1jdmPWD+oLTUX8XkpyftA8AskpaQzuRkxg7dcjAnmXOUYBsccBZ8vTbrxrRzX5WrdRTwbmtx/Q9uNg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1",
-				"lodash": "^4.17.10"
+				"@babel/template": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.1.tgz",
-			"integrity": "sha512-hz6QmlnaBFYt4ra8DfRLCMgrI7yfwQ13kJtufSO5dVCasxmAng2LeeQiT6H4iN5TpFONcayp5f/2mXqHH/zn/g==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.2.tgz",
+			"integrity": "sha512-MBtzTAeZT7MxWETY0JRh5yyIKY4tN/q68BU4/XgzZUaHJ+G74fJUoR7mPO3TbTiwLIEFVBbZQA9AG4yYqe5W2g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-rc.1.tgz",
-			"integrity": "sha512-LrqRD4+jEkQGVQsCRi7bPkSmYFAUd3pv9tYAC8nsr9Y0Qfus8oycqxDj60QW4dmigRKBRRbVVLr/0kMI2pk0MA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-rc.2.tgz",
+			"integrity": "sha512-uq+7oYjrJCDj2cV9ZpxiWzLeLZFmsM8V4lyfGyOIEsv87biGE+UcOb8R0OHnA8Hkq2CpF73pCj7nm3tdhj8k+g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-rc.1",
-				"@babel/template": "7.0.0-rc.1",
-				"@babel/traverse": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/helper-function-name": "7.0.0-rc.2",
+				"@babel/template": "7.0.0-rc.2",
+				"@babel/traverse": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.1.tgz",
-			"integrity": "sha512-4+AkDbZ0Usr7mNH4wGX8fVx4WJzHdrcjRkJy52EIWyBAQEoKqb5HXca1VjejWtnVwaGwW7zk/h6oQ9FQPywQfA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.2.tgz",
+			"integrity": "sha512-X5e6FnKEhS8UtSJfjjkEvY8Mq+W52FES6p55g16gHmVycVrggjwZryQKqK+iMJlus7Dgz6MrrdOtC1SWx4jDDg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.0.0-rc.1",
-				"@babel/traverse": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1"
+				"@babel/template": "7.0.0-rc.2",
+				"@babel/traverse": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
-			"integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
+			"integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
-			},
-			"dependencies": {
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
+				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.1.tgz",
-			"integrity": "sha512-rC+bIz2eZnJlacERmJO25UAbXVZttcSxh0Px0gRGinOTzug5tL7+L9urfIdSWlv1ZzP03+f2xkOFLOxZqSsVmQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.2.tgz",
+			"integrity": "sha512-zDB1QPgQWYwuJty3Ymbx1hq7zbBEbZjTprHOhforvzyQFV86LNh6FS0InjnOUXM6p6QUyONz8KTt/v+MRMd0Hg==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-rc.1.tgz",
-			"integrity": "sha512-ewJnWv10AFUh+Yi6axMVQKW8L1pZCm86a44m2biYtXNSyt6FyWgdRloBbR7iCviPkeurfTCVdPS61G/t5cXVkQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-rc.2.tgz",
+			"integrity": "sha512-t2Cgx5Xwsxn7EBEmmrUWW8g9+12sbYHAPa0kAiiQa/hHTPrxnF9y4Kxsvk2VvAhaFzIFzSNSpq3jJvEQ5K8SWw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-remap-async-to-generator": "7.0.0-rc.1",
-				"@babel/plugin-syntax-async-generators": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-remap-async-to-generator": "7.0.0-rc.2",
+				"@babel/plugin-syntax-async-generators": "7.0.0-rc.2"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0-rc.2.tgz",
+			"integrity": "sha512-VMkSumDfbzHK61VkkIj/+jQBSnW2+iv1Z82aJacgQWF+xiwGmaCr/nrEBjZGi4PuAfFJm9b/35bw3imF3xnzWg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/plugin-syntax-json-strings": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.1.tgz",
-			"integrity": "sha512-J9qLEkxuZrYh/mel9RA5wDrMGE7jQMOMa1XPZMysih4C0mveeQUExbAPyrVSrFQo5BXLcLIc6ccM24G9xPCCXA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.2.tgz",
+			"integrity": "sha512-WYF4Pe5qwxWGfbjacz7XCfjlgI6eDyWhCFoWFeAwGVX+43INjKCMt3S+4AzfBYb2wlRh1omzBpUmgGfq1isYUg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-rc.1.tgz",
-			"integrity": "sha512-mNJULpCOErHPVvnqj2i464uVuWuTTrnJFoT8dYyODCSjHBypdVvEGZx4Rk67etdDMv+iytZTdKDHUXq5JtWCdg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-rc.2.tgz",
+			"integrity": "sha512-s/gOdmc6im0RTIe93FKCCyIFRQy+0BbUQfl7tclpmqU2F9UnjuVBlVqQMyV2HXhlAq5cEoKM5VuVflcndtL1ow==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-rc.1.tgz",
-			"integrity": "sha512-NrUBXqwxnvrhJDzeJ4yOiPDDpPbjVQsydRELHVqzjy+WAOh/cAT4JOmMrQegU/vOjj62LM8S1Kp8wHpDgskTLQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-rc.2.tgz",
+			"integrity": "sha512-nb6BL9jdAi7t7QV9fGj3ttJwhX4kez2rMiqiVeSAL+NOVfmE4dwkMJ4LliN3gg/ESktsEOQeWXv4rik4q9T9Ug==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-regex": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-regex": "7.0.0-rc.2",
 				"regexpu-core": "^4.2.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-rc.1.tgz",
-			"integrity": "sha512-2F5FYc89TCrqE/8+qFlr5jVMTHfkhEOg9JUx+GXI3inW2OfcY+J6bN8EDc8PLz84PHaR8W630YOuh2PveJu3WA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-rc.2.tgz",
+			"integrity": "sha512-ZG9eCI+3RJVYZL/i794SsW0gFXj75nF+Kk14XvhxyvVAiT7DP1z+iMcNckr0dzZ4pvEymVCVxkU++X1dkgQQow==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0-rc.2.tgz",
+			"integrity": "sha512-CvojPyEfHjkwwHJATQe/x7F3xBuaB3wfVkOAvsnvGiLTnUDx2E1kYPsvPGoEfWgdS1zkLGlwtPH621bS3rYKQQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-rc.1.tgz",
-			"integrity": "sha512-n0BcD2LmCrQkDKRhUd7lSiXiRpbo6Z7x77v3FSuevH5oWTFChjX34vHCCOszgVP37NLAxhuf4Jz0KwiPgXnexg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-rc.2.tgz",
+			"integrity": "sha512-iReV06m3hBc/RyD85vtHNNcYz4wqf0jPUFzUR+yAkzbhupYclHf6Eecse3GMWSNS3sVNMDA/+hCFcgMni41Dwg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.1.tgz",
-			"integrity": "sha512-stOESgG+lc68DSFvXrqoH5dW91ZtedDoR40g9wJ1ruLahCdr9X5hVLv/ddf/g/1zzjevq59A1Q+xdUREhEnrvQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.2.tgz",
+			"integrity": "sha512-TcwJSyWkA5ruAuWhJvmj7N9gmiHTGAz44Rqr6Fgkf6fhdlEYcBHRQQvYEKcYyPLLpqgWCqFvfiW7HgfqkCCe3A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-rc.1.tgz",
-			"integrity": "sha512-e4dGUnZGhg1LWTvyQ6/m8nKZ9bUrtPwl9M487CEVhTA5lVUvYxASHBCEtkVWPwT16NzcWlFR/PghsHeLFGIw7A==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-rc.2.tgz",
+			"integrity": "sha512-uZyLBqAFX4142Thord85PcTxD3nTiQE+0BiBL1rHMGc7ln63Auj/EJoWdYa9reb7Bax7OcuwY1lhDbxrgKUYiA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-rc.1.tgz",
-			"integrity": "sha512-9JnWkl+iKmjNgMFrLjfGJQm3f66SJxwaYjdsm49Vpvo9x7ADHMGMZYa5Yto9WNQBlIdtf+fhypwBcz6IPxdyvg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-rc.2.tgz",
+			"integrity": "sha512-wCZZpEfjPBiO7kRLzLLxcaImgHzlrJKjl5pHpTbng+btsCb53hNgE0dm8ph/YRRHv0NdGej0Mo3+kKNJHARjYg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-rc.1.tgz",
-			"integrity": "sha512-8oE9Frx07ILINop9hOejXgcDVhmt4FuB3ZjXnIMcSMkAuiT3xLrxFMDo1Qo0kf5mty2jLlnOO6tbbH0kiIWxWA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-rc.2.tgz",
+			"integrity": "sha512-NIRF0AbXilqtr8VuTNqhQUgKGeOVu2AosUxJxAQ0e0NaxnNMRWdVTVj4p/Pl1FuSuA5oftDbSGeQYi3VOFktpg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-remap-async-to-generator": "7.0.0-rc.1"
+				"@babel/helper-module-imports": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-remap-async-to-generator": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-rc.1.tgz",
-			"integrity": "sha512-dFEgZqmyWXaVYrFU11IgLX8M1+gK7GSU+CVRv42D7P1FFMNndg1u36jXIa7URExEuTeTUykLM/IWgk5pHWxo6A==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-rc.2.tgz",
+			"integrity": "sha512-l2vetC7pegLd1yhDf0uMQsHpACTqBHqiVB5TaMpiGk7Ixz5qS5R4IXdl2hoSAi6ytAAs7VPRtsWrLqfXgjWYwQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-rc.1.tgz",
-			"integrity": "sha512-9uGwvSqJcmcKPEkLHA7ffrG0lKXTXprupwGjEKDw27OoRWXHdWUmA4VwpuzMrUsYyV+q+P6mgj6TPzoGJA3fAw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-rc.2.tgz",
+			"integrity": "sha512-bJ8717eZ0Y3oY8t5qnCS0f9AQd6aDt5gJiNjqtEYs9OZkwxKfcadnRuIiC49UdfrgbNqVPbXHz/y6ueJiLtheA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-rc.1.tgz",
-			"integrity": "sha512-mPXMbQR8zNHMXvaJ71wQ7iPcQLHPv12XjWwvYkDjtsEvknDQ2HWA+UYZGVpZ0bv3jLQIZuwc1kZ6f5vSsavvog==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-rc.2.tgz",
+			"integrity": "sha512-VGLIza5QhmNBuSQ7wRYl5vSjjb1jdYIJcJsJ7Kgv5QvAasFbjjVAhqiv3/LJae7IJqetjNYN9V+2Bec64399tw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-rc.1",
-				"@babel/helper-define-map": "7.0.0-rc.1",
-				"@babel/helper-function-name": "7.0.0-rc.1",
-				"@babel/helper-optimise-call-expression": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-replace-supers": "7.0.0-rc.1",
-				"@babel/helper-split-export-declaration": "7.0.0-rc.1",
+				"@babel/helper-annotate-as-pure": "7.0.0-rc.2",
+				"@babel/helper-define-map": "7.0.0-rc.2",
+				"@babel/helper-function-name": "7.0.0-rc.2",
+				"@babel/helper-optimise-call-expression": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-replace-supers": "7.0.0-rc.2",
+				"@babel/helper-split-export-declaration": "7.0.0-rc.2",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-rc.1.tgz",
-			"integrity": "sha512-dfJNqbyF6S8nvFzGc6NthqCqopn1PoY3q2E1KcgrFSgxwYAMOLuhu5eA5iFeXwggp6tIo6OVVXC55/Twsolmow==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-rc.2.tgz",
+			"integrity": "sha512-XZMHsEAM0KRcvEWHIO/5r8kUrPTFlb4oSKf771dlfA7Hfg60YFY8S4UDGmL6Fw5qBn1j0E9pbDoJ5V/MVeU7hA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-rc.1.tgz",
-			"integrity": "sha512-YpuGA3cj5+gRD053nWtogo+3wxc10mNAAyf5syXXCVS/cOWpRjc3qPidzHtPodz+v8TgAwwaXwIz/ghLOojRQw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-rc.2.tgz",
+			"integrity": "sha512-fmtP2ZOtXQGv2ncSZtGzWL/cz5aevgKjvVrdz9t3dPHkyX2CTDBdtJWNds6XLFPkWuN4ayjCbVp7z70Pl98dMg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-rc.1.tgz",
-			"integrity": "sha512-6G62wnwVWCjhvmWmWatXHO4wfvWhUL1bJX0MABYIf1bpD5ROFly/HxgWkuMVcTSeIuLzsfsYKSF1CMUI0bykXw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-rc.2.tgz",
+			"integrity": "sha512-BCeZNoleLez7Rg0+iLKK+dqCJDGufKUPISRZr8e6NvSjwwRvovQuNMtdj4Dxww9Xk8zz0e9eKyf2Dt/h9CyECQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-regex": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-regex": "7.0.0-rc.2",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-rc.1.tgz",
-			"integrity": "sha512-cWyoUi1izJk5JbWFG07GZrZyZgG+DW4axPKI0MA+lSAxjP8VZwFUhJyjT7R4bGN81KTVv1aprKclQnKxN2R0Lw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-rc.2.tgz",
+			"integrity": "sha512-CeEHFlCgeZAb57buALjNFmOYgfblKuQBK2ti09nk2PkhJE3+uf1LbCrLra9sU90lOl474AinQqwkmYyogmkjkw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-rc.1.tgz",
-			"integrity": "sha512-5lc0nlX8TPdkHSIX3/3jMtqvvJfzcARcev4qqsaVkXWQ6XNrNnD8ExyTEVgoGhr5Ppz1wA0ymAK8W33uGeKSOg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-rc.2.tgz",
+			"integrity": "sha512-VnotPddF7jLAQK6QgBNNwzhPUsxxullq+BEFaDKi1zvXnNGqOcgJ+fmemrdfGUoZWV82Zv2aRehwswPkxPcK2w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-rc.1.tgz",
-			"integrity": "sha512-v09o2ywKHu+b/vkLknjKPV9QXCxuU2cVFxkWhBqcKwl3ERe3clhiab7a/8T9Sc332o4Im6n/LLugKMtpfxqRsQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-rc.2.tgz",
+			"integrity": "sha512-6alRFzRGQEYlsYsm/WCOZ3+XND9f+/Pj0wkM4+uWPy7lmYoUHLVESGYJc8wFXjk/diNYzjowrx9JZn6sn6lXNw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-rc.1.tgz",
-			"integrity": "sha512-MiUORPQo3kvSCYBn/T6kKIfdDKqFAnEsaiRnTz36Y6M/p6NX7br5MgqPumVNgDboYKQ9kzaFNM8YJvWLcjL6SQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-rc.2.tgz",
+			"integrity": "sha512-UmP+TGefcAAakV54Gs1RPwt0WCD1MogSMlWjEjJXUCrjvWlGGUIlcz5YR2bxtvPHBv3anpt9fxS1LZb0fjd2Mw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-function-name": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-rc.1.tgz",
-			"integrity": "sha512-iI468X7shsmB/oIPi8+UfMcOpcQPEsMAz5hDc0H8dKBGUWbPcAlyQpC8CaNDZ7y1/7lK65wtvXs5OGTQd3OsJg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-rc.2.tgz",
+			"integrity": "sha512-lW0hoPqS4WhYgSQ0ifNk1tHn+e4OateqWXaM7BW7wZEU0dtP+RQ0x4z5Xghc7u82ZA4IwPN7mS1i201I7eT+dw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-rc.1.tgz",
-			"integrity": "sha512-xKIF2ZAFOZRgIhEeW6zuyieyqfjft59NaHvb2C7+N9omdFDVkrx5ZeHVLb8y163a3mUb2MqJg1PLfZXdwvz1EA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-rc.2.tgz",
+			"integrity": "sha512-phr4bjRHDvLv3OK4g0NvT998A19kmqZKMrnOFZC5gvIEvdGCa18y9Y2mZPg2Jxi+tKI1lkh248L0puLUsEtwfw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-module-transforms": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-rc.1.tgz",
-			"integrity": "sha512-G2Y2HwdUVSR+6V1g5q7D6hLm6HQ5f0HJ4TeYzPDIwKj3Ij3djyJ1lrFRtMRxanclcRy/N01sVe0z31m8Dslmzw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-rc.2.tgz",
+			"integrity": "sha512-GWwKVT/vqQ9jSXmLPDZXPJkhuJRKyfE+SZkeM8D9EwcZYpy9DLiKFHyLbw5vKW0wHOwovbeD9/0pvPASuT2rAg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-simple-access": "7.0.0-rc.1"
+				"@babel/helper-module-transforms": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-simple-access": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-rc.1.tgz",
-			"integrity": "sha512-denli1X4utH2boaedaCv3uDmrmBH0CMioIswTxViNY4M8nti3DV1m7wfKE4kDYq8UrIILLYwxxOsAvGxOS9/Ug==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-rc.2.tgz",
+			"integrity": "sha512-uIDk/4+OzSSrW9whicWupSfcfDixWUxppUCkPEHBA3UKMNSo7ageneh+35rWKDvZh3f+DrgJxbDfyolFBsr7kg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-hoist-variables": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-rc.1.tgz",
-			"integrity": "sha512-wvhxd77dRxyQGSEqfSRfe6dEBDy7Q13MaC1RKLX2H4+SQKZPvGuNr0BS0CEJ3Fm3uSEZ7potTBfRO4YNAygjXg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-rc.2.tgz",
+			"integrity": "sha512-4gnDpcZ8/F9eoYZlQKAvh5wzax3UQFmZEBMKJabl133iTLb0aXkd+yVJGmn7Vu/+Q8wRH4kkH6Kc2pbsvlbnHQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-module-transforms": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-rc.1.tgz",
-			"integrity": "sha512-mI10u9cgVpTjJllgISn6SmM2H/3X1osvmgT/4sjQjYARGgEfG9khrxtI74IBRhRhtBF9VBgwhah6sYAym+aghw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-rc.2.tgz",
+			"integrity": "sha512-eZR2hgV0rIDAQIYHihqxbGaGNaci7HIOEcpgN207ytlKr0ynw8QFPLGHcu2HNJ3zPF08LltjlfREqttFbdnYzA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-rc.1.tgz",
-			"integrity": "sha512-mwoid0Rx+L55NupRE9xs1JAgFRz0JIYS/JR0aqBlLOQwBY1KrbrAtQfNwHQobwZrP9O24VBRfViMsiYLh/UV4A==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-rc.2.tgz",
+			"integrity": "sha512-VuV9E57/MQLLw5uQ1fiVhyC25gTTa+rNUVz6DEzInIV81VFm1KM0U5/b3FgTqtLMMHp/dFDExqwkHjmvlWpdzw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-replace-supers": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-replace-supers": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-rc.1.tgz",
-			"integrity": "sha512-PKjm+xf23XvdP0WRj/fIiP3xa5DYOg6qd0150Mpu4JvCIci6vrWvkc+kU9RtwkXLycWRfzdSnnyuSZABxPAP8A==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-rc.2.tgz",
+			"integrity": "sha512-jjl/rEU3LAHPWdlNokNex0sOZ6ytEw8+f1tvSZCGuSzmqGZbMreLOLB1HFSKRCsu6zsQNYY/in2h11fgQU40yQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "7.0.0-rc.1",
-				"@babel/helper-get-function-arity": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-call-delegate": "7.0.0-rc.2",
+				"@babel/helper-get-function-arity": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-rc.1.tgz",
-			"integrity": "sha512-lGSDCkRp8/2JMu0vBeayMLF2xLSiD1n9KZFH+zRSLtrvdNJFhifmzHJ9dYYBcDY7qDQayEpj/Ze9UpyxaU+oSA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-rc.2.tgz",
+			"integrity": "sha512-lxGw4nT8AO0QVdmGdWzi35rZxkTp10+igJZXnp37X7BYTWzap/gayBCvchIT21k1noUowgJoeURPoAFCyIk8kQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/plugin-syntax-jsx": "7.0.0-rc.1"
+				"@babel/helper-builder-react-jsx": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/plugin-syntax-jsx": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-rc.1.tgz",
-			"integrity": "sha512-a73XZOJGt0Ft8/YbRAUl0Vs1GuPpjB6QVQNYPxWUNXblSiywhkkZxLssHZnao2xTD26kLRfMoXfOtj9FMz5fcw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-rc.2.tgz",
+			"integrity": "sha512-t4d/kBjxwLgmLWwI/Kz9CnO4z8rsiQ5dS3EYgGRua4VGkczde6m3jpzZx0+7b6iw+frGI12W27V50D5Ruv5juw==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-rc.1.tgz",
-			"integrity": "sha512-Tmg0jYdu/Bn0r8iQpQXNmybenq65ci8z/ReMO+IR5CBtnhEYBYtIPxZgvmwZFbggLm1MJ/oRdDRmRl4a/G8QEw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-rc.2.tgz",
+			"integrity": "sha512-8zpYlgNvTIaFBmCnWWD5kAqk19vTQYXm6IrE+hZsWuvA4hPdvU6BTJ29R+5iY3NkNkQIq3BHZgc+PkTyv/mm0A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-module-imports": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"resolve": "^1.8.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-rc.1.tgz",
-			"integrity": "sha512-NkUsTSKL8txvPt9vtdkcbJEyiUtcSOAr6ZnAE+Vg4mB0hYI0sWEJCAzl26KDDFgdVSKJSAaenjX5UR3BAF3KaA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-rc.2.tgz",
+			"integrity": "sha512-IKkCwaGhfgRTGFrGKCqQmPFm7Z+y4hfzWPgctZNhZFtjPN0Y6B+ixaX7Ey0aFEIq6K+2cAIMiZTJbDflQEb0Fg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-rc.1.tgz",
-			"integrity": "sha512-/3EkUVVi55i/JCbL2CxXTaoCXCopj3qQMTZ0lvgtpepx1yAMpoHYFBNWLIuQmjG7JhDauOwEdBg8TRsneYRmmw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-rc.2.tgz",
+			"integrity": "sha512-Xmw5FxsvrxHv94j9i54IfIpbNbaGC4TpokMmMjuqdgeezCEZkCFUolqydhgDKgxCg5pqKDh6oDistJIJ/8RLMA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-rc.1.tgz",
-			"integrity": "sha512-sXPFGI3GTtSMxVTDwrRmgwmUcq+l0ovzUZFfAd4YK1zJQ7YQCaCjcmLskuiGM20SoteYserDADg0SrLw+8B8hA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-rc.2.tgz",
+			"integrity": "sha512-//QPQAuZE6BqOkZNqr2GLfBE0gssKucez91+4wX3f4x0QN9lsMD6fLN5mymnVGWw7FKlM3XuPYEF8syqqJD4Dw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-regex": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-regex": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-rc.1.tgz",
-			"integrity": "sha512-xq9eSNA65VXbMmVEjKUXB0czP8y/CRs88S8HcwZbJ7XGo4FARUJV3aGQfIPvGUmbkQegsxZx5rlTPlw3NPl+Aw==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-rc.2.tgz",
+			"integrity": "sha512-6ICqvslFDU6S+zggiF73e9chbb1MicgPMFgnjo3QikfKe0aolOfyoKTcBNRRXywnZr+ILUcY44zkF3jI3mr2Fw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-annotate-as-pure": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-rc.1.tgz",
-			"integrity": "sha512-wUKNscuv3WOOFy3tGOBeayeOLyZjixjOSvb0QNXrCDRuENhfPaFQjZt/T0UDAZN0mXvAQ7Ksx2pOtXBsyIBxUA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-rc.2.tgz",
+			"integrity": "sha512-nL5PV6/VjuBreNsaJm00RzdIuC8ITK1O++WFwlZLOen5CPNSFmpOqP84J088hGk3tU9Iw5x4ETEzYHrf/5/72g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1"
+				"@babel/helper-plugin-utils": "7.0.0-rc.2"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-rc.1.tgz",
-			"integrity": "sha512-3yz7ehk0VFLqoKVV1GbTdH2sfMtYznhllkBDtnybveM6MeFA5WYCf6iWf+I/vF/8QIMDd1b4359GGWKCI+KuIQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-rc.2.tgz",
+			"integrity": "sha512-C+28QnIFb8jmw1NegaOtVxnZpBz748h/zsxmAq+uP9J8yGXLA7LtKrFLi00Ky+554BCnqf8Ftp5Fd3NaYpPOOQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/helper-regex": "7.0.0-rc.1",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/helper-regex": "7.0.0-rc.2",
 				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-rc.1.tgz",
-			"integrity": "sha512-c1mn7dKMBnkcS9Se9cuB5K2PAN48I0/mFXIA/ARyu7dHnLxiteSL0wyQukVp4NenKqFlAtPFx5ZtgWEMjaYmbg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-rc.2.tgz",
+			"integrity": "sha512-R9Jwm67dPSjlIJmI85hhRsI+JvHCBQLmDwkpo8URCGZ9YxoMgB2Xz3w0fN8x81adIKWZ0/JZaB1m4KWy56qg1g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-rc.1",
-				"@babel/helper-plugin-utils": "7.0.0-rc.1",
-				"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
-				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-rc.1",
-				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-rc.1",
-				"@babel/plugin-syntax-async-generators": "7.0.0-rc.1",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.1",
-				"@babel/plugin-transform-arrow-functions": "7.0.0-rc.1",
-				"@babel/plugin-transform-async-to-generator": "7.0.0-rc.1",
-				"@babel/plugin-transform-block-scoped-functions": "7.0.0-rc.1",
-				"@babel/plugin-transform-block-scoping": "7.0.0-rc.1",
-				"@babel/plugin-transform-classes": "7.0.0-rc.1",
-				"@babel/plugin-transform-computed-properties": "7.0.0-rc.1",
-				"@babel/plugin-transform-destructuring": "7.0.0-rc.1",
-				"@babel/plugin-transform-dotall-regex": "7.0.0-rc.1",
-				"@babel/plugin-transform-duplicate-keys": "7.0.0-rc.1",
-				"@babel/plugin-transform-exponentiation-operator": "7.0.0-rc.1",
-				"@babel/plugin-transform-for-of": "7.0.0-rc.1",
-				"@babel/plugin-transform-function-name": "7.0.0-rc.1",
-				"@babel/plugin-transform-literals": "7.0.0-rc.1",
-				"@babel/plugin-transform-modules-amd": "7.0.0-rc.1",
-				"@babel/plugin-transform-modules-commonjs": "7.0.0-rc.1",
-				"@babel/plugin-transform-modules-systemjs": "7.0.0-rc.1",
-				"@babel/plugin-transform-modules-umd": "7.0.0-rc.1",
-				"@babel/plugin-transform-new-target": "7.0.0-rc.1",
-				"@babel/plugin-transform-object-super": "7.0.0-rc.1",
-				"@babel/plugin-transform-parameters": "7.0.0-rc.1",
-				"@babel/plugin-transform-regenerator": "7.0.0-rc.1",
-				"@babel/plugin-transform-shorthand-properties": "7.0.0-rc.1",
-				"@babel/plugin-transform-spread": "7.0.0-rc.1",
-				"@babel/plugin-transform-sticky-regex": "7.0.0-rc.1",
-				"@babel/plugin-transform-template-literals": "7.0.0-rc.1",
-				"@babel/plugin-transform-typeof-symbol": "7.0.0-rc.1",
-				"@babel/plugin-transform-unicode-regex": "7.0.0-rc.1",
+				"@babel/helper-module-imports": "7.0.0-rc.2",
+				"@babel/helper-plugin-utils": "7.0.0-rc.2",
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.2",
+				"@babel/plugin-proposal-json-strings": "7.0.0-rc.2",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.2",
+				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-rc.2",
+				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-rc.2",
+				"@babel/plugin-syntax-async-generators": "7.0.0-rc.2",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.2",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.2",
+				"@babel/plugin-transform-arrow-functions": "7.0.0-rc.2",
+				"@babel/plugin-transform-async-to-generator": "7.0.0-rc.2",
+				"@babel/plugin-transform-block-scoped-functions": "7.0.0-rc.2",
+				"@babel/plugin-transform-block-scoping": "7.0.0-rc.2",
+				"@babel/plugin-transform-classes": "7.0.0-rc.2",
+				"@babel/plugin-transform-computed-properties": "7.0.0-rc.2",
+				"@babel/plugin-transform-destructuring": "7.0.0-rc.2",
+				"@babel/plugin-transform-dotall-regex": "7.0.0-rc.2",
+				"@babel/plugin-transform-duplicate-keys": "7.0.0-rc.2",
+				"@babel/plugin-transform-exponentiation-operator": "7.0.0-rc.2",
+				"@babel/plugin-transform-for-of": "7.0.0-rc.2",
+				"@babel/plugin-transform-function-name": "7.0.0-rc.2",
+				"@babel/plugin-transform-literals": "7.0.0-rc.2",
+				"@babel/plugin-transform-modules-amd": "7.0.0-rc.2",
+				"@babel/plugin-transform-modules-commonjs": "7.0.0-rc.2",
+				"@babel/plugin-transform-modules-systemjs": "7.0.0-rc.2",
+				"@babel/plugin-transform-modules-umd": "7.0.0-rc.2",
+				"@babel/plugin-transform-new-target": "7.0.0-rc.2",
+				"@babel/plugin-transform-object-super": "7.0.0-rc.2",
+				"@babel/plugin-transform-parameters": "7.0.0-rc.2",
+				"@babel/plugin-transform-regenerator": "7.0.0-rc.2",
+				"@babel/plugin-transform-shorthand-properties": "7.0.0-rc.2",
+				"@babel/plugin-transform-spread": "7.0.0-rc.2",
+				"@babel/plugin-transform-sticky-regex": "7.0.0-rc.2",
+				"@babel/plugin-transform-template-literals": "7.0.0-rc.2",
+				"@babel/plugin-transform-typeof-symbol": "7.0.0-rc.2",
+				"@babel/plugin-transform-unicode-regex": "7.0.0-rc.2",
 				"browserslist": "^3.0.0",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
 				"semver": "^5.3.0"
 			}
 		},
+		"@babel/runtime": {
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-rc.2.tgz",
+			"integrity": "sha512-QugZtHk0uVHqHmgwNn2f2uOtTwXWPBBZVSH2EFRm9iw1fFmi5fm46ye6NSVSiXT9Ymejh7fKIw3riCv23SNtSQ==",
+			"requires": {
+				"regenerator-runtime": "^0.12.0"
+			}
+		},
 		"@babel/runtime-corejs2": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-rc.1.tgz",
-			"integrity": "sha512-2QWAvXXu7r0zmgrXExWXnXh7vuarvjgsDB9qL4hN925dSRrrFZWXjiIQ+LB14753shjZkZ+4xLEJrO9hBKGwRA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-rc.2.tgz",
+			"integrity": "sha512-WjHH8Zi6h8laPiNjX08rOWUvn3QoeMp4wba8dKwWelQv4812jvoqRtbxqM5ieeRgUmjVVBKXmZf+AzlCyPu27A==",
 			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
@@ -715,38 +734,37 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.1.tgz",
-			"integrity": "sha512-gPLng2iedNlkaGD0UdwaUByQXK8k4bnaoq2RH5JgR2mqHvh2RyjkDdaMbZFlSss1Iu8+PrXwbIRworTl8iRqbA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.2.tgz",
+			"integrity": "sha512-CryGZ01Nko2/g8gkYiiPc7x9ZinrX59/BTWMZV1sDj5cAeia64vhyNnXTcNeim885IdGOdYyia1PNBWKnFxuSw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-rc.1",
-				"@babel/parser": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1",
-				"lodash": "^4.17.10"
+				"@babel/code-frame": "7.0.0-rc.2",
+				"@babel/parser": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.1.tgz",
-			"integrity": "sha512-lNOpJ5xzakg+fCobQQHdeDRYeN54b+bAZpeTYMeeYPAvN+hTldg9/FSNKYEMRs5EWoQ0Yt74gwq98InSORdSDQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.2.tgz",
+			"integrity": "sha512-x8y9E+KZHs3Xmy5uiYmr1TtDhOBAZnL9vUtLIt95Pw3jovkY9q2NIwgLzfSlzOU83sQvzAooZWuJ65JERwxx+Q==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-rc.1",
-				"@babel/generator": "7.0.0-rc.1",
-				"@babel/helper-function-name": "7.0.0-rc.1",
-				"@babel/helper-split-export-declaration": "7.0.0-rc.1",
-				"@babel/parser": "7.0.0-rc.1",
-				"@babel/types": "7.0.0-rc.1",
+				"@babel/code-frame": "7.0.0-rc.2",
+				"@babel/generator": "7.0.0-rc.2",
+				"@babel/helper-function-name": "7.0.0-rc.2",
+				"@babel/helper-split-export-declaration": "7.0.0-rc.2",
+				"@babel/parser": "7.0.0-rc.2",
+				"@babel/types": "7.0.0-rc.2",
 				"debug": "^3.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.1.tgz",
-			"integrity": "sha512-MBwO1JQKin9BwKTGydrYe4VDJbStCUy35IhJzeZt3FByOdx/q3CYaqMRrH70qVD2RA7+Xk8e3RN0mzKZkYBYuQ==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.2.tgz",
+			"integrity": "sha512-I2SMGD8bUX7sysOwGM8TcwCoaHiOx2YWZmT9h5oAncsPQ9Wy068yJneCF4vkOGTCzPFIETPDR5i3EIEm5QgMFg==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -1946,14 +1964,14 @@
 		"@wordpress/a11y": {
 			"version": "file:packages/a11y",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/dom-ready": "file:packages/dom-ready"
 			}
 		},
 		"@wordpress/api-fetch": {
 			"version": "file:packages/api-fetch",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n"
 			}
@@ -1961,21 +1979,21 @@
 		"@wordpress/autop": {
 			"version": "file:packages/autop",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1"
+				"@babel/runtime": "7.0.0-rc.2"
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "file:packages/babel-plugin-import-jsx-pragma",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1"
+				"@babel/runtime": "7.0.0-rc.2"
 			}
 		},
 		"@wordpress/babel-plugin-makepot": {
 			"version": "file:packages/babel-plugin-makepot",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.10"
 			}
@@ -1984,12 +2002,12 @@
 			"version": "file:packages/babel-preset-default",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
-				"@babel/plugin-transform-react-jsx": "7.0.0-rc.1",
-				"@babel/plugin-transform-runtime": "7.0.0-rc.1",
-				"@babel/preset-env": "7.0.0-rc.1",
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.2",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.2",
+				"@babel/plugin-transform-react-jsx": "7.0.0-rc.2",
+				"@babel/plugin-transform-runtime": "7.0.0-rc.2",
+				"@babel/preset-env": "7.0.0-rc.2",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"babel-core": "^7.0.0-bridge.0"
 			}
@@ -1997,13 +2015,13 @@
 		"@wordpress/blob": {
 			"version": "file:packages/blob",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1"
+				"@babel/runtime": "7.0.0-rc.2"
 			}
 		},
 		"@wordpress/block-library": {
 			"version": "file:packages/block-library",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/blocks": "file:packages/blocks",
@@ -2034,7 +2052,7 @@
 		"@wordpress/blocks": {
 			"version": "file:packages/blocks",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-spec-parser": "file:packages/block-serialization-spec-parser",
@@ -2063,7 +2081,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/compose": "file:packages/compose",
@@ -2365,7 +2383,7 @@
 		"@wordpress/compose": {
 			"version": "file:packages/compose",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10"
@@ -2374,7 +2392,7 @@
 		"@wordpress/core-data": {
 			"version": "file:packages/core-data",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/url": "file:packages/url",
@@ -2387,14 +2405,14 @@
 			"version": "file:packages/custom-templated-path-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"@wordpress/data": {
 			"version": "file:packages/data",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
@@ -2407,7 +2425,7 @@
 		"@wordpress/date": {
 			"version": "file:packages/date",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.16"
 			}
@@ -2415,14 +2433,14 @@
 		"@wordpress/deprecated": {
 			"version": "file:packages/deprecated",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/hooks": "file:packages/hooks"
 			}
 		},
 		"@wordpress/dom": {
 			"version": "file:packages/dom",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"element-closest": "^2.0.2",
 				"lodash": "^4.17.10"
 			}
@@ -2430,13 +2448,13 @@
 		"@wordpress/dom-ready": {
 			"version": "file:packages/dom-ready",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1"
+				"@babel/runtime": "7.0.0-rc.2"
 			}
 		},
 		"@wordpress/editor": {
 			"version": "file:packages/editor",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blob": "file:packages/blob",
@@ -2477,7 +2495,7 @@
 		"@wordpress/element": {
 			"version": "file:packages/element",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"lodash": "^4.17.10",
 				"react": "^16.4.1",
 				"react-dom": "^16.4.1"
@@ -2496,19 +2514,19 @@
 		"@wordpress/hooks": {
 			"version": "file:packages/hooks",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1"
+				"@babel/runtime": "7.0.0-rc.2"
 			}
 		},
 		"@wordpress/html-entities": {
 			"version": "file:packages/html-entities",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1"
+				"@babel/runtime": "7.0.0-rc.2"
 			}
 		},
 		"@wordpress/i18n": {
 			"version": "file:packages/i18n",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"gettext-parser": "^1.3.1",
 				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
@@ -2518,14 +2536,14 @@
 		"@wordpress/is-shallow-equal": {
 			"version": "file:packages/is-shallow-equal",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1"
+				"@babel/runtime": "7.0.0-rc.2"
 			}
 		},
 		"@wordpress/jest-console": {
 			"version": "file:packages/jest-console",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"jest-matcher-utils": "^22.4.3",
 				"lodash": "^4.17.10"
 			}
@@ -2544,7 +2562,7 @@
 		"@wordpress/keycodes": {
 			"version": "file:packages/keycodes",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -2552,7 +2570,7 @@
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"lodash": "^4.17.10",
 				"webpack-sources": "^1.1.0"
 			}
@@ -2564,7 +2582,7 @@
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
@@ -2577,7 +2595,7 @@
 		"@wordpress/plugins": {
 			"version": "file:packages/plugins",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
@@ -2588,14 +2606,14 @@
 			"version": "file:packages/postcss-themes",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"postcss": "^6.0.16"
 			}
 		},
 		"@wordpress/redux-routine": {
 			"version": "file:packages/redux-routine",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1"
+				"@babel/runtime": "7.0.0-rc.2"
 			},
 			"dependencies": {
 				"js-tokens": {
@@ -2641,28 +2659,28 @@
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@wordpress/token-list": {
 			"version": "file:packages/token-list",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"lodash": "^4.17.10"
 			}
 		},
 		"@wordpress/url": {
 			"version": "file:packages/url",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"qs": "^6.5.2s"
 			}
 		},
 		"@wordpress/viewport": {
 			"version": "file:packages/viewport",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
@@ -2672,7 +2690,7 @@
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
-				"@babel/runtime": "7.0.0-rc.1",
+				"@babel/runtime": "7.0.0-rc.2",
 				"lodash": "^4.17.10"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-rc.2",
-		"@babel/runtime-corejs2": "7.0.0-rc.2",
+		"@babel/core": "^7.0.0",
+		"@babel/runtime-corejs2": "^7.0.0",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
@@ -72,8 +72,8 @@
 		"@wordpress/postcss-themes": "file:packages/postcss-themes",
 		"@wordpress/scripts": "file:packages/scripts",
 		"autoprefixer": "8.2.0",
-		"babel-eslint": "8.0.3",
-		"babel-loader": "8.0.0-beta.4",
+		"babel-eslint": "8.0.1",
+		"babel-loader": "8.0.0",
 		"chalk": "2.4.1",
 		"check-node-version": "3.1.1",
 		"codecov": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-rc.1",
-		"@babel/runtime-corejs2": "7.0.0-rc.1",
+		"@babel/core": "7.0.0-rc.2",
+		"@babel/runtime-corejs2": "7.0.0-rc.2",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.0.0",
-		"@babel/runtime-corejs2": "^7.0.0",
+		"@babel/core": "7.0.0",
+		"@babel/runtime-corejs2": "7.0.0",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
@@ -72,7 +72,7 @@
 		"@wordpress/postcss-themes": "file:packages/postcss-themes",
 		"@wordpress/scripts": "file:packages/scripts",
 		"autoprefixer": "8.2.0",
-		"babel-eslint": "8.0.1",
+		"babel-eslint": "8.0.3",
 		"babel-loader": "8.0.0",
 		"chalk": "2.4.1",
 		"check-node-version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-beta.56",
+		"@babel/core": "7.0.0-rc.1",
+		"@babel/runtime-corejs2": "7.0.0-rc.1",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",

--- a/packages/a11y/CHANGELOG.md
+++ b/packages/a11y/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (Unreleased)
+
+### Breaking Change
+
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+
 ## 1.1.0 (2018-07-12)
 
 ### New feature

--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/a11y --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## speak
 
 Allows you to easily announce dynamic interface updates to screen readers using ARIA live regions. This module is inspired by the `speak` function in wp-a11y.js

--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/a11y --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## speak
 

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/dom-ready": "file:../dom-ready"
 	},
 	"publishConfig": {

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/dom-ready": "file:../dom-ready"
 	},
 	"publishConfig": {

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/dom-ready": "file:../dom-ready"
 	},
 	"publishConfig": {

--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/api-fetch --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 ```js

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/api-fetch --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n"
 	},

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n"
 	},

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n"
 	},

--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (Unreleased)
+
+### Breaking Change
+
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+
 ## 1.1.0 (2018-07-12)
 
 ### New Feature

--- a/packages/autop/README.md
+++ b/packages/autop/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/autop --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ### Usage
 

--- a/packages/autop/README.md
+++ b/packages/autop/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/autop --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ### Usage
 
 Import the desired function(s) from `@wordpress/autop`:

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime": "7.0.0-rc.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1"
+		"@babel/runtime": "7.0.0-rc.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2"
+		"@babel/runtime": "^7.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.1.0 (Unreleased)
+
+### New Feature
+
+- Plugin updated to work with the stable version of Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -26,14 +26,14 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime": "7.0.0-rc.1"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-beta.56",
-		"@babel/plugin-syntax-jsx": "7.0.0-beta.56"
+		"@babel/core": "7.0.0-rc.1",
+		"@babel/plugin-syntax-jsx": "7.0.0-rc.1"
 	},
 	"peerDependencies": {
-		"@babel/core": "7.0.0-beta.56"
+		"@babel/core": "7.0.0-rc.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -26,14 +26,14 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1"
+		"@babel/runtime": "7.0.0-rc.2"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-rc.1",
-		"@babel/plugin-syntax-jsx": "7.0.0-rc.1"
+		"@babel/core": "7.0.0-rc.2",
+		"@babel/plugin-syntax-jsx": "7.0.0-rc.2"
 	},
 	"peerDependencies": {
-		"@babel/core": "7.0.0-rc.1"
+		"@babel/core": "7.0.0-rc.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -26,14 +26,14 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2"
+		"@babel/runtime": "^7.0.0"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-rc.2",
-		"@babel/plugin-syntax-jsx": "7.0.0-rc.2"
+		"@babel/core": "^7.0.0",
+		"@babel/plugin-syntax-jsx": "^7.0.0"
 	},
 	"peerDependencies": {
-		"@babel/core": "7.0.0-rc.2"
+		"@babel/core": "^7.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-makepot/CHANGELOG.md
+++ b/packages/babel-plugin-makepot/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (Unreleased)
+
+### New Feature
+
+- Plugin updated to work with the stable version of Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).
+
 ## 2.0.0 (2018-07-12)
 
 ### Breaking Change

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -25,16 +25,16 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-beta.56",
-		"@babel/traverse": "7.0.0-beta.56"
+		"@babel/core": "7.0.0-rc.1",
+		"@babel/traverse": "7.0.0-rc.1"
 	},
 	"peerDependencies": {
-		"@babel/core": "7.0.0-beta.56"
+		"@babel/core": "7.0.0-rc.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -25,16 +25,16 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-rc.1",
-		"@babel/traverse": "7.0.0-rc.1"
+		"@babel/core": "7.0.0-rc.2",
+		"@babel/traverse": "7.0.0-rc.2"
 	},
 	"peerDependencies": {
-		"@babel/core": "7.0.0-rc.1"
+		"@babel/core": "7.0.0-rc.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -25,16 +25,16 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10"
 	},
 	"devDependencies": {
-		"@babel/core": "7.0.0-rc.2",
-		"@babel/traverse": "7.0.0-rc.2"
+		"@babel/core": "^7.0.0",
+		"@babel/traverse": "^7.0.0"
 	},
 	"peerDependencies": {
-		"@babel/core": "7.0.0-rc.2"
+		"@babel/core": "^7.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (Unreleased)
+
+### New Feature
+
+- Plugin updated to work with the stable version of Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).
+
 ## 2.0.0 (2018-07-12)
 
 ### Breaking Change

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -23,17 +23,17 @@
 	},
 	"main": "index.js",
 	"dependencies": {
-		"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.56",
-		"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.56",
-		"@babel/plugin-transform-react-jsx": "7.0.0-beta.56",
-		"@babel/plugin-transform-runtime": "7.0.0-beta.56",
-		"@babel/preset-env": "7.0.0-beta.56",
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
+		"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
+		"@babel/plugin-transform-react-jsx": "7.0.0-rc.1",
+		"@babel/plugin-transform-runtime": "7.0.0-rc.1",
+		"@babel/preset-env": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"babel-core": "^7.0.0-bridge.0"
 	},
 	"peerDependencies": {
-		"@babel/core": "^7.0.0-beta.50"
+		"@babel/core": "^7.0.0-rc.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -33,7 +33,7 @@
 		"babel-core": "^7.0.0-bridge.0"
 	},
 	"peerDependencies": {
-		"@babel/core": "^7.0.0-rc.2"
+		"@babel/core": "^7.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -23,12 +23,12 @@
 	},
 	"main": "index.js",
 	"dependencies": {
-		"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.2",
-		"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.2",
-		"@babel/plugin-transform-react-jsx": "7.0.0-rc.2",
-		"@babel/plugin-transform-runtime": "7.0.0-rc.2",
-		"@babel/preset-env": "7.0.0-rc.2",
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+		"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+		"@babel/plugin-transform-react-jsx": "^7.0.0",
+		"@babel/plugin-transform-runtime": "^7.0.0",
+		"@babel/preset-env": "^7.0.0",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"babel-core": "^7.0.0-bridge.0"
 	},

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -23,17 +23,17 @@
 	},
 	"main": "index.js",
 	"dependencies": {
-		"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
-		"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
-		"@babel/plugin-transform-react-jsx": "7.0.0-rc.1",
-		"@babel/plugin-transform-runtime": "7.0.0-rc.1",
-		"@babel/preset-env": "7.0.0-rc.1",
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.2",
+		"@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.2",
+		"@babel/plugin-transform-react-jsx": "7.0.0-rc.2",
+		"@babel/plugin-transform-runtime": "7.0.0-rc.2",
+		"@babel/preset-env": "7.0.0-rc.2",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"babel-core": "^7.0.0-bridge.0"
 	},
 	"peerDependencies": {
-		"@babel/core": "^7.0.0-rc.1"
+		"@babel/core": "^7.0.0-rc.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/blob/CHANGELOG.md
+++ b/packages/blob/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime": "7.0.0-rc.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1"
+		"@babel/runtime": "7.0.0-rc.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2"
+		"@babel/runtime": "^7.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/block-library --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/block-library --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 ```js

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/blocks": "file:../blocks",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/blocks": "file:../blocks",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/blocks": "file:../blocks",

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,8 +1,9 @@
-## v3.0.0 (Unreleased)
+## 3.0.0 (Unreleased)
 
 ### Breaking Change
 
 - The `isSharedBlock` function is removed. Use `isReusableBlock` instead.
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
 
 ### Deprecations
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -14,6 +14,16 @@ blog.
 The following documentation outlines steps you as a developer will need to
 follow to add your own custom blocks to WordPress's editor interfaces.
 
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/bocks --save
+```
+
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Getting Started
 
 If you're not already accustomed to working with JavaScript in your WordPress

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -22,7 +22,7 @@ Install the module
 npm install @wordpress/bocks --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Getting Started
 

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,9 +1,10 @@
-## v3.0.0 (Unreleased)
+## 3.0.0 (Unreleased)
 
 ### Breaking Change
 
 - `withAPIData` has been removed. Please use the Core Data module or `@wordpress/api-fetch` directly instead.
 - `wp.components.Draggable` as a DOM node drag handler has been deprecated. Please, use `wp.components.Draggable` as a wrap component for your DOM node drag handler.
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
 
 ### New Feature
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/components --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 Within Gutenberg, these components can be accessed by importing from the `components` root directory:

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/components --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/compose": "file:../compose",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/compose": "file:../compose",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/compose": "file:../compose",

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/compose --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/compose --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 ```js

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10"

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10"

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10"

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.0.0 (Unreleased)
+## 2.0.0 (Unreleased)
 
 ### Breaking Change
 
@@ -8,3 +8,4 @@
 - `select("core").getCategories` has been deprecated. Please use `select("core").getEntityRecords` instead.
 - `wp.data.select("core").isRequestingCategories` has been deprecated. Please use `wp.data.select("core/data").isResolving` instead.
 - `select("core").isRequestingTerms` has been deprecated. Please use `select("core").isResolving` instead.
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -12,7 +12,7 @@ Install the module
 npm install @wordpress/core-data --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Example
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -12,6 +12,8 @@ Install the module
 npm install @wordpress/core-data --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Example
 
 Below is an example of a component which simply renders a list of authors:

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"@wordpress/url": "file:../url",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"@wordpress/url": "file:../url",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"@wordpress/url": "file:../url",

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -24,7 +24,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"escape-string-regexp": "^1.0.5"
 	},
 	"devDependencies": {

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -24,7 +24,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"escape-string-regexp": "^1.0.5"
 	},
 	"devDependencies": {

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -24,7 +24,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"escape-string-regexp": "^1.0.5"
 	},
 	"devDependencies": {

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,7 +1,8 @@
-## v2.0.0 (Unreleased)
+## 2.0.0 (Unreleased)
 
 ### Breaking Change
 
 - The `withRehdyration` function is removed. Use the persistence plugin instead.
 - The `loadAndPersist` function is removed. Use the persistence plugin instead.
 - `restrictPersistence`, `setPersistenceStorage` and  `setupPersistence` functions have been removed. Please use the data persistence plugin instead.
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -12,6 +12,8 @@ Install the module
 npm install @wordpress/data --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Registering a Store
 
 Use the `registerStore` function to add your own store to the centralized data registry. This function accepts two arguments: a name to identify the module, and an object with values describing how your state is represented, modified, and accessed. At a minimum, you must provide a reducer function describing the shape of your state and how it changes in response to actions dispatched to the store.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -12,7 +12,7 @@ Install the module
 npm install @wordpress/data --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Registering a Store
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -10,4 +10,6 @@ Install the module
 npm install @wordpress/date --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -10,6 +10,6 @@ Install the module
 npm install @wordpress/date --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.16"
 	},

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.16"
 	},

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.16"
 	},

--- a/packages/deprecated/CHANGELOG.md
+++ b/packages/deprecated/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.1.0 (Unreleased)
+## 2.0.0 (Unreleased)
+
+### Breaking Change
+
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
 
 ### New Feature
 

--- a/packages/deprecated/README.md
+++ b/packages/deprecated/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/deprecated --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/deprecated/README.md
+++ b/packages/deprecated/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/deprecated --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 ```js

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/hooks": "file:../hooks"
 	},
 	"publishConfig": {

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/hooks": "file:../hooks"
 	},
 	"publishConfig": {

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/hooks": "file:../hooks"
 	},
 	"publishConfig": {

--- a/packages/dom-ready/README.md
+++ b/packages/dom-ready/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/dom-ready --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ### Usage
 

--- a/packages/dom-ready/README.md
+++ b/packages/dom-ready/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/dom-ready --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ### Usage
 
 ```JS

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime": "7.0.0-rc.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1"
+		"@babel/runtime": "7.0.0-rc.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2"
+		"@babel/runtime": "^7.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"element-closest": "^2.0.2",
 		"lodash": "^4.17.10"
 	},

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"element-closest": "^2.0.2",
 		"lodash": "^4.17.10"
 	},

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"element-closest": "^2.0.2",
 		"lodash": "^4.17.10"
 	},

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `isFetchingSharedBlock` selector has been removed. Use `isFetchingReusableBlock` instead.
 - `getSharedBlocks` selector has been removed. Use `getReusableBlocks` instead.
 - `editorMediaUpload` has been removed. Use `mediaUpload` instead.
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
 
 ### Deprecation
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1,5 +1,19 @@
 # Editor
 
+Building blocks for WordPress editors.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/editor --save
+```
+
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
+## How it works
+
 The logic flow concerning the editor includes: inferring a block representation of the post content (parsing); describing the state of a post (representation); rendering of the post to the DOM (rendering); attaching controls to manipulate the content a.k.a blocks (UI).
 
 ![Diagram](https://docs.google.com/drawings/d/1iuownt5etcih7rMMvPvh0Mny8zUA1Z28saxjxaWmfJ0/pub?w=1234&h=453)

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/editor --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## How it works
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -21,7 +21,7 @@ Install the module
 npm install @wordpress/element --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -21,6 +21,8 @@ Install the module
 npm install @wordpress/element --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 Let's render a customized greeting into an empty element:

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"lodash": "^4.17.10",
 		"react": "^16.4.1",
 		"react-dom": "^16.4.1"

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"lodash": "^4.17.10",
 		"react": "^16.4.1",
 		"react-dom": "^16.4.1"

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"lodash": "^4.17.10",
 		"react": "^16.4.1",
 		"react-dom": "^16.4.1"

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (Unreleased)
+
+### Breaking Change
+
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+
 ## 1.2.0 (2018-07-12)
 
 ### New Feature

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/hooks --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ### Usage
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -10,7 +10,10 @@ Install the module
 npm install @wordpress/hooks --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ### Usage
+
 In your JavaScript project, use hooks as follows:
 ```javascript
 import { createHooks } from '@wordpress/hooks';

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime": "7.0.0-rc.1"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2"
+		"@babel/runtime": "^7.0.0"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1"
+		"@babel/runtime": "7.0.0-rc.2"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4"

--- a/packages/html-entities/CHANGELOG.md
+++ b/packages/html-entities/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/html-entities/README.md
+++ b/packages/html-entities/README.md
@@ -10,4 +10,6 @@ Install the module
 npm install @wordpress/html-entities --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/html-entities/README.md
+++ b/packages/html-entities/README.md
@@ -10,6 +10,6 @@ Install the module
 npm install @wordpress/html-entities --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime": "7.0.0-rc.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1"
+		"@babel/runtime": "7.0.0-rc.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2"
+		"@babel/runtime": "^7.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (Unreleased)
+
+### Breaking Change
+
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+
 ## 1.2.0 (2018-07-12)
 
 ### New Feature

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -12,7 +12,7 @@ Install the module:
 npm install @wordpress/i18n --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -4,7 +4,6 @@ Internationalization utilities for client-side localization.
 
 https://codex.wordpress.org/I18n_for_WordPress_Developers
 
-
 ## Installation
 
 Install the module:
@@ -12,6 +11,10 @@ Install the module:
 ```bash
 npm install @wordpress/i18n --save
 ```
+
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
+## Usage
 
 ```js
 import { sprintf, _n } from '@wordpress/i18n';

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,7 +22,7 @@
 		"pot-to-php": "./tools/pot-to-php.js"
 	},
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"gettext-parser": "^1.3.1",
 		"jed": "^1.1.1",
 		"lodash": "^4.17.10",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,7 +22,7 @@
 		"pot-to-php": "./tools/pot-to-php.js"
 	},
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"gettext-parser": "^1.3.1",
 		"jed": "^1.1.1",
 		"lodash": "^4.17.10",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,7 +22,7 @@
 		"pot-to-php": "./tools/pot-to-php.js"
 	},
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"gettext-parser": "^1.3.1",
 		"jed": "^1.1.1",
 		"lodash": "^4.17.10",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -24,7 +24,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime": "7.0.0-rc.1"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -24,7 +24,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1"
+		"@babel/runtime": "7.0.0-rc.2"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -24,7 +24,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2"
+		"@babel/runtime": "^7.0.0"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -25,7 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"jest-matcher-utils": "^22.4.3",
 		"lodash": "^4.17.10"
 	},

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -25,7 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"jest-matcher-utils": "^22.4.3",
 		"lodash": "^4.17.10"
 	},

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -25,7 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"jest-matcher-utils": "^22.4.3",
 		"lodash": "^4.17.10"
 	},

--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/keycodes --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/keycodes --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 Check which key was used in an `onKeyDown` event:

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -23,7 +23,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"lodash": "^4.17.10",
 		"webpack-sources": "^1.1.0"
 	},

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -23,7 +23,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"lodash": "^4.17.10",
 		"webpack-sources": "^1.1.0"
 	},

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -23,7 +23,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"lodash": "^4.17.10",
 		"webpack-sources": "^1.1.0"
 	},

--- a/packages/nux/CHANGELOG.md
+++ b/packages/nux/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/nux/README.md
+++ b/packages/nux/README.md
@@ -14,6 +14,8 @@ Install the module
 npm install @wordpress/nux --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## DotTip
 
 `DotTip` is a React component that renders a single _tip_ on the screen. The tip will point to the React element that `DotTip` is nested within. Each tip is uniquely identified by a string passed to `id`.

--- a/packages/nux/README.md
+++ b/packages/nux/README.md
@@ -14,7 +14,7 @@ Install the module
 npm install @wordpress/nux --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## DotTip
 

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/plugins/CHANGELOG.md
+++ b/packages/plugins/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/plugins --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ### Plugins API
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/plugins --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ### Plugins API
 
 The plugins API contains the following methods:

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -26,7 +26,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"postcss": "^6.0.16"
 	},
 	"publishConfig": {

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -26,7 +26,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"postcss": "^6.0.16"
 	},
 	"publishConfig": {

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -26,7 +26,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"postcss": "^6.0.16"
 	},
 	"publishConfig": {

--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56"
+		"@babel/runtime": "7.0.0-rc.1"
 	},
 	"devDependencies": {
 		"redux": "^4.0.0"

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1"
+		"@babel/runtime": "7.0.0-rc.2"
 	},
 	"devDependencies": {
 		"redux": "^4.0.0"

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2"
+		"@babel/runtime": "^7.0.0"
 	},
 	"devDependencies": {
 		"redux": "^4.0.0"

--- a/packages/shortcode/CHANGELOG.md
+++ b/packages/shortcode/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/shortcode/README.md
+++ b/packages/shortcode/README.md
@@ -10,6 +10,6 @@ Install the module
 npm install @wordpress/shortcode --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/shortcode/README.md
+++ b/packages/shortcode/README.md
@@ -10,4 +10,6 @@ Install the module
 npm install @wordpress/shortcode --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/token-list/CHANGELOG.md
+++ b/packages/token-list/CHANGELOG.md
@@ -1,3 +1,3 @@
-## v1.0.0 (Unreleased)
+## 1.0.0 (Unreleased)
 
 - Initial release

--- a/packages/token-list/README.md
+++ b/packages/token-list/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/token-list
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 Construct a new token list, optionally with an initial value. A value with an interface matching DOMTokenList is returned.

--- a/packages/token-list/README.md
+++ b/packages/token-list/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/token-list
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -18,7 +18,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -18,7 +18,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -18,7 +18,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/token-list",
-	"version": "1.0.0",
+	"version": "1.0.0-beta.0",
 	"description": "Constructable, plain JavaScript DOMTokenList implementation, supporting non-browser runtimes.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/url --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Usage
 
 ```JS

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/url --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
 

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"qs": "^6.5.2s"
 	},
 	"publishConfig": {

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"qs": "^6.5.2s"
 	},
 	"publishConfig": {

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"qs": "^6.5.2s"
 	},
 	"publishConfig": {

--- a/packages/viewport/CHANGELOG.md
+++ b/packages/viewport/CHANGELOG.md
@@ -3,13 +3,3 @@
 ### Breaking Change
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-
-## 1.1.0 (2018-07-12)
-
-### New Feature
-
-- Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
-
-### Polish
-
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))

--- a/packages/viewport/README.md
+++ b/packages/viewport/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/viewport --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Breakpoints
 

--- a/packages/viewport/README.md
+++ b/packages/viewport/README.md
@@ -10,6 +10,8 @@ Install the module
 npm install @wordpress/viewport --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
 ## Breakpoints
 
 The standard set of breakpoint thresholds is as follows:

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",

--- a/packages/wordcount/CHANGELOG.md
+++ b/packages/wordcount/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (Unreleased)
+
+### Breaking Change
+
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+
 ## 1.1.0 (2018-07-12)
 
 ### New Feature

--- a/packages/wordcount/README.md
+++ b/packages/wordcount/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/wordcount --save
 ```
 
-_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Accepted Paramaters
 

--- a/packages/wordcount/README.md
+++ b/packages/wordcount/README.md
@@ -10,8 +10,10 @@ Install the module
 npm install @wordpress/wordcount --save
 ```
 
+_This package assumes that your code will run in an ES5 environment. If you're using an environment that has limited or no support for ES5 such as lower versions of IE then using [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Accepted Paramaters
+
 ```JS
 count( text, type, userSettings )
 ````
@@ -21,6 +23,7 @@ count accepts three parameters:
 3. userSettings: An object that contains the list of regular expressions that will be used to count. See defaultSettings.js for the defaults.
 
 ## Usage
+
 ```JS
 import { count } from '@wordpress/wordcount';
 const numberOfWords = count( 'Words to count', 'words', {} )

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@babel/runtime": "7.0.0-rc.1",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.1",
+		"@babel/runtime": "7.0.0-rc.2",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "7.0.0-rc.2",
+		"@babel/runtime": "^7.0.0",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## Description
Fixes #8727.
Closes #9478.

Discussed during Core JS meeting: https://make.wordpress.org/core/2018/08/14/javascript-chat-summary-august-14/.

**Problem:** The current npm packages that being built for Gutenberg polyfill usage of some browser features that are not available on older browsers. This polyfill is global and affects any client who uses WordPress npm packages. This is unexpected and can alter the runtime environment in surprising ways.

**Action items:**
* [x] corejs flag should be set to false when generating distribution version for packages and set to 2 when bundling with Webpack.
* [x] we should inform developers consuming WordPress packages to install proper polyfills on their own.

This PR also updates Babel to the latest RC version since we need to update all occurrences of `@babel/runtime-corejs2` with `@babel/runtime` anyways.

~I also changed the configuration for the `build-module` distribution output. I took advantage of the new setting for `@babel/preset-env`: `"targets": { "esmodules": true }`~

~We use Babel twice to produce output for packages and then use Webpack to produce build files to consume inside WordPress, so we can take advantage of it and offer `build` version of package which works with all browsers and `build-module` version which works with all browsers that support `<script type="module"></script>`.~

## How has this been tested?
`npm run dev`
`npm run build`
`npm test`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

/cc @blowery @jsnajdr