### PR TITLE
Change keyboard shortcut for remove block to Cmd+Shift+X / Ctrl+Shift+X

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -70,7 +70,7 @@ This is the canonical list of keyboard shortcuts:
 ### Block shortcuts
 
 * <kbd>Shift</kbd>+<kbd>⌘D</kbd> Duplicate the selected block(s).
-* <kbd>Option</kbd>+<kbd>⌘Backspace</kbd> Remove the selected block(s).
+* <kbd>Shift</kbd>+<kbd>⌘X</kbd> Remove the selected block(s).
 * <kbd>Option</kbd>+<kbd>⌘T</kbd> Insert a new block before the selected block(s).
 * <kbd>Option</kbd>+<kbd>⌘Y</kbd> Insert a new block after the selected block(s).
 * <kbd>/</kbd> Change the block type after adding a new paragraph.

--- a/edit-post/components/keyboard-shortcut-help-modal/config.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/config.js
@@ -88,7 +88,7 @@ const blockShortcuts = {
 			description: __( 'Duplicate the selected block(s).' ),
 		},
 		{
-			keyCombination: primaryAlt( 'backspace' ),
+			keyCombination: ctrlShift( '-' ),
 			description: __( 'Remove the selected block(s).' ),
 		},
 		{

--- a/edit-post/components/keyboard-shortcut-help-modal/config.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/config.js
@@ -88,7 +88,7 @@ const blockShortcuts = {
 			description: __( 'Duplicate the selected block(s).' ),
 		},
 		{
-			keyCombination: ctrlShift( '-' ),
+			keyCombination: primaryShift( 'x' ),
 			description: __( 'Remove the selected block(s).' ),
 		},
 		{

--- a/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -167,7 +167,7 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
               "+",
               "Shift",
               "+",
-              "-",
+              "X",
             ],
           },
           Object {

--- a/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -165,9 +165,9 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
             "keyCombination": Array [
               "Ctrl",
               "+",
-              "Alt",
+              "Shift",
               "+",
-              "Backspace",
+              "-",
             ],
           },
           Object {

--- a/packages/components/src/keyboard-shortcuts/index.js
+++ b/packages/components/src/keyboard-shortcuts/index.js
@@ -15,6 +15,10 @@ class KeyboardShortcuts extends Component {
 		super( ...arguments );
 
 		this.bindKeyTarget = this.bindKeyTarget.bind( this );
+
+		// Firefox uses keycode 173 for '-', while other browsers use 189.
+		// This line makes binding to the '-' key work consistently.
+		Mousetrap.addKeycodes( { 173: '-' } );
 	}
 
 	componentDidMount() {

--- a/packages/components/src/keyboard-shortcuts/index.js
+++ b/packages/components/src/keyboard-shortcuts/index.js
@@ -15,10 +15,6 @@ class KeyboardShortcuts extends Component {
 		super( ...arguments );
 
 		this.bindKeyTarget = this.bindKeyTarget.bind( this );
-
-		// Firefox uses keycode 173 for '-', while other browsers use 189.
-		// This line makes binding to the '-' key work consistently.
-		Mousetrap.addKeycodes( { 173: '-' } );
 	}
 
 	componentDidMount() {

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -37,8 +37,8 @@ const shortcuts = {
 		display: displayShortcut.primaryShift( 'd' ),
 	},
 	removeBlock: {
-		raw: rawShortcut.ctrlShift( '-' ),
-		display: displayShortcut.ctrlShift( '-' ),
+		raw: rawShortcut.primaryShift( 'x' ),
+		display: displayShortcut.primaryShift( 'x' ),
 	},
 	insertBefore: {
 		raw: rawShortcut.primaryAlt( 't' ),

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -37,8 +37,8 @@ const shortcuts = {
 		display: displayShortcut.primaryShift( 'd' ),
 	},
 	removeBlock: {
-		raw: rawShortcut.primaryAlt( 'backspace' ),
-		display: displayShortcut.primaryAlt( 'bksp' ),
+		raw: rawShortcut.ctrlShift( '-' ),
+		display: displayShortcut.ctrlShift( '-' ),
 	},
 	insertBefore: {
 		raw: rawShortcut.primaryAlt( 't' ),


### PR DESCRIPTION
## Description
Closes #9036 

- Change the remove block shortcut to Cmd+Shift+X (Mac) or Ctrl+Shift+X (Others)

## How has this been tested?
- Tested manually on Mac OS - Chrome, Firefox, Safari, Opera (using a British keyboard layout)
- Tested manually on Windows - Chrome, Firefox, Safari, IE11, Edge (again, British keyboard layout)
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
**Block Settings Menu**
![screen shot 2018-08-27 at 6 11 05 pm](https://user-images.githubusercontent.com/677833/44654567-b8286600-aa24-11e8-9369-1a7a6c934999.png)

**Keyboard Shortcut Help**
![screen shot 2018-08-27 at 6 11 22 pm](https://user-images.githubusercontent.com/677833/44654579-beb6dd80-aa24-11e8-8501-9d0644801062.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
