### PR TITLE
Update on Gallery Block. Replaced FormFileUpload with MediaPlaceholder.

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -11,7 +11,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	IconButton,
 	DropZone,
-	FormFileUpload,
 	PanelBody,
 	RangeControl,
 	SelectControl,
@@ -55,7 +54,8 @@ class GalleryEdit extends Component {
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.addFiles = this.addFiles.bind( this );
-		this.uploadFromFiles = this.uploadFromFiles.bind( this );
+		this.onAddMoreImages = this.onAddMoreImages.bind( this );
+		this.updateImagesAttribute = this.updateImagesAttribute.bind( this );
 
 		this.state = {
 			selectedImage: null,
@@ -123,10 +123,6 @@ class GalleryEdit extends Component {
 		} );
 	}
 
-	uploadFromFiles( event ) {
-		this.addFiles( event.target.files );
-	}
-
 	addFiles( files ) {
 		const currentImages = this.props.attributes.images || [];
 		const { noticeOperations, setAttributes } = this.props;
@@ -139,6 +135,21 @@ class GalleryEdit extends Component {
 				} );
 			},
 			onError: noticeOperations.createErrorNotice,
+		} );
+	}
+
+	onAddMoreImages( newImages ) {
+		if ( ! window.event ) { // from "Upload" option after newImages absolute paths have been generated
+			this.updateImagesAttribute( newImages );
+		} else if ( window.event.type === 'click' ) { // from "Media Library" option
+			this.updateImagesAttribute( newImages );
+		}
+	}
+
+	updateImagesAttribute( newImages ) {
+		const currentImages = this.props.attributes.images || [];
+		this.props.setAttributes( {
+			images: currentImages.concat( newImages.map( ( image ) => pick( image, [ 'url', 'link', 'alt', 'id', 'caption' ] ) ) ),
 		} );
 	}
 
@@ -253,16 +264,20 @@ class GalleryEdit extends Component {
 					) ) }
 					{ isSelected &&
 						<li className="blocks-gallery-item has-add-item-button">
-							<FormFileUpload
-								multiple
-								isLarge
-								className="block-library-gallery-add-item-button"
-								onChange={ this.uploadFromFiles }
+							<MediaPlaceholder
+								icon="format-gallery"
+								className={ className }
+								labels={ {
+									title: __( 'Gallery' ),
+									name: __( 'images' ),
+								} }
+								onSelect={ this.onAddMoreImages }
 								accept="image/*"
-								icon="insert"
-							>
-								{ __( 'Upload an image' ) }
-							</FormFileUpload>
+								type="*"
+								multiple
+								notices={ noticeUI }
+								onError={ noticeOperations.createErrorNotice }
+							/>
 						</li>
 					}
 				</ul>

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -53,31 +53,6 @@
 		}
 	}
 
-	.components-form-file-upload,
-	.components-button.block-library-gallery-add-item-button {
-		width: 100%;
-		height: 100%;
-	}
-
-	.components-button.block-library-gallery-add-item-button {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		box-shadow: none;
-		border: none;
-		border-radius: 0;
-		min-height: 100px;
-
-		& .dashicon {
-			margin-top: 10px;
-		}
-
-		&:hover,
-		&:focus {
-			border: $border-width solid $dark-gray-500;
-		}
-	}
-
 	.editor-rich-text .editor-rich-text__tinymce {
 		a {
 			color: $white;

--- a/packages/editor/src/components/media-upload/README.md
+++ b/packages/editor/src/components/media-upload/README.md
@@ -1,7 +1,7 @@
 MediaUpload
 ===========
 
-MediaUpload is a React component used to render a button that opens a the WordPress media modal.
+MediaUpload is a React component used to render a button that opens the WordPress media modal.
 
 ## Setup
 


### PR DESCRIPTION
## PROBLEM

**At the beginning**
Empty gallery block gives you 2 options;
	1. Upload images from computer
	2. Use images in media library

**In case you want to add more images**	
Used gallery block gives you 1 option;
	1. Upload images from computer
	
## SOLUTION

**In case you want to add more images**	
Used gallery block now gives you 2 options;
	1. Upload images from computer
	2. Use images in media library 
	
Solution to issue: https://github.com/WordPress/gutenberg/issues/8309

## Types of changes
Replaced FormFileUpload with MediaPlaceholder.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
