### PR TITLE
Packages: Add notices package

### DIFF
--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -4,5 +4,6 @@
  - [**core/blocks**: Block Types Data](../../docs/data/data-core-blocks.md)
  - [**core/editor**: The Editor’s Data](../../docs/data/data-core-editor.md)
  - [**core/edit-post**: The Editor’s UI Data](../../docs/data/data-core-edit-post.md)
+ - [**core/notices**: Notices Data](../../docs/data/data-core-notices.md)
  - [**core/nux**: The NUX (New User Experience) Data](../../docs/data/data-core-nux.md)
  - [**core/viewport**: The Viewport Data](../../docs/data/data-core-viewport.md)

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1370,7 +1370,6 @@ the specified post object and editor settings.
 *Parameters*
 
  * post: Post object.
- * autosaveStatus: The Post's autosave status.
 
 ### resetPost
 

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1061,18 +1061,6 @@ before falling back to serialization of block state.
 
 Post content.
 
-### getNotices
-
-Returns the user notices array.
-
-*Parameters*
-
- * state: Global application state.
-
-*Returns*
-
-List of notices.
-
 ### canInsertBlockType
 
 Determines if the given block type is allowed to be inserted, and, if
@@ -1636,26 +1624,6 @@ Returns an action object used in signalling that the user has begun to type.
 
 Returns an action object used in signalling that the user has stopped typing.
 
-### createNotice
-
-Returns an action object used to create a notice.
-
-*Parameters*
-
- * status: The notice status.
- * content: The notice content.
- * options: The notice options.  Available options:
-                             `id` (string; default auto-generated)
-                             `isDismissible` (boolean; default `true`).
-
-### removeNotice
-
-Returns an action object used to remove a notice.
-
-*Parameters*
-
- * id: The notice id.
-
 ### updatePostLock
 
 Returns an action object used to lock the editor.
@@ -1781,3 +1749,5 @@ Returns an action object used to signal that post saving is unlocked.
 *Parameters*
 
  * lockName: The lock name.
+
+### createNotice

--- a/docs/data/data-core-notices.md
+++ b/docs/data/data-core-notices.md
@@ -1,0 +1,84 @@
+# **core/notices**: Notices Data
+
+## Selectors
+
+### getNotices
+
+Returns all notices as an array, optionally for a given context. Defaults to
+the global context.
+
+*Parameters*
+
+ * state: Notices state.
+ * context: Optional grouping context.
+
+## Actions
+
+### createNotice
+
+Yields action objects used in signalling that a notice is to be created.
+
+*Parameters*
+
+ * status: Notice status.
+                                                      Defaults to `info`.
+ * content: Notice message.
+ * options: Notice options.
+ * options.context: Context under which to
+                                                      group notice.
+ * options.id: Identifier for notice.
+                                                      Automatically assigned
+                                                      if not specified.
+ * options.isDismissible: Whether the notice can
+                                                      be dismissed by user.
+                                                      Defaults to `true`.
+
+### createSuccessNotice
+
+Returns an action object used in signalling that a success notice is to be
+created. Refer to `createNotice` for options documentation.
+
+*Parameters*
+
+ * content: Notice message.
+ * options: Optional notice options.
+
+### createInfoNotice
+
+Returns an action object used in signalling that an info notice is to be
+created. Refer to `createNotice` for options documentation.
+
+*Parameters*
+
+ * content: Notice message.
+ * options: Optional notice options.
+
+### createErrorNotice
+
+Returns an action object used in signalling that an error notice is to be
+created. Refer to `createNotice` for options documentation.
+
+*Parameters*
+
+ * content: Notice message.
+ * options: Optional notice options.
+
+### createWarningNotice
+
+Returns an action object used in signalling that a warning notice is to be
+created. Refer to `createNotice` for options documentation.
+
+*Parameters*
+
+ * content: Notice message.
+ * options: Optional notice options.
+
+### removeNotice
+
+Returns an action object used in signalling that a notice is to be removed.
+
+*Parameters*
+
+ * id: Notice unique identifier.
+ * context: Optional context (grouping) in which the notice is
+                         intended to appear. Defaults to default context.

--- a/docs/data/data-core-notices.md
+++ b/docs/data/data-core-notices.md
@@ -32,6 +32,8 @@ Yields action objects used in signalling that a notice is to be created.
  * options.isDismissible: Whether the notice can
                                                       be dismissed by user.
                                                       Defaults to `true`.
+ * options.actions: User actions to be
+                                                      presented with notice.
 
 ### createSuccessNotice
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -462,6 +462,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/notices",
+		"slug": "packages-notices",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/notices/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/npm-package-json-lint-config",
 		"slug": "packages-npm-package-json-lint-config",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/npm-package-json-lint-config/README.md",
@@ -933,6 +939,12 @@
 		"title": "The Editor’s UI Data",
 		"slug": "data-core-edit-post",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/data-core-edit-post.md",
+		"parent": "data"
+	},
+	{
+		"title": "Notices Data",
+		"slug": "data-core-notices",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/data/data-core-notices.md",
 		"parent": "data"
 	},
 	{

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -4,6 +4,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 
 - `wp.date.getSettings` has been removed. Please use `wp.date.__experimentalGetSettings` instead.
 - `wp.compose.remountOnPropChange` has been removed.
+- The following editor store actions have been removed: `createNotice`, `removeNotice`, `createSuccessNotice`, `createInfoNotice`, `createErrorNotice`, `createWarningNotice`. Use the equivalent actions by the same name from the `@wordpress/notices` module.
 
 ## 4.3.0
 

--- a/docs/tool/config.js
+++ b/docs/tool/config.js
@@ -30,6 +30,11 @@ module.exports = {
 			selectors: [ path.resolve( root, 'packages/edit-post/src/store/selectors.js' ) ],
 			actions: [ path.resolve( root, 'packages/edit-post/src/store/actions.js' ) ],
 		},
+		'core/notices': {
+			title: 'Notices Data',
+			selectors: [ path.resolve( root, 'packages/notices/src/store/selectors.js' ) ],
+			actions: [ path.resolve( root, 'packages/notices/src/store/actions.js' ) ],
+		},
 		'core/nux': {
 			title: 'The NUX (New User Experience) Data',
 			selectors: [ path.resolve( root, 'packages/nux/src/store/selectors.js' ) ],

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -451,8 +451,8 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-is-shallow-equal',
 			'wp-keycodes',
 			'wp-polyfill',
-			'wp-url',
 			'wp-rich-text',
+			'wp-url',
 		),
 		filemtime( gutenberg_dir_path() . 'build/components/index.js' ),
 		true

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -478,6 +478,18 @@ function gutenberg_register_scripts_and_styles() {
 		true
 	);
 	gutenberg_override_script(
+		'wp-notices',
+		gutenberg_url( 'build/notices/index.js' ),
+		array(
+			'lodash',
+			'wp-a11y',
+			'wp-data',
+			'wp-polyfill-ecmascript',
+		),
+		filemtime( gutenberg_dir_path() . 'build/notices/index.js' ),
+		true
+	);
+	gutenberg_override_script(
 		'wp-viewport',
 		gutenberg_url( 'build/viewport/index.js' ),
 		array( 'wp-polyfill', 'wp-element', 'wp-data', 'wp-compose', 'lodash' ),
@@ -680,6 +692,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-i18n',
 			'wp-is-shallow-equal',
 			'wp-keycodes',
+			'wp-notices',
 			'wp-nux',
 			'wp-polyfill',
 			'wp-tinymce',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2269,6 +2269,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
+				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/nux": "file:packages/nux",
 				"@wordpress/token-list": "file:packages/token-list",
 				"@wordpress/url": "file:packages/url",
@@ -2287,8 +2288,7 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"tinymce": "^4.7.2",
-				"traverse": "^0.6.6",
-				"uuid": "^3.1.0"
+				"traverse": "^0.6.6"
 			}
 		},
 		"@wordpress/element": {
@@ -2383,6 +2383,15 @@
 				"@babel/runtime": "^7.0.0",
 				"lodash": "^4.17.10",
 				"webpack-sources": "^1.1.0"
+			}
+		},
+		"@wordpress/notices": {
+			"version": "file:packages/notices",
+			"requires": {
+				"@babel/runtime": "^7.0.0",
+				"@wordpress/a11y": "file:packages/a11y",
+				"@wordpress/data": "file:packages/data",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@wordpress/i18n": "file:packages/i18n",
 		"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 		"@wordpress/keycodes": "file:packages/keycodes",
+		"@wordpress/notices": "file:packages/notices",
 		"@wordpress/nux": "file:packages/nux",
 		"@wordpress/plugins": "file:packages/plugins",
 		"@wordpress/redux-routine": "file:packages/redux-routine",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## 5.0.0 (Unreleased)
 
-### Breaking Changes
+### Breaking Change
 
 - `AccessibleSVG` component has been removed. Please use `SVG` instead.
+
+### New Feature
+
+- The `Notice` component accepts an array of action objects via the `actions` prop. Each member object should contain a `label` and either a `url` link string or `onClick` callback function.
 
 ## 4.2.1 (2018-10-22)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,6 +48,7 @@
 		"uuid": "^3.1.0"
 	},
 	"devDependencies": {
+		"@wordpress/token-list": "file:../token-list",
 		"enzyme": "^3.3.0",
 		"react-test-renderer": "^16.4.1"
 	},

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -30,4 +30,5 @@ The following props are used to control the display of the component.
 
 * `status`: (string) can be `warning` (yellow), `success` (green), `error` (red).
 * `onRemove`: function called when dismissing the notice
-* `isDismissible`: (bool) defaults to true, whether the notice should be dismissible or not
+* `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
+* `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function.

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString, noop } from 'lodash';
+import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -12,17 +12,36 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import IconButton from '../icon-button';
+import { Button, IconButton } from '../';
 
