### PR TITLE
Add a label to the URL field in the Publishing Flow panel

### DIFF
--- a/assets/stylesheets/_colors.scss
+++ b/assets/stylesheets/_colors.scss
@@ -19,7 +19,7 @@ $light-gray-800: #b5bcc2;
 $light-gray-700: #ccd0d4;
 $light-gray-600: #d7dade;
 $light-gray-500: #e2e4e7; // Good for "grayed" items and borders.
-$light-gray-400: #e8eaeb;
+$light-gray-400: #e8eaeb; // Good for "readonly" input fields and special text selection.
 $light-gray-300: #edeff0;
 $light-gray-200: #f3f4f5;
 $light-gray-100: #f8f9f9;

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -6,11 +6,10 @@ import { get } from 'lodash';
 /**
  * WordPress Dependencies
  */
-import { PanelBody, Button, ClipboardButton } from '@wordpress/components';
+import { PanelBody, Button, ClipboardButton, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
-import { withInstanceId, compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -49,10 +48,9 @@ class PostPublishPanelPostpublish extends Component {
 	}
 
 	render() {
-		const { children, isScheduled, post, postType, instanceId } = this.props;
+		const { children, isScheduled, post, postType } = this.props;
 		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
-		const id = `post-publish-panel__postpublish-link-input-${ instanceId }`;
 
 		const postPublishNonLinkHeader = isScheduled ?
 			<Fragment>{ __( 'is now scheduled. It will go live on' ) } <PostScheduleLabel />.</Fragment> :
@@ -67,19 +65,15 @@ class PostPublishPanelPostpublish extends Component {
 					<p className="post-publish-panel__postpublish-subheader">
 						<strong>{ __( 'What’s next?' ) }</strong>
 					</p>
-					<label htmlFor={ id } className="post-publish-panel__postpublish-link-label">
-						{ sprintf(
+					<TextControl
+						className="post-publish-panel__postpublish-post-address"
+						readOnly
+						label={ sprintf(
 							/* translators: %s: post type singular name */
 							__( '%s address' ), postLabel
 						) }
-					</label>
-					<input
-						id={ id }
-						className="post-publish-panel__postpublish-link-input"
-						readOnly
 						value={ post.link }
 						onFocus={ this.onSelectInput }
-						type="text"
 					/>
 					<div className="post-publish-panel__postpublish-buttons">
 						{ ! isScheduled && (
@@ -99,16 +93,13 @@ class PostPublishPanelPostpublish extends Component {
 	}
 }
 
-export default compose(
-	withSelect( ( select ) => {
-		const { getEditedPostAttribute, getCurrentPost, isCurrentPostScheduled } = select( 'core/editor' );
-		const { getPostType } = select( 'core' );
+export default withSelect( ( select ) => {
+	const { getEditedPostAttribute, getCurrentPost, isCurrentPostScheduled } = select( 'core/editor' );
+	const { getPostType } = select( 'core' );
 
-		return {
-			post: getCurrentPost(),
-			postType: getPostType( getEditedPostAttribute( 'type' ) ),
-			isScheduled: isCurrentPostScheduled(),
-		};
-	} ),
-	withInstanceId
-)( PostPublishPanelPostpublish );
+	return {
+		post: getCurrentPost(),
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
+		isScheduled: isCurrentPostScheduled(),
+	};
+} )( PostPublishPanelPostpublish );

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -107,18 +107,15 @@
 	}
 }
 
-.post-publish-panel__postpublish-link-label {
-	display: inline-block;
-	margin-top: $grid-size;
-}
+.post-publish-panel__postpublish-post-address {
+	margin-bottom: $grid-size-large;
 
-.post-publish-panel__postpublish-link-input[readonly] {
-	width: 100%;
-	padding: 10px;
-	margin: $grid-size-small 0 $grid-size-large;
-	background: $white;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	input[readonly] {
+		padding: 10px;
+		background: $light-gray-400;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 }
 
 .post-publish-panel__postpublish-header {
@@ -126,7 +123,7 @@
 }
 
 .post-publish-panel__postpublish-subheader {
-	margin: 0;
+	margin: 0 0 $grid-size;
 }
 
 .post-publish-panel__tip {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -107,10 +107,15 @@
 	}
 }
 
+.post-publish-panel__postpublish-link-label {
+	display: inline-block;
+	margin-top: $grid-size;
+}
+
 .post-publish-panel__postpublish-link-input[readonly] {
 	width: 100%;
 	padding: 10px;
-	margin: 15px 0;
+	margin: $grid-size-small 0 $grid-size-large;
 	background: $white;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -118,6 +123,10 @@
 
 .post-publish-panel__postpublish-header {
 	font-weight: 500;
+}
+
+.post-publish-panel__postpublish-subheader {
+	margin: 0;
 }
 
 .post-publish-panel__tip {


### PR DESCRIPTION
## Description

The Post URL field in the Publishing Flow panel is unlabelled. This PR adds a visible label. Also simplifies a bit the text for the Scheduled posts. I know there are pending proposal to improve and add features to the publishing flow so this part will be very likely improved and iterated. The most important thing in this PR is the input field label.

## Screenshots <!-- if applicable -->

Before:

<img width="700" alt="screen shot 2018-09-01 at 14 16 53" src="https://user-images.githubusercontent.com/1682452/44947053-6fe3bc00-ae07-11e8-9829-cffb4eea9035.png">

After:

<img width="700" alt="screen shot 2018-09-01 at 15 46 11" src="https://user-images.githubusercontent.com/1682452/44947056-78d48d80-ae07-11e8-8040-7e4b8e710943.png">

Note 1:
the sentence "The post address will be:" is not appropriate anyways, as a post can be of different types: post, page, or a custom post type. To keep things simple I've just removed it in favor of "What’s next?".

Note 2:
since the URL field is `readonly`, I'd suggest to communicate to users it can't be edited. Usually in WordPress this is done by using a light gray background. Something like in the screenshot below or a lighter gray could work:

<img width="281" alt="screen shot 2018-09-01 at 16 29 05" src="https://user-images.githubusercontent.com/1682452/44947071-b3d6c100-ae07-11e8-9912-6b07a1eeb689.png">


Fixes #9535