### PR TITLE
Switch to block settings from plugin sidebar

### DIFF
--- a/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/edit-post/components/header/plugin-sidebar-more-menu-item/index.js
@@ -47,9 +47,16 @@ export default compose(
 			closeGeneralSidebar,
 			openGeneralSidebar,
 		} = dispatch( 'core/edit-post' );
+		const {
+			clearSelectedBlock,
+		} = dispatch( 'core/editor' );
+
 		const onClick = isSelected ?
 			closeGeneralSidebar :
-			() => openGeneralSidebar( sidebarName );
+			() => {
+				clearSelectedBlock();
+				openGeneralSidebar( sidebarName );
+			};
 
 		return { onClick };
 	} ),

--- a/edit-post/components/sidebar/plugin-sidebar/index.js
+++ b/edit-post/components/sidebar/plugin-sidebar/index.js
@@ -98,6 +98,9 @@ export default compose(
 			openGeneralSidebar,
 			togglePinnedPluginItem,
 		} = dispatch( 'core/edit-post' );
+		const {
+			clearSelectedBlock,
+		} = dispatch( 'core/editor' );
 
 		return {
 			togglePin() {
@@ -107,6 +110,7 @@ export default compose(
 				if ( isActive ) {
 					closeGeneralSidebar();
 				} else {
+					clearSelectedBlock();
 					openGeneralSidebar( sidebarName );
 				}
 			},

--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -128,9 +128,6 @@ const effects = {
 		subscribe( onChangeListener(
 			() => !! select( 'core/editor' ).getBlockSelectionStart(),
 			( hasBlockSelection ) => {
-				if ( ! select( 'core/edit-post' ).isEditorSidebarOpened() ) {
-					return;
-				}
 				if ( hasBlockSelection ) {
 					store.dispatch( openGeneralSidebar( 'edit-post/block' ) );
 				} else {


### PR DESCRIPTION
## Description

Previously Gutenberg would only switch to the block settings if the document settings were open. This change makes sure this behavior is also present when switching from a plugin sidebar.

## How has this been tested?

I've tested this with the Yoast SEO sidebar. I've tried opening it as a pinned plugin and with the menu item.

## Screenshots <!-- if applicable -->

## Types of changes

* Bug fix. A user expects to have the block settings open when they click a block. See also:
https://wordpress.slack.com/archives/C02QB2JS7/p1534765134000100.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->