### PR TITLE
Introduce get_blocks function

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -333,6 +333,26 @@ function gutenberg_can_edit_post_type( $post_type ) {
 }
 
 /**
+ * Returns blocks from a post or content string.
+ *
+ * @since 3.7.0
+ * @see gutenberg_parse_blocks()
+ *
+ * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
+ * @return array Array of parsed block objects.
+ */
+function get_blocks( $post = null ) {
+	if ( ! is_string( $post ) ) {
+		$wp_post = get_post( $post );
+		if ( $wp_post instanceof WP_Post ) {
+			$post = $wp_post->post_content;
+		}
+	}
+
+	return gutenberg_parse_blocks( (string) $post );
+}
+
+/**
  * Determine whether a post or content string has blocks.
  *
  * This test optimizes for performance rather than strict accuracy, detecting

--- a/phpunit/class-registration-test.php
+++ b/phpunit/class-registration-test.php
@@ -76,6 +76,52 @@ class Registration_Test extends WP_UnitTestCase {
 		$this->assertNotContains( 'core/dummy', $dynamic_block_names );
 	}
 
+	/**
+	 * @covers ::get_blocks, ::gutenberg_parse_blocks
+	 */
+	function test_get_blocks() {
+		$default = array(
+			array(
+				'attrs'     => array(),
+				'innerHTML' => '',
+			),
+		);
+
+		// Post ID.
+		$blocks = get_blocks( self::$post_id );
+		$this->assertInternalType( 'array', $blocks );
+
+		// WP_Post object.
+		$post = get_post( self::$post_id );
+		$blocks = get_blocks( $post );
+		$this->assertInternalType( 'array', $blocks );
+
+		// Content string.
+		$blocks = get_blocks( $post->post_content );
+		$this->assertInternalType( 'array', $blocks );
+
+		foreach ( $blocks as $block ) {
+			$this->assertInternalType( 'array', $block );
+			$this->assertArrayHasKey( 'attrs', $block );
+			$this->assertArrayHasKey( 'innerHTML', $block );
+		}
+
+		// No attribute, outside of loop.
+		$blocks = get_blocks();
+		$this->assertInternalType( 'array', $blocks );
+		$this->assertEqualSetsWithIndex( $default, $blocks );
+
+		// No attribute, inside of loop.
+		$query = new WP_Query( array( 'post__in' => array( self::$post_id ) ) );
+		$query->the_post();
+		$blocks = get_blocks();
+		$this->assertInternalType( 'array', $blocks );
+		$this->assertEquals( 9, count( $blocks ) );
+	}
+
+	/**
+	 * @covers ::has_blocks
+	 */
 	function test_has_blocks() {
 		// Test with passing post ID.
 		$this->assertTrue( has_blocks( self::$post_id ) );

--- a/phpunit/class-registration-test.php
+++ b/phpunit/class-registration-test.php
@@ -92,7 +92,7 @@ class Registration_Test extends WP_UnitTestCase {
 		$this->assertInternalType( 'array', $blocks );
 
 		// WP_Post object.
-		$post = get_post( self::$post_id );
+		$post   = get_post( self::$post_id );
 		$blocks = get_blocks( $post );
 		$this->assertInternalType( 'array', $blocks );
 


### PR DESCRIPTION
See #8352.

## Description
A convenient wrapper for `gutenberg_parse_blocks()` that can be used as a template tag as well, complimentary to `has_blocks()` and `has_block()`.

## How has this been tested?
Through unit tests, as well as checking the output of `get_blocks()` on `'template_redirect'`.

## Types of changes
Adds a wrapper function for `gutenberg_parse_blocks()` that can be used inside and outside of loops.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
