### PR TITLE
Treat Verse lines consistently on the front end

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -18,6 +18,7 @@
 @import "./subhead/style.scss";
 @import "./table/style.scss";
 @import "./text-columns/style.scss";
+@import "./verse/style.scss";
 @import "./video/style.scss";
 
 .has-pale-pink-background-color {

--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,0 +1,4 @@
+pre.wp-block-verse {
+	white-space: nowrap;
+	overflow: auto;
+}


### PR DESCRIPTION
## Description
Today, we prevent wrapping Verse block lines in the editor because we want to preserve the author's intent, but that intent is not respected consistently on the front end where certain themes wrap Verse lines. This PR simply adds a rule to prevent Verse lines from wrapping on the front end in addition to the editor.

Fixes #4138.

## How has this been tested?

I loaded a Verse block with a long line in the following themes and verified it was not wrapped:
* TwentyTwelve (previously did not wrap)
* TwentyFifteen (previously wrapped Verse lines)
* TwentySixteen (previously wrapped Verse lines)