### PR TITLE
[Enhancement] Introduce Link Target in Image Block

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -27,6 +27,7 @@ import {
 	TextareaControl,
 	Toolbar,
 	withNotices,
+	ToggleControl,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import {
@@ -266,7 +267,7 @@ class ImageEdit extends Component {
 	render() {
 		const { isEditing } = this.state;
 		const { attributes, setAttributes, isLargeViewport, isSelected, className, maxWidth, noticeOperations, noticeUI, toggleSelection, isRTL } = this.props;
-		const { url, alt, caption, align, id, href, linkDestination, width, height } = attributes;
+		const { url, alt, caption, align, id, href, linkDestination, width, height, linkTarget } = attributes;
 		const isExternal = isExternalImage( id, url );
 
 		let toolbarEditButton;
@@ -431,13 +432,19 @@ class ImageEdit extends Component {
 						onChange={ this.onSetLinkDestination }
 					/>
 					{ linkDestination !== LINK_DESTINATION_NONE && (
-						<TextControl
-							label={ __( 'Link URL' ) }
-							value={ href || '' }
-							onChange={ this.onSetCustomHref }
-							placeholder={ ! isLinkURLInputDisabled ? 'https://' : undefined }
-							disabled={ isLinkURLInputDisabled }
-						/>
+						<Fragment>
+							<TextControl
+								label={ __( 'Link URL' ) }
+								value={ href || '' }
+								onChange={ this.onSetCustomHref }
+								placeholder={ ! isLinkURLInputDisabled ? 'https://' : undefined }
+								disabled={ isLinkURLInputDisabled }
+							/>
+							<ToggleControl
+								label={ __( 'Open in New Tab' ) }
+								onChange={ () => setAttributes( { linkTarget: ! linkTarget ? '_blank' : undefined } ) }
+								checked={ linkTarget === '_blank' } />
+						</Fragment>
 					) }
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -68,6 +68,12 @@ const blockAttributes = {
 		type: 'string',
 		default: 'none',
 	},
+	linkTarget: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'figure > a',
+		attribute: 'target',
+	},
 };
 
 const imageSchema = {
@@ -83,7 +89,7 @@ const schema = {
 		children: {
 			...imageSchema,
 			a: {
-				attributes: [ 'href' ],
+				attributes: [ 'href', 'target' ],
 				children: imageSchema,
 			},
 			figcaption: {
@@ -204,7 +210,7 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { url, alt, caption, align, href, width, height, id } = attributes;
+		const { url, alt, caption, align, href, width, height, id, linkTarget } = attributes;
 
 		const classes = classnames( {
 			[ `align${ align }` ]: align,
@@ -223,7 +229,7 @@ export const settings = {
 
 		const figure = (
 			<Fragment>
-				{ href ? <a href={ href }>{ image }</a> : image }
+				{ href ? <a href={ href } target={ linkTarget } rel={ linkTarget === '_blank' ? 'noreferrer noopener' : undefined }>{ image }</a> : image }
 				{ ! RichText.isEmpty( caption ) && <RichText.Content tagName="figcaption" value={ caption } /> }
 			</Fragment>
 		);


### PR DESCRIPTION
## Description
This PR closes #9458 which requests the addition of an option to open the image in a new tab under "Link Options" in the Image block.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the "Image" block.
3. Made sure the "Open in New Window" option shows up under "Link Options".
4. Made sure the link target functionality works in the front-end.

## Screenshots <!-- if applicable -->
![pull-9458-min](https://user-images.githubusercontent.com/20284937/44929082-91976180-ad7b-11e8-9c07-5604641243fe.gif)
(Apologies about the crappy screencast, had to shrink the browser down and compress for Github to accept it).

## Types of changes
This PR introduces a new `boolean` attribute named `linkTarget`, which if `true`, applies the `_blank` target attribute. It adds `ToggleControl` in the `InspectorControls`, which toggles the attribute `onChange`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
