### PR TITLE
Fix sibling inserter hit area

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -718,6 +718,7 @@
 .editor-block-list__insertion-point {
 	position: relative;
 	z-index: z-index(".editor-block-list__insertion-point");
+	margin-top: -$block-padding;
 }
 
 .editor-block-list__insertion-point-indicator {
@@ -729,6 +730,7 @@
 	background: theme(primary);
 }
 
+// This is the clickable plus.
 .editor-block-list__insertion-point-inserter {
 	// Don't show on mobile.
 	display: none;
@@ -740,12 +742,7 @@
 	bottom: auto;
 	left: 0;
 	right: 0;
-	// Matches the whole empty space between two blocks
-	height: $block-padding * 2;
 	justify-content: center;
-
-	// Position above block.
-	top: -$block-padding;
 
 	// Show a clickable plus.
 	.editor-block-list__insertion-point-button {
@@ -786,6 +783,7 @@
 	}
 }
 
+// This is the edge-to-edge hover area that contains the plus.
 .editor-block-list__block {
 	> .editor-block-list__insertion-point {
 		position: absolute;


### PR DESCRIPTION
This fixes #8881.

The sibling inserter hit area was not centered perfectly between two blocks. This PR fixes that.

Props to @chrisvanpatten for this fix.

The issue, as described in #8881, is that the sibling inserter covered actual text of text blocks. Specifically, it has a large empty hit area whose sole purpose is to show you the sibling inserter button when you hover that area. However this was misaligned, and covered text below.

This fixes that by aligning it correctly. Here's a GIF with debug colors. The orange shows the sibling inserter hit area, the red shows the text input fields:

![now](https://user-images.githubusercontent.com/1204802/44450110-5add8080-a5f0-11e8-9130-45051dd9b76f.gif)

Noting to myself that if we move further with https://github.com/WordPress/gutenberg/pull/8350, we need to account for that with the sibling inserter positioning and height. I have some ideas, including simply having a smaller minimum height of the hoverable area, but this is something to think about. The code in question is this:

<img width="615" alt="screen shot 2018-08-22 at 09 44 10" src="https://user-images.githubusercontent.com/1204802/44450157-79dc1280-a5f0-11e8-86a2-17df6be37110.png">
