### PR TITLE
File Block: break long file names

### DIFF
--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -10,6 +10,7 @@
 
 	&__content-wrapper {
 		flex-grow: 1;
+		word-break: break-word;
 	}
 
 	&__textlink {


### PR DESCRIPTION
## Description
Files with really long file names are to long for the file block. I added `word-break: break-word;` to show the filename and the copy-url button inside the block. I think it's better than use `text-overflow: ellipsis`, because you can see the whole name and can edit it more easily.

If you use a file name with several words it's the same behavior:
![bildschirmfoto 2018-08-24 um 16 30 48](https://user-images.githubusercontent.com/695201/44591204-692cc780-a7bd-11e8-91ad-8331cc72dd68.png)

fixes: #8966

## How has this been tested?
Use a long file name.
example: `this_is_a_really_long_file_name_for_testing_the_file_block_and_so_on_just_to_test_this`

## Screenshots
Before:
![bildschirmfoto 2018-08-24 um 16 30 27](https://user-images.githubusercontent.com/695201/44590708-10a8fa80-a7bc-11e8-9cb8-e24949938fff.png)

After:
![bildschirmfoto 2018-08-24 um 16 30 21](https://user-images.githubusercontent.com/695201/44590705-10a8fa80-a7bc-11e8-97ff-eef52e9c866e.png)