### PR TITLE
feat: Save data offline (close #7367)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"@wordpress/redux-routine": "file:packages/redux-routine",
 		"@wordpress/rich-text": "file:packages/rich-text",
 		"@wordpress/shortcode": "file:packages/shortcode",
+		"@wordpress/storage": "file:packages/storage",
 		"@wordpress/token-list": "file:packages/token-list",
 		"@wordpress/url": "file:packages/url",
 		"@wordpress/viewport": "file:packages/viewport",

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -51,6 +51,7 @@ import {
 	requestPostUpdate,
 	requestPostUpdateSuccess,
 	requestPostUpdateFailure,
+	requestPostUpdatePending,
 	trashPost,
 	trashPostFailure,
 	refreshPost,
@@ -146,6 +147,7 @@ export default {
 	},
 	REQUEST_POST_UPDATE_SUCCESS: requestPostUpdateSuccess,
 	REQUEST_POST_UPDATE_FAILURE: requestPostUpdateFailure,
+	REQUEST_POST_UPDATE_PENDING: requestPostUpdatePending,
 	TRASH_POST: ( action, store ) => {
 		trashPost( action, store );
 	},

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -979,6 +979,13 @@ export function saving( state = {}, action ) {
 				options: action.options || {},
 			};
 
+		case 'REQUEST_POST_UPDATE_PENDING':
+			return {
+				requesting: false,
+				successful: false,
+				error: null,
+			};
+
 		case 'REQUEST_POST_UPDATE_FAILURE':
 			return {
 				requesting: false,

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,0 +1,13 @@
+# Storage
+
+Storage module for WordPress; built using localForage.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/storage --save
+```
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@wordpress/storage",
+	"version": "0.0.1",
+	"description": "Offline storage module for WordPress.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"shortcode"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/storage/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"dependencies": {
+		"@babel/runtime-corejs2": "7.0.0-beta.56",
+		"localforage": "^1.6.2"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/storage/src/index.js
+++ b/packages/storage/src/index.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import localforage from 'localforage';
+
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Returns a localForage instance given a storeName.
+ *
+ * @param {string}   storeName   alphanumeric+underscore identifier for
+ *                               a store. Passed to localForage's `config()`
+ *                               method as the `storeName` prop.
+ *
+ * @return {localforage} localForage instance
+ */
+export default function createStorage( storeName ) {
+	if ( ! storeName || ! storeName.length ) {
+		throw new Error( 'storeName is required for editor/utils/storage' );
+	}
+
+	return localforage.createInstance( {
+		name: 'WordPress Editor',
+		storeName,
+	} );
+}
+
+const DEFAULT_STATE = {};
+
+const actions = {
+	getItem( storeName, key ) {
+		return {
+			type: 'GET_STORAGE_ITEM',
+			key,
+			storeName,
+		};
+	},
+
+	getItemFromStorageBackend( storeName, key ) {
+		return {
+			type: 'GET_STORAGE_ITEM_FROM_STORAGE_BACKEND',
+			key,
+			storeName,
+		};
+	},
+
+	setItem( storeName, key, value ) {
+		return {
+			type: 'SET_STORAGE_ITEM',
+			key,
+			storeName,
+			value,
+		};
+	},
+};
+
+registerStore( 'storage', {
+	reducer( state = DEFAULT_STATE, action ) {
+		switch ( action.type ) {
+			case 'RETRIEVE_STORAGE_ITEM':
+				return {
+					...state,
+					[ action.storageName ]: {
+						[ action.key ]: action.value,
+					},
+				};
+		}
+
+		return state;
+	},
+
+	actions,
+
+	selectors: {},
+
+	controls: {
+		GET_STORAGE_ITEM_FROM_STORAGE_BACKEND( action ) {
+			return createStorage( action.storeName ).getItem( action.key );
+		},
+		SET_ITEM( action ) {
+			return createStorage( action.storeName ).setItem( action.key, action.value );
+		},
+	},
+
+	resolvers: {
+		* getItem( state, storeName, key ) {
+			const value = yield actions.getItemFromStorageBackend( storeName, key );
+
+			return actions.retrieveStorageItem( storeName, key, value );
+		},
+		* setItem( state, storeName, key, value ) {
+			yield actions.setItemInStorageBackend( storeName, key, value );
+
+			return actions.retrieveStorageItem( storeName, key, value );
+		},
+	},
+} );

--- a/packages/storage/src/test/index.js
+++ b/packages/storage/src/test/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+// import { next, replace, attrs } from '../';
+
+describe( 'storage', () => {
+	it( 'should work', () => {
+		expect( true ).toEqual( true );
+	} );
+} );


### PR DESCRIPTION
**Experimental and still a work-in-progress.**

## Description
Experiment to save data offline for autosaves and saves when there is no network connection.

That part works and the UI doesn't complain about failures, but we'll likely want to:

* [ ] Allow a restore from local content
* [ ] Hook the data storage into WP Data instead of just accessing localForage directly

## How has this been tested?
Locally in Firefox only so far; it may not work in other browsers as the off-line check relies on the error message in the Fetch API… and I'm not sure they're consistent across browsers.

## Screenshots <!-- if applicable -->
Coming later...

## Types of changes
This is a new feature and part of #6322.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->