### PR TITLE
Fix small visual regression in the inspector

### DIFF
--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -37,17 +37,19 @@ const BlockInspector = ( { selectedBlock, blockType, count } ) => {
 			</div>
 		</div>,
 		<div key="inspector-controls"><InspectorControls.Slot /></div>,
-		<InspectorAdvancedControls.Slot key="inspector-advanced-controls">
-			{ ( fills ) => ! isEmpty( fills ) && (
-				<PanelBody
-					className="editor-block-inspector__advanced"
-					title={ __( 'Advanced' ) }
-					initialOpen={ false }
-				>
-					{ fills }
-				</PanelBody>
-			) }
-		</InspectorAdvancedControls.Slot>,
+		<div key="inspector-advanced-controls">
+			<InspectorAdvancedControls.Slot>
+				{ ( fills ) => ! isEmpty( fills ) && (
+					<PanelBody
+						className="editor-block-inspector__advanced"
+						title={ __( 'Advanced' ) }
+						initialOpen={ false }
+					>
+						{ fills }
+					</PanelBody>
+				) }
+			</InspectorAdvancedControls.Slot>
+		</div>,
 		<SkipToSelectedBlock key="back" />,
 	];
 };


### PR DESCRIPTION
closes #9616

Just a small regression introduced by #9572 when we removed the slot's wrapper.

**Testing instructions**

Repeat instructions from #9616