### PR TITLE
Fix the PostTitle font size

### DIFF
--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -1,6 +1,7 @@
 .editor-post-title__block {
 	position: relative;
 	padding: 5px 0;
+	font-size: $editor-font-size;
 
 	@include break-small() {
 		padding: 5px $block-parent-side-ui-clearance;


### PR DESCRIPTION
With the editor styles refactoring #9008 we moved the default font size definition which caused breakage in the post title's font size

This should fix it.