### PR TITLE
Fix placeholder contrast.

### DIFF
--- a/edit-post/assets/stylesheets/_colors.scss
+++ b/edit-post/assets/stylesheets/_colors.scss
@@ -33,7 +33,7 @@ $dark-opacity-700: rgba(#06060b, 0.8);
 $dark-opacity-600: rgba(#000913, 0.75);
 $dark-opacity-500: rgba(#0a1829, 0.7);
 $dark-opacity-400: rgba(#0a1829, 0.65);
-$dark-opacity-300: rgba(#0e1c2e, 0.6);
+$dark-opacity-300: rgba(#0e1c2e, 0.62);
 $dark-opacity-200: rgba(#162435, 0.55);
 $dark-opacity-100: rgba(#223443, 0.5);
 $dark-opacity-light-900: rgba(#304455, 0.45);

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -300,7 +300,7 @@
 @mixin caption-style() {
 	margin-top: 0.5em;
 	margin-bottom: 1em;
-	color: $dark-gray-300;
+	color: $dark-gray-500;
 	text-align: center;
 	font-size: $default-font-size;
 }

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -227,31 +227,31 @@ body.gutenberg-editor-page {
 .editor-block-list__block {
 	input,
 	textarea {
-		// use opacity to work in various editor styles
+		// Use opacity to work in various editor styles.
 		&::-webkit-input-placeholder {
-			color: $dark-opacity-100;
+			color: $dark-opacity-300;
 		}
+
 		&::-moz-placeholder {
-			color: $dark-opacity-100;
+			opacity: 1; // Necessary because Firefox reduces this from 1.
+			color: $dark-opacity-300;
 		}
+
 		&:-ms-input-placeholder {
-			color: $dark-opacity-100;
-		}
-		&:-moz-placeholder {
-			color: $dark-opacity-100;
+			color: $dark-opacity-300;
 		}
 
 		.is-dark-theme & {
 			&::-webkit-input-placeholder {
 				color: $light-opacity-300;
 			}
+
 			&::-moz-placeholder {
+				opacity: 1; // Necessary because Firefox reduces this from 1.
 				color: $light-opacity-300;
 			}
+
 			&:-ms-input-placeholder {
-				color: $light-opacity-300;
-			}
-			&:-moz-placeholder {
 				color: $light-opacity-300;
 			}
 		}

--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -8,28 +8,25 @@
 		@include loading_fade;
 	}
 
-	&__content-wrapper {
+	.wp-block-file__content-wrapper {
 		flex-grow: 1;
 	}
 
-	&__textlink {
+	.wp-block-file__textlink {
 		display: inline-block;
-		color: $blue-medium-700;
 		min-width: 1em;
-		text-decoration: underline;
 
 		&:focus {
 			box-shadow: none;
-			color: $blue-medium-700;
 		}
 	}
 
-	&__button-richtext-wrapper {
+	.wp-block-file__button-richtext-wrapper {
 		display: inline-block;
 		margin-left: 0.75em;
 	}
 
-	&__copy-url-button {
+	.wp-block-file__copy-url-button {
 		margin-left: 1em;
 	}
 }

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -9,7 +9,7 @@
 		text-align: right;
 	}
 
-	&__button {
+	.wp-block-file__button {
 		background: $dark-gray-700;
 		border-radius: 2em;
 		color: $white;
@@ -17,7 +17,7 @@
 		padding: 0.5em 1em;
 	}
 
-	a#{&}__button {
+	a.wp-block-file__button {
 		text-decoration: none;
 
 		&:hover,
@@ -31,7 +31,7 @@
 		}
 	}
 
-	* + &__button {
+	* + .wp-block-file__button {
 		margin-left: 0.75em;
 	}
 }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -86,6 +86,11 @@
 		&:focus a[data-mce-selected] {
 			color: rgba(0, 0, 0, 0.2);
 		}
+
+		// Caption placeholder text.
+		&[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
+			opacity: 0.8;
+		}
 	}
 }
 

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -17,7 +17,7 @@
 
 		&::before {
 			content: "\00b7 \00b7 \00b7";
-			color: $dark-gray-700;
+			color: $dark-gray-900;
 			font-size: 20px;
 			letter-spacing: 2em;
 			padding-left: 2em;

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -15,6 +15,7 @@
 		background: transparent;
 		font-family: $editor-font;
 		line-height: $default-line-height;
+		color: $dark-gray-900;
 		transition: border 0.1s ease-out;
 
 		// Show wider parent padding on Desktop breakpoints.
@@ -33,9 +34,22 @@
 			border-width: $border-width;
 		}
 
-		// Match h1 heading
+		// Match h1 heading.
 		font-size: 2.441em;
 		font-weight: 600;
+
+		// Large text needs a 3:1 contrast ratio.
+		&::-webkit-input-placeholder {
+			color: $dark-opacity-200;
+		}
+
+		&::-moz-placeholder {
+			color: $dark-opacity-200;
+		}
+
+		&:-ms-input-placeholder {
+			color: $dark-opacity-200;
+		}
 	}
 
 	&:not(.is-focus-mode):not(.has-fixed-toolbar) {

--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -89,9 +89,18 @@
 		}
 	}
 
-	& + .editor-rich-text__tinymce {
-		opacity: 0.5;
+	// Placeholder text.
+	& + .editor-rich-text__tinymce, {
 		pointer-events: none;
+
+		// Use opacity to work in various editor styles.
+		&,
+		p {
+			color: $dark-opacity-300;
+			.is-dark-theme & {
+				color: $light-opacity-300;
+			}
+		}
 	}
 
 	&.mce-content-body {

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -1,11 +1,11 @@
 .wp-block {
-	width: 610px;
+	width: $content-width;
 }
 
 body {
 	font-family: $editor-font;
 	line-height: $editor-line-height;
-	color: $dark-gray-700;
+	color: $dark-gray-900;
 	font-size: $editor-font-size;
 }
 


### PR DESCRIPTION
This fixes #9502 and fixes #9532.

Screenshots:

![3-1 title 4 5-1 prompt](https://user-images.githubusercontent.com/1204802/44975314-7175c700-af62-11e8-8015-9a0ceaa30633.png)

Title is large text and needs 3:1 contrast. Placeholder is small text and needs 4.5:1.

![screen shot 2018-09-03 at 10 10 46](https://user-images.githubusercontent.com/1204802/44975353-7e92b600-af62-11e8-8ca8-7834f8248c16.png)

![screen shot 2018-09-03 at 10 12 09](https://user-images.githubusercontent.com/1204802/44975357-818da680-af62-11e8-876a-2cd7936a705c.png)

![screen shot 2018-09-03 at 10 14 17](https://user-images.githubusercontent.com/1204802/44975365-84889700-af62-11e8-9a3e-ad289af55350.png)

![screen shot 2018-09-03 at 10 14 35](https://user-images.githubusercontent.com/1204802/44975368-87838780-af62-11e8-9682-258185bedf4d.png)
