### PR TITLE
docs: Remove TODO about edit class property

### DIFF
--- a/docs/block-api/block-edit-save.md
+++ b/docs/block-api/block-edit-save.md
@@ -13,9 +13,7 @@ edit() {
 }
 ```
 
-// Todo: for more advanced uses, `edit` can return a component with lifecycle.
-
-The function receives the following properties through an object argument.
+The function receives the following properties through an object argument:
 
 ### attributes
 


### PR DESCRIPTION
See: #8890

Remove a TODO about a functionality we don't want to support.