### PR TITLE
Verse block: add link button to toolbar

### DIFF
--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -77,7 +77,6 @@ export const settings = {
 					style={ { textAlign: textAlign } }
 					placeholder={ __( 'Write…' ) }
 					wrapperClassName={ className }
-					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
 				/>
 			</Fragment>
 		);


### PR DESCRIPTION
Haiku have no links.
I can not see a reason?
Toolbar has the space.

Users will complain,
noticing the lack of links,
if this is not fixed.

Now haiku have links!
Perhaps to other haiku?
It's all red, no green!