### PR TITLE
Data: Update register behaviors to merge with existing set

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 - Breaking: The `withRehdyration` function is removed. Use the persistence plugin instead.
 - Breaking: The `loadAndPersist` function is removed. Use the persistence plugin instead.
+- Breaking: `registerSelectors`, `registerActions`, and `registerResolvers` will merge into the existing set of selectors, actions, and resolvers, if any exist (previously replaced all except those matching keys of the new set). This is intended to facilitate extensibility of singular function handlers.


### PR DESCRIPTION
This pull request seeks to update the behavior of the `data` module's `registerSelectors`, `registerActions`, and `registerResolvers` functions to merge into the existing set of selectors, actions, and resolvers, if any exist. Previously it would replace all except those matching keys of the new set). This is intended to facilitate extensibility of singular function handlers, which has been an expected use-case of the data module since its inception (particularly around resolvers fulfillment alternatives).

This is being flagged as a breaking change, since while it was not previously a documented behavior, the new behavior is not compatible with previous expectations. I do not assume that there is much of a likelihood for breakage, and it is not possible to provide a fallback. It is being included in the set of breaking changes slated for a pending `@wordpress/data@2.0.0` release.

Included is a new section in the documentation detailing an extensibility example. 

In the future, we may consider:

- Refactoring `select` results to an internally-extensible flow
   - As part of refactoring resolvers as a plugin?
- Offering option to merge controls
   - There is no `registerControls` function. Should the `controls` plugin add one?

**Testing instructions:**

It's not expected that this should have an impact on the application, as to my knowledge there are no instances of multiple calls to register selectors, actions, or resolvers.

Verify still that normal behaviors of each occur as expected (it's unlikely the editor would load at all if they were not functional). 

Ensure unit tests pass:

```
npm run test-unit
```