### PR TITLE
Use "Save as Pending" when the Pending checkbox is active

### DIFF
--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -41,6 +41,8 @@ export function PostPublishPanelToggle( {
 		return <PostPublishButton forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />;
 	}
 
+	const publishButtonLabel = hasPublishAction ? __( 'Publish…' ) : __( 'Submit for review…' );
+
 	return (
 		<Button
 			className="editor-post-publish-panel__toggle"
@@ -50,7 +52,7 @@ export function PostPublishPanelToggle( {
 			disabled={ ! isButtonEnabled }
 			isBusy={ isSaving && isPublished }
 		>
-			{ isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' ) }
+			{ isBeingScheduled ? __( 'Schedule…' ) : publishButtonLabel }
 			<DotTip id="core/editor.publish">
 				{ __( 'Finished writing? That’s great, let’s get this published right now. Just click “Publish” and you’re good to go.' ) }
 			</DotTip>

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -41,7 +41,7 @@ export function PostPublishPanelToggle( {
 		return <PostPublishButton forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />;
 	}
 
-	const publishButtonLabel = hasPublishAction ? __( 'Publish…' ) : __( 'Submit for review…' );
+	const publishButtonLabel = hasPublishAction ? __( 'Publish…' ) : __( 'Submit for Review…' );
 
 	return (
 		<Button

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -41,8 +41,6 @@ export function PostPublishPanelToggle( {
 		return <PostPublishButton forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />;
 	}
 
-	const publishButtonLabel = hasPublishAction ? __( 'Publish…' ) : __( 'Submit for Review…' );
-
 	return (
 		<Button
 			className="editor-post-publish-panel__toggle"
@@ -52,7 +50,7 @@ export function PostPublishPanelToggle( {
 			disabled={ ! isButtonEnabled }
 			isBusy={ isSaving && isPublished }
 		>
-			{ isBeingScheduled ? __( 'Schedule…' ) : publishButtonLabel }
+			{ isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' ) }
 			<DotTip id="core/editor.publish">
 				{ __( 'Finished writing? That’s great, let’s get this published right now. Just click “Publish” and you’re good to go.' ) }
 			</DotTip>

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -41,8 +42,9 @@ export class PostSavedState extends Component {
 	}
 
 	render() {
-		const { isNew, isScheduled, isPublished, isDirty, isSaving, isSaveable, onSave, isAutosaving, isPending } = this.props;
+		const { post, isNew, isScheduled, isPublished, isDirty, isSaving, isSaveable, onSave, isAutosaving, isPending } = this.props;
 		const { forceSavedMessage } = this.state;
+		const hasPublishAction = get( post, [ '_links', 'wp:action-publish' ], false );
 		if ( isSaving ) {
 			// TODO: Classes generation should be common across all return
 			// paths of this function, including proper naming convention for
@@ -74,6 +76,12 @@ export class PostSavedState extends Component {
 					{ __( 'Saved' ) }
 				</span>
 			);
+		}
+
+		// Once the post has been submitted for review this button
+		// is not needed for the contributor role.
+		if ( ! hasPublishAction ) {
+			return null;
 		}
 
 		return (

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -80,7 +80,7 @@ export class PostSavedState extends Component {
 
 		// Once the post has been submitted for review this button
 		// is not needed for the contributor role.
-		if ( ! hasPublishAction ) {
+		if ( ! hasPublishAction && isPending ) {
 			return null;
 		}
 

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -41,7 +41,7 @@ export class PostSavedState extends Component {
 	}
 
 	render() {
-		const { isNew, isScheduled, isPublished, isDirty, isSaving, isSaveable, onSave, isAutosaving } = this.props;
+		const { isNew, isScheduled, isPublished, isDirty, isSaving, isSaveable, onSave, isAutosaving, isPending } = this.props;
 		const { forceSavedMessage } = this.state;
 		if ( isSaving ) {
 			// TODO: Classes generation should be common across all return
@@ -83,7 +83,7 @@ export class PostSavedState extends Component {
 				icon="cloud-upload"
 				shortcut={ displayShortcut.primary( 's' ) }
 			>
-				{ __( 'Save Draft' ) }
+				{ isPending ? __( 'Save as Pending' ) : __( 'Save Draft' ) }
 			</IconButton>
 		);
 	}
@@ -100,6 +100,7 @@ export default compose( [
 			isEditedPostSaveable,
 			getCurrentPost,
 			isAutosavingPost,
+			getEditedPostAttribute,
 		} = select( 'core/editor' );
 		return {
 			post: getCurrentPost(),
@@ -110,6 +111,7 @@ export default compose( [
 			isSaving: forceIsSaving || isSavingPost(),
 			isSaveable: isEditedPostSaveable(),
 			isAutosaving: isAutosavingPost(),
+			isPending: 'pending' === getEditedPostAttribute( 'status' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {


### PR DESCRIPTION
## Description
This my suggestion to fix #8894, an issue I posted 2 weeks ago. It simply gets the edited post status and use "Save as Pending" instead as "Save Draft" if this status is pending (meaning the Pending checkbox is active). As soon as this checkbox is unchecked, the button use "Save Draft".

## How has this been tested?
I've tested using Gutenberg on my local environnement. I also ran successfully `npm run test`

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
