### PR TITLE
Components: Improve empty elements filters in Slot implementation

### DIFF
--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -1,12 +1,23 @@
 /**
  * External dependencies
  */
-import { noop, map, isString, isFunction } from 'lodash';
+import {
+	isFunction,
+	isString,
+	map,
+	negate,
+	noop,
+} from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { Component, Children, cloneElement, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { isEmptyElement } from './utils';
 
 class Slot extends Component {
 	constructor() {
@@ -64,11 +75,16 @@ class Slot extends Component {
 				const childKey = `${ fillKey }---${ child.key || childIndex }`;
 				return cloneElement( child, { key: childKey } );
 			} );
-		} );
+		} ).filter(
+			// In some cases fills are rendered only when some conditions apply.
+			// This ensures that we only use non-empty fills when rendering, i.e.,
+			// it allows us to render wrappers only when the fills are actually present.
+			negate( isEmptyElement )
+		);
 
 		return (
 			<Fragment>
-				{ isFunction( children ) ? children( fills.filter( Boolean ) ) : fills }
+				{ isFunction( children ) ? children( fills ) : fills }
 			</Fragment>
 		);
 	}

--- a/packages/components/src/slot-fill/test/utils.js
+++ b/packages/components/src/slot-fill/test/utils.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { isEmptyElement } from '../utils';
+
+describe( 'isEmptyElement', () => {
+	test( 'should be empty', () => {
+		expect( isEmptyElement( undefined ) ).toBe( true );
+		expect( isEmptyElement( false ) ).toBe( true );
+		expect( isEmptyElement( '' ) ).toBe( true );
+		expect( isEmptyElement( [] ) ).toBe( true );
+	} );
+
+	test( 'should not be empty', () => {
+		expect( isEmptyElement( 0 ) ).toBe( false );
+		expect( isEmptyElement( 100 ) ).toBe( false );
+		expect( isEmptyElement( 'test' ) ).toBe( false );
+		expect( isEmptyElement( createElement( 'div' ) ) ).toBe( false );
+		expect( isEmptyElement( [ 'x' ] ) ).toBe( false );
+	} );
+} );

--- a/packages/components/src/slot-fill/test/utils.js
+++ b/packages/components/src/slot-fill/test/utils.js
@@ -13,6 +13,7 @@ describe( 'isEmptyElement', () => {
 		expect( isEmptyElement( undefined ) ).toBe( true );
 		expect( isEmptyElement( false ) ).toBe( true );
 		expect( isEmptyElement( '' ) ).toBe( true );
+		expect( isEmptyElement( new String( '' ) ) ).toBe( true );
 		expect( isEmptyElement( [] ) ).toBe( true );
 	} );
 

--- a/packages/components/src/slot-fill/utils.js
+++ b/packages/components/src/slot-fill/utils.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import {
+	isArray,
+	isNumber,
+	isString,
+} from 'lodash';
+
+/**
+ * Checks if the provided WP element is empty.
+ *
+ * @param {*} element WP element to check.
+ * @return {boolean} True when an element is considered empty.
+ */
+export const isEmptyElement = ( element ) => {
+	if ( isNumber( element ) ) {
+		return false;
+	}
+
+	if ( isString( element ) || isArray( element ) ) {
+		return ! element.length;
+	}
+
+	return ! element;
+};


### PR DESCRIPTION
## Description
Raised by @aduth in https://github.com/WordPress/gutenberg/pull/5952#discussion_r212715645:

> Why do we filter here?

> To get rid of empty elements. Some fills render nothing based on Redux state. If you want to prevent rendering a slot wrapper it it has no fill which render something this is the way to go. In retrospective, I think this could be also done outside. Should we move it out or improve here and add some comments?

> Comments would be good.
> It was also strange to me that we filter only if the children is passed as a function, but not otherwise.
> Also, `filter( Boolean )` doesn't sound like a sufficient way to imitate React's treatment of "empty". For example, a child of 0 would be omitted here, but is a valid / non-empty child to render.

This PR adds `isEmptyElement` helper method and adds proper inline documentation explaining why it is used with `fills`.

## How has this been tested?
`npm test`

## Types of changes
Refactoring.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
