### PR TITLE
Update Facebook icon SVG

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -384,7 +384,7 @@ export const common = [
 			title: 'Facebook',
 			icon: {
 				foreground: '#3b5998',
-				src: <svg viewBox="0 0 24 24"><path d="M20 3H4L3 4v16l1 1h9v-7h-3v-3h3V9c0-2 1-3 3-3h2v2h-1l-2 2v1h3v3h-3v7h5l1-1V4l-1-1z" /></svg>,
+				src: <svg viewBox="0 0 24 24"><path d="M20 3H4c-.6 0-1 .4-1 1v16c0 .5.4 1 1 1h8.6v-7h-2.3v-2.7h2.3v-2c0-2.3 1.4-3.6 3.5-3.6 1 0 1.8.1 2.1.1v2.4h-1.4c-1.1 0-1.3.5-1.3 1.3v1.7h2.7l-.4 2.8h-2.3v7H20c.5 0 1-.4 1-1V4c0-.6-.4-1-1-1z" /></svg>,
 			},
 		} ),
 		patterns: [ /^https?:\/\/www\.facebook.com\/.+/i ],


### PR DESCRIPTION
## Description

#8916 added some custom block icons, including a facebook icon. For some reason, the facebook icon is missing most of its curved lines, and its proportions are incorrect. This PR replaces it with a new SVG. 

Current icon on the left, new icon on the right:

<img width="669" alt="screen shot 2018-08-20 at 3 46 35 pm" src="https://user-images.githubusercontent.com/1202812/44363074-096aaf80-a491-11e8-8af5-ead41ddceeb6.png">

---

Before, in context: 

<img width="400" alt="screen shot 2018-08-20 at 3 44 37 pm" src="https://user-images.githubusercontent.com/1202812/44363085-112a5400-a491-11e8-976d-b72229bbf037.png">

<img width="589" alt="screen shot 2018-08-20 at 3 44 57 pm" src="https://user-images.githubusercontent.com/1202812/44363095-19828f00-a491-11e8-83cc-8b535e827ea7.png">

After, in context: 

<img width="400" alt="screen shot 2018-08-20 at 3 43 43 pm" src="https://user-images.githubusercontent.com/1202812/44363112-23a48d80-a491-11e8-98d1-5493c39323df.png">

<img width="601" alt="screen shot 2018-08-20 at 3 47 01 pm" src="https://user-images.githubusercontent.com/1202812/44363119-2901d800-a491-11e8-96ce-2b21fc57c6e8.png">


---

This icon was sourced from https://github.com/Automattic/social-logos, and I'm fairly certain it follows the same icon grid we've been using. cc @jasmussen for a gut check there though.