### PR TITLE
Taxonomies: Load all taxonomies

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1245,7 +1245,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$preload_paths = array(
 		'/',
 		'/wp/v2/types?context=edit',
-		'/wp/v2/taxonomies?context=edit',
+		'/wp/v2/taxonomies?per_page=-1&context=edit',
 		sprintf( '/wp/v2/%s/%s?context=edit', $rest_base, $post->ID ),
 		sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
 		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -16,7 +16,7 @@ import { REDUCER_KEY } from './name';
 const createEntityRecordGetter = ( source ) => defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name ) ] = ( state, key ) => source.getEntityRecord( state, kind, name, key );
-	result[ getMethodName( kind, name, 'get', true ) ] = ( state ) => source.getEntityRecords( state, kind, name );
+	result[ getMethodName( kind, name, 'get', true ) ] = ( state, ...args ) => source.getEntityRecords( state, kind, name, ...args );
 	return result;
 }, {} );
 

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -38,7 +38,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		return {
 			postType: select( 'core/editor' ).getCurrentPostType(),
-			taxonomies: select( 'core' ).getTaxonomies(),
+			taxonomies: select( 'core' ).getTaxonomies( { per_page: -1 } ),
 		};
 	} ),
 ] )( PostTaxonomies );


### PR DESCRIPTION
closes #9589

By default the REST API requests load a limited chunk of records (pagination). This PR makes sure we load all the taxonomies.


**Testing instructions**

Register a bunch of taxonomies and test that they appear all.

 ```
add_action( 'init', 'loadtaxonomies' );

function loadtaxonomies() {
for ( $i = 1; $i <20; $i++) {
	register_taxonomy(
		'genre'. $i,
		'post',
		array(
			'label' => __( 'Genre' ),
			'rewrite' => array( 'slug' => 'genre' ),
			'hierarchical' => true,
			'show_in_rest' => true
		)
	);
}
}

```
