### PR TITLE
Text Columns block: change title/description to include deprecation notice.

### DIFF
--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -25,9 +25,9 @@ export const settings = {
 		inserter: false,
 	},
 
-	title: __( 'Text Columns' ),
+	title: __( 'Text Columns (deprecated)' ),
 
-	description: __( 'Add text, and display it in two or more columns. Like a newspaper! This block is experimental.' ),
+	description: __( 'This block is deprecated. Please use the Columns block instead.' ),
 
 	icon: 'columns',
 


### PR DESCRIPTION
## Description
This is a minor change which makes it more obvious for the average user to see that the Text Columns block is deprecated. Previously, warnings were only shown in the JavaScript console. This PR adds <samp>(deprecated)</samp> to the block title and changes the description to recommend usage of the Columns block instead. This should make it more obvious that the block is deprecated.

## Additional notes
I wanted to also add the ability to transform a Text Columns block into a Columns block, but that is a much trickier task, so I am not doing it in this PR. <del>If anyone with more experience wants to do that, then please do.</del> <ins>I have created a separate PR for that: #9364.</ins> I think providing one-way transforms from deprecated blocks to their recommended replacements/closest-equivalents is a good idea for smooth transitions.

Ideally, you would want to automatically transform deprecated blocks into the recommended replacements, but the deprecated blocks API does not currently support migrating from/to a completely different block.

## Related issues and PRs
- #9364