### PR TITLE
Plugins: Move PinnedPlugins component

### DIFF
--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -5,4 +5,5 @@
  - [**core/editor**: The Editor’s Data](../../docs/data/data-core-editor.md)
  - [**core/edit-post**: The Editor’s UI Data](../../docs/data/data-core-edit-post.md)
  - [**core/nux**: The NUX (New User Experience) Data](../../docs/data/data-core-nux.md)
+ - [**core/plugins**: The Plugins Data](../../docs/data/data-core-plugins.md)
  - [**core/viewport**: The Viewport Data](../../docs/data/data-core-viewport.md)

--- a/docs/data/data-core-edit-post.md
+++ b/docs/data/data-core-edit-post.md
@@ -128,20 +128,6 @@ Returns whether the given feature is enabled or not.
 
 Is active.
 
-### isPluginItemPinned
-
-Returns true if the plugin item is pinned to the header.
-When the value is not set it defaults to true.
-
-*Parameters*
-
- * state: Global application state.
- * pluginName: Plugin item name.
-
-*Returns*
-
-Whether the plugin item is pinned.
-
 ### getMetaBoxes
 
 Returns the state of legacy meta boxes.
@@ -234,14 +220,6 @@ Returns an action object used to toggle a feature flag.
 *Parameters*
 
  * feature: Feature name.
-
-### togglePinnedPluginItem
-
-Returns an action object used to toggle a plugin name flag.
-
-*Parameters*
-
- * pluginName: Plugin name.
 
 ### initializeMetaBoxState
 

--- a/docs/data/data-core-nux.md
+++ b/docs/data/data-core-nux.md
@@ -4,18 +4,14 @@
 
 ### isTipVisible
 
-Determines whether the given tip or DotTip instance should be visible. Checks:
-
-- That all tips are enabled.
-- That the given tip has not been dismissed.
-- If the given tip is part of a guide, that the given tip is the current tip in the guide.
-- If instanceId is provided, that this is the first DotTip instance for the given tip.
+Determines whether or not the given tip is showing. Tips are hidden if they
+are disabled, have been dismissed, or are not the current tip in any
+guide that they have been added to.
 
 *Parameters*
 
  * state: Global application state.
  * tipId: The tip to query.
- * instanceId: A number which uniquely identifies the DotTip instance.
 
 ### areTipsEnabled
 
@@ -39,29 +35,6 @@ the user through a series of tips step by step.
 *Parameters*
 
  * tipIds: Which tips to show in the guide.
-
-### registerTipInstance
-
-Returns an action object that, when dispatched, associates an instance of the
-DotTip component with a tip. This is usually done when the component mounts.
-Tracking this lets us only show one DotTip at a time per tip.
-
-*Parameters*
-
- * tipId: The tip to associate this instance with.
- * instanceId: A number which uniquely identifies the instance.
-
-### unregisterTipInstance
-
-Returns an action object that, when dispatched, removes the association
-between a DotTip component instance and a tip. This is usually done when the
-component unmounts. Tracking this lets us only show one DotTip at a time per
-tip.
-
-*Parameters*
-
- * tipId: The tip to disassociate this instance with.
- * instanceId: A number which uniquely identifies the instance.
 
 ### dismissTip
 

