### PR TITLE
Testing: Add lint rule for path on Lodash property functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -118,6 +118,10 @@ module.exports = {
 				message: 'Always pass an array as the path argument',
 			},
 			{
+				selector: 'CallExpression[callee.name=/^(property|matchesProperty|path)$/] > Literal:nth-child(1)',
+				message: 'Always pass an array as the path argument',
+			},
+			{
 				selector: 'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] Literal[value=/\\.{3}/]',
 				message: 'Use ellipsis character (…) in place of three dots',
 			},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { escapeRegExp } = require( 'lodash' );
+const { escapeRegExp, map } = require( 'lodash' );
 
 /**
  * Internal dependencies
@@ -114,11 +114,32 @@ module.exports = {
 				message: 'Deprecated functions must be removed before releasing this version.',
 			},
 			{
-				selector: 'CallExpression[callee.name=/^(invokeMap|get|has|hasIn|invoke|result|set|setWith|unset|update|updateWith)$/] > Literal:nth-child(2)',
-				message: 'Always pass an array as the path argument',
-			},
-			{
-				selector: 'CallExpression[callee.name=/^(property|matchesProperty|path)$/] > Literal:nth-child(1)',
+				// Builds a selector which handles CallExpression with path
+				// argument at varied position by function.
+				//
+				// See: https://github.com/WordPress/gutenberg/pull/9615
+				selector: map( {
+					1: [
+						'property',
+						'matchesProperty',
+						'path',
+					],
+					2: [
+						'invokeMap',
+						'get',
+						'has',
+						'hasIn',
+						'invoke',
+						'result',
+						'set',
+						'setWith',
+						'unset',
+						'update',
+						'updateWith',
+					],
+				}, ( functionNames, argPosition ) => (
+					`CallExpression[callee.name=/^(${ functionNames.join( '|' ) })$/] > Literal:nth-child(${ argPosition })`
+				) ).join( ',' ),
 				message: 'Always pass an array as the path argument',
 			},
 			{

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, property, without } from 'lodash';
+import { filter, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -137,7 +137,7 @@ describe( 'selectors', () => {
 			parent: [ 'core/test-block-b' ],
 		} );
 
-		cachedSelectors = filter( selectors, property( 'clear' ) );
+		cachedSelectors = filter( selectors, ( selector ) => selector.clear );
 	} );
 
 	beforeEach( () => {

--- a/packages/viewport/src/index.js
+++ b/packages/viewport/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { reduce, forEach, debounce, mapValues, property } from 'lodash';
+import { reduce, forEach, debounce, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -47,7 +47,7 @@ const OPERATORS = {
  * maximum of one time per call stack.
  */
 const setIsMatching = debounce( () => {
-	const values = mapValues( queries, property( 'matches' ) );
+	const values = mapValues( queries, ( query ) => query.matches );
 	dispatch( 'core/viewport' ).setIsMatching( values );
 }, { leading: true } );
 


### PR DESCRIPTION
Related: #6247

This pull request seeks to enhance existing custom ESLint rules forbidding the use of string paths for Lodash functions (see #6247 for context). It adds a few more functions which allow for path as an argument. It's suspected these were previously overlooked because for other functions, path was passed as the second argument.

For existing usage, instead of adding array wrappers, I opted to stop using the Lodash utility in favor of an equivalent arrow function. It uses a few more characters, but I think is a bit easier to read for those who aren't already familiar with the intent of the `property` utility function. This may be open to debate and I'm not strongly committed to keeping it this way.

**Testing instructions:**

Verify linting passes:

```
npm run lint
```

Ensure there are no regressions in affected runtime behavior: The updating of components which depend on viewport size (e.g. small screen requiring two-tap for select vs. interaction of a block).