-function Notice( { className, status, children, onRemove = noop, isDismissible = true } ) {
-	const classNames = classnames( className, 'components-notice', {
-		[ `is-${ status }` ]: ! ! status,
-	}, {
+function Notice( {
+	className,
+	status,
+	children,
+	onRemove = noop,
+	isDismissible = true,
+	actions = [],
+} ) {
+	const classes = classnames( className, 'components-notice', 'is-' + status, {
 		'is-dismissible': isDismissible,
 	} );
+
 	return (
-		<div className={ classNames }>
-			{ isString( children ) ? <div className="components-notice__content">{ children }</div> : children }
+		<div className={ classes }>
+			<div className="components-notice__content">
+				{ children }
+				{ actions.map( ( { label, url, onClick }, index ) => (
+					<Button
+						key={ index }
+						href={ url }
+						isLink={ !! url }
+						onClick={ onClick }
+						className="components-notice__action"
+					>
+						{ label }
+					</Button>
+				) ) }
+			</div>
 			{ isDismissible && (
 				<IconButton
 					className="components-notice__dismiss"

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -29,6 +29,13 @@
 	margin: 1em 0;
 }
 
+.components-notice__action.components-button {
+	&,
+	&.is-link {
+		margin-left: 4px;
+	}
+}
+
 .components-notice__dismiss {
 	position: absolute;
 	top: 0;

--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -2,8 +2,20 @@
 
 exports[`Notice should match snapshot 1`] = `
 <div
-  className="components-notice is-example is-dismissible"
+  className="components-notice is-success is-dismissible"
 >
+  <div
+    className="components-notice__content"
+  >
+    Example
+    <ForwardRef(Button)
+      className="components-notice__action"
+      href="https://example.com"
+      isLink={true}
+    >
+      View
+    </ForwardRef(Button)>
+  </div>
   <IconButton
     className="components-notice__dismiss"
     icon="no"

--- a/packages/components/src/notice/test/index.js
+++ b/packages/components/src/notice/test/index.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+/**
+ * WordPress dependencies
+ */
+import TokenList from '@wordpress/token-list';
 
 /**
  * Internal dependencies
@@ -10,13 +15,29 @@ import Notice from '../index';
 
 describe( 'Notice', () => {
 	it( 'should match snapshot', () => {
-		const wrapper = shallow( <Notice status="example" /> );
+		const renderer = new ShallowRenderer();
 
-		expect( wrapper ).toMatchSnapshot();
+		renderer.render(
+			<Notice
+				status="success"
+				actions={ [
+					{ label: 'View', url: 'https://example.com' },
+				] }
+			>
+				Example
+			</Notice>
+		);
+
+		expect( renderer.getRenderOutput() ).toMatchSnapshot();
 	} );
 
 	it( 'should not have is-dismissible class when isDismissible prop is false', () => {
-		const wrapper = shallow( <Notice isDismissible={ false } /> );
-		expect( wrapper.hasClass( 'is-dismissible' ) ).toBe( false );
+		const renderer = new ShallowRenderer();
+
+		renderer.render( <Notice isDismissible={ false } /> );
+
+		const classes = new TokenList( renderer.getRenderOutput().props.className );
+		expect( classes.contains( 'components-notice' ) ).toBe( true );
+		expect( classes.contains( 'is-dismissible' ) ).toBe( false );
 	} );
 } );

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -38,6 +38,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/notices": "file:../notices",
 		"@wordpress/nux": "file:../nux",
 		"@wordpress/token-list": "file:../token-list",
 		"@wordpress/url": "file:../url",
@@ -56,8 +57,7 @@
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
 		"tinymce": "^4.7.2",
-		"traverse": "^0.6.6",
-		"uuid": "^3.1.0"
+		"traverse": "^0.6.6"
 	},
 	"devDependencies": {
 		"deep-freeze": "^0.0.1",

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -20,9 +20,9 @@ function EditorNotices( props ) {
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		notices: select( 'core/editor' ).getNotices(),
+		notices: select( 'core/notices' ).getNotices(),
 	} ) ),
 	withDispatch( ( dispatch ) => ( {
-		onRemove: dispatch( 'core/editor' ).removeNotice,
+		onRemove: dispatch( 'core/notices' ).removeNotice,
 	} ) ),
 ] )( EditorNotices );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -10,6 +10,7 @@ import { compose } from '@wordpress/compose';
 import { createElement, Component } from '@wordpress/element';
 import { DropZoneProvider, SlotFillProvider } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -21,10 +22,27 @@ class EditorProvider extends Component {
 		super( ...arguments );
 
 		// Assume that we don't need to initialize in the case of an error recovery.
-		if ( ! props.recovery ) {
-			this.props.updateEditorSettings( props.settings );
-			this.props.updatePostLock( props.settings.postLock );
-			this.props.setupEditor( props.post, props.settings.autosave );
+		if ( props.recovery ) {
+			return;
+		}
+
+		props.updateEditorSettings( props.settings );
+		props.updatePostLock( props.settings.postLock );
+		props.setupEditor( props.post );
+
+		if ( props.settings.autosave ) {
+			props.createWarningNotice(
+				__( 'There is an autosave of this post that is more recent than the version below.' ),
+				{
+					id: 'autosave-exists',
+					actions: [
+						{
+							label: __( 'View the autosave' ),
+							url: props.settings.autosave.editLink,
+						},
+					],
+				}
+			);
 		}
 	}
 
@@ -92,9 +110,12 @@ export default withDispatch( ( dispatch ) => {
 		updateEditorSettings,
 		updatePostLock,
 	} = dispatch( 'core/editor' );
+	const { createWarningNotice } = dispatch( 'core/notices' );
+
 	return {
 		setupEditor,
 		updateEditorSettings,
 		updatePostLock,
+		createWarningNotice,
 	};
 } )( EditorProvider );

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -3,6 +3,7 @@
  */
 import '@wordpress/blocks';
 import '@wordpress/core-data';
+import '@wordpress/notices';
 import '@wordpress/nux';
 import '@wordpress/viewport';
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -763,7 +763,7 @@ export function createNotice( status, content, options ) {
 	deprecated( 'createNotice action (`core/editor` store)', {
 		alternative: 'createNotice action (`core/notices` store)',
 		plugin: 'Gutenberg',
-		version: '4.0',
+		version: '4.4.0',
 	} );
 
 	dispatch( 'core/notices' ).createNotice( status, content, options );
@@ -775,7 +775,7 @@ export function removeNotice( id ) {
 	deprecated( 'removeNotice action (`core/editor` store)', {
 		alternative: 'removeNotice action (`core/notices` store)',
 		plugin: 'Gutenberg',
-		version: '4.0',
+		version: '4.4.0',
 	} );
 
 	dispatch( 'core/notices' ).removeNotice( id );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -17,15 +17,13 @@ import { dispatch } from '@wordpress/data';
  * Returns an action object used in signalling that editor has initialized with
  * the specified post object and editor settings.
  *
- * @param {Object}  post           Post object.
- * @param {Object}  autosaveStatus The Post's autosave status.
+ * @param {Object} post Post object.
  *
  * @return {Object} Action object.
  */
-export function setupEditor( post, autosaveStatus ) {
+export function setupEditor( post ) {
 	return {
 		type: 'SETUP_EDITOR',
-		autosave: autosaveStatus,
 		post,
 	};
 }

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import uuid from 'uuid/v4';
 import { partial, castArray } from 'lodash';
 
 /**
@@ -11,6 +10,8 @@ import {
 	getDefaultBlockName,
 	createBlock,
 } from '@wordpress/blocks';
+import deprecated from '@wordpress/deprecated';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Returns an action object used in signalling that editor has initialized with
@@ -537,49 +538,6 @@ export function stopTyping() {
 }
 
 /**
- * Returns an action object used to create a notice.
- *
- * @param {string}    status  The notice status.
- * @param {WPElement} content The notice content.
- * @param {?Object}   options The notice options.  Available options:
- *                              `id` (string; default auto-generated)
- *                              `isDismissible` (boolean; default `true`).
- *
- * @return {Object} Action object.
- */
-export function createNotice( status, content, options = {} ) {
-	const {
-		id = uuid(),
-		isDismissible = true,
-		spokenMessage,
-	} = options;
-	return {
-		type: 'CREATE_NOTICE',
-		notice: {
-			id,
-			status,
-			content,
-			isDismissible,
-			spokenMessage,
-		},
-	};
-}
-
-/**
- * Returns an action object used to remove a notice.
- *
- * @param {string} id The notice id.
- *
- * @return {Object} Action object.
- */
-export function removeNotice( id ) {
-	return {
-		type: 'REMOVE_NOTICE',
-		noticeId: id,
-	};
-}
-
-/**
  * Returns an action object used to lock the editor.
  *
  * @param {Object}  lock Details about the post lock status, user, and nonce.
@@ -592,11 +550,6 @@ export function updatePostLock( lock ) {
 		lock,
 	};
 }
-
-export const createSuccessNotice = partial( createNotice, 'success' );
-export const createInfoNotice = partial( createNotice, 'info' );
-export const createErrorNotice = partial( createNotice, 'error' );
-export const createWarningNotice = partial( createNotice, 'warning' );
 
 /**
  * Returns an action object used to fetch a single reusable block or all
@@ -802,3 +755,35 @@ export function unlockPostSaving( lockName ) {
 	};
 }
 
+//
+// Deprecated
+//
+
+export function createNotice( status, content, options ) {
+	deprecated( 'createNotice action (`core/editor` store)', {
+		alternative: 'createNotice action (`core/notices` store)',
+		plugin: 'Gutenberg',
+		version: '4.0',
+	} );
+
+	dispatch( 'core/notices' ).createNotice( status, content, options );
+
+	return { type: '__INERT__' };
+}
+
+export function removeNotice( id ) {
+	deprecated( 'removeNotice action (`core/editor` store)', {
+		alternative: 'removeNotice action (`core/notices` store)',
+		plugin: 'Gutenberg',
+		version: '4.0',
+	} );
+
+	dispatch( 'core/notices' ).removeNotice( id );
+
+	return { type: '__INERT__' };
+}
+
+export const createSuccessNotice = partial( createNotice, 'success' );
+export const createInfoNotice = partial( createNotice, 'info' );
+export const createErrorNotice = partial( createNotice, 'error' );
+export const createWarningNotice = partial( createNotice, 'warning' );

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -14,7 +14,6 @@ import {
 	synchronizeBlocksWithTemplate,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -273,10 +272,6 @@ export default {
 	RECEIVE_REUSABLE_BLOCKS: receiveReusableBlocks,
 	CONVERT_BLOCK_TO_STATIC: convertBlockToStatic,
 	CONVERT_BLOCK_TO_REUSABLE: convertBlockToReusable,
-	CREATE_NOTICE( { notice: { content, spokenMessage } } ) {
-		const message = spokenMessage || content;
-		speak( message, 'assertive' );
-	},
 	REMOVE_BLOCKS: [
 		selectPreviousBlock,
 		ensureDefaultBlock,

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -13,7 +13,6 @@ import {
 	doBlocksMatchTemplate,
 	synchronizeBlocksWithTemplate,
 } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -21,7 +20,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	setupEditorState,
 	replaceBlocks,
-	createWarningNotice,
 	selectBlock,
 	resetBlocks,
 	setTemplateValidity,
@@ -53,7 +51,6 @@ import {
 	trashPost,
 	trashPostFailure,
 	refreshPost,
-	AUTOSAVE_POST_NOTICE_ID,
 } from './effects/posts';
 
 /**
@@ -200,7 +197,7 @@ export default {
 		) );
 	},
 	SETUP_EDITOR( action, store ) {
-		const { post, autosave } = action;
+		const { post } = action;
 		const state = store.getState();
 
 		// Parse content as blocks
@@ -219,28 +216,10 @@ export default {
 			edits.title = post.title.raw;
 		}
 
-		// Check the auto-save status
-		let autosaveAction;
-		if ( autosave ) {
-			const noticeMessage = __( 'There is an autosave of this post that is more recent than the version below.' );
-			autosaveAction = createWarningNotice(
-				<p>
-					{ noticeMessage }
-					{ ' ' }
-					<a href={ autosave.editLink }>{ __( 'View the autosave' ) }</a>
-				</p>,
-				{
-					id: AUTOSAVE_POST_NOTICE_ID,
-					spokenMessage: noticeMessage,
-				}
-			);
-		}
-
 		const setupAction = setupEditorState( post, blocks, edits );
 
 		return compact( [
 			setupAction,
-			autosaveAction,
 
 			// TODO: This is temporary, necessary only so long as editor setup
 			// is a separate action from block resetting.

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -10,6 +10,10 @@ import { pick, includes } from 'lodash';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+// TODO: Ideally this would be the only dispatch in scope. This requires either
+// refactoring editor actions to yielded controls, or replacing direct dispatch
+// on the editor store with action creators (e.g. `REQUEST_POST_UPDATE_START`).
+import { dispatch as dataDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,9 +22,6 @@ import {
 	resetAutosave,
 	resetPost,
 	updatePost,
-	removeNotice,
-	createSuccessNotice,
-	createErrorNotice,
 } from '../actions';
 import {
 	getCurrentPost,
@@ -38,8 +39,7 @@ import { resolveSelector } from './utils';
 /**
  * Module Constants
  */
-const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
-export const AUTOSAVE_POST_NOTICE_ID = 'AUTOSAVE_POST_NOTICE_ID';
+export const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
 const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 
 /**
@@ -120,8 +120,8 @@ export const requestPostUpdate = async ( action, store ) => {
 			data: toSend,
 		} );
 	} else {
-		dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
-		dispatch( removeNotice( AUTOSAVE_POST_NOTICE_ID ) );
+		dataDispatch( 'core/notices' ).removeNotice( SAVE_POST_NOTICE_ID );
+		dataDispatch( 'core/notices' ).removeNotice( 'autosave-exists' );
 
 		request = apiFetch( {
 			path: `/wp/v2/${ postType.rest_base }/${ post.id }`,
@@ -218,14 +218,21 @@ export const requestPostUpdateSuccess = ( action, store ) => {
 	}
 
 	if ( noticeMessage ) {
-		dispatch( createSuccessNotice(
-			<p>
-				{ noticeMessage }
-				{ ' ' }
-				{ shouldShowLink && <a href={ post.link }>{ postType.labels.view_item }</a> }
-			</p>,
-			{ id: SAVE_POST_NOTICE_ID, spokenMessage: noticeMessage }
-		) );
+		const actions = [];
+		if ( shouldShowLink ) {
+			actions.push( {
+				label: postType.labels.view_item,
+				url: post.link,
+			} );
+		}
+
+		dataDispatch( 'core/notices' ).createSuccessNotice(
+			noticeMessage,
+			{
+				id: SAVE_POST_NOTICE_ID,
+				actions,
+			}
+		);
 	}
 };
 
@@ -233,9 +240,8 @@ export const requestPostUpdateSuccess = ( action, store ) => {
  * Request Post Update Failure Effect handler
  *
  * @param {Object} action  action object.
- * @param {Object} store   Redux Store.
  */
-export const requestPostUpdateFailure = ( action, store ) => {
+export const requestPostUpdateFailure = ( action ) => {
 	const { post, edits, error } = action;
 
 	if ( error && 'rest_autosave_no_changes' === error.code ) {
@@ -243,8 +249,6 @@ export const requestPostUpdateFailure = ( action, store ) => {
 		// result in an error notice for the user.
 		return;
 	}
-
-	const { dispatch } = store;
 
 	const publishStatus = [ 'publish', 'private', 'future' ];
 	const isPublished = publishStatus.indexOf( post.status ) !== -1;
@@ -259,26 +263,28 @@ export const requestPostUpdateFailure = ( action, store ) => {
 		messages[ edits.status ] :
 		__( 'Updating failed' );
 
-	const cloudflareDetailsLink = addQueryArgs(
-		'post.php',
-		{
-			post: post.id,
-			action: 'edit',
-			'classic-editor': '',
-			'cloudflare-error': '',
-		} );
+	dataDispatch( 'core/notices' ).createErrorNotice( noticeMessage, {
+		id: SAVE_POST_NOTICE_ID,
+	} );
 
-	const cloudflaredMessage = error && 'cloudflare_error' === error.code ?
-		<p>
-			{ noticeMessage }
-			<br />
-			{ __( 'Cloudflare is blocking REST API requests.' ) }
-			{ ' ' }
-			<a href={ cloudflareDetailsLink }>{ __( 'Learn More' ) } </a>
-		</p> :
-		noticeMessage;
-
-	dispatch( createErrorNotice( cloudflaredMessage, { id: SAVE_POST_NOTICE_ID } ) );
+	if ( error && 'cloudflare_error' === error.code ) {
+		dataDispatch( 'core/notices' ).createErrorNotice(
+			__( 'Cloudflare is blocking REST API requests.' ),
+			{
+				actions: [
+					{
+						label: __( 'Learn More' ),
+						url: addQueryArgs( 'post.php', {
+							post: post.id,
+							action: 'edit',
+							'classic-editor': '',
+							'cloudflare-error': '',
+						} ),
+					},
+				],
+			},
+		);
+	}
 };
 
 /**
@@ -293,7 +299,7 @@ export const trashPost = async ( action, store ) => {
 	const postTypeSlug = getCurrentPostType( getState() );
 	const postType = await resolveSelector( 'core', 'getPostType', postTypeSlug );
 
-	dispatch( removeNotice( TRASH_POST_NOTICE_ID ) );
+	dataDispatch( 'core/notices' ).removeNotice( TRASH_POST_NOTICE_ID );
 	try {
 		await apiFetch( { path: `/wp/v2/${ postType.rest_base }/${ postId }`, method: 'DELETE' } );
 		const post = getCurrentPost( getState() );
@@ -316,9 +322,11 @@ export const trashPost = async ( action, store ) => {
  * @param {Object} action  action object.
  * @param {Object} store   Redux Store.
  */
-export const trashPostFailure = ( action, store ) => {
+export const trashPostFailure = ( action ) => {
 	const message = action.error.message && action.error.code !== 'unknown_error' ? action.error.message : __( 'Trashing failed' );
-	store.dispatch( createErrorNotice( message, { id: TRASH_POST_NOTICE_ID } ) );
+	dataDispatch( 'core/notices' ).createErrorNotice( message, {
+		id: TRASH_POST_NOTICE_ID,
+	} );
 };
 
 /**

--- a/packages/editor/src/store/effects/reusable-blocks.js
+++ b/packages/editor/src/store/effects/reusable-blocks.js
@@ -16,6 +16,10 @@ import {
 	cloneBlock,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+// TODO: Ideally this would be the only dispatch in scope. This requires either
+// refactoring editor actions to yielded controls, or replacing direct dispatch
+// on the editor store with action creators (e.g. `REMOVE_REUSABLE_BLOCK`).
+import { dispatch as dataDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -23,8 +27,6 @@ import { __ } from '@wordpress/i18n';
 import { resolveSelector } from './utils';
 import {
 	receiveReusableBlocks as receiveReusableBlocksAction,
-	createSuccessNotice,
-	createErrorNotice,
 	removeBlocks,
 	replaceBlocks,
 	receiveBlocks,
@@ -131,13 +133,14 @@ export const saveReusableBlocks = async ( action, store ) => {
 			id,
 		} );
 		const message = isTemporary ? __( 'Block created.' ) : __( 'Block updated.' );
-		dispatch( createSuccessNotice( message, { id: REUSABLE_BLOCK_NOTICE_ID } ) );
+		dataDispatch( 'core/notices' ).createSuccessNotice( message, {
+			id: REUSABLE_BLOCK_NOTICE_ID,
+		} );
 	} catch ( error ) {
 		dispatch( { type: 'SAVE_REUSABLE_BLOCK_FAILURE', id } );
-		dispatch( createErrorNotice( error.message, {
+		dataDispatch( 'core/notices' ).createErrorNotice( error.message, {
 			id: REUSABLE_BLOCK_NOTICE_ID,
-			spokenMessage: error.message,
-		} ) );
+		} );
 	}
 };
 
@@ -194,17 +197,18 @@ export const deleteReusableBlocks = async ( action, store ) => {
 			optimist: { type: COMMIT, id: transactionId },
 		} );
 		const message = __( 'Block deleted.' );
-		dispatch( createSuccessNotice( message, { id: REUSABLE_BLOCK_NOTICE_ID } ) );
+		dataDispatch( 'core/notices' ).createSuccessNotice( message, {
+			id: REUSABLE_BLOCK_NOTICE_ID,
+		} );
 	} catch ( error ) {
 		dispatch( {
 			type: 'DELETE_REUSABLE_BLOCK_FAILURE',
 			id,
 			optimist: { type: REVERT, id: transactionId },
 		} );
-		dispatch( createErrorNotice( error.message, {
+		dataDispatch( 'core/notices' ).createErrorNotice( error.message, {
 			id: REUSABLE_BLOCK_NOTICE_ID,
-			spokenMessage: error.message,
-		} ) );
+		} );
 	}
 };
 

--- a/packages/editor/src/store/effects/test/reusable-blocks.js
+++ b/packages/editor/src/store/effects/test/reusable-blocks.js
@@ -12,7 +12,7 @@ import {
 	unregisterBlockType,
 	createBlock,
 } from '@wordpress/blocks';
-import '@wordpress/core-data'; // Needed to load the core store
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -37,8 +37,10 @@ import {
 	fetchReusableBlocks as fetchReusableBlocksAction,
 } from '../../actions';
 import reducer from '../../reducer';
+import '../../..'; // Ensure store dependencies are imported via root.
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( '@wordpress/deprecated', () => jest.fn() );
 
 describe( 'reusable blocks effects', () => {
 	beforeAll( () => {
@@ -227,6 +229,7 @@ describe( 'reusable blocks effects', () => {
 				id: 123,
 				updatedId: 456,
 			} );
+			expect( deprecated ).toHaveBeenCalled();
 		} );
 
 		it( 'should handle an API error', async () => {

--- a/packages/editor/src/store/effects/test/reusable-blocks.js
+++ b/packages/editor/src/store/effects/test/reusable-blocks.js
@@ -12,7 +12,6 @@ import {
 	unregisterBlockType,
 	createBlock,
 } from '@wordpress/blocks';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -40,7 +39,6 @@ import reducer from '../../reducer';
 import '../../..'; // Ensure store dependencies are imported via root.
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
-jest.mock( '@wordpress/deprecated', () => jest.fn() );
 
 describe( 'reusable blocks effects', () => {
 	beforeAll( () => {
@@ -229,7 +227,6 @@ describe( 'reusable blocks effects', () => {
 				id: 123,
 				updatedId: 456,
 			} );
-			expect( deprecated ).toHaveBeenCalled();
 		} );
 
 		it( 'should handle an API error', async () => {

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -10,8 +10,6 @@ import {
 	omit,
 	without,
 	mapValues,
-	findIndex,
-	reject,
 	omitBy,
 	keys,
 	isEqual,
@@ -861,30 +859,6 @@ export function saving( state = {}, action ) {
 	return state;
 }
 
-export function notices( state = [], action ) {
-	switch ( action.type ) {
-		case 'CREATE_NOTICE':
-			return [
-				...reject( state, { id: action.notice.id } ),
-				action.notice,
-			];
-
-		case 'REMOVE_NOTICE':
-			const { noticeId } = action;
-			const index = findIndex( state, { id: noticeId } );
-			if ( index === -1 ) {
-				return state;
-			}
-
-			return [
-				...state.slice( 0, index ),
-				...state.slice( index + 1 ),
-			];
-	}
-
-	return state;
-}
-
 /**
  * Post Lock State.
  *
@@ -1126,7 +1100,6 @@ export default optimist( combineReducers( {
 	preferences,
 	saving,
 	postLock,
-	notices,
 	reusableBlocks,
 	template,
 	autosave,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -2064,7 +2064,7 @@ export function getNotices() {
 	deprecated( 'getNotices selector (`core/editor` store)', {
 		alternative: 'getNotices selector (`core/notices` store)',
 		plugin: 'Gutenberg',
-		version: '4.0',
+		version: '4.4.0',
 	} );
 
 	return select( 'core/notices' ).getNotices();

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -34,6 +34,8 @@ import {
 } from '@wordpress/blocks';
 import { moment } from '@wordpress/date';
 import { removep } from '@wordpress/autop';
+import { select } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Dependencies
@@ -1491,17 +1493,6 @@ export const getEditedPostContent = createSelector(
 );
 
 /**
- * Returns the user notices array.
- *
- * @param {Object} state Global application state.
- *
- * @return {Array} List of notices.
- */
-export function getNotices( state ) {
-	return state.notices;
-}
-
-/**
  * Determines if the given block type is allowed to be inserted, and, if
  * parentClientId is provided, whether it is allowed to be nested within the
  * given parent.
@@ -2063,4 +2054,18 @@ export function isPublishSidebarEnabled( state ) {
 		return state.preferences.isPublishSidebarEnabled;
 	}
 	return PREFERENCES_DEFAULTS.isPublishSidebarEnabled;
+}
+
+//
+// Deprecated
+//
+
+export function getNotices() {
+	deprecated( 'getNotices selector (`core/editor` store)', {
+		alternative: 'getNotices selector (`core/notices` store)',
+		plugin: 'Gutenberg',
+		version: '4.0',
+	} );
+
+	return select( 'core/notices' ).getNotices();
 }

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -35,12 +35,6 @@ import {
 	removeBlocks,
 	removeBlock,
 	toggleBlockMode,
-	createNotice,
-	createSuccessNotice,
-	createInfoNotice,
-	createErrorNotice,
-	createWarningNotice,
-	removeNotice,
 	updateBlockListSettings,
 } from '../actions';
 
@@ -348,114 +342,6 @@ describe( 'actions', () => {
 		it( 'should return the STOP_TYPING action', () => {
 			expect( stopTyping() ).toEqual( {
 				type: 'STOP_TYPING',
-			} );
-		} );
-	} );
-
-	describe( 'createNotice', () => {
-		const status = 'status';
-		const content = <p>element</p>;
-		it( 'should return CREATE_NOTICE action when options is empty', () => {
-			const result = createNotice( status, content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status,
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-		it( 'should return CREATE_NOTICE action when options is desined', () => {
-			const id = 'my-id';
-			const options = {
-				id,
-				isDismissible: false,
-			};
-			const result = createNotice( status, content, options );
-			expect( result ).toEqual( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					id,
-					status,
-					content,
-					isDismissible: false,
-				},
-			} );
-		} );
-	} );
-
-	describe( 'createSuccessNotice', () => {
-		it( 'should return CREATE_NOTICE action', () => {
-			const content = <p>element</p>;
-			const result = createSuccessNotice( content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status: 'success',
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-	} );
-
-	describe( 'createInfoNotice', () => {
-		it( 'should return CREATE_NOTICE action', () => {
-			const content = <p>element</p>;
-			const result = createInfoNotice( content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status: 'info',
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-	} );
-
-	describe( 'createErrorNotice', () => {
-		it( 'should return CREATE_NOTICE action', () => {
-			const content = <p>element</p>;
-			const result = createErrorNotice( content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status: 'error',
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-	} );
-
-	describe( 'createWarningNotice', () => {
-		it( 'should return CREATE_NOTICE action', () => {
-			const content = <p>element</p>;
-			const result = createWarningNotice( content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status: 'warning',
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-	} );
-
-	describe( 'removeNotice', () => {
-		it( 'should return REMOVE_NOTICE actions', () => {
-			const noticeId = 'id';
-			expect( removeNotice( noticeId ) ).toEqual( {
-				type: 'REMOVE_NOTICE',
-				noticeId,
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -42,12 +42,10 @@ describe( 'actions', () => {
 	describe( 'setupEditor', () => {
 		it( 'should return the SETUP_EDITOR action', () => {
 			const post = {};
-			const autosave = {};
-			const result = setupEditor( post, autosave );
+			const result = setupEditor( post );
 			expect( result ).toEqual( {
 				type: 'SETUP_EDITOR',
 				post,
-				autosave,
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/effects.js
+++ b/packages/editor/src/store/test/effects.js
@@ -13,6 +13,7 @@ import {
 	createBlock,
 } from '@wordpress/blocks';
 import { createRegistry } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -32,6 +33,9 @@ import effects, { validateBlocksToTemplate } from '../effects';
 import * as selectors from '../selectors';
 import reducer from '../reducer';
 import applyMiddlewares from '../middlewares';
+import '../../';
+
+jest.mock( '@wordpress/deprecated', () => jest.fn() );
 
 describe( 'effects', () => {
 	const defaultBlockSettings = { save: () => 'Saved', category: 'common', title: 'block title' };
@@ -258,16 +262,7 @@ describe( 'effects', () => {
 			handler( { post, previousPost, postType }, store );
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( {
-				notice: {
-					content: <p>Post published.{ ' ' }<a>View post</a></p>, // eslint-disable-line jsx-a11y/anchor-is-valid
-					id: 'SAVE_POST_NOTICE_ID',
-					isDismissible: true,
-					status: 'success',
-					spokenMessage: 'Post published.',
-				},
-				type: 'CREATE_NOTICE',
-			} ) );
+			expect( deprecated ).toHaveBeenCalled();
 		} );
 
 		it( 'should dispatch notices when reverting a published post to a draft', () => {
@@ -281,20 +276,7 @@ describe( 'effects', () => {
 			handler( { post, previousPost, postType }, store );
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( {
-				notice: {
-					content: <p>
-						Post reverted to draft.
-						{ ' ' }
-						{ false }
-					</p>,
-					id: 'SAVE_POST_NOTICE_ID',
-					isDismissible: true,
-					status: 'success',
-					spokenMessage: 'Post reverted to draft.',
-				},
-				type: 'CREATE_NOTICE',
-			} ) );
+			expect( deprecated ).toHaveBeenCalled();
 		} );
 
 		it( 'should dispatch notices when just updating a published post again', () => {
@@ -308,16 +290,7 @@ describe( 'effects', () => {
 			handler( { post, previousPost, postType }, store );
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( {
-				notice: {
-					content: <p>Post updated.{ ' ' }<a>{ 'View post' }</a></p>, // eslint-disable-line jsx-a11y/anchor-is-valid
-					id: 'SAVE_POST_NOTICE_ID',
-					isDismissible: true,
-					status: 'success',
-					spokenMessage: 'Post updated.',
-				},
-				type: 'CREATE_NOTICE',
-			} ) );
+			expect( deprecated ).toHaveBeenCalled();
 		} );
 
 		it( 'should do nothing if the updated post was autosaved', () => {

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -28,7 +28,6 @@ import {
 	blockSelection,
 	preferences,
 	saving,
-	notices,
 	blocksMode,
 	isInsertionPointVisible,
 	reusableBlocks,
@@ -1721,91 +1720,6 @@ describe( 'state', () => {
 					message: 'update failed',
 				},
 			} );
-		} );
-	} );
-
-	describe( 'notices()', () => {
-		it( 'should create a notice', () => {
-			const originalState = [
-				{
-					id: 'b',
-					content: 'Error saving',
-					status: 'error',
-				},
-			];
-			const state = notices( deepFreeze( originalState ), {
-				type: 'CREATE_NOTICE',
-				notice: {
-					id: 'a',
-					content: 'Post saved',
-					status: 'success',
-				},
-			} );
-			expect( state ).toEqual( [
-				originalState[ 0 ],
-				{
-					id: 'a',
-					content: 'Post saved',
-					status: 'success',
-				},
-			] );
-		} );
-
-		it( 'should remove a notice', () => {
-			const originalState = [
-				{
-					id: 'a',
-					content: 'Post saved',
-					status: 'success',
-				},
-				{
-					id: 'b',
-					content: 'Error saving',
-					status: 'error',
-				},
-			];
-			const state = notices( deepFreeze( originalState ), {
-				type: 'REMOVE_NOTICE',
-				noticeId: 'a',
-			} );
-			expect( state ).toEqual( [
-				originalState[ 1 ],
-			] );
-		} );
-
-		it( 'should dedupe distinct ids', () => {
-			const originalState = [
-				{
-					id: 'a',
-					content: 'Post saved',
-					status: 'success',
-				},
-				{
-					id: 'b',
-					content: 'Error saving',
-					status: 'error',
-				},
-			];
-			const state = notices( deepFreeze( originalState ), {
-				type: 'CREATE_NOTICE',
-				notice: {
-					id: 'a',
-					content: 'Post updated',
-					status: 'success',
-				},
-			} );
-			expect( state ).toEqual( [
-				{
-					id: 'b',
-					content: 'Error saving',
-					status: 'error',
-				},
-				{
-					id: 'a',
-					content: 'Post updated',
-					status: 'success',
-				},
-			] );
 		} );
 	} );
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -89,7 +89,6 @@ const {
 	didPostSaveRequestFail,
 	getSuggestedPostFormat,
 	getEditedPostContent,
-	getNotices,
 	getReusableBlock,
 	isSavingReusableBlock,
 	isFetchingReusableBlock,
@@ -3278,19 +3277,6 @@ describe( 'selectors', () => {
 			const content = getEditedPostContent( state );
 
 			expect( content ).toBe( '<!-- wp:default {\"modified\":true} /-->' );
-		} );
-	} );
-
-	describe( 'getNotices', () => {
-		it( 'should return the notices array', () => {
-			const state = {
-				notices: [
-					{ id: 'b', content: 'Post saved' },
-					{ id: 'a', content: 'Error saving' },
-				],
-			};
-
-			expect( getNotices( state ) ).toEqual( state.notices );
 		} );
 	} );
 

--- a/packages/notices/.npmrc
+++ b/packages/notices/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0 (Unreleased)
+
+- Initial release.

--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -1,0 +1,25 @@
+Notices
+=======
+
+State management for notices.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/notices
+```
+
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
+
+## Usage
+
+When imported, the notices module registers a data store on the `core/notices` namespace.
+
+For more information about consuming from a data store, refer to [the `@wordpress/data` documentation on _Data Access and Manipulation_](https://wordpress.org/gutenberg/handbook/packages/packages-data/#data-access-and-manipulation).
+
+For a full list of actions and selectors available in the `core/notices` namespace, refer to the [_Notices Data_ Handbook page](https://wordpress.org/gutenberg/handbook/packages/packages-data/packages-data-core-edit-post/).
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "@wordpress/notices",
+	"version": "1.0.0-beta.0",
+	"description": "State management for notices.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"notices"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/notices/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"files": [
+		"build",
+		"build-module"
+	],
+	"main": "build/index.js",
+	"dependencies": {
+		"@babel/runtime": "^7.0.0",
+		"@wordpress/a11y": "file:../a11y",
+		"@wordpress/data": "file:../data",
+		"lodash": "^4.17.10"
+	},
+	"devDependencies": {
+		"deep-freeze": "^0.0.1"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/notices/src/index.js
+++ b/packages/notices/src/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './store';

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -23,12 +23,15 @@ import { DEFAULT_CONTEXT } from './constants';
  * @param {?boolean}               options.isDismissible Whether the notice can
  *                                                       be dismissed by user.
  *                                                       Defaults to `true`.
+ * @param {?Array<WPNoticeAction>} options.actions       User actions to be
+ *                                                       presented with notice.
  */
 export function* createNotice( status = 'info', content, options = {} ) {
 	const {
 		isDismissible = true,
 		context = DEFAULT_CONTEXT,
 		id = uniqueId( context ),
+		actions = [],
 	} = options;
 
 	yield { type: 'SPEAK', message: content };
@@ -41,6 +44,7 @@ export function* createNotice( status = 'info', content, options = {} ) {
 			status,
 			content,
 			isDismissible,
+			actions,
 		},
 	};
 }

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { uniqueId } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_CONTEXT } from './constants';
+
+/**
+ * Yields action objects used in signalling that a notice is to be created.
+ *
+ * @param {?string}                status                Notice status.
+ *                                                       Defaults to `info`.
+ * @param {string}                 content               Notice message.
+ * @param {?Object}                options               Notice options.
+ * @param {?string}                options.context       Context under which to
+ *                                                       group notice.
+ * @param {?string}                options.id            Identifier for notice.
+ *                                                       Automatically assigned
+ *                                                       if not specified.
+ * @param {?boolean}               options.isDismissible Whether the notice can
+ *                                                       be dismissed by user.
+ *                                                       Defaults to `true`.
+ */
+export function* createNotice( status = 'info', content, options = {} ) {
+	const {
+		isDismissible = true,
+		context = DEFAULT_CONTEXT,
+		id = uniqueId( context ),
+	} = options;
+
+	yield { type: 'SPEAK', message: content };
+
+	yield {
+		type: 'CREATE_NOTICE',
+		context,
+		notice: {
+			id,
+			status,
+			content,
+			isDismissible,
+		},
+	};
+}
+
+/**
+ * Returns an action object used in signalling that a success notice is to be
+ * created. Refer to `createNotice` for options documentation.
+ *
+ * @see createNotice
+ *
+ * @param {string}  content Notice message.
+ * @param {?Object} options Optional notice options.
+ *
+ * @return {Object} Action object.
+ */
+export function createSuccessNotice( content, options ) {
+	return createNotice( 'success', content, options );
+}
+
+/**
+ * Returns an action object used in signalling that an info notice is to be
+ * created. Refer to `createNotice` for options documentation.
+ *
+ * @see createNotice
+ *
+ * @param {string}  content Notice message.
+ * @param {?Object} options Optional notice options.
+ *
+ * @return {Object} Action object.
+ */
+export function createInfoNotice( content, options ) {
+	return createNotice( 'info', content, options );
+}
+
+/**
+ * Returns an action object used in signalling that an error notice is to be
+ * created. Refer to `createNotice` for options documentation.
+ *
+ * @see createNotice
+ *
+ * @param {string}  content Notice message.
+ * @param {?Object} options Optional notice options.
+ *
+ * @return {Object} Action object.
+ */
+export function createErrorNotice( content, options ) {
+	return createNotice( 'error', content, options );
+}
+
+/**
+ * Returns an action object used in signalling that a warning notice is to be
+ * created. Refer to `createNotice` for options documentation.
+ *
+ * @see createNotice
+ *
+ * @param {string}  content Notice message.
+ * @param {?Object} options Optional notice options.
+ *
+ * @return {Object} Action object.
+ */
+export function createWarningNotice( content, options ) {
+	return createNotice( 'warning', content, options );
+}
+
+/**
+ * Returns an action object used in signalling that a notice is to be removed.
+ *
+ * @param {string}  id      Notice unique identifier.
+ * @param {?string} context Optional context (grouping) in which the notice is
+ *                          intended to appear. Defaults to default context.
+ *
+ * @return {Object} Action object.
+ */
+export function removeNotice( id, context = DEFAULT_CONTEXT ) {
+	return {
+		type: 'REMOVE_NOTICE',
+		id,
+		context,
+	};
+}

--- a/packages/notices/src/store/constants.js
+++ b/packages/notices/src/store/constants.js
@@ -1,0 +1,8 @@
+/**
+ * Default context to use for notice grouping when not otherwise specified. Its
+ * specific value doesn't hold much meaning, but it must be reasonably unique
+ * and, more importantly, referenced consistently in the store implementation.
+ *
+ * @type {string}
+ */
+export const DEFAULT_CONTEXT = 'global';

--- a/packages/notices/src/store/controls.js
+++ b/packages/notices/src/store/controls.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { speak } from '@wordpress/a11y';
+
+export default {
+	SPEAK( action ) {
+		speak( action.message, 'assertive' );
+	},
+};

--- a/packages/notices/src/store/index.js
+++ b/packages/notices/src/store/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+import controls from './controls';
+
+export default registerStore( 'core/notices', {
+	reducer,
+	actions,
+	selectors,
+	controls,
+} );

--- a/packages/notices/src/store/reducer.js
+++ b/packages/notices/src/store/reducer.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { reject } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import onSubKey from './utils/on-sub-key';
+
+/**
+ * Reducer returning the next notices state. The notices state is an object
+ * where each key is a context, its value an array of notice objects.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+const notices = onSubKey( 'context' )( ( state = [], action ) => {
+	switch ( action.type ) {
+		case 'CREATE_NOTICE':
+			// Avoid duplicates on ID.
+			return [
+				...reject( state, { id: action.notice.id } ),
+				action.notice,
+			];
+
+		case 'REMOVE_NOTICE':
+			return reject( state, { id: action.id } );
+	}
+
+	return state;
+} );
+
+export default notices;

--- a/packages/notices/src/store/selectors.js
+++ b/packages/notices/src/store/selectors.js
@@ -17,15 +17,28 @@ const DEFAULT_NOTICES = [];
 /**
  * Notice object.
  *
- * @property {string}  id            Unique identifier of notice.
- * @property {string}  status        Status sort of notice, one of `success`,
- *                                   `info`, `error`, or `warning`. Defaults to
- *                                   `info`.
- * @property {string}  content       Notice message.
- * @property {boolean} isDismissible Whether the notice can be dismissed by the
- *                                   user. Defaults to `true`.
+ * @property {string}  id               Unique identifier of notice.
+ * @property {string}  status           Status of notice, one of `success`,
+ *                                      `info`, `error`, or `warning`. Defaults
+ *                                      to `info`.
+ * @property {string}  content          Notice message.
+ * @property {boolean} isDismissible    Whether the notice can be dismissed by
+ *                                      user. Defaults to `true`.
+ * @property {WPNoticeAction[]} actions User actions to present with notice.
  *
  * @typedef {Notice}
+ */
+
+/**
+ * Object describing a user action option associated with a notice.
+ *
+ * @property {string}    label    Message to use as action label.
+ * @property {?string}   url      Optional URL of resource if action incurs
+ *                                browser navigation.
+ * @property {?Function} callback Optional function to invoke when action is
+ *                                triggered by user.
+ *
+ * @typedef {WPNoticeAction}
  */
 
 /**

--- a/packages/notices/src/store/selectors.js
+++ b/packages/notices/src/store/selectors.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_CONTEXT } from './constants';
+
+/**
+ * The default empty set of notices to return when there are no notices
+ * assigned for a given notices context. This can occur if the getNotices
+ * selector is called without a notice ever having been created for the
+ * context. A shared value is used to ensure referential equality between
+ * sequential selector calls, since otherwise `[] !== []`.
+ *
+ * @type {Array}
+ */
+const DEFAULT_NOTICES = [];
+
+/**
+ * Notice object.
+ *
+ * @property {string}  id            Unique identifier of notice.
+ * @property {string}  status        Status sort of notice, one of `success`,
+ *                                   `info`, `error`, or `warning`. Defaults to
+ *                                   `info`.
+ * @property {string}  content       Notice message.
+ * @property {boolean} isDismissible Whether the notice can be dismissed by the
+ *                                   user. Defaults to `true`.
+ *
+ * @typedef {Notice}
+ */
+
+/**
+ * Returns all notices as an array, optionally for a given context. Defaults to
+ * the global context.
+ *
+ * @param {Object}  state   Notices state.
+ * @param {?string} context Optional grouping context.
+ *
+ * @return {Notice[]} Array of notices.
+ */
+export function getNotices( state, context = DEFAULT_CONTEXT ) {
+	return state[ context ] || DEFAULT_NOTICES;
+}

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -32,6 +32,7 @@ describe( 'actions', () => {
 					content,
 					isDismissible: true,
 					id: expect.any( String ),
+					actions: [],
 				},
 			} );
 		} );
@@ -60,6 +61,7 @@ describe( 'actions', () => {
 					status,
 					content,
 					isDismissible: false,
+					actions: [],
 				},
 			} );
 		} );

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -1,0 +1,186 @@
+/**
+ * Internal dependencies
+ */
+import {
+	createNotice,
+	createSuccessNotice,
+	createInfoNotice,
+	createErrorNotice,
+	createWarningNotice,
+	removeNotice,
+} from '../actions';
+import { DEFAULT_CONTEXT } from '../constants';
+
+describe( 'actions', () => {
+	describe( 'createNotice', () => {
+		const status = 'status';
+		const content = 'my message';
+
+		it( 'should yields actions when options is empty', () => {
+			const result = createNotice( status, content );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'SPEAK',
+				message: content,
+			} );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status,
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+
+		it( 'should yields actions when options passed', () => {
+			const id = 'my-id';
+			const context = 'foo';
+			const options = {
+				id,
+				isDismissible: false,
+				context: 'foo',
+			};
+
+			const result = createNotice( status, content, options );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'SPEAK',
+				message: content,
+			} );
+
+			expect( result.next().value ).toEqual( {
+				type: 'CREATE_NOTICE',
+				context,
+				notice: {
+					id,
+					status,
+					content,
+					isDismissible: false,
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createSuccessNotice', () => {
+		it( 'should return action', () => {
+			const content = 'my message';
+
+			const result = createSuccessNotice( content );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'SPEAK',
+				message: content,
+			} );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status: 'success',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createInfoNotice', () => {
+		it( 'should return action', () => {
+			const content = 'my message';
+
+			const result = createInfoNotice( content );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'SPEAK',
+				message: content,
+			} );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status: 'info',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createErrorNotice', () => {
+		it( 'should return action', () => {
+			const content = 'my message';
+
+			const result = createErrorNotice( content );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'SPEAK',
+				message: content,
+			} );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status: 'error',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createWarningNotice', () => {
+		it( 'should return action', () => {
+			const content = 'my message';
+
+			const result = createWarningNotice( content );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'SPEAK',
+				message: content,
+			} );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status: 'warning',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+	} );
+
+	describe( 'removeNotice', () => {
+		it( 'should return action', () => {
+			const id = 'id';
+
+			expect( removeNotice( id ) ).toEqual( {
+				type: 'REMOVE_NOTICE',
+				id,
+				context: DEFAULT_CONTEXT,
+			} );
+		} );
+
+		it( 'should return action with custom context', () => {
+			const id = 'id';
+			const context = 'foo';
+
+			expect( removeNotice( id, context ) ).toEqual( {
+				type: 'REMOVE_NOTICE',
+				id,
+				context,
+			} );
+		} );
+	} );
+} );

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -35,6 +35,7 @@ describe( 'reducer', () => {
 					content: 'save error',
 					status: 'error',
 					isDismissible: true,
+					actions: [],
 				},
 			],
 		} );
@@ -51,6 +52,7 @@ describe( 'reducer', () => {
 					content: 'save error',
 					status: 'error',
 					isDismissible: true,
+					actions: [],
 				},
 			],
 		} );
