### PR TITLE
WIP: Try new publishing flow

### DIFF
--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -101,14 +101,17 @@
 	}
 }
 
+// Pre-publish panel. Should perhaps be shifted to the post-publish-panel component?
 .edit-post-layout .editor-post-publish-panel {
 	position: fixed;
 	z-index: z-index(".edit-post-layout .edit-post-post-publish-panel");
 	top: $admin-bar-height-big;
 	bottom: 0;
 	right: 0;
-	left: 0;
+	left: auto;
 	overflow: auto;
+	border-left: $border-width solid $light-gray-500;
+	@include slide_in_right;
 
 	body.is-fullscreen-mode & {
 		top: 0;
@@ -116,28 +119,6 @@
 
 	@include break-medium() {
 		top: $admin-bar-height;
-		left: auto;
-		width: $sidebar-width;
-		border-left: $border-width solid $light-gray-500;
-		@include slide_in_right;
-
-		body.is-fullscreen-mode & {
-			top: 0;
-		}
-	}
-}
-
-.edit-post-layout .editor-post-publish-panel__header-publish-button {
-	// Match the size of the Publish... button.
-	.components-button.is-large {
-		height: 33px;
-		line-height: 32px;
-	}
-
-	// Size the spacer flexibly to allow for different button lengths.
-	.editor-post-publish-panel__spacer {
-		display: inline-flex;
-		flex: 0 1 52px; // This number is approximative to keep the publish button at the same position when opening the panel
 	}
 }
 

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -61,20 +61,23 @@ class PostPublishPanel extends Component {
 		this.setState( { loading: true } );
 	}
 
-	onUpdateDisableToggle() {
-		// There should be a setting to allow users to skip the pre-publish step forever.
-		// When a user toggles this option on, their setting will be saved and they won't need
-		// to press two "publish" buttons in order to make a post happen.
-	}
-
 	render() {
-		const { isScheduled, isPublishSidebarEnabled, onClose, onTogglePublishSidebar, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension, ...additionalProps } = this.props;
-		const { loading, submitted, hasPublishAction } = this.state;
+		const { hasPublishAction, isScheduled, isBeingScheduled, onClose, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension, ...additionalProps } = this.props;
+		const { loading, submitted } = this.state;
+		let prePublishTitle;
+
+		if ( ! hasPublishAction ) {
+			prePublishTitle = __( 'Ready to submit for review?' );
+		} else if ( isBeingScheduled ) {
+			prePublishTitle = __( 'Ready to schedule?' );
+		} else {
+			prePublishTitle = __( 'Ready to publish?' );
+		}
 		return (
 			<div className="editor-post-publish-panel" { ...additionalProps }>
 				<div className="editor-post-publish-panel__header">
 					<strong className="editor-post-publish-panel__title">
-						{ hasPublishAction ? __( 'Ready to submit for review?' ) : __( 'Ready to publish?' ) }
+						{ prePublishTitle }
 					</strong>
 
 					<IconButton
@@ -110,8 +113,6 @@ class PostPublishPanel extends Component {
 						</div>
 					) }
 				</div>
-<<<<<<< HEAD
-=======
 
 				<div className="editor-post-publish-panel__disable-check">
 					<CheckboxControl
@@ -121,7 +122,6 @@ class PostPublishPanel extends Component {
 					/>
 				</div>
 
->>>>>>> Add a checkbox to skip the prepublish panel.
 			</div>
 		);
 	}
@@ -134,6 +134,7 @@ export default compose( [
 			getCurrentPostType,
 			isCurrentPostPublished,
 			isCurrentPostScheduled,
+			isEditedPostBeingScheduled,
 			isSavingPost,
 			isEditedPostDirty,
 		} = select( 'core/editor' );
@@ -143,6 +144,7 @@ export default compose( [
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			isPublished: isCurrentPostPublished(),
 			isScheduled: isCurrentPostScheduled(),
+			isBeingScheduled: isEditedPostBeingScheduled(),
 			isSaving: isSavingPost(),
 			isDirty: isEditedPostDirty(),
 			isPublishSidebarEnabled: isPublishSidebarEnabled(),

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -62,7 +62,7 @@ class PostPublishPanel extends Component {
 	}
 
 	render() {
-		const { hasPublishAction, isScheduled, isBeingScheduled, onClose, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension, ...additionalProps } = this.props;
+		const { hasPublishAction, isScheduled, isBeingScheduled, isPublishSidebarEnabled, onClose, onTogglePublishSidebar, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension, ...additionalProps } = this.props;
 		const { loading, submitted } = this.state;
 		let prePublishTitle;
 
@@ -116,9 +116,9 @@ class PostPublishPanel extends Component {
 
 				<div className="editor-post-publish-panel__disable-check">
 					<CheckboxControl
-						label={ __( 'Show this panel every time I publish a post' ) }
-						checked={ false }
-						onChange={ () => this.onUpdateDisableToggle() }
+						label={ __( 'Always show pre-publish checks.' ) }
+						checked={ isPublishSidebarEnabled }
+						onChange={ onTogglePublishSidebar }
 					/>
 				</div>
 

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -61,6 +61,12 @@ class PostPublishPanel extends Component {
 		this.setState( { loading: true } );
 	}
 
+	onUpdateDisableToggle() {
+		// There should be a setting to allow users to skip the pre-publish step forever.
+		// When a user toggles this option on, their setting will be saved and they won't need
+		// to press two "publish" buttons in order to make a post happen.
+	}
+
 	render() {
 		const { isScheduled, isPublishSidebarEnabled, onClose, onTogglePublishSidebar, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension, ...additionalProps } = this.props;
 		const { loading, submitted, hasPublishAction } = this.state;
@@ -92,7 +98,7 @@ class PostPublishPanel extends Component {
 					) }
 				</div>
 
-				<div className="editor-post-publish-panel__footer">
+				<div className="editor-post-publish-panel__action-buttons">
 					{ ! submitted && (
 						<div className="editor-post-publish-panel__header-publish-button">
 							<PostPublishButton focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
@@ -104,6 +110,18 @@ class PostPublishPanel extends Component {
 						</div>
 					) }
 				</div>
+<<<<<<< HEAD
+=======
+
+				<div className="editor-post-publish-panel__disable-check">
+					<CheckboxControl
+						label={ __( 'Don’t show this again' ) }
+						checked={ false }
+						onChange={ () => this.onUpdateDisableToggle() }
+					/>
+				</div>
+
+>>>>>>> Add a checkbox to skip the prepublish panel.
 			</div>
 		);
 	}

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -63,21 +63,14 @@ class PostPublishPanel extends Component {
 
 	render() {
 		const { isScheduled, isPublishSidebarEnabled, onClose, onTogglePublishSidebar, forceIsDirty, forceIsSaving, PrePublishExtension, PostPublishExtension, ...additionalProps } = this.props;
-		const { loading, submitted } = this.state;
+		const { loading, submitted, hasPublishAction } = this.state;
 		return (
 			<div className="editor-post-publish-panel" { ...additionalProps }>
 				<div className="editor-post-publish-panel__header">
-					{ ! submitted && (
-						<div className="editor-post-publish-panel__header-publish-button">
-							<PostPublishButton focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
-							<span className="editor-post-publish-panel__spacer"></span>
-						</div>
-					) }
-					{ submitted && (
-						<div className="editor-post-publish-panel__header-published">
-							{ isScheduled ? __( 'Scheduled' ) : __( 'Published' ) }
-						</div>
-					) }
+					<strong className="editor-post-publish-panel__title">
+						{ hasPublishAction ? __( 'Ready to submit for review?' ) : __( 'Ready to publish?' ) }
+					</strong>
+
 					<IconButton
 						aria-expanded={ true }
 						onClick={ onClose }
@@ -98,12 +91,18 @@ class PostPublishPanel extends Component {
 						</PostPublishPanelPostpublish>
 					) }
 				</div>
+
 				<div className="editor-post-publish-panel__footer">
-					<CheckboxControl
-						label={ __( 'Always show pre-publish checks.' ) }
-						checked={ isPublishSidebarEnabled }
-						onChange={ onTogglePublishSidebar }
-					/>
+					{ ! submitted && (
+						<div className="editor-post-publish-panel__header-publish-button">
+							<PostPublishButton focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
+						</div>
+					) }
+					{ submitted && (
+						<div className="editor-post-publish-panel__header-published">
+							{ isScheduled ? __( 'Scheduled' ) : __( 'Published' ) }
+						</div>
+					) }
 				</div>
 			</div>
 		);

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -115,7 +115,7 @@ class PostPublishPanel extends Component {
 
 				<div className="editor-post-publish-panel__disable-check">
 					<CheckboxControl
-						label={ __( 'Don’t show this again' ) }
+						label={ __( 'Show this panel every time I publish a post' ) }
 						checked={ false }
 						onChange={ () => this.onUpdateDisableToggle() }
 					/>

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -26,22 +26,18 @@ function PostPublishPanelPrepublish( {
 	isBeingScheduled,
 	children,
 } ) {
-	let prePublishTitle, prePublishBodyText;
+	let prePublishBodyText;
 
 	if ( ! hasPublishAction ) {
-		prePublishTitle = __( 'Are you ready to submit for review?' );
 		prePublishBodyText = __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' );
 	} else if ( isBeingScheduled ) {
-		prePublishTitle = __( 'Are you ready to schedule?' );
 		prePublishBodyText = __( 'Your post will be published at the specified date and time.' );
 	} else {
-		prePublishTitle = __( 'Are you ready to publish?' );
 		prePublishBodyText = __( 'Double-check your settings, then use the button to publish your post.' );
 	}
 
 	return (
 		<div className="editor-post-publish-panel__prepublish">
-			<div><strong>{ prePublishTitle }</strong></div>
 			<p>{ prePublishBodyText }</p>
 
 			{ hasPublishAction && (

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -43,6 +43,7 @@ function PostPublishPanelPrepublish( {
 		<div className="editor-post-publish-panel__prepublish">
 			<div><strong>{ prePublishTitle }</strong></div>
 			<p>{ prePublishBodyText }</p>
+
 			{ hasPublishAction && (
 				<Fragment>
 					<PanelBody initialOpen={ false } title={ [

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -54,6 +54,32 @@
 	margin: 0;
 }
 
+.editor-post-publish-panel__prepublish {
+	strong {
+		color: $dark-gray-900;
+	}
+
+	.editor-post-visibility__dialog-legend {
+		display: none;
+	}
+
+	.editor-post-visibility__choice input[type="radio"] {
+		margin-right: 4px;
+	}
+
+	.editor-post-visibility__choice input[type="radio"] + label {
+		vertical-align: top;
+	}
+
+	.editor-post-visibility__choice {
+		padding-bottom: 8px;
+	}
+
+	.editor-post-visibility__dialog-info {
+		margin-top: 0.5em;
+	}
+}
+
 // Panel footer (publish button)
 .editor-post-publish-panel__footer {
 	padding: 32px;

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -43,6 +43,7 @@
 
 .editor-post-publish-panel .components-panel__body {
 	border-top: 0;
+	border-bottom: 0;
 	padding: 0;
 }
 

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -4,12 +4,15 @@
 	color: $dark-gray-500;
 	right: 0;
 	left: auto;
-	padding: 32px; // We're doubling standard padding to make it feel a bit more spacious.
+	padding: 32px 32px 18px; // We're doubling standard padding to make it feel a bit more spacious.
 	width: 420px;
 	max-width: calc(100% - 20px);
+	display: flex;
+	flex-direction: column;
+	justify-content: normal;
 }
 
-// Loading spinner?
+// Spinner shows whilst publishing. Maybe we should change it.
 .editor-post-publish-panel__content {
 	.components-spinner {
 		display: block;
@@ -81,8 +84,8 @@
 	}
 }
 
-// Panel footer (publish button)
-.editor-post-publish-panel__footer {
+// Action buttons (used for publishing button and flow)
+.editor-post-publish-panel__action-buttons {
 	padding: 32px;
 	text-align: center;
 }
@@ -119,6 +122,11 @@
 	.components-clipboard-button {
 		width: 100%;
 	}
+}
+
+// Checkbox to disable pre-publish panel.
+.editor-post-publish-panel__disable-check {
+	margin-top: auto; // Since our parent container uses flexbox, this floats the checkmark to the bottom of the screen.
 }
 
 // A toggle of some sort? May not be needed anymore.

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -1,8 +1,15 @@
+// Overall panel styles.
 .editor-post-publish-panel {
 	background: $white;
 	color: $dark-gray-500;
+	right: 0;
+	left: auto;
+	padding: 32px; // We're doubling standard padding to make it feel a bit more spacious.
+	width: 420px;
+	max-width: calc(100% - 20px);
 }
 
+// Loading spinner?
 .editor-post-publish-panel__content {
 	.components-spinner {
 		display: block;
@@ -11,77 +18,60 @@
 	}
 }
 
+// Panel header.
 .editor-post-publish-panel__header {
-	background: $white;
-	padding-left: 16px;
-	height: $header-height;
-	border-bottom: $border-width solid $light-gray-500;
 	display: flex;
 	align-items: center;
-	align-content: space-between;
+	justify-content: space-between;
+	color: $dark-gray-900;
 }
 
-.editor-post-publish-panel__header-publish-button {
-	display: flex;
-	justify-content: flex-end;
-	flex-grow: 1;
-	text-align: right;
-	flex-wrap: nowrap;
+.editor-post-publish-panel__title {
+	font-size: 15px;
 }
 
-.editor-post-publish-panel__header-published {
-	flex-grow: 1;
-}
-
-.editor-post-publish-panel__footer {
-	padding: 16px;
-	position: absolute;
-	bottom: 0;
-}
-
-.components-button.editor-post-publish-panel__toggle.is-primary {
-	display: inline-flex;
-	align-items: center;
-
-	&.is-busy .dashicon {
-		display: none;
-	}
-
-	.dashicon {
-		margin-right: -4px;
-	}
+// Individual sub-panels, mostly resetting a bunch of things here to simplify styling.
+.editor-post-publish-panel .components-panel__body-toggle.components-button {
+	padding: 20px 0;
 }
 
 .editor-post-publish-panel__link {
-	color: $blue-medium-700;
+	color: $blue-dark-900;
 	font-weight: 400;
 	padding-left: 4px;
-	text-decoration: underline;
 }
 
-.editor-post-publish-panel__prepublish {
-	padding: 16px;
-
-	strong {
-		color: $dark-gray-900;
-	}
-
-	.components-panel__body {
-		background: $white;
-		margin-left: -16px;
-		margin-right: -16px;
-	}
-
-	.editor-post-visibility__dialog-legend {
-		display: none;
-	}
+.editor-post-publish-panel .components-panel__body {
+	border-top: 0;
+	padding: 0;
 }
 
-.post-publish-panel__postpublish .components-panel__body {
-	border-bottom: $border-width solid $light-gray-500;
-	border-top: none;
+.editor-post-publish-panel .components-panel__body.is-opened {
+	padding-bottom: 16px;
 }
 
+.editor-post-publish-panel .components-panel__body.is-opened > .components-panel__body-title {
+	margin: 0;
+}
+
+// Panel footer (publish button)
+.editor-post-publish-panel__footer {
+	padding: 32px;
+	text-align: center;
+}
+
+.components-button.editor-post-publish-button {
+	justify-content: center;
+	padding: 6px 32px;
+	height: auto;
+	font-size: 15px;
+	text-shadow: none;
+	box-shadow: none;
+	border-radius: 6px;
+	background: $blue-dark-900;
+}
+
+// Buttons that appear in post-publish panel. (Probably will move to their own component.)
 .post-publish-panel__postpublish-buttons {
 	display: flex;
 	align-content: space-between;
@@ -104,6 +94,21 @@
 	}
 }
 
+// A toggle of some sort? May not be needed anymore.
+.components-button.editor-post-publish-panel__toggle.is-primary {
+	display: inline-flex;
+	align-items: center;
+
+	&.is-busy .dashicon {
+		display: none;
+	}
+
+	.dashicon {
+		margin-right: -4px;
+	}
+}
+
+// MYSTERY.
 .post-publish-panel__postpublish-link-input[readonly] {
 	width: 100%;
 	padding: 10px;
@@ -111,12 +116,4 @@
 	background: $white;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-.post-publish-panel__postpublish-header {
-	font-weight: 500;
-}
-
-.post-publish-panel__tip {
-	color: $alert-yellow;
 }


### PR DESCRIPTION
This is my attempt to start implementing publishing flow changes in #7602. I've done some of the cosmetic changes, but some of the more heavy-lifting will need a friendly developer, especially since some of the code in here I'm finding a bit hard to follow.

I've tried some bigger changes here, with respect to adding a lot more spacing between elements and adding some typographic hierarchy. It may be a bit much here, since it's inconsistent with styling used elsewhere, but we can always dial it back if it feels too disjointed. 

## Before:

![2018-08-28 12 23 25](https://user-images.githubusercontent.com/376315/44720046-47815800-aabd-11e8-880e-cf195a4c9993.gif)

## After: 

![2018-08-28 11 16 43](https://user-images.githubusercontent.com/376315/44717122-18b2b400-aab4-11e8-8e06-9e06dc67c410.gif)

## What's missing?

- [ ] scrolling should only scroll the panel, not the window itself
- [ ] dimming the background via a scrim would be good, and I think this would also solve the interaction issue where the page gets scrolled rather than the panel, by making the page itself non-interactive
- [ ] might make sense to refactor so there's pre-publish-panel and post-publish-panel, since they are now (or will be) more separate entities, and there's a lot of functionality changes happening here—I started doing this but got a bit lost in the weeds, so I'd appreciate some help there
- [x] panel title doesn't seem to be behaving properly, I think because I've moved it up a level and the logic is different
- [ ] there's an awkward lag for suggestion panel to come up (not introduced via this PR but could be nice to get fixed if it's relatively trivial)
- [x] the checkbox for "don't show this again" should probably not show this again (via an option)
<s>- [ ] clicking "private" toggle immediately publishes the post (#9396)</s>
- [ ] changed the password input field to be more consistent with the other inputs and it broke things (will file separately)

## Next phase
I've only dealt with the pre-publish panel right now, mostly due to technical limitations. Here's what I'd like for the post-publish phase:

There should be one state for "publishing" and one for "published" (both of which currently exist), and then, once the post has published, we should redirect to show the post, with a modal overlay giving some next-step advise as per the mockup. 

I can adjust the styling of the "publishing..." and the "published!" states, but it would help to be able to get them to display temporarily, which I'm having troubles making happen. (Setting `submitted: true` on `PostPublishPanel` brings up the published state, but I'm having troubles getting the publishing state to stay on the screen for any length of time, making it super difficult to style or adjust since it disappears quite quickly!)