### PR TITLE
Revert shortcut change in block-deletion e2e test

### DIFF
--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -42,6 +42,8 @@ describe( 'block deletion -', () => {
 
 	describe( 'deleting the third block using the Remove Block shortcut', () => {
 		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
+			// Type some text to assert that the shortcut also deletes block content.
+			await page.keyboard.type( 'this is block 2' );
 			await pressWithModifier( [ 'Alt', META_KEY ], 'Backspace' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -42,7 +42,7 @@ describe( 'block deletion -', () => {
 
 	describe( 'deleting the third block using the Remove Block shortcut', () => {
 		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
-			await pressWithModifier( [ 'Shift', META_KEY ], 'Backspace' );
+			await pressWithModifier( [ 'Alt', META_KEY ], 'Backspace' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 
 			// Type additional text and assert that caret position is correct by comparing to snapshot.


### PR DESCRIPTION
This reverts commit ef01a14365c0c13da0740a7b12cc536e9df01b6f.

An e2e test that uses the block deletion shortcut was merged in #8961. Unfortunately the shortcut key was reverted back. This PR also reverts the shortcut used in the test.