### PR TITLE
Remove extra classNames from integration test

### DIFF
--- a/phpunit/fixtures/long-content.html
+++ b/phpunit/fixtures/long-content.html
@@ -19,8 +19,8 @@
 <!-- wp:paragraph -->
 <p>Handling images and media with the utmost care is a primary focus of the new editor. Hopefully, you&#x27;ll find aspects of adding captions or going full-width with your pictures much easier and robust than before.</p>
 <!-- /wp:paragraph -->
-<!-- wp:image {"align":"center","className":"aligncenter"} -->
-<div class="wp-block-image aligncenter"><figure class="aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>Give it a try. Press the &quot;wide&quot; button on the image toolbar.</figcaption></figure></div>
+<!-- wp:image {"align":"center"} -->
+<div class="wp-block-image"><figure class="aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>Give it a try. Press the &quot;wide&quot; button on the image toolbar.</figcaption></figure></div>
 <!-- /wp:image -->
 <!-- wp:paragraph -->
 <p>Try selecting and removing or editing the caption, now you don&#x27;t have to be careful about selecting the image or other text by mistake and ruining the presentation.</p>

--- a/post-content.php
+++ b/post-content.php
@@ -26,8 +26,8 @@
 <p><?php _e( 'Handling images and media with the utmost care is a primary focus of the new editor. Hopefully, you&#8217;ll find aspects of adding captions or going full-width with your pictures much easier and robust than before.', 'gutenberg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"align":"center","className":"aligncenter"} -->
-<div class="wp-block-image aligncenter">
+<!-- wp:image {"align":"center"} -->
+<div class="wp-block-image">
 	<figure class="aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="<?php esc_attr_e( 'Beautiful landscape', 'gutenberg' ); ?>" />
 		<figcaption><?php _e( 'If your theme supports it, you&#8217;ll see the "wide" button on the image toolbar. Give it a try.', 'gutenberg' ); ?></figcaption>
 	</figure>

--- a/test/integration/full-content/fixtures/core__image__center-caption.html
+++ b/test/integration/full-content/fixtures/core__image__center-caption.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"align":"center"} -->
-<div class="wp-block-image aligncenter"><figure class="aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt="" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>
+<div class="wp-block-image"><figure class="aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt="" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>
 <!-- /wp:core/image -->

--- a/test/integration/full-content/fixtures/core__image__center-caption.json
+++ b/test/integration/full-content/fixtures/core__image__center-caption.json
@@ -10,10 +10,9 @@
                 "Give it a try. Press the \"really wide\" button on the image toolbar."
             ],
             "align": "center",
-            "linkDestination": "none",
-            "className": "aligncenter"
+            "linkDestination": "none"
         },
         "innerBlocks": [],
-        "originalContent": "<div class=\"wp-block-image aligncenter\"><figure class=\"aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>"
+        "originalContent": "<div class=\"wp-block-image\"><figure class=\"aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__image__center-caption.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__center-caption.parsed.json
@@ -5,7 +5,7 @@
             "align": "center"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-image aligncenter\"><figure class=\"aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>\n"
+        "innerHTML": "\n<div class=\"wp-block-image\"><figure class=\"aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>\n"
     },
     {
         "attrs": {},

--- a/test/integration/full-content/fixtures/core__image__center-caption.serialized.html
+++ b/test/integration/full-content/fixtures/core__image__center-caption.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"align":"center","className":"aligncenter"} -->
-<div class="wp-block-image aligncenter"><figure class="aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt=""/><figcaption>Give it a try. Press the "really wide" button on the image toolbar.</figcaption></figure></div>
+<!-- wp:image {"align":"center"} -->
+<div class="wp-block-image"><figure class="aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt=""/><figcaption>Give it a try. Press the "really wide" button on the image toolbar.</figcaption></figure></div>
 <!-- /wp:image -->


### PR DESCRIPTION
closes #9160

It looks like this wasn't critical, just that we kept the className in the wrapper in the test source fixture.

