### PR TITLE
Polish Classic block.

### DIFF
--- a/block-library/freeform/editor.scss
+++ b/block-library/freeform/editor.scss
@@ -151,6 +151,13 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 	z-index: z-index(".freeform-toolbar");
 	top: $block-padding;
 	transform: translateY(-$block-padding);
+
+	// On mobile, toolbars go edge to edge.
+	padding: 0 $block-padding;
+
+	@include break-small() {
+		padding: 0;
+	}
 }
 
 .freeform-toolbar:empty {

--- a/block-library/freeform/editor.scss
+++ b/block-library/freeform/editor.scss
@@ -213,11 +213,27 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 			transform: translateY(-#{ $block-padding });
 			top: $block-padding;
 
+			.editor-block-toolbar {
+				border: none;
+
+				// Match the TinyMCE "mobile" breakpoint buttons alignment.
+				margin-top: 3px;
+				@include break-medium() {
+					margin-top: 0;
+				}
+
+				&::before {
+					content: "";
+					display: block;
+					border-left: 1px solid $light-gray-500;
+					margin-top: $grid-size-small;
+					margin-bottom: $grid-size-small;
+				}
+			}
+
 			.components-toolbar {
 				background: transparent;
-				border-top: none;
-				border-right: none;
-				border-bottom: none;
+				border: none;
 			}
 		}
 

--- a/block-library/freeform/editor.scss
+++ b/block-library/freeform/editor.scss
@@ -115,6 +115,20 @@
 }
 
 .editor-block-list__layout .editor-block-list__block[data-type="core/freeform"] {
+
+	// Not sure why this is necessary, there seems to be a skin file that overrides this upstream.
+	.mce-btn.mce-active button,
+	.mce-btn.mce-active:hover button,
+	.mce-btn.mce-active i,
+	.mce-btn.mce-active:hover i {
+		color: $dark-gray-800;
+	}
+
+	// Adjust padding to not cause a jump.
+	.mce-toolbar-grp > div {
+		padding: 1px 3px;
+	}
+
 	.editor-block-list__block-edit::before {
 		outline: $border-width solid #e2e4e7;
 	}
@@ -182,13 +196,22 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 	display: block;
 }
 
+// We don't want the ellipsis to overlap the classic toolbar, which it will due to position sticky.
+// So we move it to the right, and make room for it.
 @include break-small() {
 	.editor-block-list__block[data-type="core/freeform"] {
 		.editor-block-contextual-toolbar {
 			float: right;
 			margin-right: -$block-padding - $block-side-ui-clearance - $border-width;
-			transform: translateY(-#{ $block-padding - $border-width });
+			transform: translateY(-#{ $block-padding });
 			top: $block-padding;
+
+			.components-toolbar {
+				background: transparent;
+				border-top: none;
+				border-right: none;
+				border-bottom: none;
+			}
 		}
 
 		.mce-container.mce-toolbar.mce-stack-layout-item {


### PR DESCRIPTION
The classic block has received a few regressions recently. This PR aims to fix and polish a few.

Notably, the block More menu is now visible on the selected block, and is now part of the block toolbar. Due to the Classic block not having a block toolbar but its own style of toolbar, if we allow the More menu to sit where the block toolbar is, it will overlap and cover buttons once the sticky positioning kicks in. That's why we moved it on the right on the classic block. The visuals of that have been polished so it now looks more integrated.

There was a weird regression where a pressed button would receive a white icon color, which obv. isn't contrasty enough. This fixes that, though would like @iseulde input -- it looks like a skin file adds this white color, maybe we don't need that skin?

Finally, I tweaked some paddings a bit so the toolbar doesn't jump when selected & initialized.

![polish classic block](https://user-images.githubusercontent.com/1204802/45207598-a8ace680-b288-11e8-9d63-d20814946c01.gif)
