### PR TITLE
Adhere to Mac platform when showing shortcuts on a Mac

### DIFF
--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -38,7 +38,7 @@ const shortcuts = {
 	},
 	removeBlock: {
 		raw: rawShortcut.primaryAlt( 'backspace' ),
-		display: displayShortcut.primaryAlt( 'bksp' ),
+		display: displayShortcut.primaryAlt( 'Backspace' ),
 	},
 	insertBefore: {
 		raw: rawShortcut.primaryAlt( 't' ),

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -73,16 +73,16 @@ export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
 	return ( character, _isApple = isAppleOS ) => {
 		const isMac = _isApple();
 		const replacementKeyMap = {
-			[ ALT ]: isMac ? 'Option' : 'Alt',
-			[ CTRL ]: 'Ctrl',
+			[ ALT ]: isMac ? '⌥' : 'Alt',
+			[ CTRL ]: isMac ? '^' : 'Ctrl',
 			[ COMMAND ]: '⌘',
-			[ SHIFT ]: 'Shift',
+			[ SHIFT ]: isMac ? '⇧' : 'Shift',
 		};
 
 		const modifierKeys = modifier( _isApple ).reduce( ( accumulator, key ) => {
 			const replacementKey = get( replacementKeyMap, key, key );
-			// When the mac's clover symbol is used, do not display a + afterwards
-			if ( replacementKey === '⌘' ) {
+			// If on the Mac, adhere to platform convention and don't show plus between keys.
+			if ( isMac ) {
 				return [ ...accumulator, replacementKey ];
 			}
 

--- a/packages/keycodes/src/test/index.js
+++ b/packages/keycodes/src/test/index.js
@@ -34,14 +34,14 @@ describe( 'displayShortcutList', () => {
 			expect( shortcut ).toEqual( [ 'Ctrl', '+', 'Shift', '+', 'M' ] );
 		} );
 
-		it( 'should output [ Shift, +, ⌘, M ] on MacOS', () => {
+		it( 'should output [ ⇧, ⌘, M ] on MacOS', () => {
 			const shortcut = displayShortcutList.primaryShift( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( [ 'Shift', '+', '⌘', 'M' ] );
+			expect( shortcut ).toEqual( [ '⇧', '⌘', 'M' ] );
 		} );
 
-		it( 'outputs [ Shift, +, ⌘, Del ] on MacOS (works for multiple character keys)', () => {
+		it( 'outputs [ ⇧, ⌘, Del ] on MacOS (works for multiple character keys)', () => {
 			const shortcut = displayShortcutList.primaryShift( 'del', isAppleOSTrue );
-			expect( shortcut ).toEqual( [ 'Shift', '+', '⌘', 'Del' ] );
+			expect( shortcut ).toEqual( [ '⇧', '⌘', 'Del' ] );
 		} );
 	} );
 
@@ -51,9 +51,9 @@ describe( 'displayShortcutList', () => {
 			expect( shortcut ).toEqual( [ 'Ctrl', '+', 'Shift', '+', 'Alt', '+', 'M' ] );
 		} );
 
-		it( 'should output [ Shift, +, Option, +, Command, M ] on MacOS', () => {
+		it( 'should output [ ⇧, ⌥, ⌘, M ] on MacOS', () => {
 			const shortcut = displayShortcutList.secondary( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( [ 'Shift', '+', 'Option', '+', '⌘', 'M' ] );
+			expect( shortcut ).toEqual( [ '⇧', '⌥', '⌘', 'M' ] );
 		} );
 	} );
 
@@ -63,9 +63,9 @@ describe( 'displayShortcutList', () => {
 			expect( shortcut ).toEqual( [ 'Shift', '+', 'Alt', '+', 'M' ] );
 		} );
 
-		it( 'should output [Ctrl, +, Option, +, M ] on MacOS', () => {
+		it( 'should output [^, ⌥, M ] on MacOS', () => {
 			const shortcut = displayShortcutList.access( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( [ 'Ctrl', '+', 'Option', '+', 'M' ] );
+			expect( shortcut ).toEqual( [ '^', '⌥', 'M' ] );
 		} );
 	} );
 } );
@@ -96,12 +96,12 @@ describe( 'displayShortcut', () => {
 
 		it( 'should output shift+command symbols on MacOS', () => {
 			const shortcut = displayShortcut.primaryShift( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'Shift+⌘M' );
+			expect( shortcut ).toEqual( '⇧⌘M' );
 		} );
 
-		it( 'outputs shift+command Del on MacOS (works for multiple character keys)', () => {
+		it( 'outputs ⇧⌘Del on MacOS (works for multiple character keys)', () => {
 			const shortcut = displayShortcut.primaryShift( 'del', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'Shift+⌘Del' );
+			expect( shortcut ).toEqual( '⇧⌘Del' );
 		} );
 	} );
 
@@ -111,9 +111,9 @@ describe( 'displayShortcut', () => {
 			expect( shortcut ).toEqual( 'Ctrl+Shift+Alt+M' );
 		} );
 
-		it( 'should output shift+option+command symbols on MacOS', () => {
+		it( 'should output ⇧+option+command symbols on MacOS', () => {
 			const shortcut = displayShortcut.secondary( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'Shift+Option+⌘M' );
+			expect( shortcut ).toEqual( '⇧⌥⌘M' );
 		} );
 	} );
 
@@ -125,7 +125,7 @@ describe( 'displayShortcut', () => {
 
 		it( 'should output control+option symbols on MacOS', () => {
 			const shortcut = displayShortcut.access( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( 'Ctrl+Option+M' );
+			expect( shortcut ).toEqual( '^⌥M' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This fixes #9226.

This changes the display of keyboard shortcuts on the Mac to:

- not have the plus between
- use unicode symbols for the characters

The larger discussion for why we're doing this is in the ticket referenced, but the gist of it is: this is what MacOS does, and we mean to tap into that same pattern that Mac users will be used to.

Screenshots:

![screen shot 2018-08-29 at 14 19 46](https://user-images.githubusercontent.com/1204802/44787559-cba80e00-ab97-11e8-883f-ef3362dc0fa7.png)

![screen shot 2018-08-29 at 14 24 45](https://user-images.githubusercontent.com/1204802/44787562-ccd93b00-ab97-11e8-8d14-2441ccfc8df2.png)

![screen shot 2018-08-29 at 14 24 54](https://user-images.githubusercontent.com/1204802/44787564-ce0a6800-ab97-11e8-8e6a-968df44646f7.png)

![screen shot 2018-08-29 at 14 24 59](https://user-images.githubusercontent.com/1204802/44787569-cfd42b80-ab97-11e8-820c-133bb5fd5417.png)

![screen shot 2018-08-29 at 14 28 49](https://user-images.githubusercontent.com/1204802/44787598-df537480-ab97-11e8-9f8e-7633187a80c1.png)

