### PR TITLE
Allow Filtering of Editor Modes

### DIFF
--- a/edit-post/components/header/mode-switcher/index.js
+++ b/edit-post/components/header/mode-switcher/index.js
@@ -17,14 +17,14 @@ import shortcuts from '../../../keyboard-shortcuts';
  * @type {Array}
  */
 const MODES = applyFilters( 'editor.modeSwitcher', [
-    {
-        value: 'visual',
-        label: __( 'Visual Editor' ),
-    },
-    {
-        value: 'text',
-        label: __( 'Code Editor' ),
-    },
+	{
+		value: 'visual',
+		label: __( 'Visual Editor' ),
+	},
+	{
+		value: 'text',
+		label: __( 'Code Editor' ),
+	},
 ] );
 
 function ModeSwitcher( { onSwitch, mode } ) {

--- a/edit-post/components/header/mode-switcher/index.js
+++ b/edit-post/components/header/mode-switcher/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
+import { applyFilters } from '@wordpress/hooks';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
@@ -15,16 +16,16 @@ import shortcuts from '../../../keyboard-shortcuts';
  *
  * @type {Array}
  */
-const MODES = [
-	{
-		value: 'visual',
-		label: __( 'Visual Editor' ),
-	},
-	{
-		value: 'text',
-		label: __( 'Code Editor' ),
-	},
-];
+const MODES = applyFilters( 'editor.modeSwitcher', [
+    {
+        value: 'visual',
+        label: __( 'Visual Editor' ),
+    },
+    {
+        value: 'text',
+        label: __( 'Code Editor' ),
+    },
+] );
 
 function ModeSwitcher( { onSwitch, mode } ) {
 	const choices = MODES.map( ( choice ) => {


### PR DESCRIPTION
## Description
Allow filtering of Editor Modes to let Plugins register custom editors
Example uses:
- Block Outline
- Device Previews
- Geolocation Editor
- Syndication Editor
- SEO Report

* Known issues surrounding keyboard shortcut language/display in UI.

## Screenshots

![screen shot 2018-08-23 at 3 18 47 pm](https://user-images.githubusercontent.com/9565066/44555001-fe5d8c80-a6e7-11e8-8a85-79088a3a9253.png)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
