### PR TITLE
Framework: Bump npm-package-json-lint lock to 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14414,8 +14414,8 @@
 			}
 		},
 		"npm-package-json-lint": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.3.0.tgz",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.3.1.tgz",
 			"integrity": "sha512-Npd7o3qMkNWcBr/2sjNWJPY7N8911+EIdlqwLpfMOMUNGNo230eJTWA0zVc/PzIlviyO4d5o545cc4hLpIn7jg==",
 			"dev": true,
 			"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2640,7 +2640,7 @@
 				"chalk": "^2.4.1",
 				"cross-spawn": "^5.1.0",
 				"jest": "^23.4.2",
-				"npm-package-json-lint": "^3.3.0",
+				"npm-package-json-lint": "^3.3.1",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0"
 			}

--- a/packages/npm-package-json-lint-config/CHANGELOG.md
+++ b/packages/npm-package-json-lint-config/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.1.1 (Unreleased)
+
+### Bug Fix
+
+- Resolves an issue where npm package lint script did not work in Windows environments ([#9321](https://github.com/WordPress/gutenberg/pull/9321)
+
 ## 1.1.0 (2018-07-12)
 
 - Updated build to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -22,7 +22,7 @@
 		"is-plain-obj": "^1.1.0"
 	},
 	"peerDependencies": {
-		"npm-package-json-lint": ">= 3.0.0"
+		"npm-package-json-lint": ">= 3.3.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 2.1.0 (Unreleased)
 
+### Bug Fix
+
+- Resolves an issue where npm package lint script did not work in Windows environments ([#9321](https://github.com/WordPress/gutenberg/pull/9321)
+
+### Updated Dependencies
+
 - Updated dependencies: `jest`, `npm-package-json-lint` and `read-pkg-up`
+
 
 ## 2.0.0 (2018-07-12)
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -37,7 +37,7 @@
 		"chalk": "^2.4.1",
 		"cross-spawn": "^5.1.0",
 		"jest": "^23.4.2",
-		"npm-package-json-lint": "^3.3.0",
+		"npm-package-json-lint": "^3.3.1",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0"
 	},


### PR DESCRIPTION
Related: https://github.com/tclindner/npm-package-json-lint/issues/91

This pull request seeks to resolve an issue where npm package lint script does not work in Windows environments.

**Testing instructions:**

Install updated dependencies:

```
npm install
```

In Windows and your preferred operating system, ensure that you can run `npm run lint`.