### PR TITLE
[Fix] Include Caption Styles in Video Block Caption

### DIFF
--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -12,4 +12,11 @@
 	&.aligncenter {
 		text-align: center;
 	}
+
+	// Supply caption styles to videos, even if the theme hasn't opted in.
+	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those themes.
+	figcaption {
+		@include caption-style();
+	}
 }


### PR DESCRIPTION
## Description
This PR closes #9581 which reports the unavailability of front-end styles for the video block's caption.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the "Video" block.
3. Added a video and a caption below it.
4. Made sure the `<figcaption>` element for the video caption in the front-end is styled, even if the theme is not doing so.

This was tested in WordPress 4.9.8, Gutenberg 3.7.0 and it doesn't seem to be affecting any other parts.

## Screenshots <!-- if applicable -->
![pull-9581](https://user-images.githubusercontent.com/20284937/45041259-a892c800-b089-11e8-91c8-92d4cd44e436.png)

## Types of changes
This PR just includes the `caption-style()` mixin in the `.wp-block-video figcaption` element into the style.scss file for the video block which is getting rendered in the front-end.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
