### PR TITLE
Framework: Use @babel/runtime universally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -757,16 +757,6 @@
 				"regenerator-runtime": "^0.12.0"
 			}
 		},
-		"@babel/runtime-corejs2": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0.tgz",
-			"integrity": "sha512-Yww0jXgolNtkhcK+Txo5JN+DjBpNmmAtD7G99HOebhEjBzjnACG09Tip9C8lSOF6PrhA56OeJWeOZduNJaKxBA==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.5.7",
-				"regenerator-runtime": "^0.12.0"
-			}
-		},
 		"@babel/template": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz",
@@ -2317,8 +2307,7 @@
 					"version": "file:packages/deprecated",
 					"bundled": true,
 					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"@wordpress/hooks": "file:packages/hooks"
+						"@babel/runtime": "^7.0.0"
 					},
 					"dependencies": {
 						"@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "7.0.0",
-		"@babel/runtime-corejs2": "7.0.0",
+		"@babel/runtime": "7.0.0",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -20,7 +20,7 @@ module.exports = function( api ) {
 				pragma: 'createElement',
 			} ],
 			'@babel/plugin-proposal-async-generator-functions',
-			! isTestEnv && [ '@babel/plugin-transform-runtime', { corejs: 2 } ],
+			! isTestEnv && [ '@babel/plugin-transform-runtime' ],
 		].filter( Boolean ),
 	};
 };


### PR DESCRIPTION
Fixes #9640 
Related: #8580, #8586
Alternative to: #9643

This pull request seeks to remove usage of `@babel/runtime-corejs2` in an effort to resolve issues with loading the editor in Internet Explorer. This work is largely speculative, though is verified as a fix to the issue described in #9640. I'm not entirely clear on the context provided in #8580 and #8586, but as best I can tell the use of `@babel/runtime-corejs2` was specific to how packages were built for npm consumption. Since, as far as I'm aware, this is no longer the case as of #9171, there should not be expected a regression on #8580.

**Testing instructions:**

Repeat Steps to Reproduce described in #9640 both in Internet Explorer and your preferred browser, verifying that the editor loads as expected.