### PR TITLE
 Allow dynamic blocks to create loops

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -162,6 +162,12 @@ function do_blocks( $content ) {
 	$rendered_content      = '';
 	$dynamic_block_pattern = get_dynamic_blocks_regex();
 
+	/*
+	 * Back up global post, to restore after render callback.
+	 * Allows callbacks to run new WP_Query instances without breaking the global post.
+	 */
+	$global_post = $post;
+
 	while ( preg_match( $dynamic_block_pattern, $content, $block_match, PREG_OFFSET_CAPTURE ) ) {
 		$opening_tag     = $block_match[0][0];
 		$offset          = $block_match[0][1];
@@ -216,14 +222,10 @@ function do_blocks( $content ) {
 			$content       = substr( $content, $end_offset + strlen( $end_tag ) );
 		}
 
-		/*
-		 * Back up global post, to restore after render callback.
-		 * Allows callbacks to run new WP_Query instances without breaking the global post.
-		 */
-		$global_post = $post;
-
 		// Replace dynamic block with server-rendered output.
 		$rendered_content .= $block_type->render( $attributes, $inner_content );
+
+		// Restore global $post.
 		$post = $global_post;
 	}
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -151,11 +151,14 @@ function gutenberg_render_block( $block ) {
  * Parses dynamic blocks out of `post_content` and re-renders them.
  *
  * @since 0.1.0
+ * @global WP_Post $post The post to edit.
  *
  * @param  string $content Post content.
  * @return string          Updated post content.
  */
 function do_blocks( $content ) {
+	global $post;
+
 	$rendered_content      = '';
 	$dynamic_block_pattern = get_dynamic_blocks_regex();
 
@@ -213,8 +216,15 @@ function do_blocks( $content ) {
 			$content       = substr( $content, $end_offset + strlen( $end_tag ) );
 		}
 
+		/*
+		 * Back up global post, to restore after render callback.
+		 * Allows callbacks to run new WP_Query instances without breaking the global post.
+		 */
+		$global_post = $post;
+
 		// Replace dynamic block with server-rendered output.
 		$rendered_content .= $block_type->render( $attributes, $inner_content );
+		$post = $global_post;
 	}
 
 	// Append remaining unmatched content.

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -123,13 +123,20 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	function test_global_post_persistence() {
 		global $post;
 
-		register_block_type( 'core/dummy', array(
-			'render_callback' => array( $this, 'render_dummy_block_wp_query' ),
-		) );
+		register_block_type(
+			'core/dummy',
+			array(
+				'render_callback' => array(
+					$this,
+					'render_dummy_block_wp_query',
+				),
+			)
+		);
 
 		$posts = self::factory()->post->create_many( 5 );
-		$global_post = $post = get_post( end( $posts ) );
+		$post  = get_post( end( $posts ) );
 
+		$global_post = $post;
 		do_blocks( '<!-- wp:core/dummy /-->' );
 
 		$this->assertEquals( $global_post, $post );


### PR DESCRIPTION
Fixes #7427, fixes #8035.

## Description
Stores and restores the global post object around dynamic block callbacks. This allows dynamic blocks to create new `WP_Query` instances and set up its post data, without changing the currently edited post.

## How has this been tested?
Added a new unit test.
Tested with a custom dynamic block in wp-admin and front-end with the block callback I added in the unit test. I could recreate the scenario described in #7427.

## Types of changes
Stores global `$post` in `do_blocks()` and resets it after every dynamic block callback.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
