### PR TITLE
Fix drag and drop in chrome when the document has iframes

### DIFF
--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -17,7 +17,7 @@ const cloneHeightTransformationBreakpoint = 700;
 const clonePadding = 20;
 
 const isChromeUA = ( ) => /Chrome/.test( window.navigator.userAgent );
-const documentHasIframes = ( ) => [ ...document.body.querySelectorAll( 'iframe' ) ].length > 0;
+const documentHasIframes = ( ) => [ ...document.getElementById( 'editor' ).querySelectorAll( 'iframe' ) ].length > 0;
 
 class Draggable extends Component {
 	constructor() {

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -16,14 +16,20 @@ const cloneWrapperClass = 'components-draggable__clone';
 const cloneHeightTransformationBreakpoint = 700;
 const clonePadding = 20;
 
+const isChromeUA = ( ) => /Chrome/.test( window.navigator.userAgent );
+const documentHasIframes = ( ) => [ ...document.body.querySelectorAll( 'iframe' ) ].length > 0;
+
 class Draggable extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.onDragStart = this.onDragStart.bind( this );
 		this.onDragOver = this.onDragOver.bind( this );
+		this.onDrop = this.onDrop.bind( this );
 		this.onDragEnd = this.onDragEnd.bind( this );
 		this.resetDragState = this.resetDragState.bind( this );
+
+		this.isChromeAndHasIframes = false;
 	}
 
 	componentWillUnmount() {
@@ -36,10 +42,11 @@ class Draggable extends Component {
 	 */
 	onDragEnd( event ) {
 		const { onDragEnd = noop } = this.props;
-		event.preventDefault();
+		if ( event ) {
+			event.preventDefault();
+		}
 
 		this.resetDragState();
-
 		this.props.setTimeout( onDragEnd );
 	}
 
@@ -56,6 +63,13 @@ class Draggable extends Component {
 		// Update cursor coordinates.
 		this.cursorLeft = event.clientX;
 		this.cursorTop = event.clientY;
+	}
+
+	onDrop( ) {
+		// As per https://html.spec.whatwg.org/multipage/dnd.html#dndevents
+		// the target node for the dragend is the source node that started the drag operation,
+		// while drop event's target is the current target element.
+		this.onDragEnd( null );
 	}
 
 	/**
@@ -128,6 +142,17 @@ class Draggable extends Component {
 		document.body.classList.add( 'is-dragging-components-draggable' );
 		document.addEventListener( 'dragover', this.onDragOver );
 
+		// Fixes https://bugs.chromium.org/p/chromium/issues/detail?id=737691#c8
+		// dragend event won't be dispatched in the chrome browser
+		// when iframes are affected by the drag operation. So, in that case,
+		// we use the drop event to wrap up the dragging operation.
+		// This way the hack is contained to a specific use case and the external API
+		// still relies mostly on the dragend event.
+		if ( isChromeUA() && documentHasIframes() ) {
+			this.isChromeAndHasIframes = true;
+			document.addEventListener( 'drop', this.onDrop );
+		}
+
 		this.props.setTimeout( onDragStart );
 	}
 
@@ -141,6 +166,11 @@ class Draggable extends Component {
 		if ( this.cloneWrapper && this.cloneWrapper.parentNode ) {
 			this.cloneWrapper.parentNode.removeChild( this.cloneWrapper );
 			this.cloneWrapper = null;
+		}
+
+		if ( this.isChromeAndHasIframes ) {
+			this.isChromeAndHasIframes = false;
+			document.removeEventListener( 'drop', this.onDrop );
 		}
 
 		// Reset cursor.

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -16,7 +16,7 @@ const cloneWrapperClass = 'components-draggable__clone';
 const cloneHeightTransformationBreakpoint = 700;
 const clonePadding = 20;
 
-const isChromeUA = ( ) => /Chrome/.test( window.navigator.userAgent );
+const isChromeUA = ( ) => /Chrome/i.test( window.navigator.userAgent );
 const documentHasIframes = ( ) => [ ...document.getElementById( 'editor' ).querySelectorAll( 'iframe' ) ].length > 0;
 
 class Draggable extends Component {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/6145

In Chrome, the `dragend` event won't be dispatched if an iframe is affected by the drag operation (moved as a result of dragging other nodes, etc). [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=737691#c8).

## Testing

- Create a post that contains an iframe. For example, you can add an embed block (twitter, youtube video, etc).
- Drag it to several positions. 
- Drag other elements above and below it.

The expected result is that the drag-and-drop operation works and it's not stuck mid-drag.