### PR TITLE
Add 'download' attr in anchor of file block

### DIFF
--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -208,6 +208,10 @@ export const settings = {
 						href={ textLinkHref }
 						target={ textLinkTarget }
 						rel={ textLinkTarget ? 'noreferrer noopener' : false }
+						// ensure download attribute is still set when fileName
+						// is undefined. Using '' here as `true` still leaves
+						// the attribute unset.
+						download={ fileName || '' }
 					>
 						{ fileName }
 					</a>


### PR DESCRIPTION
## Description
Regardless of the download button is shown or not, the link is also intended to perform the download, so the anchor must also have the 'download' attribute

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
