### PR TITLE
Components: Update FocusableIframe component example

### DIFF
--- a/packages/components/src/focusable-iframe/README.md
+++ b/packages/components/src/focusable-iframe/README.md
@@ -11,7 +11,7 @@ import { FocusableIframe } from '@wordpress/components';
 
 const MyFocusableIframe = () => (
 	<FocusableIframe
-		src="/"
+		src="/my-iframe-url"
 		onFocus={ () => console.log( 'iframe is focused' ) }
 	/>
 );


### PR DESCRIPTION
This changes the url used in the example for the `FocusableIframe` component in order to avoid performance issues when rendering the example, as the previous url was causing to load again the root site of the web displaying the example (i.e. Calypso DevDocs is rendering this example and the rest of the page freezes until the iframe finishes to render the the front site).