### PR TITLE
TinyMCE: Fix script registration

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -67,6 +67,27 @@ function gutenberg_get_script_polyfill( $tests ) {
 }
 
 /**
+ * Registers the main TinyMCE scripts.
+ */
+function register_tinymce_scripts() {
+	global $concatenate_scripts, $compress_scripts;
+	if ( ! isset( $concatenate_scripts ) ) {
+		script_concat_settings();
+	}
+	$suffix     = SCRIPT_DEBUG ? '' : '.min';
+	$compressed = $compress_scripts && $concatenate_scripts && isset( $_SERVER['HTTP_ACCEPT_ENCODING'] )
+		&& false !== stripos( $_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip' );
+	// Load tinymce.js when running from /src, else load wp-tinymce.js.gz (production) or tinymce.min.js (SCRIPT_DEBUG).
+	$mce_suffix = false !== strpos( get_bloginfo( 'version' ), '-src' ) ? '' : '.min';
+	if ( $compressed ) {
+		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array() );
+	} else {
+		wp_register_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array() );
+		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ) );
+	}
+}
+
+/**
  * Registers common scripts and styles to be used as dependencies of the editor
  * and plugins.
  *
@@ -75,8 +96,7 @@ function gutenberg_get_script_polyfill( $tests ) {
 function gutenberg_register_scripts_and_styles() {
 	gutenberg_register_vendor_scripts();
 
-	// WordPress packages.
-	wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array() );
+	register_tinymce_scripts();
 
 	wp_register_script(
 		'wp-url',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -77,7 +77,8 @@ function register_tinymce_scripts() {
 	$suffix     = SCRIPT_DEBUG ? '' : '.min';
 	$compressed = $compress_scripts && $concatenate_scripts && isset( $_SERVER['HTTP_ACCEPT_ENCODING'] )
 		&& false !== stripos( $_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip' );
-	// Load tinymce.js when running from /src, else load wp-tinymce.js.gz (production) or tinymce.min.js (SCRIPT_DEBUG).
+	// Load tinymce.js when running from /src, otherwise load wp-tinymce.js.gz (in production) or
+	// tinymce.min.js (when SCRIPT_DEBUG is true).
 	$mce_suffix = false !== strpos( get_bloginfo( 'version' ), '-src' ) ? '' : '.min';
 	if ( $compressed ) {
 		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array() );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -70,7 +70,7 @@ function gutenberg_get_script_polyfill( $tests ) {
  * Registers the main TinyMCE scripts.
  */
 function register_tinymce_scripts() {
-	global $concatenate_scripts, $compress_scripts;
+	global $tinymce_version, $concatenate_scripts, $compress_scripts;
 	if ( ! isset( $concatenate_scripts ) ) {
 		script_concat_settings();
 	}
@@ -81,10 +81,10 @@ function register_tinymce_scripts() {
 	// tinymce.min.js (when SCRIPT_DEBUG is true).
 	$mce_suffix = false !== strpos( get_bloginfo( 'version' ), '-src' ) ? '' : '.min';
 	if ( $compressed ) {
-		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array() );
+		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array(), $tinymce_version );
 	} else {
-		wp_register_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array() );
-		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ) );
+		wp_register_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array(), $tinymce_version );
+		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ), $tinymce_version );
 	}
 }
 


### PR DESCRIPTION
closes #7133

In WordPress core, TinyMCE is loaded as "compressed" via `wp-tinymce.php` or uncompressed (?) via `tinymce.min.js` depending on a [handful of conditions](https://github.com/WordPress/wordpress-develop/blob/29a63fe774c4db4bbc253bbbb723eab9d1b65761/src/wp-includes/class-wp-editor.php#L1422-L1433). (Whether the browser supports gzip or not etc...)

This PR mimics the way Core loads TinyMCE in Gutenberg. I expect this PR might fix the issues where people are having "The block has encountered an error" message in all RichText blocks #8936 #8690