### PR TITLE
Update: Allow blocks with supports align to have a default alignment

### DIFF
--- a/packages/editor/src/hooks/align.js
+++ b/packages/editor/src/hooks/align.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { assign, includes } from 'lodash';
+import { assign, get, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -23,6 +23,10 @@ import { BlockControls, BlockAlignmentToolbar } from '../components';
  * @return {Object}          Filtered block settings
  */
 export function addAttribute( settings ) {
+	// allow blocks to specify their own attribute definition with default values if needed.
+	if ( get( settings.attributes, [ 'align', 'type' ] ) === 'string' ) {
+		return settings;
+	}
 	if ( hasBlockSupport( settings, 'align' ) ) {
 		// Use Lodash's assign to gracefully handle if attributes are undefined
 		settings.attributes = assign( settings.attributes, {


### PR DESCRIPTION
## Description
Supports align option allow blocks to have an alignment option (toolbar, attributes, and class names in the editor and save) with just one line. That is awesome to avoid duplicate code.
But if we need a block with supports align but also have a default alignment (e.g: right) that was not possible.
This Pr's makes sure blocks can use supports align and have a default alignment. To do that blocks have to provide their own align attribute definition with the default option set.

## How has this been tested?
I used the following test block https://gist.github.com/jorgefilipecosta/d3cc0a9937ac1105e0a0537efd0e615b and checked the default align right is applied.