### PR TITLE
Use flexbox for the inserter layout

### DIFF
--- a/packages/editor/src/components/block-icon/style.scss
+++ b/packages/editor/src/components/block-icon/style.scss
@@ -2,8 +2,6 @@
 	display: inline-block;
 	border-radius: 4px;
 	margin: 0;
-	width: 24px;
-	height: 24px;
 
 	&.has-colors {
 		svg {
@@ -11,15 +9,8 @@
 		}
 	}
 
-	svg {
-		// Don't let SVG icons get bigger than 24x24px.
-		max-height: 24px;
-		max-width: 24px;
-
-		// Keep the icon vertically centered. We do this
-		// over flexbox alignment because it causes
-		// issues if the SVG element does not have an
-		// explicit width and height.
-		vertical-align: middle;
+	svg:not(.dashicon) {
+		height: 24px;
+		width: 24px;
 	}
 }

--- a/packages/editor/src/components/block-icon/style.scss
+++ b/packages/editor/src/components/block-icon/style.scss
@@ -2,6 +2,8 @@
 	display: inline-block;
 	border-radius: 4px;
 	margin: 0;
+	width: 24px;
+	height: 24px;
 
 	&.has-colors {
 		svg {
@@ -9,8 +11,15 @@
 		}
 	}
 
-	svg:not(.dashicon) {
-		height: 24px;
-		width: 24px;
+	svg {
+		// Don't let SVG icons get bigger than 24x24px.
+		max-height: 24px;
+		max-width: 24px;
+
+		// Keep the icon vertically centered. We do this
+		// over flexbox alignment because it causes
+		// issues if the SVG element does not have an
+		// explicit width and height.
+		vertical-align: middle;
 	}
 }

--- a/packages/editor/src/components/block-types-list/style.scss
+++ b/packages/editor/src/components/block-types-list/style.scss
@@ -94,7 +94,7 @@
 		background: $white;
 		margin-right: 3px;
 		margin-bottom: 6px;
-		padding: 10px 20px 10px;
+		padding: 9px 20px 9px;
 		position: relative;
 		top: -2px;
 		left: -2px;

--- a/packages/editor/src/components/block-types-list/style.scss
+++ b/packages/editor/src/components/block-types-list/style.scss
@@ -8,7 +8,7 @@
 
 .editor-block-types-list__list-item {
 	display: block;
-	flex: 0 1 33.333333%;
+	width: 33.33%;
 	padding: 0 4px;
 	margin: 0 0 12px;
 }

--- a/packages/editor/src/components/block-types-list/style.scss
+++ b/packages/editor/src/components/block-types-list/style.scss
@@ -1,19 +1,22 @@
-
 .editor-block-types-list {
 	list-style: none;
 	padding: 2px 0;
 	overflow: hidden;
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .editor-block-types-list__list-item {
-	display: inline;
+	display: block;
+	flex: 0 1 33.333333%;
+	padding: 0 4px;
+	margin: 0 0 12px;
 }
 
 .editor-block-types-list__item {
-	display: inline-flex;
+	display: flex;
 	flex-direction: column;
-	width: calc(33.3% - 8px);
-	margin: 0 4px 12px 4px;
+	width: 100%;
 	font-size: $default-font-size;
 	color: $dark-gray-700;
 	padding: 0;
@@ -26,7 +29,6 @@
 	border: $border-width solid transparent;
 	transition: all 0.05s ease-in-out;
 	position: relative;
-	float: left; // This shouldn't be necessary, but without it, IE11 mangles margins.
 
 	&:disabled {
 		@include block-style__disabled();
@@ -54,6 +56,7 @@
 				color: currentColor;
 			}
 		}
+
 		&:active,
 		&.is-active,
 		&:focus {
@@ -83,7 +86,7 @@
 }
 
 .editor-block-types-list__item-title {
-	padding: 4px 2px;
+	padding: 4px 2px 8px;
 }
 
 .editor-block-types-list__item-has-children {
@@ -91,7 +94,7 @@
 		background: $white;
 		margin-right: 3px;
 		margin-bottom: 6px;
-		padding: 12px 20px 8px;
+		padding: 10px 20px 10px;
 		position: relative;
 		top: -2px;
 		left: -2px;


### PR DESCRIPTION
This PR changes the inserter icon grid from using `display: inline` on each `<li>` to using a flexbox-based approach.

This solves a few things:

+ staggered icons due to varying heights
+ ~block icons smaller than 24px (the `display: inline` was causing issues with smaller icons shifting the baseline of the icon)~

Here's a screenshot, with red borders applied, to show how the buttons and icons are all correctly sized and positioned.

![image](https://user-images.githubusercontent.com/1231306/44911689-bcd76d80-acf5-11e8-901c-0a93f4aae4e6.png)

I haven't done thorough testing in IE just yet, but I'm happy with how it's looking in Safari, Firefox, and Chrome.

At this point I'm very interested in just getting feedback on whether this approach is viable, and — in particular — any regressions that might have arisen as a result of this change.