### PR TITLE
Add Code → Preformatted block transform

### DIFF
--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -28,7 +28,7 @@ export const settings = {
 		from: [
 			{
 				type: 'block',
-				blocks: [ 'core/paragraph' ],
+				blocks: [ 'core/code', 'core/paragraph' ],
 				transform: ( attributes ) =>
 					createBlock( 'core/preformatted', attributes ),
 			},


### PR DESCRIPTION
## Description
Adds the ability to transform Code blocks into Preformatted blocks. Due to the similar behavior of the two blocks, the transformation is completely lossless.

## How has this been tested?
I made a packaged version of this branch, installed it on my website, created a Code block, added some content and a custom CSS class, and converted it to a Preformatted block successfully, with the content and CSS class being preserved.

## Additional notes
I would have also added a Preformatted → Code transformation as well, but since the Code block lacks support for inline HTML elements (it does not use RichText), it would be a lossy conversion.

I made an issue about this: #6672. I _would_ have fixed it in this PR and added the aforementioned Preformatted → Code transformation, but fixing it would require updating the Code block to use a RichText field.

At first, this sounds like no problem. However, RichText fields apparently have issues when they are inline elements. See #8785, #9180, and #9195. The content of the Code block is stored inside a `<code>` element nested in a `<pre>` element. The `<code>` element is an inline element, which means that issues like #9180 could occur if the Code block was updated to use RichText.

You might think that the solution to this issue is simply removing the `<code>` tags from the Code block, but doing so would remove the semantics that separate the Code block from the Preformatted block, making the former redundant. So unless some solution to the inline RichText issues is found, the Code block is pretty much stuck being unable to support inline elements, unfortunately. :disappointed: