### PR TITLE
UI: Add a fullscreen mode

### DIFF
--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -272,6 +272,10 @@
 			margin-left: -18px;
 		}
 	}
+
+	body.is-fullscreen-mode #{$selector} {
+		left: 0 !important;
+	}
 }
 
 /**

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -105,11 +105,19 @@ body.gutenberg-editor-page {
 		bottom: 0;
 		left: 0;
 		min-height: calc(100vh - #{ $admin-bar-height-big });
+
+		body.is-fullscreen-mode & {
+			min-height: calc(100vh);
+		}
 	}
 
 	// The WP header height changes at this breakpoint
 	@include break-medium {
 		min-height: calc(100vh - #{ $admin-bar-height });
+
+		body.is-fullscreen-mode & {
+			min-height: calc(100vh);
+		}
 	}
 
 	img {
@@ -261,4 +269,13 @@ body.gutenberg-editor-page {
 
 .ephox-snooker-resizer-bar-dragging {
 	background: $blue-medium-500;
+}
+
+// This style is defined here instead of the modal component
+// because the modal should be context agnostic.
+.components-modal__content {
+	height: calc(100% - #{ $header-height } - #{ $admin-bar-height });
+	body.is-fullscreen-mode & {
+		height: calc(100% - #{ $header-height });
+	}
 }

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -107,7 +107,7 @@ body.gutenberg-editor-page {
 		min-height: calc(100vh - #{ $admin-bar-height-big });
 
 		body.is-fullscreen-mode & {
-			min-height: calc(100vh);
+			min-height: 100vh;
 		}
 	}
 
@@ -116,7 +116,7 @@ body.gutenberg-editor-page {
 		min-height: calc(100vh - #{ $admin-bar-height });
 
 		body.is-fullscreen-mode & {
-			min-height: calc(100vh);
+			min-height: 100vh;
 		}
 	}
 

--- a/edit-post/components/fullscreen-mode/index.js
+++ b/edit-post/components/fullscreen-mode/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class FullscreenMode extends Component {
+	componentDidMount() {
+		this.sync();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.isActive !== prevProps.isActive ) {
+			this.sync();
+		}
+	}
+
+	sync() {
+		const { isActive } = this.props;
+		if ( isActive ) {
+			document.body.classList.add( 'is-fullscreen-mode' );
+		} else {
+			document.body.classList.remove( 'is-fullscreen-mode' );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default withSelect( ( select ) => ( {
+	isActive: select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ),
+} ) )( FullscreenMode );

--- a/edit-post/components/fullscreen-mode/style.scss
+++ b/edit-post/components/fullscreen-mode/style.scss
@@ -1,0 +1,17 @@
+body.is-fullscreen-mode {
+	// Reset the html.wp-topbar padding
+	margin-top: -$admin-bar-height-big;
+	@include break-medium() {
+		margin-top: -$admin-bar-height;
+	}
+
+	#adminmenumain,
+	#wpadminbar {
+		display: none;
+	}
+
+	#wpcontent,
+	#wpfooter {
+		margin-left: 0;
+	}
+}

--- a/edit-post/components/header/feature-toggle/index.js
+++ b/edit-post/components/header/feature-toggle/index.js
@@ -2,10 +2,6 @@
  * WordPress Dependencies
  */
 import { withSelect, withDispatch } from '@wordpress/data';
-
-/**
- * WordPress Dependencies
- */
 import { compose } from '@wordpress/compose';
 import { MenuItem } from '@wordpress/components';
 

--- a/edit-post/components/header/fullscreen-mode-close/index.js
+++ b/edit-post/components/header/fullscreen-mode-close/index.js
@@ -1,4 +1,9 @@
 /**
+ * External Dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress Dependencies
  */
 import { withSelect } from '@wordpress/data';
@@ -12,7 +17,7 @@ import { addQueryArgs } from '@wordpress/url';
 import './style.scss';
 
 function FullscreenModeClose( { isActive, postType } ) {
-	if ( ! isActive ) {
+	if ( ! isActive || ! postType ) {
 		return null;
 	}
 
@@ -20,14 +25,24 @@ function FullscreenModeClose( { isActive, postType } ) {
 		<Toolbar className="edit-post-fullscreen-mode-close__toolbar">
 			<IconButton
 				icon="no-alt"
-				href={ addQueryArgs( 'edit.php', { post_type: postType } ) }
-				label={ __( 'Close' ) }
+				href={ addQueryArgs( 'edit.php', { post_type: postType.slug } ) }
+				label={ get(
+					postType,
+					[ 'labels', 'view_items' ],
+					__( 'View Posts' )
+				) }
 			/>
 		</Toolbar>
 	);
 }
 
-export default withSelect( ( select ) => ( {
-	isActive: select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ),
-	postType: select( 'core/editor' ).getCurrentPostType(),
-} ) )( FullscreenModeClose );
+export default withSelect( ( select ) => {
+	const { getCurrentPostType } = select( 'core/editor' );
+	const { isFeatureActive } = select( 'core/edit-post' );
+	const { getPostType } = select( 'core' );
+
+	return {
+		isActive: isFeatureActive( 'fullscreenMode' ),
+		postType: getPostType( getCurrentPostType() ),
+	};
+} )( FullscreenModeClose );

