### PR TITLE
Refactors List Block Edit to support Text & Background Colors

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -1,0 +1,242 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { find } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	Component,
+	Fragment,
+} from '@wordpress/element';
+import {
+	withFallbackStyles,
+} from '@wordpress/components';
+import {
+	withColors,
+	BlockControls,
+	InspectorControls,
+	PanelColorSettings,
+	ContrastChecker,
+	RichText,
+} from '@wordpress/editor';
+import { createBlock } from '@wordpress/blocks';
+import { compose } from '@wordpress/compose';
+
+const { getComputedStyle } = window;
+
+class ListBlockEdit extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.setupEditor = this.setupEditor.bind( this );
+		this.getEditorSettings = this.getEditorSettings.bind( this );
+		this.setNextValues = this.setNextValues.bind( this );
+
+		this.state = {
+			internalListType: null,
+		};
+	}
+
+	findInternalListType( { parents } ) {
+		const list = find( parents, ( node ) => node.nodeName === 'UL' || node.nodeName === 'OL' );
+		return list ? list.nodeName : null;
+	}
+
+	setupEditor( editor ) {
+		editor.on( 'nodeChange', ( nodeInfo ) => {
+			this.setState( {
+				internalListType: this.findInternalListType( nodeInfo ),
+			} );
+		} );
+
+		// this checks for languages that do not typically have square brackets on their keyboards
+		const lang = window.navigator.browserLanguage || window.navigator.language;
+		const keyboardHasSqBracket = ! /^(?:fr|nl|sv|ru|de|es|it)/.test( lang );
+
+		if ( keyboardHasSqBracket ) {
+			// keycode 219 = '[' and keycode 221 = ']'
+			editor.shortcuts.add( 'meta+219', 'Decrease indent', 'Outdent' );
+			editor.shortcuts.add( 'meta+221', 'Increase indent', 'Indent' );
+		} else {
+			editor.shortcuts.add( 'meta+shift+m', 'Decrease indent', 'Outdent' );
+			editor.shortcuts.add( 'meta+m', 'Increase indent', 'Indent' );
+		}
+
+		this.editor = editor;
+	}
+
+	createSetListType( type, command ) {
+		return () => {
+			const { setAttributes } = this.props;
+			const { internalListType } = this.state;
+			if ( internalListType ) {
+				// only change list types, don't toggle off internal lists
+				if ( internalListType !== type && this.editor ) {
+					this.editor.execCommand( command );
+				}
+			} else {
+				setAttributes( { ordered: type === 'OL' } );
+			}
+		};
+	}
+
+	createExecCommand( command ) {
+		return () => {
+			if ( this.editor ) {
+				this.editor.execCommand( command );
+			}
+		};
+	}
+
+	getEditorSettings( editorSettings ) {
+		return {
+			...editorSettings,
+			plugins: ( editorSettings.plugins || [] ).concat( 'lists' ),
+			lists_indent_on_tab: false,
+		};
+	}
+
+	setNextValues( nextValues ) {
+		this.props.setAttributes( { values: nextValues } );
+	}
+
+	render() {
+		const {
+			attributes,
+			insertBlocksAfter,
+			setAttributes,
+			mergeBlocks,
+			onReplace,
+			className,
+			backgroundColor,
+			textColor,
+			setBackgroundColor,
+			setTextColor,
+			fallbackBackgroundColor,
+			fallbackTextColor,
+		} = this.props;
+		const { ordered, values } = attributes;
+		const tagName = ordered ? 'ol' : 'ul';
+
+		return (
+			<Fragment>
+				<BlockControls
+					controls={ [
+						{
+							icon: 'editor-ul',
+							title: __( 'Convert to unordered list' ),
+							isActive: ! ordered,
+							onClick: this.createSetListType( 'UL', 'InsertUnorderedList' ),
+						},
+						{
+							icon: 'editor-ol',
+							title: __( 'Convert to ordered list' ),
+							isActive: ordered,
+							onClick: this.createSetListType( 'OL', 'InsertOrderedList' ),
+						},
+						{
+							icon: 'editor-outdent',
+							title: __( 'Outdent list item' ),
+							onClick: this.createExecCommand( 'Outdent' ),
+						},
+						{
+							icon: 'editor-indent',
+							title: __( 'Indent list item' ),
+							onClick: this.createExecCommand( 'Indent' ),
+						},
+					] }
+				/>
+				<InspectorControls>
+					<PanelColorSettings
+						title={ __( 'Color Settings' ) }
+						initialOpen={ false }
+						colorSettings={ [
+							{
+								value: backgroundColor.color,
+								onChange: setBackgroundColor,
+								label: __( 'Background Color' ),
+							},
+							{
+								value: textColor.color,
+								onChange: setTextColor,
+								label: __( 'Text Color' ),
+							},
+						] }
+					>
+						<ContrastChecker
+							{ ...{
+								textColor: textColor.color,
+								backgroundColor: backgroundColor.color,
+								fallbackTextColor,
+								fallbackBackgroundColor,
+							} }
+						/>
+					</PanelColorSettings>
+				</InspectorControls>
+				<RichText
+					multiline="li"
+					tagName={ tagName }
+					unstableGetSettings={ this.getEditorSettings }
+					unstableOnSetup={ this.setupEditor }
+					onChange={ this.setNextValues }
+					value={ values }
+					wrapperClassName="block-library-list"
+					placeholder={ __( 'Write list…' ) }
+					onMerge={ mergeBlocks }
+					className={ classnames( className, {
+						'has-background': backgroundColor.color,
+						[ backgroundColor.class ]: backgroundColor.class,
+						[ textColor.class ]: textColor.class,
+					} ) }
+					style={ {
+						backgroundColor: backgroundColor.color,
+						color: textColor.color,
+					} }
+					onSplit={
+						insertBlocksAfter ?
+							( before, after, ...blocks ) => {
+								if ( ! blocks.length ) {
+									blocks.push( createBlock( 'core/paragraph' ) );
+								}
+
+								if ( after.length ) {
+									blocks.push( createBlock( 'core/list', {
+										ordered,
+										values: after,
+									} ) );
+								}
+
+								setAttributes( { values: before } );
+								insertBlocksAfter( blocks );
+							} :
+							undefined
+					}
+					onRemove={ () => onReplace( [] ) }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+const withAppliedFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textColor, backgroundColor, fontSize, customFontSize } = ownProps.attributes;
+	const editableNode = node.querySelector( '[contenteditable="true"]' );
+	//verify if editableNode is available, before using getComputedStyle.
+	const computedStyles = editableNode ? getComputedStyle( editableNode ) : null;
+	return {
+		fallbackBackgroundColor: backgroundColor || ! computedStyles ? undefined : computedStyles.backgroundColor,
+		fallbackTextColor: textColor || ! computedStyles ? undefined : computedStyles.color,
+		fallbackFontSize: fontSize || customFontSize || ! computedStyles ? undefined : parseInt( computedStyles.fontSize ) || undefined,
+	};
+} );
+
+const ListEdit = compose( [
+	withColors( 'backgroundColor', { textColor: 'color' } ),
+	withAppliedFallbackStyles,
+] )( ListBlockEdit );
+
+export default ListEdit;

