### PR TITLE
Fix: hasSelectedInnerBlock does not accounts for multi selected innerBlocks

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -373,6 +373,7 @@ export class BlockListBlock extends Component {
 			isPreviousBlockADefaultEmptyBlock,
 			hasSelectedInnerBlock,
 			isParentOfSelectedBlock,
+			hasMultiSelection,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -387,7 +388,7 @@ export class BlockListBlock extends Component {
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && isSelected && ! isTypingWithinBlock;
-		const shouldAppearSelectedParent = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;
+		const shouldAppearSelectedParent = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock && ! hasMultiSelection;
 		const shouldAppearHovered = ! isFocusMode && ! hasFixedToolbar && isHovered && ! isEmptyDefaultBlock;
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ! isFocusMode && ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
@@ -607,6 +608,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		getEditorSettings,
 		hasSelectedInnerBlock,
 		getTemplateLock,
+		hasMultiSelection,
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( clientId );
 	const { hasFixedToolbar, focusMode } = getEditorSettings();
@@ -640,6 +642,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		block,
 		isSelected,
 		isParentOfSelectedBlock,
+		hasMultiSelection: hasMultiSelection(),
 	};
 } );
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1112,6 +1112,7 @@ export function hasSelectedInnerBlock( state, clientId, deep = false ) {
 		getBlockOrder( state, clientId ),
 		( innerClientId ) => (
 			isBlockSelected( state, innerClientId ) ||
+			isBlockMultiSelected( state, innerClientId ) ||
 			( deep && hasSelectedInnerBlock( state, innerClientId, deep ) )
 		)
 	);

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2240,6 +2240,35 @@ describe( 'selectors', () => {
 
 			expect( hasSelectedInnerBlock( state, 4 ) ).toBe( true );
 		} );
+
+		it( 'should return true if a multi selection exists that contains children of the block with the given ClientId', () => {
+			const state = {
+				editor: {
+					present: {
+						blockOrder: {
+							6: [ 5, 4, 3, 2, 1 ],
+						},
+					},
+				},
+				blockSelection: { start: 2, end: 4 },
+			};
+			expect( hasSelectedInnerBlock( state, 6 ) ).toBe( true );
+		} );
+
+		it( 'should return false if a multi selection exists bot does not contains children of the block with the given ClientId', () => {
+			const state = {
+				editor: {
+					present: {
+						blockOrder: {
+							3: [ 2, 1 ],
+							6: [ 5, 4 ],
+						},
+					},
+				},
+				blockSelection: { start: 5, end: 4 },
+			};
+			expect( hasSelectedInnerBlock( state, 3 ) ).toBe( false );
+		} );
 	} );
 
 	describe( 'isBlockWithinSelection', () => {


### PR DESCRIPTION
If a block contained multi-selected children the selector hasSelectedInnerBlock returned false anyway. This caused a bug in Spotlight mode. If we had multiple blocks selected inside a column they still appeared with the grey mark as if they were not focused.

## How has this been tested?
I checked that on Spotlight mode multi-selected blocks inside columns appear focused.

## Screenshots <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/11271197/45001592-31e0c680-afc6-11e8-8b73-096ab956d393.png)

After:
![image](https://user-images.githubusercontent.com/11271197/45001566-0cec5380-afc6-11e8-944d-7caa3805bc56.png)

