### PR TITLE
Fix import source of RangeControl in Readme

### DIFF
--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -7,7 +7,7 @@ RangeControl component is used to create range slider to input numerical values.
 
 Render a user interface to select the number of columns between 2 and 10.
 ```jsx
-import { RadioControl } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
 
 const MyRangeControl = withState( {


### PR DESCRIPTION
## Description
Replaced unused 'RadioControl' with required 'RangeControl'. 

## How has this been tested?
* Used the RangeControl component in the Inspector with changed import source. 
* Made sure that GitHub's Markdown parser could parse the markdown.

## Checklist:
- [x] My code is tested.
