### PR TITLE
Babel Makepot: Translator comments have been extracted from the file

### DIFF
--- a/packages/babel-plugin-makepot/CHANGELOG.md
+++ b/packages/babel-plugin-makepot/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fix
 
 - Fixed Babel plugin for POT file generation to properly handle plural numbers specified in the passed header. ([#13577](https://github.com/WordPress/gutenberg/pull/13577))
+- Fix extracted translator comments to be written as prefixed by `#.` ([#9440](https://github.com/WordPress/gutenberg/pull/9440))
 
 ## 2.1.0 (2018-09-05)
 

--- a/packages/babel-plugin-makepot/src/index.js
+++ b/packages/babel-plugin-makepot/src/index.js
@@ -268,7 +268,7 @@ module.exports = function() {
 				// If exists, also assign translator comment
 				const translator = getTranslatorComment( path );
 				if ( translator ) {
-					translation.comments.translator = translator;
+					translation.comments.extracted = translator;
 				}
 
 				// Create context grouping for translation if not yet exists

--- a/packages/babel-plugin-makepot/src/index.js
+++ b/packages/babel-plugin-makepot/src/index.js
@@ -107,15 +107,15 @@ function getNodeAsString( node ) {
 }
 
 /**
- * Returns translator comment for a given AST traversal path if one exists.
+ * Returns the extracted comment for a given AST traversal path if one exists.
  *
  * @param {Object} path              Traversal path.
  * @param {number} _originalNodeLine Private: In recursion, line number of
  *                                     the original node passed.
  *
- * @return {?string} Translator comment.
+ * @return {?string} Extracted comment.
  */
-function getTranslatorComment( path, _originalNodeLine ) {
+function getExtractedComment( path, _originalNodeLine ) {
 	const { node, parent, parentPath } = path;
 
 	// Assign original node line so we can keep track in recursion whether a
@@ -152,7 +152,7 @@ function getTranslatorComment( path, _originalNodeLine ) {
 	// Only recurse as long as parent node is on the same or previous line
 	const { line } = parent.loc.start;
 	if ( line >= _originalNodeLine - 1 && line <= _originalNodeLine ) {
-		return getTranslatorComment( parentPath, _originalNodeLine );
+		return getExtractedComment( parentPath, _originalNodeLine );
 	}
 }
 
@@ -266,7 +266,7 @@ module.exports = function() {
 				};
 
 				// If exists, also assign translator comment
-				const translator = getTranslatorComment( path );
+				const translator = getExtractedComment( path );
 				if ( translator ) {
 					translation.comments.extracted = translator;
 				}
@@ -340,6 +340,6 @@ module.exports = function() {
 };
 
 module.exports.getNodeAsString = getNodeAsString;
-module.exports.getTranslatorComment = getTranslatorComment;
+module.exports.getExtractedComment = getExtractedComment;
 module.exports.isValidTranslationKey = isValidTranslationKey;
 module.exports.isSameTranslation = isSameTranslation;

--- a/packages/babel-plugin-makepot/test/index.js
+++ b/packages/babel-plugin-makepot/test/index.js
@@ -12,7 +12,7 @@ import babelPlugin from '../src';
 describe( 'babel-plugin', () => {
 	const {
 		getNodeAsString,
-		getTranslatorComment,
+		getExtractedComment,
 		isValidTranslationKey,
 		isSameTranslation,
 	} = babelPlugin;
@@ -43,12 +43,12 @@ describe( 'babel-plugin', () => {
 		} );
 	} );
 
-	describe( '.getTranslatorComment()', () => {
+	describe( '.getExtractedComment()', () => {
 		function getCommentFromString( string ) {
 			let comment;
 			traverse( transformSync( string, { ast: true } ).ast, {
 				CallExpression( path ) {
-					comment = getTranslatorComment( path );
+					comment = getExtractedComment( path );
 				},
 			} );
 

--- a/packages/i18n/tools/pot-to-php.js
+++ b/packages/i18n/tools/pot-to-php.js
@@ -53,17 +53,17 @@ function convertTranslationToPHP( translation, textdomain, context = '' ) {
 				NEWLINE;
 		}
 
-		if ( ! isEmpty( comments.extracted ) ) {
+		if ( ! isEmpty( comments.translator ) ) {
 			// All extracted comments are split by newlines, add a tab to line them up nicely.
-			const extracted = comments.extracted
+			const translator = comments.translator
 				.split( NEWLINE )
 				.join( NEWLINE + TAB + '   ' );
 
-			php += TAB + `/* ${ extracted } */${ NEWLINE }`;
+			php += TAB + `/* ${ translator } */${ NEWLINE }`;
 		}
 
-		if ( ! isEmpty( comments.translator ) ) {
-			php += TAB + `/* translators: ${ comments.translator } */${ NEWLINE }`;
+		if ( ! isEmpty( comments.extracted ) ) {
+			php += TAB + `/* translators: ${ comments.extracted } */${ NEWLINE }`;
 		}
 	}
 


### PR DESCRIPTION
## Description
In the POT file generated by Gutenberg the translator comments are extracted into regular comments (denoted with just a `#`) while they should be denoted with a `#.`

This is a mixup on the term "translator" comments. As can be seen in section "2.2.1 Extracted Comments" of [The PO Format](http://pology.nedohodnik.net/doc/user/en_US/ch-poformat.html), the comments denoted with `translators:` are actually called "extracted comments" in the PO file format.

## How has this been tested?
1. Run `npm run build` to create the POT file in languages/gutenberg.pot
2. Run `npx pot-to-php ./languages/gutenberg.pot ./languages/gutenberg-translations.php gutenberg` to generate the PHP file

## Types of changes
Janitorial

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->