### PR TITLE
Focus Mode: Hide Block Outlines

### DIFF
--- a/edit-post/components/header/feature-toggle/index.js
+++ b/edit-post/components/header/feature-toggle/index.js
@@ -6,7 +6,6 @@ import { withSelect, withDispatch } from '@wordpress/data';
 /**
  * WordPress Dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { MenuItem } from '@wordpress/components';
 
@@ -18,7 +17,7 @@ function FeatureToggle( { onToggle, isActive, label } ) {
 			onClick={ onToggle }
 			role="menuitemcheckbox"
 		>
-			{ __( label ) }
+			{ label }
 		</MenuItem>
 	);
 }

--- a/edit-post/components/header/feature-toggle/index.js
+++ b/edit-post/components/header/feature-toggle/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { MenuItem } from '@wordpress/components';
 
-function FixedToolbarToggle( { onToggle, isActive } ) {
+function FeatureToggle( { onToggle, isActive, label } ) {
 	return (
 		<MenuItem
 			icon={ isActive && 'yes' }
@@ -18,19 +18,19 @@ function FixedToolbarToggle( { onToggle, isActive } ) {
 			onClick={ onToggle }
 			role="menuitemcheckbox"
 		>
-			{ __( 'Focus Mode' ) }
+			{ __( label ) }
 		</MenuItem>
 	);
 }
 
 export default compose( [
-	withSelect( ( select ) => ( {
-		isActive: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+	withSelect( ( select, { feature } ) => ( {
+		isActive: select( 'core/edit-post' ).isFeatureActive( feature ),
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		onToggle() {
-			dispatch( 'core/edit-post' ).toggleFeature( 'fixedToolbar' );
+			dispatch( 'core/edit-post' ).toggleFeature( ownProps.feature );
 			ownProps.onToggle();
 		},
 	} ) ),
-] )( FixedToolbarToggle );
+] )( FeatureToggle );

--- a/edit-post/components/header/fixed-toolbar-toggle/index.js
+++ b/edit-post/components/header/fixed-toolbar-toggle/index.js
@@ -9,7 +9,6 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { MenuItem } from '@wordpress/components';
-import { ifViewportMatches } from '@wordpress/viewport';
 
 function FixedToolbarToggle( { onToggle, isActive } ) {
 	return (
@@ -34,5 +33,4 @@ export default compose( [
 			ownProps.onToggle();
 		},
 	} ) ),
-	ifViewportMatches( 'medium' ),
 ] )( FixedToolbarToggle );

--- a/edit-post/components/header/fixed-toolbar-toggle/index.js
+++ b/edit-post/components/header/fixed-toolbar-toggle/index.js
@@ -19,7 +19,7 @@ function FixedToolbarToggle( { onToggle, isActive } ) {
 			onClick={ onToggle }
 			role="menuitemcheckbox"
 		>
-			{ __( 'Fix Toolbar to Top' ) }
+			{ __( 'Focus Mode' ) }
 		</MenuItem>
 	);
 }

--- a/edit-post/components/header/more-menu/index.js
+++ b/edit-post/components/header/more-menu/index.js
@@ -30,19 +30,19 @@ const MoreMenu = () => (
 		) }
 		renderContent={ ( { onClose } ) => (
 			<Fragment>
-				<ModeSwitcher onSelect={ onClose } />
 				<MenuGroup
-					label={ __( 'Settings' ) }
-					filterName="editPost.MoreMenu.settings"
+					label={ __( 'Writing' ) }
+					filterName="editPost.MoreMenu.writing"
 				>
 					<FixedToolbarToggle onToggle={ onClose } />
-					<TipsToggle onToggle={ onClose } />
 				</MenuGroup>
+				<ModeSwitcher onSelect={ onClose } />
 				<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />
 				<MenuGroup
 					label={ __( 'Tools' ) }
 					filterName="editPost.MoreMenu.tools"
 				>
+					<TipsToggle onToggle={ onClose } />
 					<KeyboardShortcutsHelpMenuItem onSelect={ onClose } />
 				</MenuGroup>
 			</Fragment>

--- a/edit-post/components/header/more-menu/index.js
+++ b/edit-post/components/header/more-menu/index.js
@@ -10,10 +10,10 @@ import { Fragment } from '@wordpress/element';
  */
 import './style.scss';
 import ModeSwitcher from '../mode-switcher';
