### PR TITLE
Make outline level 'Title' translatable

### DIFF
--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -90,7 +90,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 			<ul>
 				{ hasTitle && (
 					<DocumentOutlineItem
-						level="Title"
+						level={ __( 'Title' ) }
 						isValid
 						onClick={ focusTitle }
 					>


### PR DESCRIPTION
## Description
The outline level `Title` should be translatable.

## Screenshots
<img width="401" alt="bildschirmfoto 2018-09-05 um 23 50 04" src="https://user-images.githubusercontent.com/695201/45123397-0c3ef300-b167-11e8-90ee-4d9207055994.png">
