### PR TITLE
Revert "Change keyboard shortcut for remove block to Cmd+Shift+X / Ct…

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -70,7 +70,7 @@ This is the canonical list of keyboard shortcuts:
 ### Block shortcuts
 
 * <kbd>Shift</kbd>+<kbd>⌘D</kbd> Duplicate the selected block(s).
-* <kbd>Shift</kbd>+<kbd>⌘X</kbd> Remove the selected block(s).
+* <kbd>Option</kbd>+<kbd>⌘Backspace</kbd> Remove the selected block(s).
 * <kbd>Option</kbd>+<kbd>⌘T</kbd> Insert a new block before the selected block(s).
 * <kbd>Option</kbd>+<kbd>⌘Y</kbd> Insert a new block after the selected block(s).
 * <kbd>/</kbd> Change the block type after adding a new paragraph.

--- a/edit-post/components/keyboard-shortcut-help-modal/config.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/config.js
@@ -88,7 +88,7 @@ const blockShortcuts = {
 			description: __( 'Duplicate the selected block(s).' ),
 		},
 		{
-			keyCombination: primaryShift( 'x' ),
+			keyCombination: primaryAlt( 'backspace' ),
 			description: __( 'Remove the selected block(s).' ),
 		},
 		{

--- a/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -165,9 +165,9 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
             "keyCombination": Array [
               "Ctrl",
               "+",
-              "Shift",
+              "Alt",
               "+",
-              "X",
+              "Backspace",
             ],
           },
           Object {

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -37,8 +37,8 @@ const shortcuts = {
 		display: displayShortcut.primaryShift( 'd' ),
 	},
 	removeBlock: {
-		raw: rawShortcut.primaryShift( 'x' ),
-		display: displayShortcut.primaryShift( 'x' ),
+		raw: rawShortcut.primaryAlt( 'backspace' ),
+		display: displayShortcut.primaryAlt( 'bksp' ),
 	},
 	insertBefore: {
 		raw: rawShortcut.primaryAlt( 't' ),


### PR DESCRIPTION
…rl+Shift+X (#9190)"

This reverts commit 32b1f9273995063c10a9737259fa36794eaee8d2.

Reverted since we discovered the updated keyboard shortcut clashes with a firefox shortcut to toggle RTL text direction.