-import FixedToolbarToggle from '../fixed-toolbar-toggle';
 import PluginMoreMenuGroup from '../plugins-more-menu-group';
 import TipsToggle from '../tips-toggle';
 import KeyboardShortcutsHelpMenuItem from '../keyboard-shortcuts-help-menu-item';
+import WritingMenu from '../writing-menu';
 
 const MoreMenu = () => (
 	<Dropdown
@@ -30,12 +30,7 @@ const MoreMenu = () => (
 		) }
 		renderContent={ ( { onClose } ) => (
 			<Fragment>
-				<MenuGroup
-					label={ __( 'Writing' ) }
-					filterName="editPost.MoreMenu.writing"
-				>
-					<FixedToolbarToggle onToggle={ onClose } />
-				</MenuGroup>
+				<WritingMenu onClose={ onClose } />
 				<ModeSwitcher onSelect={ onClose } />
 				<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />
 				<MenuGroup

--- a/edit-post/components/header/writing-menu/index.js
+++ b/edit-post/components/header/writing-menu/index.js
@@ -16,8 +16,8 @@ function WritingMenu( { onClose } ) {
 			label={ __( 'Writing' ) }
 			filterName="editPost.MoreMenu.writing"
 		>
-			<FeatureToggle feature="fixedToolbar" label={ __( 'Fix Toolbar To Top' ) } onToggle={ onClose } />
-			<FeatureToggle feature="focusMode" label={ __( 'Focus Mode' ) } onToggle={ onClose } />
+			<FeatureToggle feature="fixedToolbar" label={ __( 'Unified Toolbar' ) } onToggle={ onClose } />
+			<FeatureToggle feature="focusMode" label={ __( 'Spotlight Mode' ) } onToggle={ onClose } />
 		</MenuGroup>
 	);
 }

--- a/edit-post/components/header/writing-menu/index.js
+++ b/edit-post/components/header/writing-menu/index.js
@@ -8,7 +8,7 @@ import { ifViewportMatches } from '@wordpress/viewport';
 /**
  * Internal dependencies
  */
-import FixedToolbarToggle from '../fixed-toolbar-toggle';
+import FeatureToggle from '../feature-toggle';
 
 function WritingMenu( { onClose } ) {
 	return (
@@ -16,7 +16,8 @@ function WritingMenu( { onClose } ) {
 			label={ __( 'Writing' ) }
 			filterName="editPost.MoreMenu.writing"
 		>
-			<FixedToolbarToggle onToggle={ onClose } />
+			<FeatureToggle feature="fixedToolbar" label={ __( 'Fix Toolbar To Top' ) } onToggle={ onClose } />
+			<FeatureToggle feature="focusMode" label={ __( 'Focus Mode' ) } onToggle={ onClose } />
 		</MenuGroup>
 	);
 }

--- a/edit-post/components/header/writing-menu/index.js
+++ b/edit-post/components/header/writing-menu/index.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress Dependencies
+ */
+import { MenuGroup } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ifViewportMatches } from '@wordpress/viewport';
+
+/**
+ * Internal dependencies
+ */
+import FixedToolbarToggle from '../fixed-toolbar-toggle';
+
+function WritingMenu( { onClose } ) {
+	return (
+		<MenuGroup
+			label={ __( 'Writing' ) }
+			filterName="editPost.MoreMenu.writing"
+		>
+			<FixedToolbarToggle onToggle={ onClose } />
+		</MenuGroup>
+	);
+}
+
+export default ifViewportMatches( 'medium' )( WritingMenu );

--- a/edit-post/editor.js
+++ b/edit-post/editor.js
@@ -10,7 +10,15 @@ import { StrictMode } from '@wordpress/element';
  */
 import Layout from './components/layout';
 
-function Editor( { settings, hasFixedToolbar, post, overridePost, onError, ...props } ) {
+function Editor( {
+	settings,
+	hasFixedToolbar,
+	focusMode,
+	post,
+	overridePost,
+	onError,
+	...props
+} ) {
 	if ( ! post ) {
 		return null;
 	}
@@ -18,11 +26,16 @@ function Editor( { settings, hasFixedToolbar, post, overridePost, onError, ...pr
 	const editorSettings = {
 		...settings,
 		hasFixedToolbar,
+		focusMode,
 	};
 
 	return (
 		<StrictMode>
-			<EditorProvider settings={ editorSettings } post={ { ...post, ...overridePost } } { ...props }>
+			<EditorProvider
+				settings={ editorSettings }
+				post={ { ...post, ...overridePost } }
+				{ ...props }
+			>
 				<ErrorBoundary onError={ onError }>
 					<Layout />
 				</ErrorBoundary>
@@ -33,5 +46,6 @@ function Editor( { settings, hasFixedToolbar, post, overridePost, onError, ...pr
 
 export default withSelect( ( select, { postId, postType } ) => ( {
 	hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+	focusMode: select( 'core/edit-post' ).isFeatureActive( 'focusMode' ),
 	post: select( 'core' ).getEntityRecord( 'postType', postType, postId ),
 } ) )( Editor );

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -355,6 +355,7 @@ export class BlockListBlock extends Component {
 			order,
 			mode,
 			isFocusMode,
+			hasFixedToolbar,
 			isLocked,
 			isFirst,
 			isLast,
@@ -391,7 +392,7 @@ export class BlockListBlock extends Component {
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection;
 		const shouldShowBreadcrumb = isHovered && ! isEmptyDefaultBlock;
-		const shouldShowContextualToolbar = ! isFocusMode && ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected );
+		const shouldShowContextualToolbar = ! hasFixedToolbar && ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
 
@@ -606,7 +607,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( clientId );
 	const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId );
-	const { hasFixedToolbar } = getEditorSettings();
+	const { hasFixedToolbar, focusMode } = getEditorSettings();
 	const block = getBlock( clientId );
 	const previousBlockClientId = getPreviousBlockClientId( clientId );
 	const previousBlock = getBlock( previousBlockClientId );
@@ -630,7 +631,8 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		isPreviousBlockADefaultEmptyBlock: previousBlock && isUnmodifiedDefaultBlock( previousBlock ),
 		isMovable: 'all' !== templateLock,
 		isLocked: !! templateLock,
-		isFocusMode: hasFixedToolbar && isLargeViewport,
+		isFocusMode: focusMode && isLargeViewport,
+		hasFixedToolbar: hasFixedToolbar && isLargeViewport,
 		previousBlockClientId,
 		block,
 		isSelected,

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -372,6 +372,7 @@ export class BlockListBlock extends Component {
 			isMovable,
 			isPreviousBlockADefaultEmptyBlock,
 			hasSelectedInnerBlock,
+			isParentOfSelectedBlock,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -412,7 +413,8 @@ export class BlockListBlock extends Component {
 			'is-reusable': isReusableBlock( blockType ),
 			'is-hidden': dragging,
 			'is-typing': isTypingWithinBlock,
-			'is-not-focused': isFocusMode && ! isSelected,
+			'is-focused': isFocusMode && ( isSelected || isParentOfSelectedBlock ),
+			'is-focus-mode': isFocusMode,
 		} );
 
 		const { onReplace } = this.props;
@@ -607,19 +609,19 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		getTemplateLock,
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( clientId );
-	const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId );
 	const { hasFixedToolbar, focusMode } = getEditorSettings();
 	const block = getBlock( clientId );
 	const previousBlockClientId = getPreviousBlockClientId( clientId );
 	const previousBlock = getBlock( previousBlockClientId );
 	const templateLock = getTemplateLock( rootClientId );
+	const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 
 	return {
 		nextBlockClientId: getNextBlockClientId( clientId ),
 		isPartOfMultiSelection: isBlockMultiSelected( clientId ) || isAncestorMultiSelected( clientId ),
 		isFirstMultiSelected: isFirstMultiSelectedBlock( clientId ),
 		isMultiSelecting: isMultiSelecting(),
-		hasSelectedInnerBlock: isParentOfSelectedBlock,
+		hasSelectedInnerBlock: hasSelectedInnerBlock( clientId, false ),
 		// We only care about this prop when the block is selected
 		// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
 		isTypingWithinBlock: ( isSelected || isParentOfSelectedBlock ) && isTyping(),
@@ -637,6 +639,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		previousBlockClientId,
 		block,
 		isSelected,
+		isParentOfSelectedBlock,
 	};
 } );
 

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -354,7 +354,7 @@ export class BlockListBlock extends Component {
 			block,
 			order,
 			mode,
-			hasFixedToolbar,
+			isFocusMode,
 			isLocked,
 			isFirst,
 			isLast,
@@ -367,7 +367,6 @@ export class BlockListBlock extends Component {
 			isTypingWithinBlock,
 			isMultiSelecting,
 			hoverArea,
-			isLargeViewport,
 			isEmptyDefaultBlock,
 			isMovable,
 			isPreviousBlockADefaultEmptyBlock,
@@ -385,13 +384,14 @@ export class BlockListBlock extends Component {
 		// Empty paragraph blocks should always show up as unselected.
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
-		const shouldAppearSelected = ! showSideInserter && isSelected && ! isTypingWithinBlock;
-		const shouldAppearSelectedParent = ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
+		const shouldAppearSelected = ! isFocusMode && ! showSideInserter && isSelected && ! isTypingWithinBlock;
+		const shouldAppearSelectedParent = ! isFocusMode && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
+		const shouldAppearHovered = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection;
 		const shouldShowBreadcrumb = isHovered && ! isEmptyDefaultBlock;
-		const shouldShowContextualToolbar = ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected ) && ( ! hasFixedToolbar || ! isLargeViewport );
+		const shouldShowContextualToolbar = ! isFocusMode && ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
 
@@ -407,7 +407,7 @@ export class BlockListBlock extends Component {
 			'is-selected': shouldAppearSelected,
 			'is-multi-selected': isPartOfMultiSelection,
 			'is-selected-parent': shouldAppearSelectedParent,
-			'is-hovered': isHovered && ! isEmptyDefaultBlock,
+			'is-hovered': shouldAppearHovered,
 			'is-reusable': isReusableBlock( blockType ),
 			'is-hidden': dragging,
 			'is-typing': isTypingWithinBlock,
@@ -584,7 +584,7 @@ export class BlockListBlock extends Component {
 	}
 }
 
-const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
+const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeViewport } ) => {
 	const {
 		isBlockSelected,
 		getPreviousBlockClientId,
@@ -630,10 +630,10 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 		isPreviousBlockADefaultEmptyBlock: previousBlock && isUnmodifiedDefaultBlock( previousBlock ),
 		isMovable: 'all' !== templateLock,
 		isLocked: !! templateLock,
+		isFocusMode: hasFixedToolbar && isLargeViewport,
 		previousBlockClientId,
 		block,
 		isSelected,
-		hasFixedToolbar,
 	};
 } );
 
@@ -689,9 +689,9 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 } );
 
 export default compose(
+	withViewportMatch( { isLargeViewport: 'medium' } ),
 	applyWithSelect,
 	applyWithDispatch,
-	withViewportMatch( { isLargeViewport: 'medium' } ),
 	withFilters( 'editor.BlockListBlock' ),
 	withHoverAreas,
 )( BlockListBlock );

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -390,7 +390,7 @@ export class BlockListBlock extends Component {
 		const shouldAppearSelectedParent = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
 		const shouldAppearHovered = ! isFocusMode && ! hasFixedToolbar && isHovered && ! isEmptyDefaultBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
-		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
+		const shouldRenderMovers = ! isFocusMode && ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection;
 		const shouldShowBreadcrumb = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;
 		const shouldShowContextualToolbar = ! hasFixedToolbar && ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected );

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -391,7 +391,7 @@ export class BlockListBlock extends Component {
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection;
-		const shouldShowBreadcrumb = isHovered && ! isEmptyDefaultBlock;
+		const shouldShowBreadcrumb = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;
 		const shouldShowContextualToolbar = ! hasFixedToolbar && ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock && isValid ) || isFirstMultiSelected );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
@@ -412,6 +412,7 @@ export class BlockListBlock extends Component {
 			'is-reusable': isReusableBlock( blockType ),
 			'is-hidden': dragging,
 			'is-typing': isTypingWithinBlock,
+			'is-not-focused': isFocusMode && ! isSelected,
 		} );
 
 		const { onReplace } = this.props;

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -386,9 +386,9 @@ export class BlockListBlock extends Component {
 		// Empty paragraph blocks should always show up as unselected.
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
-		const shouldAppearSelected = ! isFocusMode && ! showSideInserter && isSelected && ! isTypingWithinBlock;
-		const shouldAppearSelectedParent = ! isFocusMode && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
-		const shouldAppearHovered = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;
+		const shouldAppearSelected = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && isSelected && ! isTypingWithinBlock;
+		const shouldAppearSelectedParent = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
+		const shouldAppearHovered = ! isFocusMode && ! hasFixedToolbar && isHovered && ! isEmptyDefaultBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isPartOfMultiSelection;

--- a/packages/editor/src/components/block-list/breadcrumb.js
+++ b/packages/editor/src/components/block-list/breadcrumb.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
@@ -48,10 +53,12 @@ export class BlockBreadcrumb extends Component {
 	}
 
 	render() {
-		const { clientId, rootClientId } = this.props;
+		const { clientId, rootClientId, isLight } = this.props;
 
 		return (
-			<div className={ 'editor-block-list__breadcrumb' }>
+			<div className={ classnames( 'editor-block-list__breadcrumb', {
+				'is-light': isLight,
+			} ) }>
 				<Toolbar>
 					{ rootClientId && (
 						<Fragment>
@@ -68,11 +75,12 @@ export class BlockBreadcrumb extends Component {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { getBlockRootClientId } = select( 'core/editor' );
+		const { getBlockRootClientId, getEditorSettings } = select( 'core/editor' );
 		const { clientId } = ownProps;
 
 		return {
 			rootClientId: getBlockRootClientId( clientId ),
+			isLight: getEditorSettings().hasFixedToolbar,
 		};
 	} ),
 ] )( BlockBreadcrumb );

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -1021,6 +1021,11 @@
 			@include fade_in(60ms, 0.5s);
 		}
 	}
