### PR TITLE
Docs: Update examples for components to look according to guidelines

### DIFF
--- a/packages/components/src/README.md
+++ b/packages/components/src/README.md
@@ -13,7 +13,7 @@ Within Gutenberg, these components can be accessed by importing from the `compon
  */
 import { Button } from '@wordpress/components';
 
-export default function MyButton() {
+const MyButton = () => {
 	return <Button>Click Me!</Button>;
 }
 ```

--- a/packages/components/src/draggable/README.md
+++ b/packages/components/src/draggable/README.md
@@ -66,7 +66,6 @@ const MyDraggable = () => (
 		</Panel>
 	</div>
 );
-export default MyDraggable;
 ```
 
 In case you want to call your own `dragstart` / `dragend` event handlers as well, you can pass them to `Draggable` and it'll take care of calling them after their own:
@@ -99,6 +98,4 @@ const MyDraggable = ( { onDragStart, onDragEnd } ) => (
 		</Panel>
 	</div>
 );
-
-export default MyDraggable;
 ```


### PR DESCRIPTION
## Description
This PR update examples in README.md documments to follow [Contributing guidelines](https://github.com/WordPress/gutenberg/blob/master/packages/components/CONTRIBUTING.md).

See related comment from @mmtr: https://github.com/Automattic/wp-calypso/pull/27022#issuecomment-419246465

> Yep, that's right. Examples are extracted by `react-live` in order to generate in real time the DevDocs and `export` is not supported there, so that's why examples shouldn't export anything.

At the moment they are used outside of Gutenberg. However, we want to have a common contract to make it possible to generate docs with examples in other places. Hopefully, in Gutenberg manual, too.
