### PR TITLE
Add end 2 end test to font size to font choosing mechanism.

### DIFF
--- a/test/e2e/specs/__snapshots__/font-size-picker.test.js.snap
+++ b/test/e2e/specs/__snapshots__/font-size-picker.test.js.snap
@@ -1,36 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Font Size Picker Should apply a custom font size using the font size input 1`] = `
+exports[`Font Size Picker should apply a custom font size using the font size input 1`] = `
 "<!-- wp:paragraph {\\"customFontSize\\":23} -->
 <p style=\\"font-size:23px\\">Paragraph to be made \\"small\\"</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Font Size Picker Should apply a named font size using the font size buttons 1`] = `
+exports[`Font Size Picker should apply a named font size using the font size buttons 1`] = `
 "<!-- wp:paragraph {\\"fontSize\\":\\"large\\"} -->
 <p class=\\"has-large-font-size\\">Paragraph to be made \\"large\\"</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Font Size Picker Should apply a named font size using the font size input 1`] = `
+exports[`Font Size Picker should apply a named font size using the font size input 1`] = `
 "<!-- wp:paragraph {\\"fontSize\\":\\"small\\"} -->
 <p class=\\"has-small-font-size\\">Paragraph to be made \\"small\\"</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Font Size Picker Should reset a custom font size using input field 1`] = `
+exports[`Font Size Picker should reset a custom font size using input field 1`] = `
 "<!-- wp:paragraph -->
 <p>Paragraph to be made \\"small\\"</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Font Size Picker Should reset a named font size using input field 1`] = `
+exports[`Font Size Picker should reset a named font size using input field 1`] = `
 "<!-- wp:paragraph -->
 <p>Paragraph with font size reset using input field</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Font Size Picker Should reset a named font size using the reset button 1`] = `
+exports[`Font Size Picker should reset a named font size using the reset button 1`] = `
 "<!-- wp:paragraph -->
 <p>Paragraph with font size reset using button</p>
 <!-- /wp:paragraph -->"

--- a/test/e2e/specs/__snapshots__/font-size-picker.test.js.snap
+++ b/test/e2e/specs/__snapshots__/font-size-picker.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Font Size Picker Should apply a custom font size using the font size input 1`] = `
+"<!-- wp:paragraph {\\"customFontSize\\":23} -->
+<p style=\\"font-size:23px\\">Paragraph to be made \\"small\\"</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Font Size Picker Should apply a named font size using the font size buttons 1`] = `
+"<!-- wp:paragraph {\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-large-font-size\\">Paragraph to be made \\"large\\"</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Font Size Picker Should apply a named font size using the font size input 1`] = `
+"<!-- wp:paragraph {\\"fontSize\\":\\"small\\"} -->
+<p class=\\"has-small-font-size\\">Paragraph to be made \\"small\\"</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Font Size Picker Should reset a custom font size using input field 1`] = `
+"<!-- wp:paragraph -->
+<p>Paragraph to be made \\"small\\"</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Font Size Picker Should reset a named font size using input field 1`] = `
+"<!-- wp:paragraph -->
+<p>Paragraph with font size reset using input field</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Font Size Picker Should reset a named font size using the reset button 1`] = `
+"<!-- wp:paragraph -->
+<p>Paragraph with font size reset using button</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/font-size-picker.test.js
+++ b/test/e2e/specs/font-size-picker.test.js
@@ -1,0 +1,101 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	newPost,
+} from '../support/utils';
+
+describe( 'Font Size Picker', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'Should apply a named font size using the font size buttons', async () => {
+		// Creating a paragraph block with some content
+		await clickBlockAppender();
+		await page.keyboard.type( 'Paragraph to be made "large"' );
+
+		const largeButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'L\']' ) )[ 0 ];
+		await largeButton.click();
+		// Check content
+		const content = await getEditedPostContent();
+		expect( content ).toMatchSnapshot();
+	} );
+
+	it( 'Should apply a named font size using the font size input', async () => {
+		// Creating a paragraph block with some content
+		await clickBlockAppender();
+		await page.keyboard.type( 'Paragraph to be made "small"' );
+
+		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.keyboard.type( '14' );
+		// Check content
+		const content = await getEditedPostContent();
+		expect( content ).toMatchSnapshot();
+	} );
+
+	it( 'Should apply a custom font size using the font size input', async () => {
+		// Creating a paragraph block with some content
+		await clickBlockAppender();
+		await page.keyboard.type( 'Paragraph to be made "small"' );
+
+		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.keyboard.type( '23' );
+		// Check content
+		const content = await getEditedPostContent();
+		expect( content ).toMatchSnapshot();
+	} );
+
+	it( 'Should reset a named font size using the reset button', async () => {
+		// Creating a paragraph block with some content
+		await clickBlockAppender();
+		await page.keyboard.type( 'Paragraph with font size reset using button' );
+
+		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.keyboard.type( '14' );
+
+		const resetButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'Reset\']' ) )[ 0 ];
+		await resetButton.click();
+
+		// Check content
+		const content = await getEditedPostContent();
+		expect( content ).toMatchSnapshot();
+	} );
+
+	it( 'Should reset a named font size using input field', async () => {
+		// Creating a paragraph block with some content
+		await clickBlockAppender();
+		await page.keyboard.type( 'Paragraph with font size reset using input field' );
+
+		const largeButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'L\']' ) )[ 0 ];
+		await largeButton.click();
+
+		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
+
+		// Check content
+		const content = await getEditedPostContent();
+		expect( content ).toMatchSnapshot();
+	} );
+
+	it( 'Should reset a custom font size using input field', async () => {
+		// Creating a paragraph block with some content
+		await clickBlockAppender();
+		await page.keyboard.type( 'Paragraph to be made "small"' );
+
+		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.keyboard.type( '23' );
+
+		await page.keyboard.press( 'Backspace' );
+
+		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
+		// Check content
+		const content = await getEditedPostContent();
+		expect( content ).toMatchSnapshot();
+	} );
+} );

