### PR TITLE
Data: Registry - check for window

### DIFF
--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -140,7 +140,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 */
 	function registerReducer( reducerKey, reducer ) {
 		const enhancers = [];
-		if ( window && window.__REDUX_DEVTOOLS_EXTENSION__ ) {
+		if ( typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__ ) {
 			enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__( { name: reducerKey, instanceId: reducerKey } ) );
 		}
 		const store = createStore( reducer, flowRight( enhancers ) );

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -140,7 +140,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 */
 	function registerReducer( reducerKey, reducer ) {
 		const enhancers = [];
-		if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
+		if ( window && window.__REDUX_DEVTOOLS_EXTENSION__ ) {
 			enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__( { name: reducerKey, instanceId: reducerKey } ) );
 		}
 		const store = createStore( reducer, flowRight( enhancers ) );


### PR DESCRIPTION
## Description
The current registry code is blindly deferencing window, which will fail if ever
run in node for test or server-side rendering. This adds a simple check
to ensure window exists before dereferencing.

## How has this been tested?
There's not much to test for this line, as it only affects redux dev tools when there is no global window instance, which should never happen.

## Types of changes
Sort of a bug fix maybe? As this code is causing a CI test to fail for Calypso: https://github.com/Automattic/wp-calypso/pull/26838

This change should not break a thing, as it's just doing an additional check.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
