### PR TITLE
NUX: Move first tip to the toolbar

### DIFF
--- a/edit-post/components/header/header-toolbar/index.js
+++ b/edit-post/components/header/header-toolbar/index.js
@@ -4,6 +4,7 @@
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
+import { DotTip } from '@wordpress/nux';
 
 /**
  * WordPress dependencies
@@ -29,7 +30,11 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport } ) {
 			className="edit-post-header-toolbar"
 			aria-label={ __( 'Editor Toolbar' ) }
 		>
-			<Inserter position="bottom right" />
+			<Inserter position="bottom right">
+				<DotTip id="core/editor.inserter">
+					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!' ) }
+				</DotTip>
+			</Inserter>
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents />

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -143,8 +143,7 @@ class Popover extends Component {
 		window.console.warn( `<Popover> component: focusOnMount argument "${ focusOnMount }" not recognized.` );
 	}
 
-	getAnchorRect() {
-		const anchor = this.anchorNode.current;
+	getAnchorRect( anchor ) {
 		if ( ! anchor || ! anchor.parentNode ) {
 			return;
 		}
@@ -185,7 +184,10 @@ class Popover extends Component {
 	computePopoverPosition( popoverSize ) {
 		const { getAnchorRect = this.getAnchorRect, position = 'top', expandOnMobile } = this.props;
 		const newPopoverPosition = computePopoverPosition(
-			getAnchorRect(), popoverSize || this.state.popoverSize, position, expandOnMobile
+			getAnchorRect( this.anchorNode.current ),
+			popoverSize || this.state.popoverSize,
+			position,
+			expandOnMobile
 		);
 
 		if (

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { get } from 'lodash';
 
 /**
@@ -12,7 +11,6 @@ import { compose } from '@wordpress/compose';
 import { getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { DotTip } from '@wordpress/nux';
 
 /**
  * Internal dependencies
@@ -29,7 +27,6 @@ export function DefaultBlockAppender( {
 	placeholder,
 	layout,
 	rootClientId,
-	hasTip,
 } ) {
 	if ( isLocked || ! isVisible ) {
 		return null;
@@ -51,11 +48,7 @@ export function DefaultBlockAppender( {
 	// See: https://gist.github.com/cvrebert/68659d0333a578d75372
 
 	return (
-		<div
-			data-root-client-id={ rootClientId || '' }
-			className={ classnames( 'editor-default-block-appender', {
-				'has-tip': hasTip,
-			} ) }>
+		<div data-root-client-id={ rootClientId || '' } className="editor-default-block-appender">
 			<BlockDropZone rootClientId={ rootClientId } layout={ layout } />
 			<input
 				role="button"
@@ -67,18 +60,13 @@ export function DefaultBlockAppender( {
 				value={ showPrompt ? value : '' }
 			/>
 			<InserterWithShortcuts rootClientId={ rootClientId } layout={ layout } />
-			<Inserter position="top right">
-				<DotTip id="core/editor.inserter">
-					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!' ) }
-				</DotTip>
-			</Inserter>
+			<Inserter position="top right" />
 		</div>
 	);
 }
 export default compose(
 	withSelect( ( select, ownProps ) => {
 		const { getBlockCount, getBlock, getEditorSettings, getTemplateLock } = select( 'core/editor' );
-		const { isTipVisible } = select( 'core/nux' );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
 		const lastBlock = getBlock( ownProps.lastBlockClientId );
@@ -90,7 +78,6 @@ export default compose(
 			showPrompt: isEmpty,
 			isLocked: !! getTemplateLock( ownProps.rootClientId ),
 			placeholder: bodyPlaceholder,
-			hasTip: isTipVisible( 'core/editor.inserter' ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
@@ -99,11 +86,9 @@ export default compose(
 			startTyping,
 		} = dispatch( 'core/editor' );
 
-		const { dismissTip } = dispatch( 'core/nux' );
-
 		return {
 			onAppend() {
-				const { layout, rootClientId, hasTip } = ownProps;
+				const { layout, rootClientId } = ownProps;
 
 				let attributes;
 				if ( layout ) {
@@ -112,10 +97,6 @@ export default compose(
 
 				insertDefaultBlock( attributes, rootClientId );
 				startTyping();
-
-				if ( hasTip ) {
-					dismissTip( 'core/editor.inserter' );
-				}
 			},
 		};
 	} ),

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -40,17 +40,15 @@
 		}
 	}
 
-	&:hover .editor-inserter-with-shortcuts {
-		opacity: 1;
+	// Don't show the inserter until mousing over.
+	.editor-inserter__toggle:not([aria-expanded="true"]) {
+		opacity: 0;
 	}
-
-	// Show the inserter if mousing over or there is a tip.
-	&:not(.has-tip) {
-		.editor-inserter__toggle:not([aria-expanded="true"]) {
-			opacity: 0;
+	&:hover {
+		.editor-inserter-with-shortcuts {
+			opacity: 1;
 		}
-
-		&:hover .editor-inserter__toggle {
+		.editor-inserter__toggle {
 			opacity: 1;
 		}
 	}

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -25,13 +25,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(WithDispatch(Inserter))
     position="top right"
-  >
-    <WithInstanceId(WithSelect(WithDispatch(DotTip)))
-      id="core/editor.inserter"
-    >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithInstanceId(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  />
 </div>
 `;
 
@@ -53,13 +47,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(WithDispatch(Inserter))
     position="top right"
-  >
-    <WithInstanceId(WithSelect(WithDispatch(DotTip)))
-      id="core/editor.inserter"
-    >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithInstanceId(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  />
 </div>
 `;
 
@@ -81,12 +69,6 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(WithDispatch(Inserter))
     position="top right"
-  >
-    <WithInstanceId(WithSelect(WithDispatch(DotTip)))
-      id="core/editor.inserter"
-    >
-      Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!
-    </WithInstanceId(WithSelect(WithDispatch(DotTip)))>
-  </WithSelect(WithDispatch(Inserter))>
+  />
 </div>
 `;

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -8,10 +8,10 @@ exports[`PostPreviewButton render() should match the snapshot 1`] = `
   onClick={[Function]}
 >
   Preview
-  <WithInstanceId(WithSelect(WithDispatch(DotTip)))
+  <WithSelect(WithDispatch(DotTip))
     id="core/editor.preview"
   >
     Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.
-  </WithInstanceId(WithSelect(WithDispatch(DotTip)))>
+  </WithSelect(WithDispatch(DotTip))>
 </Button>
 `;

--- a/packages/nux/src/components/dot-tip/README.md
+++ b/packages/nux/src/components/dot-tip/README.md
@@ -3,8 +3,6 @@ DotTip
 
 `DotTip` is a React component that renders a single _tip_ on the screen. The tip will point to the React element that `DotTip` is nested within. Each tip is uniquely identified by a string passed to `id`.
 
-When there are multiple instances of `DotTip` that reference the same tip identifier, only the first instance to have been mounted will be visible.
-
 ## Usage
 
 ```jsx
@@ -23,7 +21,7 @@ The component accepts the following props:
 
 ### id
 
-A string that uniquely identifies the tip. Identifiers should be prefixed with the name of the plugin, followed by a `/`. For example, `acme/add-to-cart`. Changing the identifier after the component has mounted is not supported.
+A string that uniquely identifies the tip. Identifiers should be prefixed with the name of the plugin, followed by a `/`. For example, `acme/add-to-cart`.
 
 - Type: `string`
 - Required: Yes

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -1,84 +1,64 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { compose, withInstanceId } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 import { Popover, Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-export class DotTip extends Component {
-	componentDidMount() {
-		this.props.onRegister();
+export function DotTip( {
+	children,
+	isVisible,
+	hasNextTip,
+	onDismiss,
+	onDisable,
+} ) {
+	if ( ! isVisible ) {
+		return null;
 	}
 
-	componentWillUnmount() {
-		this.props.onUnregister();
-	}
-
-	render() {
-		const { children, isVisible, hasNextTip, onDismiss, onDisable } = this.props;
-
-		if ( ! isVisible ) {
-			return null;
-		}
-
-		return (
-			<Popover
-				className="nux-dot-tip"
-				position="middle right"
-				noArrow
-				focusOnMount="container"
-				role="dialog"
-				aria-label={ __( 'Gutenberg tips' ) }
-				onClick={ ( event ) => {
-					// Tips are often nested within buttons. We stop propagation so that clicking
-					// on a tip doesn't result in the button being clicked.
-					event.stopPropagation();
-				} }
-			>
-				<p>{ children }</p>
-				<p>
-					<Button isLink onClick={ onDismiss }>
-						{ hasNextTip ? __( 'See next tip' ) : __( 'Got it' ) }
-					</Button>
-				</p>
-				<IconButton
-					className="nux-dot-tip__disable"
-					icon="no-alt"
-					label={ __( 'Disable tips' ) }
-					onClick={ onDisable }
-				/>
-			</Popover>
-		);
-	}
+	return (
+		<Popover
+			className="nux-dot-tip"
+			position="middle right"
+			noArrow
+			focusOnMount="container"
+			role="dialog"
+			aria-label={ __( 'Gutenberg tips' ) }
+			onClick={ ( event ) => {
+				// Tips are often nested within buttons. We stop propagation so that clicking
+				// on a tip doesn't result in the button being clicked.
+				event.stopPropagation();
+			} }
+		>
+			<p>{ children }</p>
+			<p>
+				<Button isLink onClick={ onDismiss }>
+					{ hasNextTip ? __( 'See next tip' ) : __( 'Got it' ) }
+				</Button>
+			</p>
+			<IconButton
+				className="nux-dot-tip__disable"
+				icon="no-alt"
+				label={ __( 'Disable tips' ) }
+				onClick={ onDisable }
+			/>
+		</Popover>
+	);
 }
 
 export default compose(
-	withInstanceId,
-	withSelect( ( select, { id, instanceId } ) => {
+	withSelect( ( select, { id } ) => {
 		const { isTipVisible, getAssociatedGuide } = select( 'core/nux' );
 		const associatedGuide = getAssociatedGuide( id );
 		return {
-			isVisible: isTipVisible( id, instanceId ),
+			isVisible: isTipVisible( id ),
 			hasNextTip: !! ( associatedGuide && associatedGuide.nextTipId ),
 		};
 	} ),
-	withDispatch( ( dispatch, { id, instanceId } ) => {
-		const {
-			registerTipInstance,
-			unregisterTipInstance,
-			dismissTip,
-			disableTips,
-		} = dispatch( 'core/nux' );
-
+	withDispatch( ( dispatch, { id } ) => {
+		const { dismissTip, disableTips } = dispatch( 'core/nux' );
 		return {
-			onRegister() {
-				registerTipInstance( id, instanceId );
-			},
-			onUnregister() {
-				unregisterTipInstance( id, instanceId );
-			},
 			onDismiss() {
 				dismissTip( id );
 			},

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -6,6 +6,19 @@ import { Popover, Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 
+function getAnchorRect( anchor ) {
+	// The default getAnchorRect() excludes an element's top and bottom padding
+	// from its calculation. We want tips to point to the outer margin of an
+	// element, so we override getAnchorRect() to include all padding.
+	return anchor.parentNode.getBoundingClientRect();
+}
+
+function onClick( event ) {
+	// Tips are often nested within buttons. We stop propagation so that clicking
+	// on a tip doesn't result in the button being clicked.
+	event.stopPropagation();
+}
+
 export function DotTip( {
 	children,
 	isVisible,
@@ -23,13 +36,10 @@ export function DotTip( {
 			position="middle right"
 			noArrow
 			focusOnMount="container"
+			getAnchorRect={ getAnchorRect }
 			role="dialog"
 			aria-label={ __( 'Gutenberg tips' ) }
-			onClick={ ( event ) => {
-				// Tips are often nested within buttons. We stop propagation so that clicking
-				// on a tip doesn't result in the button being clicked.
-				event.stopPropagation();
-			} }
+			onClick={ onClick }
 		>
 			<p>{ children }</p>
 			<p>

--- a/packages/nux/src/components/dot-tip/style.scss
+++ b/packages/nux/src/components/dot-tip/style.scss
@@ -51,10 +51,16 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 	}
 
 	// Position the dot right next to the edge of the button
-	&.is-left {
+	&.is-top {
+		margin-top: -$dot-size / 2;
+	}
+	&.is-bottom {
+		margin-top: $dot-size / 2;
+	}
+	&.is-middle.is-left {
 		margin-left: -$dot-size / 2;
 	}
-	&.is-right {
+	&.is-middle.is-right {
 		margin-left: $dot-size / 2;
 	}
 

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -5,6 +5,7 @@ exports[`DotTip should render correctly 1`] = `
   aria-label="Gutenberg tips"
   className="nux-dot-tip"
   focusOnMount="container"
+  getAnchorRect={[Function]}
   noArrow={true}
   onClick={[Function]}
   position="middle right"

--- a/packages/nux/src/components/dot-tip/test/index.js
+++ b/packages/nux/src/components/dot-tip/test/index.js
@@ -14,7 +14,7 @@ jest.mock( '../../../../../components/src/button' );
 describe( 'DotTip', () => {
 	it( 'should not render anything if invisible', () => {
 		const wrapper = shallow(
-			<DotTip onRegister={ noop } onUnregister={ noop }>
+			<DotTip>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
@@ -23,7 +23,7 @@ describe( 'DotTip', () => {
 
 	it( 'should render correctly', () => {
 		const wrapper = shallow(
-			<DotTip isVisible onRegister={ noop } onUnregister={ noop }>
+			<DotTip isVisible setTimeout={ noop }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
@@ -33,7 +33,7 @@ describe( 'DotTip', () => {
 	it( 'should call onDismiss when the dismiss button is clicked', () => {
 		const onDismiss = jest.fn();
 		const wrapper = shallow(
-			<DotTip isVisible onDismiss={ onDismiss } onRegister={ noop } onUnregister={ noop }>
+			<DotTip isVisible onDismiss={ onDismiss } setTimeout={ noop }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
@@ -44,7 +44,7 @@ describe( 'DotTip', () => {
 	it( 'should call onDisable when the X button is clicked', () => {
 		const onDisable = jest.fn();
 		const wrapper = shallow(
-			<DotTip isVisible onDisable={ onDisable } onRegister={ noop } onUnregister={ noop }>
+			<DotTip isVisible onDisable={ onDisable } setTimeout={ noop }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);

--- a/packages/nux/src/store/actions.js
+++ b/packages/nux/src/store/actions.js
@@ -14,43 +14,6 @@ export function triggerGuide( tipIds ) {
 }
 
 /**
- * Returns an action object that, when dispatched, associates an instance of the
- * DotTip component with a tip. This is usually done when the component mounts.
- * Tracking this lets us only show one DotTip at a time per tip.
- *
- * @param {string} tipId      The tip to associate this instance with.
- * @param {number} instanceId A number which uniquely identifies the instance.
- *
- * @return {Object} Action object.
- */
-export function registerTipInstance( tipId, instanceId ) {
-	return {
-		type: 'REGISTER_TIP_INSTANCE',
-		tipId,
-		instanceId,
-	};
-}
-
-/**
- * Returns an action object that, when dispatched, removes the association
- * between a DotTip component instance and a tip. This is usually done when the
- * component unmounts. Tracking this lets us only show one DotTip at a time per
- * tip.
- *
- * @param {string} tipId      The tip to disassociate this instance with.
- * @param {number} instanceId A number which uniquely identifies the instance.
- *
- * @return {Object} Action object.
- */
-export function unregisterTipInstance( tipId, instanceId ) {
-	return {
-		type: 'UNREGISTER_TIP_INSTANCE',
-		tipId,
-		instanceId,
-	};
-}
-
-/**
  * Returns an action object that, when dispatched, dismisses the given tip. A
  * dismissed tip will not show again.
  *

--- a/packages/nux/src/store/reducer.js
+++ b/packages/nux/src/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { uniq, without } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -24,36 +19,6 @@ export function guides( state = [], action ) {
 				...state,
 				action.tipIds,
 			];
-	}
-
-	return state;
-}
-
-/**
- * Reducer that maps each tip to an array of DotTip component instance IDs that are
- * displaying that tip. Tracking this allows us to only show one DotTip at a
- * time per tip.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function tipInstanceIds( state = {}, action ) {
-	switch ( action.type ) {
-		case 'REGISTER_TIP_INSTANCE': {
-			const existingInstanceIds = state[ action.tipId ] || [];
-			return {
-				...state,
-				[ action.tipId ]: uniq( [ ...existingInstanceIds, action.instanceId ] ),
-			};
-		}
-
-		case 'UNREGISTER_TIP_INSTANCE':
-			return {
-				...state,
-				[ action.tipId ]: without( state[ action.tipId ], action.instanceId ),
-			};
 	}
 
 	return state;
@@ -105,4 +70,4 @@ export function dismissedTips( state = {}, action ) {
 
 const preferences = combineReducers( { areTipsEnabled, dismissedTips } );
 
-export default combineReducers( { guides, tipInstanceIds, preferences } );
+export default combineReducers( { guides, preferences } );

--- a/packages/nux/src/store/selectors.js
+++ b/packages/nux/src/store/selectors.js
@@ -41,38 +41,27 @@ export const getAssociatedGuide = createSelector(
 );
 
 /**
- * Determines whether the given tip or DotTip instance should be visible. Checks:
+ * Determines whether or not the given tip is showing. Tips are hidden if they
+ * are disabled, have been dismissed, or are not the current tip in any
+ * guide that they have been added to.
  *
- * - That all tips are enabled.
- * - That the given tip has not been dismissed.
- * - If the given tip is part of a guide, that the given tip is the current tip in the guide.
- * - If instanceId is provided, that this is the first DotTip instance for the given tip.
+ * @param {Object} state Global application state.
+ * @param {string} id    The tip to query.
  *
- * @param {Object}  state      Global application state.
- * @param {string}  tipId      The tip to query.
- * @param {?number} instanceId A number which uniquely identifies the DotTip instance.
- *
- * @return {boolean} Whether the given tip or Dottip instance should be shown.
+ * @return {boolean} Whether or not the given tip is showing.
  */
