### PR TITLE
Fix separator BG.

### DIFF
--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -8,6 +8,7 @@
 
 	// Dots style
 	&.is-style-dots {
+		background: none; // Override any background themes often set on the hr tag for this style.
 		border: none;
 		text-align: center;
 		max-width: none;


### PR DESCRIPTION
Themes often style the hr tag by removing the border, setting a bg color, and setting the height to 1px. This is fine, but for the "dots" variation, this should not have a background color. This PR simply removes it for that variation.

<img width="872" alt="screen shot 2018-09-04 at 09 32 24" src="https://user-images.githubusercontent.com/1204802/45016641-85cec800-b025-11e8-9b4e-aa5c3b52ac03.png">
