### PR TITLE
Only request the embed preview if we have a URL

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -295,8 +295,8 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 				const { url } = ownProps.attributes;
 				const core = select( 'core' );
 				const { getEmbedPreview, isPreviewEmbedFallback, isRequestingEmbedPreview } = core;
-				const preview = getEmbedPreview( url );
-				const previewIsFallback = isPreviewEmbedFallback( url );
+				const preview = url && getEmbedPreview( url );
+				const previewIsFallback = url && isPreviewEmbedFallback( url );
 				const fetching = undefined !== url && isRequestingEmbedPreview( url );
 				return {
 					preview,


### PR DESCRIPTION
## Description

We were requesting a preview for URLs even if the URL hadn't been entered yet, so creating a new embed block resulted in an unneeded API call. This stops that.

## How has this been tested?

Create a new embed block, check there are no API calls sent to the embed endpoints.

## Types of changes
Bug fix
