### PR TITLE
Inserter: Fix small style issue

### DIFF
--- a/packages/editor/src/components/block-types-list/style.scss
+++ b/packages/editor/src/components/block-types-list/style.scss
@@ -1,7 +1,7 @@
 
 .editor-block-types-list {
 	list-style: none;
-	padding: 0;
+	padding: 2px 0;
 	overflow: hidden;
 }
 

--- a/packages/editor/src/components/block-types-list/style.scss
+++ b/packages/editor/src/components/block-types-list/style.scss
@@ -2,6 +2,7 @@
 .editor-block-types-list {
 	list-style: none;
 	padding: 0;
+	overflow: hidden;
 }
 
 .editor-block-types-list__list-item {


### PR DESCRIPTION
closes #9491 Regression introduces in #9310

This PR fixes the small issue where the border bottom of the block list was not properly displayed because the block list was containing exclusively floated elements, so its height doesn't fit its content.

**Testing instructions**

 - Check testing instructions from #9491