+
+	&.is-light .components-toolbar {
+		background: rgba($white, 0.5);
+		color: $dark-gray-700;
+	}
 }
 
 .editor-block-list__descendant-arrow::before {

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -102,8 +102,13 @@
 		z-index: z-index(".editor-block-list__block-edit .reusable-block-edit-panel *");
 	}
 
-	&.is-not-focused {
+	&.is-focus-mode {
 		opacity: 0.6;
+
+		&:not(.is-focused) .editor-block-list__block,
+		&.is-focused {
+			opacity: 1;
+		}
 	}
 }
 
@@ -856,7 +861,6 @@
 	.components-toolbar {
 		border-top: none;
 		border-bottom: none;
-
 	}
 
 	@include break-small() {
@@ -899,6 +903,10 @@
 	& > * {
 		pointer-events: auto;
 	}
+}
+
+.editor-block-list__block.is-focus-mode > .editor-block-contextual-toolbar {
+	margin-left: -$block-side-ui-width;
 }
 
 // Enable toolbar footprint collapsing

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -103,7 +103,7 @@
 	}
 
 	&.is-focus-mode:not(.is-multi-selected) {
-		opacity: 0.6;
+		opacity: 0.5;
 		transition: opacity 0.1s linear;
 
 		&:not(.is-focused) .editor-block-list__block,

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -102,7 +102,7 @@
 		z-index: z-index(".editor-block-list__block-edit .reusable-block-edit-panel *");
 	}
 
