### PR TITLE
Templates: Always parse blocks from content

### DIFF
--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -121,21 +121,18 @@ export default {
 		const isNewPost = post.status === 'auto-draft';
 
 		// Parse content as blocks
-		let blocks;
+		let blocks = parse( post.content.raw );
 		let isValidTemplate = true;
-		if ( ! isNewPost ) {
-			blocks = parse( post.content.raw );
-
+		if ( isNewPost && template ) {
+			// Apply a template for new posts only, if exists.
+			blocks = synchronizeBlocksWithTemplate( blocks, template );
+		} else {
 			// Unlocked templates are considered always valid because they act as default values only.
 			isValidTemplate = (
 				! template ||
 				templateLock !== 'all' ||
 				doBlocksMatchTemplate( blocks, template )
 			);
-		} else if ( template ) {
-			blocks = synchronizeBlocksWithTemplate( [], template );
-		} else {
-			blocks = [];
 		}
 
 		// Include auto draft title in edits while not flagging post as dirty


### PR DESCRIPTION
Fixes #9433 

This pull request seeks to resolve an issue where no demo content is shown on the demo screen. It does without sacrificing the original intent of #9288, which had been the cause for the regression described by #9433.

Post content is always parsed, regardless of whether a template is assigned or the post is new or being edited. This allows the initial demo content to be parsed as blocks.

If a template exists and the post is new, only then is the template applied by synchronizing. In most cases, the initial content would have been empty and the blocks an empty array (as had existed in previous logic), but this also accounts for potential divergences between content of the new post and the template.

**Testing instructions:**

Repeat steps to reproduce from #9433, verifying demo content is shown.

Repeat testing instructions from #9288.

Ensure end-to-end tests pass:

```
npm run test-e2e
```