--- a/edit-post/components/header/fullscreen-mode-close/index.js
+++ b/edit-post/components/header/fullscreen-mode-close/index.js
@@ -4,14 +4,15 @@
 import { withSelect } from '@wordpress/data';
 import { IconButton, Toolbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-function FullscreenModeClose( { isActive, returnURL } ) {
-	if ( ! isActive || ! returnURL ) {
+function FullscreenModeClose( { isActive, postType } ) {
+	if ( ! isActive ) {
 		return null;
 	}
 
@@ -19,7 +20,7 @@ function FullscreenModeClose( { isActive, returnURL } ) {
 		<Toolbar className="edit-post-fullscreen-mode-close__toolbar">
 			<IconButton
 				icon="no-alt"
-				href={ returnURL }
+				href={ addQueryArgs( 'edit.php', { post_type: postType } ) }
 				label={ __( 'Close' ) }
 			/>
 		</Toolbar>
@@ -28,5 +29,5 @@ function FullscreenModeClose( { isActive, returnURL } ) {
 
 export default withSelect( ( select ) => ( {
 	isActive: select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ),
-	returnURL: select( 'core/editor' ).getEditorSettings().returnURL,
+	postType: select( 'core/editor' ).getCurrentPostType(),
 } ) )( FullscreenModeClose );

--- a/edit-post/components/header/fullscreen-mode-close/index.js
+++ b/edit-post/components/header/fullscreen-mode-close/index.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress Dependencies
+ */
+import { withSelect } from '@wordpress/data';
+import { IconButton, Toolbar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function FullscreenModeClose( { isActive, returnURL } ) {
+	if ( ! isActive || ! returnURL ) {
+		return null;
+	}
+
+	return (
+		<Toolbar className="edit-post-fullscreen-mode-close__toolbar">
+			<IconButton
+				icon="no-alt"
+				href={ returnURL }
+				label={ __( 'Close' ) }
+			/>
+		</Toolbar>
+	);
+}
+
+export default withSelect( ( select ) => ( {
+	isActive: select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ),
+	returnURL: select( 'core/editor' ).getEditorSettings().returnURL,
+} ) )( FullscreenModeClose );

--- a/edit-post/components/header/fullscreen-mode-close/style.scss
+++ b/edit-post/components/header/fullscreen-mode-close/style.scss
@@ -1,0 +1,7 @@
+.edit-post-fullscreen-mode-close__toolbar {
+	border-top: 0;
+	border-bottom: 0;
+	border-left: 0;
+	margin: -9px 10px -9px -10px;
+	padding: 9px 10px;
+}

--- a/edit-post/components/header/header-toolbar/index.js
+++ b/edit-post/components/header/header-toolbar/index.js
@@ -23,6 +23,7 @@ import {
  * Internal dependencies
  */
 import './style.scss';
+import FullscreenModeClose from '../fullscreen-mode-close';
 
 function HeaderToolbar( { hasFixedToolbar, isLargeViewport } ) {
 	return (
@@ -30,6 +31,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport } ) {
 			className="edit-post-header-toolbar"
 			aria-label={ __( 'Editor Toolbar' ) }
 		>
+			<FullscreenModeClose />
 			<div>
 				<Inserter position="bottom right" />
 				<DotTip id="core/editor.inserter">

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -21,10 +21,18 @@
 		position: fixed;
 		padding: $item-spacing;
 		top: $admin-bar-height-big;
+
+		body.is-fullscreen-mode & {
+			top: 0;
+		}
 	}
 
 	@include break-medium() {
 		top: $admin-bar-height;
+
+		body.is-fullscreen-mode & {
+			top: 0;
+		}
 	}
 
 	.editor-post-switch-to-draft + .editor-post-preview {

--- a/edit-post/components/header/writing-menu/index.js
+++ b/edit-post/components/header/writing-menu/index.js
@@ -18,6 +18,7 @@ function WritingMenu( { onClose } ) {
 		>
 			<FeatureToggle feature="fixedToolbar" label={ __( 'Unified Toolbar' ) } onToggle={ onClose } />
 			<FeatureToggle feature="focusMode" label={ __( 'Spotlight Mode' ) } onToggle={ onClose } />
+			<FeatureToggle feature="fullscreenMode" label={ __( 'Fullscreen Mode' ) } onToggle={ onClose } />
 		</MenuGroup>
 	);
 }

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -39,6 +39,7 @@ import { getMetaBoxContainer } from '../../utils/meta-boxes';
 import Sidebar from '../sidebar';
 import PluginPostPublishPanel from '../sidebar/plugin-post-publish-panel';
 import PluginPrePublishPanel from '../sidebar/plugin-pre-publish-panel';
+import FullscreenMode from '../fullscreen-mode';
 
 function Layout( {
 	mode,
@@ -68,6 +69,7 @@ function Layout( {
 	};
 	return (
 		<div className={ className }>
+			<FullscreenMode />
 			<BrowserURL />
 			<UnsavedChangesWarning forceIsDirty={ () => {
 				return some( metaBoxes, ( metaBox, location ) => {

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -17,10 +17,18 @@
 		height: auto;
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;
+
+		body.is-fullscreen-mode & {
+			top: $header-height;
+		}
 	}
 
 	@include break-medium() {
 		top: $admin-bar-height + $header-height;
+
+		body.is-fullscreen-mode & {
+			top: $header-height;
+		}
 	}
 
 	> .components-panel {
@@ -32,6 +40,13 @@
 		max-height: calc(100vh - #{ $admin-bar-height-big + $panel-header-height });
 		margin-top: -1px;
 		margin-bottom: -1px;
+
+		body.is-fullscreen-mode & {
+			max-height: calc(100vh - #{ $panel-header-height });
+			@include break-small() {
+				max-height: none;
+			}
+		}
 
 		@include break-small() {
 			overflow: inherit;

--- a/edit-post/components/text-editor/style.scss
+++ b/edit-post/components/text-editor/style.scss
@@ -3,10 +3,18 @@
 
 	@include break-small() {
 		padding-top: 40px + $admin-bar-height-big;
+
+		body.is-fullscreen-mode & {
+			padding-top: 40px;
+		}
 	}
 
 	@include break-medium() {
-		padding-top: 40px + $admin-bar-height;
+		padding-top: 40px;
+
+		body.is-fullscreen-mode & {
+			padding-top: 40px;
+		}
 	}
 }
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -435,5 +435,6 @@ add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_b
  * @return string The $classes string, with gutenberg-editor-page appended.
  */
 function gutenberg_add_admin_body_class( $classes ) {
-	return "$classes gutenberg-editor-page";
+	// Default to is-fullscreen-mode to avoid jumps in the UI
+	return "$classes gutenberg-editor-page is-fullscreen-mode";
 }

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -435,6 +435,6 @@ add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_b
  * @return string The $classes string, with gutenberg-editor-page appended.
  */
 function gutenberg_add_admin_body_class( $classes ) {
-	// Default to is-fullscreen-mode to avoid jumps in the UI
+	// Default to is-fullscreen-mode to avoid jumps in the UI.
 	return "$classes gutenberg-editor-page is-fullscreen-mode";
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1425,15 +1425,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		}
 	}
 
-	//	Return URL of fullscreen mode.
-	$referer                    = wp_get_referer();
-	$excluded_referer_basenames = array( 'post.php', 'wp-login.php' );
-	if ( $referer && ! in_array( basename( parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
-		$return_url = $referer;
-	} else {
-		$return_url = home_url( '/' );
-	}
-
 	$editor_settings = array(
 		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
 		'availableTemplates'  => $available_templates,
@@ -1446,8 +1437,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'autosaveInterval'    => 10,
 		'maxUploadFileSize'   => $max_upload_size,
 		'allowedMimeTypes'    => get_allowed_mime_types(),
-		'styles'              => $styles,
-		'returnURL'           => $return_url
+		'styles'              => $styles
 	);
 
 	$post_autosave = get_autosave_newer_than_post_save( $post );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1425,6 +1425,15 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		}
 	}
 
+	//	Return URL of fullscreen mode.
+	$referer                    = wp_get_referer();
+	$excluded_referer_basenames = array( 'post.php', 'wp-login.php' );
+	if ( $referer && ! in_array( basename( parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
+		$return_url = $referer;
+	} else {
+		$return_url = home_url( '/' );
+	}
+
 	$editor_settings = array(
 		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
 		'availableTemplates'  => $available_templates,
@@ -1438,6 +1447,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'maxUploadFileSize'   => $max_upload_size,
 		'allowedMimeTypes'    => get_allowed_mime_types(),
 		'styles'              => $styles,
+		'returnURL'           => $return_url
 	);
 
 	$post_autosave = get_autosave_newer_than_post_save( $post );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1437,7 +1437,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'autosaveInterval'    => 10,
 		'maxUploadFileSize'   => $max_upload_size,
 		'allowedMimeTypes'    => get_allowed_mime_types(),
-		'styles'              => $styles
+		'styles'              => $styles,
 	);
 
 	$post_autosave = get_autosave_newer_than_post_save( $post );

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -83,7 +83,7 @@
 
 .components-modal__content {
 	// The height of the content is the height of it's parent, minus the header. after that, the offset was 3px.
-	height: calc(100% - #{ $header-height } - #{ $admin-bar-height });
+	height: 100%;
 	overflow: auto;
 	padding: $panel-padding;
 }


### PR DESCRIPTION
closes #9334

This PR is the second part of #9334 and adds a fullscreen mode.
The CSS contains some "hacks" to allow switching modes without refreshing the page but I think it's fine.