--- a/docs/data/data-core-plugins.md
+++ b/docs/data/data-core-plugins.md
@@ -1,0 +1,23 @@
+# **core/plugins**: The Plugins Data
+
+## Selectors
+
+### isPluginItemPinned
+
+Returns true if the plugin item is pinned.
+When the value is not set it defaults to true.
+
+*Parameters*
+
+ * state: Global application state.
+ * itemName: Item name.
+
+## Actions
+
+### togglePinnedPluginItem
+
+Returns an action object used to toggle a plugin item flag.
+
+*Parameters*
+
+ * itemName: Item name.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -834,6 +834,12 @@
 		"parent": "data"
 	},
 	{
+		"title": "The Plugins Data",
+		"slug": "data-core-plugins",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/data-core-plugins.md",
+		"parent": "data"
+	},
+	{
 		"title": "The Viewport Data",
 		"slug": "data-core-viewport",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/data-core-viewport.md",

--- a/docs/tool/config.js
+++ b/docs/tool/config.js
@@ -44,6 +44,11 @@ module.exports = {
 			selectors: [ path.resolve( root, 'packages/nux/src/store/selectors.js' ) ],
 			actions: [ path.resolve( root, 'packages/nux/src/store/actions.js' ) ],
 		},
+		'core/plugins': {
+			title: 'The Plugins Data',
+			selectors: [ path.resolve( root, 'packages/plugins/src/store/selectors.js' ) ],
+			actions: [ path.resolve( root, 'packages/plugins/src/store/actions.js' ) ],
+		},
 		'core/viewport': {
 			title: 'The Viewport Data',
 			selectors: [ path.resolve( root, 'packages/viewport/src/store/selectors.js' ) ],

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -11,6 +11,7 @@ import {
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { DotTip } from '@wordpress/nux';
+import { PinnedPlugins } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -18,7 +19,6 @@ import { DotTip } from '@wordpress/nux';
 import './style.scss';
 import MoreMenu from './more-menu';
 import HeaderToolbar from './header-toolbar';
-import PinnedPlugins from './pinned-plugins';
 import shortcuts from '../../keyboard-shortcuts';
 
 function Header( {

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -5,13 +5,12 @@ import { IconButton, Panel } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { withPluginContext } from '@wordpress/plugins';
+import { PinnedPlugins, withPluginContext } from '@wordpress/plugins';
 import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import PinnedPlugins from '../../header/pinned-plugins';
 import Sidebar from '../';
 import SidebarHeader from '../sidebar-header';
 
@@ -82,10 +81,8 @@ export default compose(
 		};
 	} ),
 	withSelect( ( select, { sidebarName } ) => {
-		const {
-			getActiveGeneralSidebarName,
-			isPluginItemPinned,
-		} = select( 'core/edit-post' );
+		const { getActiveGeneralSidebarName } = select( 'core/edit-post' );
+		const { isPluginItemPinned } = select( 'core/plugins' );
 
 		return {
 			isActive: getActiveGeneralSidebarName() === sidebarName,
@@ -96,8 +93,8 @@ export default compose(
 		const {
 			closeGeneralSidebar,
 			openGeneralSidebar,
-			togglePinnedPluginItem,
 		} = dispatch( 'core/edit-post' );
+		const { togglePinnedPluginItem } = dispatch( 'core/plugins' );
 
 		return {
 			togglePin() {

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -4,6 +4,7 @@
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
+import '@wordpress/plugins';
 
 /**
  * Internal dependencies

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -118,20 +118,6 @@ export function switchEditorMode( mode ) {
 }
 
 /**
- * Returns an action object used to toggle a plugin name flag.
- *
- * @param {string} pluginName Plugin name.
- *
- * @return {Object} Action object.
- */
-export function togglePinnedPluginItem( pluginName ) {
-	return {
-		type: 'TOGGLE_PINNED_PLUGIN_ITEM',
-		pluginName,
-	};
-}
-
-/**
  * Returns an action object used to check the state of meta boxes at a location.
  *
  * This should only be fired once to initialize meta box state. If a meta box

--- a/edit-post/store/defaults.js
+++ b/edit-post/store/defaults.js
@@ -5,5 +5,4 @@ export const PREFERENCES_DEFAULTS = {
 	features: {
 		fixedToolbar: false,
 	},
-	pinnedPluginItems: {},
 };

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -74,15 +69,6 @@ export const preferences = combineReducers( {
 			return action.mode;
 		}
 
-		return state;
-	},
-	pinnedPluginItems( state = PREFERENCES_DEFAULTS.pinnedPluginItems, action ) {
-		if ( action.type === 'TOGGLE_PINNED_PLUGIN_ITEM' ) {
-			return {
-				...state,
-				[ action.pluginName ]: ! get( state, [ action.pluginName ], true ),
-			};
-		}
 		return state;
 	},
 } );

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { get, includes, some } from 'lodash';
+import { includes, some } from 'lodash';
 
 /**
  * Returns the current editing mode.
@@ -134,21 +134,6 @@ export function isModalActive( state, modalName ) {
  */
 export function isFeatureActive( state, feature ) {
 	return !! state.preferences.features[ feature ];
-}
-
-/**
- * Returns true if the plugin item is pinned to the header.
- * When the value is not set it defaults to true.
- *
- * @param  {Object}  state      Global application state.
- * @param  {string}  pluginName Plugin item name.
- *
- * @return {boolean} Whether the plugin item is pinned.
- */
-export function isPluginItemPinned( state, pluginName ) {
-	const pinnedPluginItems = getPreference( state, 'pinnedPluginItems', {} );
-
-	return get( pinnedPluginItems, [ pluginName ], true );
 }
 
 /**

--- a/edit-post/store/test/actions.js
+++ b/edit-post/store/test/actions.js
@@ -11,7 +11,6 @@ import {
 	openModal,
 	closeModal,
 	toggleFeature,
-	togglePinnedPluginItem,
 	requestMetaBoxUpdates,
 	initializeMetaBoxState,
 } from '../actions';
@@ -93,17 +92,6 @@ describe( 'actions', () => {
 			expect( toggleFeature( feature ) ).toEqual( {
 				type: 'TOGGLE_FEATURE',
 				feature,
-			} );
-		} );
-	} );
-
-	describe( 'togglePinnedPluginItem', () => {
-		it( 'should return TOGGLE_PINNED_PLUGIN_ITEM action', () => {
-			const pluginName = 'foo/bar';
-
-			expect( togglePinnedPluginItem( pluginName ) ).toEqual( {
-				type: 'TOGGLE_PINNED_PLUGIN_ITEM',
-				pluginName,
 			} );
 		} );
 	} );

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -25,7 +25,6 @@ describe( 'state', () => {
 				isGeneralSidebarDismissed: false,
 				panels: { 'post-status': true },
 				features: { fixedToolbar: false },
-				pinnedPluginItems: {},
 			} );
 		} );
 
@@ -85,42 +84,6 @@ describe( 'state', () => {
 			} );
 
 			expect( state.features ).toEqual( { chicken: false } );
-		} );
-
-		describe( 'pinnedPluginItems', () => {
-			const initialState = deepFreeze( {
-				pinnedPluginItems: {
-					'foo/enabled': true,
-					'foo/disabled': false,
-				},
-			} );
-
-			it( 'should disable a pinned plugin flag when the value does not exist', () => {
-				const state = preferences( initialState, {
-					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
-					pluginName: 'foo/does-not-exist',
-				} );
-
-				expect( state.pinnedPluginItems[ 'foo/does-not-exist' ] ).toBe( false );
-			} );
-
-			it( 'should disable a pinned plugin flag when it is enabled', () => {
-				const state = preferences( initialState, {
-					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
-					pluginName: 'foo/enabled',
-				} );
-
-				expect( state.pinnedPluginItems[ 'foo/enabled' ] ).toBe( false );
-			} );
-
-			it( 'should enable a pinned plugin flag when it is disabled', () => {
-				const state = preferences( initialState, {
-					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
-					pluginName: 'foo/disabled',
-				} );
-
-				expect( state.pinnedPluginItems[ 'foo/disabled' ] ).toBe( true );
-			} );
 		} );
 	} );
 

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -10,7 +10,6 @@ import {
 	isFeatureActive,
 	isPluginSidebarOpened,
 	getActiveGeneralSidebarName,
-	isPluginItemPinned,
 	getMetaBoxes,
 	hasMetaBoxes,
 	isSavingMetaBoxes,
@@ -254,29 +253,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( isFeatureActive( state, 'chicken' ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'isPluginItemPinned', () => {
-		const state = {
-			preferences: {
-				pinnedPluginItems: {
-					'foo/pinned': true,
-					'foo/unpinned': false,
-				},
-			},
-		};
-
-		it( 'should return true if the flag is not set for the plugin item', () => {
-			expect( isPluginItemPinned( state, 'foo/unknown' ) ).toBe( true );
-		} );
-
-		it( 'should return true if plugin item is not pinned', () => {
-			expect( isPluginItemPinned( state, 'foo/pinned' ) ).toBe( true );
-		} );
-
-		it( 'should return false if plugin item item is unpinned', () => {
-			expect( isPluginItemPinned( state, 'foo/unpinned' ) ).toBe( false );
 		} );
 	} );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -549,6 +549,20 @@ function gutenberg_register_scripts_and_styles() {
 	);
 
 	wp_register_script(
+		'wp-plugins',
+		gutenberg_url( 'build/plugins/index.js' ),
+		array(
+			'lodash',
+			'wp-components',
+			'wp-compose',
+			'wp-data',
+			'wp-element',
+			'wp-hooks',
+		),
+		filemtime( gutenberg_dir_path() . 'build/plugins/index.js' )
+	);
+
+	wp_register_script(
 		'wp-editor',
 		gutenberg_url( 'build/editor/index.js' ),
 		array(
@@ -636,7 +650,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_style(
 		'wp-edit-post',
 		gutenberg_url( 'build/edit-post/style.css' ),
-		array( 'wp-components', 'wp-editor', 'wp-edit-blocks', 'wp-block-library', 'wp-nux' ),
+		array( 'wp-components', 'wp-editor', 'wp-edit-blocks', 'wp-block-library', 'wp-nux', 'wp-plugins' ),
 		filemtime( gutenberg_dir_path() . 'build/edit-post/style.css' )
 	);
 	wp_style_add_data( 'wp-edit-post', 'rtl', 'replace' );
@@ -679,19 +693,20 @@ function gutenberg_register_scripts_and_styles() {
 	wp_style_add_data( 'wp-nux', 'rtl', 'replace' );
 
 	wp_register_style(
+		'wp-plugins',
+		gutenberg_url( 'build/plugins/style.css' ),
+		array( 'wp-components' ),
+		filemtime( gutenberg_dir_path() . 'build/plugins/style.css' )
+	);
+	wp_style_add_data( 'wp-plugins', 'rtl', 'replace' );
+
+	wp_register_style(
 		'wp-block-library-theme',
 		gutenberg_url( 'build/block-library/theme.css' ),
 		array(),
 		filemtime( gutenberg_dir_path() . 'build/block-library/theme.css' )
 	);
 	wp_style_add_data( 'wp-block-library-theme', 'rtl', 'replace' );
-
-	wp_register_script(
-		'wp-plugins',
-		gutenberg_url( 'build/plugins/index.js' ),
-		array( 'lodash', 'wp-element', 'wp-hooks', 'wp-compose' ),
-		filemtime( gutenberg_dir_path() . 'build/plugins/index.js' )
-	);
 
 	if ( defined( 'GUTENBERG_LIVE_RELOAD' ) && GUTENBERG_LIVE_RELOAD ) {
 		$live_reload_url = ( GUTENBERG_LIVE_RELOAD === true ) ? 'http://localhost:35729/livereload.js' : GUTENBERG_LIVE_RELOAD;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2586,7 +2586,9 @@
 			"version": "file:packages/plugins",
 			"requires": {
 				"@babel/runtime-corejs2": "7.0.0-beta.56",
+				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"lodash": "^4.17.10"

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
 		"*.js": [
 			"eslint"
 		],
-		"{docs/{root-manifest.json,tool/*.js},packages/{*/README.md,*/src/{actions,selectors}.js,components/src/*/README.md}}": [
+		"{docs/{root-manifest.json,tool/*.js},packages/{*/README.md,*/src/store/{actions,selectors}.js,components/src/*/README.md}}": [
 			"npm run docs:build"
 		]
 	}

--- a/packages/jest-preset-default/jest-preset.json
+++ b/packages/jest-preset-default/jest-preset.json
@@ -21,6 +21,11 @@
 		"**/?(*.)(spec|test).js",
 		"**/test/*.js"
 	],
+	"testPathIgnorePatterns": [
+		"/node_modules/",
+		"<rootDir>/.*/build/",
+		"<rootDir>/.*/build-module/"
+	],
 	"timers": "fake",
 	"transform": {
 		"^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -20,10 +20,15 @@
 	"module": "build-module/index.js",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"lodash": "^4.17.10"
+	},
+	"devDependencies": {
+		"deep-freeze": "^0.0.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/plugins/src/components/index.js
+++ b/packages/plugins/src/components/index.js
@@ -1,2 +1,3 @@
+export { default as PinnedPlugins } from './pinned-plugins';
 export { default as PluginArea } from './plugin-area';
 export { withPluginContext } from './plugin-context';

--- a/packages/plugins/src/components/pinned-plugins/index.js
+++ b/packages/plugins/src/components/pinned-plugins/index.js
@@ -8,17 +8,12 @@ import { isEmpty } from 'lodash';
  */
 import { createSlotFill } from '@wordpress/components';
 
-/**
- * Internal dependencies
- */
-import './style.scss';
-
 const { Fill: PinnedPlugins, Slot } = createSlotFill( 'PinnedPlugins' );
 
 PinnedPlugins.Slot = ( props ) => (
 	<Slot { ...props }>
 		{ ( fills ) => ! isEmpty( fills ) && (
-			<div className="edit-post-pinned-plugins">
+			<div className="plugins-pinned-plugins">
 				{ fills }
 			</div>
 		) }

--- a/packages/plugins/src/components/pinned-plugins/style.scss
+++ b/packages/plugins/src/components/pinned-plugins/style.scss
@@ -1,4 +1,4 @@
-.edit-post-pinned-plugins {
+.plugins-pinned-plugins {
 	display: flex;
 
 	.components-icon-button {

--- a/packages/plugins/src/index.js
+++ b/packages/plugins/src/index.js
@@ -1,2 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import './store';
+
 export * from './components';
 export * from './api';

--- a/packages/plugins/src/store/actions.js
+++ b/packages/plugins/src/store/actions.js
@@ -1,0 +1,13 @@
+/**
+ * Returns an action object used to toggle a plugin item flag.
+ *
+ * @param {string} itemName Item name.
+ *
+ * @return {Object} Action object.
+ */
+export function togglePinnedPluginItem( itemName ) {
+	return {
+		type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+		itemName,
+	};
+}

--- a/packages/plugins/src/store/defaults.js
+++ b/packages/plugins/src/store/defaults.js
@@ -1,0 +1,3 @@
+export const PREFERENCES_DEFAULTS = {
+	pinnedPluginItems: {},
+};

--- a/packages/plugins/src/store/index.js
+++ b/packages/plugins/src/store/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+
+registerStore( 'core/plugins', {
+	reducer,
+	selectors,
+	actions,
+	persist: [ 'preferences' ],
+} );

--- a/packages/plugins/src/store/reducer.js
+++ b/packages/plugins/src/store/reducer.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_DEFAULTS } from './defaults';
+
+/**
+ * Reducer returning the user preferences.
+ *
+ * @param {Object}  state                   Current state.
+ * @param {Object}  state.pinnedPluginItems The state of the different pinned plugin items.
+ * @param {Object}  action                  Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export const preferences = combineReducers( {
+	pinnedPluginItems( state = PREFERENCES_DEFAULTS.pinnedPluginItems, action ) {
+		if ( action.type === 'TOGGLE_PINNED_PLUGIN_ITEM' ) {
+			return {
+				...state,
+				[ action.itemName ]: ! get( state, [ action.itemName ], true ),
+			};
+		}
+		return state;
+	},
+} );
+
+export default combineReducers( {
+	preferences,
+} );

--- a/packages/plugins/src/store/selectors.js
+++ b/packages/plugins/src/store/selectors.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns true if the plugin item is pinned.
+ * When the value is not set it defaults to true.
+ *
+ * @param  {Object}  state    Global application state.
+ * @param  {string}  itemName Item name.
+ *
+ * @return {boolean} Whether the plugin item is pinned.
+ */
+export function isPluginItemPinned( state, itemName ) {
+	return get( state, [ 'preferences', 'pinnedPluginItems', itemName ], true );
+}

--- a/packages/plugins/src/store/test/actions.js
+++ b/packages/plugins/src/store/test/actions.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import {
+	togglePinnedPluginItem,
+} from '../actions';
+
+describe( 'actions', () => {
+	describe( 'togglePinnedPluginItem', () => {
+		it( 'should return TOGGLE_PINNED_PLUGIN_ITEM action', () => {
+			const itemName = 'foo/bar';
+
+			expect( togglePinnedPluginItem( itemName ) ).toEqual( {
+				type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+				itemName,
+			} );
+		} );
+	} );
+} );

--- a/packages/plugins/src/store/test/reducer.js
+++ b/packages/plugins/src/store/test/reducer.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import {
+	preferences,
+} from '../reducer';
+
+describe( 'state', () => {
+	describe( 'preferences()', () => {
+		it( 'should apply all defaults', () => {
+			const state = preferences( undefined, {} );
+
+			expect( state ).toEqual( {
+				pinnedPluginItems: {},
+			} );
+		} );
+
+		describe( 'pinnedPluginItems', () => {
+			const initialState = deepFreeze( {
+				pinnedPluginItems: {
+					'foo/enabled': true,
+					'foo/disabled': false,
+				},
+			} );
+
+			it( 'should disable a pinned plugin flag when the value does not exist', () => {
+				const state = preferences( initialState, {
+					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+					itemName: 'foo/does-not-exist',
+				} );
+
+				expect( state.pinnedPluginItems[ 'foo/does-not-exist' ] ).toBe( false );
+			} );
+
+			it( 'should disable a pinned plugin flag when it is enabled', () => {
+				const state = preferences( initialState, {
+					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+					itemName: 'foo/enabled',
+				} );
+
+				expect( state.pinnedPluginItems[ 'foo/enabled' ] ).toBe( false );
+			} );
+
+			it( 'should enable a pinned plugin flag when it is disabled', () => {
+				const state = preferences( initialState, {
+					type: 'TOGGLE_PINNED_PLUGIN_ITEM',
+					itemName: 'foo/disabled',
+				} );
+
+				expect( state.pinnedPluginItems[ 'foo/disabled' ] ).toBe( true );
+			} );
+		} );
+	} );
+} );

--- a/packages/plugins/src/store/test/selectors.js
+++ b/packages/plugins/src/store/test/selectors.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import {
+	isPluginItemPinned,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'isPluginItemPinned', () => {
+		const state = {
+			preferences: {
+				pinnedPluginItems: {
+					'foo/pinned': true,
+					'foo/unpinned': false,
+				},
+			},
+		};
+
+		it( 'should return true if the flag is not set for the plugin item', () => {
+			expect( isPluginItemPinned( state, 'foo/unknown' ) ).toBe( true );
+		} );
+
+		it( 'should return true if plugin item is not pinned', () => {
+			expect( isPluginItemPinned( state, 'foo/pinned' ) ).toBe( true );
+		} );
+
+		it( 'should return false if plugin item item is unpinned', () => {
+			expect( isPluginItemPinned( state, 'foo/unpinned' ) ).toBe( false );
+		} );
+	} );
+} );

--- a/packages/plugins/src/style.scss
+++ b/packages/plugins/src/style.scss
@@ -1,0 +1,1 @@
+@import "./components/pinned-plugins/style.scss";

--- a/test/unit/jest.config.json
+++ b/test/unit/jest.config.json
@@ -22,6 +22,8 @@
 	],
 	"testPathIgnorePatterns": [
 		"/node_modules/",
-		"/test/e2e"
+		"<rootDir>/.*/build/",
+		"<rootDir>/.*/build-module/",
+		"<rootDir>/test/e2e/"
 	]
 }


### PR DESCRIPTION
## Description

Related #6115.

This is pre-requisite to offer `PluginModal` component inside `@wordpress/editor` package. It is page agnostic so I believe that it shouldn't be tied to the `edit-post` module the same way `PluginSidebar` is.

To make it possible this PR move `PinnedPlugins` component to `@wordpress/plugins` package to allow reuse between different packages. This include also related data store. I think that the feature of pinning should work the same regardless of which page you open - whether it is going to be the edit post page or edit template page or whatever the future brings.

## How has this been tested?
I copied the following plugin code into JS console to ensure pinning feature still works:

```js
var Button = wp.components.Button;
var PanelBody = wp.components.PanelBody;
var PanelRow = wp.components.PanelRow;
var compose = wp.compose.compose;
var withDispatch = wp.data.withDispatch;
var withSelect = wp.data.withSelect;
var PlainText = wp.editor.PlainText;
var Fragment = wp.element.Fragment;
var el = wp.element.createElement;
var __ = wp.i18n.__;
var registerPlugin = wp.plugins.registerPlugin;
var PluginSidebar = wp.editPost.PluginSidebar;
var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;

function SidebarContents( props ) {
	return el(
		PanelBody,
		{},
		el(
			PanelRow,
			{},
			el(
				'label',
				{
					'htmlFor': 'title-plain-text'
				},
				__( 'Title:' ),
			),
			el(
				PlainText,
				{
					id: 'title-plain-text',
					onChange: props.updateTitle,
					placeholder: __( '(no title)' ),
					value: props.title
				}
			)
		),
		el(
			PanelRow,
			{},
			el(
				Button,
				{
					isPrimary: true,
					onClick: props.resetTitle
				},
				__( 'Reset' )
			)
		)
	);
}

var SidebarContentsWithDataHandling = compose( [
	withSelect( function( select ) {
		return {
			title: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
		};
	} ),
	withDispatch( function( dispatch ) {
		function editPost( title ) {
			dispatch( 'core/editor' ).editPost( {
				title: title
			} );
		}

		return {
			updateTitle: function( title ) {
				editPost( title );
			},
			resetTitle: function() {
				editPost( '' );
			}
		};
	} )
] )( SidebarContents );

function MySidebarPlugin() {
	return el(
		Fragment,
		{},
		el(
			PluginSidebar,
			{
				name: 'title-sidebar',
				title: __( 'Sidebar title plugin' )
			},
			el(
				SidebarContentsWithDataHandling,
				{}
			)
		),
		el(
			PluginSidebarMoreMenuItem,
			{
				target: 'title-sidebar'
			},
			__( 'Sidebar title plugin' )
		)
	);
}

registerPlugin( 'my-sidebar-plugin', {
	icon: 'text',
	render: MySidebarPlugin
} );
```

## Types of changes
Refactoring

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
