### PR TITLE
Fixes Embed photo previews for providers that don't return thumbnail_url

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -144,6 +144,12 @@ export function getEmbedEdit( title, icon ) {
 
 			// Some plugins only return HTML with no type info, so default this to 'rich'.
 			let { type = 'rich' } = preview;
+
+			// If provider does not return a thumbnail_url we can't show a photo preview.
+			if ( type === 'photo' && ! preview.thumbnail_url ) {
+				type = 'rich';
+			}
+
 			// If we got a provider name from the API, use it for the slug, otherwise we use the title,
 			// because not all embed code gives us a provider name.
 			const { html, provider_name: providerName } = preview;


### PR DESCRIPTION
## Description

Fixes #9003

Some OEmbed providers like Giphy do not return the `thumbnail_url` property in the oembed discovery. Since these providers cannot show a Photo preview they need to be rendered inside the Sandbox. This PR forces such embeds to render within the Sandbox iframe.

## How has this been tested?

1. Create a new Post
2. Paste a Giphy page URL or direct .gif link without selecting a block
3. Gif now appears correctly

## Screenshots

![Giphy Preview](https://i.imgur.com/5x6y6BZ.png)

## Types of changes

Bug fix for #9003

## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
