### PR TITLE
Fix: Shortcut inserter on invalid paragraphs

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -384,7 +384,7 @@ export class BlockListBlock extends Component {
 
 		// If the block is selected and we're typing the block should not appear.
 		// Empty paragraph blocks should always show up as unselected.
-		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
+		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock && isValid;
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && isSelected && ! isTypingWithinBlock;
 		const shouldAppearSelectedParent = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && hasSelectedInnerBlock && ! isTypingWithinBlock;

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -71,10 +71,11 @@ export default compose(
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
 		const lastBlock = getBlock( ownProps.lastBlockClientId );
 		const isLastBlockDefault = get( lastBlock, [ 'name' ] ) === getDefaultBlockName();
+		const isLastBlockValid = get( lastBlock, [ 'isValid' ] );
 		const { bodyPlaceholder } = getEditorSettings();
 
 		return {
-			isVisible: isEmpty || ! isLastBlockDefault,
+			isVisible: isEmpty || ! isLastBlockDefault || ! isLastBlockValid,
 			showPrompt: isEmpty,
 			isLocked: !! getTemplateLock( ownProps.rootClientId ),
 			placeholder: bodyPlaceholder,


### PR DESCRIPTION
## Description
On invalid paragraph blocks (that don't show the paragraph UI) we still had the shortcut inserter and the side inserter showing but as the background was not a paragraph the design looked wrong and made hard to click on the sibling menu of invalid blocks.
This PR's makes sure we don't show shortcut & side inserter on invalid paragraphs making the way we handle invalid paragraphs equal to how we handle all other invalid blocks.
Besides that, we show the DefaultBlockAppender even if the last block was an invalid paragraph (again to have the same behavior that we have for other invalid blocks). 

## How has this been tested?
I added the following content in the editor:
```
<!-- wp:paragraph -->
<sdsp>/dsf</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<sdsp>/dsf</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<psd>sdfds</p>
<!-- /wp:paragraph -->
```
And checked that the shortcuts/side inserter only appear when they should.

## Screenshots <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/11271197/45051333-bccfc880-b07b-11e8-933e-a3d5ca9acc24.png)


After:
![image](https://user-images.githubusercontent.com/11271197/45051265-8e51ed80-b07b-11e8-969b-f26d2659eafa.png)

