### PR TITLE
Use double quotes in all NUX tips

### DIFF
--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -63,7 +63,7 @@ function Header( {
 						shortcut={ shortcuts.toggleSidebar.display }
 					>
 						<DotTip id="core/editor.settings">
-							{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click ‘Settings’ to open it.' ) }
+							{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” to open it.' ) }
 						</DotTip>
 					</IconButton>
 					<PinnedPlugins.Slot />

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -127,7 +127,7 @@ export class PostPreviewButton extends Component {
 			>
 				{ _x( 'Preview', 'imperative verb' ) }
 				<DotTip id="core/editor.preview">
-					{ __( 'Click ‘Preview’ to load a preview of this page, so you can make sure you’re happy with your blocks.' ) }
+					{ __( 'Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.' ) }
 				</DotTip>
 			</Button>
 		);

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -11,7 +11,7 @@ exports[`PostPreviewButton render() should match the snapshot 1`] = `
   <WithInstanceId(WithSelect(WithDispatch(DotTip)))
     id="core/editor.preview"
   >
-    Click ‘Preview’ to load a preview of this page, so you can make sure you’re happy with your blocks.
+    Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.
   </WithInstanceId(WithSelect(WithDispatch(DotTip)))>
 </Button>
 `;

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -52,7 +52,7 @@ export function PostPublishPanelToggle( {
 		>
 			{ isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' ) }
 			<DotTip id="core/editor.publish">
-				{ __( 'Finished writing? That’s great, let’s get this published right now. Just click ‘Publish’ and you’re good to go.' ) }
+				{ __( 'Finished writing? That’s great, let’s get this published right now. Just click “Publish” and you’re good to go.' ) }
 			</DotTip>
 		</Button>
 	);


### PR DESCRIPTION
## Description
Fixes #9205. Changes all NUX tips to consistently use double quotes rather than single quotes.

:tada::balloon:First Gutenberg PR hype!:balloon::tada: