### PR TITLE
Show lint errors when there are lint problems

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
 	},
 	"scripts": {
 		"format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
-		"lint": "phpcs --standard=phpcs.xml.dist --report-summary --report-source"
+		"lint": "phpcs --standard=phpcs.xml.dist"
 	}
 }


### PR DESCRIPTION
A summary saying there were lint errors isn't too helpful
when you want to fix the lint errors, so this changes
the output so that the lint failures are shown.

## How has this been tested?

Put a lint error in a php file, run `run-script lint` and it should tell you where the error is.

