### PR TITLE
Fix: Range Control: Reset value when setting range control to empty

### DIFF
--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -29,7 +29,15 @@ function RangeControl( {
 	...props
 } ) {
 	const id = `inspector-range-control-${ instanceId }`;
-	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
+	const resetValue = () => onChange();
+	const onChangeValue = ( event ) => {
+		const newValue = event.target.value;
+		if ( newValue === '' ) {
+			resetValue();
+			return;
+		}
+		onChange( Number( newValue ) );
+	};
 	const initialSliderValue = isFinite( value ) ? value : initialPosition || '';
 
 	return (
@@ -58,7 +66,7 @@ function RangeControl( {
 				{ ...props }
 			/>
 			{ allowReset &&
-				<Button onClick={ () => onChange() } disabled={ value === undefined }>
+				<Button onClick={ resetValue } disabled={ value === undefined }>
 					{ __( 'Reset' ) }
 				</Button>
 			}


### PR DESCRIPTION
Currently, when setting the number input to empty, onChange is called with the value equal to 0 instead of the value being reset.
Fixes: https://github.com/WordPress/gutenberg/issues/9191

## How has this been tested?
I created a paragraph.
I made the font size equal to 20.
I deleted the font size value and checked in code view that the paragraph was not font size setting applied. In master font size 0 was applied.
