### PR TITLE
Columns: Disable inserter on column block; Don't show stacked icon on columns

### DIFF
--- a/packages/block-library/src/columns/column.js
+++ b/packages/block-library/src/columns/column.js
@@ -17,6 +17,10 @@ export const settings = {
 
 	category: 'common',
 
+	supports: {
+		inserter: false,
+	},
+
 	edit() {
 		return <InnerBlocks templateLock={ false } />;
 	},


### PR DESCRIPTION
## Description
We can not use the inserter to inserter a column so the inserter should be disabled on this block.
This will also make sure the icon of the columns block does not appear stacked as in fact for the columns we don't have children that we can insert using the inserter.
Depends on: https://github.com/WordPress/gutenberg/pull/9337

## How has this been tested?
I Verified column block does not appear on the inserter, and that the columns block icon appear normally without the stacked indication.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/44940480-189e0700-ad87-11e8-9cd6-f050dd2970bd.png)
