### PR TITLE
Fix selection of small table cells

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -332,6 +332,7 @@ export default class TableEdit extends Component {
 							return (
 								<CellTag key={ columnIndex } className={ classes }>
 									<RichText
+										className="wp-block-table__cell-content"
 										value={ content }
 										onChange={ this.onChange }
 										unstableOnFocus={ this.createOnFocus( cell ) }

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -6,7 +6,7 @@
 
 	td,
 	th {
-		padding: 0.5em;
+		padding: 0;
 		border: $border-width solid currentColor;
 	}
 
@@ -15,5 +15,9 @@
 		border-color: $blue-medium-500;
 		box-shadow: inset 0 0 0 1px $blue-medium-500;
 		border-style: double;
+	}
+
+	&__cell-content {
+		padding: 0.5em;
 	}
 }


### PR DESCRIPTION
## Description
I noticed that it can be difficult to select very narrow table cells. The RichText element within the table cell is the element that receives selection. In the gif below the rich text has collapsed to just 1px wide and is hard to select:
![table-cell-selection](https://user-images.githubusercontent.com/677833/45178741-6d6dd180-b20e-11e8-8488-6415512540e7.gif)

This PR moves padding from the `td` element to the RichText (just for the editor) so that there's a larger selection area.

Pretty open to other suggestions of how to fix this - this seemed like the simplest.

## How has this been tested?
Manually tested selection of a narrow cell

## Screenshots <!-- if applicable -->
**Gif showing the fix**
![table-cell-selection-with-fix](https://user-images.githubusercontent.com/677833/45178752-73fc4900-b20e-11e8-97f7-da914f4e6b59.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
