### PR TITLE
Add new getBlockCategories() function for retrieving filtered list of block categories

### DIFF
--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -42,6 +42,7 @@ export {
 	hasChildBlocks,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 	registerBlockStyle,
+	getBlockCategories,
 } from './registration';
 export {
 	isUnmodifiedDefaultBlock,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -130,7 +130,7 @@ export function registerBlockType( name, settings ) {
 	}
 	if (
 		'category' in settings &&
-		! some( select( 'core/blocks' ).getCategories(), { slug: settings.category } )
+		! some( getBlockCategories(), { slug: settings.category } )
 	) {
 		console.error(
 			'The block "' + name + '" must have a registered category.'
@@ -345,3 +345,15 @@ export const registerBlockStyle = ( blockName, styleVariation ) => {
 		};
 	} );
 };
+
+/**
+ * Returns filtered array of all registered block categories.
+ *
+ * @return {Array} Block categories.
+ */
+export function getBlockCategories() {
+	return applyFilters(
+		'blocks.getBlockCategories',
+		select( 'core/blocks' ).getCategories()
+	);
+}


### PR DESCRIPTION
## Description
Currently custom block categories can only be registered server side via a filter using PHP ( https://wordpress.org/gutenberg/handbook/extensibility/extending-blocks/#managing-block-categories ).

Attempting to write javascript unit tests for blocks that utilize a custom block category results in a console error being output from the following code found in `/packages/blocks/src/api/registration.js` 

```js
	if (
		'category' in settings &&
		! some( select( 'core/blocks' ).getCategories(), { slug: settings.category } )
	) {
		console.error(
			'The block "' + name + '" must have a registered category.'
		);
		return;
	}
```

It appears that the `'block_categories'` filter does not run during unit testing because no matter where I run that filter, its additions do not get picked up during unit testing. I'm assuming that plugins are simply not loading during API requests made during testing.

Attempts to manually add the required custom category using `setCategories()` from `@wordpress/blocks` ( ie: `/packages/blocks/src/api/categories.js` ) does not appear to work as the list of categories retrieved in the code above will not include the new category that was just added. We have also tried mocking `@wordpress/blocks` but that obviously interferes with registering the block and being able to perform snapshots testing on it.

The only successful solution we have found is to use a getter for retrieving the list of block categories and to wrap the returned results in a filter, but we are open to other suggestions and would be more than happy to implement some other solution that allows custom categories to be used during unit tests.

## How has this been tested?
This has only been tested indirectly through use in our custom block unit tests that no longer trigger a console error when using a custom block category.

## Types of changes
added the following function to `/packages/blocks/src/api/registration.js`:

```js
/**
 * Returns filtered array of all registered block categories.
 *
 * @return {Array} Block categories.
 */
export function getBlockCategories() {
	return applyFilters(
		'blocks.getBlockCategories',
		select( 'core/blocks' ).getCategories()
	);
}
```

and used during block registration:


```js
	if (
		'category' in settings &&
		! some( getBlockCategories(), { slug: settings.category } )
	) {
		console.error(
			'The block "' + name + '" must have a registered category.'
		);
		return;
	}
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
