### PR TITLE
Move video caption styles to style.scss

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -8,7 +8,7 @@
 }
 
 .wp-block-embed {
-	// Supply caption styles to images, even if the theme hasn't opted in.
+	// Supply caption styles to embeds, even if the theme hasn't opted in.
 	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,
 	// so we supply the styles so as to not appear broken or unstyled in those.
 	figcaption {

--- a/packages/block-library/src/theme.scss
+++ b/packages/block-library/src/theme.scss
@@ -4,4 +4,3 @@
 @import "./quote/theme.scss";
 @import "./separator/theme.scss";
 @import "./table/theme.scss";
-@import "./video/theme.scss";

--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -1,4 +1,8 @@
 .wp-block-video {
+	// Remove the left and right margin the figure is born with.
+	margin-left: 0;
+	margin-right: 0;
+
 	video {
 		max-width: 100%;
 	}
@@ -11,5 +15,12 @@
 
 	&.aligncenter {
 		text-align: center;
+	}
+
+	// Supply caption styles to images, even if the theme hasn't opted in.
+	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those themes.
+	figcaption {
+		@include caption-style();
 	}
 }

--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -17,7 +17,7 @@
 		text-align: center;
 	}
 
-	// Supply caption styles to images, even if the theme hasn't opted in.
+	// Supply caption styles to videos, even if the theme hasn't opted in.
 	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
 	// so we supply the styles so as to not appear broken or unstyled in those themes.
 	figcaption {

--- a/packages/block-library/src/video/theme.scss
+++ b/packages/block-library/src/video/theme.scss
@@ -1,5 +1,0 @@
-.wp-block-video {
-	figcaption {
-		@include caption-style();
-	}
-}


### PR DESCRIPTION
The theme.scss file exists to let themes opt into opinionated styles.

However caption styles using the new figcaption markup are unlikely to be styled by themes. Therefore it should be in style.scss or it will look broken.

In addition to adding the caption styles back, this PR neutralizes the left and right margin on the video block that the `figure` comes born with.

Frontend:

<img width="887" alt="frontend" src="https://user-images.githubusercontent.com/1204802/45015785-0b9d4400-b023-11e8-804d-205e3440559f.png">

Backend:

<img width="697" alt="backend" src="https://user-images.githubusercontent.com/1204802/45015788-0dff9e00-b023-11e8-932b-c1f7d323feec.png">