@@ -70,12 +72,14 @@ describe( 'reducer', () => {
 					content: 'save error',
 					status: 'error',
 					isDismissible: true,
+					actions: [],
 				},
 				{
 					id: expect.any( String ),
 					content: 'successfully saved',
 					status: 'success',
 					isDismissible: true,
+					actions: [],
 				},
 			],
 		} );
@@ -129,6 +133,7 @@ describe( 'reducer', () => {
 					content: 'save error (2)',
 					status: 'error',
 					isDismissible: true,
+					actions: [],
 				},
 			],
 		} );

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+import { matchesProperty, find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import { createNotice, removeNotice } from '../actions';
+import { getNotices } from '../selectors';
+import { DEFAULT_CONTEXT } from '../constants';
+
+const getYieldedOfType = ( generatorAction, type ) => find(
+	Array.from( generatorAction ),
+	matchesProperty( [ 'type' ], type )
+);
+
+describe( 'reducer', () => {
+	it( 'should default to an empty object', () => {
+		const state = reducer( undefined, {} );
+
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'should track a notice', () => {
+		const action = getYieldedOfType( createNotice( 'error', 'save error' ), 'CREATE_NOTICE' );
+		const state = reducer( undefined, action );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [
+				{
+					id: expect.any( String ),
+					content: 'save error',
+					status: 'error',
+					isDismissible: true,
+				},
+			],
+		} );
+	} );
+
+	it( 'should track a notice by context', () => {
+		const action = getYieldedOfType( createNotice( 'error', 'save error', { context: 'foo' } ), 'CREATE_NOTICE' );
+		const state = reducer( undefined, action );
+
+		expect( state ).toEqual( {
+			foo: [
+				{
+					id: expect.any( String ),
+					content: 'save error',
+					status: 'error',
+					isDismissible: true,
+				},
+			],
+		} );
+	} );
+
+	it( 'should track notices, respecting order by which they were created', () => {
+		let action = getYieldedOfType( createNotice( 'error', 'save error' ), 'CREATE_NOTICE' );
+		const original = deepFreeze( reducer( undefined, action ) );
+
+		action = getYieldedOfType( createNotice( 'success', 'successfully saved' ), 'CREATE_NOTICE' );
+		const state = reducer( original, action );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [
+				{
+					id: expect.any( String ),
+					content: 'save error',
+					status: 'error',
+					isDismissible: true,
+				},
+				{
+					id: expect.any( String ),
+					content: 'successfully saved',
+					status: 'success',
+					isDismissible: true,
+				},
+			],
+		} );
+	} );
+
+	it( 'should omit a removed notice', () => {
+		const action = getYieldedOfType( createNotice( 'error', 'save error' ), 'CREATE_NOTICE' );
+		const original = deepFreeze( reducer( undefined, action ) );
+		const id = getNotices( original )[ 0 ].id;
+
+		const state = reducer( original, removeNotice( id ) );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [],
+		} );
+	} );
+
+	it( 'should omit a removed notice by context', () => {
+		const action = getYieldedOfType( createNotice( 'error', 'save error', { context: 'foo' } ), 'CREATE_NOTICE' );
+		const original = deepFreeze( reducer( undefined, action ) );
+		const id = getNotices( original, 'foo' )[ 0 ].id;
+
+		const state = reducer( original, removeNotice( id, 'foo' ) );
+
+		expect( state ).toEqual( {
+			foo: [],
+		} );
+	} );
+
+	it( 'should omit a removed notice across contexts', () => {
+		const action = getYieldedOfType( createNotice( 'error', 'save error' ), 'CREATE_NOTICE' );
+		const original = deepFreeze( reducer( undefined, action ) );
+		const id = getNotices( original )[ 0 ].id;
+
+		const state = reducer( original, removeNotice( id, 'foo' ) );
+
+		expect( state[ DEFAULT_CONTEXT ] ).toHaveLength( 1 );
+	} );
+
+	it( 'should dedupe distinct ids, preferring new', () => {
+		let action = getYieldedOfType( createNotice( 'error', 'save error (1)', { id: 'error-message' } ), 'CREATE_NOTICE' );
+		const original = deepFreeze( reducer( undefined, action ) );
+
+		action = getYieldedOfType( createNotice( 'error', 'save error (2)', { id: 'error-message' } ), 'CREATE_NOTICE' );
+		const state = reducer( original, action );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [
+				{
+					id: 'error-message',
+					content: 'save error (2)',
+					status: 'error',
+					isDismissible: true,
+				},
+			],
+		} );
+	} );
+} );