--- a/packages/block-library/src/list/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/list/test/__snapshots__/index.js.snap
@@ -1,33 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`core/list block edit matches snapshot 1`] = `
-<div
-  class="block-library-list editor-rich-text"
->
-  <div>
+<div>
+   
+  <div
+    class="block-library-list editor-rich-text"
+  >
     <div>
-      <div
-        class="components-autocomplete"
-      >
-        <ul
-          aria-autocomplete="list"
-          aria-expanded="false"
-          aria-label="Write list…"
-          aria-multiline="true"
-          class="editor-rich-text__tinymce"
-          contenteditable="true"
-          data-is-placeholder-visible="true"
-          role="textbox"
-        />
-        <ul
-          class="editor-rich-text__tinymce"
+      <div>
+        <div
+          class="components-autocomplete"
         >
-          <li>
-            Write list…
-          </li>
-        </ul>
+          <ul
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Write list…"
+            aria-multiline="true"
+            class="editor-rich-text__tinymce"
+            contenteditable="true"
+            data-is-placeholder-visible="true"
+            role="textbox"
+          />
+          <ul
+            class="editor-rich-text__tinymce"
+          >
+            <li>
+              Write list…
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
+   
 </div>
 `;


### PR DESCRIPTION
## Description

Fixes #9016 

This PR makes the Color Settings Panel available to the List Block. The Contrast Checker is also reused in a similar fashion as the Paragraph Block.

## How has this been tested?

1. Go to create a new post
1. Click on '+.' (top left) and add new block "list"
1. On the right side there is now a Color Settings Panel to change colors.
1. If Background & Text color contrast is poor, a warning is shown in the settings.

## Screenshots

### New Color Settings Panel:
![List Block with Color Settings](https://i.imgur.com/P0pnXC4.png)

### Contrast Warning:
![List Block Color Settings Contrast Warning](https://i.imgur.com/Re0G9BD.png)

## Types of changes

* New Feature ( Addresses #9016 )
* Refactors List Block, moves block edit code into edit.js
* Adds textColor & backgroundColor attributes to List blocks
* Adds Color Settings & Contrast Checker inspector controls to List blocks

## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
