### PR TITLE
Fix codetabs block in extensibility docs by adding closing tag

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -43,7 +43,7 @@ registerBlockType( 'mytheme/red-block', {
 	}
 } );
 ```
-
+{% end %}
 
 If you want to learn more about block creation, the [Blocks Tutorial](../docs/blocks.md) is the best place to start.
 


### PR DESCRIPTION
The codetabs block wasn't rendering the interactive widget in the handbook, which appears to
have been caused by a missing closing tag.

## Description
The extensibility page in the Gutenberg handbook isn't rendering the codetabs block correctly: https://wordpress.org/gutenberg/handbook/extensibility/

This appears to be because of a missing closing tag. I wasn't 100% sure which approach you're using for generating the documentation, but it looks something like Gitbook with the [codetabs](https://github.com/GitbookIO/plugin-codetabs) plugin? (I'd be curious to know what the setup is, I couldn't quite work it out from the docs). I've copied the closing tag from the other docs, so assume this would work on this page, too.

## How has this been tested?
This hasn't been tested, but I'm assuming the closing tag would work the same way as it does for the other pages generated for the handbook.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/14988353/45025147-11744300-b07e-11e8-9e3f-1ed7edcc919e.png)

## Types of changes
A single line fix for the generated handbook documentation.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- ~[ ] My code is tested.~
- ~[ ] My code follows the WordPress code style.~ <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- ~[ ] My code follows the accessibility standards.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- ~[ ] My code has proper inline documentation.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
