### PR TITLE
Editor: Restore isCleanNewPost selector

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -49,6 +49,22 @@ false if the editing state matches the saved or new post.
 
 Whether unsaved values exist.
 
+### isCleanNewPost
+
+Returns true if there are no unsaved values for the current edit session and
+if the currently edited post is new (has never been saved before).
+
+Note: This selector is not currently used by the editor package, but is made
+available as an assumed-useful selector for external integrations.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether new post and unsaved values exist.
+
 ### getCurrentPost
 
 Returns the post currently being edited in its last known saved state, not

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -22,7 +22,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
  - `wp.components.withContext` has been removed. Please use `wp.element.createContext` instead. See: https://reactjs.org/docs/context.html.
  - `wp.coreBlocks.registerCoreBlocks` has been removed. Please use `wp.blockLibrary.registerCoreBlocks` instead.
  - `wp.editor.DocumentTitle` component has been removed.
- - `isCleanNewPost` and `getDocumentTitle` selectors (`core/editor`) have been removed.
+ - `getDocumentTitle` selector (`core/editor`) has been removed.
 
 ## 3.7.0
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `editorMediaUpload` has been removed. Use `mediaUpload` instead.
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
 - `wp.editor.DocumentTitle` component has been removed.
-- `isCleanNewPost` and `getDocumentTitle` selectors (`core/editor`) have been removed.
+- `getDocumentTitle` selector (`core/editor`) has been removed.
 
 ### Deprecation
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -99,6 +99,21 @@ export function isEditedPostDirty( state ) {
 }
 
 /**
+ * Returns true if there are no unsaved values for the current edit session and
+ * if the currently edited post is new (has never been saved before).
+ *
+ * Note: This selector is not currently used by the editor package, but is made
+ * available as an assumed-useful selector for external integrations.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether new post and unsaved values exist.
+ */
+export function isCleanNewPost( state ) {
+	return ! isEditedPostDirty( state ) && isEditedPostNew( state );
+}
+
+/**
  * Returns the post currently being edited in its last known saved state, not
  * including unsaved edits. Returns an object containing relevant default post
  * values if the post has not yet been saved.

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -20,6 +20,7 @@ const {
 	hasEditorRedo,
 	isEditedPostNew,
 	isEditedPostDirty,
+	isCleanNewPost,
 	getCurrentPost,
 	getCurrentPostId,
 	getCurrentPostLastRevisionId,
@@ -279,6 +280,59 @@ describe( 'selectors', () => {
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isCleanNewPost', () => {
+		it( 'should return true when the post is not dirty and has not been saved before', () => {
+			const state = {
+				editor: {
+					isDirty: false,
+				},
+				currentPost: {
+					id: 1,
+					status: 'auto-draft',
+				},
+				saving: {
+					requesting: false,
+				},
+			};
+
+			expect( isCleanNewPost( state ) ).toBe( true );
+		} );
+
+		it( 'should return false when the post is not dirty but the post has been saved', () => {
+			const state = {
+				editor: {
+					isDirty: false,
+				},
+				currentPost: {
+					id: 1,
+					status: 'draft',
+				},
+				saving: {
+					requesting: false,
+				},
+			};
+
+			expect( isCleanNewPost( state ) ).toBe( false );
+		} );
+
+		it( 'should return false when the post is dirty but the post has not been saved', () => {
+			const state = {
+				editor: {
+					isDirty: true,
+				},
+				currentPost: {
+					id: 1,
+					status: 'auto-draft',
+				},
+				saving: {
+					requesting: false,
+				},
+			};
+
+			expect( isCleanNewPost( state ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Previously: #8831
Related Slack conversation: https://wordpress.slack.com/archives/C02QB2JS7/p1536218969000100?thread_ts=1536160199.000100&cid=C02QB2JS7 ([link requires registration](https://make.wordpress.org/chat/))

This pull request seeks to restore an `isCleanNewPost` selector which was previously removed as part of the removal of its sole consumer within the editor package. It has surfaced that there were third-party integrations which depended upon this selector. As no alternative exists and it appears to be a useful selector for integrations, it has been restored here. A note has been included to indicate that it is not in use by the editor package itself.

**Testing instructions:**

There is no impact on the application.

Ensure unit tests pass:

```
npm run test-unit packages/editor/src/store/test/selectors.js
```

cc @ZebulanStanphill 