### PR TITLE
Allow text to be dragged in and out of blocks

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -254,15 +254,27 @@ export class BlockListBlock extends Component {
 	}
 
 	/**
-	 * Prevents default dragging behavior within a block to allow for multi-
-	 * selection to take effect unhampered.
+	 * Handle dragging behavior within a block to allow for multi-selection or
+	 * dragging selected text to take effect unhampered. If dragging selected
+	 * text, current multi-selection should revert and stop. Any other drag
+	 * behaviour should be default prevented.
 	 *
 	 * @param {DragEvent} event Drag event.
 	 *
 	 * @return {void}
 	 */
 	preventDrag( event ) {
-		event.preventDefault();
+		// If there is plain text being transferred, this means that there is a
+		// text selection being dragged. Images, for example, have HTML transfer
+		// data, but no plain text.
+		if ( event.dataTransfer.getData( 'text/plain' ) ) {
+			// Cancel multi-selection.
+			this.props.onSelectionEnd();
+			// Revert to selecting the block if there is multi-selection.
+			this.props.onSelect();
+		} else {
+			event.preventDefault();
+		}
 	}
 
 	/**

--- a/packages/editor/src/components/block-list/layout.js
+++ b/packages/editor/src/components/block-list/layout.js
@@ -217,6 +217,7 @@ class BlockListLayout extends Component {
 						blockRef={ this.setBlockRef }
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
+						onSelectionEnd={ this.onSelectionEnd }
 						rootClientId={ rootClientId }
 						layout={ defaultLayout }
 						isFirst={ blockIndex === 0 }


### PR DESCRIPTION
## Description

This PR tries to accomplish two things:

* It should be possible to drag selected text into any editable (`RichText` or `PlainText`) area.
* It should be possible to drag selected text out of any editable area (and into another or somewhere else). Fixes #3339. Addressed by 9091dc1.

Still working on the first point.

## How has this been tested?
See above.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->