### PR TITLE
Templates: Assign default post format block as template setting

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -8,6 +8,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - `wp.editor.getColorClass` has been renamed. Please use `wp.editor.getColorClassName` instead.
 - `value` property in color objects passed by `wp.editor.withColors` has been removed. Please use color property instead.
 - The Subheading block has been removed. Please use the Paragraph block instead.
+- `wp.blocks.getDefaultBlockForPostFormat` has been removed.
 
 ## 3.8.0
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -3,3 +3,7 @@
 ### Breaking Change
 
 - The `isSharedBlock` function is removed. Use `isReusableBlock` instead.
+
+### Deprecations
+
+- The `getDefaultBlockForPostFormat` function has been deprecated.

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -10,6 +10,7 @@ import { get, isFunction, some } from 'lodash';
  */
 import { applyFilters, addFilter } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -228,6 +229,11 @@ export function getDefaultBlockName() {
  * @return {string}            Block name.
  */
 export function getDefaultBlockForPostFormat( postFormat ) {
+	deprecated( 'getDefaultBlockForPostFormat', {
+		plugin: 'Gutenberg',
+		version: '3.9',
+	} );
+
 	const blockName = POST_FORMAT_BLOCK_MAP[ postFormat ];
 	if ( blockName && getBlockType( blockName ) ) {
 		return blockName;

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, last } from 'lodash';
+import { last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,8 +10,6 @@ import {
 	parse,
 	getBlockType,
 	switchToBlockType,
-	createBlock,
-	getDefaultBlockForPostFormat,
 	doBlocksMatchTemplate,
 	synchronizeBlocksWithTemplate,
 } from '@wordpress/blocks';
@@ -25,14 +23,12 @@ import {
 	setupEditorState,
 	replaceBlocks,
 	createWarningNotice,
-	insertBlock,
 	selectBlock,
 	resetBlocks,
 	setTemplateValidity,
 } from './actions';
 import {
 	getBlock,
-	getBlockCount,
 	getBlockRootClientId,
 	getBlocks,
 	getPreviousBlockClientId,
@@ -138,8 +134,6 @@ export default {
 			);
 		} else if ( template ) {
 			blocks = synchronizeBlocksWithTemplate( [], template );
-		} else if ( getDefaultBlockForPostFormat( post.format ) ) {
-			blocks = [ createBlock( getDefaultBlockForPostFormat( post.format ) ) ];
 		} else {
 			blocks = [];
 		}
@@ -213,18 +207,6 @@ export default {
 		const message = spokenMessage || content;
 		speak( message, 'assertive' );
 	},
-
-	EDIT_POST( action, { getState } ) {
-		const format = get( action, [ 'edits', 'format' ] );
-		if ( ! format ) {
-			return;
-		}
-		const blockName = getDefaultBlockForPostFormat( format );
-		if ( blockName && getBlockCount( getState() ) === 0 ) {
-			return insertBlock( createBlock( blockName ) );
-		}
-	},
-
 	REMOVE_BLOCKS( action, { getState, dispatch } ) {
 		// if the action says previous block should not be selected don't do anything.
 		if ( ! action.selectPrevious ) {

--- a/test/e2e/specs/__snapshots__/templates.test.js.snap
+++ b/test/e2e/specs/__snapshots__/templates.test.js.snap
@@ -53,3 +53,13 @@ exports[`templates Using a CPT with a predefined template Should respect user ed
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
+
+exports[`templates With default post format assigned should not populate edited post with default block for format 1`] = `""`;
+
+exports[`templates With default post format assigned should not populate new page with default block for format 1`] = `""`;
+
+exports[`templates With default post format assigned should populate new post with default block for format 1`] = `
+"<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+<!-- /wp:image -->"
+`;

--- a/test/e2e/specs/templates.test.js
+++ b/test/e2e/specs/templates.test.js
@@ -7,6 +7,8 @@ import {
 	getEditedPostContent,
 	saveDraft,
 	pressWithModifier,
+	visitAdmin,
+	clickBlockAppender,
 } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
@@ -49,6 +51,49 @@ describe( 'templates', () => {
 			await page.keyboard.press( 'Backspace' );
 			await saveDraft();
 			await page.reload();
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'With default post format assigned', () => {
+		const STANDARD_FORMAT_VALUE = '0';
+
+		async function setPostFormat( format ) {
+			await visitAdmin( 'options-writing.php' );
+			await page.select( '#default_post_format', format );
+			return Promise.all( [
+				page.waitForNavigation(),
+				page.click( '#submit' ),
+			] );
+		}
+
+		beforeAll( async () => await setPostFormat( 'image' ) );
+		afterAll( async () => await setPostFormat( STANDARD_FORMAT_VALUE ) );
+
+		it( 'should populate new post with default block for format', async () => {
+			await newPost();
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'should not populate edited post with default block for format', async () => {
+			await newPost();
+
+			// Remove the default block template to verify that it's not
+			// re-added after saving and reloading the editor.
+			await page.type( '.editor-post-title__input', 'My Image Format' );
+			await clickBlockAppender();
+			await page.keyboard.press( 'Backspace' );
+			await page.keyboard.press( 'Backspace' );
+			await saveDraft();
+			await page.reload();
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'should not populate new page with default block for format', async () => {
+			await newPost( { postType: 'page' } );
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );


### PR DESCRIPTION
This pull request seeks to refactor default block by post format to be effected as a template.

This is being proposed for two primary reasons:

- It is a simplification, reusing existing template mechanisms in place of an additional step for enacting the default post format block
- As an extension of the previous point, it will serve to benefit a planned subsequent refactoring of editor initialization aimed at eliminating "setup" steps of the editor, for which the default post format block is otherwise difficult to mimic in state without a designated start point.

There are two notable differences from how this behaves in master:

- The template is not enacted except when editing a new post.
   - Arguably, I find this behavior, both for the default post format block and templates in general, to be buggy. For example, on master try:
      1. Set default post format to Image on Settings > Writing
      2. Navigate to Posts > Add New
      3. Add a title
      4. Remove the default image block
      5. Save the post
      6. Reload the editor
         - Expected: My changes are reflected (i.e. the removal of the default block)
         - Actual: The image placeholder block returns! Again, I acknowledge this could be an argued as intentional, but to me it seems like the default block should serve as a starting point niceity, but ultimately we respect the user's decisions to manipulate or remove those defaults.
- The default block is no longer inserted when changing Post Format field
   - Another niceity, but I don't find it to be a worrisome change

**Testing instructions:**

Verify there are no regressions in the behavior of the default block by post format.

Ensure new end-to-end tests pass:

```
npm run test-e2e
```