### PR TITLE
Video Block: Fix drag and drop to create blocks

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -20,7 +20,7 @@ import {
 	MediaPlaceholder,
 	MediaUpload,
 	RichText,
-	editorMediaUpload,
+	mediaUpload,
 } from '@wordpress/editor';
 import { getBlobByURL } from '@wordpress/blob';
 
@@ -46,7 +46,7 @@ class VideoEdit extends Component {
 		if ( ! id && src.indexOf( 'blob:' ) === 0 ) {
 			const file = getBlobByURL( src );
 			if ( file ) {
-				editorMediaUpload( {
+				mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ { url } ] ) => {
 						setAttributes( { src: url } );


### PR DESCRIPTION
closes #9484

This PRs fixed a regression in the video block. It was using `editorMediaUpload` which was deprecated in favor of `mediaUpload`

**Testing instructions**

 - Repeat testing instructions in #9484 you shouldn't notice any error.