--- a/test/e2e/specs/font-size-picker.test.js
+++ b/test/e2e/specs/font-size-picker.test.js
@@ -12,44 +12,47 @@ describe( 'Font Size Picker', () => {
 		await newPost();
 	} );
 
-	it( 'Should apply a named font size using the font size buttons', async () => {
-		// Creating a paragraph block with some content
+	it( 'should apply a named font size using the font size buttons', async () => {
+		// Create a paragraph block with some content.
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "large"' );
 
 		const largeButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'L\']' ) )[ 0 ];
 		await largeButton.click();
-		// Check content
+
+		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
 		expect( content ).toMatchSnapshot();
 	} );
 
-	it( 'Should apply a named font size using the font size input', async () => {
-		// Creating a paragraph block with some content
+	it( 'should apply a named font size using the font size input', async () => {
+		// Create a paragraph block with some content.
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "small"' );
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
 		await page.keyboard.type( '14' );
-		// Check content
+
+		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
 		expect( content ).toMatchSnapshot();
 	} );
 
-	it( 'Should apply a custom font size using the font size input', async () => {
-		// Creating a paragraph block with some content
+	it( 'should apply a custom font size using the font size input', async () => {
+		// Create a paragraph block with some content.
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "small"' );
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
 		await page.keyboard.type( '23' );
-		// Check content
+
+		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
 		expect( content ).toMatchSnapshot();
 	} );
 
-	it( 'Should reset a named font size using the reset button', async () => {
-		// Creating a paragraph block with some content
+	it( 'should reset a named font size using the reset button', async () => {
+		// Create a paragraph block with some content.
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph with font size reset using button' );
 
@@ -59,13 +62,13 @@ describe( 'Font Size Picker', () => {
 		const resetButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'Reset\']' ) )[ 0 ];
 		await resetButton.click();
 
-		// Check content
+		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
 		expect( content ).toMatchSnapshot();
 	} );
 
-	it( 'Should reset a named font size using input field', async () => {
-		// Creating a paragraph block with some content
+	it( 'should reset a named font size using input field', async () => {
+		// Create a paragraph block with some content.
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph with font size reset using input field' );
 
@@ -76,13 +79,13 @@ describe( 'Font Size Picker', () => {
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.press( 'Backspace' );
 
-		// Check content
+		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
 		expect( content ).toMatchSnapshot();
 	} );
 
-	it( 'Should reset a custom font size using input field', async () => {
-		// Creating a paragraph block with some content
+	it( 'should reset a custom font size using input field', async () => {
+		// Create a paragraph block with some content.
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "small"' );
 
@@ -94,7 +97,8 @@ describe( 'Font Size Picker', () => {
 		await page.click( '.blocks-font-size .components-range-control__number' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.press( 'Backspace' );
-		// Check content
+
+		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
 		expect( content ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
## Description
Until now, we had no end 2 end test testing the font size choosing logic and we were unable to catch some problems as https://github.com/WordPress/gutenberg/issues/9191.

This PR adds a set of the end 2 end tests that test if the font size choosing mechanism is working correctly.

## How has this been tested?
I checked that the new end 2 end tests pass and I introduced some bugs on purpose ( eg.: the revert of https://github.com/WordPress/gutenberg/pull/9253/files) and verified they fail.
