### PR TITLE
Smooth out the block switcher animation

### DIFF
--- a/packages/editor/src/components/block-switcher/style.scss
+++ b/packages/editor/src/components/block-switcher/style.scss
@@ -32,8 +32,9 @@
 		display: flex;
 		align-items: center;
 
-		// Transition opacity slightly slower than the movement for a smoother effect
-		transition: opacity 0.3s ease-in-out, transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1);
+		// The opacity and transform transitions use separate easings so the opacity
+		// animation starts while the "incoming" icon is mostly in frame.
+		transition: opacity 0.2s cubic-bezier(1, 0, 0.8, 0.65), transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1);
 	}
 
 	// Add a dropdown arrow indicator.
@@ -57,7 +58,7 @@
 		height: $icon-button-size-small + 6px;
 		padding: 3px 9px 3px 9px;
 
-		// Start fully transparent so the icon fades into place
+		// Start fully transparent so the icon fades into place.
 		opacity: 0;
 	}
 
@@ -70,7 +71,7 @@
 			transform: translateY(-$icon-button-size);
 		}
 
-		// Swap opacities on hover
+		// Swap the icon opacities on hover.
 		.editor-block-icon {
 			opacity: 0;
 		}

--- a/packages/editor/src/components/block-switcher/style.scss
+++ b/packages/editor/src/components/block-switcher/style.scss
@@ -31,7 +31,9 @@
 		padding: 0 6px;
 		display: flex;
 		align-items: center;
-		transition: all 0.1s cubic-bezier(0.165, 0.84, 0.44, 1);
+
+		// Transition opacity slightly slower than the movement for a smoother effect
+		transition: opacity 0.3s ease-in-out, transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1);
 	}
 
 	// Add a dropdown arrow indicator.
@@ -54,16 +56,28 @@
 		border-radius: $radius-round-rectangle;
 		height: $icon-button-size-small + 6px;
 		padding: 3px 9px 3px 9px;
+
+		// Start fully transparent so the icon fades into place
+		opacity: 0;
 	}
 
 	// Block hover and focus style.
-	&[aria-expanded="true"] .editor-block-icon,
-	&[aria-expanded="true"] .editor-block-switcher__transform,
-	&:not(:disabled):hover .editor-block-icon,
-	&:not(:disabled):hover .editor-block-switcher__transform,
-	&:not(:disabled):focus .editor-block-icon,
-	&:not(:disabled):focus .editor-block-switcher__transform {
-		transform: translateY(-$icon-button-size);
+	&[aria-expanded="true"],
+	&:not(:disabled):hover,
+	&:not(:disabled):focus {
+		.editor-block-icon,
+		.editor-block-switcher__transform {
+			transform: translateY(-$icon-button-size);
+		}
+
+		// Swap opacities on hover
+		.editor-block-icon {
+			opacity: 0;
+		}
+
+		.editor-block-switcher__transform {
+			opacity: 1;
+		}
 	}
 
 	// Block focus style.


### PR DESCRIPTION
This PR tries a slightly smoother block switcher hover animation.

The switcher still moves, but as the icons move they fade in or out (the "incoming" icon fades from transparent to opaque, and the "outgoing" icon fades from opaque to transparent).

It also changes the animation speed of the movement to `0.2s` instead of `0.1s`.

Because GIFs compress the heck out of the animation, I made a video you can watch instead if you don't want to try it out directly. It's a split screen: the left shows the animation in `master`, and the right shows the animation in this branch.

https://www.dropbox.com/s/q18q0cug1x8it8s/demo.mov?dl=0

Overall the effect is very subtle, but I think it makes the motion feel a bit less aggressive than it currently does.