### PR TITLE
Docs: Enable syntax highlighting for HTML code

### DIFF
--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -53,7 +53,7 @@ Gutenberg adds additional markup to floated images to make styling them easier.
 
 Here's the markup for an `Image` with a caption:
 
-```
+```html
 <figure class="wp-block-image">
 	<img src="..." alt="" width="200px">
 	<figcaption>Short image caption.</figcaption>
@@ -62,7 +62,7 @@ Here's the markup for an `Image` with a caption:
 
 Here's the markup for a left-floated image:
 
-```
+```html
 <div class="wp-block-image">
 	<figure class="alignleft">
 		<img src="..." alt="" width="200px">


### PR DESCRIPTION
 Add language identifier to enable syntax highlighting for HTML code