### PR TITLE
Editor: Sync blocks state to edited post content

### DIFF
--- a/edit-post/editor.js
+++ b/edit-post/editor.js
@@ -1,50 +1,76 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { EditorProvider, ErrorBoundary } from '@wordpress/editor';
-import { StrictMode } from '@wordpress/element';
+import { StrictMode, Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Layout from './components/layout';
 
-function Editor( {
-	settings,
-	hasFixedToolbar,
-	focusMode,
-	post,
-	onError,
-	...props
-} ) {
-	if ( ! post ) {
-		return null;
+class Editor extends Component {
+	constructor( props ) {
+		super( ...arguments );
+
+		const { initialEdits, editPost } = props;
+		if ( initialEdits ) {
+			editPost( initialEdits, { quiet: true } );
+		}
 	}
 
-	const editorSettings = {
-		...settings,
-		hasFixedToolbar,
-		focusMode,
-	};
+	render() {
+		const {
+			settings,
+			hasFixedToolbar,
+			focusMode,
+			post,
+			onError,
+			...props
+		} = this.props;
 
-	return (
-		<StrictMode>
-			<EditorProvider
-				settings={ editorSettings }
-				post={ post }
-				{ ...props }
-			>
-				<ErrorBoundary onError={ onError }>
-					<Layout />
-				</ErrorBoundary>
-			</EditorProvider>
-		</StrictMode>
-	);
+		if ( ! post ) {
+			return null;
+		}
+
+		const editorSettings = {
+			...settings,
+			hasFixedToolbar,
+			focusMode,
+		};
+
+		return (
+			<StrictMode>
+				<EditorProvider
+					settings={ editorSettings }
+					post={ post }
+					{ ...props }
+				>
+					<ErrorBoundary onError={ onError }>
+						<Layout />
+					</ErrorBoundary>
+				</EditorProvider>
+			</StrictMode>
+		);
+	}
 }
 
-export default withSelect( ( select, { postId, postType } ) => ( {
-	hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
-	focusMode: select( 'core/edit-post' ).isFeatureActive( 'focusMode' ),
-	post: select( 'core' ).getEntityRecord( 'postType', postType, postId ),
-} ) )( Editor );
+export default compose( [
+	withSelect( ( select, { postId, postType } ) => {
+		const { isFeatureActive } = select( 'core/edit-post' );
+		const { getEntityRecord } = select( 'core' );
+
+		return {
+			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+			focusMode: isFeatureActive( 'focusMode' ),
+			post: getEntityRecord( 'postType', postType, postId ),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { editPost } = dispatch( 'core/editor' );
+
+		return { editPost };
+	} ),
+] )( Editor );

--- a/edit-post/editor.js
+++ b/edit-post/editor.js
@@ -15,7 +15,6 @@ function Editor( {
 	hasFixedToolbar,
 	focusMode,
 	post,
-	overridePost,
 	onError,
 	...props
 } ) {
@@ -33,7 +32,7 @@ function Editor( {
 		<StrictMode>
 			<EditorProvider
 				settings={ editorSettings }
-				post={ { ...post, ...overridePost } }
+				post={ post }
 				{ ...props }
 			>
 				<ErrorBoundary onError={ onError }>

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -23,18 +23,17 @@ import Editor from './editor';
  * an unhandled error occurs, replacing previously mounted editor element using
  * an initial state from prior to the crash.
  *
- * @param {Object}  postType       Post type of the post to edit.
- * @param {Object}  postId         ID of the post to edit.
- * @param {Element} target         DOM node in which editor is rendered.
- * @param {?Object} settings       Editor settings object.
- * @param {Object}  overridePost   Post properties to override.
+ * @param {Object}  postType Post type of the post to edit.
+ * @param {Object}  postId   ID of the post to edit.
+ * @param {Element} target   DOM node in which editor is rendered.
+ * @param {?Object} settings Editor settings object.
  */
-export function reinitializeEditor( postType, postId, target, settings, overridePost ) {
+export function reinitializeEditor( postType, postId, target, settings ) {
 	unmountComponentAtNode( target );
-	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, overridePost );
+	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings );
 
 	render(
-		<Editor settings={ settings } onError={ reboot } postId={ postId } postType={ postType } overridePost={ overridePost } recovery />,
+		<Editor settings={ settings } onError={ reboot } postId={ postId } postType={ postType } recovery />,
 		target
 	);
 }
@@ -45,17 +44,17 @@ export function reinitializeEditor( postType, postId, target, settings, override
  * The return value of this function is not necessary if we change where we
  * call initializeEditor(). This is due to metaBox timing.
  *
- * @param {string}  id            Unique identifier for editor instance.
- * @param {Object}  postType      Post type of the post to edit.
- * @param {Object}  postId        ID of the post to edit.
- * @param {?Object} settings      Editor settings object.
- * @param {Object}  overridePost  Post properties to override.
+ * @param {string}  id           Unique identifier for editor instance.
+ * @param {Object}  postType     Post type of the post to edit.
+ * @param {Object}  postId       ID of the post to edit.
+ * @param {?Object} settings     Editor settings object.
+ * @param {Object}  initialEdits Post properties to override.
  *
  * @return {Object} Editor interface.
  */
-export function initializeEditor( id, postType, postId, settings, overridePost ) {
+export function initializeEditor( id, postType, postId, settings, initialEdits ) {
 	const target = document.getElementById( id );
-	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, overridePost );
+	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings );
 
 	registerCoreBlocks();
 
@@ -66,8 +65,12 @@ export function initializeEditor( id, postType, postId, settings, overridePost )
 		'core/editor.publish',
 	] );
 
+	if ( initialEdits ) {
+		dispatch( 'core/editor' ).editPost( initialEdits, { quiet: true } );
+	}
+
 	render(
-		<Editor settings={ settings } onError={ reboot } postId={ postId } postType={ postType } overridePost={ overridePost } />,
+		<Editor settings={ settings } onError={ reboot } postId={ postId } postType={ postType } />,
 		target
 	);
 

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -65,12 +65,14 @@ export function initializeEditor( id, postType, postId, settings, initialEdits )
 		'core/editor.publish',
 	] );
 
-	if ( initialEdits ) {
-		dispatch( 'core/editor' ).editPost( initialEdits, { quiet: true } );
-	}
-
 	render(
-		<Editor settings={ settings } onError={ reboot } postId={ postId } postType={ postType } />,
+		<Editor
+			settings={ settings }
+			onError={ reboot }
+			postId={ postId }
+			postType={ postType }
+			initialEdits={ initialEdits }
+		/>,
 		target
 	);
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1331,20 +1331,14 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		$demo_content = ob_get_clean();
 
 		$initial_edits = array(
-			'title'   => array(
-				'raw' => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
-			),
-			'content' => array(
-				'raw' => $demo_content,
-			),
+			'title'   => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
+			'content' => $demo_content,
 		);
 	} elseif ( $is_new_post ) {
 		// Override "(Auto Draft)" new post default title with empty string,
 		// or filtered value.
 		$initial_edits = array(
-			'title' => array(
-				'raw' => apply_filters( 'the_title', '', $post->ID ),
-			),
+			'title' => apply_filters( 'the_title', '', $post->ID ),
 		);
 	} else {
 		$initial_edits = null;

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -40,6 +40,12 @@
 
 - `wp.editor.RichTextProvider` flagged for deprecation. Please use `wp.data.select( 'core/editor' )` methods instead.
 
+### Deprecations
+
+- The `setupEditor` action has been deprecated. Note: An editor is kept in sync automatically by its post state, without a predefined start point.
+- The `setupEditorState` action has been deprecated. Note: An editor is kept in sync automatically by its post state, without a predefined start point.
+- The `checkTemplateValidity` action has been deprecated. Note: Validity is verified automatically upon block reset.
+
 ### Bug Fixes
 
 - The `PostTextEditor` component will respect its in-progress state edited value, even if the assigned prop value changes.

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -9,7 +9,6 @@ import Textarea from 'react-autosize-textarea';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Component, Fragment } from '@wordpress/element';
-import { parse } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 
@@ -97,13 +96,13 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { editPost, resetBlocks } = dispatch( 'core/editor' );
+		const { editPost } = dispatch( 'core/editor' );
 		return {
 			onChange( content ) {
-				editPost( { content } );
+				editPost( { content }, { skipContentParse: true } );
 			},
 			onPersist( content ) {
-				resetBlocks( parse( content ) );
+				editPost( { content }, { skipContentParse: false } );
 			},
 		};
 	} ),

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -23,6 +23,12 @@ import deprecated from '@wordpress/deprecated';
  * @return {Object} Action object.
  */
 export function setupEditor( post, autosaveStatus ) {
+	deprecated( 'setupEditor', {
+		version: '4.0',
+		plugin: 'Gutenberg',
+		hint: 'An editor is kept in sync automatically by its post state, without a predefined start point.',
+	} );
+
 	return {
 		type: 'SETUP_EDITOR',
 		autosave: autosaveStatus,
@@ -85,6 +91,12 @@ export function updatePost( edits ) {
  * @return {Object} Action object.
  */
 export function setupEditorState( post, blocks, edits ) {
+	deprecated( 'setupEditorState', {
+		version: '4.0',
+		plugin: 'Gutenberg',
+		hint: 'An editor is kept in sync automatically by its post state, without a predefined start point.',
+	} );
+
 	return {
 		type: 'SETUP_EDITOR_STATE',
 		post,
@@ -398,10 +410,23 @@ export function synchronizeTemplate() {
 	};
 }
 
-export function editPost( edits ) {
+/**
+ * Returns an action object used in signalling that attributes of the post have
+ * been edited.
+ *
+ * @param {Object}   edits         Post attributes to edit.
+ * @param {?Object}  options       Options for editing.
+ * @param {?boolean} options.quiet Whether edit is triggered programmatically,
+ *                                 contrasted with explicit user interaction,
+ *                                 to bypass change detection and undo history.
+ *
+ * @return {Object} Action object.
+ */
+export function editPost( edits, options = {} ) {
 	return {
 		type: 'EDIT_POST',
 		edits,
+		options,
 	};
 }
 

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -21,6 +21,7 @@ import {
 	removeNotice,
 	createSuccessNotice,
 	createErrorNotice,
+	editPost,
 } from '../actions';
 import {
 	getCurrentPost,
@@ -39,7 +40,6 @@ import { resolveSelector } from './utils';
  * Module Constants
  */
 const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
-export const AUTOSAVE_POST_NOTICE_ID = 'AUTOSAVE_POST_NOTICE_ID';
 const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 
 /**
@@ -81,9 +81,20 @@ export const requestPostUpdate = async ( action, store ) => {
 		edits = { status: 'draft', ...edits };
 	}
 
+	const content = getEditedPostContent( state );
+
+	// The edited post property is not kept in sync with blocks state. At save
+	// time, we derive the content and set the edit before calling the update,
+	// such that it is considered synced at the time of the optimistic update,
+	// and divergences in the persisted value are accounted for in the post
+	// reset which follows (i.e. mark as dirty if saved content differs).
+	// Bypass blocks parsing since the updated content is derived from blocks
+	// from state, thus is assumed to be in sync.
+	dispatch( editPost( { content }, { skipContentParse: true } ) );
+
 	let toSend = {
 		...edits,
-		content: getEditedPostContent( state ),
+		content,
 		id: post.id,
 	};
 
@@ -95,9 +106,9 @@ export const requestPostUpdate = async ( action, store ) => {
 		isAutosave,
 	} );
 
-	// Optimistically apply updates under the assumption that the post
-	// will be updated. See below logic in success resolution for revert
-	// if the autosave is applied as a revision.
+	// Optimistically apply updates under the assumption that the post will be
+	// updated. See below logic in success resolution for revert if autosave is
+	// applied as a revision.
 	dispatch( {
 		...updatePost( toSend ),
 		optimist: { id: POST_UPDATE_TRANSACTION_ID },
@@ -121,7 +132,7 @@ export const requestPostUpdate = async ( action, store ) => {
 		} );
 	} else {
 		dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
-		dispatch( removeNotice( AUTOSAVE_POST_NOTICE_ID ) );
+		dispatch( removeNotice( 'autosave-exists' ) );
 
 		request = apiFetch( {
 			path: `/wp/v2/${ postType.rest_base }/${ post.id }`,

--- a/packages/editor/src/store/middlewares.js
+++ b/packages/editor/src/store/middlewares.js
@@ -9,6 +9,9 @@ import { flowRight } from 'lodash';
  * Internal dependencies
  */
 import effects from './effects';
+import syncBlocksToContent from './middlewares/sync-blocks-to-content';
+
+// TODO: Move this file contents to ./middlewares/index.js
 
 /**
  * Applies the custom middlewares used specifically in the editor module.
@@ -21,6 +24,7 @@ function applyMiddlewares( store ) {
 	const middlewares = [
 		refx( effects ),
 		multi,
+		syncBlocksToContent,
 	];
 
 	let enhancedDispatch = () => {

--- a/packages/editor/src/store/middlewares/sync-blocks-to-content.js
+++ b/packages/editor/src/store/middlewares/sync-blocks-to-content.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { merge } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { resetBlocks } from '../actions';
+import { getPostEdits, getCurrentPostAttribute } from '../selectors';
+
+/**
+ * Returns true if the action includes the `skipContentParse` option indicating
+ * that content should be synced to blocks state, regardless of whether the
+ * value has changed.
+ *
+ * @param {Object} action Action object to test.
+ *
+ * @return {boolean} Whether block parse is to be forced.
+ */
+export function isForcedParse( action ) {
+	return Boolean( action.options ) && action.options.skipContentParse === false;
+}
+
+/**
+ * Returns true if the action includes the `skipContentParse` option indicating
+ * that a parse to sync blocks state should be skipped, even if content has
+ * changed. This can be used to optimize frequent updates to content, followed
+ * by a subsequent force parse.
+ *
+ * @param {Object} action Action object to test.
+ *
+ * @return {boolean} Whether block parse is to be forced.
+ */
+export function isSkippedParse( action ) {
+	return Boolean( action.options && action.options.skipContentParse );
+}
+
+/**
+ * Returns the current edited post content. Unlike the `getEditedPostContent`
+ * selector from the editor store, this intentionally disregards the blocks
+ * state, since it's assumed this would be used by the middleware in populating
+ * said blocks state.
+ *
+ * In all other usage of edited post content, the blocks state is considered
+ * the canonical source of truth. The middleware is responsible for making this
+ * blocks state available. For example, when editing an existing post, blocks
+ * state will have a default value of an empty array. In resetting the blocks
+ * state, the middleware will consider initial edits, if any exist, but defer
+ * to the post's persisted value.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string} Edited post content.
+ */
+export function getPostContent( state ) {
+	const edits = getPostEdits( state );
+	if ( edits.hasOwnProperty( 'content' ) ) {
+		return edits.content;
+	}
+
+	return getCurrentPostAttribute( state, 'content' );
+}
+
+export default ( store ) => {
+	const { getState } = store;
+	let previousContent;
+
+	return ( next ) => ( action ) => {
+		const result = next( action );
+
+		const content = getPostContent( getState() );
+
+		// Reset blocks if content has changed. This also accounts for the case
+		// where there is no edited content (treat as undefined).
+		if ( content !== previousContent || isForcedParse( action ) ) {
+			previousContent = content;
+
+			// An instruction to skip the content parse implies that content
+			// may have in-fact changed, but a re-parse is not necessary. It's
+			// important to update previousContent to avoid a future unrelated
+			// action without skip flag incurring the re-parse.
+			if ( ! isSkippedParse( action ) ) {
+				// Avoid parsing blocks if content empty. This is not just an
+				// optimization, but avoids passing an invalid undefined
+				// argument to the block parser.
+				const blocks = content ? parse( content ) : [];
+
+				// Avoid infinite loop and instruct next middleware pass to
+				// avoid content parse by merging skip into action options.
+				const resetAction = merge(
+					resetBlocks( blocks ),
+					{ options: { skipContentParse: true } }
+				);
+
+				store.dispatch( resetAction );
+			}
+		}
+
+		return result;
+	};
+};

--- a/packages/editor/src/store/middlewares/test/sync-blocks-to-content.js
+++ b/packages/editor/src/store/middlewares/test/sync-blocks-to-content.js
@@ -1,0 +1,105 @@
+/**
+ * Internal dependencies
+ */
+import * as selectors from '../../selectors';
+import { isForcedParse, isSkippedParse, getPostContent } from '../sync-blocks-to-content';
+
+jest.mock( '../../selectors', () => ( {
+	getPostEdits: jest.fn(),
+	getCurrentPostAttribute: jest.fn(),
+} ) );
+
+describe( 'syncBlocksToContent', () => {
+	beforeEach( () => {
+		selectors.getPostEdits.mockReset();
+		selectors.getCurrentPostAttribute.mockReset();
+	} );
+
+	describe( 'isForcedParse', () => {
+		it( 'should return false if there are no action options', () => {
+			const result = isForcedParse( {} );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false if there is no skip flag', () => {
+			const result = isForcedParse( { options: {} } );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false if skip flag is present and not false', () => {
+			const result = isForcedParse( {
+				options: { skipContentParse: true },
+			} );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return true if skip flag is present and explicitly false', () => {
+			const result = isForcedParse( {
+				options: { skipContentParse: false },
+			} );
+
+			expect( result ).toBe( true );
+		} );
+	} );
+
+	describe( 'isSkippedParse', () => {
+		it( 'should return false if there are no action options', () => {
+			const result = isForcedParse( {} );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false if there is no skip flag', () => {
+			const result = isForcedParse( { options: {} } );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false if skip flag is present and false', () => {
+			const result = isSkippedParse( {
+				options: { skipContentParse: false },
+			} );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return true if skip flag is present and true', () => {
+			const result = isSkippedParse( {
+				options: { skipContentParse: true },
+			} );
+
+			expect( result ).toBe( true );
+		} );
+	} );
+
+	describe( 'getPostContent', () => {
+		it( 'should prefer the edited content', () => {
+			selectors.getPostEdits.mockReturnValue( { content: '' } );
+			selectors.getCurrentPostAttribute.mockImplementation( ( state, attribute ) => {
+				return attribute === 'content' ? 'bar' : '__unexpected__';
+			} );
+
+			const state = {};
+
+			const content = getPostContent( state );
+
+			expect( content ).toBe( '' );
+		} );
+
+		it( 'should fall back to using persisted post content', () => {
+			selectors.getPostEdits.mockReturnValue( {} );
+			selectors.getCurrentPostAttribute.mockImplementation( ( state, attribute ) => {
+				return attribute === 'content' ? 'bar' : '__unexpected__';
+			} );
+
+			const state = {};
+
+			const content = getPostContent( state );
+
+			expect( content ).toBe( 'bar' );
+		} );
+	} );
+} );

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -215,22 +215,22 @@ export const editor = flow( [
 
 	// Track undo history, starting at editor initialization.
 	withHistory( {
-		resetTypes: [ 'SETUP_EDITOR_STATE' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'UPDATE_POST' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'RESET_BLOCKS', 'UPDATE_POST' ],
+		isIgnored: ( action ) => !! ( action.options && action.options.quiet ),
 		shouldOverwriteState,
 	} ),
 
 	// Track whether changes exist, resetting at each post save. Relies on
 	// editor initialization firing post reset as an effect.
 	withChangeDetection( {
-		resetTypes: [ 'SETUP_EDITOR_STATE', 'REQUEST_POST_UPDATE_START' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'UPDATE_POST' ],
+		resetTypes: [ 'REQUEST_POST_UPDATE_START' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'RESET_BLOCKS', 'UPDATE_POST' ],
+		isIgnored: ( action ) => !! ( action.options && action.options.quiet ),
 	} ),
 ] )( {
 	edits( state = {}, action ) {
 		switch ( action.type ) {
 			case 'EDIT_POST':
-			case 'SETUP_EDITOR_STATE':
 				return reduce( action.edits, ( result, value, key ) => {
 					// Only assign into result if not already same value
 					if ( value !== state[ key ] ) {
@@ -245,13 +245,6 @@ export const editor = flow( [
 
 					return result;
 				}, state );
-
-			case 'RESET_BLOCKS':
-				if ( 'content' in state ) {
-					return omit( state, 'content' );
-				}
-
-				return state;
 
 			case 'DIRTY_ARTIFICIALLY':
 				return { ...state };
@@ -282,7 +275,6 @@ export const editor = flow( [
 	blocksByClientId( state = {}, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
-			case 'SETUP_EDITOR_STATE':
 				return getFlattenedBlocks( action.blocks );
 
 			case 'RECEIVE_BLOCKS':
@@ -406,7 +398,6 @@ export const editor = flow( [
 	blockOrder( state = {}, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
-			case 'SETUP_EDITOR_STATE':
 				return mapBlockOrder( action.blocks );
 
 			case 'RECEIVE_BLOCKS':
@@ -545,7 +536,6 @@ export const editor = flow( [
  */
 export function currentPost( state = {}, action ) {
 	switch ( action.type ) {
-		case 'SETUP_EDITOR_STATE':
 		case 'RESET_POST':
 		case 'UPDATE_POST':
 			let post;

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1396,11 +1396,6 @@ export function getBlocksForSerialization( state ) {
  */
 export const getEditedPostContent = createSelector(
 	( state ) => {
-		const edits = getPostEdits( state );
-		if ( 'content' in edits ) {
-			return edits.content;
-		}
-
 		const blocks = getBlocksForSerialization( state );
 		const content = serialize( blocks );
 
@@ -1418,10 +1413,7 @@ export const getEditedPostContent = createSelector(
 
 		return content;
 	},
-	( state ) => [
-		...getBlocks.getDependants( state ),
-		state.editor.present.edits.content,
-	],
+	( state ) => getBlocks.getDependants( state )
 );
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -557,6 +557,8 @@ export const getBlocks = createSelector(
 	( state ) => [
 		state.editor.present.blockOrder,
 		state.editor.present.blocksByClientId,
+		state.editor.present.edits.meta,
+		state.currentPost.meta,
 	]
 );
 
@@ -1417,9 +1419,8 @@ export const getEditedPostContent = createSelector(
 		return content;
 	},
 	( state ) => [
+		...getBlocks.getDependants( state ),
 		state.editor.present.edits.content,
-		state.editor.present.blocksByClientId,
-		state.editor.present.blockOrder,
 	],
 );
 

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -11,7 +11,6 @@ import {
 	convertBlockToStatic,
 	convertBlockToReusable,
 	toggleSelection,
-	setupEditor,
 	resetPost,
 	resetBlocks,
 	updateBlockAttributes,
@@ -45,19 +44,6 @@ import {
 } from '../actions';
 
 describe( 'actions', () => {
-	describe( 'setupEditor', () => {
-		it( 'should return the SETUP_EDITOR action', () => {
-			const post = {};
-			const autosave = {};
-			const result = setupEditor( post, autosave );
-			expect( result ).toEqual( {
-				type: 'SETUP_EDITOR',
-				post,
-				autosave,
-			} );
-		} );
-	} );
-
 	describe( 'resetPost', () => {
 		it( 'should return the RESET_POST action', () => {
 			const post = {};
@@ -236,6 +222,17 @@ describe( 'actions', () => {
 			expect( editPost( edits ) ).toEqual( {
 				type: 'EDIT_POST',
 				edits,
+				options: {},
+			} );
+		} );
+
+		it( 'should return EDIT_POST action with options', () => {
+			const edits = { format: 'sample' };
+			const options = { quiet: true };
+			expect( editPost( edits, options ) ).toEqual( {
+				type: 'EDIT_POST',
+				edits,
+				options,
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/effects.js
+++ b/packages/editor/src/store/test/effects.js
@@ -19,7 +19,6 @@ import { createRegistry } from '@wordpress/data';
  */
 import actions, {
 	updateEditorSettings,
-	setupEditorState,
 	mergeBlocks,
 	replaceBlocks,
 	resetBlocks,
@@ -417,102 +416,6 @@ describe( 'effects', () => {
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
 			expect( dispatch ).toHaveBeenCalledWith( createErrorNotice( 'Updating failed', { id: 'SAVE_POST_NOTICE_ID' } ) );
-		} );
-	} );
-
-	describe( '.SETUP_EDITOR', () => {
-		const handler = effects.SETUP_EDITOR;
-
-		afterEach( () => {
-			getBlockTypes().forEach( ( block ) => {
-				unregisterBlockType( block.name );
-			} );
-		} );
-
-		it( 'should return post reset action', () => {
-			const post = {
-				id: 1,
-				title: {
-					raw: 'A History of Pork',
-				},
-				content: {
-					raw: '',
-				},
-				status: 'draft',
-			};
-			const getState = () => ( {
-				settings: {
-					template: null,
-					templateLock: false,
-				},
-				template: {
-					isValid: true,
-				},
-			} );
-
-			const result = handler( { post, settings: {} }, { getState } );
-
-			expect( result ).toEqual( [
-				setupEditorState( post, [], {} ),
-			] );
-		} );
-
-		it( 'should return block reset with non-empty content', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-			const post = {
-				id: 1,
-				title: {
-					raw: 'A History of Pork',
-				},
-				content: {
-					raw: '<!-- wp:core/test-block -->Saved<!-- /wp:core/test-block -->',
-				},
-				status: 'draft',
-			};
-			const getState = () => ( {
-				settings: {
-					template: null,
-					templateLock: false,
-				},
-				template: {
-					isValid: true,
-				},
-			} );
-
-			const result = handler( { post }, { getState } );
-
-			expect( result[ 0 ].blocks ).toHaveLength( 1 );
-			expect( result ).toEqual( [
-				setupEditorState( post, result[ 0 ].blocks, {} ),
-			] );
-		} );
-
-		it( 'should return post setup action only if auto-draft', () => {
-			const post = {
-				id: 1,
-				title: {
-					raw: 'A History of Pork',
-				},
-				content: {
-					raw: '',
-				},
-				status: 'auto-draft',
-			};
-			const getState = () => ( {
-				settings: {
-					template: null,
-					templateLock: false,
-				},
-				template: {
-					isValid: true,
-				},
-			} );
-
-			const result = handler( { post }, { getState } );
-
-			expect( result ).toEqual( [
-				setupEditorState( post, [], { title: 'A History of Pork' } ),
-			] );
 		} );
 	} );
 

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1184,7 +1184,7 @@ describe( 'state', () => {
 					} ],
 				} );
 
-				expect( state.past ).toHaveLength( 1 );
+				expect( state.past ).toHaveLength( 0 );
 
 				state = editor( state, {
 					type: 'UPDATE_BLOCK_ATTRIBUTES',
@@ -1202,7 +1202,7 @@ describe( 'state', () => {
 					},
 				} );
 
-				expect( state.past ).toHaveLength( 2 );
+				expect( state.past ).toHaveLength( 1 );
 			} );
 
 			it( 'should not overwrite present history if updating different attributes', () => {
@@ -1217,7 +1217,7 @@ describe( 'state', () => {
 					} ],
 				} );
 
-				expect( state.past ).toHaveLength( 1 );
+				expect( state.past ).toHaveLength( 0 );
 
 				state = editor( state, {
 					type: 'UPDATE_BLOCK_ATTRIBUTES',
@@ -1235,7 +1235,7 @@ describe( 'state', () => {
 					},
 				} );
 
-				expect( state.past ).toHaveLength( 3 );
+				expect( state.past ).toHaveLength( 2 );
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1037,22 +1037,6 @@ describe( 'state', () => {
 				} );
 			} );
 
-			it( 'should save initial post state', () => {
-				const state = editor( undefined, {
-					type: 'SETUP_EDITOR_STATE',
-					edits: {
-						status: 'draft',
-						title: 'post title',
-					},
-					blocks: [],
-				} );
-
-				expect( state.present.edits ).toEqual( {
-					status: 'draft',
-					title: 'post title',
-				} );
-			} );
-
 			it( 'should omit content when resetting', () => {
 				// Use case: When editing in Text mode, we defer to content on
 				// the property, but we reset blocks by parse when switching

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2931,31 +2931,6 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		it( 'defers to returning an edited post attribute', () => {
-			const block = createBlock( 'core/block' );
-
-			const state = {
-				editor: {
-					present: {
-						blockOrder: {
-							'': [ block.clientId ],
-						},
-						blocksByClientId: {
-							[ block.clientId ]: block,
-						},
-						edits: {
-							content: 'custom edit',
-						},
-					},
-				},
-				currentPost: {},
-			};
-
-			const content = getEditedPostContent( state );
-
-			expect( content ).toBe( 'custom edit' );
-		} );
-
 		it( 'returns serialization of blocks', () => {
 			const block = createBlock( 'core/block' );
 

--- a/packages/editor/src/utils/with-change-detection/index.js
+++ b/packages/editor/src/utils/with-change-detection/index.js
@@ -4,17 +4,35 @@
 import { includes } from 'lodash';
 
 /**
+ * Default options for withChangeDetection reducer enhancer. Refer to
+ * withChangeDetection documentation for options explanation.
+ *
+ * @see withChangeDetection
+ *
+ * @type {Object}
+ */
+const DEFAULT_OPTIONS = {
+	resetTypes: [],
+	ignoreTypes: [],
+	isIgnored: () => false,
+};
+
+/**
  * Higher-order reducer creator for tracking changes to state over time. The
  * returned reducer will include a `isDirty` property on the object reflecting
  * whether the original reference of the reducer has changed.
  *
- * @param {?Object} options             Optional options.
- * @param {?Array}  options.ignoreTypes Action types upon which to skip check.
- * @param {?Array}  options.resetTypes  Action types upon which to reset dirty.
+ * @param {?Object}   options             Optional options.
+ * @param {?Array}    options.ignoreTypes Action types at which to skip check.
+ * @param {?Array}    options.resetTypes  Action types at which to reset dirty.
+ * @param {?Function} options.isIgnored   Function given action, to return true
+ *                                        if to disregard changing state.
  *
  * @return {Function} Higher-order reducer.
  */
-const withChangeDetection = ( options = {} ) => ( reducer ) => {
+const withChangeDetection = ( options ) => ( reducer ) => {
+	options = { ...DEFAULT_OPTIONS, ...options };
+
 	return ( state, action ) => {
 		let nextState = reducer( state, action );
 
@@ -47,7 +65,10 @@ const withChangeDetection = ( options = {} ) => ( reducer ) => {
 			nextState = { ...nextState };
 		}
 
-		const isIgnored = includes( options.ignoreTypes, action.type );
+		const isIgnored = (
+			includes( options.ignoreTypes, action.type ) ||
+			options.isIgnored( action )
+		);
 
 		if ( isIgnored ) {
 			// Preserve the original value if ignored.

--- a/packages/editor/src/utils/with-change-detection/index.js
+++ b/packages/editor/src/utils/with-change-detection/index.js
@@ -18,6 +18,14 @@ const withChangeDetection = ( options = {} ) => ( reducer ) => {
 	return ( state, action ) => {
 		let nextState = reducer( state, action );
 
+		// If initial state, assume non-dirty.
+		if ( state === undefined ) {
+			return {
+				...nextState,
+				isDirty: false,
+			};
+		}
+
 		// Reset at:
 		//  - Initial state
 		//  - Reset types
@@ -34,8 +42,8 @@ const withChangeDetection = ( options = {} ) => ( reducer ) => {
 		}
 
 		// Avoid mutating state, unless it's already changing by original
-		// reducer and not initial.
-		if ( ! isChanging || state === undefined ) {
+		// reducer.
+		if ( ! isChanging ) {
 			nextState = { ...nextState };
 		}
 

--- a/packages/editor/src/utils/with-change-detection/test/index.js
+++ b/packages/editor/src/utils/with-change-detection/test/index.js
@@ -65,6 +65,20 @@ describe( 'withChangeDetection()', () => {
 		expect( state ).toEqual( { count: 1, isDirty: false } );
 	} );
 
+	it( 'should allow ignore callback as option', () => {
+		const reducer = withChangeDetection( {
+			isIgnored: ( action ) => action.type === 'INCREMENT',
+		} )( originalReducer );
+
+		let state;
+
+		state = reducer( undefined, {} );
+		expect( state ).toEqual( { count: 0, isDirty: false } );
+
+		state = reducer( deepFreeze( state ), { type: 'INCREMENT' } );
+		expect( state ).toEqual( { count: 1, isDirty: false } );
+	} );
+
 	it( 'should treat an initial ignore type as default false dirty', () => {
 		const reducer = withChangeDetection( { ignoreTypes: [ 'INCREMENT' ] } )( originalReducer );
 

--- a/packages/editor/src/utils/with-change-detection/test/index.js
+++ b/packages/editor/src/utils/with-change-detection/test/index.js
@@ -65,6 +65,13 @@ describe( 'withChangeDetection()', () => {
 		expect( state ).toEqual( { count: 1, isDirty: false } );
 	} );
 
+	it( 'should treat an initial ignore type as default false dirty', () => {
+		const reducer = withChangeDetection( { ignoreTypes: [ 'INCREMENT' ] } )( originalReducer );
+
+		const state = reducer( undefined, { type: 'INCREMENT' } );
+		expect( state ).toEqual( { count: 1, isDirty: false } );
+	} );
+
 	it( 'should preserve isDirty into non-resetting non-reference-changing types', () => {
 		const reducer = withChangeDetection( { resetTypes: [ 'RESET' ] } )( originalReducer );
 

--- a/packages/editor/src/utils/with-history/index.js
+++ b/packages/editor/src/utils/with-history/index.js
@@ -15,6 +15,7 @@ const DEFAULT_OPTIONS = {
 	resetTypes: [],
 	ignoreTypes: [],
 	shouldOverwriteState: () => false,
+	isIgnored: () => false,
 };
 
 /**
@@ -26,6 +27,9 @@ const DEFAULT_OPTIONS = {
  *                                                 clear past.
  * @param {?Array}    options.ignoreTypes          Action types upon which to
  *                                                 avoid history tracking.
+ * @param {?Function} options.isIgnored            Function given action, to
+ *                                                 return true if intended to
+ *                                                 avoid history tracking.
  * @param {?Function} options.shouldOverwriteState Function receiving last and
  *                                                 current actions, returning
  *                                                 boolean indicating whether
@@ -34,13 +38,14 @@ const DEFAULT_OPTIONS = {
  *
  * @return {Function} Higher-order reducer.
  */
-const withHistory = ( options = {} ) => ( reducer ) => {
+const withHistory = ( options ) => ( reducer ) => {
 	options = { ...DEFAULT_OPTIONS, ...options };
 
-	// `ignoreTypes` is simply a convenience for `shouldOverwriteState`
+	// `ignoreTypes`, `isIgnored` are conveniences for `shouldOverwriteState`
 	options.shouldOverwriteState = overSome( [
 		options.shouldOverwriteState,
 		( action ) => includes( options.ignoreTypes, action.type ),
+		( action ) => options.isIgnored( action ),
 	] );
 
 	const initialState = {

--- a/packages/editor/src/utils/with-history/index.js
+++ b/packages/editor/src/utils/with-history/index.js
@@ -116,7 +116,6 @@ const withHistory = ( options = {} ) => ( reducer ) => {
 
 		if (
 			shouldCreateUndoLevel ||
-			! past.length ||
 			! shouldOverwriteState( action, previousAction )
 		) {
 			nextPast = [ ...past, present ];

--- a/packages/editor/src/utils/with-history/test/index.js
+++ b/packages/editor/src/utils/with-history/test/index.js
@@ -131,6 +131,25 @@ describe( 'withHistory', () => {
 		} );
 	} );
 
+	it( 'should ignore history by options.isIgnored', () => {
+		const reducer = withHistory( {
+			isIgnored: ( action ) => action.type === 'INCREMENT',
+		} )( counter );
+
+		let state;
+		state = reducer( undefined, {} );
+		state = reducer( state, { type: 'INCREMENT' } );
+		state = reducer( state, { type: 'INCREMENT' } );
+
+		expect( state ).toEqual( {
+			past: [],
+			present: 2,
+			future: [],
+			lastAction: { type: 'INCREMENT' },
+			shouldCreateUndoLevel: false,
+		} );
+	} );
+
 	it( 'should return same reference if state has not changed', () => {
 		const reducer = withHistory()( counter );
 		const original = reducer( undefined, {} );

--- a/packages/editor/src/utils/with-history/test/index.js
+++ b/packages/editor/src/utils/with-history/test/index.js
@@ -123,7 +123,7 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ 0 ], // Needs at least one history
+			past: [],
 			present: 2,
 			future: [],
 			lastAction: { type: 'INCREMENT' },
@@ -149,18 +149,8 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ 0 ],
+			past: [],
 			present: 1,
-			future: [],
-			lastAction: { type: 'INCREMENT' },
-			shouldCreateUndoLevel: false,
-		} );
-
-		state = reducer( state, { type: 'INCREMENT' } );
-
-		expect( state ).toEqual( {
-			past: [ 0 ],
-			present: 2,
 			future: [],
 			lastAction: { type: 'INCREMENT' },
 			shouldCreateUndoLevel: false,
@@ -178,7 +168,7 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'CREATE_UNDO_LEVEL' } );
 
 		expect( state ).toEqual( {
-			past: [ 0 ],
+			past: [],
 			present: 1,
 			future: [],
 			lastAction: null,
@@ -188,7 +178,7 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ 0, 1 ],
+			past: [ 1 ],
 			present: 2,
 			future: [],
 			lastAction: { type: 'INCREMENT' },

--- a/test/e2e/specs/code-editor.test.js
+++ b/test/e2e/specs/code-editor.test.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { newPost, switchToEditor } from '../support/utils';
+
+describe( 'Code Editor', () => {
+	beforeEach( async () => {
+		await newPost();
+		await switchToEditor( 'Code' );
+	} );
+
+	it( 'should dirty when text is input', async () => {
+	} );
+
+	it( 'should display save option when blurring field', async () => {
+	} );
+
+	it( 'should allow the user to delete all content from field', async () => {
+	} );
+} );


### PR DESCRIPTION
~Blocked by: #9287~ (merged)
~Fixes regression introduced in #9288 (https://github.com/WordPress/gutenberg/pull/9288#issuecomment-416150437)~ (Fixed separately by #9448)
Related: #7970

This pull request seeks to refactor how blocks state is kept in sync with the edited post content, in an effort to simplify / improve consistency of behaviors around editor content initialization.

**Status:** This pull request is rather large and includes a few changes that could potentially be forked out into their own, blocking pull requests (see commits as standalone indicators). It is otherwise expected to be fully functional and passing all tests. New end-to-end tests are planned to verify associated code editor impact, but there are presently issues with the local Docker installation, making end-to-end test authoring impossible for the moment.

**Goal:** The editor module needn't be so conscious of distinct start and end points. It should render itself as derived by its state at any given moment in time. This should help enable efforts like that of #7970, where the editor may need to present itself without relying on a synchronous initialization setup. It is made challenging by various factors such as: enacting a template, assigning initial edits, alerting the user to the presence of an existing autosave which can be restored. To me, these are considerations which should be moved into the scope of `edit-post`. This has its own set of challenges, and is proposed to be addressed separately to the work here.

**Changes:**

- Deprecating `setupEditor`, `setupEditorState`, and `checkTemplateValidity` actions from the editor module
   - Template validation occurs automatically as an effect of `RESET_BLOCKS`
- Refactoring `overridePost` as representing an initial set of edits (for demo content, auto-draft edits)
   - This also avoids needing to account for the auto-draft initial title edit in the editor effects
- Avoid initial history for ignored types in `withHistory` higher-order reducer
   - cc @iseulde , I cannot recall the original reason for this behavior, and while it's sensible to have the initial value to revert back upon as the "starting" history, it doesn't follow that ignored types option would be disregarded to assign this initial value. As it impacts the changes here, without the change it was causing an initial Undo option to be shown when loading the editor.
- Fix bug with how we consider prop and state relationship of edited content value in `PostTextEditor`

**Implementation notes:**

- This changes how we consider the source of truth for post content.
   - Previously there was an awkward juggling of `edits`, where if `content` was assigned as `edits` (as in by the Code Editor textarea), it would be preferred. This was to accommodate the fact that parsing content is a non-performant task to perform on each key press, thus the parse was deferred. However, this introduced a dual source of truth for content (sometimes as a serialization of blocks state, sometimes as the `edits.content` property).
   - With these changes, blocks are always considered as the source of truth for content, and the state value is synced automatically to any changes which occur to the post's edited or persisted content string (via the newly-introduced middleware).
   - To maintain existing Code Editor behavior, an optional flag is supported in the sync middleware to skip the parse. It's assumed this would be followed by a later deferred parse; in the code editor, on the blur of the text field.
      - However, this has a few consequences on how the Code Editor behaves:
         - If the post was not saveable because it had no title, content, or excerpt, and I add content in the Code Editor, it will not be reflected in the UI (by presence of the save button) until I blur the field. 
         - If autosave occurs while I am within Code Editor, the saved payload will not include the in-progress edits, but rather the value of content before I began editing. If I then blur the field, the editor will correctly show as having changes needing to be saved (the deferred parse). One exception is if I press Cmd+R (reload) while within the code editor, I may not be prompted about unsaved changes because the deferred parse has not yet occurred by that time. This could probably be remedied by enhancements proposed by #7409.
      - Considering the goal in consolidating how we consider post content, these changes aren't _technically_ unexpected, but have the potential for a negative impact on user experience.
- This introduces an affordance of "quiet" state changes. We already have a number of state mechanisms and initialization steps which cause state values to change, but for which we don't want to prompt the user about unsaved changes / add history levels. This can be seen with demo content and the auto-draft initial edits, where the initial edits should not be considered as "unsaved", nor should they be undo-able.

**Future tasks:**

- Consider moving more behaviors which continue to live in `EditorProvider` into the `edit-post` module, namely template synchronization and the autosave warning.
   - It's unclear whether "template" should be considered a setting of the editor, as there is mixed expectations on when it is synchronized. Is it just a starting point for a new post? Do we apply the template when editing an existing post which does not adhere to the template? This has the potential for being destructive, and if we were to consider changing it to a user behavior, it would seem to follow that the editor doesn't need to be aware of some ongoing template, since the enacting of the template synchronization would be an explicit action.

**Testing instructions:**

Verify there are no regressions in the initialization of the editor, notably:

- New post without template
   - Should not show "Auto Draft" title
   - Should not save an "Auto Draft" title, even if title is left empty
- New post with template
- Editing existing post with content
- Editing existing post where template would exist, but content differs from template (see also testing instructions from #9288 )
- Demo post

Verify that HTML edits made in the Code Editor are respected:

- Post should be marked as dirty _after focus leaves the textarea field_
- Switching back to Visual Editor should display blocks as edited in Code Editor