### PR TITLE
Fix table regressions.

### DIFF
--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -1,6 +1,7 @@
 .wp-block-table {
 	// Fixed layout toggle
 	&.has-fixed-layout tbody {
+		display: table;
 		table-layout: fixed;
 	}
 }

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -1,6 +1,8 @@
 .wp-block-table {
 	// Fixed layout toggle
-	&.has-fixed-layout tbody {
+	&.has-fixed-layout thead,
+	&.has-fixed-layout tbody,
+	&.has-fixed-layout tfoot {
 		display: table;
 		table-layout: fixed;
 	}

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -5,5 +5,6 @@
 	&.has-fixed-layout tfoot {
 		display: table;
 		table-layout: fixed;
+		width: 100%;
 	}
 }

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -9,6 +9,7 @@
 	tfoot {
 		width: 100%;
 		min-width: $break-mobile / 2;
+		display: table;
 	}
 
 	td,

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -4,7 +4,9 @@
 	border-collapse: collapse;
 	width: 100%;
 
-	tbody {
+	thead,
+	tbody,
+	tfoot {
 		width: 100%;
 		min-width: $break-mobile / 2;
 	}

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -1,5 +1,6 @@
 .wp-block-table {
 	overflow-x: auto;
+	display: block; // Necessary in order for this table to be mobile responsive.
 	border-collapse: collapse;
 	width: 100%;
 


### PR DESCRIPTION
This PR fixes table block regressions introduced in https://github.com/WordPress/gutenberg/pull/7899#issuecomment-411732824

The block property for the table makes sure that it's mobile responsive. The "display table" is necessary for fixed layout to work.

- `display: table;` on `tbody` is necessary for the `has-fixed-layout` option to work. Please see https://github.com/WordPress/gutenberg/pull/6314 for a GIF
- `display: block` on `.wp-block-table` is necessary for the table itself to be responsive. Please see https://github.com/WordPress/gutenberg/pull/2152.

Note that the responsiveness for the table is in the `theme.scss` file, which means themes have to opt into these "opinionated styles".

Please test this PR with and without the fixed table cells option enabled, frontend and backend. And please verify that this PR does not regress what #7899 was meant to fix. 