### PR TITLE
Fix: Align Hook: Impossible to set no alignment when a default align exists

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -418,10 +418,10 @@ The block can apply a default alignment by specifying its own align attribute wi
 ```
 attributes: {
 	...
-		align: {
-			type: 'string',
-			default: 'right'
-		},
+	align: {
+		type: 'string',
+		default: 'right'
+	},
 	...
 }
 ```

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -412,6 +412,19 @@ align: true,
 // Pick which alignment options to display.
 align: [ 'left', 'right', 'full' ],
 ```
+When supports align is used the block attributes definition is extended to include an align attribute with a string type.
+By default, no alignment is assigned to the block. 
+The block can apply a default alignment by specifying its own align attribute with a default e.g.:
+```
+attributes: {
+	...
+		align: {
+			type: 'string',
+			default: 'right'
+		},
+	...
+}
+```
 
 - `alignWide` (default `true`): This property allows to enable [wide alignment](../docs/extensibility/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
 

--- a/packages/editor/src/hooks/align.js
+++ b/packages/editor/src/hooks/align.js
@@ -9,7 +9,7 @@ import { assign, get, includes } from 'lodash';
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport, getBlockSupport } from '@wordpress/blocks';
+import { hasBlockSupport, getBlockSupport, getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -77,7 +77,16 @@ export const withToolbarControls = createHigherOrderComponent( ( BlockEdit ) => 
 	return ( props ) => {
 		const validAlignments = getBlockValidAlignments( props.name );
 
-		const updateAlignment = ( nextAlign ) => props.setAttributes( { align: nextAlign } );
+		const updateAlignment = ( nextAlign ) => {
+			if ( ! nextAlign ) {
+				const blockType = getBlockType( props.name );
+				const blockDefaultAlign = get( blockType, [ 'attributes', 'align', 'default' ] );
+				if ( blockDefaultAlign ) {
+					nextAlign = null;
+				}
+			}
+			props.setAttributes( { align: nextAlign } );
+		};
 
 		return [
 			validAlignments.length > 0 && props.isSelected && (

--- a/packages/editor/src/hooks/align.js
+++ b/packages/editor/src/hooks/align.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { assign, get, includes } from 'lodash';
+import { assign, get, has, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,7 +24,7 @@ import { BlockControls, BlockAlignmentToolbar } from '../components';
  */
 export function addAttribute( settings ) {
 	// allow blocks to specify their own attribute definition with default values if needed.
-	if ( get( settings.attributes, [ 'align', 'type' ] ) === 'string' ) {
+	if ( has( settings.attributes, [ 'align', 'type' ] ) ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'align' ) ) {

--- a/packages/editor/src/hooks/align.js
+++ b/packages/editor/src/hooks/align.js
@@ -82,7 +82,7 @@ export const withToolbarControls = createHigherOrderComponent( ( BlockEdit ) => 
 				const blockType = getBlockType( props.name );
 				const blockDefaultAlign = get( blockType, [ 'attributes', 'align', 'default' ] );
 				if ( blockDefaultAlign ) {
-					nextAlign = null;
+					nextAlign = '';
 				}
 			}
 			props.setAttributes( { align: nextAlign } );

--- a/test/e2e/specs/__snapshots__/align-hook.test.js.snap
+++ b/test/e2e/specs/__snapshots__/align-hook.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Align Hook Works As Expected Block with align array Correctly applies the selected alignment and correctly removes the alignment 1`] = `
+"<!-- wp:test/test-align-array {\\"align\\":\\"center\\"} -->
+<div style=\\"outline:1px solid gray;padding:5px\\" class=\\"wp-block-test-test-align-array aligncenter\\">Test Align Hook</div>
+<!-- /wp:test/test-align-array -->"
+`;
+
+exports[`Align Hook Works As Expected Block with align array Correctly applies the selected alignment and correctly removes the alignment 2`] = `
+"<!-- wp:test/test-align-array -->
+<div style=\\"outline:1px solid gray;padding:5px\\" class=\\"wp-block-test-test-align-array\\">Test Align Hook</div>
+<!-- /wp:test/test-align-array -->"
+`;
+
+exports[`Align Hook Works As Expected Block with align true Correctly applies the selected alignment and correctly removes the alignment 1`] = `
+"<!-- wp:test/test-align-true {\\"align\\":\\"right\\"} -->
+<div style=\\"outline:1px solid gray;padding:5px\\" class=\\"wp-block-test-test-align-true alignright\\">Test Align Hook</div>
+<!-- /wp:test/test-align-true -->"
+`;
+
+exports[`Align Hook Works As Expected Block with align true Correctly applies the selected alignment and correctly removes the alignment 2`] = `
+"<!-- wp:test/test-align-true -->
+<div style=\\"outline:1px solid gray;padding:5px\\" class=\\"wp-block-test-test-align-true\\">Test Align Hook</div>
+<!-- /wp:test/test-align-true -->"
+`;
+
+exports[`Align Hook Works As Expected Block with default align Correctly applies the selected alignment and correctly removes the alignment 1`] = `
+"<!-- wp:test/test-default-align {\\"align\\":\\"center\\"} -->
+<div style=\\"outline:1px solid gray;padding:5px\\" class=\\"wp-block-test-test-default-align aligncenter\\">Test Align Hook</div>
+<!-- /wp:test/test-default-align -->"
+`;
+
+exports[`Align Hook Works As Expected Block with default align Correctly applies the selected alignment and correctly removes the alignment 2`] = `
+"<!-- wp:test/test-default-align {\\"align\\":null} -->
+<div style=\\"outline:1px solid gray;padding:5px\\" class=\\"wp-block-test-test-default-align\\">Test Align Hook</div>
+<!-- /wp:test/test-default-align -->"
+`;
+
+exports[`Align Hook Works As Expected Block with no alignment set Does not save any alignment related attribute or class 1`] = `
+"<!-- wp:test/test-no-alignment-set -->
+<div style=\\"outline:1px solid gray;padding:5px\\" class=\\"wp-block-test-test-no-alignment-set\\">Test Align Hook</div>
+<!-- /wp:test/test-no-alignment-set -->"
+`;

