### PR TITLE
Quote block: use block element to prevent "cite" from disappearing

### DIFF
--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -70,7 +70,7 @@ export const settings = {
 				/>
 				{ ( citation || isSelected ) && (
 					<RichText
-						tagName="cite"
+						tagName="footer"
 						value={ citation }
 						/* translators: the individual or entity quoted */
 						placeholder={ __( 'Write citation…' ) }

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -204,7 +204,7 @@ export const settings = {
 					/>
 					{ ( ( citation && citation.length > 0 ) || isSelected ) && (
 						<RichText
-							tagName="cite"
+							tagName="footer"
 							value={ citation }
 							onChange={
 								( nextCitation ) => setAttributes( {


### PR DESCRIPTION
## Description

Should fix #9180. The quote blocks currently use `cite` tags as a container for `RichText`, but `cite` tags are inline tags, so this seems to have some buggy side effects. This branch is just for testing to see if everything works as expected. Maybe additionally we should switch back to use `footer` instead of `cite`.

## How has this been tested?
See #9180.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->