-	&.is-focus-mode {
+	&.is-focus-mode:not(.is-multi-selected) {
 		opacity: 0.6;
 		transition: opacity 0.1s linear;
 

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -101,6 +101,10 @@
 	.editor-block-list__block-edit .reusable-block-edit-panel * {
 		z-index: z-index(".editor-block-list__block-edit .reusable-block-edit-panel *");
 	}
+
+	&.is-not-focused {
+		opacity: 0.6;
+	}
 }
 
 

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -104,6 +104,7 @@
 
 	&.is-focus-mode {
 		opacity: 0.6;
+		transition: opacity 0.1s linear;
 
 		&:not(.is-focused) .editor-block-list__block,
 		&.is-focused {

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -906,7 +906,7 @@
 	}
 }
 
-.editor-block-list__block.is-focus-mode > .editor-block-contextual-toolbar {
+.editor-block-list__block.is-focus-mode:not(.is-multi-selected) > .editor-block-contextual-toolbar {
 	margin-left: -$block-side-ui-width;
 }
 

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -10,7 +10,6 @@
 
 	// Use opacity to work in various editor styles.
 	border: $border-width solid $dark-opacity-light-500;
-	border-bottom: none;
 	background-clip: padding-box;
 
 	// Put toolbar snugly to edge on mobile.

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -94,7 +94,6 @@ class PostTitle extends Component {
 			'is-selected': isSelected,
 			'is-focus-mode': isFocusMode,
 			'has-fixed-toolbar': hasFixedToolbar,
-			'is-focused': isFocusMode && isSelected,
 		} );
 		const decodedPlaceholder = decodeEntities( placeholder );
 

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -88,11 +88,11 @@ class PostTitle extends Component {
 	}
 
 	render() {
-		const { title, placeholder, instanceId, isPostTypeViewable, hasFixedToolbar } = this.props;
+		const { title, placeholder, instanceId, isPostTypeViewable, isFocusMode } = this.props;
 		const { isSelected } = this.state;
 		const className = classnames( 'editor-post-title__block', {
 			'is-selected': isSelected,
-			'is-focus-mode': hasFixedToolbar,
+			'is-focus-mode': isFocusMode,
 		} );
 		const decodedPlaceholder = decodeEntities( placeholder );
 
@@ -132,13 +132,13 @@ const applyWithSelect = withSelect( ( select ) => {
 	const { getEditedPostAttribute, getEditorSettings } = select( 'core/editor' );
 	const { getPostType } = select( 'core' );
 	const postType = getPostType( getEditedPostAttribute( 'type' ) );
-	const { titlePlaceholder, hasFixedToolbar } = getEditorSettings();
+	const { titlePlaceholder, focusMode } = getEditorSettings();
 
 	return {
 		title: getEditedPostAttribute( 'title' ),
 		isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 		placeholder: titlePlaceholder,
-		hasFixedToolbar,
+		isFocusMode: focusMode,
 	};
 } );
 

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -88,11 +88,13 @@ class PostTitle extends Component {
 	}
 
 	render() {
-		const { title, placeholder, instanceId, isPostTypeViewable, isFocusMode } = this.props;
+		const { title, placeholder, instanceId, isPostTypeViewable, isFocusMode, hasFixedToolbar } = this.props;
 		const { isSelected } = this.state;
 		const className = classnames( 'editor-post-title__block', {
 			'is-selected': isSelected,
 			'is-focus-mode': isFocusMode,
+			'has-fixed-toolbar': hasFixedToolbar,
+			'is-focused': isFocusMode && isSelected,
 		} );
 		const decodedPlaceholder = decodeEntities( placeholder );
 
@@ -132,13 +134,14 @@ const applyWithSelect = withSelect( ( select ) => {
 	const { getEditedPostAttribute, getEditorSettings } = select( 'core/editor' );
 	const { getPostType } = select( 'core' );
 	const postType = getPostType( getEditedPostAttribute( 'type' ) );
-	const { titlePlaceholder, focusMode } = getEditorSettings();
+	const { titlePlaceholder, focusMode, hasFixedToolbar } = getEditorSettings();
 
 	return {
 		title: getEditedPostAttribute( 'title' ),
 		isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 		placeholder: titlePlaceholder,
 		isFocusMode: focusMode,
+		hasFixedToolbar,
 	};
 } );
 

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -88,9 +88,12 @@ class PostTitle extends Component {
 	}
 
 	render() {
-		const { title, placeholder, instanceId, isPostTypeViewable } = this.props;
+		const { title, placeholder, instanceId, isPostTypeViewable, hasFixedToolbar } = this.props;
 		const { isSelected } = this.state;
-		const className = classnames( 'editor-post-title__block', { 'is-selected': isSelected } );
+		const className = classnames( 'editor-post-title__block', {
+			'is-selected': isSelected,
+			'is-focus-mode': hasFixedToolbar,
+		} );
 		const decodedPlaceholder = decodeEntities( placeholder );
 
 		return (
@@ -129,12 +132,13 @@ const applyWithSelect = withSelect( ( select ) => {
 	const { getEditedPostAttribute, getEditorSettings } = select( 'core/editor' );
 	const { getPostType } = select( 'core' );
 	const postType = getPostType( getEditedPostAttribute( 'type' ) );
-	const { titlePlaceholder } = getEditorSettings();
+	const { titlePlaceholder, hasFixedToolbar } = getEditorSettings();
 
 	return {
 		title: getEditedPostAttribute( 'title' ),
 		isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 		placeholder: titlePlaceholder,
+		hasFixedToolbar,
 	};
 } );
 

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -37,17 +37,28 @@
 		font-weight: 600;
 	}
 
-	&.is-selected:not(.is-focus-mode) .editor-post-title__input {
-		// use opacity to work in various editor styles
-		border-color: $dark-opacity-light-500;
+	&:not(.is-focus-mode):not(.has-fixed-toolbar) {
+		&.is-selected .editor-post-title__input {
+			// use opacity to work in various editor styles
+			border-color: $dark-opacity-light-500;
 
-		.is-dark-theme & {
-			border-color: $light-opacity-light-500;
+			.is-dark-theme & {
+				border-color: $light-opacity-light-500;
+			}
+		}
+
+		.editor-post-title__input:hover {
+			border-color: theme(outlines);
 		}
 	}
 
-	&:not(.is-focus-mode) .editor-post-title__input:hover {
-		border-color: theme(outlines);
+	&.is-focus-mode {
+		opacity: 0.5;
+		transition: opacity 0.1s linear;
+
+		&.is-focused {
+			opacity: 1;
+		}
 	}
 }
 

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -52,11 +52,11 @@
 		}
 	}
 
-	&.is-focus-mode {
+	&.is-focus-mode .editor-post-title__input {
 		opacity: 0.5;
 		transition: opacity 0.1s linear;
 
-		&.is-focused {
+		&:focus {
 			opacity: 1;
 		}
 	}

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -37,7 +37,7 @@
 		font-weight: 600;
 	}
 
-	&.is-selected .editor-post-title__input {
+	&.is-selected:not(.is-focus-mode) .editor-post-title__input {
 		// use opacity to work in various editor styles
 		border-color: $dark-opacity-light-500;
 
@@ -46,7 +46,7 @@
 		}
 	}
 
-	.editor-post-title__input:hover {
+	&:not(.is-focus-mode) .editor-post-title__input:hover {
 		border-color: theme(outlines);
 	}
 }
@@ -55,7 +55,7 @@
 	font-size: $default-font-size;
 	color: $dark-gray-900;
 	position: absolute;
-	top: -$block-toolbar-height + $border-width + $border-width; // Shift this element upward the same height as the block toolbar, minus the border size
+	top: -$block-toolbar-height + $border-width + $border-width + 1px; // Shift this element upward the same height as the block toolbar, minus the border size
 	left: 0;
 	right: 0;
 

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -16,6 +16,7 @@ export const PREFERENCES_DEFAULTS = {
  *  maxWidth          number         Max width to constraint resizing
  *  blockTypes        boolean|Array  Allowed block types
  *  hasFixedToolbar   boolean        Whether or not the editor toolbar is fixed
+ *  focusMode         boolean        Whether the focus mode is enabled or not
  */
 export const EDITOR_SETTINGS_DEFAULTS = {
 	alignWide: false,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1101,15 +1101,19 @@ export function isBlockSelected( state, clientId ) {
 /**
  * Returns true if one of the block's inner blocks is selected.
  *
- * @param {Object} state    Editor state.
- * @param {string} clientId Block client ID.
+ * @param {Object}  state    Editor state.
+ * @param {string}  clientId Block client ID.
+ * @param {boolean} deep     Perform a deep check.
  *
  * @return {boolean} Whether the block as an inner block selected
  */
-export function hasSelectedInnerBlock( state, clientId ) {
+export function hasSelectedInnerBlock( state, clientId, deep = false ) {
 	return some(
 		getBlockOrder( state, clientId ),
-		( innerClientId ) => isBlockSelected( state, innerClientId )
+		( innerClientId ) => (
+			isBlockSelected( state, innerClientId ) ||
+			( deep && hasSelectedInnerBlock( state, innerClientId, deep ) )
+		)
 	);
 }
 

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -42,7 +42,7 @@ describe( 'block deletion -', () => {
 
 	describe( 'deleting the third block using the Remove Block shortcut', () => {
 		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
-			await pressWithModifier( [ 'Shift', META_KEY ], 'x' );
+			await pressWithModifier( [ 'Shift', META_KEY ], 'Backspace' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 
 			// Type additional text and assert that caret position is correct by comparing to snapshot.

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -195,9 +195,9 @@ describe( 'Links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	const setFixedToolbar = async ( b ) => {
+	const setFocusMode = async ( b ) => {
 		await page.click( '.edit-post-more-menu button' );
-		const button = ( await page.$x( "//button[contains(text(), 'Fix Toolbar to Top')]" ) )[ 0 ];
+		const button = ( await page.$x( "//button[contains(text(), 'Focus Mode')]" ) )[ 0 ];
 		const buttonClassNameProperty = await button.getProperty( 'className' );
 		const buttonClassName = await buttonClassNameProperty.jsonValue();
 		const isSelected = buttonClassName.indexOf( 'is-selected' ) !== -1;
@@ -208,8 +208,8 @@ describe( 'Links', () => {
 		}
 	};
 
-	it( 'allows Left to be pressed during creation in "Fixed to Toolbar" mode', async () => {
-		await setFixedToolbar( true );
+	it( 'allows Left to be pressed during creation in Focus mode', async () => {
+		await setFocusMode( true );
 
 		await clickBlockAppender();
 		await page.keyboard.type( 'Text' );
@@ -227,7 +227,7 @@ describe( 'Links', () => {
 	} );
 
 	it( 'allows Left to be pressed during creation in "Docked Toolbar" mode', async () => {
-		await setFixedToolbar( false );
+		await setFocusMode( false );
 
 		await clickBlockAppender();
 		await page.keyboard.type( 'Text' );

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -197,7 +197,7 @@ describe( 'Links', () => {
 
 	const toggleFixedToolbar = async ( b ) => {
 		await page.click( '.edit-post-more-menu button' );
-		const button = ( await page.$x( "//button[contains(text(), 'Fix Toolbar To Top')]" ) )[ 0 ];
+		const button = ( await page.$x( "//button[contains(text(), 'Unified Toolbar')]" ) )[ 0 ];
 		const buttonClassNameProperty = await button.getProperty( 'className' );
 		const buttonClassName = await buttonClassNameProperty.jsonValue();
 		const isSelected = buttonClassName.indexOf( 'is-selected' ) !== -1;

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -195,9 +195,9 @@ describe( 'Links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	const setFocusMode = async ( b ) => {
+	const toggleFixedToolbar = async ( b ) => {
 		await page.click( '.edit-post-more-menu button' );
-		const button = ( await page.$x( "//button[contains(text(), 'Focus Mode')]" ) )[ 0 ];
+		const button = ( await page.$x( "//button[contains(text(), 'Fix Toolbar To Top')]" ) )[ 0 ];
 		const buttonClassNameProperty = await button.getProperty( 'className' );
 		const buttonClassName = await buttonClassNameProperty.jsonValue();
 		const isSelected = buttonClassName.indexOf( 'is-selected' ) !== -1;
@@ -208,8 +208,8 @@ describe( 'Links', () => {
 		}
 	};
 
-	it( 'allows Left to be pressed during creation in Focus mode', async () => {
-		await setFocusMode( true );
+	it( 'allows Left to be pressed during creation when the toolbar is fixed to top', async () => {
+		await toggleFixedToolbar( true );
 
 		await clickBlockAppender();
 		await page.keyboard.type( 'Text' );
@@ -227,7 +227,7 @@ describe( 'Links', () => {
 	} );
 
 	it( 'allows Left to be pressed during creation in "Docked Toolbar" mode', async () => {
-		await setFocusMode( false );
+		await toggleFixedToolbar( false );
 
 		await clickBlockAppender();
 		await page.keyboard.type( 'Text' );


### PR DESCRIPTION
Related #9334 

This PR bootstraps the work on the focus mode proposed in #9334. Ideally, we'd be able to iterate and ship additions to the focus mode iteratively.

In this first step, I'm:

 - Renaming the option in the menu "Focus Mode" (note that the selectors, the state stays as is: `isFixedToolbar`, this can be changed later)
 - Removing the block outlines from the Focus Mode.
 - I'm also considering the focus mode available only in desktop (it was already the case for the fixed toolbar to top option)
