### PR TITLE
Templates: Apply template for new post only

### DIFF
--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -122,11 +122,12 @@ export default {
 		const state = getState();
 		const template = getTemplate( state );
 		const templateLock = getTemplateLock( state );
+		const isNewPost = post.status === 'auto-draft';
 
 		// Parse content as blocks
 		let blocks;
 		let isValidTemplate = true;
-		if ( post.content.raw ) {
+		if ( ! isNewPost ) {
 			blocks = parse( post.content.raw );
 
 			// Unlocked templates are considered always valid because they act as default values only.
@@ -145,7 +146,7 @@ export default {
 
 		// Include auto draft title in edits while not flagging post as dirty
 		const edits = {};
-		if ( post.status === 'auto-draft' ) {
+		if ( isNewPost ) {
 			edits.title = post.title.raw;
 		}
 

--- a/test/e2e/specs/__snapshots__/templates.test.js.snap
+++ b/test/e2e/specs/__snapshots__/templates.test.js.snap
@@ -1,11 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Using a CPT with a predefined template Should add a custom post types with a predefined template 1`] = `
+exports[`templates Using a CPT with a predefined template Should add a custom post types with a predefined template 1`] = `
 "<!-- wp:image -->
 <figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {\\"placeholder\\":\\"Add a book description\\"} -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:columns -->
+<div class=\\"wp-block-columns has-2-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a inner paragraph\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`templates Using a CPT with a predefined template Should respect user edits to not re-apply template after save (full delete) 1`] = `""`;
+
+exports[`templates Using a CPT with a predefined template Should respect user edits to not re-apply template after save 1`] = `
+"<!-- wp:paragraph {\\"placeholder\\":\\"Add a book description\\"} -->
 <p></p>
 <!-- /wp:paragraph -->
 

--- a/test/e2e/specs/__snapshots__/templates.test.js.snap
+++ b/test/e2e/specs/__snapshots__/templates.test.js.snap
@@ -30,7 +30,7 @@ exports[`templates Using a CPT with a predefined template Should add a custom po
 
 exports[`templates Using a CPT with a predefined template Should respect user edits to not re-apply template after save (full delete) 1`] = `""`;
 
-exports[`templates Using a CPT with a predefined template Should respect user edits to not re-apply template after save 1`] = `
+exports[`templates Using a CPT with a predefined template Should respect user edits to not re-apply template after save (single block removal) 1`] = `
 "<!-- wp:paragraph {\\"placeholder\\":\\"Add a book description\\"} -->
 <p></p>
 <!-- /wp:paragraph -->

--- a/test/e2e/specs/nux.test.js
+++ b/test/e2e/specs/nux.test.js
@@ -5,6 +5,7 @@ import {
 	clickBlockAppender,
 	clickOnMoreMenuItem,
 	newPost,
+	saveDraft,
 } from '../support/utils';
 
 describe( 'New User Experience (NUX)', () => {
@@ -164,10 +165,7 @@ describe( 'New User Experience (NUX)', () => {
 		await page.keyboard.type( 'Post title' );
 		await clickBlockAppender();
 		await page.keyboard.type( 'Post content goes here.' );
-		// Save the post as a draft.
-		await page.click( '.editor-post-save-draft' );
-
-		await page.waitForSelector( '.editor-post-saved-state.is-saved' );
+		await saveDraft();
 
 		// Refresh the page; tips should be disabled.
 		await page.reload();

--- a/test/e2e/specs/templates.test.js
+++ b/test/e2e/specs/templates.test.js
@@ -1,25 +1,56 @@
 /**
  * Internal dependencies
  */
-import { clickOnMoreMenuItem, newPost } from '../support/utils';
+import {
+	META_KEY,
+	newPost,
+	getEditedPostContent,
+	saveDraft,
+	pressWithModifier,
+} from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
-describe( 'Using a CPT with a predefined template', () => {
-	beforeAll( async () => {
-		await activatePlugin( 'gutenberg-test-plugin-templates' );
-		await newPost( { postType: 'book' } );
-	} );
+describe( 'templates', () => {
+	describe( 'Using a CPT with a predefined template', () => {
+		beforeAll( async () => {
+			await activatePlugin( 'gutenberg-test-plugin-templates' );
+		} );
 
-	afterAll( async () => {
-		await deactivatePlugin( 'gutenberg-test-plugin-templates' );
-	} );
+		beforeEach( async () => {
+			await newPost( { postType: 'book' } );
+		} );
 
-	it( 'Should add a custom post types with a predefined template', async () => {
-		//Switch to Code Editor to check HTML output
-		await clickOnMoreMenuItem( 'Code Editor' );
+		afterAll( async () => {
+			await deactivatePlugin( 'gutenberg-test-plugin-templates' );
+		} );
 
-		// Assert that the post already contains the template defined blocks
-		const textEditorContent = await page.$eval( '.editor-post-text-editor', ( element ) => element.value );
-		expect( textEditorContent ).toMatchSnapshot();
+		it( 'Should add a custom post types with a predefined template', async () => {
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'Should respect user edits to not re-apply template after save (single block removal)', async () => {
+			// Remove a block from the template to verify that it's not
+			// re-added after saving and reloading the editor.
+			await page.click( '.editor-post-title__input' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'Backspace' );
+			await saveDraft();
+			await page.reload();
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'Should respect user edits to not re-apply template after save (full delete)', async () => {
+			// Remove all blocks from the template to verify that they're not
+			// re-added after saving and reloading the editor.
+			await page.type( '.editor-post-title__input', 'My Empty Book' );
+			await page.keyboard.press( 'ArrowDown' );
+			await pressWithModifier( META_KEY, 'A' );
+			await page.keyboard.press( 'Backspace' );
+			await saveDraft();
+			await page.reload();
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
 	} );
 } );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -295,6 +295,17 @@ export async function publishPost() {
 }
 
 /**
+ * Saves the post as a draft, resolving once the request is complete (once the
+ * "Saved" indicator is displayed).
+ *
+ * @return {Promise} Promise resolving when draft save is complete.
+ */
+export async function saveDraft() {
+	await page.click( '.editor-post-save-draft' );
+	return page.waitForSelector( '.editor-post-saved-state.is-saved' );
+}
+
+/**
  * Given the clientId of a block, selects the block on the editor.
  *
  * @param {string} clientId Identified of the block.


### PR DESCRIPTION
Related: #9287

This pull request seeks to resolve an issue where removing all blocks from a post with a template assigned would reintroduce the template blocks after saving and reloading the editor. This is in contrast with removal of a single block from template, where the edits would be respected. 

It may be that we want to communicate to the user that the block content is in conflict with the template, or provide the option to insert the template for a truly-empty post, but the default behavior should respect the saved content of the user if they had removed the blocks in a previous session.

**Testing instructions:**

Verify that removing all blocks from a post with template, saving that post, and reloading the page, reflects that the blocks are still removed. I found this easiest by reusing the template plugin from within the test folder:

```
cd path/to/plugins
ln -s gutenberg/test/e2e/test-plugins/templates.php templates.php
```

Then activate the plugin from Plugins screen in administration. This will enable a new Books post type with a default template.

Ensure end-to-end tests pass:

```
npm run test-e2e
```