### PR TITLE
Fix empty invalid block showing empty block inserter

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -564,7 +564,7 @@ export class BlockListBlock extends Component {
 					) }
 					{ !! error && <BlockCrashWarning /> }
 				</IgnoreNestedEvents>
-				{ showEmptyBlockSideInserter && (
+				{ showEmptyBlockSideInserter && isValid && (
 					<Fragment>
 						<div className="editor-block-list__side-inserter">
 							<InserterWithShortcuts


### PR DESCRIPTION
## Description
An empty block that is also invalid will show the empty block inserter, which overlaps with the invalid block message

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44915668-70a72000-ad2b-11e8-8909-a4c8f43f1ac5.jpg)

This PR prevents the empty block inserter appearing when a block is invalid.

An empty block probably shouldn't trigger an invalid block, and I'll look at that separately.

Side note: the block list is quite complicated and leads to situations like this where things can appear in unexpected situations. It probably could use a refactor, but that's out of scope for this PR.

## How has this been tested?
1. Add a block
2. Edit block HTML and delete all content
3. Note that the invalid block message is shown as well as the empty block inserter 
4. Apply PR and repeat, note that the empty block inserter doesn't appear

## Types of changes

This is a small change that only affects the empty block inserter.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
