### PR TITLE
Docs fixes: Correct 'the the' and remove trailing space

### DIFF
--- a/docs/data/data-core-blocks.md
+++ b/docs/data/data-core-blocks.md
@@ -1,6 +1,6 @@
 # **core/blocks**: Block Types Data
 
-## Selectors 
+## Selectors
 
 ### getBlockType
 

--- a/docs/data/data-core-edit-post.md
+++ b/docs/data/data-core-edit-post.md
@@ -1,6 +1,6 @@
 # **core/edit-post**: The Editor’s UI Data
 
-## Selectors 
+## Selectors
 
 ### getEditorMode
 
@@ -130,7 +130,7 @@ Is active.
 
 ### isPluginItemPinned
 
-Returns true if the the plugin item is pinned to the header.
+Returns true if the plugin item is pinned to the header.
 When the value is not set it defaults to true.
 
 *Parameters*
@@ -169,7 +169,7 @@ State of meta box at specified location.
 
 ### isSavingMetaBoxes
 
-Returns true if the the Meta Boxes are being saved.
+Returns true if the Meta Boxes are being saved.
 
 *Parameters*
 

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1,6 +1,6 @@
 # **core/editor**: The Editor’s Data
 
-## Selectors 
+## Selectors
 
 ### hasEditorUndo
 

--- a/docs/data/data-core-nux.md
+++ b/docs/data/data-core-nux.md
@@ -1,6 +1,6 @@
 # **core/nux**: The NUX (New User Experience) Data
 
-## Selectors 
+## Selectors
 
 ### isTipVisible
 

--- a/docs/data/data-core-viewport.md
+++ b/docs/data/data-core-viewport.md
@@ -1,6 +1,6 @@
 # **core/viewport**: The Viewport Data
 
-## Selectors 
+## Selectors
 
 ### isViewportMatch
 

--- a/docs/data/data-core.md
+++ b/docs/data/data-core.md
@@ -1,6 +1,6 @@
 # **core**: WordPress Core Data
 
-## Selectors 
+## Selectors
 
 ### getTerms
 

--- a/docs/tool/generator.js
+++ b/docs/tool/generator.js
@@ -65,7 +65,7 @@ function generateNamespaceDocs( parsedNamespace ) {
 	return [
 		`# **${ parsedNamespace.name }**: ${ parsedNamespace.title }`,
 		'',
-		'## Selectors ',
+		'## Selectors',
 		'',
 		( parsedNamespace.selectors.map( generateFunctionDocs ) ).join( '\n\n' ),
 		'',

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -137,7 +137,7 @@ export function isFeatureActive( state, feature ) {
 }
 
 /**
- * Returns true if the the plugin item is pinned to the header.
+ * Returns true if the plugin item is pinned to the header.
  * When the value is not set it defaults to true.
  *
  * @param  {Object}  state      Global application state.
@@ -193,7 +193,7 @@ export const hasMetaBoxes = createSelector(
 );
 
 /**
- * Returns true if the the Meta Boxes are being saved.
+ * Returns true if the Meta Boxes are being saved.
  *
  * @param   {Object}  state Global application state.
  *

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1494,7 +1494,7 @@ function getInsertUsage( state, id ) {
 }
 
 /**
- * Determines the items that appear in the the inserter. Includes both static
+ * Determines the items that appear in the inserter. Includes both static
  * items (e.g. a regular block type) and dynamic items (e.g. a reusable block).
  *
  * Each item object contains what's necessary to display a button in the


### PR DESCRIPTION
Originally #7677