### PR TITLE
Update invalid block copy

### DIFF
--- a/edit-post/hooks/validate-multiple-use/index.js
+++ b/edit-post/hooks/validate-multiple-use/index.js
@@ -96,7 +96,7 @@ const withMultipleValidation = createHigherOrderComponent( ( BlockEdit ) => {
 				] }
 			>
 				<strong>{ blockType.title }: </strong>
-				{ __( 'This block may not be used more than once.' ) }
+				{ __( 'This block can only be used once.' ) }
 			</Warning>,
 		];
 	} );

--- a/packages/editor/src/components/block-compare/index.js
+++ b/packages/editor/src/components/block-compare/index.js
@@ -67,7 +67,7 @@ class BlockCompare extends Component {
 					title={ __( 'Current' ) }
 					className="editor-block-compare__current"
 					action={ onKeep }
-					actionText={ __( 'Keep as HTML' ) }
+					actionText={ __( 'Convert to HTML' ) }
 					rawContent={ original.rawContent }
 					renderedContent={ original.renderedContent }
 				/>

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -39,7 +39,7 @@ export class BlockInvalidWarning extends Component {
 		const hasHTMLBlock = !! getBlockType( 'core/html' );
 		const { compare } = this.state;
 		const hiddenActions = [
-			{ title: __( 'Convert to Blocks' ), onClick: convertToBlocks },
+			{ title: __( 'Try Recovery' ), onClick: convertToBlocks },
 			{ title: __( 'Convert to Classic Block' ), onClick: convertToClassic },
 			{ title: __( 'Compare Conversion' ), onClick: this.onCompare },
 		];
@@ -56,7 +56,7 @@ export class BlockInvalidWarning extends Component {
 						onKeep={ convertToHTML }
 						onConvert={ convertToBlocks }
 						convertor={ blockToBlocks }
-						convertButtonText={ __( 'Convert to Blocks' ) }
+						convertButtonText={ __( 'Try Recovery' ) }
 					/>
 				</Modal>
 			);
@@ -66,17 +66,17 @@ export class BlockInvalidWarning extends Component {
 			<Warning
 				actions={ [
 					<Button key="convert" onClick={ convertToBlocks } isLarge isPrimary={ ! hasHTMLBlock }>
-						{ __( 'Convert to Blocks' ) }
+						{ __( 'Try Recovery' ) }
 					</Button>,
 					hasHTMLBlock && (
 						<Button key="edit" onClick={ convertToHTML } isLarge isPrimary>
-							{ __( 'Keep as HTML' ) }
+							{ __( 'Convert to HTML' ) }
 						</Button>
 					),
 				] }
 				secondaryActions={ hiddenActions }
 			>
-				{ __( 'This block has been modified externally.' ) }
+				{ __( 'This block is unrecognized or contains invalid HTML.' ) }
 			</Warning>
 		);
 	}

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -39,15 +39,13 @@ export class BlockInvalidWarning extends Component {
 		const hasHTMLBlock = !! getBlockType( 'core/html' );
 		const { compare } = this.state;
 		const hiddenActions = [
-			{ title: __( 'Try Recovery' ), onClick: convertToBlocks },
 			{ title: __( 'Convert to Classic Block' ), onClick: convertToClassic },
-			{ title: __( 'Compare Conversion' ), onClick: this.onCompare },
 		];
 
 		if ( compare ) {
 			return (
 				<Modal
-					title={ __( 'Compare Block Conversion' ) }
+					title={ __( 'Resolve Block' ) }
 					onRequestClose={ this.onCompareClose }
 					className="editor-block-compare"
 				>
@@ -56,7 +54,7 @@ export class BlockInvalidWarning extends Component {
 						onKeep={ convertToHTML }
 						onConvert={ convertToBlocks }
 						convertor={ blockToBlocks }
-						convertButtonText={ __( 'Try Recovery' ) }
+						convertButtonText={ __( 'Convert to Blocks' ) }
 					/>
 				</Modal>
 			);
@@ -65,8 +63,8 @@ export class BlockInvalidWarning extends Component {
 		return (
 			<Warning
 				actions={ [
-					<Button key="convert" onClick={ convertToBlocks } isLarge isPrimary={ ! hasHTMLBlock }>
-						{ __( 'Try Recovery' ) }
+					<Button key="convert" onClick={ this.onCompare } isLarge isPrimary={ ! hasHTMLBlock }>
+						{ __( 'Resolve' ) }
 					</Button>,
 					hasHTMLBlock && (
 						<Button key="edit" onClick={ convertToHTML } isLarge isPrimary>
@@ -76,7 +74,7 @@ export class BlockInvalidWarning extends Component {
 				] }
 				secondaryActions={ hiddenActions }
 			>
-				{ __( 'This block is unrecognized or contains invalid HTML.' ) }
+				{ __( 'This block contains unexpected or invalid content.' ) }
 			</Warning>
 		);
 	}


### PR DESCRIPTION
Based on feedback in #9473 this tries to improve the text for the content and buttons of an invalid block from:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/45164306-1bb35000-b1ea-11e8-9dd1-fb2e85f53dfe.jpg)

To:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/45159595-17ce0080-b1df-11e8-8733-48b820267579.jpg)

It also changes the text for a single-use block to make it more active. From:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/45164394-3eddff80-b1ea-11e8-9708-d742f894a301.jpg)

To:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/45164448-6339dc00-b1ea-11e8-97f1-d8338efb44e5.jpg)

Finally it removes the duplicate invalid block button from:

![overview_of_block_validation_experience_ _issue__7604_ _wordpress_gutenberg](https://user-images.githubusercontent.com/1277682/45164516-81074100-b1ea-11e8-8f3d-d8cdae64a3d1.jpg)

To:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/45164493-7482e880-b1ea-11e8-8ad8-baa3e8c1d803.jpg)

## How has this been tested?
This is a text only change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