-export function isTipVisible( state, tipId, instanceId ) {
+export function isTipVisible( state, id ) {
 	if ( ! state.preferences.areTipsEnabled ) {
 		return false;
 	}
 
-	if ( state.preferences.dismissedTips[ tipId ] ) {
+	if ( state.preferences.dismissedTips[ id ] ) {
 		return false;
 	}
 
-	const associatedGuide = getAssociatedGuide( state, tipId );
-	if ( associatedGuide && associatedGuide.currentTipId !== tipId ) {
+	const associatedGuide = getAssociatedGuide( state, id );
+	if ( associatedGuide && associatedGuide.currentTipId !== id ) {
 		return false;
-	}
-
-	if ( instanceId ) {
-		const [ firstInstanceId ] = state.tipInstanceIds[ tipId ] || [];
-		if ( instanceId !== firstInstanceId ) {
-			return false;
-		}
 	}
 
 	return true;

--- a/packages/nux/src/store/selectors.js
+++ b/packages/nux/src/store/selectors.js
@@ -46,21 +46,21 @@ export const getAssociatedGuide = createSelector(
  * guide that they have been added to.
  *
  * @param {Object} state Global application state.
- * @param {string} id    The tip to query.
+ * @param {string} tipId The tip to query.
  *
  * @return {boolean} Whether or not the given tip is showing.
  */
-export function isTipVisible( state, id ) {
+export function isTipVisible( state, tipId ) {
 	if ( ! state.preferences.areTipsEnabled ) {
 		return false;
 	}
 
-	if ( state.preferences.dismissedTips[ id ] ) {
+	if ( state.preferences.dismissedTips[ tipId ] ) {
 		return false;
 	}
 
-	const associatedGuide = getAssociatedGuide( state, id );
-	if ( associatedGuide && associatedGuide.currentTipId !== id ) {
+	const associatedGuide = getAssociatedGuide( state, tipId );
+	if ( associatedGuide && associatedGuide.currentTipId !== tipId ) {
 		return false;
 	}
 

--- a/packages/nux/src/store/test/actions.js
+++ b/packages/nux/src/store/test/actions.js
@@ -1,14 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	triggerGuide,
-	registerTipInstance,
-	unregisterTipInstance,
-	dismissTip,
-	disableTips,
-	enableTips,
-} from '../actions';
+import { triggerGuide, dismissTip, disableTips, enableTips } from '../actions';
 
 describe( 'actions', () => {
 	describe( 'triggerGuide', () => {
@@ -16,26 +9,6 @@ describe( 'actions', () => {
 			expect( triggerGuide( [ 'test/tip-1', 'test/tip-2' ] ) ).toEqual( {
 				type: 'TRIGGER_GUIDE',
 				tipIds: [ 'test/tip-1', 'test/tip-2' ],
-			} );
-		} );
-	} );
-
-	describe( 'registerTipInstance', () => {
-		it( 'should return a REGISTER_TIP_INSTANCE action', () => {
-			expect( registerTipInstance( 'test/tip-1', 123 ) ).toEqual( {
-				type: 'REGISTER_TIP_INSTANCE',
-				tipId: 'test/tip-1',
-				instanceId: 123,
-			} );
-		} );
-	} );
-
-	describe( 'unregisterTipInstance', () => {
-		it( 'should return an UNREGISTER_TIP_INSTANCE action', () => {
-			expect( unregisterTipInstance( 'test/tip-1', 123 ) ).toEqual( {
-				type: 'UNREGISTER_TIP_INSTANCE',
-				tipId: 'test/tip-1',
-				instanceId: 123,
 			} );
 		} );
 	} );

--- a/packages/nux/src/store/test/reducer.js
+++ b/packages/nux/src/store/test/reducer.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import deepFreeze from 'deep-freeze';
-
-/**
  * Internal dependencies
  */
-import { guides, tipInstanceIds, areTipsEnabled, dismissedTips } from '../reducer';
+import { guides, areTipsEnabled, dismissedTips } from '../reducer';
 
 describe( 'reducer', () => {
 	describe( 'guides', () => {
@@ -15,74 +10,13 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should add a guide when it is triggered', () => {
-			const original = deepFreeze( [] );
-			const state = guides( original, {
+			const state = guides( [], {
 				type: 'TRIGGER_GUIDE',
 				tipIds: [ 'test/tip-1', 'test/tip-2' ],
 			} );
 			expect( state ).toEqual( [
 				[ 'test/tip-1', 'test/tip-2' ],
 			] );
-		} );
-	} );
-
-	describe( 'tipInstanceIds', () => {
-		it( 'should start out empty', () => {
-			expect( tipInstanceIds( undefined, {} ) ).toEqual( {} );
-		} );
-
-		it( 'should register an initial tip instance', () => {
-			const original = deepFreeze( {} );
-			const state = tipInstanceIds( original, {
-				type: 'REGISTER_TIP_INSTANCE',
-				tipId: 'test/tip-1',
-				instanceId: 123,
-			} );
-			expect( state ).toEqual( {
-				'test/tip-1': [ 123 ],
-			} );
-		} );
-
-		it( 'should register an second tip instance', () => {
-			const original = deepFreeze( {
-				'test/tip-1': [ 123 ],
-			} );
-			const state = tipInstanceIds( original, {
-				type: 'REGISTER_TIP_INSTANCE',
-				tipId: 'test/tip-1',
-				instanceId: 456,
-			} );
-			expect( state ).toEqual( {
-				'test/tip-1': [ 123, 456 ],
-			} );
-		} );
-
-		it( 'should not register duplicate tip instances', () => {
-			const original = deepFreeze( {
-				'test/tip-1': [ 123 ],
-			} );
-			const state = tipInstanceIds( original, {
-				type: 'REGISTER_TIP_INSTANCE',
-				tipId: 'test/tip-1',
-				instanceId: 123,
-			} );
-			expect( state ).toEqual( {
-				'test/tip-1': [ 123 ],
-			} );
-		} );
-
-		it( 'should unregister a tip instance', () => {
-			const original = deepFreeze( {
-				'test/tip-1': [ 123, 456 ],
-			} );
-			const state = tipInstanceIds( original, {
-				type: 'UNREGISTER_TIP_INSTANCE',
-				tipId: 'test/tip-1',
-				instanceId: 123,
-			} );
-			expect( state ).toEqual( {
-				'test/tip-1': [ 456 ],
-			} );
 		} );
 	} );
 
@@ -112,8 +46,7 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should mark tips as dismissed', () => {
-			const original = deepFreeze( {} );
-			const state = dismissedTips( original, {
+			const state = dismissedTips( {}, {
 				type: 'DISMISS_TIP',
 				id: 'test/tip',
 			} );
@@ -123,10 +56,10 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should reset if tips are enabled', () => {
-			const original = deepFreeze( {
+			const initialState = {
 				'test/tip': true,
-			} );
-			const state = dismissedTips( original, {
+			};
+			const state = dismissedTips( initialState, {
 				type: 'ENABLE_TIPS',
 			} );
 			expect( state ).toEqual( {} );

--- a/packages/nux/src/store/test/selectors.js
+++ b/packages/nux/src/store/test/selectors.js
@@ -11,7 +11,6 @@ describe( 'selectors', () => {
 				[ 'test/tip-a', 'test/tip-b', 'test/tip-c' ],
 				[ 'test/tip-α', 'test/tip-β', 'test/tip-γ' ],
 			],
-			tipInstanceIds: {},
 			preferences: {
 				dismissedTips: {
 					'test/tip-1': true,
@@ -57,7 +56,6 @@ describe( 'selectors', () => {
 		it( 'should return true by default', () => {
 			const state = {
 				guides: [],
-				tipInstanceIds: {},
 				preferences: {
 					areTipsEnabled: true,
 					dismissedTips: {},
@@ -69,7 +67,6 @@ describe( 'selectors', () => {
 		it( 'should return false if tips are disabled', () => {
 			const state = {
 				guides: [],
-				tipInstanceIds: {},
 				preferences: {
 					areTipsEnabled: false,
 					dismissedTips: {},
@@ -81,7 +78,6 @@ describe( 'selectors', () => {
 		it( 'should return false if the tip is dismissed', () => {
 			const state = {
 				guides: [],
-				tipInstanceIds: {},
 				preferences: {
 					areTipsEnabled: true,
 					dismissedTips: {
@@ -97,7 +93,6 @@ describe( 'selectors', () => {
 				guides: [
 					[ 'test/tip-1', 'test/tip-2', 'test/tip-3' ],
 				],
-				tipInstanceIds: {},
 				preferences: {
 					areTipsEnabled: true,
 					dismissedTips: {},
@@ -105,53 +100,12 @@ describe( 'selectors', () => {
 			};
 			expect( isTipVisible( state, 'test/tip-2' ) ).toBe( false );
 		} );
-
-		it( 'should return true if an instanceId that was registered first is provided', () => {
-			const state = {
-				guides: [],
-				tipInstanceIds: {
-					'test/tip': [ 123, 456 ],
-				},
-				preferences: {
-					areTipsEnabled: true,
-					dismissedTips: {},
-				},
-			};
-			expect( isTipVisible( state, 'test/tip', 123 ) ).toBe( true );
-		} );
-
-		it( 'should return false if an instanceId that was NOT registered is provided', () => {
-			const state = {
-				guides: [],
-				tipInstanceIds: {},
-				preferences: {
-					areTipsEnabled: true,
-					dismissedTips: {},
-				},
-			};
-			expect( isTipVisible( state, 'test/tip', 123 ) ).toBe( false );
-		} );
-
-		it( 'should return false if an instanceId that was NOT registered first is provided', () => {
-			const state = {
-				guides: [],
-				tipInstanceIds: {
-					'test/tip': [ 123, 456 ],
-				},
-				preferences: {
-					areTipsEnabled: true,
-					dismissedTips: {},
-				},
-			};
-			expect( isTipVisible( state, 'test/tip', 456 ) ).toBe( false );
-		} );
 	} );
 
 	describe( 'areTipsEnabled', () => {
 		it( 'should return true if tips are enabled', () => {
 			const state = {
 				guides: [],
-				tipInstanceIds: {},
 				preferences: {
 					areTipsEnabled: true,
 					dismissedTips: {},
@@ -163,7 +117,6 @@ describe( 'selectors', () => {
 		it( 'should return false if tips are disabled', () => {
 			const state = {
 				guides: [],
-				tipInstanceIds: {},
 				preferences: {
 					areTipsEnabled: false,
 					dismissedTips: {},


### PR DESCRIPTION
## Description
Fixes #8050. Reverts https://github.com/WordPress/gutenberg/pull/8642.

Moves the first tip to the toolbar so that post content isn't covered, and adjusts `DotTip` so that it can correctly position itself _below_ buttons when necessary.

Since doing this means that multiple instances of the same tip can no longer appear, I've reverted https://github.com/WordPress/gutenberg/pull/8642 as it is no longer necessary.

## How has this been tested?
1. Re-enable tips via the More menu
2. The first tip should point to the inserter in the top left of the page

## Screenshots <!-- if applicable -->
![localhost_8888_wp-admin_post-new php screen recording 1](https://user-images.githubusercontent.com/612155/44441091-44462200-a60e-11e8-87cf-2342e2da425a.png)