### PR TITLE
Dont trigger invalid block on empty HTML content

### DIFF
--- a/packages/editor/src/components/block-list/block-html.js
+++ b/packages/editor/src/components/block-list/block-html.js
@@ -10,10 +10,10 @@ import { isEqual } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { getBlockAttributes, getBlockContent, getBlockType, isValidBlock } from '@wordpress/blocks';
+import { getBlockAttributes, getBlockContent, getBlockType, isValidBlock, getSaveContent } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-class BlockHTML extends Component {
+export class BlockHTML extends Component {
 	constructor( props ) {
 		super( ...arguments );
 		this.onChange = this.onChange.bind( this );
@@ -32,10 +32,18 @@ class BlockHTML extends Component {
 	}
 
 	onBlur() {
+		const { html } = this.state;
 		const blockType = getBlockType( this.props.block.name );
-		const attributes = getBlockAttributes( blockType, this.state.html, this.props.block.attributes );
-		const isValid = isValidBlock( this.state.html, blockType, attributes );
-		this.props.onChange( this.props.clientId, attributes, this.state.html, isValid );
+		const attributes = getBlockAttributes( blockType, html, this.props.block.attributes );
+
+		// If html is empty  we reset the block to the default HTML and mark it as valid to avoid triggering an error
+		const content = html ? html : getSaveContent( blockType, attributes );
+		const isValid = html ? isValidBlock( content, blockType, attributes ) : true;
+
+		this.props.onChange( this.props.clientId, attributes, content, isValid );
+
+		// Ensure the state is updated if we reset
+		this.setState( { html: content } );
 	}
 
 	onChange( event ) {

--- a/packages/editor/src/components/block-list/block-html.js
+++ b/packages/editor/src/components/block-list/block-html.js
@@ -42,8 +42,10 @@ export class BlockHTML extends Component {
 
 		this.props.onChange( this.props.clientId, attributes, content, isValid );
 
-		// Ensure the state is updated if we reset
-		this.setState( { html: content } );
+		// Ensure the state is updated if we reset so it displays the default content
+		if ( ! html ) {
+			this.setState( { html: content } );
+		}
 	}
 
 	onChange( event ) {

--- a/packages/editor/src/components/block-list/test/block-html.js
+++ b/packages/editor/src/components/block-list/test/block-html.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
+ * Internal dependencies
+ */
+import { BlockHTML } from '../block-html';
+
+describe( 'BlockHTML', () => {
+	beforeAll( () => {
+		registerCoreBlocks();
+	} );
+
+	it( 'renders HTML editor', () => {
+		const wrapper = shallow( <BlockHTML block={ { isValid: true } } /> );
+
+		expect( wrapper.name() ).toBe( 'TextareaAutosize' );
+	} );
+
+	describe( 'block content', () => {
+		it( 'use originalContent for an invalid block', () => {
+			const wrapper = shallow( <BlockHTML block={ { isValid: false, originalContent: 'test' } } /> );
+
+			expect( wrapper.state( 'html' ) ).toBe( 'test' );
+		} );
+
+		it( 'use block content for a valid block', () => {
+			const block = createBlock( 'core/paragraph', {
+				content: 'test-block',
+				isValid: true,
+			} );
+
+			const wrapper = shallow( <BlockHTML block={ block } /> );
+
+			expect( wrapper.state( 'html' ) ).toBe( '<p>test-block</p>' );
+		} );
+
+		it( 'onChange updates block html', () => {
+			const wrapper = shallow( <BlockHTML block={ { isValid: true } } /> );
+
+			wrapper.instance().onChange( { target: { value: 'update' } } );
+
+			expect( wrapper.state( 'html' ) ).toBe( 'update' );
+		} );
+	} );
+
+	describe( 'onBlur', () => {
+		const onChange = jest.fn();
+
+		beforeEach( () => {
+			onChange.mockClear();
+		} );
+
+		it( 'onBlur updates valid HTML string in block', () => {
+			const block = createBlock( 'core/paragraph', {
+				content: 'test-block',
+				isValid: true,
+			} );
+			const wrapper = shallow( <BlockHTML block={ block } onChange={ onChange } /> );
+
+			wrapper.instance().onChange( { target: { value: '<p>update</p>' } } );
+			wrapper.instance().onBlur();
+
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+			expect( onChange.mock.calls[ 0 ][ 2 ] ).toBe( '<p>update</p>' );
+			expect( onChange.mock.calls[ 0 ][ 3 ] ).toBe( true );
+		} );
+
+		it( 'onBlur updates invalid HTML string in block', () => {
+			const block = createBlock( 'core/paragraph', {
+				content: 'test-block',
+				isValid: true,
+			} );
+			const wrapper = shallow( <BlockHTML block={ block } onChange={ onChange } /> );
+
+			wrapper.instance().onChange( { target: { value: '<p>update' } } );
+			wrapper.instance().onBlur();
+
+			expect( console ).toHaveErrored();
+			expect( console ).toHaveWarned();
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+			expect( onChange.mock.calls[ 0 ][ 2 ] ).toBe( '<p>update' );
+			expect( onChange.mock.calls[ 0 ][ 3 ] ).toBe( false );
+		} );
+
+		it( 'onBlur resets block to default content if supplied empty string', () => {
+			const block = createBlock( 'core/paragraph', {
+				content: 'test-block',
+				isValid: true,
+			} );
+			const wrapper = shallow( <BlockHTML block={ block } onChange={ onChange } /> );
+
+			wrapper.instance().onChange( { target: { value: '' } } );
+			wrapper.instance().onBlur();
+
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+			expect( onChange.mock.calls[ 0 ][ 2 ] ).toBe( '<p></p>' );
+			expect( onChange.mock.calls[ 0 ][ 3 ] ).toBe( true );
+			expect( wrapper.state( 'html' ) ).toBe( '<p></p>' );
+		} );
+	} );
+} );


### PR DESCRIPTION
If you edit a block's HTML, delete all the content, and then deselect the block it will trigger an invalid block warning:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/44954740-eda6d680-ae9e-11e8-8f34-94f3f3ba46eb.jpg)

Note that 'empty block toolbar' also shows, and will be fixed in #9501.

This PR changes this so the block is reset to its default state and not marked as invalid. The block's 'empty block toolbar' will then also show correctly:

![block editor](https://user-images.githubusercontent.com/1277682/44955214-ba1c7a00-aea7-11e8-9efa-8e67472c4871.gif)

This matches the behaviour of the page HTML editor where if you delete a block's HTML it will revert to the default:

![html editor](https://user-images.githubusercontent.com/1277682/44955218-ca345980-aea7-11e8-9558-eb13cf565c5c.gif)

## How has this been tested?
An additional set of tests has been added for the `block-html.js` component which tests existing behaviour as well as the modified behaviour.

This can be manually verified on different block types, and undo still works.

## Types of changes

This does affect a block's HTML editor mode and so needs to be thoroughly tested. The difference should only occur when the HTML is empty, otherwise it behaves as currently.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