--- a/test/e2e/specs/__snapshots__/align-hook.test.js.snap
+++ b/test/e2e/specs/__snapshots__/align-hook.test.js.snap
@@ -31,7 +31,7 @@ exports[`Align Hook Works As Expected Block with default align Correctly applies
 `;
 
 exports[`Align Hook Works As Expected Block with default align Correctly applies the selected alignment and correctly removes the alignment 2`] = `
-"<!-- wp:test/test-default-align {\\"align\\":null} -->
+"<!-- wp:test/test-default-align {\\"align\\":\\"\\"} -->
 <div style=\\"outline:1px solid gray;padding:5px\\" class=\\"wp-block-test-test-default-align\\">Test Align Hook</div>
 <!-- /wp:test/test-default-align -->"
 `;

--- a/test/e2e/specs/align-hook.test.js
+++ b/test/e2e/specs/align-hook.test.js
@@ -191,8 +191,7 @@ describe( 'Align Hook Works As Expected', () => {
 			// remove the alignment.
 			await page.click( PRESSED_BUTTON_SELECTOR );
 			const markup = await getEditedPostContent();
-			expect( markup ).toContain( '"align":null' );
-			expect( markup ).not.toContain( 'alignnull' );
+			expect( markup ).toContain( '"align":""' );
 		} );
 
 		createCorrectlyAppliesAndRemovesAlignmentTest( BLOCK_NAME, 'center' );

--- a/test/e2e/specs/align-hook.test.js
+++ b/test/e2e/specs/align-hook.test.js
@@ -8,7 +8,6 @@ import {
 	setPostContent,
 	getAllBlocks,
 	selectBlockByClientId,
-	switchToEditor,
 } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
@@ -60,9 +59,7 @@ describe( 'Align Hook Works As Expected', () => {
 	};
 
 	const verifyMarkupIsValid = async ( htmlMarkup ) => {
-		await switchToEditor( 'Code' );
 		await setPostContent( htmlMarkup );
-		await switchToEditor( 'Visual' );
 		const blocks = await getAllBlocks();
 		expect( blocks ).toHaveLength( 1 );
 		expect( blocks[ 0 ].isValid ).toBeTruthy();

--- a/test/e2e/specs/align-hook.test.js
+++ b/test/e2e/specs/align-hook.test.js
@@ -1,0 +1,185 @@
+/**
+ * Internal dependencies
+ */
+import {
+	newPost,
+	insertBlock,
+	getEditedPostContent,
+	setPostContent,
+	getAllBlocks,
+	selectBlockByClientId,
+	switchToEditor,
+} from '../support/utils';
+import { activatePlugin, deactivatePlugin } from '../support/plugins';
+
+describe( 'Align Hook Works As Expected', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-align-hook' );
+	} );
+
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-align-hook' );
+	} );
+
+	const getAlignmentToolbarLabels = async () => {
+		const buttonLabels = await page.evaluate( () => {
+			const buttons = [];
+			document.querySelectorAll(
+				'.editor-block-toolbar button[aria-label^="Align"]'
+			).forEach(
+				( button ) => {
+					buttons.push( button.getAttribute( 'aria-label' ) );
+				}
+			);
+			return buttons;
+		} );
+		return buttonLabels;
+	};
+
+	const createShowsTheExpectedButtonsTest = ( blockName, buttonLabels ) => {
+		it( 'Shows the expected buttons on the alignment toolbar', async () => {
+			await insertBlock( blockName );
+			expect( await getAlignmentToolbarLabels() ).toEqual( buttonLabels );
+		} );
+	};
+
+	const createDoesNotApplyAlignmentByDefaultTest = ( blockName ) => {
+		it( 'Does not apply any alignment by default', async () => {
+			await insertBlock( blockName );
+			// verify no alignment button is in pressed state
+			const pressedButtons = await page.$$( '.editor-block-toolbar button[aria-label^="Align"][aria-pressed="true"]' );
+			expect( pressedButtons ).toHaveLength( 0 );
+		} );
+	};
+
+	const verifyMarkupIsValid = async ( htmlMarkup ) => {
+		await switchToEditor( 'Code' );
+		await setPostContent( htmlMarkup );
+		await switchToEditor( 'Visual' );
+		const blocks = await getAllBlocks();
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].isValid ).toBeTruthy();
+	};
+
+	const createCorrectlyAppliesAndRemovesAlignmentTest = ( blockName, alignment ) => {
+		it( 'Correctly applies the selected alignment and correctly removes the alignment', async () => {
+			const BUTTON_SELECTOR = `.editor-block-toolbar button[aria-label="Align ${ alignment }"]`;
+			const BUTTON_PRESSED_SELECTOR = `${ BUTTON_SELECTOR }[aria-pressed="true"]`;
+			// set the specified alignment.
+			await insertBlock( blockName );
+			await page.click( BUTTON_SELECTOR );
+
+			// verify the button of the specified alignment is pressed.
+			let pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
+			expect( pressedButtons ).toHaveLength( 1 );
+
+			let htmlMarkup = await getEditedPostContent();
+
+			// verify the markup of the selected alignment was generated.
+			expect( htmlMarkup ).toMatchSnapshot();
+
+			// verify the markup can be correctly parsed
+			await verifyMarkupIsValid( htmlMarkup );
+
+			await selectBlockByClientId( ( await getAllBlocks() )[ 0 ].clientId );
+
+			// remove the alignment.
+			await page.click( BUTTON_SELECTOR );
+
+			// verify no alignment button is in pressed state.
+			pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
+			expect( pressedButtons ).toHaveLength( 0 );
+
+			// verify alignment markup was removed from the block.
+			htmlMarkup = await getEditedPostContent();
+			expect( htmlMarkup ).toMatchSnapshot();
+
+			// verify the markup when no alignment is set is valid
+			await verifyMarkupIsValid( htmlMarkup );
+
+			await selectBlockByClientId( ( await getAllBlocks() )[ 0 ].clientId );
+
+			// verify no alignment button is in pressed state after parsing the block.
+			pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
+			expect( pressedButtons ).toHaveLength( 0 );
+		} );
+	};
+
+	describe( 'Block with no alignment set', () => {
+		const BLOCK_NAME = 'Test No Alignment Set';
+		it( 'Shows no alignment buttons on the alignment toolbar', async () => {
+			expect( await getAlignmentToolbarLabels() ).toHaveLength( 0 );
+		} );
+
+		it( 'Does not save any alignment related attribute or class', async () => {
+			await insertBlock( BLOCK_NAME );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'Block with align true', () => {
+		const BLOCK_NAME = 'Test Align True';
+
+		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
+			'Align left',
+			'Align center',
+			'Align right',
+		] );
+
+		createDoesNotApplyAlignmentByDefaultTest( BLOCK_NAME );
+
+		createCorrectlyAppliesAndRemovesAlignmentTest( BLOCK_NAME, 'right' );
+	} );
+
+	describe( 'Block with align array', () => {
+		const BLOCK_NAME = 'Test Align Array';
+
+		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
+			'Align left',
+			'Align center',
+		] );
+
+		createDoesNotApplyAlignmentByDefaultTest( BLOCK_NAME );
+
+		createCorrectlyAppliesAndRemovesAlignmentTest( BLOCK_NAME, 'center' );
+	} );
+
+	describe( 'Block with default align', () => {
+		const BLOCK_NAME = 'Test Default Align';
+		const PRESSED_BUTTON_SELECTOR = '.editor-block-toolbar button[aria-label="Align right"][aria-pressed="true"]';
+		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
+			'Align left',
+			'Align center',
+			'Align right',
+		] );
+
+		it( 'Applies the selected alignment by default', async () => {
+			await insertBlock( BLOCK_NAME );
+			// verify the correct alignment button is pressed
+			const pressedButtons = await page.$$( PRESSED_BUTTON_SELECTOR );
+			expect( pressedButtons ).toHaveLength( 1 );
+		} );
+
+		it( 'The default markup does not contain the alignment attribute but contains the alignment class', async () => {
+			await insertBlock( BLOCK_NAME );
+			const markup = await getEditedPostContent();
+			expect( markup ).not.toContain( '"align":"right"' );
+			expect( markup ).toContain( 'alignright' );
+		} );
+
+		it( 'Can remove the default alignment and the align attribute equals none but alignnone class is not applied', async () => {
+			await insertBlock( BLOCK_NAME );
+			// remove the alignment.
+			await page.click( PRESSED_BUTTON_SELECTOR );
+			const markup = await getEditedPostContent();
+			expect( markup ).toContain( '"align":null' );
+			expect( markup ).not.toContain( 'alignnull' );
+		} );
+
+		createCorrectlyAppliesAndRemovesAlignmentTest( BLOCK_NAME, 'center' );
+	} );
+} );

