### PR TITLE
Add Text Columns → Columns transform

### DIFF
--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -39,6 +39,10 @@ const getColumnsTemplate = memoize( ( columns ) => {
 	return times( columns, () => [ 'core/column' ] );
 } );
 
+const supports = {
+	align: [ 'wide', 'full' ],
+};
+
 export const name = 'core/columns';
 
 export const settings = {
@@ -62,8 +66,32 @@ export const settings = {
 
 	description: __( 'Add a block that displays content in multiple columns, then add whatever content blocks you’d like.' ),
 
-	supports: {
-		align: [ 'wide', 'full' ],
+	supports,
+
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/text-columns' ],
+				transform: ( { className, columns, content, width } ) => (
+					createBlock(
+						'core/columns',
+						{
+							align: supports.align.includes( width ) ? width : undefined,
+							className,
+							columns,
+						},
+						content.map( ( { children } ) =>
+							createBlock(
+								'core/column',
+								{},
+								[ createBlock( 'core/paragraph', { content: children } ) ]
+							)
+						)
+					)
+				),
+			},
+		],
 	},
 
 	deprecated: [

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -39,10 +39,6 @@ const getColumnsTemplate = memoize( ( columns ) => {
 	return times( columns, () => [ 'core/column' ] );
 } );
 
-const supports = {
-	align: [ 'wide', 'full' ],
-};
-
 export const name = 'core/columns';
 
 export const settings = {
@@ -66,32 +62,8 @@ export const settings = {
 
 	description: __( 'Add a block that displays content in multiple columns, then add whatever content blocks you’d like.' ),
 
-	supports,
-
-	transforms: {
-		from: [
-			{
-				type: 'block',
-				blocks: [ 'core/text-columns' ],
-				transform: ( { className, columns, content, width } ) => (
-					createBlock(
-						'core/columns',
-						{
-							align: supports.align.includes( width ) ? width : undefined,
-							className,
-							columns,
-						},
-						content.map( ( { children } ) =>
-							createBlock(
-								'core/column',
-								{},
-								[ createBlock( 'core/paragraph', { content: children } ) ]
-							)
-						)
-					)
-				),
-			},
-		],
+	supports: {
+		align: [ 'wide', 'full' ],
 	},
 
 	deprecated: [

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -6,6 +6,7 @@ import { get, times } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
@@ -52,6 +53,32 @@ export const settings = {
 		width: {
 			type: 'string',
 		},
+	},
+
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/columns' ],
+				transform: ( { className, columns, content, width } ) => (
+					createBlock(
+						'core/columns',
+						{
+							align: ( 'wide' === width || 'full' === width ) ? width : undefined,
+							className,
+							columns,
+						},
+						content.map( ( { children } ) =>
+							createBlock(
+								'core/column',
+								{},
+								[ createBlock( 'core/paragraph', { content: children } ) ]
+							)
+						)
+					)
+				),
+			},
+		],
 	},
 
 	getEditWrapperProps( attributes ) {


### PR DESCRIPTION
## Description
This PR adds a one-way Text Columns → Columns transform to make it easier to migrate from the deprecated block. The alignment, custom CSS classes, and content are all preserved.

## How has this been tested?
You can test this branch by copy-pasting this markup into a post and trying out the transforms on the Text Columns blocks:
```html
<!-- wp:text-columns {"className":"yoyo"} -->
<div class="wp-block-text-columns alignundefined columns-2 yoyo"><div class="wp-block-column"><p>Content<br/>2nd line in same paragraph<br/><br/>4th line<br/></p></div><div class="wp-block-column"><p>More content</p></div></div>
<!-- /wp:text-columns -->

<!-- wp:text-columns {"width":"center","className":"donut"} -->
<div class="wp-block-text-columns aligncenter columns-2 donut"><div class="wp-block-column"><p>Content<br/>2nd line in same paragraph<br/><br/>4th line<br/></p></div><div class="wp-block-column"><p>More content</p></div></div>
<!-- /wp:text-columns -->

<!-- wp:text-columns {"width":"wide","className":"neato"} -->
<div class="wp-block-text-columns alignwide columns-2 neato"><div class="wp-block-column"><p>Content<br/>2nd line in same paragraph<br/><br/>4th line<br/></p></div><div class="wp-block-column"><p>More content</p></div></div>
<!-- /wp:text-columns -->
```

## Additional notes
Ideally, you would want to automatically transform deprecated blocks into the recommended replacements, but the deprecated blocks API does not currently support migrating from/to a completely different block, so using the transforms API to allow for easy user-initiated transforms is currently the best option.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

## Related issues and PRs
- #9355
- #9358