### PR TITLE
Change the Gutenberg release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -17,6 +17,10 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
+Please add whether this is a regression from a previous Gutenberg release:
+
+- [ ] This is a regression.
+
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -45,11 +45,6 @@ if [ ! -z "$changed" ]; then
 fi
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$branch" != 'master' ]; then
-	warning "WARNING: You should probably be running this script against the
-         'master' branch (current: '$branch')"
-	sleep 2
-fi
 
 # Do a dry run of the repository reset. Prompting the user for a list of all
 # files that will be removed should prevent them from losing important files!

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -4,22 +4,22 @@ This document is a checklist for building and releasing a new version of Gutenbe
 
 ## Writing the Release Post and Changelog
 
-* Open the [recently updated PRs view](https://github.com/WordPress/gutenberg/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc) and find the PR where the last version bump occurred.
-* Read through each PR since the last version bump to determine if it needs to be included in the Release Post and/or changelog.
+* Open the [recently updated PRs view](https://github.com/WordPress/gutenberg/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc) and filter for all the PRs that are set to the current milestone.
+* Read through each PR tagged to this milestone to determine if it needs to be included in the Release Post and/or changelog.
 * Choose a feature or two to highlight in the release post–record an animation of them in action.
 * Save the draft post on [make.wordpress.org/core](https://make.wordpress.org/core/), for publishing after the release.
 
 ## Bumping the Version
 
 * Create a PR like [this one](https://github.com/WordPress/gutenberg/pull/3479/files), bumping the version number in `gutenberg.php`, `package.json`, and `package-lock.json`.
-* Check that there's no work-in-progress that's just about to land. [Inform committers in `#core-editor` on Slack](https://make.wordpress.org/chat/) to hold off on merging any changes until after the release process is complete.
+* Check that there's no work-in-progress that's just about to land. [Inform committers in `#core-editor` on Slack](https://make.wordpress.org/chat/) that you're about to release a new version and that they should no longer merge on the release branch.
 * Merge the version bump PR.
 
 ### For Patch Releases Done via `git cherry-pick`
 
-If you're creating a bugfix release which is cherry-picked instead of tagged from `master` (example: https://github.com/WordPress/gutenberg/compare/v3.1.0…v3.1.1), you should go about things a bit differently:
+If you're creating a bugfix release which is cherry-picked, you should go about things a bit differently:
 
-1. Check out the last release (for example: `git checkout v3.1.0`).
+1. Check out the last release (for example: `git checkout master`).
 2. Cherry-pick commits (in chronological order) with `git cherry-pick [SHA]`.
 3. Tag this release and push it to GitHub:
 ```bash
@@ -32,11 +32,19 @@ git push origin v3.1.1
 
 Note: The `1.x.0` notation `git` and `svn` commands should be replaced with the version number of the new release.
 
-* Run `git checkout master` and `git pull`. Make sure your local `master` is up to date; you can confirm this by opening `gutenberg.php` and checking for the version bump you merged previously.
+* Run `git checkout release/1.x.0` and `git pull`.
 * Run `./bin/build-plugin-zip.sh` from the root of project. This packages a zip file with a release build of `gutenberg.zip`.
+* Rename the zip file `gutenberg-1.x.0.zip`.
 * Check that the zip file looks good. Drop it in the [`#core-editor` channel](https://wordpress.slack.com/messages/C02QB2JS7) for people to test. Again: make sure if you unzip the file that the version number is correct.
 * Run `git tag v1.x.0` from `master` branch (with the new version we are shipping).
 * Run `git push --tags`.
+
+## Build the RC for the Next Version
+
+* Run `git checkout develop` and `git pull`. 
+* Run `./bin/build-plugin-zip.sh` from the root of project. This packages a zip file with a release build of `gutenberg.zip`.
+* Rename the zip file `gutenberg-1.x.0-RC.zip`, make sure to rename if for the _next_ version.
+* Check that the zip file looks good. Drop it in the [`#core-editor` channel](https://wordpress.slack.com/messages/C02QB2JS7) for people to test. Again: make sure if you unzip the file that the version number is correct.
 
 ## Push the Release
 
@@ -46,8 +54,10 @@ You'll need to use Subversion to publish the plugin to WordPress.org.
   * If this is your first checkout, run: `svn checkout https://plugins.svn.wordpress.org/gutenberg`
   * If you already have a copy, run: `svn up`
 * Delete the contents of `trunk` except for the `readme.txt` and `changelog.txt` files (these files don’t exist in the git repo, only in subversion).
-* Extract the contents of the zip file to `trunk`.
-* Edit `readme.txt`, replacing the changelog for the previous version with the current release's changelog.
+* Extract the contents of the `gutenberg-master.zip` file to `trunk`.
+* Edit `readme.txt`:
+  * point to the new tag. The **Stable version** header in `readme.txt` should be updated to match the new release version number.
+  * replace the changelog for the previous version with the current release's changelog.
 * Add the changelog for the current release to `changelog.txt`.
 * Add new files to the SVN repo, and remove old files, in the `trunk` directory:
 ```bash
@@ -57,26 +67,33 @@ svn st | grep '^\?' | awk '{print $2}' | xargs svn add
 svn st | grep '^!' | awk '{print $2}' | xargs svn rm
 ```
 
-* Commit the new version to `trunk`:
-```bash
-svn ci -m "Committing version 1.x.0"
-```
-
 * Tag the new version. Change to the parent directory, and run:
 ```bash
 svn cp trunk tags/1.x.0
-svn ci -m "Tagging version 1.x.0."
 ```
 
-* Edit `trunk/readme.txt` to point to the new tag. The **Stable version** header in `readme.txt` should be updated to match the new release version number. After updating and committing that, the new version will be released:
+* Extract the contents of the zip file for the RC to `trunk`.
+* Once again add new files to the SVN repo, and remove old files, in the `trunk` directory:
 ```bash
-svn ci -m "Releasing version 1.x.0"
+# Add new files:
+svn st | grep '^\?' | awk '{print $2}' | xargs svn add
+# Delete old files:
+svn st | grep '^!' | awk '{print $2}' | xargs svn rm
+```
+
+* Commit the new version and the RC:
+```bash
+svn ci -m "Releasing stable version 1.x.0 and RC 1.x.0"
 ```
 
 ## Post-Release
 
 * Check that folks are able to install the new version from their Dashboard.
 * Publish the make/core post.
+* Merge the release branch you've just released back into `master` and `develop`.
+* Create a new `release/1.x.0` branch for the next release off of `develop`.
+* Set the date for the next release on the milestone for the next release.
+* Create a milestone for the release _after_ the next release.
 * Pat yourself on the back! 👍
 
 Ta-da! 🎉


### PR DESCRIPTION
## Description
As more and more people are testing Gutenberg, we must make sure we improve the stability of the Gutenberg project. In order to do that, we should switch from just releasing `master` every week or two weeks to a system where we have a slightly longer RC period. 

I therefore propose we switch to a system where every time we do a release, we create a new release branch for the next release, and treat that as an RC. To do this we need a `develop` branch as the default, and a `master` branch as the current released version. The following describes the workflow and ground rules I think would work well for this:

## Workflow

On the day of a release:

- Create the release branch for the next release, in the format of `release/1.x.0`.
- Set the release date on the milestone for the next release. 
- Create the milestone for the release _after_ the next release, so if you're creating the release branch for 3.8, you create the milestone for 3.9. 
- The release branch becomes the RC for the next release, allowing developers that build integrations to test with this RC.
- The release branch is committed to Subversion `trunk` on wordpress.org's SVN so translators can already start translating.
- Releases are merged back into the `master` and `develop` branch as soon as they're released, so `master` always reflects the current released state.

## Ground rules

- Only bug fixes for regressions are merged on the release branch, everything else goes into the `develop` branch.
- Releases can, if needed, go out _after_ their planned date, but never before, because developers that build integrations need to be able to do planning on when they can test.
- For reasons of stability, every public API is deprecated with a 4 week notice period.
- Merges should be milestoned to the correct milestone on merge.

## Steps to take

* [ ] Update `release.md` with the new workflow (in this pull).
* [ ] Remove the branch check from `build-plugin-zip.sh` as it no longer works with this workflow (in this pull).
* [ ] Add a checkbox to the `Bug_report.md` issue template to check whether the issue is a regression  (in this pull).
* [ ] Create a new `develop` branch, and make it the default.
* [ ] Protect the `master` branch and only allow commits / merges by the people that do releases.
* [ ] Create a new `release/x.x` branch for every new release.