### PR TITLE
Allow custom-size-icons

### DIFF
--- a/packages/editor/src/components/block-icon/style.scss
+++ b/packages/editor/src/components/block-icon/style.scss
@@ -9,8 +9,16 @@
 		}
 	}
 
-	svg:not(.dashicon) {
+	// By default, library icons should be 24x24px.
+	// If an icon is provided that has a `dashicons` class, or an explicit width/height, don't override.
+	svg:not(.dashicon):not([width]) {
 		height: 24px;
 		width: 24px;
+	}
+
+	// Don't allow icons to be bigger than the recommended standard.
+	svg {
+		max-width: 24px;
+		max-height: 24px;
 	}
 }

--- a/packages/editor/src/components/block-icon/style.scss
+++ b/packages/editor/src/components/block-icon/style.scss
@@ -9,8 +9,9 @@
 		}
 	}
 
-	// By default, library icons should be 24x24px.
-	// If an icon is provided that has a `dashicons` class, or an explicit width/height, don't override.
+	// By default, library icons should be 24px by 24px.
+	// If an icon is provided that has a `dashicons` class, or an explicit width/height,
+	// we don't override the height/width.
 	svg:not(.dashicon):not([width]) {
 		height: 24px;
 		width: 24px;

--- a/packages/editor/src/components/inserter-with-shortcuts/style.scss
+++ b/packages/editor/src/components/inserter-with-shortcuts/style.scss
@@ -5,9 +5,17 @@
 	.components-icon-button {
 		border-radius: $radius-round-rectangle;
 
-		svg:not(.dashicon) {
+		// By default, library icons should be 24x24px.
+		// If an icon is provided that has a `dashicons` class, or an explicit width/height, don't override.
+		svg:not(.dashicon):not([width]) {
 			height: 24px;
 			width: 24px;
+		}
+
+		// Don't allow icons to be bigger than the recommended standard.
+		svg {
+			max-width: 24px;
+			max-height: 24px;
 		}
 	}
 }

--- a/packages/editor/src/components/inserter-with-shortcuts/style.scss
+++ b/packages/editor/src/components/inserter-with-shortcuts/style.scss
@@ -5,8 +5,9 @@
 	.components-icon-button {
 		border-radius: $radius-round-rectangle;
 
-		// By default, library icons should be 24x24px.
-		// If an icon is provided that has a `dashicons` class, or an explicit width/height, don't override.
+		// By default, library icons should be 24px by 24px.
+		// If an icon is provided that has a `dashicons` class, or an explicit width/height,
+		// we don't override the height/width.
 		svg:not(.dashicon):not([width]) {
 			height: 24px;
 			width: 24px;


### PR DESCRIPTION
This fixes 9243.

This allows custom sized icons in the block library, by simply not overriding SVG provided dimensions. It works this way:

- If you provide a dashicon, its dimensions come from the SVG itself, because it has a dashicons class
- If you provide an icon without explicit dimensions, we count on it being a 24x24px icon
- If you provide a custom icon that does not have the dashicons class, and is not 24x24, you need to provide your own dimensions (width and height) in the SVG.

So as to keep some consistency, a max-width and max-height are applied, which kick in if a block icon larger than 24x24 is supplied.

![screen shot 2018-08-23 at 10 10 24](https://user-images.githubusercontent.com/1204802/44513374-79f61400-a6bd-11e8-8ffa-07280c3cb230.png)

☝️ in this screenshot, a 20x20px icon is provided for dev purposes to test this. This icon does not have a CSS class, but does have explicitly provided dimensions, so it's not scaled up.