### PR TITLE
Editor: PostTextEditor: Fix case where empty state value defers to prop

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.0 (Unreleased)
 
-### Breaking Change
+### Breaking Changes
 
 - The `wideAlign` block supports hook has been removed. Use `alignWide` instead.
 - `fetchSharedBlocks` action has been removed. Use `fetchReusableBlocks` instead.
@@ -18,3 +18,7 @@
 ### Deprecation
 
 - `wp.editor.RichTextProvider` flagged for deprecation. Please use `wp.data.select( 'core/editor' )` methods instead.
+
+### Bug Fixes
+
+- The `PostTextEditor` component will respect its in-progress state edited value, even if the assigned prop value changes.

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { create } from 'react-test-renderer';
+import Textarea from 'react-autosize-textarea';
+
+/**
+ * Internal dependencies
+ */
+import { PostTextEditor } from '../';
+
+// "Downgrade" ReactAutosizeTextarea to a regular textarea. Assumes aligned
+// props interface.
+jest.mock( 'react-autosize-textarea', () => ( props ) => <textarea { ...props } /> );
+
+describe( 'PostTextEditor', () => {
+	it( 'should render via the prop value', () => {
+		const wrapper = create( <PostTextEditor value="Hello World" /> );
+
+		const textarea = wrapper.root.findByType( Textarea );
+		expect( textarea.props.value ).toBe( 'Hello World' );
+	} );
+
+	it( 'should render via the state value when edits made', () => {
+		const onChange = jest.fn();
+		const wrapper = create(
+			<PostTextEditor
+				value="Hello World"
+				onChange={ onChange }
+			/>
+		);
+
+		const textarea = wrapper.root.findByType( Textarea );
+		textarea.props.onChange( { target: { value: 'Hello Chicken' } } );
+
+		expect( textarea.props.value ).toBe( 'Hello Chicken' );
+		expect( onChange ).toHaveBeenCalledWith( 'Hello Chicken' );
+	} );
+
+	it( 'should render via the state value when edits made, even if prop value changes', () => {
+		const onChange = jest.fn();
+		const wrapper = create(
+			<PostTextEditor
+				value="Hello World"
+				onChange={ onChange }
+			/>
+		);
+
+		const textarea = wrapper.root.findByType( Textarea );
+		textarea.props.onChange( { target: { value: 'Hello Chicken' } } );
+
+		wrapper.update(
+			<PostTextEditor
+				value="Goodbye World"
+				onChange={ onChange }
+			/>
+		);
+
+		expect( textarea.props.value ).toBe( 'Hello Chicken' );
+		expect( onChange ).toHaveBeenCalledWith( 'Hello Chicken' );
+	} );
+
+	it( 'should render via the state value when edits made, even if prop value changes and state value empty', () => {
+		const onChange = jest.fn();
+		const wrapper = create(
+			<PostTextEditor
+				value="Hello World"
+				onChange={ onChange }
+			/>
+		);
+
+		const textarea = wrapper.root.findByType( Textarea );
+		textarea.props.onChange( { target: { value: '' } } );
+
+		wrapper.update(
+			<PostTextEditor
+				value="Goodbye World"
+				onChange={ onChange }
+			/>
+		);
+
+		expect( textarea.props.value ).toBe( '' );
+		expect( onChange ).toHaveBeenCalledWith( '' );
+	} );
+} );

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -82,4 +82,66 @@ describe( 'PostTextEditor', () => {
 		expect( textarea.props.value ).toBe( '' );
 		expect( onChange ).toHaveBeenCalledWith( '' );
 	} );
+
+	it( 'calls onPersist after changes made and user stops editing', () => {
+		const onPersist = jest.fn();
+		const wrapper = create(
+			<PostTextEditor
+				value="Hello World"
+				onChange={ () => {} }
+				onPersist={ onPersist }
+			/>
+		);
+
+		const textarea = wrapper.root.findByType( Textarea );
+		textarea.props.onChange( { target: { value: '' } } );
+		textarea.props.onBlur();
+
+		expect( onPersist ).toHaveBeenCalledWith( '' );
+	} );
+
+	it( 'does not call onPersist after user stops editing without changes', () => {
+		const onPersist = jest.fn();
+		const wrapper = create(
+			<PostTextEditor
+				value="Hello World"
+				onChange={ () => {} }
+				onPersist={ onPersist }
+			/>
+		);
+
+		const textarea = wrapper.root.findByType( Textarea );
+		textarea.props.onBlur();
+
+		expect( onPersist ).not.toHaveBeenCalled();
+	} );
+
+	it( 'resets to prop value after user stops editing', () => {
+		// This isn't the most realistic case, since typically we'd assume the
+		// parent renderer to pass the value as it had received onPersist. The
+		// test here is more an edge case to stress that it's intentionally
+		// differentiating between state and prop values.
+		const wrapper = create(
+			<PostTextEditor
+				value="Hello World"
+				onChange={ () => {} }
+				onPersist={ () => {} }
+			/>
+		);
+
+		const textarea = wrapper.root.findByType( Textarea );
+		textarea.props.onChange( { target: { value: '' } } );
+
+		wrapper.update(
+			<PostTextEditor
+				value="Goodbye World"
+				onChange={ () => {} }
+				onPersist={ () => {} }
+			/>
+		);
+
+		textarea.props.onBlur();
+
+		expect( textarea.props.value ).toBe( 'Goodbye World' );
+	} );
 } );


### PR DESCRIPTION
Extracted from #9403

This pull request seeks to fix a bug with PostTextEditor where intended state value is not always reflected in the rendered textarea when empty. Since previously, it relied on a simple truthy condition to determine whether to use state or props value, if the user had erased all content from the textarea, it would effectively trigger this fallback to props value to occur, thus disregarding the local (user-intended) state.

In practice, this had no effect only because props edit state was kept in sync, so the value remained the same. The issue became more obvious through related refactoring in #9403.

**Testing instructions:**

There should be no regressions in the behavior of the PostTextEditor.

Ensure unit tests pass:

```
npm run test-unit editor/src/components/post-text-editor/test/index.js
```

**Future tasks:**

In testing this myself, I discovered some unfortunate consequences of our "delayed sync" blocks parsing behavior. Since we rely on the `blur` event to persist content, the sync doesn't always occur, for example when using the keyboard shortcut to switch between modes. I created an issue at #9512 to track (with potential fix included).