### PR TITLE
Fix/9467

### DIFF
--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -88,7 +88,7 @@ export function mediaUpload( {
 			return;
 		}
 
-		// verify if uploaded file is not empty
+		// verify if uploaded file is empty
 		if ( mediaFile.size === 0 ) {
 			onError( {
 				code: 'ZERO_BYTE_FILE',

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -79,6 +79,20 @@ export function mediaUpload( {
 
 	files.forEach( ( mediaFile, idx ) => {
 		if ( ! isAllowedType( mediaFile.type ) ) {
+			onError( {
+				code: 'INVALID_FILETYPE',
+				message: sprintf( __( 'Sorry, this file type is not permitted for security reasons.' ) ),
+				file: mediaFile,
+			} );
+			return;
+		}
+
+		if ( mediaFile.size === 0 ) {
+			onError( {
+				code: 'ZERO_BYTE_FILE',
+				message: sprintf( __( 'This file is empty. Please try another.' ) ),
+				file: mediaFile,
+			} );
 			return;
 		}
 

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -78,6 +78,7 @@ export function mediaUpload( {
 	};
 
 	files.forEach( ( mediaFile, idx ) => {
+		// verify if uploaded file is allowed
 		if ( ! isAllowedType( mediaFile.type ) ) {
 			onError( {
 				code: 'INVALID_FILETYPE',
@@ -87,6 +88,7 @@ export function mediaUpload( {
 			return;
 		}
 
+		// verify if uploaded file is not empty
 		if ( mediaFile.size === 0 ) {
 			onError( {
 				code: 'ZERO_BYTE_FILE',


### PR DESCRIPTION
## Description
Added warning message for invalid file types upload in Editor

## How has this been tested?
Uploading a bunch of files in Editor -> Image Block.
Tested in latest version of Chrome and Firefox.
Minimal impact, won't affect other project areas.

## Screenshots <!-- if applicable -->
![exe_upload](https://user-images.githubusercontent.com/3958547/44947264-4df03680-ae13-11e8-8d8c-f81da7a62c5e.png)

## Types of changes
Bug Fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
