### PR TITLE
[Enhancement] Establish consistency regarding alignment options between the archives and categories blocks

### DIFF
--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -37,6 +37,7 @@ export const settings = {
 
 	supports: {
 		align: true,
+		alignWide: false,
 		html: false,
 	},
 


### PR DESCRIPTION
## Description
This PR closes #9413 which suggests the sync up of alignment options in the archives and categories blocks. This removes the "Full" alignment option from the categories block so it stays consistent with the archives block.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the "Categories" block.
3. Made sure that the "Full" alignment option doesn't show up in the block alignment toolbar.

## Screenshots <!-- if applicable -->
![pull-9413](https://user-images.githubusercontent.com/20284937/44855356-a6e19280-ac8c-11e8-9561-0b33f6877c21.png)

## Types of changes
This PR just removes the `full` option from the `controls` parameter that defined the alignment options in the "Categories" block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
