### PR TITLE
Change the write story placeholder

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1378,7 +1378,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
-		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
+		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Add text or type / to add content', 'gutenberg' ), $post ),
 		'isRTL'               => is_rtl(),
 		'autosaveInterval'    => 10,
 		'maxUploadFileSize'   => $max_upload_size,

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -222,7 +222,7 @@ class ParagraphBlock extends Component {
 					onMerge={ mergeBlocks }
 					onReplace={ this.onReplace }
 					onRemove={ () => onReplace( [] ) }
-					placeholder={ placeholder || __( 'Add text or type / to add content' ) }
+					placeholder={ placeholder }
 				/>
 			</Fragment>
 		);

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -32,7 +32,7 @@ export function DefaultBlockAppender( {
 		return null;
 	}
 
-	const value = decodeEntities( placeholder ) || __( 'Write your story' );
+	const value = decodeEntities( placeholder ) || __( 'Add text or type / to add content' );
 
 	// The appender "button" is in-fact a text field so as to support
 	// transitions by WritingFlow occurring by arrow key press. WritingFlow


### PR DESCRIPTION
closes #9076

This PR tries to replace the "Write your story" placeholder with the paragraph placeholder "Add text or type / to add content" and also removes the default placeholder from the paragraph block.

Let me know how it feels.