### PR TITLE
Use new block icons in media placeholders

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -14,12 +14,18 @@ import {
 import { Component, Fragment } from '@wordpress/element';
 import {
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	RichText,
 	mediaUpload,
 } from '@wordpress/editor';
 import { getBlobByURL } from '@wordpress/blob';
+
+/**
+ * Internal dependencies
+ */
+import { icon } from './index';
 
 class AudioEdit extends Component {
 	constructor() {
@@ -100,7 +106,7 @@ class AudioEdit extends Component {
 		if ( editing ) {
 			return (
 				<MediaPlaceholder
-					icon="media-audio"
+					icon=<BlockIcon icon={ icon } />
 					labels={ {
 						title: __( 'Audio' ),
 						name: __( 'an audio' ),

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -13,12 +13,14 @@ import { createBlobURL } from '@wordpress/blob';
 
 export const name = 'core/audio';
 
+export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z" /></svg>;
+
 export const settings = {
 	title: __( 'Audio' ),
 
 	description: __( 'Embed an audio file and a simple audio player.' ),
 
-	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z" /></svg>,
+	icon,
 
 	category: 'common',
 

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -13,14 +13,12 @@ import { createBlobURL } from '@wordpress/blob';
 
 export const name = 'core/audio';
 
-export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z" /></svg>;
-
 export const settings = {
 	title: __( 'Audio' ),
 
 	description: __( 'Embed an audio file and a simple audio player.' ),
 
-	icon,
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z" /></svg>,
 
 	category: 'common',
 
@@ -97,3 +95,5 @@ export const settings = {
 		);
 	},
 };
+
+export const icon = settings.icon;

--- a/packages/block-library/src/audio/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/index.js.snap
@@ -7,20 +7,25 @@ exports[`core/audio block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-media-audio"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="editor-block-icon"
     >
-      <path
-        d="M12 2l4 4v12H4V2h8zm0 4h3l-3-3v3zm1 7.26V8.09c0-.11-.04-.21-.12-.29-.07-.08-.16-.11-.27-.1 0 0-3.97.71-4.25.78C8.07 8.54 8 8.8 8 9v3.37c-.2-.09-.42-.07-.6-.07-.38 0-.7.13-.96.39-.26.27-.4.58-.4.96 0 .37.14.69.4.95.26.27.58.4.96.4.34 0 .7-.04.96-.26.26-.23.64-.65.64-1.12V10.3l3-.6V12c-.67-.2-1.17.04-1.44.31-.26.26-.39.58-.39.95 0 .38.13.69.39.96.27.26.71.39 1.08.39.38 0 .7-.13.96-.39.26-.27.4-.58.4-.96z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0,0h24v24H0V0z"
+          fill="none"
+        />
+        <path
+          d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z"
+        />
+      </svg>
+    </div>
     Audio
   </div>
   <div

--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -55,7 +55,7 @@ const blockAttributes = {
 
 export const name = 'core/cover-image';
 
-export const icon = <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" /><path d="M0 0h24v24H0z" fill="none" /></svg>;
+const icon = <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" /><path d="M0 0h24v24H0z" fill="none" /></svg>;
 
 export const settings = {
 	title: __( 'Cover Image' ),

--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import {
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	BlockAlignmentToolbar,
 	MediaPlaceholder,
@@ -54,12 +55,14 @@ const blockAttributes = {
 
 export const name = 'core/cover-image';
 
+export const icon = <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" /><path d="M0 0h24v24H0z" fill="none" /></svg>;
+
 export const settings = {
 	title: __( 'Cover Image' ),
 
 	description: __( 'Add a full-width image, and layer text over it — great for headers.' ),
 
-	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" /><path d="M0 0h24v24H0z" fill="none" /></svg>,
+	icon,
 
 	category: 'common',
 
@@ -194,7 +197,6 @@ export const settings = {
 
 		if ( ! url ) {
 			const hasTitle = ! isEmpty( title );
-			const icon = hasTitle ? undefined : 'format-image';
 			const label = hasTitle ? (
 				<RichText
 					tagName="h2"
@@ -208,7 +210,7 @@ export const settings = {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon={ icon }
+						icon={ hasTitle ? undefined : <BlockIcon icon={ icon } /> }
 						className={ className }
 						labels={ {
 							title: label,

--- a/packages/block-library/src/cover-image/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/cover-image/test/__snapshots__/index.js.snap
@@ -7,20 +7,25 @@ exports[`core/cover-image block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-format-image"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="editor-block-icon"
     >
-      <path
-        d="M2.25 1h15.5c.69 0 1.25.56 1.25 1.25v15.5c0 .69-.56 1.25-1.25 1.25H2.25C1.56 19 1 18.44 1 17.75V2.25C1 1.56 1.56 1 2.25 1zM17 17V3H3v14h14zM10 6c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2 2-.9 2-2zm3 5s0-6 3-6v10c0 .55-.45 1-1 1H5c-.55 0-1-.45-1-1V8c2 0 3 4 3 4s1-3 3-3 3 2 3 2z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z"
+        />
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+      </svg>
+    </div>
     Cover Image
   </div>
   <div

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -20,6 +20,7 @@ import {
 	MediaUpload,
 	MediaPlaceholder,
 	BlockControls,
+	BlockIcon,
 	RichText,
 	mediaUpload,
 } from '@wordpress/editor';
@@ -29,6 +30,7 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import FileBlockInspector from './inspector';
+import { icon } from './index';
 
 class FileEdit extends Component {
 	constructor() {
@@ -140,7 +142,7 @@ class FileEdit extends Component {
 		if ( ! href || hasError ) {
 			return (
 				<MediaPlaceholder
-					icon="media-default"
+					icon=<BlockIcon icon={ icon } />
 					labels={ {
 						title: __( 'File' ),
 						name: __( 'a file' ),

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -18,14 +18,12 @@ import edit from './edit';
 
 export const name = 'core/file';
 
-export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M9 6l2 2h9v10H4V6h5m1-2H4L2 6v12l2 2h16l2-2V8l-2-2h-8l-2-2z" /></svg>;
-
 export const settings = {
 	title: __( 'File' ),
 
 	description: __( 'Add a link to a file that visitors can download.' ),
 
-	icon,
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M9 6l2 2h9v10H4V6h5m1-2H4L2 6v12l2 2h16l2-2V8l-2-2h-8l-2-2z" /></svg>,
 
 	category: 'common',
 
@@ -229,5 +227,6 @@ export const settings = {
 			</div>
 		);
 	},
-
 };
+
+export const icon = settings.icon;

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -18,12 +18,14 @@ import edit from './edit';
 
 export const name = 'core/file';
 
+export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M9 6l2 2h9v10H4V6h5m1-2H4L2 6v12l2 2h16l2-2V8l-2-2h-8l-2-2z" /></svg>;
+
 export const settings = {
 	title: __( 'File' ),
 
 	description: __( 'Add a link to a file that visitors can download.' ),
 
-	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M9 6l2 2h9v10H4V6h5m1-2H4L2 6v12l2 2h16l2-2V8l-2-2h-8l-2-2z" /></svg>,
+	icon,
 
 	category: 'common',
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -21,6 +21,7 @@ import {
 } from '@wordpress/components';
 import {
 	BlockControls,
+	BlockIcon,
 	MediaUpload,
 	MediaPlaceholder,
 	InspectorControls,
@@ -31,6 +32,7 @@ import {
  * Internal dependencies
  */
 import GalleryImage from './gallery-image';
+import { icon } from './index';
 
 const MAX_COLUMNS = 8;
 const linkOptions = [
@@ -191,7 +193,7 @@ class GalleryEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon="format-gallery"
+						icon=<BlockIcon icon={ icon } />
 						className={ className }
 						labels={ {
 							title: __( 'Gallery' ),

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -66,12 +66,10 @@ const blockAttributes = {
 
 export const name = 'core/gallery';
 
-export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><g><path d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z" /><path d="M12 12l1 2 3-3 3 4H9z" /><path d="M2 6v14l2 2h14v-2H4V6H2z" /></g></svg>;
-
 export const settings = {
 	title: __( 'Gallery' ),
 	description: __( 'Display multiple images in an elegantly organized tiled layout.' ),
-	icon,
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><g><path d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z" /><path d="M12 12l1 2 3-3 3 4H9z" /><path d="M2 6v14l2 2h14v-2H4V6H2z" /></g></svg>,
 	category: 'common',
 	keywords: [ __( 'images' ), __( 'photos' ) ],
 	attributes: blockAttributes,
@@ -272,3 +270,5 @@ export const settings = {
 		},
 	],
 };
+
+export const icon = settings.icon;

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -66,10 +66,12 @@ const blockAttributes = {
 
 export const name = 'core/gallery';
 
+export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><g><path d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z" /><path d="M12 12l1 2 3-3 3 4H9z" /><path d="M2 6v14l2 2h14v-2H4V6H2z" /></g></svg>;
+
 export const settings = {
 	title: __( 'Gallery' ),
 	description: __( 'Display multiple images in an elegantly organized tiled layout.' ),
-	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><g><path d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z" /><path d="M12 12l1 2 3-3 3 4H9z" /><path d="M2 6v14l2 2h14v-2H4V6H2z" /></g></svg>,
+	icon,
 	category: 'common',
 	keywords: [ __( 'images' ), __( 'photos' ) ],
 	attributes: blockAttributes,

--- a/packages/block-library/src/gallery/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/index.js.snap
@@ -7,20 +7,33 @@ exports[`core/gallery block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-format-gallery"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="editor-block-icon"
     >
-      <path
-        d="M16 4h1.96c.57 0 1.04.47 1.04 1.04v12.92c0 .57-.47 1.04-1.04 1.04H5.04C4.47 19 4 18.53 4 17.96V16H2.04C1.47 16 1 15.53 1 14.96V2.04C1 1.47 1.47 1 2.04 1h12.92c.57 0 1.04.47 1.04 1.04V4zM3 14h11V3H3v11zm5-8.5C8 4.67 7.33 4 6.5 4S5 4.67 5 5.5 5.67 7 6.5 7 8 6.33 8 5.5zm2 4.5s1-5 3-5v8H4V7c2 0 2 3 2 3s.33-2 2-2 2 2 2 2zm7 7V6h-1v8.96c0 .57-.47 1.04-1.04 1.04H6v1h11z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 0h24v24H0V0z"
+          fill="none"
+        />
+        <g>
+          <path
+            d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z"
+          />
+          <path
+            d="M12 12l1 2 3-3 3 4H9z"
+          />
+          <path
+            d="M2 6v14l2 2h14v-2H4V6H2z"
+          />
+        </g>
+      </svg>
+    </div>
     Gallery
   </div>
   <div

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -32,6 +32,7 @@ import { withSelect } from '@wordpress/data';
 import {
 	RichText,
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaUpload,
@@ -45,6 +46,7 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import ImageSize from './image-size';
+import { icon } from './index';
 
 /**
  * Module constants
@@ -241,7 +243,7 @@ class ImageEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon="format-image"
+						icon=<BlockIcon icon={ icon } />
 						labels={ {
 							title: __( 'Image' ),
 							name: __( 'an image' ),

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -90,12 +90,14 @@ const schema = {
 	},
 };
 
+export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></svg>;
+
 export const settings = {
 	title: __( 'Image' ),
 
 	description: __( 'They’re worth 1,000 words! Insert a single image.' ),
 
-	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></svg>,
+	icon,
 
 	category: 'common',
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -90,14 +90,12 @@ const schema = {
 	},
 };
 
-export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></svg>;
-
 export const settings = {
 	title: __( 'Image' ),
 
 	description: __( 'They’re worth 1,000 words! Insert a single image.' ),
 
-	icon,
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></svg>,
 
 	category: 'common',
 
@@ -320,3 +318,5 @@ export const settings = {
 		},
 	],
 };
+
+export const icon = settings.icon;

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -16,6 +16,7 @@ import {
 import { Component, Fragment, createRef } from '@wordpress/element';
 import {
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaUpload,
@@ -23,6 +24,11 @@ import {
 	mediaUpload,
 } from '@wordpress/editor';
 import { getBlobByURL } from '@wordpress/blob';
+
+/**
+ * Internal dependencies
+ */
+import { icon } from './index';
 
 class VideoEdit extends Component {
 	constructor() {
@@ -129,7 +135,7 @@ class VideoEdit extends Component {
 		if ( editing ) {
 			return (
 				<MediaPlaceholder
-					icon="media-video"
+					icon=<BlockIcon icon={ icon } />
 					labels={ {
 						title: __( 'Video' ),
 						name: __( 'a video' ),

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -13,12 +13,14 @@ import edit from './edit';
 
 export const name = 'core/video';
 
+export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z" /></svg>;
+
 export const settings = {
 	title: __( 'Video' ),
 
 	description: __( 'Embed a video file and a simple video player.' ),
 
-	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z" /></svg>,
+	icon,
 
 	keywords: [ __( 'movie' ) ],
 

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -13,14 +13,12 @@ import edit from './edit';
 
 export const name = 'core/video';
 
-export const icon = <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z" /></svg>;
-
 export const settings = {
 	title: __( 'Video' ),
 
 	description: __( 'Embed a video file and a simple video player.' ),
 
-	icon,
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z" /></svg>,
 
 	keywords: [ __( 'movie' ) ],
 
@@ -130,3 +128,5 @@ export const settings = {
 		);
 	},
 };
+
+export const icon = settings.icon;

--- a/packages/block-library/src/video/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/video/test/__snapshots__/index.js.snap
@@ -7,20 +7,25 @@ exports[`core/video block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-media-video"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="editor-block-icon"
     >
-      <path
-        d="M12 2l4 4v12H4V2h8zm0 4h3l-3-3v3zm-1 8v-3c0-.27-.1-.51-.29-.71-.2-.19-.44-.29-.71-.29H7c-.27 0-.51.1-.71.29-.19.2-.29.44-.29.71v3c0 .27.1.51.29.71.2.19.44.29.71.29h3c.27 0 .51-.1.71-.29.19-.2.29-.44.29-.71zm3 1v-5l-2 2v1z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 0h24v24H0V0z"
+          fill="none"
+        />
+        <path
+          d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z"
+        />
+      </svg>
+    </div>
     Video
   </div>
   <div


### PR DESCRIPTION
## Description
This PR changes the media placeholders of the following blocks to use the new block icons:
- Audio
- Cover Image
- File
- Gallery
- Image
- Video

This PR changes the placeholders to source the icons from the same place as the main block property, meaning that future icon updates will only have to be applied to one place rather than two.

Closes #9642.

## Screenshot
![image](https://user-images.githubusercontent.com/19592990/45132203-af870c80-b155-11e8-8ebb-eaada390eb63.png)