### PR TITLE
fix: Author select overflows in IE11

### DIFF
--- a/edit-post/components/sidebar/post-author/style.scss
+++ b/edit-post/components/sidebar/post-author/style.scss
@@ -1,3 +1,11 @@
 .editor-post-author__select {
 	margin: -5px 0;
+
+	// Set the width of the author select box in IE11 to prevent it overflowing
+	// outside of the container because of IE11 flexbox bugs.
+	// We reset it to `width: auto;` for non-IE11 browsers.
+	width: 100%;
+	@supports (position: sticky) {
+		width: auto;
+	}
 }


### PR DESCRIPTION
Fix #3432.

## Description
Add an explicit width to the author select for IE11 because of flex box bugs. This prevents a long author name causing horizontal scrollbars.

## How has this been tested?
Tested in IE11; scrollbars disappear. Tested in Firefox and previously styles remained.

## Before
![2018-09-04 01 05 36](https://user-images.githubusercontent.com/90871/45003853-b5a6ad00-afde-11e8-970b-f081f19d1394.gif)

## After
<img width="1277" alt="screenshot 2018-09-04 00 51 49" src="https://user-images.githubusercontent.com/90871/45003859-bccdbb00-afde-11e8-8e12-f3b69501aef9.png">