### PR TITLE
Add description for Reusable Blocks

### DIFF
--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -15,7 +15,7 @@ export const settings = {
 
 	category: 'reusable',
 
-	description: __( 'When updated, content and formatting will change everywhere this Block is inserted.' ),
+	description: __( 'When updated, changes apply everywhere this block is inserted.' ),
 
 	attributes: {
 		ref: {

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -15,9 +15,9 @@ export const settings = {
 
 	category: 'reusable',
 
-    description: __( 'Use again in any Post -- changes sync. Convert to Regular Block to use as starter template.' ),
+	description: __( 'Use again in any Post -- changes sync. Convert to Regular Block to use as starter template.' ),
 
-    attributes: {
+	attributes: {
 		ref: {
 			type: 'number',
 		},

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -12,9 +12,12 @@ export const name = 'core/block';
 
 export const settings = {
 	title: __( 'Reusable Block' ),
+
 	category: 'reusable',
 
-	attributes: {
+    description: __( 'Use again in any Post -- changes sync. Convert to Regular Block to use as starter template.' ),
+
+    attributes: {
 		ref: {
 			type: 'number',
 		},

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -15,7 +15,7 @@ export const settings = {
 
 	category: 'reusable',
 
-	description: __( 'Use again in any Post -- changes sync. Convert to Regular Block to use as starter template.' ),
+	description: __( 'When updated, content and formatting will change everywhere this Block is inserted.' ),
 
 	attributes: {
 		ref: {

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -15,7 +15,7 @@ export const settings = {
 
 	category: 'reusable',
 
-	description: __( 'When updated, changes apply everywhere this block is inserted.' ),
+	description: __( 'Create content, and save it to reuse across your site. Update the block, and the changes apply everywhere it\'s used.' ),
 
 	attributes: {
 		ref: {

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -15,7 +15,7 @@ export const settings = {
 
 	category: 'reusable',
 
-	description: __( 'Create content, and save it to reuse across your site. Update the block, and the changes apply everywhere it\'s used.' ),
+	description: __( 'Create content, and save it to reuse across your site. Update the block, and the changes apply everywhere it’s used.' ),
 
 	attributes: {
 		ref: {


### PR DESCRIPTION
Addresses #8345

## Description
Add description guidance for Reusable Blocks.

## Screenshots
![reusable-block-description](https://user-images.githubusercontent.com/9565066/44355692-1e7c1a00-a462-11e8-823a-945e95ed59ce.png)

## Types of changes
* In-app documentation