### PR TITLE
Add .directory files from to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ languages/gutenberg.pot
 /languages/gutenberg-translations.php
 
 # Directories/files that may appear in your environment
+.directory
 .DS_Store
 *.log
 phpcs.xml


### PR DESCRIPTION
## Description
The KDE Dolphin file manager creates `.directory` files that store folder metadata like the view (e.g. list versus thumbnails) that was last used when viewing a folder. This PR adds `.directory` files to `.gitignore`. This should be useful to people developing Gutenberg on Linux distros using the KDE Plasma desktop environment.

Or in other words, I got tired of not being able to use `git add *` without having to then remove all the `.directory` files from the staged file list. :stuck_out_tongue: