### PR TITLE
Update documentation

### DIFF
--- a/packages/components/src/clipboard-button/README.md
+++ b/packages/components/src/clipboard-button/README.md
@@ -17,5 +17,5 @@ const MyClipboardButton = withState( {
 	>
 		{ hasCopied ? 'Copied!' : 'Copy Text' }
 	</ClipboardButton>
-) )
+) );
 ```

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -16,5 +16,5 @@ const MyMenuItem = withState( {
 	>
 		Toggle
 	</MenuItem>
-) )
+) );
 ```


### PR DESCRIPTION
## Description
Added semicolons to the constant in documentation examples of the following components:

-  ClipboardButton
- MenuItem

## How has this been tested?
I made sure that GitHub's Markdown parser could parse the markdown.

## Checklist:
- [x] My code is tested.