### PR TITLE
Compose: Drop explicit window reference from withSafeTimeout

### DIFF
--- a/packages/compose/src/with-safe-timeout/index.js
+++ b/packages/compose/src/with-safe-timeout/index.js
@@ -14,11 +14,6 @@ import { Component } from '@wordpress/element';
 import createHigherOrderComponent from '../create-higher-order-component';
 
 /**
- * Browser dependencies
- */
-const { clearTimeout, setTimeout } = window;
-
-/**
  * A higher-order component used to provide and manage delayed function calls
  * that ought to be bound to a component's lifecycle.
  *


### PR DESCRIPTION
## Description
Fixes #9265, i.e. makes `withSafeTimeout` compatible with server side rendering.

## How has this been tested?
TBD

## Types of changes
Both `setTimeout` and `clearTimeout` are methods of the `window` object, so they are be globally available -- as they are in [Node](https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args). Removing the explicit window reference unbreaks this for use with Node.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
