### PR TITLE
Add dark editor style support

### DIFF
--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -209,6 +209,13 @@ function mytheme_block_editor_styles() {
 add_action( 'enqueue_block_editor_assets', 'mytheme_block_editor_styles' );
 ```
 
+If your editor style relies on a dark background, you can add the following to invert the UI colors:
+
+```php
+add_theme_support( 'dark-theme' );
+```
+
+
 ### Basic colors
 
 You can style the editor like any other webpage. Here's how to change the background color and the font color to blue:

--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -213,10 +213,10 @@ If your editor style relies on a dark background, you can add the following to a
 
 ```php
 add_theme_support( 'editor-styles' );
-add_theme_support( 'dark-theme' );
+add_theme_support( 'dark-editor-style' );
 ```
 
-Note you don't need to add `add_theme_support( 'editor-styles' );` twice, but that rule does need to be present for the `dark-theme` rule to work.
+Note you don't need to add `add_theme_support( 'editor-styles' );` twice, but that rule does need to be present for the `dark-editor-style` rule to work.
 
 ### Basic colors
 

--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -209,12 +209,14 @@ function mytheme_block_editor_styles() {
 add_action( 'enqueue_block_editor_assets', 'mytheme_block_editor_styles' );
 ```
 
-If your editor style relies on a dark background, you can add the following to invert the UI colors:
+If your editor style relies on a dark background, you can add the following to adjust the color of the UI to work on dark backgrounds:
 
 ```php
+add_theme_support( 'editor-styles' );
 add_theme_support( 'dark-theme' );
 ```
 
+Note you don't need to add `add_theme_support( 'editor-styles' );` twice, but that rule does need to be present for the `dark-theme` rule to work.
 
 ### Basic colors
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -468,7 +468,7 @@ add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_b
  * @return string The $classes string, with gutenberg-editor-page appended.
  */
 function gutenberg_add_admin_body_class( $classes ) {
-	if ( current_theme_supports( 'editor-styles' ) && current_theme_supports( 'dark-theme' ) ) {
+	if ( current_theme_supports( 'editor-styles' ) && current_theme_supports( 'dark-editor-style' ) ) {
 		return "$classes gutenberg-editor-page is-fullscreen-mode is-dark-theme";
 	} else {
 		// Default to is-fullscreen-mode to avoid jumps in the UI.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -468,6 +468,10 @@ add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_b
  * @return string The $classes string, with gutenberg-editor-page appended.
  */
 function gutenberg_add_admin_body_class( $classes ) {
-	// Default to is-fullscreen-mode to avoid jumps in the UI.
-	return "$classes gutenberg-editor-page is-fullscreen-mode";
+	if ( current_theme_supports( 'editor-styles' ) && current_theme_supports( 'dark-theme' ) ) {
+		return "$classes gutenberg-editor-page is-fullscreen-mode is-dark-theme";
+	} else {
+		// Default to is-fullscreen-mode to avoid jumps in the UI.
+		return "$classes gutenberg-editor-page is-fullscreen-mode";
+	}
 }


### PR DESCRIPTION
This fixes #6451.

This PR enables a new command to themers. They can now add `add_theme_support( 'dark-theme' );` in order to ask the editing canvas to be friendly to dark themes.

What this does is add a body class to the editor, `is-dark-theme`, which enables already present color changes to the side UI and borders, that are friendly to dark themes.

To test, add a dark editor style, then enable support. For example, add this to your theme functions.php:

```
/**
 * Enqueue editor style in Gutenberg
 */

function navi_gutenberg_styles() {
	 wp_enqueue_style( 'navi-gutenberg', get_theme_file_uri( '/style-editor.css' ), false, '1.0', 'all' );
}
add_action( 'enqueue_block_editor_assets', 'navi_gutenberg_styles' );
add_theme_support( 'editor-styles' );
add_theme_support( 'dark-theme' );
```

In "style-editor.css", put the following:

```
/**
 * Editor style
 */

body.gutenberg-editor-page {
	background-color: #252526;
}

body.gutenberg-editor-page .editor-post-title__block,
body.gutenberg-editor-page .editor-post-title__input,
body.gutenberg-editor-page .editor-default-block-appender,
body.gutenberg-editor-page .editor-block-list__block {
	color: white;
}
```
Now test and see that the UI is usable.

Screenshots:

<img width="777" alt="screen shot 2018-09-07 at 11 53 39" src="https://user-images.githubusercontent.com/1204802/45212410-1e1eb400-b295-11e8-8636-124f6ee30ade.png">

<img width="728" alt="screen shot 2018-09-07 at 11 56 19" src="https://user-images.githubusercontent.com/1204802/45212411-1fe87780-b295-11e8-9aef-8b8d2f96fe61.png">
