### PR TITLE
Bug: Embed Block Pattern Mismatch (Mixcloud/Polldaddy)

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -557,7 +557,7 @@ export const others = [
 			title: 'Polldaddy',
 			icon: embedContentIcon,
 		} ),
-		patterns: [ /^https?:\/\/(www\.)?mixcloud\.com\/.+/i ],
+		patterns: [ /^https?:\/\/(www\.)?polldaddy\.com\/.+/i ],
 	},
 	{
 		name: 'core-embed/reddit',


### PR DESCRIPTION
## Description
Appears in copy-paste the pattern used to match Polldaddy embeds was left as mixcloud URL pattern.
