### PR TITLE
Make the withNotices notices announced by assistive technologies

### DIFF
--- a/packages/components/src/higher-order/with-spoken-messages/index.js
+++ b/packages/components/src/higher-order/with-spoken-messages/index.js
@@ -11,8 +11,8 @@ import { speak } from '@wordpress/a11y';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
- * A Higher Order Component used to be provide a unique instance ID by
- * component.
+ * A Higher Order Component used to be provide audible messages to assistive
+ * technologies using ARIA live regions.
  *
  * @param {WPElement} WrappedComponent  The wrapped component.
  *

--- a/packages/components/src/icon-button/README.md
+++ b/packages/components/src/icon-button/README.md
@@ -1,5 +1,7 @@
 # IconButton
 
+**Note:** For accessibility reasons, icon buttons that have no text and use only an icon must expose their aria-label visually via the tooltip; in these cases, never set the tooltip prop to `false`.
+
 ## Usage
 
 ```jsx

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -1,6 +1,6 @@
 # Notice
 
-This component is used to display notices in the editor. Notices use an ARIA `role="alert"`: they're assertive live regions and will be processed as such by assistive technologies. For this reason, they must be returned directly, without any wrappers.
+This component is used to display notices in the editor. Notices also provide audible messages to assistive technologies using ARIA live regions. By default, the audible message will be the content fo the notice. To use a different audible message, use the `spokenMessage` prop.
 
 ## Usage
 
@@ -24,10 +24,21 @@ const MyNotice = () => (
 );
 ```
 
+Use the `spokenMessage` prop to provide a meaningful audible message, for example to exclude part of the content that wouldn't make much sense for assistive technologies users:
+
+```jsx
+const MyNotice = () => (
+	<Notice status="error" spokenMessage="An error occurred while saving">
+		<p>An error occurred while saving. <a href={ myLink }>Learn more</a>.</p>
+	</Notice>
+);
+```
+
 ### Props
 
-The following props are used to control the display of the component.
+The following props are used to control the component.
 
 * `status`: (string) can be `warning` (yellow), `success` (green), `error` (red).
 * `onRemove`: function called when dismissing the notice
 * `isDismissible`: (bool) defaults to true, whether the notice should be dismissible or not
+* `spokenMessage`: (string) alternate audible message for the ARIA live region

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -1,6 +1,6 @@
 # Notice
 
