### PR TITLE
Block: fix invalid block scrim overflowing toolbar on mobile

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -547,13 +547,13 @@ export class BlockListBlock extends Component {
 							<BlockHtml clientId={ clientId } />
 						) }
 						{ ! isValid && [
-							<div key="invalid-preview">
-								{ getSaveElement( blockType, block.attributes ) }
-							</div>,
 							<BlockInvalidWarning
 								key="invalid-warning"
 								block={ block }
 							/>,
+							<div key="invalid-preview">
+								{ getSaveElement( blockType, block.attributes ) }
+							</div>,
 						] }
 					</BlockCrashBoundary>
 					{ shouldShowMobileToolbar && (

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -1083,18 +1083,18 @@
 	position: relative;
 
 	// Stretch the warning edge to edge.
-	margin-left: -$parent-block-padding;
-	margin-right: -$parent-block-padding;
+	margin-left: -$parent-block-padding - $border-width;
+	margin-right: -$parent-block-padding - $border-width;
 
 	// Stretch the warning less in nested contexts.
 	.editor-block-list__block & {
-		margin-left: -$block-padding;
-		margin-right: -$block-padding;
+		margin-left: -$block-padding - $border-width;
+		margin-right: -$block-padding - $border-width;
 	}
 
 	// Pull the warning upwards to the edge, and add a negative bottom margin to compensate.
-	margin-bottom: -$block-padding;
-	transform: translateY(-$block-padding);
+	margin-bottom: -$block-padding - $border-width;
+	transform: translateY(-$block-padding - $border-width);
 
 	// Bigger padding on mobile where blocks are edge to edge.
 	padding: 10px $parent-block-padding;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -312,7 +312,7 @@
 	&.has-warning .editor-block-list__block-edit::after {
 		content: "";
 		position: absolute;
-		background-color: rgba($light-gray-100, 0.8);
+		background-color: rgba($light-gray-100, 0.4);
 
 		top: -$block-padding;
 		bottom: -$block-padding;
@@ -1080,16 +1080,15 @@
 
 .editor-block-list__block .editor-warning {
 	z-index: z-index(".editor-warning");
-	position: absolute;
-	top: -$block-padding - $border-width;
-	right: -$parent-block-padding - $border-width;
-	left: -$parent-block-padding - $border-width;
+	position: relative;
 
-	// Position for nested blocks
-	.editor-block-list__block & {
-		right: -$block-padding - $border-width;
-		left: -$block-padding - $border-width;
-	}
+	// Stretch the warning edge to edge.
+	margin-left: -$parent-block-padding;
+	margin-right: -$parent-block-padding;
+
+	// Pull the warning upwards to the edge, and add a negative bottom margin to compensate.
+	margin-bottom: -$block-padding;
+	transform: translateY(-$block-padding);
 
 	// Bigger padding on mobile where blocks are edge to edge.
 	padding: 10px $parent-block-padding;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -326,6 +326,14 @@
 		}
 	}
 
+	&.has-warning.is-selected .editor-block-list__block-edit::after {
+		bottom: ( $block-toolbar-height - $block-padding - 1px );
+
+		@include break-small() {
+			bottom: -$block-padding;
+		}
+	}
+
 	// Appender
 	&.is-typing .editor-block-list__empty-block-inserter,
 	&.is-typing .editor-block-list__side-inserter {

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -327,7 +327,7 @@
 	}
 
 	&.has-warning.is-selected .editor-block-list__block-edit::after {
-		bottom: ( $block-toolbar-height - $block-padding - 1px );
+		bottom: ( $block-toolbar-height - $block-padding - $border-width );
 
 		@include break-small() {
 			bottom: -$block-padding;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -1086,6 +1086,12 @@
 	margin-left: -$parent-block-padding;
 	margin-right: -$parent-block-padding;
 
+	// Stretch the warning less in nested contexts.
+	.editor-block-list__block & {
+		margin-left: -$block-padding;
+		margin-right: -$block-padding;
+	}
+
 	// Pull the warning upwards to the edge, and add a negative bottom margin to compensate.
 	margin-bottom: -$block-padding;
 	transform: translateY(-$block-padding);

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -4,7 +4,7 @@
 	justify-content: space-between;
 	flex-wrap: nowrap;
 	background-color: $white;
-	border-bottom: $border-width solid $light-gray-500;
+	border: $border-width solid $light-gray-500;
 	text-align: left;
 	padding: 20px;
 

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -4,7 +4,7 @@
 	justify-content: space-between;
 	flex-wrap: nowrap;
 	background-color: $white;
-	border: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $light-gray-500;
 	text-align: left;
 	padding: 20px;
 


### PR DESCRIPTION
On small screens the invalid block scrim overflows a block’s dropdown menu / toolbar, which is positioned beneath the block.

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44737384-c096a480-aae9-11e8-9590-4b26af6f4f34.jpg)

This only happens when the block is selected.

This PR shortens the scrim so it doesn't overlap the bottom toolbar, as discussed in #9402.

Fixes #9402 

## Testing

1. Make a block invalid (i.e. edit HTML on a paragraph and remove the trailing `</p>`)
2. Switch browser to a mobile display
3. Ensure block is selected and verify that without this PR the scrim overflows the bottom of the block, as shown above
4. Apply PR and verify that the scrim does not cover the toolbar and dropdown menu at the bottom of the block.
![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44860197-9a017680-ac6d-11e8-952e-da92f5fe6039.jpg)
5. Switch back to desktop  mode and verify that the scrim fully covers the block
![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44860245-b1d8fa80-ac6d-11e8-8080-eecf253871fd.jpg)
5. Verify that an unselected block looks correct in both desktop and mobile mode

## Types of changes

The CSS changes are tightly coupled to a selected block on a small screen so shouldn't affect anything else.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
