### PR TITLE
Fix library position and mobile regression.

### DIFF
--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -84,6 +84,10 @@
 		display: block;
 		margin: auto;
 	}
+
+	.editor-inserter .editor-inserter__toggle {
+		margin-right: 0;
+	}
 }
 
 // Left side.
@@ -119,7 +123,8 @@
 }
 
 // Quick block insertion icons on the right side.
-.editor-inserter-with-shortcuts {
+// Needs specificity to styles from the component itself.
+.editor-block-list__side-inserter .editor-inserter-with-shortcuts {
 	right: $block-padding;
 	display: none; // Don't show on mobile.
 	z-index: z-index(".editor-inserter-with-shortcuts"); // Elevate above the sibling inserter.

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -124,7 +124,7 @@
 
 // Quick block insertion icons on the right side.
 // Needs specificity to styles from the component itself.
-.editor-block-list__side-inserter .editor-inserter-with-shortcuts {
+.editor-default-block-appender .editor-inserter-with-shortcuts {
 	right: $block-padding;
 	display: none; // Don't show on mobile.
 	z-index: z-index(".editor-inserter-with-shortcuts"); // Elevate above the sibling inserter.

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -85,7 +85,7 @@
 		margin: auto;
 	}
 
-	.editor-inserter .editor-inserter__toggle {
+	.editor-inserter__toggle {
 		margin-right: 0;
 	}
 }

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -124,6 +124,7 @@
 
 // Quick block insertion icons on the right side.
 // Needs specificity to styles from the component itself.
+.editor-block-list__side-inserter .editor-inserter-with-shortcuts,
 .editor-default-block-appender .editor-inserter-with-shortcuts {
 	right: $block-padding;
 	display: none; // Don't show on mobile.

--- a/packages/editor/src/components/inserter-with-shortcuts/style.scss
+++ b/packages/editor/src/components/inserter-with-shortcuts/style.scss
@@ -1,5 +1,5 @@
 .editor-inserter-with-shortcuts {
-	//display: flex;
+	display: flex;
 	align-items: center;
 
 	.components-icon-button {
@@ -18,9 +18,8 @@
 	height: $icon-button-size;
 	padding-top: 8px;
 
-	// use opacity to work in various editor styles
+	// Use opacity to work in various editor styles.
 	color: $dark-opacity-light-700;
-
 	.is-dark-theme & {
 		color: $light-opacity-light-700;
 	}

--- a/packages/editor/src/components/inserter-with-shortcuts/style.scss
+++ b/packages/editor/src/components/inserter-with-shortcuts/style.scss
@@ -1,5 +1,5 @@
 .editor-inserter-with-shortcuts {
-	display: flex;
+	//display: flex;
 	align-items: center;
 
 	.components-icon-button {


### PR DESCRIPTION
This PR fixes two things.

1. When invoking the block library from the plus on the side, it aligns it correctly

2. On mobile breakpoints, the "recently used" blocks were shown on the right even though they should be hidden.

After:

<img width="542" alt="screen shot 2018-08-21 at 09 28 01" src="https://user-images.githubusercontent.com/1204802/44387423-c73f7d80-a525-11e8-9ac0-e85910b6c5bb.png">

<img width="498" alt="screen shot 2018-08-21 at 09 34 55" src="https://user-images.githubusercontent.com/1204802/44387428-c9094100-a525-11e8-900f-2658e10e2674.png">

Before:

<img width="489" alt="screen shot 2018-08-21 at 09 29 02" src="https://user-images.githubusercontent.com/1204802/44387432-cc9cc800-a525-11e8-902c-0d80f83e7791.png">