-This component is used to display notices in editor.
+This component is used to display notices in the editor. Notices use an ARIA `role="alert"`: they're assertive live regions and will be processed as such by assistive technologies. For this reason, they must be returned directly, without any wrappers.
 
 ## Usage
 

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -29,7 +29,6 @@ function Notice( { className, status, children, onRemove = noop, isDismissible =
 					icon="no"
 					label={ __( 'Dismiss this notice' ) }
 					onClick={ onRemove }
-					tooltip={ false }
 				/>
 			) }
 		</div>

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -21,7 +21,7 @@ function Notice( { className, status, children, onRemove = noop, isDismissible =
 		'is-dismissible': isDismissible,
 	} );
 	return (
-		<div className={ classNames }>
+		<div className={ classNames } role="alert">
 			{ isString( children ) ? <div className="components-notice__content">{ children }</div> : children }
 			{ isDismissible && (
 				<IconButton

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -8,20 +8,33 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import withSpokenMessages from '../higher-order/with-spoken-messages';
 
 /**
  * Internal dependencies
  */
 import IconButton from '../icon-button';
 
-function Notice( { className, status, children, onRemove = noop, isDismissible = true } ) {
+function Notice( {
+	className,
+	status,
+	children,
+	onRemove = noop,
+	isDismissible = true,
+	spokenMessage,
+	speak,
+} ) {
 	const classNames = classnames( className, 'components-notice', {
 		[ `is-${ status }` ]: ! ! status,
 	}, {
 		'is-dismissible': isDismissible,
 	} );
+
+	const message = spokenMessage || children;
+	speak( message, 'assertive' );
+
 	return (
-		<div className={ classNames } role="alert">
+		<div className={ classNames }>
 			<div className="components-notice__content">{ children }</div>
 			{ isDismissible && (
 				<IconButton
@@ -35,4 +48,4 @@ function Notice( { className, status, children, onRemove = noop, isDismissible =
 	);
 }
 
-export default Notice;
+export default withSpokenMessages( Notice );

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString, noop } from 'lodash';
+import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -22,7 +22,7 @@ function Notice( { className, status, children, onRemove = noop, isDismissible =
 	} );
 	return (
 		<div className={ classNames } role="alert">
-			{ isString( children ) ? <div className="components-notice__content">{ children }</div> : children }
+			<div className="components-notice__content">{ children }</div>
 			{ isDismissible && (
 				<IconButton
 					className="components-notice__dismiss"

--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -13,7 +13,6 @@ exports[`Notice should match snapshot 1`] = `
     icon="no"
     label="Dismiss this notice"
     onClick={[Function]}
-    tooltip={false}
   />
 </div>
 `;

--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -3,6 +3,7 @@
 exports[`Notice should match snapshot 1`] = `
 <div
   className="components-notice is-example is-dismissible"
+  role="alert"
 >
   <IconButton
     className="components-notice__dismiss"

--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -5,6 +5,9 @@ exports[`Notice should match snapshot 1`] = `
   className="components-notice is-example is-dismissible"
   role="alert"
 >
+  <div
+    className="components-notice__content"
+  />
   <IconButton
     className="components-notice__dismiss"
     icon="no"

--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -1,18 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Notice should match snapshot 1`] = `
-<div
-  className="components-notice is-example is-dismissible"
-  role="alert"
->
-  <div
-    className="components-notice__content"
-  />
-  <IconButton
-    className="components-notice__dismiss"
-    icon="no"
-    label="Dismiss this notice"
-    onClick={[Function]}
-  />
-</div>
+<Notice
+  debouncedSpeak={[Function]}
+  speak={[Function]}
+  status="example"
+/>
 `;

--- a/packages/editor/src/components/contrast-checker/index.js
+++ b/packages/editor/src/components/contrast-checker/index.js
@@ -35,11 +35,9 @@ function ContrastChecker( {
 		__( 'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.' ) :
 		__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.' );
 	return (
-		<div className="editor-contrast-checker">
-			<Notice status="warning" isDismissible={ false }>
-				{ msg }
-			</Notice>
-		</div>
+		<Notice status="warning" isDismissible={ false } className="editor-contrast-checker">
+			{ msg }
+		</Notice>
 	);
 }
 

--- a/packages/editor/src/components/contrast-checker/style.scss
+++ b/packages/editor/src/components/contrast-checker/style.scss
@@ -1,3 +1,3 @@
-.editor-contrast-checker > .components-notice {
+.editor-contrast-checker.components-notice {
 	margin: 0;
 }

--- a/packages/editor/src/components/contrast-checker/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/contrast-checker/test/__snapshots__/index.js.snap
@@ -8,22 +8,29 @@ exports[`ContrastChecker should render component when the colors do not meet AA 
   isLargeText={true}
   textColor="#666"
 >
-  <Notice
+  <WithSpokenMessages(Notice)
     className="editor-contrast-checker"
     isDismissible={false}
     status="warning"
   >
-    <div
-      className="editor-contrast-checker components-notice is-warning"
-      role="alert"
+    <Notice
+      className="editor-contrast-checker"
+      debouncedSpeak={[Function]}
+      isDismissible={false}
+      speak={[Function]}
+      status="warning"
     >
       <div
-        className="components-notice__content"
+        className="editor-contrast-checker components-notice is-warning"
       >
-        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        <div
+          className="components-notice__content"
+        >
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </div>
       </div>
-    </div>
-  </Notice>
+    </Notice>
+  </WithSpokenMessages(Notice)>
 </ContrastChecker>
 `;
 
@@ -35,22 +42,29 @@ exports[`ContrastChecker should render different message matching snapshot when 
   isLargeText={false}
   textColor="#666"
 >
-  <Notice
+  <WithSpokenMessages(Notice)
     className="editor-contrast-checker"
     isDismissible={false}
     status="warning"
   >
-    <div
-      className="editor-contrast-checker components-notice is-warning"
-      role="alert"
+    <Notice
+      className="editor-contrast-checker"
+      debouncedSpeak={[Function]}
+      isDismissible={false}
+      speak={[Function]}
+      status="warning"
     >
       <div
-        className="components-notice__content"
+        className="editor-contrast-checker components-notice is-warning"
       >
-        This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.
+        <div
+          className="components-notice__content"
+        >
+          This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.
+        </div>
       </div>
-    </div>
-  </Notice>
+    </Notice>
+  </WithSpokenMessages(Notice)>
 </ContrastChecker>
 `;
 
@@ -59,22 +73,29 @@ exports[`ContrastChecker should render messages when the textColor is valid, but
   fallbackBackgroundColor="#000000"
   textColor="#000000"
 >
-  <Notice
+  <WithSpokenMessages(Notice)
     className="editor-contrast-checker"
     isDismissible={false}
     status="warning"
   >
-    <div
-      className="editor-contrast-checker components-notice is-warning"
-      role="alert"
+    <Notice
+      className="editor-contrast-checker"
+      debouncedSpeak={[Function]}
+      isDismissible={false}
+      speak={[Function]}
+      status="warning"
     >
       <div
-        className="components-notice__content"
+        className="editor-contrast-checker components-notice is-warning"
       >
-        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        <div
+          className="components-notice__content"
+        >
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </div>
       </div>
-    </div>
-  </Notice>
+    </Notice>
+  </WithSpokenMessages(Notice)>
 </ContrastChecker>
 `;
 
@@ -84,22 +105,29 @@ exports[`ContrastChecker should take into consideration the font size passed 1`]
   fontSize={17}
   textColor="#000000"
 >
-  <Notice
+  <WithSpokenMessages(Notice)
     className="editor-contrast-checker"
     isDismissible={false}
     status="warning"
   >
-    <div
-      className="editor-contrast-checker components-notice is-warning"
-      role="alert"
+    <Notice
+      className="editor-contrast-checker"
+      debouncedSpeak={[Function]}
+      isDismissible={false}
+      speak={[Function]}
+      status="warning"
     >
       <div
-        className="components-notice__content"
+        className="editor-contrast-checker components-notice is-warning"
       >
-        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        <div
+          className="components-notice__content"
+        >
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </div>
       </div>
-    </div>
-  </Notice>
+    </Notice>
+  </WithSpokenMessages(Notice)>
 </ContrastChecker>
 `;
 
@@ -109,22 +137,29 @@ exports[`ContrastChecker should take into consideration wherever text is large o
   isLargeText={false}
   textColor="#000000"
 >
-  <Notice
+  <WithSpokenMessages(Notice)
     className="editor-contrast-checker"
     isDismissible={false}
     status="warning"
   >
-    <div
-      className="editor-contrast-checker components-notice is-warning"
-      role="alert"
+    <Notice
+      className="editor-contrast-checker"
+      debouncedSpeak={[Function]}
+      isDismissible={false}
+      speak={[Function]}
+      status="warning"
     >
       <div
-        className="components-notice__content"
+        className="editor-contrast-checker components-notice is-warning"
       >
-        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        <div
+          className="components-notice__content"
+        >
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </div>
       </div>
-    </div>
-  </Notice>
+    </Notice>
+  </WithSpokenMessages(Notice)>
 </ContrastChecker>
 `;
 
@@ -135,21 +170,28 @@ exports[`ContrastChecker should use isLargeText to make decisions if both isLarg
   isLargeText={false}
   textColor="#000000"
 >
-  <Notice
+  <WithSpokenMessages(Notice)
     className="editor-contrast-checker"
     isDismissible={false}
     status="warning"
   >
-    <div
-      className="editor-contrast-checker components-notice is-warning"
-      role="alert"
+    <Notice
+      className="editor-contrast-checker"
+      debouncedSpeak={[Function]}
+      isDismissible={false}
+      speak={[Function]}
+      status="warning"
     >
       <div
-        className="components-notice__content"
+        className="editor-contrast-checker components-notice is-warning"
       >
-        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        <div
+          className="components-notice__content"
+        >
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </div>
       </div>
-    </div>
-  </Notice>
+    </Notice>
+  </WithSpokenMessages(Notice)>
 </ContrastChecker>
 `;

--- a/packages/editor/src/components/contrast-checker/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/contrast-checker/test/__snapshots__/index.js.snap
@@ -17,6 +17,7 @@ exports[`ContrastChecker should render component when the colors do not meet AA 
     >
       <div
         className="components-notice is-warning"
+        role="alert"
       >
         <div
           className="components-notice__content"
@@ -46,6 +47,7 @@ exports[`ContrastChecker should render different message matching snapshot when 
     >
       <div
         className="components-notice is-warning"
+        role="alert"
       >
         <div
           className="components-notice__content"
@@ -72,6 +74,7 @@ exports[`ContrastChecker should render messages when the textColor is valid, but
     >
       <div
         className="components-notice is-warning"
+        role="alert"
       >
         <div
           className="components-notice__content"
@@ -99,6 +102,7 @@ exports[`ContrastChecker should take into consideration the font size passed 1`]
     >
       <div
         className="components-notice is-warning"
+        role="alert"
       >
         <div
           className="components-notice__content"
@@ -126,6 +130,7 @@ exports[`ContrastChecker should take into consideration wherever text is large o
     >
       <div
         className="components-notice is-warning"
+        role="alert"
       >
         <div
           className="components-notice__content"
@@ -154,6 +159,7 @@ exports[`ContrastChecker should use isLargeText to make decisions if both isLarg
     >
       <div
         className="components-notice is-warning"
+        role="alert"
       >
         <div
           className="components-notice__content"

--- a/packages/editor/src/components/contrast-checker/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/contrast-checker/test/__snapshots__/index.js.snap
@@ -8,25 +8,22 @@ exports[`ContrastChecker should render component when the colors do not meet AA 
   isLargeText={true}
   textColor="#666"
 >
-  <div
+  <Notice
     className="editor-contrast-checker"
+    isDismissible={false}
+    status="warning"
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker components-notice is-warning"
+      role="alert"
     >
       <div
-        className="components-notice is-warning"
-        role="alert"
+        className="components-notice__content"
       >
-        <div
-          className="components-notice__content"
-        >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
-        </div>
+        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
       </div>
-    </Notice>
-  </div>
+    </div>
+  </Notice>
 </ContrastChecker>
 `;
 
@@ -38,25 +35,22 @@ exports[`ContrastChecker should render different message matching snapshot when 
   isLargeText={false}
   textColor="#666"
 >
-  <div
+  <Notice
     className="editor-contrast-checker"
+    isDismissible={false}
+    status="warning"
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker components-notice is-warning"
+      role="alert"
     >
       <div
-        className="components-notice is-warning"
-        role="alert"
+        className="components-notice__content"
       >
-        <div
-          className="components-notice__content"
-        >
-          This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.
-        </div>
+        This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.
       </div>
-    </Notice>
-  </div>
+    </div>
+  </Notice>
 </ContrastChecker>
 `;
 
@@ -65,25 +59,22 @@ exports[`ContrastChecker should render messages when the textColor is valid, but
   fallbackBackgroundColor="#000000"
   textColor="#000000"
 >
-  <div
+  <Notice
     className="editor-contrast-checker"
+    isDismissible={false}
+    status="warning"
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker components-notice is-warning"
+      role="alert"
     >
       <div
-        className="components-notice is-warning"
-        role="alert"
+        className="components-notice__content"
       >
-        <div
-          className="components-notice__content"
-        >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
-        </div>
+        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
       </div>
-    </Notice>
-  </div>
+    </div>
+  </Notice>
 </ContrastChecker>
 `;
 
@@ -93,25 +84,22 @@ exports[`ContrastChecker should take into consideration the font size passed 1`]
   fontSize={17}
   textColor="#000000"
 >
-  <div
+  <Notice
     className="editor-contrast-checker"
+    isDismissible={false}
+    status="warning"
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker components-notice is-warning"
+      role="alert"
     >
       <div
-        className="components-notice is-warning"
-        role="alert"
+        className="components-notice__content"
       >
-        <div
-          className="components-notice__content"
-        >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
-        </div>
+        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
       </div>
-    </Notice>
-  </div>
+    </div>
+  </Notice>
 </ContrastChecker>
 `;
 
@@ -121,25 +109,22 @@ exports[`ContrastChecker should take into consideration wherever text is large o
   isLargeText={false}
   textColor="#000000"
 >
-  <div
+  <Notice
     className="editor-contrast-checker"
+    isDismissible={false}
+    status="warning"
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker components-notice is-warning"
+      role="alert"
     >
       <div
-        className="components-notice is-warning"
-        role="alert"
+        className="components-notice__content"
       >
-        <div
-          className="components-notice__content"
-        >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
-        </div>
+        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
       </div>
-    </Notice>
-  </div>
+    </div>
+  </Notice>
 </ContrastChecker>
 `;
 
@@ -150,24 +135,21 @@ exports[`ContrastChecker should use isLargeText to make decisions if both isLarg
   isLargeText={false}
   textColor="#000000"
 >
-  <div
+  <Notice
     className="editor-contrast-checker"
+    isDismissible={false}
+    status="warning"
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker components-notice is-warning"
+      role="alert"
     >
       <div
-        className="components-notice is-warning"
-        role="alert"
+        className="components-notice__content"
       >
-        <div
-          className="components-notice__content"
-        >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
-        </div>
+        This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
       </div>
-    </Notice>
-  </div>
+    </div>
+  </Notice>
 </ContrastChecker>
 `;

--- a/packages/editor/src/components/template-validation-notice/index.js
+++ b/packages/editor/src/components/template-validation-notice/index.js
@@ -18,9 +18,16 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 		}
 	};
 
+	const message = __( 'The content of your post doesn’t match the template assigned to your post type.' );
+
 	return (
-		<Notice className="editor-template-validation-notice" isDismissible={ false } status="warning">
-			<p>{ __( 'The content of your post doesn’t match the template assigned to your post type.' ) }</p>
+		<Notice
+			className="editor-template-validation-notice"
+			isDismissible={ false }
+			status="warning"
+			spokenMessage={ message }
+		>
+			<p>{ message }</p>
 			<div>
 				<Button isDefault onClick={ props.resetTemplateValidity }>{ __( 'Keep it as is' ) }</Button>
 				<Button onClick={ confirmSynchronization } isPrimary>{ __( 'Reset the template' ) }</Button>


### PR DESCRIPTION
## Description

The notices created by `withNotices` convey important information to users but they're not announced by screen readers. This PR simply adds a `role="alert"` attribute to the notice wrapper. Reference: https://www.w3.org/TR/wai-aria-1.1/#alert
> Alerts are assertive live regions and will be processed as such by assistive technologies. 

So in this case, this is all it takes to make the notices text announced by screen readers.

To test, use a screen reader. On a mac you can use Safari and VoiceOver (Cmd+F5). 
To make one of these notices appear, you can set background and text color on a paragraph in a way to make the contrast ratio notice appear.
Before this change, nothing is announced. After this change, VoiceOver automatically announces the notice text:

![screen shot 2018-08-29 at 19 38 56](https://user-images.githubusercontent.com/1682452/44805555-daf18080-abc4-11e8-85bb-311063492f1d.png)

Other similar notices are used in the blocks, typically when dragging e media file within a block that accepts media. You can, for example, set "Offline" in your dev tools, drag an image on an Image block, and see the related norice appear (and be announced).

Fixes #9442 