### PR TITLE
Fixing post visibility radio button alignment

### DIFF
--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -4,6 +4,9 @@
 		margin-bottom: 1em;
 		margin-top: 0.5em;
 	}
+	.editor-post-visibility__dialog-radio {
+		margin-top: 2px;
+	}
 	.editor-post-visibility__dialog-label {
 		font-weight: 600;
 	}


### PR DESCRIPTION
## Description
After #9138 was merged, something seems to have gone missing in the CSS. The horizontal alignment of the post visibility radio buttons does not correspond with the associated labels.

This PR fixes that.

## How has this been tested?
Manual testing only. No automated tests needed as this is only a minor stylesheet tweak.

## Screenshots <!-- if applicable -->

### Before:
![screen shot 2018-09-01 at 17 48 27](https://user-images.githubusercontent.com/191583/44947613-c1904480-ae0f-11e8-97b6-6649a9bf2e5a.png)

### After:
![screen shot 2018-09-01 at 17 52 46](https://user-images.githubusercontent.com/191583/44947617-dd93e600-ae0f-11e8-8a67-6ec7d10cf504.png)
