### PR TITLE
Add "Text & Image" Block

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -14,6 +14,7 @@
 @import "./image/editor.scss";
 @import "./latest-comments/editor.scss";
 @import "./latest-posts/editor.scss";
+@import "./media-text/editor.scss";
 @import "./list/editor.scss";
 @import "./more/editor.scss";
 @import "./nextpage/editor.scss";

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -28,6 +28,7 @@ import * as cover from './cover';
 import * as embed from './embed';
 import * as file from './file';
 import * as html from './html';
+import * as mediaText from './media-text';
 import * as latestComments from './latest-comments';
 import * as latestPosts from './latest-posts';
 import * as list from './list';
@@ -76,6 +77,7 @@ export const registerCoreBlocks = () => {
 		file,
 		window.wp && window.wp.oldEditor ? classic : null, // Only add the classic block in WP Context
 		html,
+		mediaText,
 		latestComments,
 		latestPosts,
 		missing,

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -100,10 +100,16 @@ class MediaTextEdit extends Component {
 	}
 
 	render() {
-		const { attributes, backgroundColor, setAttributes, setBackgroundColor } = this.props;
+		const {
+			attributes,
+			className,
+			backgroundColor,
+			setAttributes,
+			setBackgroundColor,
+		} = this.props;
 		const { mediaPosition, mediaWidth } = attributes;
 		const temporaryMediaWidth = this.state.mediaWidth;
-		const className = classnames( 'wp-block-media-text', {
+		const classNames = classnames( className, {
 			'has-media-on-the-right': 'right' === mediaPosition,
 			[ backgroundColor.class ]: backgroundColor.class,
 		} );
@@ -142,7 +148,7 @@ class MediaTextEdit extends Component {
 						controls={ toolbarControls }
 					/>
 				</BlockControls>
-				<div className={ className } style={ style } >
+				<div className={ classNames } style={ style } >
 					{ this.renderMediaArea() }
 					<InnerBlocks
 						allowedBlocks={ ALLOWED_BLOCKS }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	BlockControls,
+	InnerBlocks,
+	InspectorControls,
+	PanelColorSettings,
+	withColors,
+} from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import { Toolbar } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import MediaContainer from './media-container';
+
+/**
+ * Constants
+ */
+const ALLOWED_BLOCKS = [ 'core/button', 'core/paragraph', 'core/heading', 'core/list' ];
+const TEMPLATE = [
+	[ 'core/paragraph', { fontSize: 'large', placeholder: 'Content…' } ],
+];
+
+class MediaTextEdit extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onSelectMedia = this.onSelectMedia.bind( this );
+		this.onWidthChange = this.onWidthChange.bind( this );
+		this.commitWidthChange = this.commitWidthChange.bind( this );
+		this.state = {
+			mediaWidth: null,
+		};
+	}
+
+	onSelectMedia( media ) {
+		const { setAttributes } = this.props;
+
+		let mediaType;
+		// for media selections originated from a file upload.
+		if ( media.media_type ) {
+			if ( media.media_type === 'image' ) {
+				mediaType = 'image';
+			} else {
+				// only images and videos are accepted so if the media_type is not an image we can assume it is a video.
+				// video contain the media type of 'file' in the object returned from the rest api.
+				mediaType = 'video';
+			}
+		} else { // for media selections originated from existing files in the media library.
+			mediaType = media.type;
+		}
+
+		setAttributes( {
+			mediaAlt: media.alt,
+			mediaId: media.id,
+			mediaType,
+			mediaUrl: media.url,
+		} );
+	}
+
+	onWidthChange( width ) {
+		this.setState( {
+			mediaWidth: width,
+		} );
+	}
+
+	commitWidthChange( width ) {
+		const { setAttributes } = this.props;
+
+		setAttributes( {
+			mediaWidth: width,
+		} );
+		this.setState( {
+			mediaWidth: null,
+		} );
+	}
+
+	renderMediaArea() {
+		const { attributes } = this.props;
+		const { mediaAlt, mediaId, mediaPosition, mediaType, mediaUrl, mediaWidth } = attributes;
+
+		return (
+			<MediaContainer
+				className="block-library-media-text__media-container"
+				onSelectMedia={ this.onSelectMedia }
+				onWidthChange={ this.onWidthChange }
+				commitWidthChange={ this.commitWidthChange }
+				{ ...{ mediaAlt, mediaId, mediaType, mediaUrl, mediaPosition, mediaWidth } }
+			/>
+		);
+	}
+
+	render() {
+		const { attributes, backgroundColor, setAttributes, setBackgroundColor } = this.props;
+		const { mediaPosition, mediaWidth } = attributes;
+		const temporaryMediaWidth = this.state.mediaWidth;
+		const className = classnames( 'wp-block-media-text', {
+			'has-media-on-the-right': 'right' === mediaPosition,
+			[ backgroundColor.class ]: backgroundColor.class,
+		} );
+		const widthString = `${ temporaryMediaWidth || mediaWidth }%`;
+		const style = {
+			gridTemplateColumns: 'right' === mediaPosition ? `auto ${ widthString }` : `${ widthString } auto`,
+			backgroundColor: backgroundColor.color,
+		};
+		const colorSettings = [ {
+			value: backgroundColor.color,
+			onChange: setBackgroundColor,
+			label: __( 'Background Color' ),
+		} ];
+		const toolbarControls = [ {
+			icon: 'align-pull-left',
+			title: __( 'Show media on left' ),
+			isActive: mediaPosition === 'left',
+			onClick: () => setAttributes( { mediaPosition: 'left' } ),
+		}, {
+			icon: 'align-pull-right',
+			title: __( 'Show media on right' ),
+			isActive: mediaPosition === 'right',
+			onClick: () => setAttributes( { mediaPosition: 'right' } ),
+		} ];
+		return (
+			<Fragment>
+				<InspectorControls>
+					<PanelColorSettings
+						title={ __( 'Color Settings' ) }
+						initialOpen={ false }
+						colorSettings={ colorSettings }
+					/>
+				</InspectorControls>
+				<BlockControls>
+					<Toolbar
+						controls={ toolbarControls }
+					/>
+				</BlockControls>
+				<div className={ className } style={ style } >
+					{ this.renderMediaArea() }
+					<InnerBlocks
+						allowedBlocks={ ALLOWED_BLOCKS }
+						template={ TEMPLATE }
+					/>
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+export default withColors( 'backgroundColor' )( MediaTextEdit );

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -1,5 +1,3 @@
-
-
 .wp-block-media-text,
 .wp-block-media-text.aligncenter {
 	grid-template-areas:

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -1,0 +1,61 @@
+
+
+.wp-block-media-text,
+.wp-block-media-text.aligncenter {
+	grid-template-areas:
+		"media-text-media media-text-content"
+		"resizer resizer";
+}
+
+.wp-block-media-text.has-media-on-the-right,
+.wp-block-media-text.has-media-on-the-right.aligncenter {
+	grid-template-areas:
+		"media-text-content media-text-media"
+		"resizer resizer";
+}
+
+.wp-block-media-text .__resizable_base__ {
+	grid-area: resizer;
+}
+
+.wp-block-media-text .editor-media-container__resizer {
+	grid-area: media-text-media;
+	align-self: center;
+	// The resizer sets a inline width but as we are using a grid layout,
+	// we set the width on container.
+	width: 100% !important;
+}
+
+.wp-block-media-text .editor-inner-blocks {
+	word-break: break-word;
+	grid-area: media-text-content;
+	text-align: initial;
+	padding: 0 8% 0 8%;
+}
+
+.wp-block-media-text > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block {
+	max-width: unset;
+}
+
+figure.block-library-media-text__media-container {
+	margin: 0;
+	height: 100%;
+	width: 100%;
+}
+
+.wp-block-media-text .block-library-media-text__media-container img,
+.wp-block-media-text .block-library-media-text__media-container video {
+	margin-bottom: -8px;
+	width: 100%;
+}
+
+.editor-media-container__resizer .components-resizable-box__handle {
+	display: none;
+}
+
+.editor-block-list__block.is-selected,
+.editor-block-list__block.is-focused {
+	.editor-media-container__resizer .components-resizable-box__handle {
+		display: block;
+	}
+}

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	InnerBlocks,
+	getColorClassName,
+} from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+
+const DEFAULT_MEDIA_WIDTH = 50;
+
+export const name = 'core/media-text';
+
+export const settings = {
+	title: __( 'Media & Text' ),
+
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 17h8v-2h-8v2zM3 19h8V5H3v14zM13 9h8V7h-8v2zm0 4h8v-2h-8v2z" /></svg>,
+
+	category: 'layout',
+
+	attributes: {
+		align: {
+			type: 'string',
+			default: 'wide',
+		},
+		backgroundColor: {
+			type: 'string',
+		},
+		customBackgroundColor: {
+			type: 'string',
+		},
+		mediaAlt: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure img',
+			attribute: 'alt',
+			default: '',
+		},
+		mediaPosition: {
+			type: 'string',
+			default: 'left',
+		},
+		mediaId: {
+			type: 'number',
+		},
+		mediaUrl: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure video,figure img',
+			attribute: 'src',
+		},
+		mediaType: {
+			type: 'string',
+		},
+		mediaWidth: {
+			type: 'number',
+			default: 50,
+		},
+	},
+
+	supports: {
+		align: [ 'wide', 'full' ],
+	},
+
+	edit,
+
+	save( { attributes } ) {
+		const {
+			backgroundColor,
+			customBackgroundColor,
+			mediaAlt,
+			mediaPosition,
+			mediaType,
+			mediaUrl,
+			mediaWidth,
+		} = attributes;
+		const mediaTypeRenders = {
+			image: () => {
+				return (
+					<img src={ mediaUrl } alt={ mediaAlt } />
+				);
+			},
+			video: () => {
+				return (
+					<video controls src={ mediaUrl } />
+				);
+			},
+		};
+
+		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+		const className = classnames( {
+			'has-media-on-the-right': 'right' === mediaPosition,
+			[ backgroundClass ]: backgroundClass,
+		} );
+
+		let gridTemplateColumns;
+		if ( mediaWidth !== DEFAULT_MEDIA_WIDTH ) {
+			gridTemplateColumns = 'right' === mediaPosition ? `auto ${ mediaWidth }%` : `${ mediaWidth }% auto`;
+		}
+		const style = {
+			backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+			gridTemplateColumns,
+		};
+		return (
+			<div className={ className } style={ style }>
+				<figure className="wp-block-media-text__media" >
+					{ ( mediaTypeRenders[ mediaType ] || noop )() }
+				</figure>
+				<div className="wp-block-media-text__content">
+					<InnerBlocks.Content />
+				</div>
+			</div>
+		);
+	},
+};

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -29,6 +29,8 @@ export const settings = {
 
 	category: 'layout',
 
+	keywords: [ __( 'image' ), __( 'video' ), __( 'half' ) ],
+
 	attributes: {
 		align: {
 			type: 'string',
@@ -86,16 +88,8 @@ export const settings = {
 			mediaWidth,
 		} = attributes;
 		const mediaTypeRenders = {
-			image: () => {
-				return (
-					<img src={ mediaUrl } alt={ mediaAlt } />
-				);
-			},
-			video: () => {
-				return (
-					<video controls src={ mediaUrl } />
-				);
-			},
+			image: () => <img src={ mediaUrl } alt={ mediaAlt } />,
+			video: () => <video controls src={ mediaUrl } />,
 		};
 
 		const backgroundClass = getColorClassName( 'background-color', backgroundColor );

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -1,0 +1,125 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { IconButton, ResizableBox, Toolbar } from '@wordpress/components';
+import {
+	BlockControls,
+	MediaPlaceholder,
+	MediaUpload,
+} from '@wordpress/editor';
+
+/**
+ * Constants
+ */
+const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+
+class MediaContainer extends Component {
+	renderToolbarEditButton() {
+		const { mediaId, onSelectMedia } = this.props;
+		return (
+			<BlockControls>
+				<Toolbar>
+					<MediaUpload
+						onSelect={ onSelectMedia }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ mediaId }
+						render={ ( { open } ) => (
+							<IconButton
+								className="components-toolbar__control"
+								label={ __( 'Edit Media' ) }
+								icon="edit"
+								onClick={ open }
+							/>
+						) }
+					/>
+				</Toolbar>
+			</BlockControls>
+		);
+	}
+
+	renderImage() {
+		const { mediaAlt, mediaUrl, className } = this.props;
+		return (
+			<Fragment>
+				{ this.renderToolbarEditButton() }
+				<figure className={ className }>
+					<img src={ mediaUrl } alt={ mediaAlt } />
+				</figure>
+			</Fragment>
+		);
+	}
+
+	renderVideo() {
+		const { mediaUrl, className } = this.props;
+		return (
+			<Fragment>
+				{ this.renderToolbarEditButton() }
+				<figure className={ className }>
+					<video controls src={ mediaUrl } />
+				</figure>
+			</Fragment>
+		);
+	}
+
+	renderPlaceholder() {
+		const { onSelectMedia, className } = this.props;
+		return (
+			<MediaPlaceholder
+				icon="format-image"
+				labels={ {
+					title: __( 'Media area' ),
+					name: __( 'a media file (image or video)' ),
+				} }
+				className={ className }
+				onSelect={ onSelectMedia }
+				accept="image/*,video/*"
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+			/>
+		);
+	}
+
+	render() {
+		const { mediaPosition, mediaUrl, mediaType, mediaWidth, commitWidthChange, onWidthChange } = this.props;
+		if ( mediaType && mediaUrl ) {
+			const onResize = ( event, direction, elt ) => {
+				onWidthChange( parseInt( elt.style.width ) );
+			};
+			const onResizeStop = ( event, direction, elt ) => {
+				commitWidthChange( parseInt( elt.style.width ) );
+			};
+			const enablePositions = {
+				right: mediaPosition === 'left',
+				left: mediaPosition === 'right',
+			};
+
+			let mediaElement = null;
+			switch ( mediaType ) {
+				case 'image':
+					mediaElement = this.renderImage();
+					break;
+				case 'video':
+					mediaElement = this.renderVideo();
+					break;
+			}
+			return (
+				<ResizableBox
+					className="editor-media-container__resizer"
+					size={ { width: mediaWidth + '%' } }
+					minWidth="10%"
+					maxWidth="100%"
+					enable={ enablePositions }
+					onResize={ onResize }
+					onResizeStop={ onResizeStop }
+					axis="x"
+				>
+					{ mediaElement }
+				</ResizableBox>
+			);
+		}
+		return this.renderPlaceholder();
+	}
+}
+
+export default MediaContainer;

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -1,0 +1,35 @@
+.wp-block-media-text,
+.wp-block-media-text.aligncenter {
+	display: grid;
+}
+
+.wp-block-media-text {
+	grid-template-rows: auto;
+	grid-template-areas: "media-text-media media-text-content";
+	align-items: center;
+	grid-template-columns: 50% auto;
+	.has-media-on-the-right {
+		grid-template-columns: auto 50%;
+	}
+}
+
+.wp-block-media-text .wp-block-media-text__media {
+	grid-area: media-text-media;
+	margin: 0;
+}
+
+.wp-block-media-text .wp-block-media-text__content {
+	word-break: break-word;
+	grid-area: media-text-content;
+	padding: 0 8% 0 8%;
+}
+.wp-block-media-text.has-media-on-the-right {
+	grid-template-areas: "media-text-content media-text-media";
+}
+
+.wp-block-media-text > figure > img,
+.wp-block-media-text > figure > video {
+	max-width: unset;
+	width: 100%;
+	margin-bottom: -6px;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -11,6 +11,7 @@
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";
 @import "./latest-posts/style.scss";
+@import "./media-text/style.scss";
 @import "./paragraph/style.scss";
 @import "./pullquote/style.scss";
 @import "./quote/style.scss";

--- a/test/integration/full-content/fixtures/core__media-text.html
+++ b/test/integration/full-content/fixtures/core__media-text.html
@@ -1,0 +1,12 @@
+<!-- wp:media-text {"mediaId":17985,"mediaType":"image"} -->
+<div class="wp-block-media-text alignwide">
+	<figure class="wp-block-media-text__media">
+		<img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt=""/>
+	</figure>
+	<div class="wp-block-media-text__content">
+		<!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+		<p class="has-large-font-size">My Content</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text.json
+++ b/test/integration/full-content/fixtures/core__media-text.json
@@ -1,0 +1,32 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/media-text",
+        "isValid": true,
+        "attributes": {
+            "align": "wide",
+            "mediaAlt": "",
+            "mediaPosition": "left",
+            "mediaId": 17985,
+            "mediaUrl": "http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg",
+            "mediaType": "image",
+            "mediaWidth": 50
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "My Content",
+                    "dropCap": false,
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p class=\"has-large-font-size\">My Content</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text.parsed.json
+++ b/test/integration/full-content/fixtures/core__media-text.parsed.json
@@ -1,0 +1,27 @@
+[
+    {
+        "blockName": "core/media-text",
+        "attrs": {
+            "mediaId": 17985,
+            "mediaType": "image"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-large-font-size\">My Content</p>\n\t\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text.serialized.html
+++ b/test/integration/full-content/fixtures/core__media-text.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:media-text {"mediaId":17985,"mediaType":"image"} -->
+<div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+<p class="has-large-font-size">My Content</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.html
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.html
@@ -1,0 +1,12 @@
+<!-- wp:media-text {"align":"none","mediaId":17985,"mediaType":"image"} -->
+<div class="wp-block-media-text">
+	<figure class="wp-block-media-text__media">
+		<img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt="my alt"/>
+	</figure>
+	<div class="wp-block-media-text__content">
+		<!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+		<p class="has-large-font-size">Content</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.json
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.json
@@ -1,0 +1,32 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/media-text",
+        "isValid": true,
+        "attributes": {
+            "align": "none",
+            "mediaAlt": "my alt",
+            "mediaPosition": "left",
+            "mediaId": 17985,
+            "mediaUrl": "http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg",
+            "mediaType": "image",
+            "mediaWidth": 50
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "Content",
+                    "dropCap": false,
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p class=\"has-large-font-size\">Content</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-media-text\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"my alt\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.parsed.json
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.parsed.json
@@ -1,0 +1,28 @@
+[
+    {
+        "blockName": "core/media-text",
+        "attrs": {
+            "align": "none",
+            "mediaId": 17985,
+            "mediaType": "image"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-large-font-size\">Content</p>\n\t\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-media-text\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"my alt\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.serialized.html
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:media-text {"align":"none","mediaId":17985,"mediaType":"image"} -->
+<div class="wp-block-media-text"><figure class="wp-block-media-text__media"><img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt="my alt"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+<p class="has-large-font-size">Content</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.html
+++ b/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.html
@@ -1,0 +1,12 @@
+<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaId":17897,"mediaType":"video","mediaWidth":41} -->
+<div class="wp-block-media-text alignfull has-media-on-the-right" style="grid-template-columns:auto 41%">
+	<figure class="wp-block-media-text__media">
+		<video controls src="http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4"></video>
+	</figure>
+	<div class="wp-block-media-text__content">
+		<!-- wp:paragraph {"align":"right","placeholder":"Content…","fontSize":"large"} -->
+		<p style="text-align:right" class="has-large-font-size">My video</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.json
+++ b/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.json
@@ -1,0 +1,33 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/media-text",
+        "isValid": true,
+        "attributes": {
+            "align": "full",
+            "mediaAlt": "",
+            "mediaPosition": "right",
+            "mediaId": 17897,
+            "mediaUrl": "http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4",
+            "mediaType": "video",
+            "mediaWidth": 41
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "My video",
+                    "align": "right",
+                    "dropCap": false,
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p style=\"text-align:right\" class=\"has-large-font-size\">My video</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-media-text alignfull has-media-on-the-right\" style=\"grid-template-columns:auto 41%\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<video controls src=\"http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4\"></video>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.parsed.json
+++ b/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.parsed.json
@@ -1,0 +1,31 @@
+[
+    {
+        "blockName": "core/media-text",
+        "attrs": {
+            "align": "full",
+            "mediaPosition": "right",
+            "mediaId": 17897,
+            "mediaType": "video",
+            "mediaWidth": 41
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "right",
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p style=\"text-align:right\" class=\"has-large-font-size\">My video</p>\n\t\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-media-text alignfull has-media-on-the-right\" style=\"grid-template-columns:auto 41%\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<video controls src=\"http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4\"></video>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.serialized.html
+++ b/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaId":17897,"mediaType":"video","mediaWidth":41} -->
+<div class="wp-block-media-text alignfull has-media-on-the-right" style="grid-template-columns:auto 41%"><figure class="wp-block-media-text__media"><video controls src="http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4"></video></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"align":"right","placeholder":"Content…","fontSize":"large"} -->
+<p style="text-align:right" class="has-large-font-size">My video</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__video.html
+++ b/test/integration/full-content/fixtures/core__media-text__video.html
@@ -1,0 +1,12 @@
+<!-- wp:media-text {"mediaId":17897,"mediaType":"video"} -->
+<div class="wp-block-media-text alignwide">
+	<figure class="wp-block-media-text__media">
+		<video controls src="http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4"></video>
+	</figure>
+	<div class="wp-block-media-text__content">
+		<!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+		<p class="has-large-font-size">My Content</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__video.json
+++ b/test/integration/full-content/fixtures/core__media-text__video.json
@@ -1,0 +1,32 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/media-text",
+        "isValid": true,
+        "attributes": {
+            "align": "wide",
+            "mediaAlt": "",
+            "mediaPosition": "left",
+            "mediaId": 17897,
+            "mediaUrl": "http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4",
+            "mediaType": "video",
+            "mediaWidth": 50
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "My Content",
+                    "dropCap": false,
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p class=\"has-large-font-size\">My Content</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<video controls src=\"http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4\"></video>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text__video.parsed.json
+++ b/test/integration/full-content/fixtures/core__media-text__video.parsed.json
@@ -1,0 +1,27 @@
+[
+    {
+        "blockName": "core/media-text",
+        "attrs": {
+            "mediaId": 17897,
+            "mediaType": "video"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-large-font-size\">My Content</p>\n\t\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<video controls src=\"http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4\"></video>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text__video.serialized.html
+++ b/test/integration/full-content/fixtures/core__media-text__video.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:media-text {"mediaId":17897,"mediaType":"video"} -->
+<div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><video controls src="http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4"></video></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+<p class="has-large-font-size">My Content</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:media-text -->


### PR DESCRIPTION
# Description

Context: #6993

This PR implements a block that contains two areas one for a media element (image/video) and one area for blocks (buttons, paragraphs etc). The elements of both areas are vertically aligned.
This PR contains an alternative to https://github.com/WordPress/gutenberg/pull/7414. So we can compare the two approaches side by side.
Here instead of middle blocks, the parent block will self-contain the media area (that allows images or videos), so we have only one simple nested area for the content.

## Screenshots
![sep-04-2018 18-49-22](https://user-images.githubusercontent.com/11271197/45048364-a02f9280-b073-11e8-8434-60cc989af4bc.gif)


![image](https://user-images.githubusercontent.com/11271197/45048283-678fb900-b073-11e8-965e-cd9c7abf9704.png)



## Reviewer notes:
Files under packages/editor/src/utils/media-upload and packages/editor/src/hooks/align.js should not be reviewed in this PR as they are just cherry picks from other PRs: https://github.com/WordPress/gutenberg/pull/9707, https://github.com/WordPress/gutenberg/pull/9704, and https://github.com/WordPress/gutenberg/pull/9634.


Depends on: https://github.com/WordPress/gutenberg/pull/9707, https://github.com/WordPress/gutenberg/pull/9704, and https://github.com/WordPress/gutenberg/pull/9634