### PR TITLE
Add mention of Material Design icons to the design docs.

### DIFF
--- a/docs/design/block-design.md
+++ b/docs/design/block-design.md
@@ -5,7 +5,7 @@ The following is a light guide to designing a new block with recommendations and
 ## Best Practices
 
 - Blocks should have a simple label for the Inserter. Keep it as short as possible.
-- Blocks should have an identifying icon, ideally using a single color. Try to avoid using the same icon used by an existing block. Look to [Dashicons](https://developer.wordpress.org/resource/dashicons/) for style inspiration.
+- Blocks should have an identifying icon, ideally using a single color. Try to avoid using the same icon used by an existing block. The core block icons are based on [Material Design Icons](https://material.io/tools/icons/). Look to that icon set, or to [Dashicons](https://developer.wordpress.org/resource/dashicons/) for style inspiration.
 - Blocks should have a instructive placeholder state when they’re first inserted. If the block includes a text input, provide placeholder text. If your block holds media, include buttons for uploading files and accessing media libraries, as well as drop-zones for drag-and-drop. 
 - When unselected, your block should preview its content as closely to the front-end output as possible.
 - When selected, your block may surface additional options like input fields or buttons to configure the block directly, if those are necessary for basic operation.


### PR DESCRIPTION
As per the update in #8916, our core blocks now use Material Design icons. This PR updates our design doc about block design to reflect that.

_Old:_
> Blocks should have an identifying icon, ideally using a single color. Try to avoid using the same icon used by an existing block. Look to [Dashicons](https://developer.wordpress.org/resource/dashicons/) for style inspiration.

_New:_
> Blocks should have an identifying icon, ideally using a single color. Try to avoid using the same icon used by an existing block. The core block icons are based on [Material Design Icons](https://material.io/tools/icons/). Look to that icon set, or to [Dashicons](https://developer.wordpress.org/resource/dashicons/) for style inspiration.