### PR TITLE
Update Heading Block description

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -60,7 +60,7 @@ export const name = 'core/heading';
 export const settings = {
 	title: __( 'Heading' ),
 
-	description: __( 'Briefly describes the following section to visitors and search engines.' ),
+	description: __( 'Help visitors (and search engines!) understand what they\'re reading with a short description.' ),
 
 	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 4v3h5.5v12h3V7H19V4z" /><path fill="none" d="M0 0h24v24H0V0z" /></svg>,
 

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -60,7 +60,7 @@ export const name = 'core/heading';
 export const settings = {
 	title: __( 'Heading' ),
 
-	description: __( 'Insert a headline above your post or page content.' ),
+	description: __( 'Briefly describes the following section to visitors and search engines.' ),
 
 	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 4v3h5.5v12h3V7H19V4z" /><path fill="none" d="M0 0h24v24H0V0z" /></svg>,
 

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -60,7 +60,7 @@ export const name = 'core/heading';
 export const settings = {
 	title: __( 'Heading' ),
 
-	description: __( 'Help visitors (and search engines!) understand what they\'re reading with a short description.' ),
+	description: __( 'Introduce topics and help visitors (and search engines!) understand how your content is organized.' ),
 
 	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 4v3h5.5v12h3V7H19V4z" /><path fill="none" d="M0 0h24v24H0V0z" /></svg>,
 

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -15,7 +15,7 @@ export const name = 'core/subhead';
 export const settings = {
 	title: __( 'Subheading' ),
 
-	description: __( 'Short, explanatory subtitle to support section headings and overall topic.' ),
+	description: __( 'What’s a subhead? Smaller than a headline, bigger than basic text.' ),
 
 	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.1 6l-.5 3h4.5L9.4 19h3l1.8-10h4.5l.5-3H7.1z" /></svg>,
 

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -15,7 +15,7 @@ export const name = 'core/subhead';
 export const settings = {
 	title: __( 'Subheading' ),
 
-	description: __( 'What’s a subhead? Smaller than a headline, bigger than basic text.' ),
+	description: __( 'Short, explanatory subtitle to support section headings and overall topic.' ),
 
 	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.1 6l-.5 3h4.5L9.4 19h3l1.8-10h4.5l.5-3H7.1z" /></svg>,
 


### PR DESCRIPTION
The current description for Heading blocks confusingly states that Headings are placed above the post or page contents, when they're used to describe document sections.

* Headings divide the page contents, aren't placed above.
* Headings may be used in CPTs -- direct reference to Post or Page should be removed.
* Headings vs. Subheadings -- one is used for SEO weighting, one is simply formatted paragraph text... we don't want to get overly technical, but this distinct difference should be gently explained.