### PR TITLE
Mobile Native -  Fix toolbar status when pressing buttons on Android (and iOS)

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -44,6 +44,9 @@ export class RichText extends Component {
 	}
 
 	onActiveFormatsChange( formats ) {
+		// force re-render the component skipping shouldComponentUpdate() See: https://reactjs.org/docs/react-component.html#forceupdate
+		// This is needed because our shouldComponentUpdate impl. doesn't take in consideration props yet.
+		this.forceUpdate();
 		const newFormats = formats.reduce( ( accFormats, activeFormat ) => {
 			accFormats[ activeFormat ] = getFormatValue( activeFormat );
 			return accFormats;
@@ -139,7 +142,6 @@ export class RichText extends Component {
 		const {
 			tagName,
 			style,
-			eventCount,
 			formattingControls,
 			formatters,
 		} = this.props;
@@ -155,6 +157,7 @@ export class RichText extends Component {
 
 		// Save back to HTML from React tree
 		const html = '<' + tagName + '>' + renderToString( this.props.content.contentTree ) + '</' + tagName + '>';
+		const eventCount = this.props.content.eventCount;
 
 		return (
 			<View>

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -82,8 +82,8 @@ export class RichText extends Component {
 	 * Handles any case where the content of the AztecRN instance has changed in size
 	 */
 
-	onContentSizeChange( event ) {
-		const contentHeight = event.nativeEvent.contentSize.height;
+	onContentSizeChange( contentSize ) {
+		const contentHeight = contentSize.height;
 		this.forceUpdate(); // force re-render the component skipping shouldComponentUpdate() See: https://reactjs.org/docs/react-component.html#forceupdate
 		this.props.onContentSizeChange( {
 			aztecHeight: contentHeight,


### PR DESCRIPTION
## Description
This PR fixes a problem where the status of the buttons in the toolbar could not be in synch with AztecRN editor. This is due to a problem in `shouldComponentUpdate` that skipped the update of RichText component after a button was pressed in the toolbar, since we're not checking the component state there, but only props (formatting options are stored in state), and then it returned `false`.

Instead of adding props to `shouldComponentUpdate`, I've decided to call `forceUpdate` (see onContentSizeChange where it is also used), that forces the component to call `render` and skips `shouldComponentUpdate`.

This PR also fixes another "huge" problem where the Native side always reset the editor from the start when content is set to it. This was due to missing `eventCount` passed to AztecRN.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
