### PR TITLE
Video block: Add poster image

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	BaseControl,
+	Button,
 	Disabled,
 	IconButton,
 	PanelBody,
@@ -16,6 +18,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	MediaPlaceholder,
+	MediaUpload,
 	RichText,
 	editorMediaUpload,
 } from '@wordpress/editor';
@@ -32,6 +35,8 @@ class VideoEdit extends Component {
 
 		this.toggleAttribute = this.toggleAttribute.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
+		this.onSelectPoster = this.onSelectPoster.bind( this );
+		this.onRemovePoster = this.onRemovePoster.bind( this );
 	}
 
 	componentDidMount() {
@@ -74,8 +79,28 @@ class VideoEdit extends Component {
 		this.setState( { editing: false } );
 	}
 
+	onSelectPoster( image ) {
+		const { setAttributes, clientId } = this.props;
+		setAttributes( { poster: image.url } );
+		document.getElementById( 'block-' + clientId ).getElementsByTagName( 'video' )[ 0 ].load();
+	}
+
+	onRemovePoster() {
+		const { setAttributes } = this.props;
+		setAttributes( { poster: '' } );
+	}
+
 	render() {
-		const { autoplay, caption, controls, loop, muted, preload, src } = this.props.attributes;
+		const {
+			autoplay,
+			caption,
+			controls,
+			loop,
+			muted,
+			poster,
+			preload,
+			src,
+		} = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
 		const switchToEditing = () => {
@@ -160,6 +185,26 @@ class VideoEdit extends Component {
 								{ value: 'none', label: __( 'None' ) },
 							] }
 						/>
+						<BaseControl
+							className="editor-video-poster-control"
+							label={ __( 'Poster Image' ) }
+						>
+							<MediaUpload
+								title={ 'Select Poster Image' }
+								onSelect={ this.onSelectPoster }
+								type="image"
+								render={ ( { open } ) => (
+									<Button isDefault onClick={ open }>
+										{ ! this.props.attributes.poster ? __( 'Select Poster Image' ) : __( 'Replace image' ) }
+									</Button>
+								) }
+							/>
+							{ !! this.props.attributes.poster &&
+								<Button onClick={ this.onRemovePoster } isLink isDestructive>
+									{ __( 'Remove Poster Image' ) }
+								</Button>
+							}
+						</BaseControl>
 					</PanelBody>
 				</InspectorControls>
 				<figure className={ className }>
@@ -168,7 +213,11 @@ class VideoEdit extends Component {
 						video when the controls are enabled.
 					*/ }
 					<Disabled>
-						<video controls={ controls } src={ src } />
+						<video
+							controls={ controls }
+							poster={ poster }
+							src={ src }
+						/>
 					</Disabled>
 					{ ( ( caption && caption.length ) || !! isSelected ) && (
 						<RichText

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -13,7 +13,7 @@ import {
 	ToggleControl,
 	withNotices,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, Fragment, createRef } from '@wordpress/element';
 import {
 	BlockControls,
 	InspectorControls,
@@ -33,6 +33,7 @@ class VideoEdit extends Component {
 			editing: ! this.props.attributes.src,
 		};
 
+		this.videoPlayer = createRef();
 		this.toggleAttribute = this.toggleAttribute.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
 		this.onSelectPoster = this.onSelectPoster.bind( this );
@@ -60,6 +61,12 @@ class VideoEdit extends Component {
 		}
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( this.props.attributes.poster !== prevProps.attributes.poster ) {
+			this.videoPlayer.current.load();
+		}
+	}
+
 	toggleAttribute( attribute ) {
 		return ( newValue ) => {
 			this.props.setAttributes( { [ attribute ]: newValue } );
@@ -80,9 +87,8 @@ class VideoEdit extends Component {
 	}
 
 	onSelectPoster( image ) {
-		const { setAttributes, clientId } = this.props;
+		const { setAttributes } = this.props;
 		setAttributes( { poster: image.url } );
-		document.getElementById( 'block-' + clientId ).getElementsByTagName( 'video' )[ 0 ].load();
 	}
 
 	onRemovePoster() {
@@ -217,6 +223,7 @@ class VideoEdit extends Component {
 							controls={ controls }
 							poster={ poster }
 							src={ src }
+							ref={ this.videoPlayer }
 						/>
 					</Disabled>
 					{ ( ( caption && caption.length ) || !! isSelected ) && (

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -190,7 +190,7 @@ class VideoEdit extends Component {
 							label={ __( 'Poster Image' ) }
 						>
 							<MediaUpload
-								title={ 'Select Poster Image' }
+								title={ __( 'Select Poster Image' ) }
 								onSelect={ this.onSelectPoster }
 								type="image"
 								render={ ( { open } ) => (

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -2,10 +2,6 @@
 	text-align: center;
 }
 
-.editor-video-poster-control {
-	margin-bottom: 1em;
-}
-
 .editor-video-poster-control .components-button + .components-button {
 	margin-top: 1em;
 	margin-right: 8px;

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -1,3 +1,12 @@
 .editor-block-list__block[data-align="center"] {
 	text-align: center;
 }
+
+.editor-video-poster-control {
+	margin-bottom: 1em;
+}
+
+.editor-video-poster-control .components-button + .components-button {
+	margin-top: 1em;
+	margin-right: 8px;
+}

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -2,7 +2,10 @@
 	text-align: center;
 }
 
+.editor-video-poster-control .components-button {
+	margin-right: 8px;
+}
+
 .editor-video-poster-control .components-button + .components-button {
 	margin-top: 1em;
-	margin-right: 8px;
 }

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -58,6 +58,12 @@ export const settings = {
 			selector: 'video',
 			attribute: 'muted',
 		},
+		poster: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'video',
+			attribute: 'poster',
+		},
 		preload: {
 			type: 'string',
 			source: 'attribute',
@@ -101,7 +107,7 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { autoplay, caption, controls, loop, muted, preload, src } = attributes;
+		const { autoplay, caption, controls, loop, muted, poster, preload, src } = attributes;
 		return (
 			<figure>
 				{ src && (
@@ -110,6 +116,7 @@ export const settings = {
 						controls={ controls }
 						loop={ loop }
 						muted={ muted }
+						poster={ poster }
 						preload={ preload !== 'metadata' ? preload : undefined }
 						src={ src }
 					/>

--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -3,6 +3,12 @@
 		max-width: 100%;
 	}
 
+	@supports (position: sticky) {
+		[poster] {
+			object-fit: cover;
+		}
+	}
+
 	&.aligncenter {
 		text-align: center;
 	}


### PR DESCRIPTION
## Description
This PR adds the ability to add a poster image to the video block.

Fixes #4837

## Screenshots
No poster selected
![bildschirmfoto 2018-08-24 um 22 32 41](https://user-images.githubusercontent.com/695201/44606846-cf7e0e00-a7ee-11e8-8037-cbb3fb8af526.png)

Poster selected
![bildschirmfoto 2018-08-24 um 22 32 29](https://user-images.githubusercontent.com/695201/44606844-cee57780-a7ee-11e8-8a84-86eb59c2e48f.png)

Workflow
![video-poster](https://user-images.githubusercontent.com/695201/44606825-c0975b80-a7ee-11e8-8392-c6c5667fc241.gif)

