### PR TITLE
Deprecate Subheading block

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -7,6 +7,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - `wp.editor.getColorName` has been removed. Please use `wp.editor.getColorObjectByColorValue` instead.
 - `wp.editor.getColorClass` has been renamed. Please use `wp.editor.getColorClassName` instead.
 - `value` property in color objects passed by `wp.editor.withColors` has been removed. Please use color property instead.
+- The Subheading block has been removed. Please use the Paragraph block instead.
 
 ## 3.8.0
 

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -44,11 +44,8 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/paragraph' ],
-				transform: ( { content } ) => {
-					return createBlock( 'core/paragraph', {
-						content,
-					} );
-				},
+				transform: ( attributes ) =>
+					createBlock( 'core/paragraph', attributes ),
 			},
 		],
 	},

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
@@ -13,15 +14,17 @@ import {
 export const name = 'core/subhead';
 
 export const settings = {
-	title: __( 'Subheading' ),
+	title: __( 'Subheading (deprecated)' ),
 
-	description: __( 'What’s a subhead? Smaller than a headline, bigger than basic text.' ),
+	description: __( 'This block is deprecated. Please use the Paragraph block instead.' ),
 
 	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.1 6l-.5 3h4.5L9.4 19h3l1.8-10h4.5l.5-3H7.1z" /></svg>,
 
 	category: 'common',
 
 	supports: {
+		// Hide from inserter as this block is deprecated.
+		inserter: false,
 		multiple: false,
 	},
 
@@ -37,17 +40,6 @@ export const settings = {
 	},
 
 	transforms: {
-		from: [
-			{
-				type: 'block',
-				blocks: [ 'core/paragraph' ],
-				transform: ( { content } ) => {
-					return createBlock( 'core/subhead', {
-						content,
-					} );
-				},
-			},
-		],
 		to: [
 			{
 				type: 'block',
@@ -63,6 +55,11 @@ export const settings = {
 
 	edit( { attributes, setAttributes, className } ) {
 		const { align, content, placeholder } = attributes;
+
+		deprecated( 'The Subheading block', {
+			alternative: 'the Paragraph block',
+			plugin: 'Gutenberg',
+		} );
 
 		return (
 			<Fragment>


### PR DESCRIPTION
## Description
This PR deprecates the Subheading (`core/subhead`) block. It removes the Subheading block from the inserter. It also removes the Paragraph→Subheading transform and improves the Subheading→Paragraph transform to preserve custom CSS classes. It also changes the visible title and description of the Subheading block to indicate that it is deprecated.

Fixes #9308 and closes #5475, #8141, #8234, and #8716.

## Additional notes
When should the Subheading block be removed entirely? I have noticed that the Text Columns block still technically exists despite being deprecated in 3.3.

Currently, there is no way to migrate from a deprecated/removed block to another block automatically. Should this feature be added before the Text Columns and Subheading blocks are removed entirely?

## Related issues and PRs
- #8821
- #9308