### PR TITLE
Add documentation about floats, and possibly expand method

### DIFF
--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -45,6 +45,33 @@ Some blocks such as the image block have the possibility to define a "wide" or "
 add_theme_support( 'align-wide' );
 ```
 
+### Wide Alignments & Floats
+
+It can be tricky to create a responsive layout that accommodates both wide images, a sidebar, a centered column, as well as floats that stay within that centered column. 
+
+For that reason, Gutenberg provides floated images with additional markup to provide more options. Here's the markup for an Image with a caption:
+
+```
+<figure class="wp-block-image">
+	<img src="..." alt="" width="200px">
+	<figcaption>Short image caption.</figcaption>
+</figure>
+```
+
+Here's the markup for a left-floated image:
+
+```
+<div class="wp-block-image">
+	<figure class="alignleft">
+		<img src="..." alt="" width="200px">
+		<figcaption>Short image caption.</figcaption>
+	</figure>
+</div>
+```
+
+In this codepen you can see one method for leveraging the above markup to achieve a responsive layout that features both a sidebar, wide images, as well as floats with bounded captions:
+https://codepen.io/joen/pen/zLWvrW
+
 ### Block Color Palettes:
 
 Different blocks have the possibility of customizing colors. Gutenberg provides a default palette, but a theme can overwrite it and provide its own:

--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -45,11 +45,13 @@ Some blocks such as the image block have the possibility to define a "wide" or "
 add_theme_support( 'align-wide' );
 ```
 
-### Wide Alignments & Floats
+### Wide Alignments and Floats
 
-It can be tricky to create a responsive layout that accommodates both wide images, a sidebar, a centered column, as well as floats that stay within that centered column. 
+It can be difficult to create a responsive layout that accommodates wide images, a sidebar, a centered column, and floated elements that stay within that centered column.
 
-For that reason, Gutenberg provides floated images with additional markup to provide more options. Here's the markup for an Image with a caption:
+Gutenberg adds additional markup to floated images to make styling them easier.
+
+Here's the markup for an `Image` with a caption:
 
 ```
 <figure class="wp-block-image">
@@ -69,10 +71,9 @@ Here's the markup for a left-floated image:
 </div>
 ```
 
-In this codepen you can see one method for leveraging the above markup to achieve a responsive layout that features both a sidebar, wide images, as well as floats with bounded captions:
-https://codepen.io/joen/pen/zLWvrW
+Here's an example using the above markup to achieve a responsive layout that features a sidebar, wide images, and floated elements with bounded captions: https://codepen.io/joen/pen/zLWvrW.
 
-### Block Color Palettes:
+### Block Color Palettes
 
 Different blocks have the possibility of customizing colors. Gutenberg provides a default palette, but a theme can overwrite it and provide its own:
 

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -1,14 +1,16 @@
 .editor-default-block-appender {
-	input[type="text"].editor-default-block-appender__content { // needs specificity
+	clear: both; // The appender doesn't scale well to sit next to floats, so clear them.
+
+	input[type="text"].editor-default-block-appender__content { // Needs specificity.
 		font-family: $editor-font;
-		font-size: $editor-font-size; // It should match the default paragraph size
+		font-size: $editor-font-size; // It should match the default paragraph size.
 		border: none;
 		background: none;
 		box-shadow: none;
 		display: block;
 		margin-left: 0;
 		margin-right: 0;
-		max-width: none; // fixes a bleed issue from the admin
+		max-width: none; // Overrides upstream CSS from the admin.
 		cursor: text;
 		width: 100%;
 		outline: $border-width solid transparent;
@@ -17,9 +19,8 @@
 		// Emulate the dimensions of a paragraph block.
 		padding: 0 #{ $block-padding + $border-width };
 
-		// use opacity to work in various editor styles
+		// Use opacity to work in various editor styles.
 		color: $dark-opacity-300;
-
 		.is-dark-theme & {
 			color: $light-opacity-300;
 		}
@@ -31,9 +32,8 @@
 		transition: opacity 0.2s;
 
 		.components-icon-button:not(:hover) {
-			// use opacity to work in various editor styles
+			// Use opacity to work in various editor styles.
 			color: $dark-opacity-500;
-
 			.is-dark-theme & {
 				color: $light-opacity-500;
 			}
@@ -107,10 +107,9 @@
 		height: $block-side-ui-width;
 		padding: 0;
 
-		// use opacity to work in various editor styles
+		// Use opacity to work in various editor styles.
 		&:not(:hover) {
 			color: $dark-opacity-500;
-
 			.is-dark-theme & {
 				color: $light-opacity-500;
 			}

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -1,7 +1,7 @@
 .editor-default-block-appender {
 	clear: both; // The appender doesn't scale well to sit next to floats, so clear them.
 
-	input[type="text"].editor-default-block-appender__content { // Needs specificity in order to override upstream input field styles.
+	input[type="text"].editor-default-block-appender__content { // Needs specificity in order to override input field styles from WP-admin styles.
 		font-family: $editor-font;
 		font-size: $editor-font-size; // It should match the default paragraph size.
 		border: none;

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -1,7 +1,7 @@
 .editor-default-block-appender {
 	clear: both; // The appender doesn't scale well to sit next to floats, so clear them.
 
-	input[type="text"].editor-default-block-appender__content { // Needs specificity.
+	input[type="text"].editor-default-block-appender__content { // Needs specificity in order to override upstream input field styles.
 		font-family: $editor-font;
 		font-size: $editor-font-size; // It should match the default paragraph size.
 		border: none;


### PR DESCRIPTION
This branch was started with the intent of porting the float improvements we recently made to images, to other blocks that can be floated, such as Cover Image, Gallery and Embeds.

However as I started doing that, I noticed a lot of different hard-to-genericize aspects of those other blocks. For example, Gallery, Cover Image do not have intrinsic widths, so we have to apply a width to them when they are floated.

For many embeds this is the same, some are resized to their minimum dimensions, such as a tweet that's embedded. Videos are respnosive, however, and rely on an aspect ratio to scale a percentage, so even if they might have an intrinsic width (like 1920px for HD) we scale that down based on the aspect ratio. Which means we have to treat those as if they do not have intrinsic widths either.

Mostly the big change is that the new floats require an extra wrapping div in order to work. I.e.
```
<div class="wp-block-image">
	<figure class="alignleft">
		<img src="..." alt="" width="200px">
		<figcaption>Short image caption.</figcaption>
	</figure>
</div>
```

It doesn't have to be a figure, and the `alignleft` class can be applied to the parent wrapper instead of the figure.

But if we are to use the same float technique, regardless of intrinsic widths, I have to add an additional containing element when the block is floated. Right now this is done for the image: https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/image/index.js#L227

However if the "floats" should be truly generic and work for any block that opts into the float mechanic, we can't implement that wrapping element on a per-block basis.

What are your thoughts on how to generically add this wrapping element for all floated blocks?

Also this PR does two other things:

1. It adds documentation for how the new markup can be leveraged to style themes
2. It adds `clear: both;` to the default appender — it simply does not scale to be functional when it doesn't clear.