### PR TITLE
Update from backtick quote to single quote

### DIFF
--- a/edit-post/components/keyboard-shortcut-help-modal/config.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/config.js
@@ -101,7 +101,7 @@ const blockShortcuts = {
 		},
 		{
 			keyCombination: '/',
-			description: __( `Change the block type after adding a new paragraph.` ),
+			description: __( 'Change the block type after adding a new paragraph.' ),
 		},
 	],
 };


### PR DESCRIPTION
## Description
The string "Change the block type after adding a new paragraph" doesn't show for translate and the only diference is the backtick quote use instead of single quote. But I don't know if that is the real cause. Anyway for codding standards I changed to single quote.

## Types of changes
Bug fix.