--- a/packages/notices/src/store/test/selectors.js
+++ b/packages/notices/src/store/test/selectors.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import { getNotices } from '../selectors';
+import { DEFAULT_CONTEXT } from '../constants';
+
+describe( 'selectors', () => {
+	describe( 'getNotices', () => {
+		it( 'should return a consistent empty array for empty state', () => {
+			const state = {};
+
+			expect( getNotices( state ) ).toEqual( [] );
+			expect( getNotices( state ) ).toBe( getNotices( state ) );
+		} );
+
+		it( 'should return the notices array for the default context', () => {
+			const state = {
+				[ DEFAULT_CONTEXT ]: [
+					{ id: 'b', content: 'message 1' },
+					{ id: 'a', content: 'message 2' },
+				],
+			};
+
+			expect( getNotices( state ) ).toEqual( [
+				{ id: 'b', content: 'message 1' },
+				{ id: 'a', content: 'message 2' },
+			] );
+		} );
+
+		it( 'should return the notices array for a given context', () => {
+			const state = {
+				foo: [
+					{ id: 'c', content: 'message 3' },
+				],
+			};
+
+			expect( getNotices( state, 'foo' ) ).toEqual( [
+				{ id: 'c', content: 'message 3' },
+			] );
+		} );
+	} );
+} );

