### PR TITLE
WIP Add: Hidden blocks feature

### DIFF
--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { filter, includes, map } from 'lodash';
+import { filter, includes, map, some } from 'lodash';
+import { hasBlockSupport } from '../api/';
 
 /**
  * Returns all the available block types.
@@ -86,7 +87,7 @@ export const getChildBlockNames = createSelector(
 );
 
 /**
- * Returns a boolean indicating if a block has child blocks or not.
+ * Returns a boolean indicating if a block has child blocks available on the inserter or not.
  *
  * @param {Object} state     Data state.
  * @param {string} blockName Block type name.
@@ -94,5 +95,7 @@ export const getChildBlockNames = createSelector(
  * @return {boolean} True if a block contains child blocks and false otherwise.
  */
 export const hasChildBlocks = ( state, blockName ) => {
-	return getChildBlockNames( state, blockName ).length > 0;
+	return some( getChildBlockNames( state, blockName ), ( currentBlockName ) => {
+		return hasBlockSupport( currentBlockName, 'inserter', true );
+	} );
 };

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -19,6 +19,7 @@ import {
 	cloneBlock,
 	getBlockType,
 	getSaveElement,
+	hasBlockSupport,
 	isReusableBlock,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
@@ -389,12 +390,14 @@ export class BlockListBlock extends Component {
 		// Empty paragraph blocks should always show up as unselected.
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
-		const shouldAppearSelected = ! showSideInserter && isSelected && ! isTypingWithinBlock;
-		const shouldAppearSelectedParent = ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
+		const supportsHoverMarks = hasBlockSupport( blockName, 'hoverMarks', true );
+		const supportsSelectionMarks = hasBlockSupport( blockName, 'selectionMarks', true );
+		const shouldAppearSelected = supportsSelectionMarks && ! showSideInserter && isSelected && ! isTypingWithinBlock;
+		const shouldAppearSelectedParent = supportsSelectionMarks && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection;
-		const shouldShowBreadcrumb = isHovered && ! isEmptyDefaultBlock;
+		const shouldShowBreadcrumb = supportsHoverMarks && isHovered && ! isEmptyDefaultBlock;
 		const shouldShowContextualToolbar = ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected ) && ( ! hasFixedToolbar || ! isLargeViewport );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
@@ -411,7 +414,7 @@ export class BlockListBlock extends Component {
 			'is-selected': shouldAppearSelected,
 			'is-multi-selected': isPartOfMultiSelection,
 			'is-selected-parent': shouldAppearSelectedParent,
-			'is-hovered': isHovered && ! isEmptyDefaultBlock,
+			'is-hovered': supportsHoverMarks && isHovered && ! isEmptyDefaultBlock,
 			'is-reusable': isReusableBlock( blockType ),
 			'is-hidden': dragging,
 			'is-typing': isTypingWithinBlock,

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { IconButton, Dropdown, NavigableMenu, MenuItem, KeyboardShortcuts } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { compose, ifCondition } from '@wordpress/compose';
 import { cloneBlock, hasBlockSupport } from '@wordpress/blocks';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
 
@@ -230,11 +230,16 @@ export default compose( [
 
 		const blocks = getBlocksByClientId( clientIds );
 
+		const isSupported = every( blocks, ( block ) => {
+			return !! block && hasBlockSupport( block.name, 'settingsMenu', true );
+		} );
+
 		const canDuplicate = every( blocks, ( block ) => {
 			return !! block && hasBlockSupport( block.name, 'multiple', true );
 		} );
 
 		return {
+			isSupported,
 			firstSelectedIndex: getBlockIndex( first( castArray( clientIds ) ), rootClientId ),
 			lastSelectedIndex: getBlockIndex( last( castArray( clientIds ) ), rootClientId ),
 			isLocked: !! getTemplateLock( rootClientId ),
@@ -243,6 +248,7 @@ export default compose( [
 			shortcuts,
 		};
 	} ),
+	ifCondition( ( { isSupported } ) => isSupported ),
 	withDispatch( ( dispatch, props ) => {
 		const {
 			clientIds,


### PR DESCRIPTION
## Description
The child blocks API provides a way for blocks to have several nested areas using different child blocks.
But from the UI perspective sometimes this intermediary child blocks should not be shown to the user.

In this PR we add this functionality. If the following code block is added a block becomes invisible in the UI:
```
	supports: {
		hoverMarks: false,
		selectionMarks: false,
		settingsMenu: false,
		inserter:false,
	},
```

The most important topic to discuss in this initial phase is the API shape.
Should we use a set of flags as we have or should we follow an alternative API?

I can think of two simple alternatives:
 - Just using one flag hidden block that disables all these UI parts. The disadvantage is that we don't have granular control over which parts should be hidden.
 - Use an array instead of flags with the UI parts the block supports by default the array contains all the block UI parts if the block wants to be hidden an empty array should be set.


## How has this been tested?
To most straightforward way to test this PR is going to PR https://github.com/WordPress/gutenberg/pull/7414 as this PR was temporarily merged there and the Hald Image Area and the Half content area make use of this feature.
