### PR TITLE
Fix: InnerBlock templates sync conditions to avoid a forced locking

### DIFF
--- a/packages/editor/src/components/inner-blocks/index.js
+++ b/packages/editor/src/components/inner-blocks/index.js
@@ -27,18 +27,33 @@ class InnerBlocks extends Component {
 		this.updateNestedSettings();
 	}
 
+	getTemplateLock() {
+		const {
+			templateLock,
+			parentLock,
+		} = this.props;
+		return templateLock === undefined ? parentLock : templateLock;
+	}
+
 	componentDidMount() {
-		this.synchronizeBlocksWithTemplate();
+		const { innerBlocks } = this.props.block;
+		// only synchronize innerBlocks with template if innerBlocks are empty or a locking all exists
+		if ( innerBlocks.length === 0 || this.getTemplateLock() === 'all' ) {
+			return 	this.synchronizeBlocksWithTemplate();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { template } = this.props;
+		const { template, block } = this.props;
+		const { innerBlocks } = block;
 
 		this.updateNestedSettings();
-
-		const hasTemplateChanged = ! isEqual( template, prevProps.template );
-		if ( hasTemplateChanged ) {
-			this.synchronizeBlocksWithTemplate();
+		// only synchronize innerBlocks with template if innerBlocks are empty or a locking all exists
+		if ( innerBlocks.length === 0 || this.getTemplateLock() === 'all' ) {
+			const hasTemplateChanged = ! isEqual( template, prevProps.template );
+			if ( hasTemplateChanged ) {
+				this.synchronizeBlocksWithTemplate();
+			}
 		}
 	}
 
@@ -62,14 +77,12 @@ class InnerBlocks extends Component {
 		const {
 			blockListSettings,
 			allowedBlocks,
-			templateLock,
-			parentLock,
 			updateNestedSettings,
 		} = this.props;
 
 		const newSettings = {
 			allowedBlocks,
-			templateLock: templateLock === undefined ? parentLock : templateLock,
+			templateLock: this.getTemplateLock(),
 		};
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {

--- a/test/e2e/specs/__snapshots__/inner-blocks-templates.test.js.snap
+++ b/test/e2e/specs/__snapshots__/inner-blocks-templates.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Correctly Renders Block Icons on Inserter and Inspector InnerBlocks Template Sync Ensures blocks without locking are kept intact even if they do not match the template  1`] = `
+"<!-- wp:test/test-inner-blocks-no-locking -->
+<!-- wp:paragraph {\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-large-font-size\\">Content…</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>added paragraph</p>
+<!-- /wp:paragraph -->
+<!-- /wp:test/test-inner-blocks-no-locking -->"
+`;
+
+exports[`Correctly Renders Block Icons on Inserter and Inspector InnerBlocks Template Sync Removes blocks that are not expected by the template if a lock all exists  1`] = `
+"<!-- wp:test/test-inner-blocks-locking-all -->
+<!-- wp:paragraph {\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-large-font-size\\">Content…</p>
+<!-- /wp:paragraph -->
+<!-- /wp:test/test-inner-blocks-locking-all -->"
+`;

--- a/test/e2e/specs/inner-blocks-templates.test.js
+++ b/test/e2e/specs/inner-blocks-templates.test.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import {
+	newPost,
+	insertBlock,
+	switchToEditor,
+	getEditedPostContent,
+} from '../support/utils';
+import { activatePlugin, deactivatePlugin } from '../support/plugins';
+
+describe( 'Correctly Renders Block Icons on Inserter and Inspector', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-innerblocks-templates' );
+	} );
+
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-innerblocks-templates' );
+	} );
+
+	describe( 'InnerBlocks Template Sync', () => {
+		const insertBlockAndAddParagraphInside = async ( blockName, blockSlug ) => {
+			const paragraphToAdd = `
+			<!-- wp:paragraph -->
+			<p>added paragraph</p>
+			<!-- /wp:paragraph -->
+			`;
+			await insertBlock( blockName );
+			await switchToEditor( 'Code' );
+			await page.$eval( '.editor-post-text-editor', ( element, _paragraph, _blockSlug ) => {
+				const blockDelimiter = `<!-- /wp:${ _blockSlug } -->`;
+				element.value = element.value.replace( blockDelimiter, _paragraph + blockDelimiter );
+			}, paragraphToAdd, blockSlug );
+			// press enter inside the code editor so the onChange events for the new value trigger
+			await page.click( '.editor-post-text-editor' );
+			await page.keyboard.press( 'Enter' );
+			await switchToEditor( 'Visual' );
+		};
+
+		it( 'Ensures blocks without locking are kept intact even if they do not match the template ', async () => {
+			await insertBlockAndAddParagraphInside( 'Test Inner Blocks no locking', 'test/test-inner-blocks-no-locking' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'Removes blocks that are not expected by the template if a lock all exists ', async () => {
+			await insertBlockAndAddParagraphInside( 'Test InnerBlocks locking all', 'test/test-inner-blocks-locking-all' );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+} );

--- a/test/e2e/test-plugins/inner-blocks-templates.php
+++ b/test/e2e/test-plugins/inner-blocks-templates.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test InnerBlocks Templates
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-inner-blocks-templates
+ */
+wp_enqueue_script(
+	'gutenberg-test-inner-blocks-templates',
+	plugins_url( 'inner-blocks-templates/index.js', __FILE__ ),
+	array(
+		'wp-blocks',
+		'wp-components',
+		'wp-element',
+		'wp-editor',
+		'wp-hooks',
+		'wp-i18n'
+	),
+	filemtime( plugin_dir_path( __FILE__ ) . 'inner-blocks-templates/index.js' ),
+	true
+);

--- a/test/e2e/test-plugins/inner-blocks-templates/index.js
+++ b/test/e2e/test-plugins/inner-blocks-templates/index.js
@@ -1,0 +1,48 @@
+( function() {
+	var registerBlockType = wp.blocks.registerBlockType;
+	var el = wp.element.createElement;
+	var InnerBlocks = wp.editor.InnerBlocks;
+	var __ = wp.i18n.__;
+	var TEMPLATE = [
+		[ 'core/paragraph', { fontSize: 'large', content: 'Content…' } ],
+	];
+
+	var save = function() {
+		return el( InnerBlocks.Content );
+	};
+
+	registerBlockType( 'test/test-inner-blocks-no-locking', {
+		title: 'Test Inner Blocks no locking',
+		icon: 'cart',
+		category: 'common',
+
+		edit: function( props ) {
+			return el(
+					InnerBlocks,
+					{
+						template: TEMPLATE,
+					}
+			);
+		},
+
+		save,
+	} );
+
+	registerBlockType( 'test/test-inner-blocks-locking-all', {
+		title: 'Test InnerBlocks locking all',
+		icon: 'cart',
+		category: 'common',
+
+		edit: function( props ) {
+			return el(
+					InnerBlocks,
+					{
+						template: TEMPLATE,
+						templateLock: 'all',
+					}
+			);
+		},
+
+		save,
+	} );
+} )();


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/8109

The InnerBlocks component executed block sync with the template each time the component mounted (or each time the component updated if the template changed).

During the document load, the InnerBlocks component is mounted again. So we had a bug even if a block used templateLock=false if blocks were added in an InnerBlocks area with a template during the load all the additional blocks were removed because of the sync.

## How has this been tested?
I used the following test block https://gist.github.com/jorgefilipecosta/9ca39e388f6c46881809f0323f681197 and I checked that if I added new blocks e.g: a paragraph after saving and reloading the blocks are still present in the inner blocks area.
I verified that the columns block continues to work as before.

## Screenshots <!-- if applicable -->
Before:
![sep-06-2018 20-13-15-b](https://user-images.githubusercontent.com/11271197/45179792-6ac0ab80-b211-11e8-8f96-39127d4d4425.gif)

After:
![sep-06-2018 20-13-43-a](https://user-images.githubusercontent.com/11271197/45179797-70b68c80-b211-11e8-897d-195f89557cb4.gif)

