### PR TITLE
Editor: Extract LinkContainer from FormatToolbar

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -28,8 +33,8 @@ function computeDerivedState( props ) {
 		selectedNodeId: props.selectedNodeId,
 		settingsVisible: false,
 		opensInNewWindow: !! props.formats.link && !! props.formats.link.target,
-		linkValue: '',
 		isEditingLink: false,
+		linkValue: get( props, [ 'formats', 'link', 'value' ], '' ),
 	};
 }
 
@@ -103,13 +108,11 @@ class FormatToolbar extends Component {
 	}
 
 	addLink() {
-		this.setState( { linkValue: '' } );
 		this.props.onChange( { link: { isAdding: true } } );
 	}
 
 	dropLink() {
 		this.props.onChange( { link: null } );
-		this.setState( { linkValue: '' } );
 	}
 
 	editLink( event ) {
@@ -126,8 +129,6 @@ class FormatToolbar extends Component {
 			rel: this.state.opensInNewWindow ? 'noreferrer noopener' : null,
 			value,
 		} } );
-
-		this.setState( { linkValue: value, isEditingLink: false } );
 		if ( ! this.props.formats.link.value ) {
 			this.props.speak( __( 'Link added.' ), 'assertive' );
 		}

--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -4,56 +4,17 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import {
-	Fill,
-	IconButton,
-	ToggleControl,
 	Toolbar,
 	withSpokenMessages,
-	Popover,
-	ExternalLink,
 } from '@wordpress/components';
-import { ESCAPE, LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER, displayShortcut } from '@wordpress/keycodes';
+import { ESCAPE, LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { prependHTTP } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import PositionedAtSelection from './positioned-at-selection';
-import URLInput from '../../url-input';
-import { filterURLForDisplay } from '../../../utils/url';
-
-const FORMATTING_CONTROLS = [
-	{
-		icon: 'editor-bold',
-		title: __( 'Bold' ),
-		shortcut: displayShortcut.primary( 'b' ),
-		format: 'bold',
-	},
-	{
-		icon: 'editor-italic',
-		title: __( 'Italic' ),
-		shortcut: displayShortcut.primary( 'i' ),
-		format: 'italic',
-	},
-	{
-		icon: 'admin-links',
-		title: __( 'Link' ),
-		shortcut: displayShortcut.primary( 'k' ),
-		format: 'link',
-	},
-	{
-		icon: 'editor-strikethrough',
-		title: __( 'Strikethrough' ),
-		shortcut: displayShortcut.access( 'd' ),
-		format: 'strikethrough',
-	},
-];
-
-// Default controls shown if no `enabledControls` prop provided
-const DEFAULT_CONTROLS = [ 'bold', 'italic', 'strikethrough', 'link' ];
-
-// Stop the key event from propagating up to maybeStartTyping in BlockListBlock
-const stopKeyPropagation = ( event ) => event.stopPropagation();
+import { FORMATTING_CONTROLS } from '../formatting-controls';
+import LinkContainer from './link-container';
 
 /**
  * Returns the Format Toolbar state given a set of props.
@@ -101,7 +62,8 @@ class FormatToolbar extends Component {
 			}
 		}
 		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-			stopKeyPropagation( event );
+			// Stop the key event from propagating up to maybeStartTyping in BlockListBlock.
+			event.stopPropagation();
 		}
 	}
 
@@ -176,9 +138,11 @@ class FormatToolbar extends Component {
 	}
 
 	render() {
-		const { formats, enabledControls = DEFAULT_CONTROLS, customControls = [], selectedNodeId } = this.props;
+		const { formats, enabledControls = [], customControls = [], selectedNodeId } = this.props;
 		const { linkValue, settingsVisible, opensInNewWindow, isEditingLink } = this.state;
 		const isAddingLink = formats.link && formats.link.isAdding;
+		const isEditing = isAddingLink || isEditingLink;
+		const isPreviewing = ! isEditing && formats.link;
 
 		const toolbarControls = FORMATTING_CONTROLS.concat( customControls )
 			.filter( ( control ) => enabledControls.indexOf( control.format ) !== -1 )
@@ -202,88 +166,26 @@ class FormatToolbar extends Component {
 				};
 			} );
 
-		let linkUIToShow = 'none';
-		if ( isAddingLink || isEditingLink ) {
-			linkUIToShow = 'editing';
-		} else if ( formats.link ) {
-			linkUIToShow = 'previewing';
-		}
-
-		const linkSettings = settingsVisible && (
-			<div className="editor-format-toolbar__link-modal-line editor-format-toolbar__link-settings">
-				<ToggleControl
-					label={ __( 'Open in New Window' ) }
-					checked={ opensInNewWindow }
-					onChange={ this.setLinkTarget } />
-			</div>
-		);
-
 		return (
 			<div className="editor-format-toolbar">
 				<Toolbar controls={ toolbarControls } />
 
-				{ linkUIToShow !== 'none' && (
-					<Fill name="RichText.Siblings">
-						<PositionedAtSelection className="editor-format-toolbar__link-container">
-							<Popover
-								position="bottom center"
-								focusOnMount={ isAddingLink ? 'firstElement' : false }
-								key={ selectedNodeId /* Used to force rerender on change */ }
-							>
-								{ linkUIToShow === 'editing' && (
-									// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-									/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-									<form
-										className="editor-format-toolbar__link-modal"
-										onKeyPress={ stopKeyPropagation }
-										onKeyDown={ this.onKeyDown }
-										onSubmit={ this.submitLink }>
-										<div className="editor-format-toolbar__link-modal-line">
-											<URLInput value={ linkValue } onChange={ this.onChangeLinkValue } />
-											<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-											<IconButton
-												className="editor-format-toolbar__link-settings-toggle"
-												icon="ellipsis"
-												label={ __( 'Link Settings' ) }
-												onClick={ this.toggleLinkSettingsVisibility }
-												aria-expanded={ settingsVisible }
-											/>
-										</div>
-										{ linkSettings }
-									</form>
-									/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
-								) }
-
-								{ linkUIToShow === 'previewing' && (
-									// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-									/* eslint-disable jsx-a11y/no-static-element-interactions */
-									<div
-										className="editor-format-toolbar__link-modal"
-										onKeyPress={ stopKeyPropagation }
-									>
-										<div className="editor-format-toolbar__link-modal-line">
-											<ExternalLink
-												className="editor-format-toolbar__link-value"
-												href={ formats.link.value }
-											>
-												{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
-											</ExternalLink>
-											<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
-											<IconButton
-												className="editor-format-toolbar__link-settings-toggle"
-												icon="ellipsis"
-												label={ __( 'Link Settings' ) }
-												onClick={ this.toggleLinkSettingsVisibility }
-												aria-expanded={ settingsVisible }
-											/>
-										</div>
-										{ linkSettings }
-									</div>
-									/* eslint-enable jsx-a11y/no-static-element-interactions */
-								) }
-							</Popover>
-						</PositionedAtSelection>
-					</Fill>
+				{ ( isEditing || isPreviewing ) && (
+					<LinkContainer
+						editLink={ this.editLink }
+						formats={ formats }
+						isEditing={ isEditing }
+						isPreviewing={ isPreviewing }
+						linkValue={ linkValue }
+						onChangeLinkValue={ this.onChangeLinkValue }
+						onKeyDown={ this.onKeyDown }
+						opensInNewWindow={ opensInNewWindow }
+						selectedNodeId={ selectedNodeId }
+						setLinkTarget={ this.setLinkTarget }
+						settingsVisible={ settingsVisible }
+						submitLink={ this.submitLink }
+						toggleLinkSettingsVisibility={ this.toggleLinkSettingsVisibility }
+					/>
 				) }
 			</div>
 		);

