### PR TITLE
Build tools: Use Webpack splitChunks feature to extract duplicated babel runtime

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -100,37 +100,45 @@ function gutenberg_register_scripts_and_styles() {
 	register_tinymce_scripts();
 
 	wp_register_script(
+		'wp-babel-runtime',
+		gutenberg_url( 'build/babel-runtime/0.index.js' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/babel-runtime/0.index.js' ),
+		true
+	);
+
+	wp_register_script(
 		'wp-url',
 		gutenberg_url( 'build/url/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/url/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-autop',
 		gutenberg_url( 'build/autop/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/autop/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-wordcount',
 		gutenberg_url( 'build/wordcount/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/wordcount/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-dom-ready',
 		gutenberg_url( 'build/dom-ready/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/dom-ready/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-a11y',
 		gutenberg_url( 'build/a11y/index.js' ),
-		array( 'wp-dom-ready' ),
+		array( 'wp-babel-runtime', 'wp-dom-ready' ),
 		filemtime( gutenberg_dir_path() . 'build/a11y/index.js' ),
 		true
 	);
@@ -144,7 +152,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-i18n',
 		gutenberg_url( 'build/i18n/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/i18n/index.js' ),
 		true
 	);
@@ -158,7 +166,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-token-list',
 		gutenberg_url( 'build/token-list/index.js' ),
-		array( 'lodash' ),
+		array( 'lodash', 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/token-list/index.js' ),
 		true
 	);
@@ -167,7 +175,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-api-fetch',
 		gutenberg_url( 'build/api-fetch/index.js' ),
-		array( 'wp-hooks', 'wp-i18n' ),
+		array( 'wp-babel-runtime', 'wp-hooks', 'wp-i18n' ),
 		filemtime( gutenberg_dir_path() . 'build/api-fetch/index.js' ),
 		true
 	);
@@ -201,28 +209,28 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-deprecated',
 		gutenberg_url( 'build/deprecated/index.js' ),
-		array( 'wp-hooks' ),
+		array( 'wp-babel-runtime', 'wp-hooks' ),
 		filemtime( gutenberg_dir_path() . 'build/deprecated/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-blob',
 		gutenberg_url( 'build/blob/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/blob/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-compose',
 		gutenberg_url( 'build/compose/index.js' ),
-		array( 'wp-element', 'wp-is-shallow-equal', 'lodash' ),
+		array( 'wp-babel-runtime', 'wp-element', 'wp-is-shallow-equal', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/compose/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-keycodes',
 		gutenberg_url( 'build/keycodes/index.js' ),
-		array( 'lodash' ),
+		array( 'lodash', 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/keycodes/index.js' ),
 		true
 	);
@@ -237,6 +245,7 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-data',
 		gutenberg_url( 'build/data/index.js' ),
 		array(
+			'wp-babel-runtime',
 			'wp-element',
 			'wp-compose',
 			'wp-is-shallow-equal',
@@ -264,14 +273,14 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-core-data',
 		gutenberg_url( 'build/core-data/index.js' ),
-		array( 'wp-data', 'wp-api-fetch', 'wp-url', 'lodash' ),
+		array( 'wp-babel-runtime', 'wp-data', 'wp-api-fetch', 'wp-url', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/core-data/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-dom',
 		gutenberg_url( 'build/dom/index.js' ),
-		array( 'wp-tinymce', 'lodash' ),
+		array( 'wp-babel-runtime', 'wp-tinymce', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/dom/index.js' ),
 		true
 	);
@@ -294,21 +303,21 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-shortcode',
 		gutenberg_url( 'build/shortcode/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/shortcode/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-redux-routine',
 		gutenberg_url( 'build/redux-routine/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/redux-routine/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-date',
 		gutenberg_url( 'build/date/index.js' ),
-		array( 'moment' ),
+		array( 'moment', 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/date/index.js' ),
 		true
 	);
@@ -350,7 +359,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-element',
 		gutenberg_url( 'build/element/index.js' ),
-		array( 'react', 'react-dom', 'lodash' ),
+		array( 'react', 'react-dom', 'lodash', 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/element/index.js' ),
 		true
 	);
@@ -362,6 +371,7 @@ function gutenberg_register_scripts_and_styles() {
 			'moment',
 			'wp-a11y',
 			'wp-api-fetch',
+			'wp-babel-runtime',
 			'wp-compose',
 			'wp-deprecated',
 			'wp-dom',
@@ -385,6 +395,7 @@ function gutenberg_register_scripts_and_styles() {
 		gutenberg_url( 'build/blocks/index.js' ),
 		array(
 			'wp-autop',
+			'wp-babel-runtime',
 			'wp-blob',
 			'wp-block-serialization-spec-parser',
 			'wp-data',
@@ -413,7 +424,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-viewport',
 		gutenberg_url( 'build/viewport/index.js' ),
-		array( 'wp-element', 'wp-data', 'wp-compose', 'lodash' ),
+		array( 'wp-babel-runtime', 'wp-element', 'wp-data', 'wp-compose', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/viewport/index.js' ),
 		true
 	);
@@ -426,6 +437,7 @@ function gutenberg_register_scripts_and_styles() {
 			'moment',
 			'wp-api-fetch',
 			'wp-autop',
+			'wp-babel-runtime',
 			'wp-blob',
 			'wp-blocks',
 			'wp-components',
@@ -448,6 +460,7 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-core-blocks',
 		gutenberg_url( 'build/core-blocks/index.js' ),
 		array(
+			'wp-babel-runtime',
 			'wp-block-library',
 			'wp-deprecated',
 		),
@@ -457,7 +470,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-nux',
 		gutenberg_url( 'build/nux/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-compose', 'wp-data', 'wp-i18n', 'lodash' ),
+		array( 'wp-babel-runtime', 'wp-element', 'wp-components', 'wp-compose', 'wp-data', 'wp-i18n', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/nux/index.js' ),
 		true
 	);
@@ -573,6 +586,7 @@ function gutenberg_register_scripts_and_styles() {
 			'tinymce-latest-lists',
 			'wp-a11y',
 			'wp-api-fetch',
+			'wp-babel-runtime',
 			'wp-blob',
 			'wp-blocks',
 			'wp-components',
@@ -609,6 +623,7 @@ function gutenberg_register_scripts_and_styles() {
 			'media-views',
 			'wp-a11y',
 			'wp-api-fetch',
+			'wp-babel-runtime',
 			'wp-components',
 			'wp-compose',
 			'wp-block-library',
@@ -721,7 +736,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-plugins',
 		gutenberg_url( 'build/plugins/index.js' ),
-		array( 'lodash', 'wp-element', 'wp-hooks', 'wp-compose' ),
+		array( 'lodash', 'wp-babel-runtime', 'wp-element', 'wp-hooks', 'wp-compose' ),
 		filemtime( gutenberg_dir_path() . 'build/plugins/index.js' )
 	);
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -101,9 +101,9 @@ function gutenberg_register_scripts_and_styles() {
 
 	wp_register_script(
 		'wp-babel-runtime',
-		gutenberg_url( 'build/babel-runtime/0.index.js' ),
+		gutenberg_url( 'build/babel-runtime/babel-runtime.index.js' ),
 		array(),
-		filemtime( gutenberg_dir_path() . 'build/babel-runtime/0.index.js' ),
+		filemtime( gutenberg_dir_path() . 'build/babel-runtime/babel-runtime.index.js' ),
 		true
 	);
 
@@ -145,7 +145,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-hooks',
 		gutenberg_url( 'build/hooks/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/hooks/index.js' ),
 		true
 	);
@@ -237,7 +237,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-html-entities',
 		gutenberg_url( 'build/html-entities/index.js' ),
-		array(),
+		array( 'wp-babel-runtime' ),
 		filemtime( gutenberg_dir_path() . 'build/html-entities/index.js' ),
 		true
 	);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -209,6 +209,17 @@ const config = {
 			},
 		],
 	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				'babel-runtime': {
+					test: /[\\/]node_modules[\\/](core-js|@babel)[\\/]/,
+					name: 'babel-runtime',
+					chunks: 'all',
+				},
+			},
+		},
+	},
 	plugins: [
 		blocksCSSPlugin,
 		editBlocksCSSPlugin,
@@ -238,7 +249,7 @@ const config = {
 					return basename( rawRequest );
 				}
 
-				return path;
+				return get( data, [ 'chunk', 'name' ], path );
 			},
 		} ),
 		new LibraryExportDefaultPlugin( [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -210,10 +210,11 @@ const config = {
 		],
 	},
 	optimization: {
+		namedChunks: true,
 		splitChunks: {
 			cacheGroups: {
 				'babel-runtime': {
-					test: /[\\/]node_modules[\\/](core-js|@babel)[\\/]/,
+					test: /[\\/]node_modules[\\/](@babel|core-js|regenerator-runtime)[\\/]/,
 					name: 'babel-runtime',
 					chunks: 'all',
 				},


### PR DESCRIPTION
## Description

I followed Webpack docs: https://webpack.js.org/plugins/split-chunks-plugin/.

It looks like this **decresases** the size of the bundles produced by Webpack by **~25%**. I need to calculate it again. It would be great to use some tools instead :)

### Todo tasks and open questions

* [x] Fix different chunk name for `development` (`build/babel-runtime/babel-runtime.index.js`) and `production` (`build/babel-runtime/0.index.js`)
* [ ] How to enable those polyfills for all individual modules? Include them everywhere? This is what this PR does at the moment

### Before

                                           Asset       Size  Chunks                    Chunk Names
                         ./build/blocks/index.js    225 KiB      23  [emitted]         blocks
                      ./build/wordcount/index.js     10 KiB       0  [emitted]         wordcount
                            ./build/url/index.js   20.6 KiB       2  [emitted]         url
                     ./build/token-list/index.js   16.1 KiB       3  [emitted]         tokenList
                      ./build/shortcode/index.js   16.2 KiB       4  [emitted]         shortcode
                  ./build/redux-routine/index.js   18.6 KiB       5  [emitted]         reduxRoutine
                        ./build/plugins/index.js   24.5 KiB       6  [emitted]         plugins
                            ./build/nux/index.js   27.6 KiB       7  [emitted]         nux
                       ./build/keycodes/index.js   14.8 KiB       8  [emitted]         keycodes
               ./build/is-shallow-equal/index.js   1.15 KiB       9  [emitted]         isShallowEqual
                           ./build/i18n/index.js   27.4 KiB      10  [emitted]         i18n
                  ./build/html-entities/index.js  986 bytes      11  [emitted]         htmlEntities
                          ./build/hooks/index.js   19.3 KiB      12  [emitted]         hooks
                        ./build/element/index.js     39 KiB      13  [emitted]         element
                         ./build/editor/index.js    340 KiB      14  [emitted]  [big]  editor
                      ./build/dom-ready/index.js  778 bytes      15  [emitted]         domReady
                            ./build/dom/index.js   22.6 KiB      16  [emitted]         dom
                     ./build/deprecated/index.js   10.8 KiB      17  [emitted]         deprecated
                           ./build/date/index.js    192 KiB      18  [emitted]         date
                           ./build/data/index.js   66.1 KiB      19  [emitted]         data
                      ./build/core-data/index.js   75.3 KiB      20  [emitted]         coreData
                        ./build/compose/index.js   32.4 KiB      21  [emitted]         compose
                       ./build/viewport/index.js   24.3 KiB       1  [emitted]         viewport
                           ./build/blob/index.js  909 bytes      24  [emitted]         blob
                          ./build/autop/index.js   29.3 KiB      25  [emitted]         autop
                      ./build/api-fetch/index.js   40.6 KiB      26  [emitted]         apiFetch
                           ./build/a11y/index.js   5.32 KiB      27  [emitted]         a11y
                    ./build/core-blocks/index.js  994 bytes      28  [emitted]         coreBlocks
                  ./build/block-library/index.js    209 KiB      29  [emitted]         blockLibrary
                      ./build/edit-post/index.js   85.1 KiB      30  [emitted]         editPost
                     ./build/components/index.js    500 KiB      31  [emitted]  [big]  components
./build/block-serialization-spec-parser/index.js   9.48 KiB      22  [emitted]         blockSerializationSpecParser

Total: ~2 100 kB (before gzip)

![screen shot 2018-08-23 at 15 21 56](https://user-images.githubusercontent.com/699132/44528005-bee37000-a6e8-11e8-9ff3-9fef9fa3e61d.png)

### After

                                           Asset       Size                        Chunks                    Chunk Names
               ./build/is-shallow-equal/index.js   1.15 KiB                isShallowEqual  [emitted]         isShallowEqual
                           ./build/a11y/index.js   2.36 KiB                          a11y  [emitted]         a11y
                          ./build/autop/index.js   6.43 KiB                         autop  [emitted]         autop
    ./build/babel-runtime/babel-runtime.index.js   75.8 KiB                 babel-runtime  [emitted]         babel-runtime
                           ./build/blob/index.js  909 bytes                          blob  [emitted]         blob
                  ./build/block-library/index.js    173 KiB                  blockLibrary  [emitted]         blockLibrary
                         ./build/blocks/index.js    178 KiB                        blocks  [emitted]         blocks
                     ./build/components/index.js    451 KiB                    components  [emitted]  [big]  components
                        ./build/compose/index.js   6.17 KiB                       compose  [emitted]         compose
                    ./build/core-blocks/index.js  992 bytes                    coreBlocks  [emitted]         coreBlocks
                      ./build/core-data/index.js   24.5 KiB                      coreData  [emitted]         coreData
                           ./build/data/index.js   21.5 KiB                          data  [emitted]         data
                           ./build/date/index.js    188 KiB                          date  [emitted]         date
                     ./build/deprecated/index.js   1.69 KiB                    deprecated  [emitted]         deprecated
                            ./build/dom/index.js   7.57 KiB                           dom  [emitted]         dom
                      ./build/dom-ready/index.js  778 bytes                      domReady  [emitted]         domReady
                      ./build/edit-post/index.js   53.8 KiB                      editPost  [emitted]         editPost
                         ./build/editor/index.js    288 KiB                        editor  [emitted]  [big]  editor
                        ./build/element/index.js    6.9 KiB                       element  [emitted]         element
                          ./build/hooks/index.js   4.99 KiB                         hooks  [emitted]         hooks
                  ./build/html-entities/index.js  986 bytes                  htmlEntities  [emitted]         htmlEntities
                           ./build/i18n/index.js   19.2 KiB                          i18n  [emitted]         i18n
                      ./build/api-fetch/index.js    4.1 KiB                      apiFetch  [emitted]         apiFetch
                       ./build/keycodes/index.js   3.48 KiB                      keycodes  [emitted]         keycodes
                            ./build/nux/index.js   6.92 KiB                           nux  [emitted]         nux
                        ./build/plugins/index.js   4.21 KiB                       plugins  [emitted]         plugins
                  ./build/redux-routine/index.js   1.75 KiB                  reduxRoutine  [emitted]         reduxRoutine
                      ./build/shortcode/index.js   4.14 KiB                     shortcode  [emitted]         shortcode
                     ./build/token-list/index.js   2.52 KiB                     tokenList  [emitted]         tokenList
                            ./build/url/index.js   8.86 KiB                           url  [emitted]         url
                       ./build/viewport/index.js   2.86 KiB                      viewport  [emitted]         viewport
                      ./build/wordcount/index.js    3.1 KiB                     wordcount  [emitted]         wordcount
./build/block-serialization-spec-parser/index.js   9.48 KiB  blockSerializationSpecParser  [emitted]         blockSerializationSpecParser

Total: ~1 580 kB  (before gzip)

<img width="1400" alt="screen shot 2018-08-29 at 12 54 31" src="https://user-images.githubusercontent.com/699132/44783455-c0021a80-ab8a-11e8-8532-b64b851deefc.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