--- a/packages/notices/src/store/utils/on-sub-key.js
+++ b/packages/notices/src/store/utils/on-sub-key.js
@@ -1,0 +1,30 @@
+/**
+ * Higher-order reducer creator which creates a combined reducer object, keyed
+ * by a property on the action object.
+ *
+ * @param {string} actionProperty Action property by which to key object.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+export const onSubKey = ( actionProperty ) => ( reducer ) => ( state = {}, action ) => {
+	// Retrieve subkey from action. Do not track if undefined; useful for cases
+	// where reducer is scoped by action shape.
+	const key = action[ actionProperty ];
+	if ( key === undefined ) {
+		return state;
+	}
+
+	// Avoid updating state if unchanged. Note that this also accounts for a
+	// reducer which returns undefined on a key which is not yet tracked.
+	const nextKeyState = reducer( state[ key ], action );
+	if ( nextKeyState === state[ key ] ) {
+		return state;
+	}
+
+	return {
+		...state,
+		[ key ]: nextKeyState,
+	};
+};
+
+export default onSubKey;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,7 @@ const gutenbergPackages = [
 	'is-shallow-equal',
 	'keycodes',
 	'list-reusable-blocks',
+	'notices',
 	'nux',
 	'plugins',
 	'redux-routine',


### PR DESCRIPTION
Closes #6388

This pull request seeks to extract notices behaviors from the `editor` module to a new `notices` module, intended to serve largely the same purpose, but generalized to serve use-cases outside the editor. The API also largely remains the same, except with the addition of a new `context` option for specifying a simplified "area" value for notices grouping.

Planned to fork out into separate pull requests:

- _Already: #9615. Removed from changes here since no longer in active use after iterations._
- Failing unit tests are because we don't load dependent stores within tests. When running tests within a directory, we should probably include its top-level `index.js` to ensure these dependencies have their expected stores defined. See related #8911.
- I copied `onSubKey` higher-order reducer creator from `core-data`. I'm starting to wonder if we might want to consider distributing these as some form of data/reducer utilities, akin to [as `@wordpress/compose` is for higher-order components](https://github.com/WordPress/gutenberg/tree/master/packages/compose). Maybe a `@wordpress/compose-data` or `@wordpress/compose-reducer`.

Open question:

- With introduction of "context", should we consider most of the notices as we have today as part of an "editor" context, or does the idea of a global context represent what we're showing today in the editor below the heading? It'd be my idea that what we have today serves the "global" usage, but it is screen-specific, and we might want to consider "properly global" notices (things like [notifications center](https://core.trac.wordpress.org/ticket/43484)), where our notices aren't quite as global.
- What should be included here so far as componentry? The "Notice" component seems generic enough that it's sensible to remain in `@wordpress/components`. With this module effectively serving as an orchestrator, it seems most all of the state-bound components should live within.

Future enhancements:

- Our existing notices should ideally not include React elements, and rather represent content as a plain string. Most of our existing use of elements could be better served by a formal "actions" option (e.g. "View Post" on the save success) which is more future-compatible to notices design revisions.
- I'm curious to explore whether the new `context` concept could be leveraged to eliminate most of what's served by the internal state of [`withNotices`](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/higher-order/with-notices/index.js).