### PR TITLE
Fix post failure and reusable block notices styling

### DIFF
--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -275,7 +275,7 @@ export const requestPostUpdateFailure = ( action, store ) => {
 			{ ' ' }
 			<a href={ cloudflareDetailsLink }>{ __( 'Learn More' ) } </a>
 		</p> :
-		noticeMessage;
+		<p>{ noticeMessage }</p>;
 
 	dispatch( createErrorNotice( cloudflaredMessage, { id: SAVE_POST_NOTICE_ID } ) );
 };

--- a/packages/editor/src/store/effects/reusable-blocks.js
+++ b/packages/editor/src/store/effects/reusable-blocks.js
@@ -120,13 +120,20 @@ export const saveReusableBlocks = async ( action, store ) => {
 			id,
 		} );
 		const message = isTemporary ? __( 'Block created.' ) : __( 'Block updated.' );
-		dispatch( createSuccessNotice( message, { id: REUSABLE_BLOCK_NOTICE_ID } ) );
+		dispatch( createSuccessNotice(
+			<p>
+				{ message }
+			</p>,
+			{ id: REUSABLE_BLOCK_NOTICE_ID, spokenMessage: message }
+		) );
 	} catch ( error ) {
 		dispatch( { type: 'SAVE_REUSABLE_BLOCK_FAILURE', id } );
-		dispatch( createErrorNotice( error.message, {
-			id: REUSABLE_BLOCK_NOTICE_ID,
-			spokenMessage: error.message,
-		} ) );
+		dispatch( createErrorNotice(
+			<p>
+				{ error.message }
+			</p>,
+			{ id: REUSABLE_BLOCK_NOTICE_ID, spokenMessage: error.message }
+		) );
 	}
 };
 
@@ -180,17 +187,24 @@ export const deleteReusableBlocks = async ( action, store ) => {
 			optimist: { type: COMMIT, id: transactionId },
 		} );
 		const message = __( 'Block deleted.' );
-		dispatch( createSuccessNotice( message, { id: REUSABLE_BLOCK_NOTICE_ID } ) );
+		dispatch( createSuccessNotice(
+			<p>
+				{ message }
+			</p>,
+			{ id: REUSABLE_BLOCK_NOTICE_ID }
+		) );
 	} catch ( error ) {
 		dispatch( {
 			type: 'DELETE_REUSABLE_BLOCK_FAILURE',
 			id,
 			optimist: { type: REVERT, id: transactionId },
 		} );
-		dispatch( createErrorNotice( error.message, {
-			id: REUSABLE_BLOCK_NOTICE_ID,
-			spokenMessage: error.message,
-		} ) );
+		dispatch( createErrorNotice(
+			<p>
+				{ error.message }
+			</p>,
+			{ id: REUSABLE_BLOCK_NOTICE_ID, spokenMessage: error.message }
+		) );
 	}
 };
 

--- a/packages/editor/src/store/test/effects.js
+++ b/packages/editor/src/store/test/effects.js
@@ -21,7 +21,6 @@ import {
 	mergeBlocks,
 	replaceBlocks,
 	selectBlock,
-	createErrorNotice,
 	setTemplateValidity,
 	editPost,
 } from '../actions';
@@ -356,7 +355,15 @@ describe( 'effects', () => {
 			handler( action, store );
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( createErrorNotice( 'Publishing failed', { id: 'SAVE_POST_NOTICE_ID' } ) );
+			expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( {
+				notice: {
+					content: <p>Publishing failed</p>,
+					id: 'SAVE_POST_NOTICE_ID',
+					isDismissible: true,
+					status: 'error',
+				},
+				type: 'CREATE_NOTICE',
+			} ) );
 		} );
 
 		it( 'should not dispatch a notice when there were no changes for autosave to save.', () => {
@@ -412,7 +419,15 @@ describe( 'effects', () => {
 			handler( action, store );
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( createErrorNotice( 'Updating failed', { id: 'SAVE_POST_NOTICE_ID' } ) );
+			expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( {
+				notice: {
+					content: <p>Updating failed</p>,
+					id: 'SAVE_POST_NOTICE_ID',
+					isDismissible: true,
+					status: 'error',
+				},
+				type: 'CREATE_NOTICE',
+			} ) );
 		} );
 	} );
 


### PR DESCRIPTION
## Description

Fixes the styling of the post failure notices by wrapping the notice text in a paragraph (as all the other notices are wrapped in paragraphs).

To test:
- create a post and enter some content
- in the Chrome dev tools > network tab, check "Offline"
- in Gutenberg, press the "Save draft" button
- observe the "Updating failed" notice styling

## Screenshots <!-- if applicable -->

before:

<img width="1089" alt="44778738-0ac96580-ab7e-11e8-9cc2-2412208618ec" src="https://user-images.githubusercontent.com/1682452/44782703-6862af80-ab88-11e8-9369-e7eee987d310.png">

after:

<img width="1049" alt="screen shot 2018-08-29 at 12 02 09" src="https://user-images.githubusercontent.com/1682452/44782762-95af5d80-ab88-11e8-9cc1-a687f3773cae.png">

Note:
I had to adjust a couple tests, really not my area of expertise. Please double check thanks 🙂 

Fixes #9422