### PR TITLE
Make Archives Block display correct empty message

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -79,12 +79,18 @@ function render_block_core_archives( $attributes ) {
 
 		$archives_args['echo'] = 0;
 
-		$block_content = wp_get_archives( $archives_args );
+		$archives = wp_get_archives( $archives_args );
 
-		$block_content = sprintf(
+		$classnames = esc_attr( $class );
+
+		$block_content = ! empty( $archives ) ? sprintf(
 			'<ul class="%1$s">%2$s</ul>',
-			esc_attr( $class ),
-			$block_content
+			$classnames,
+			$archives
+		) : sprintf(
+			'<div class="%1$s">%2$s</div>',
+			$classnames,
+			__( 'No archives to show.', 'gutenberg' )
 		);
 	}
 

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -83,15 +83,21 @@ function render_block_core_archives( $attributes ) {
 
 		$classnames = esc_attr( $class );
 
-		$block_content = ! empty( $archives ) ? sprintf(
-			'<ul class="%1$s">%2$s</ul>',
-			$classnames,
-			$archives
-		) : sprintf(
-			'<div class="%1$s">%2$s</div>',
-			$classnames,
-			__( 'No archives to show.', 'gutenberg' )
-		);
+		if ( empty( $archives ) ) {
+
+			$block_content = sprintf(
+				'<div class="%1$s">%2$s</div>',
+				$classnames,
+				__( 'No archives to show.', 'gutenberg' )
+			);
+		} else {
+
+			$block_content = sprintf(
+				'<ul class="%1$s">%2$s</ul>',
+				$classnames,
+				$archives
+			);
+		}
 	}
 
 	return $block_content;


### PR DESCRIPTION
## Description
When creating an Archives Block while having no posts published, the
Archives Block is empty and overlaps with the subsequent Blocks.

This addresses that by setting the correct Block content when there
are no Archives to show.

## How has this been tested?
Built in tests and manually

## Screenshots
*Before:*
![emptyarchives](https://user-images.githubusercontent.com/3190666/44760513-b1712000-ab04-11e8-866f-fd75cb2989ed.gif)

*After:*
![emptyarchives2](https://user-images.githubusercontent.com/3190666/44760520-b635d400-ab04-11e8-98ba-09854b1051ed.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Fixes #9418 
