### PR TITLE
raAvoid changing the public API of the warning component to avoid Backwards compatibility breakage

### DIFF
--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -20,7 +20,7 @@ function BlockInvalidWarning( { convertToHTML, convertToBlocks, convertToClassic
 
 	return (
 		<Warning
-			primaryActions={ [
+			actions={ [
 				<Button key="convert" onClick={ convertToBlocks } isLarge isPrimary={ ! hasHTMLBlock }>
 					{ __( 'Convert to Blocks' ) }
 				</Button>,

--- a/packages/editor/src/components/warning/index.js
+++ b/packages/editor/src/components/warning/index.js
@@ -10,15 +10,15 @@ import { Children } from '@wordpress/element';
 import { Dropdown, IconButton, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function Warning( { className, primaryActions, children, secondaryActions } ) {
+function Warning( { className, actions, children, secondaryActions } ) {
 	return (
 		<div className={ classnames( className, 'editor-warning' ) }>
 			<div className="editor-warning__contents">
 				<p className="editor-warning__message">{ children }</p>
 
-				{ Children.count( primaryActions ) > 0 && (
+				{ Children.count( actions ) > 0 && (
 					<div className="editor-warning__actions">
-						{ Children.map( primaryActions, ( action, i ) => (
+						{ Children.map( actions, ( action, i ) => (
 							<span key={ i } className="editor-warning__action">
 								{ action }
 							</span>

--- a/packages/editor/src/components/warning/test/index.js
+++ b/packages/editor/src/components/warning/test/index.js
@@ -24,7 +24,7 @@ describe( 'Warning', () => {
 	} );
 
 	it( 'should show child error message element', () => {
-		const wrapper = shallow( <Warning primaryActions={ <button /> }>Message</Warning> );
+		const wrapper = shallow( <Warning actions={ <button /> }>Message</Warning> );
 
 		const actions = wrapper.find( '.editor-warning__actions' );
 		const action = actions.childAt( 0 );


### PR DESCRIPTION
closes #9431

This fixes a regression introduced in #7741 where we inadvertantly broke backwards compatibility (and other usage) of the `Warning` component.

I'm restoring the old name of the `actions` prop to fix the issue.

**Testing instructions**

Repeat steps from #9431
The warning should show up properly.