### PR TITLE
Show a warning when a disallowed filetype is dropped on a MediaUpload

### DIFF
--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -82,7 +82,11 @@ export function mediaUpload( {
 		if ( allowedMimeTypesForUser && ! isAllowedMimeTypeForUser( mediaFile.type ) ) {
 			onError( {
 				code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
-				message: __( 'Sorry, this file type is not permitted for security reasons.' ),
+				message: [
+					<strong key="filename">{ mediaFile.name }</strong>,
+					': ',
+					__( 'Sorry, this file type is not permitted for security reasons.' ),
+				],
 				file: mediaFile,
 			} );
 			return;
@@ -92,7 +96,11 @@ export function mediaUpload( {
 		if ( ! isAllowedType( mediaFile.type ) ) {
 			onError( {
 				code: 'MIME_TYPE_NOT_SUPPORTED_FOR_BLOCK',
-				message: __( 'Sorry, this file type is not supported by this block.' ),
+				message: [
+					<strong key="filename">{ mediaFile.name }</strong>,
+					': ',
+					__( 'Sorry, this file type is not supported by this block.' ),
+				],
 				file: mediaFile,
 			} );
 			return;

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -78,20 +78,21 @@ export function mediaUpload( {
 	};
 
 	files.forEach( ( mediaFile, idx ) => {
-		if ( ! isAllowedType( mediaFile.type ) ) {
+		// verify if user is allowed to upload this mime type
+		if ( allowedMimeTypesForUser && ! isAllowedMimeTypeForUser( mediaFile.type ) ) {
 			onError( {
-				code: 'MIME_TYPE_NOT_ALLOWED',
+				code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
 				message: __( 'Sorry, this file type is not permitted for security reasons.' ),
 				file: mediaFile,
 			} );
 			return;
 		}
 
-		// verify if user is allowed to upload this mime type
-		if ( allowedMimeTypesForUser && ! isAllowedMimeTypeForUser( mediaFile.type ) ) {
+		// Check if the block supports this mime type
+		if ( ! isAllowedType( mediaFile.type ) ) {
 			onError( {
-				code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
-				message: __( 'Sorry, this file type is not permitted for security reasons.' ),
+				code: 'MIME_TYPE_NOT_SUPPORTED_FOR_BLOCK',
+				message: __( 'Sorry, this file type is not supported by this block.' ),
 				file: mediaFile,
 			} );
 			return;

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -77,16 +77,23 @@ export function mediaUpload( {
 		return includes( allowedMimeTypesForUser, fileType );
 	};
 
+	// Build the error message including the filename
+	const triggerError = ( error ) => {
+		error.message = [
+			<strong key="filename">{ error.file.name }</strong>,
+			': ',
+			error.message,
+		];
+
+		onError( error );
+	};
+
 	files.forEach( ( mediaFile, idx ) => {
 		// verify if user is allowed to upload this mime type
 		if ( allowedMimeTypesForUser && ! isAllowedMimeTypeForUser( mediaFile.type ) ) {
-			onError( {
+			triggerError( {
 				code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
-				message: [
-					<strong key="filename">{ mediaFile.name }</strong>,
-					': ',
-					__( 'Sorry, this file type is not permitted for security reasons.' ),
-				],
+				message: __( 'Sorry, this file type is not permitted for security reasons.' ),
 				file: mediaFile,
 			} );
 			return;
@@ -94,13 +101,9 @@ export function mediaUpload( {
 
 		// Check if the block supports this mime type
 		if ( ! isAllowedType( mediaFile.type ) ) {
-			onError( {
+			triggerError( {
 				code: 'MIME_TYPE_NOT_SUPPORTED_FOR_BLOCK',
-				message: [
-					<strong key="filename">{ mediaFile.name }</strong>,
-					': ',
-					__( 'Sorry, this file type is not supported by this block.' ),
-				],
+				message: __( 'Sorry, this file type is not supported by this block.' ),
 				file: mediaFile,
 			} );
 			return;
@@ -108,13 +111,9 @@ export function mediaUpload( {
 
 		// verify if file is greater than the maximum file upload size allowed for the site.
 		if ( maxUploadFileSize && mediaFile.size > maxUploadFileSize ) {
-			onError( {
+			triggerError( {
 				code: 'SIZE_ABOVE_LIMIT',
-				message: sprintf(
-					// translators: %s: file name
-					__( '%s exceeds the maximum upload size for this site.' ),
-					mediaFile.name
-				),
+				message: __( 'This file exceeds the maximum upload size for this site.' ),
 				file: mediaFile,
 			} );
 			return;

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -102,8 +102,8 @@ export function mediaUpload( {
 		// Check if the block supports this mime type
 		if ( ! isAllowedType( mediaFile.type ) ) {
 			triggerError( {
-				code: 'MIME_TYPE_NOT_SUPPORTED_FOR_BLOCK',
-				message: __( 'Sorry, this file type is not supported by this block.' ),
+				code: 'MIME_TYPE_NOT_SUPPORTED',
+				message: __( 'Sorry, this file type is not supported here.' ),
 				file: mediaFile,
 			} );
 			return;

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -119,6 +119,16 @@ export function mediaUpload( {
 			return;
 		}
 
+		// Don't allow empty files to be uploaded.
+		if ( mediaFile.size <= 0 ) {
+			triggerError( {
+				code: 'EMPTY_FILE',
+				message: __( 'This file is empty.' ),
+				file: mediaFile,
+			} );
+			return;
+		}
+
 		// Set temporary URL to create placeholder media file, this is replaced
 		// with final file from media gallery when upload is `done` below
 		filesSet.push( { url: window.URL.createObjectURL( mediaFile ) } );

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -79,6 +79,11 @@ export function mediaUpload( {
 
 	files.forEach( ( mediaFile, idx ) => {
 		if ( ! isAllowedType( mediaFile.type ) ) {
+			onError( {
+				code: 'MIME_TYPE_NOT_ALLOWED',
+				message: __( 'Sorry, this file type is not permitted for security reasons.' ),
+				file: mediaFile,
+			} );
 			return;
 		}
 

--- a/packages/editor/src/utils/media-upload/test/media-upload.js
+++ b/packages/editor/src/utils/media-upload/test/media-upload.js
@@ -34,7 +34,7 @@ describe( 'mediaUpload', () => {
 		} );
 		expect( onFileChangeSpy ).not.toHaveBeenCalled();
 		expect( onError ).toHaveBeenCalled();
-		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'MIME_TYPE_NOT_SUPPORTED_FOR_BLOCK' );
+		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'MIME_TYPE_NOT_SUPPORTED' );
 	} );
 
 	it( 'should call error handler with the correct error object if file size is greater than the maximum', () => {

--- a/packages/editor/src/utils/media-upload/test/media-upload.js
+++ b/packages/editor/src/utils/media-upload/test/media-upload.js
@@ -6,6 +6,7 @@ import { mediaUpload, getMimeTypesArray } from '../media-upload';
 const invalidMediaObj = {
 	url: 'https://cldup.com/uuUqE_dXzy.jpg',
 	type: 'text/xml',
+	name: 'test.xml',
 };
 
 const validMediaObj = {
@@ -32,11 +33,8 @@ describe( 'mediaUpload', () => {
 			onError,
 		} );
 		expect( onFileChangeSpy ).not.toHaveBeenCalled();
-		expect( onError ).toBeCalledWith( {
-			code: 'MIME_TYPE_NOT_SUPPORTED_FOR_BLOCK',
-			file: invalidMediaObj,
-			message: 'Sorry, this file type is not supported by this block.',
-		} );
+		expect( onError ).toHaveBeenCalled();
+		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'MIME_TYPE_NOT_SUPPORTED_FOR_BLOCK' );
 	} );
 
 	it( 'should call error handler with the correct error object if file size is greater than the maximum', () => {
@@ -49,11 +47,8 @@ describe( 'mediaUpload', () => {
 			maxUploadFileSize: 512,
 			onError,
 		} );
-		expect( onError ).toBeCalledWith( {
-			code: 'SIZE_ABOVE_LIMIT',
-			file: validMediaObj,
-			message: `${ validMediaObj.name } exceeds the maximum upload size for this site.`,
-		} );
+		expect( onError ).toHaveBeenCalled();
+		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'SIZE_ABOVE_LIMIT' );
 	} );
 
 	it( 'should call error handler with the correct error object if file type is not allowed for user', () => {
@@ -67,11 +62,8 @@ describe( 'mediaUpload', () => {
 			onError,
 			allowedMimeTypes,
 		} );
-		expect( onError ).toBeCalledWith( {
-			code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
-			file: validMediaObj,
-			message: 'Sorry, this file type is not permitted for security reasons.',
-		} );
+		expect( onError ).toHaveBeenCalled();
+		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'MIME_TYPE_NOT_ALLOWED_FOR_USER' );
 	} );
 } );
 

--- a/packages/editor/src/utils/media-upload/test/media-upload.js
+++ b/packages/editor/src/utils/media-upload/test/media-upload.js
@@ -24,8 +24,14 @@ describe( 'mediaUpload', () => {
 	} );
 
 	it( 'should do nothing on invalid image type', () => {
+		const onError = jest.fn();
 		mediaUpload( { filesList: [ invalidMediaObj ], onFileChange: onFileChangeSpy, allowedType: 'image' } );
 		expect( onFileChangeSpy ).not.toHaveBeenCalled();
+		expect( onError ).toBeCalledWith( {
+			code: 'MIME_TYPE_NOT_ALLOWED',
+			file: validMediaObj,
+			message: 'Sorry, this file type is not permitted for security reasons.',
+		} );
 	} );
 
 	it( 'should call error handler with the correct error object if file size is greater than the maximum', () => {

--- a/packages/editor/src/utils/media-upload/test/media-upload.js
+++ b/packages/editor/src/utils/media-upload/test/media-upload.js
@@ -25,12 +25,17 @@ describe( 'mediaUpload', () => {
 
 	it( 'should do nothing on invalid image type', () => {
 		const onError = jest.fn();
-		mediaUpload( { filesList: [ invalidMediaObj ], onFileChange: onFileChangeSpy, allowedType: 'image' } );
+		mediaUpload( {
+			filesList: [ invalidMediaObj ],
+			onFileChange: onFileChangeSpy,
+			allowedType: 'image',
+			onError,
+		} );
 		expect( onFileChangeSpy ).not.toHaveBeenCalled();
 		expect( onError ).toBeCalledWith( {
-			code: 'MIME_TYPE_NOT_ALLOWED',
-			file: validMediaObj,
-			message: 'Sorry, this file type is not permitted for security reasons.',
+			code: 'MIME_TYPE_NOT_SUPPORTED_FOR_BLOCK',
+			file: invalidMediaObj,
+			message: 'Sorry, this file type is not supported by this block.',
 		} );
 	} );
 


### PR DESCRIPTION
## Description

When trying to upload a disallowed filetype to a file block, or an unsupported filetype to a restricted block (eg, a zip file to an image block), there's no feedback saying why the upload failed.

This PR re-arranges the filetype checking a little, to ensure a message is triggered on the former case, and adds a new message for the latter. It also adds the filename to each warning, so the person uploading the files knows which files caused which warning.

Fixes #9467.

## How has this been tested?

* Upload a blocked file (eg, `foo.exe`) to a file block.
* Upload an allowed, but unsupported file (eg, `bar.zip`) to an image block.

## Screenshots

<img width="692" alt="screenshot of the image block showing the error messages" src="https://user-images.githubusercontent.com/352291/44991838-53718c00-af8d-11e8-9e0f-7cea4d81c3a0.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.