### PR TITLE
Gallery: Use space-between instead of negative margins

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,14 +3,15 @@
 	flex-wrap: wrap;
 	list-style-type: none;
 	padding: 0;
+	margin: 0;
 	// allow gallery items to go edge to edge
-	margin: 0 -8px 0 -8px;
+	justify-content: space-between;
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {
-		margin: 8px;
+		margin: 0;
 		display: flex;
-		flex-grow: 1;
+		flex-grow: 0;
 		flex-direction: column;
 		justify-content: center;
 		position: relative;
@@ -93,5 +94,20 @@
 	&.alignright {
 		max-width: $content-width / 2;
 		width: 100%;
+	}
+
+	// Alignments
+	&.aligncenter,
+	&.alignleft,
+	&.alignright {
+		display: flex; // Override themes alignments rules
+	}
+
+	&.alignleft {
+		float: left;
+	}
+
+	&.alignright {
+		float: right;
 	}
 }


### PR DESCRIPTION
## Description
Using `justify-content: space-between` in gallery block instead of negative margins. Also removed margins of gallery items. 

Added missing alignment rules for galleries.

## How has this been tested?
In the browser, adding 3 images to a gallery block for example and checking the width and space between images.

## Types of changes
Just style.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
