### PR TITLE
Fix broken link in documentation inside element/README.md

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -47,7 +47,7 @@ Refer to the [official React Quick Start guide](https://reactjs.org/docs/hello-w
 
 At the risk of igniting debate surrounding any single "best" front-end framework, the choice to use any tool should be motivated specifically to serve the requirements of the system. In modeling the concept of a [block](../../blocks/README.md), we observe the following technical requirements:
 
-- An understanding of a block in terms of its underlying values (in the [random image example](../../blocks/README.md#example), a category)
+- An understanding of a block in terms of its underlying values (in the [random image example](../blocks/README.md#example), a category)
 - A means to describe the UI of a block given these values
 
 At its most basic, React provides a simple input / output mechanism. __Given a set of inputs ("props"), a developer describes the output to be shown on the page.__ This is most elegantly observed in its [function components](https://reactjs.org/docs/components-and-props.html#functional-and-class-components). React serves the role of reconciling the desired output with the current state of the page.


### PR DESCRIPTION

## Description
Fix broken link in documentation inside element/README.md, broken link points to blocks/README.md#example  

## How has this been tested?
Made sure that GitHub's Markdown parser could parse the markdown.

## Checklist:
- [x] My code is tested.

