### PR TITLE
Fix regression with textbox spacing + a focus issue

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -153,8 +153,6 @@ body.gutenberg-editor-page {
 	input[type="number"],
 	select,
 	textarea {
-		margin-top: 0; // These override a "margin: 1px" from core.
-		margin-bottom: 0;
 		font-family: $default-font;
 		font-size: $default-font-size;
 		padding: 6px 8px;

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -115,19 +115,6 @@
 	}
 }
 
-// This is a focus style shown for blocks that need an indicator even when in an isEditing state
-// like for example an image block that receives arrowkey focus.
-.edit-post-visual-editor .editor-block-list__block:not(.is-selected) {
-	.editor-block-list__block-edit {
-		box-shadow: 0 0 0 0 $white, 0 0 0 0 $dark-gray-900;
-		transition: 0.1s box-shadow 0.05s;
-	}
-
-	&:focus .editor-block-list__block-edit {
-		box-shadow: 0 0 0 1px $white, 0 0 0 3px $dark-gray-900;
-	}
-}
-
 .edit-post-visual-editor .editor-default-block-appender {
 	// Default to centered and content-width, like blocks
 	max-width: $content-width;

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -87,7 +87,7 @@
 	}
 
 	.components-button {
-		text-align: center;
+		justify-content: center;
 	}
 
 	.components-clipboard-button {


### PR DESCRIPTION
This PR fixes two things.

1. It fixes a small regression where we removed the 1px margin on input fields inherited by WordPress. But we did this with too much specificity so it regressed other input fields as well. To test this works now publish a post and verify that the URL copy input field looks right.

After:

<img width="347" alt="screen shot 2018-08-21 at 09 22 07" src="https://user-images.githubusercontent.com/1204802/44386765-c0177000-a523-11e8-8373-0c22c3c89f48.png">

2. It removes a focus style we used to have a while back. Back then if you were in `isEditing` mode, where all UI fade out, arrow-keying to a placeholder or image block would not show the block UI. This focus style then at least showed it as highlighted black. Since those are now shown as "selected" effectively exiting isEditing mode, this old focus fix is no longer needed. Not only that but this focus style has increasingly as part of other changes become a focus style you accidentally invoke on the text appender.

Before:

<img width="710" alt="screen shot 2018-08-21 at 09 10 10" src="https://user-images.githubusercontent.com/1204802/44386614-4da69000-a523-11e8-8b28-c91c2a62f4cd.png">

I do still miss the days when you could use the slash command to insert an image placeholder, then press tab tab to go to the "open media library" dialog. Right now you have to tab through all the side UI and block UI to get there. But this is something to think about separately.