### PR TITLE
Editor: Deprecate usage of RichText provider component

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,5 +1,9 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 4.0.0
+
+- `wp.components.RichTextProvider` has been removed. Please use `wp.data.select( 'core/editor' )` methods instead.
+
 ## 3.9.0
 
 - RichText `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -14,3 +14,7 @@
 - `isFetchingSharedBlock` selector has been removed. Use `isFetchingReusableBlock` instead.
 - `getSharedBlocks` selector has been removed. Use `getReusableBlocks` instead.
 - `editorMediaUpload` has been removed. Use `mediaUpload` instead.
+
+### Deprecation
+
+- `wp.editor.RichTextProvider` flagged for deprecation. Please use `wp.data.select( 'core/editor' )` methods instead.

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -26,7 +26,7 @@ import {
 import { createBlobURL } from '@wordpress/blob';
 import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, rawShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { Slot } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { rawHandler, children } from '@wordpress/blocks';
 import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
@@ -241,7 +241,7 @@ export class RichText extends Component {
 	 * @param {UndoEvent} event The undo event as triggered by TinyMCE.
 	 */
 	onPropagateUndo( event ) {
-		const { onUndo, onRedo } = this.context;
+		const { onUndo, onRedo } = this.props;
 		const { command } = event;
 
 		if ( command === 'Undo' && onUndo ) {
@@ -419,7 +419,7 @@ export class RichText extends Component {
 			this.onChange();
 		}
 
-		this.context.onCreateUndoLevel();
+		this.props.onCreateUndoLevel();
 	}
 
 	/**
@@ -1005,12 +1005,6 @@ export class RichText extends Component {
 	}
 }
 
-RichText.contextTypes = {
-	onUndo: noop,
-	onRedo: noop,
-	onCreateUndoLevel: noop,
-};
-
 RichText.defaultProps = {
 	formattingControls: FORMATTING_CONTROLS.map( ( { format } ) => format ),
 	formatters: [],
@@ -1044,6 +1038,19 @@ const RichTextContainer = compose( [
 		return {
 			isViewportSmall: isViewportMatch( '< small' ),
 			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const {
+			createUndoLevel,
+			redo,
+			undo,
+		} = dispatch( 'core/editor' );
+
+		return {
+			onCreateUndoLevel: createUndoLevel,
+			onRedo: redo,
+			onUndo: undo,
 		};
 	} ),
 	withSafeTimeout,

--- a/packages/editor/src/components/rich-text/provider.js
+++ b/packages/editor/src/components/rich-text/provider.js
@@ -6,6 +6,7 @@ import { pick, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { Component } from '@wordpress/element';
 
 /**
@@ -16,6 +17,13 @@ import { Component } from '@wordpress/element';
  */
 class RichTextProvider extends Component {
 	getChildContext() {
+		deprecated( 'wp.editor.RichTextProvider', {
+			alternative: "wp.data.select( 'core/editor' ) methods",
+			version: '4.0.0',
+			plugin: 'Gutenberg',
+			hint: 'This is a global warning, shown regardless of whether the component is used.',
+		} );
+
 		return pick(
 			this.props,
 			Object.keys( this.constructor.childContextTypes )


### PR DESCRIPTION
## Description

This PR marks `RichTextProvider` component as deprecated since it is no longer needed to use undo/redo features.

I discovered it when trying to fix rarely failing `undo` test:
https://github.com/WordPress/gutenberg/issues/5685#issuecomment-409172411

### Open question

Should we keep `RichTextProvider` active as it is at the moment, or remove it from the list of the providers injected into the app. Technically, it's no longer necessary unless some plugins depend on it.

## How has this been tested?
`npm run test-e2e`

End to end test should still pass.

## Types of changes
Refactoring with the deprecation warning.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
