### PR TITLE
Fix image centering.

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -38,6 +38,11 @@
 		margin-left: 1em;
 	}
 
+	// Centered images.
+	.aligncenter {
+		margin: 0 auto;
+	}
+
 	// Supply caption styles to images, even if the theme hasn't opted in.
 	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
 	// so we supply the styles so as to not appear broken or unstyled in those themes.


### PR DESCRIPTION
Small fix, this fixes #9503.

Centering was not output as part of the new `figure` markup. This PR addresses that.

I need another vacation.