### PR TITLE
Fix metabox issue in ie11 by stop using for(var x.. of)

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -103,8 +103,15 @@ const effects = {
 
 		// Merge all form data objects into a single one.
 		const formData = reduce( formDataToMerge, ( memo, currentFormData ) => {
-			for ( const [ key, value ] of currentFormData ) {
+			// Use a while loop instead of for (var .. of ),
+			// Due to FormData polyfill.
+			const formDataEntries = currentFormData.entries();
+			let formDataEntry = formDataEntries.next();
+
+			while (!formDataEntry.done) {
+				const [key, value] = formDataEntry.value;
 				memo.append( key, value );
+				formDataEntry = formDataEntries.next();
 			}
 			return memo;
 		}, new window.FormData() );

--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -108,8 +108,8 @@ const effects = {
 			const formDataEntries = currentFormData.entries();
 			let formDataEntry = formDataEntries.next();
 
-			while (!formDataEntry.done) {
-				const [key, value] = formDataEntry.value;
+			while ( ! formDataEntry.done ) {
+				const [ key, value ] = formDataEntry.value;
 				memo.append( key, value );
 				formDataEntry = formDataEntries.next();
 			}


### PR DESCRIPTION
## Description
Using `for .. of` doesn't work with the FormData polyfill so changing it to use a while loop allows this to work correctly across all browsers

## How has this been tested?
Checked in latest Chrome, Firefox, IE11

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