--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -1,0 +1,113 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	ExternalLink,
+	Fill,
+	IconButton,
+	Popover,
+	ToggleControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PositionedAtSelection from './positioned-at-selection';
+import URLInput from '../../url-input';
+import { filterURLForDisplay } from '../../../utils/url';
+
+const stopKeyPropagation = ( event ) => event.stopPropagation();
+
+const LinkContainer = ( props ) => {
+	const {
+		editLink,
+		formats,
+		isEditing,
+		isPreviewing,
+		linkValue,
+		onChangeLinkValue,
+		onKeyDown,
+		opensInNewWindow,
+		selectedNodeId,
+		setLinkTarget,
+		settingsVisible,
+		submitLink,
+		toggleLinkSettingsVisibility,
+	} = props;
+
+	const linkSettings = settingsVisible && (
+		<div className="editor-format-toolbar__link-modal-line editor-format-toolbar__link-settings">
+			<ToggleControl
+				label={ __( 'Open in New Window' ) }
+				checked={ opensInNewWindow }
+				onChange={ setLinkTarget } />
+		</div>
+	);
+
+	return (
+		<Fill name="RichText.Siblings">
+			<PositionedAtSelection className="editor-format-toolbar__link-container">
+				<Popover
+					position="bottom center"
+					focusOnMount={ isEditing ? 'firstElement' : false }
+					key={ selectedNodeId /* Used to force rerender on change */ }
+				>
+					{ isEditing && (
+						// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+						/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+						<form
+							className="editor-format-toolbar__link-modal"
+							onKeyPress={ stopKeyPropagation }
+							onKeyDown={ onKeyDown }
+							onSubmit={ submitLink }>
+							<div className="editor-format-toolbar__link-modal-line">
+								<URLInput value={ linkValue } onChange={ onChangeLinkValue } />
+								<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
+								<IconButton
+									className="editor-format-toolbar__link-settings-toggle"
+									icon="ellipsis"
+									label={ __( 'Link Settings' ) }
+									onClick={ toggleLinkSettingsVisibility }
+									aria-expanded={ settingsVisible }
+								/>
+							</div>
+							{ linkSettings }
+						</form>
+						/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+					) }
+
+					{ isPreviewing && (
+						// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+						/* eslint-disable jsx-a11y/no-static-element-interactions */
+						<div
+							className="editor-format-toolbar__link-modal"
+							onKeyPress={ stopKeyPropagation }
+						>
+							<div className="editor-format-toolbar__link-modal-line">
+								<ExternalLink
+									className="editor-format-toolbar__link-value"
+									href={ formats.link.value }
+								>
+									{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
+								</ExternalLink>
+								<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ editLink } />
+								<IconButton
+									className="editor-format-toolbar__link-settings-toggle"
+									icon="ellipsis"
+									label={ __( 'Link Settings' ) }
+									onClick={ toggleLinkSettingsVisibility }
+									aria-expanded={ settingsVisible }
+								/>
+							</div>
+							{ linkSettings }
+						</div>
+						/* eslint-enable jsx-a11y/no-static-element-interactions */
+					) }
+				</Popover>
+			</PositionedAtSelection>
+		</Fill>
+	);
+};
+
+export default LinkContainer;

