### PR TITLE
Improve consistency of widget block settings

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -27,14 +27,14 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Archives Settings' ) }>
 					<ToggleControl
-						label={ __( 'Show Post Counts' ) }
-						checked={ showPostCounts }
-						onChange={ () => setAttributes( { showPostCounts: ! showPostCounts } ) }
-					/>
-					<ToggleControl
 						label={ __( 'Display as Dropdown' ) }
 						checked={ displayAsDropdown }
 						onChange={ () => setAttributes( { displayAsDropdown: ! displayAsDropdown } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Show Post Counts' ) }
+						checked={ showPostCounts }
+						onChange={ () => setAttributes( { showPostCounts: ! showPostCounts } ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -151,14 +151,14 @@ class CategoriesEdit extends Component {
 						onChange={ this.toggleDisplayAsDropdown }
 					/>
 					<ToggleControl
-						label={ __( 'Show Post Counts' ) }
-						checked={ showPostCounts }
-						onChange={ this.toggleShowPostCounts }
-					/>
-					<ToggleControl
 						label={ __( 'Show Hierarchy' ) }
 						checked={ showHierarchy }
 						onChange={ this.toggleShowHierarchy }
+					/>
+					<ToggleControl
+						label={ __( 'Show Post Counts' ) }
+						checked={ showPostCounts }
+						onChange={ this.toggleShowPostCounts }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -146,17 +146,17 @@ class CategoriesEdit extends Component {
 			<InspectorControls>
 				<PanelBody title={ __( 'Categories Settings' ) }>
 					<ToggleControl
-						label={ __( 'Display as dropdown' ) }
+						label={ __( 'Display as Dropdown' ) }
 						checked={ displayAsDropdown }
 						onChange={ this.toggleDisplayAsDropdown }
 					/>
 					<ToggleControl
-						label={ __( 'Show post counts' ) }
+						label={ __( 'Show Post Counts' ) }
 						checked={ showPostCounts }
 						onChange={ this.toggleShowPostCounts }
 					/>
 					<ToggleControl
-						label={ __( 'Show hierarchy' ) }
+						label={ __( 'Show Hierarchy' ) }
 						checked={ showHierarchy }
 						onChange={ this.toggleShowHierarchy }
 					/>

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -81,22 +81,22 @@ class LatestComments extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Latest Comments Settings' ) }>
 						<ToggleControl
-							label={ __( 'Display avatar' ) }
+							label={ __( 'Display Avatar' ) }
 							checked={ displayAvatar }
 							onChange={ this.toggleDisplayAvatar }
 						/>
 						<ToggleControl
-							label={ __( 'Display date' ) }
+							label={ __( 'Display Date' ) }
 							checked={ displayDate }
 							onChange={ this.toggleDisplayDate }
 						/>
 						<ToggleControl
-							label={ __( 'Display excerpt' ) }
+							label={ __( 'Display Excerpt' ) }
 							checked={ displayExcerpt }
 							onChange={ this.toggleDisplayExcerpt }
 						/>
 						<RangeControl
-							label={ __( 'Number of comments' ) }
+							label={ __( 'Number of Comments' ) }
 							value={ commentsToShow }
 							onChange={ this.setCommentsToShow }
 							min={ MIN_COMMENTS }


### PR DESCRIPTION
## Description
This PR changes the appearance of the inspector settings of the widget blocks to be more consistent. They all use Title Case now like other core blocks, and options that are in more than one widget block appear in the same order for all of them.

Fixes #9370.