--- a/test/e2e/specs/align-hook.test.js
+++ b/test/e2e/specs/align-hook.test.js
@@ -27,24 +27,27 @@ describe( 'Align Hook Works As Expected', () => {
 
 	const getAlignmentToolbarLabels = async () => {
 		const buttonLabels = await page.evaluate( () => {
-			const buttons = [];
-			document.querySelectorAll(
-				'.editor-block-toolbar button[aria-label^="Align"]'
-			).forEach(
+			return Array.from(
+				document.querySelectorAll(
+					'.editor-block-toolbar button[aria-label^="Align"]'
+				)
+			).map(
 				( button ) => {
-					buttons.push( button.getAttribute( 'aria-label' ) );
+					return button.getAttribute( 'aria-label' );
 				}
 			);
-			return buttons;
 		} );
 		return buttonLabels;
 	};
 
 	const createShowsTheExpectedButtonsTest = ( blockName, buttonLabels ) => {
-		it( 'Shows the expected buttons on the alignment toolbar', async () => {
-			await insertBlock( blockName );
-			expect( await getAlignmentToolbarLabels() ).toEqual( buttonLabels );
-		} );
+		it( 'Shows the expected buttons on the alignment toolbar',
+			async () => {
+				await insertBlock( blockName );
+				expect(
+					await getAlignmentToolbarLabels()
+				).toEqual( buttonLabels );
+			} );
 	};
 
 	const createDoesNotApplyAlignmentByDefaultTest = ( blockName ) => {
@@ -66,59 +69,69 @@ describe( 'Align Hook Works As Expected', () => {
 	};
 
 	const createCorrectlyAppliesAndRemovesAlignmentTest = ( blockName, alignment ) => {
-		it( 'Correctly applies the selected alignment and correctly removes the alignment', async () => {
-			const BUTTON_SELECTOR = `.editor-block-toolbar button[aria-label="Align ${ alignment }"]`;
-			const BUTTON_PRESSED_SELECTOR = `${ BUTTON_SELECTOR }[aria-pressed="true"]`;
-			// set the specified alignment.
-			await insertBlock( blockName );
-			await page.click( BUTTON_SELECTOR );
+		it( 'Correctly applies the selected alignment and correctly removes the alignment',
+			async () => {
+				const BUTTON_SELECTOR = `.editor-block-toolbar button[aria-label="Align ${ alignment }"]`;
+				const BUTTON_PRESSED_SELECTOR = `${ BUTTON_SELECTOR }[aria-pressed="true"]`;
+				// set the specified alignment.
+				await insertBlock( blockName );
+				await page.click( BUTTON_SELECTOR );
 
-			// verify the button of the specified alignment is pressed.
-			let pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
-			expect( pressedButtons ).toHaveLength( 1 );
+				// verify the button of the specified alignment is pressed.
+				let pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
+				expect( pressedButtons ).toHaveLength( 1 );
 
-			let htmlMarkup = await getEditedPostContent();
+				let htmlMarkup = await getEditedPostContent();
 
-			// verify the markup of the selected alignment was generated.
-			expect( htmlMarkup ).toMatchSnapshot();
+				// verify the markup of the selected alignment was generated.
+				expect( htmlMarkup ).toMatchSnapshot();
 
-			// verify the markup can be correctly parsed
-			await verifyMarkupIsValid( htmlMarkup );
+				// verify the markup can be correctly parsed
+				await verifyMarkupIsValid( htmlMarkup );
 
-			await selectBlockByClientId( ( await getAllBlocks() )[ 0 ].clientId );
+				await selectBlockByClientId(
+					( await getAllBlocks() )[ 0 ].clientId
+				);
 
-			// remove the alignment.
-			await page.click( BUTTON_SELECTOR );
+				// remove the alignment.
+				await page.click( BUTTON_SELECTOR );
 
-			// verify no alignment button is in pressed state.
-			pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
-			expect( pressedButtons ).toHaveLength( 0 );
+				// verify no alignment button is in pressed state.
+				pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
+				expect( pressedButtons ).toHaveLength( 0 );
 
-			// verify alignment markup was removed from the block.
-			htmlMarkup = await getEditedPostContent();
-			expect( htmlMarkup ).toMatchSnapshot();
+				// verify alignment markup was removed from the block.
+				htmlMarkup = await getEditedPostContent();
+				expect( htmlMarkup ).toMatchSnapshot();
 
-			// verify the markup when no alignment is set is valid
-			await verifyMarkupIsValid( htmlMarkup );
+				// verify the markup when no alignment is set is valid
+				await verifyMarkupIsValid( htmlMarkup );
 
-			await selectBlockByClientId( ( await getAllBlocks() )[ 0 ].clientId );
+				await selectBlockByClientId(
+					( await getAllBlocks() )[ 0 ].clientId
+				);
 
-			// verify no alignment button is in pressed state after parsing the block.
-			pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
-			expect( pressedButtons ).toHaveLength( 0 );
-		} );
+				// verify no alignment button is in pressed state after parsing the block.
+				pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
+				expect( pressedButtons ).toHaveLength( 0 );
+			}
+		);
 	};
 
 	describe( 'Block with no alignment set', () => {
 		const BLOCK_NAME = 'Test No Alignment Set';
-		it( 'Shows no alignment buttons on the alignment toolbar', async () => {
-			expect( await getAlignmentToolbarLabels() ).toHaveLength( 0 );
-		} );
+		it( 'Shows no alignment buttons on the alignment toolbar',
+			async () => {
+				expect( await getAlignmentToolbarLabels() ).toHaveLength( 0 );
+			}
+		);
 
-		it( 'Does not save any alignment related attribute or class', async () => {
-			await insertBlock( BLOCK_NAME );
-			expect( await getEditedPostContent() ).toMatchSnapshot();
-		} );
+		it( 'Does not save any alignment related attribute or class',
+			async () => {
+				await insertBlock( BLOCK_NAME );
+				expect( await getEditedPostContent() ).toMatchSnapshot();
+			}
+		);
 	} );
 
 	describe( 'Block with align true', () => {
@@ -164,12 +177,14 @@ describe( 'Align Hook Works As Expected', () => {
 			expect( pressedButtons ).toHaveLength( 1 );
 		} );
 
-		it( 'The default markup does not contain the alignment attribute but contains the alignment class', async () => {
-			await insertBlock( BLOCK_NAME );
-			const markup = await getEditedPostContent();
-			expect( markup ).not.toContain( '"align":"right"' );
-			expect( markup ).toContain( 'alignright' );
-		} );
+		it( 'The default markup does not contain the alignment attribute but contains the alignment class',
+			async () => {
+				await insertBlock( BLOCK_NAME );
+				const markup = await getEditedPostContent();
+				expect( markup ).not.toContain( '"align":"right"' );
+				expect( markup ).toContain( 'alignright' );
+			}
+		);
 
 		it( 'Can remove the default alignment and the align attribute equals none but alignnone class is not applied', async () => {
 			await insertBlock( BLOCK_NAME );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -411,3 +411,30 @@ export async function clickOnCloseModalButton( modalClassName ) {
 		await page.click( closeButtonClassName );
 	}
 }
+
+/**
+ * Sets code editor content
+ * @param {string} content New code editor content.
+ *
+ * @return {Promise} Promise resolving with an array containing all blocks in the document.
+ */
+export async function setPostContent( content ) {
+	return await page.evaluate( ( _content ) => {
+		const { dispatch } = window.wp.data;
+		dispatch( 'core/editor' ).editPost( { content: _content } );
+		const blocks = wp.blocks.parse( _content );
+		dispatch( 'core/editor' ).resetBlocks( blocks );
+	}, content );
+}
+
+/**
+ * Returns an array with all blocks; Equivalent to calling wp.data.select( 'core/editor' ).getBlocks();
+ *
+ * @return {Promise} Promise resolving with an array containing all blocks in the document.
+ */
+export async function getAllBlocks() {
+	return await page.evaluate( () => {
+		const { select } = window.wp.data;
+		return select( 'core/editor' ).getBlocks();
+	} );
+}

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -421,7 +421,6 @@ export async function clickOnCloseModalButton( modalClassName ) {
 export async function setPostContent( content ) {
 	return await page.evaluate( ( _content ) => {
 		const { dispatch } = window.wp.data;
-		dispatch( 'core/editor' ).editPost( { content: _content } );
 		const blocks = wp.blocks.parse( _content );
 		dispatch( 'core/editor' ).resetBlocks( blocks );
 	}, content );

--- a/test/e2e/test-plugins/align-hook.php
+++ b/test/e2e/test-plugins/align-hook.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Align Hook
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-align-hook
+ */
+wp_enqueue_script(
+	'gutenberg-test-align-hook',
+	plugins_url( 'align-hook/index.js', __FILE__ ),
+	array(
+		'wp-blocks',
+		'wp-element',
+		'wp-editor',
+		'wp-i18n'
+	),
+	filemtime( plugin_dir_path( __FILE__ ) . 'align-hook/index.js' ),
+	true
+);

--- a/test/e2e/test-plugins/align-hook/index.js
+++ b/test/e2e/test-plugins/align-hook/index.js
@@ -69,7 +69,7 @@
 				title: 'Test Default Align',
 				attributes: {
 					align: {
-						type: 'string',
+						type: [ 'string', 'null' ],
 						default: 'right',
 					},
 				},

--- a/test/e2e/test-plugins/align-hook/index.js
+++ b/test/e2e/test-plugins/align-hook/index.js
@@ -69,7 +69,7 @@
 				title: 'Test Default Align',
 				attributes: {
 					align: {
-						type: [ 'string', 'null' ],
+						type: 'string',
 						default: 'right',
 					},
 				},

--- a/test/e2e/test-plugins/align-hook/index.js
+++ b/test/e2e/test-plugins/align-hook/index.js
@@ -1,0 +1,83 @@
+( function() {
+	var registerBlockType = wp.blocks.registerBlockType;
+	var el = wp.element.createElement;
+	var InnerBlocks = wp.editor.InnerBlocks;
+	var __ = wp.i18n.__;
+	var TEMPLATE = [
+		[ 'core/paragraph', { fontSize: 'large', content: __( 'Content…' ) } ],
+	];
+
+	var baseBlock = {
+		icon: 'cart',
+		category: 'common',
+		edit: function( props ) {
+			return el(
+				'div',
+				{ style: { outline: '1px solid gray', padding: 5 } },
+				'Test Align Hook'
+			);
+		},
+		save: function() {
+			return el(
+				'div',
+				{ style: { outline: '1px solid gray', padding: 5 } },
+				'Test Align Hook'
+			);
+		},
+	};
+
+	registerBlockType(
+		'test/test-no-alignment-set',
+		Object.assign(
+			{
+				title: 'Test No Alignment Set',
+			},
+			baseBlock
+		)
+	);
+
+	registerBlockType(
+		'test/test-align-true',
+		Object.assign(
+			{
+				title: 'Test Align True',
+				supports: {
+					align: true,
+				}
+			},
+			baseBlock
+		)
+	);
+
+	registerBlockType(
+		'test/test-align-array',
+		Object.assign(
+			{
+				title: 'Test Align Array',
+				supports: {
+					align: [ 'left', 'center' ],
+				}
+			},
+			baseBlock
+		)
+	);
+
+	registerBlockType(
+		'test/test-default-align',
+		Object.assign(
+			{
+				title: 'Test Default Align',
+				attributes: {
+					align: {
+						type: 'string',
+						default: 'right',
+					},
+				},
+				supports: {
+					align: true,
+				}
+			},
+			baseBlock
+		)
+	);
+} )();


### PR DESCRIPTION
When we have a default value for an attribute, during the load of a document/block if that attribute is undefined the attribute gets the default value.
If we had a block that supports align but contained a default align we had a problem. If no align was set the post correctly saved the markup of no alignment set but the alignment attribute was not saved watching by the value of the attribute it was impossible to differentiate the state of default alignment being used, and the state of no alignment is used. The alignment attribute was just not stored in both cases.
If alignment was set to none (undefined), When the block was loaded no attribute was set, so the default value of alignment was used, but the block had the markup of alignment none, so the block becomes invalid.

This PR solves this problem by setting alignment to none when setting no alignment on the align hook, this way none is saved on the attribute and Gutenberg correctly differentiates the state of the block has the default align and the state the block has no alignment.


## How has this been tested?
I used the following test block: https://gist.github.com/jorgefilipecosta/b733f1745531dc9758c6eba0838ae3f5; I checked on the code editor that if setting no alignment for this block we set alignment comment attribute to 'none' and no align class is added. And I checked that after removing the alignment saving the post and loading it again everything works as expected. 

## Screenshots <!-- if applicable -->
Before:
![sep-05-2018 16-28-13](https://user-images.githubusercontent.com/11271197/45104639-708f9180-b12a-11e8-9ad7-bdbe34caa05e.gif)


After:
![sep-05-2018 15-46-36](https://user-images.githubusercontent.com/11271197/45104626-68cfed00-b12a-11e8-9a4d-854aa03d596e.gif)