--- a/packages/editor/src/components/rich-text/formatting-controls.js
+++ b/packages/editor/src/components/rich-text/formatting-controls.js
@@ -4,8 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { displayShortcut } from '@wordpress/keycodes';
 
-export const DEFAULT_CONTROLS = [ 'bold', 'italic', 'strikethrough', 'link', 'code' ];
-
 export const FORMATTING_CONTROLS = [
 	{
 		icon: 'editor-bold',

--- a/packages/editor/src/components/rich-text/formatting-controls.js
+++ b/packages/editor/src/components/rich-text/formatting-controls.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { displayShortcut } from '@wordpress/keycodes';
+
+export const DEFAULT_CONTROLS = [ 'bold', 'italic', 'strikethrough', 'link', 'code' ];
+
+export const FORMATTING_CONTROLS = [
+	{
+		icon: 'editor-bold',
+		title: __( 'Bold' ),
+		shortcut: displayShortcut.primary( 'b' ),
+		format: 'bold',
+	},
+	{
+		icon: 'editor-italic',
+		title: __( 'Italic' ),
+		shortcut: displayShortcut.primary( 'i' ),
+		format: 'italic',
+	},
+	{
+		icon: 'admin-links',
+		title: __( 'Link' ),
+		shortcut: displayShortcut.primary( 'k' ),
+		format: 'link',
+	},
+	{
+		icon: 'editor-strikethrough',
+		title: __( 'Strikethrough' ),
+		shortcut: displayShortcut.access( 'd' ),
+		format: 'strikethrough',
+	},
+];

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -37,7 +37,7 @@ import { isURL } from '@wordpress/url';
  */
 import Autocomplete from '../autocomplete';
 import BlockFormatControls from '../block-format-controls';
-import { DEFAULT_CONTROLS } from './formatting-controls';
+import { FORMATTING_CONTROLS } from './formatting-controls';
 import FormatToolbar from './format-toolbar';
 import TinyMCE from './tinymce';
 import { pickAriaProps } from './aria';
@@ -1003,7 +1003,7 @@ RichText.contextTypes = {
 };
 
 RichText.defaultProps = {
-	formattingControls: DEFAULT_CONTROLS,
+	formattingControls: FORMATTING_CONTROLS.map( ( { format } ) => format ),
 	formatters: [],
 	format: 'children',
 };

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -37,6 +37,7 @@ import { isURL } from '@wordpress/url';
  */
 import Autocomplete from '../autocomplete';
 import BlockFormatControls from '../block-format-controls';
+import { DEFAULT_CONTROLS } from './formatting-controls';
 import FormatToolbar from './format-toolbar';
 import TinyMCE from './tinymce';
 import { pickAriaProps } from './aria';
@@ -79,8 +80,6 @@ export function getFormatValue( formatName, parents ) {
 
 	return { isActive: true };
 }
-
-const DEFAULT_FORMATS = [ 'bold', 'italic', 'strikethrough', 'link', 'code' ];
 
 export class RichText extends Component {
 	constructor() {
@@ -1004,7 +1003,7 @@ RichText.contextTypes = {
 };
 
 RichText.defaultProps = {
-	formattingControls: DEFAULT_FORMATS,
+	formattingControls: DEFAULT_CONTROLS,
 	formatters: [],
 	format: 'children',
 };


### PR DESCRIPTION
## Description
Extracted out of #9012.

This PR extracts `LinkContainer` to make it easier to provide React Native implementation for the parts that need to work differently on mobile devices.

## How has this been tested?
`npm test`
`npm run build`

1. Add paragraph block.
2. Type some text.
3. Select text and turn it into link.
4. Type link url and save it.
5. Edit just saved url and save it.
6. Add more text and turn it into link.
7. Go back to the previously added link and try to edit it.
8. Remove added link.

All of those should work properly.

## Types of changes
There should be no visual changes. It should be still possible to add/remove links from `RichText` powered fields like Paragraph block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
