### PR TITLE
Classic editor and Cloudflare notification modals improvements

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -182,23 +182,30 @@ function gutenberg_warn_classic_about_blocks() {
 	?>
 		<style type="text/css">
 			#blocks-in-post-dialog .notification-dialog {
-				padding: 25px;
+				position: fixed;
 				top: 50%;
-				margin: 0;
+				left: 50%;
+				width: 500px;
+				box-sizing: border-box;
 				transform: translate(-50%, -50%);
+				margin: 0;
+				padding: 25px;
+				max-height: 90%;
+				background: #fff;
+				box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
+				line-height: 1.5;
+				z-index: 1000005;
+				overflow-y: auto;
 			}
 
 			@media only screen and (max-height: 480px), screen and (max-width: 450px) {
 				#blocks-in-post-dialog .notification-dialog {
+					top: 0;
+					left: 0;
 					width: 100%;
 					height: 100%;
-					box-sizing: border-box;
-					max-height: 100%;
-					position: fixed;
-					top: 0;
-					margin: 0;
-					left: 0;
 					transform: none;
+					max-height: 100%;
 				}
 			}
 		</style>
@@ -311,10 +318,20 @@ function gutenberg_warn_classic_about_cloudflare() {
 	?>
 		<style type="text/css">
 			#cloudflare-block-dialog .notification-dialog {
-				padding: 25px;
+				position: fixed;
 				top: 50%;
-				margin: 0;
+				left: 50%;
+				width: 500px;
+				box-sizing: border-box;
 				transform: translate(-50%, -50%);
+				margin: 0;
+				padding: 25px;
+				max-height: 90%;
+				background: #fff;
+				box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
+				line-height: 1.5;
+				z-index: 1000005;
+				overflow-y: auto;
 			}
 
 			#cloudflare-block-dialog ul {
@@ -324,15 +341,12 @@ function gutenberg_warn_classic_about_cloudflare() {
 
 			@media only screen and (max-height: 480px), screen and (max-width: 450px) {
 				#cloudflare-block-dialog .notification-dialog {
+					top: 0;
+					left: 0;
 					width: 100%;
 					height: 100%;
-					box-sizing: border-box;
-					max-height: 100%;
-					position: fixed;
-					top: 0;
-					margin: 0;
-					left: 0;
 					transform: none;
+					max-height: 100%;
 				}
 			}
 		</style>

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -183,17 +183,22 @@ function gutenberg_warn_classic_about_blocks() {
 		<style type="text/css">
 			#blocks-in-post-dialog .notification-dialog {
 				padding: 25px;
+				top: 50%;
+				margin: 0;
+				transform: translate(-50%, -50%);
 			}
 
 			@media only screen and (max-height: 480px), screen and (max-width: 450px) {
 				#blocks-in-post-dialog .notification-dialog {
 					width: 100%;
 					height: 100%;
+					box-sizing: border-box;
 					max-height: 100%;
 					position: fixed;
 					top: 0;
 					margin: 0;
 					left: 0;
+					transform: none;
 				}
 			}
 		</style>
@@ -307,6 +312,9 @@ function gutenberg_warn_classic_about_cloudflare() {
 		<style type="text/css">
 			#cloudflare-block-dialog .notification-dialog {
 				padding: 25px;
+				top: 50%;
+				margin: 0;
+				transform: translate(-50%, -50%);
 			}
 
 			#cloudflare-block-dialog ul {
@@ -318,11 +326,13 @@ function gutenberg_warn_classic_about_cloudflare() {
 				#cloudflare-block-dialog .notification-dialog {
 					width: 100%;
 					height: 100%;
+					box-sizing: border-box;
 					max-height: 100%;
 					position: fixed;
 					top: 0;
 					margin: 0;
 					left: 0;
+					transform: none;
 				}
 			}
 		</style>
@@ -331,7 +341,7 @@ function gutenberg_warn_classic_about_cloudflare() {
 			<div class="notification-dialog-background"></div>
 			<div class="notification-dialog">
 				<div class="cloudflare-block-message">
-					<h2><?php _e( 'Cloudflare is blocking REST API requests.', 'gutenberg' ); ?></h2>
+					<h2><?php _e( 'Cloudflare is blocking REST API requests', 'gutenberg' ); ?></h2>
 					<p><?php _e( 'Your site uses Cloudflare, which provides a Web Application Firewall (WAF) to secure your site against attacks. Unfortunately, some of these WAF rules are incorrectly blocking legitimate access to your site, preventing Gutenberg from functioning correctly.', 'gutenberg' ); ?></p>
 					<p><?php _e( "We're working closely with Cloudflare to fix this issue, but in the mean time, you can work around it in one of two ways:", 'gutenberg' ); ?></p>
 					<ul>
@@ -387,7 +397,7 @@ function gutenberg_warn_classic_about_cloudflare() {
 					// Reveal the modal and set focus on the Gutenberg button.
 					dialog.warning
 						.removeClass( 'hidden' )
-						.find( '.cloudflare-block-gutenberg-button' ).focus();
+						.find( '.cloudflare-block-classic-button' ).focus();
 
 					// Attach event handlers.
 					dialog.warningTabbables.on( 'keydown', dialog.constrainTabbing );


### PR DESCRIPTION
## Description

This PR:
- sets initial focus within the Cloudflare modal (the selector used to target the button was wrong)
- adjust the CSS to make the modals vertically and horizontally centered

Note:
the CSS is partially inherited from WP, please do let me know if it's better to replicate all the styles used and add them to `compat.php`

To test, you need to make the modals appear:
- for the Cloudflare one, maybe the quickest way is to alter the code in here and change the check to `!==`
https://github.com/WordPress/gutenberg/blob/7775e264ce9a9871ba4f0eb7b4f63f47fd8003d6/packages/editor/src/store/effects/posts.js#L270

- create a post, enter some content
- then, set Chrome dev tools > Network to "offline"
- see a notice appears with text related to Cloudflare and a link:

<img width="448" alt="screen shot 2018-08-29 at 14 46 17" src="https://user-images.githubusercontent.com/1682452/44788470-6c97c880-ab9a-11e8-92eb-a71a2462c9ad.png">

- click the "Learn more" link
- a new edit post page opens in a new browser tab, with the Cloudflare modal displayed
- for the Classic editor modal just edit in the Classic editor a post created in Gutenberg
- verify the Cloudflare modal button gets initial focus
- verify both modals are vertically and horizontally centered 
- verify content is always visible at various viewport sizes

Cloudflare modal before:

![screen shot 2018-08-29 at 13 47 24](https://user-images.githubusercontent.com/1682452/44788673-f6e02c80-ab9a-11e8-82c0-aa761eac1953.jpg)

Cloudflare modal after:

![screen shot 2018-08-29 at 14 47 49](https://user-images.githubusercontent.com/1682452/44788718-0eb7b080-ab9b-11e8-9912-b483c8602f4c.jpg)

Fixes #9428 