### PR TITLE
Ensure Gutenberg repository is clean after install

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -627,6 +627,7 @@ Returns true if one of the block's inner blocks is selected.
 
  * state: Editor state.
  * clientId: Block client ID.
+ * deep: Perform a deep check.
 
 *Returns*
 

--- a/docs/data/data-core-nux.md
+++ b/docs/data/data-core-nux.md
@@ -4,18 +4,14 @@
 
 ### isTipVisible
 
-Determines whether the given tip or DotTip instance should be visible. Checks:
-
-- That all tips are enabled.
-- That the given tip has not been dismissed.
-- If the given tip is part of a guide, that the given tip is the current tip in the guide.
-- If instanceId is provided, that this is the first DotTip instance for the given tip.
+Determines whether or not the given tip is showing. Tips are hidden if they
+are disabled, have been dismissed, or are not the current tip in any
+guide that they have been added to.
 
 *Parameters*
 
  * state: Global application state.
  * tipId: The tip to query.
- * instanceId: A number which uniquely identifies the DotTip instance.
 
 ### areTipsEnabled
 
@@ -39,29 +35,6 @@ the user through a series of tips step by step.
 *Parameters*
 
  * tipIds: Which tips to show in the guide.
-
-### registerTipInstance
-
-Returns an action object that, when dispatched, associates an instance of the
-DotTip component with a tip. This is usually done when the component mounts.
-Tracking this lets us only show one DotTip at a time per tip.
-
-*Parameters*
-
- * tipId: The tip to associate this instance with.
- * instanceId: A number which uniquely identifies the instance.
-
-### unregisterTipInstance
-
-Returns an action object that, when dispatched, removes the association
-between a DotTip component instance and a tip. This is usually done when the
-component unmounts. Tracking this lets us only show one DotTip at a time per
-tip.
-
-*Parameters*
-
- * tipId: The tip to disassociate this instance with.
- * instanceId: A number which uniquely identifies the instance.
 
 ### dismissTip
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -450,12 +450,6 @@
 		"parent": "packages"
 	},
 	{
-		"title": "@wordpress/postcss-url",
-		"slug": "packages-postcss-url",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/postcss-url/README.md",
-		"parent": "packages"
-	},
-	{
 		"title": "@wordpress/redux-routine",
 		"slug": "packages-redux-routine",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/redux-routine/README.md",
@@ -508,6 +502,12 @@
 		"slug": "components",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components.md",
 		"parent": null
+	},
+	{
+		"title": "AccessibleSvg",
+		"slug": "accessible-svg",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/accessible-svg/README.md",
+		"parent": "components"
 	},
 	{
 		"title": "Autocomplete",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2261,21 +2261,6 @@
 				"tinymce": "^4.7.2",
 				"traverse": "^0.6.6",
 				"uuid": "^3.1.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.2",
-					"bundled": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"bundled": true
-				}
 			}
 		},
 		"@wordpress/element": {
@@ -2285,16 +2270,6 @@
 				"lodash": "^4.17.10",
 				"react": "^16.4.1",
 				"react-dom": "^16.4.1"
-			},
-			"dependencies": {
-				"prop-types": {
-					"version": "15.6.2",
-					"bundled": true,
-					"requires": {
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
-					}
-				}
 			}
 		},
 		"@wordpress/hooks": {
@@ -2318,49 +2293,6 @@
 				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
 				"memize": "^1.0.5"
-			},
-			"dependencies": {
-				"@wordpress/deprecated": {
-					"version": "file:packages/deprecated",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"@wordpress/hooks": "file:packages/hooks"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.0.0",
-							"bundled": true,
-							"requires": {
-								"regenerator-runtime": "^0.12.0"
-							}
-						},
-						"@wordpress/hooks": {
-							"version": "file:packages/hooks",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0"
-							},
-							"dependencies": {
-								"@babel/runtime": {
-									"version": "7.0.0",
-									"bundled": true,
-									"requires": {
-										"regenerator-runtime": "^0.12.0"
-									}
-								},
-								"regenerator-runtime": {
-									"version": "0.12.1",
-									"bundled": true
-								}
-							}
-						},
-						"regenerator-runtime": {
-							"version": "0.12.1",
-							"bundled": true
-						}
-					}
-				}
 			}
 		},
 		"@wordpress/is-shallow-equal": {
@@ -2663,6 +2595,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -4644,6 +4577,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -5149,6 +5083,7 @@
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
 			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.1"
 			}
@@ -5156,7 +5091,8 @@
 		"color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+			"dev": true
 		},
 		"color-string": {
 			"version": "0.3.0",
@@ -6909,7 +6845,8 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.10.0",
@@ -9369,7 +9306,8 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbol-support-x": {
 			"version": "1.4.2",
@@ -18939,6 +18877,7 @@
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}


### PR DESCRIPTION
## Description
This PR fixes two things at once to ensure that fresh clone of Gutenberg repository is clean:
- updates `package-lock.json` to prevent having it changed after `npm i` gets executed
- regenerates docs for the handbook

_Aside:_ Those are 2 very common issues, we should improve our tooling to be more strict when doing `pre-commit` hook and error when docs get updated. Not sure how to prevent issues with the lock file though.