### PR TITLE
Collapsible panels for the block's toolbar

### DIFF
--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -304,3 +304,16 @@
 	text-align: center;
 	font-size: $default-font-size;
 }
+
+@mixin dropdown-arrow() {
+	content: "";
+	pointer-events: none;
+	display: block;
+	position: absolute;
+	width: 0;
+	height: 0;
+	border-left: 3px solid transparent;
+	border-right: 3px solid transparent;
+	border-top: 5px solid currentColor;
+	right: 6px;
+}

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -150,6 +150,7 @@ class ParagraphBlock extends Component {
 			<Fragment>
 				<BlockControls>
 					<AlignmentToolbar
+						isCollapsed
 						value={ align }
 						onChange={ ( nextAlign ) => {
 							setAttributes( { align: nextAlign } );

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -150,7 +150,6 @@ class ParagraphBlock extends Component {
 			<Fragment>
 				<BlockControls>
 					<AlignmentToolbar
-						isCollapsed
 						value={ align }
 						onChange={ ( nextAlign ) => {
 							setAttributes( { align: nextAlign } );

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -13,7 +13,6 @@ import { DOWN } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import IconButton from '../icon-button';
-import Dashicon from '../dashicon';
 import Dropdown from '../dropdown';
 import { NavigableMenu } from '../navigable-container';
 
@@ -61,7 +60,7 @@ function DropdownMenu( {
 						label={ label }
 						tooltip={ label }
 					>
-						<Dashicon icon="arrow-down" />
+						<span className="components-dropdown-menu__indicator" />
 					</IconButton>
 				);
 			} }

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { flatMap } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,14 +22,21 @@ function DropdownMenu( {
 	label,
 	menuLabel,
 	controls,
+	className,
 } ) {
 	if ( ! controls || ! controls.length ) {
 		return null;
 	}
 
+	// Normalize controls to nested array of objects (sets of controls)
+	let controlSets = controls;
+	if ( ! Array.isArray( controlSets[ 0 ] ) ) {
+		controlSets = [ controlSets ];
+	}
+
 	return (
 		<Dropdown
-			className="components-dropdown-menu"
+			className={ classnames( 'components-dropdown-menu', className ) }
 			contentClassName="components-dropdown-menu__popover"
 			renderToggle={ ( { isOpen, onToggle } ) => {
 				const openOnArrowDown = ( event ) => {
@@ -64,26 +72,32 @@ function DropdownMenu( {
 						role="menu"
 						aria-label={ menuLabel }
 					>
-						{ controls.map( ( control, index ) => (
-							<IconButton
-								key={ index }
-								onClick={ ( event ) => {
-									if ( control.isDisabled ) {
-										return;
-									}
-									event.stopPropagation();
-									onClose();
-									if ( control.onClick ) {
-										control.onClick();
-									}
-								} }
-								className="components-dropdown-menu__menu-item"
-								icon={ control.icon }
-								role="menuitem"
-								disabled={ control.isDisabled }
-							>
-								{ control.title }
-							</IconButton>
+						{ flatMap( controlSets, ( controlSet, indexOfSet ) => (
+							controlSet.map( ( control, indexOfControl ) => (
+								<IconButton
+									key={ [ indexOfSet, indexOfControl ].join() }
+
+									onClick={ ( event ) => {
+										if ( control.isDisabled ) {
+											return;
+										}
+										event.stopPropagation();
+										onClose();
+										if ( control.onClick ) {
+											control.onClick();
+										}
+									} }
+									className={ classnames(
+										'components-dropdown-menu__menu-item',
+										{ 'has-separator': indexOfSet > 0 && indexOfControl === 0 }
+									) }
+									icon={ control.icon }
+									role="menuitem"
+									disabled={ control.isDisabled }
+								>
+									{ control.title }
+								</IconButton>
+							) )
 						) ) }
 					</NavigableMenu>
 				);

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -47,11 +47,7 @@ function DropdownMenu( {
 				};
 				return (
 					<IconButton
-						className={
-							classnames( 'components-dropdown-menu__toggle', {
-								'is-active': isOpen,
-							} )
-						}
+						className="components-dropdown-menu__toggle"
 						icon={ icon }
 						onClick={ onToggle }
 						onKeyDown={ openOnArrowDown }

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -76,7 +76,6 @@ function DropdownMenu( {
 							controlSet.map( ( control, indexOfControl ) => (
 								<IconButton
 									key={ [ indexOfSet, indexOfControl ].join() }
-
 									onClick={ ( event ) => {
 										if ( control.isDisabled ) {
 											return;
@@ -89,7 +88,10 @@ function DropdownMenu( {
 									} }
 									className={ classnames(
 										'components-dropdown-menu__menu-item',
-										{ 'has-separator': indexOfSet > 0 && indexOfControl === 0 }
+										{
+											'has-separator': indexOfSet > 0 && indexOfControl === 0,
+											'is-active': control.isActive,
+										},
 									) }
 									icon={ control.icon }
 									role="menuitem"

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -72,9 +72,6 @@ function DropdownMenu( {
 								<IconButton
 									key={ [ indexOfSet, indexOfControl ].join() }
 									onClick={ ( event ) => {
-										if ( control.isDisabled ) {
-											return;
-										}
 										event.stopPropagation();
 										onClose();
 										if ( control.onClick ) {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -38,6 +38,17 @@
 			background-color: $dark-gray-500;
 			color: $white;
 		}
+
+		.components-dropdown-menu__indicator {
+			display: inline-block;
+			margin-left: 10px;
+
+			// Add a dropdown arrow indicator.
+			&::after {
+				@include dropdown-arrow();
+				top: $icon-button-size-small / 2 + 1px;
+			}
+		}
 	}
 }
 .components-dropdown-menu__popover .components-popover__content {
@@ -57,11 +68,6 @@
 		border-radius: 0;
 		outline: none;
 		cursor: pointer;
-
-		.dashicon {
-			margin-right: 8px;
-		}
-
 
 		&.has-separator {
 			margin-top: 6px;

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -80,6 +80,10 @@
 			right: 0;
 			height: 1px;
 		}
+
+		&:not(:disabled).is-active > svg {
+			@include formatting-button-style__active;
+		}
 	}
 }
 

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -78,16 +78,24 @@
 			height: 1px;
 		}
 
-		&:hover:not(:disabled):not([aria-disabled="true"]):not(.is-default) {
-			@include formatting-button-style__hover();
-		}
-
-		&:not(:disabled):not([aria-disabled="true"]):not(.is-default).is-active {
-			@include formatting-button-style__active();
-		}
-
+		// Plain menu styles.
 		&:focus:not(:disabled):not([aria-disabled="true"]):not(.is-default) {
-			@include formatting-button-style__focus();
+			@include menu-style__focus();
+		}
+
+		// Formatting buttons
+		> svg {
+			border-radius: $radius-round-rectangle;
+
+			// This assumes 20x20px dashicons.
+			padding: 2px;
+			width: $icon-button-size-small;
+			height: $icon-button-size-small;
+			margin: -1px $grid-size -1px 0;
+		}
+
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default).is-active > svg {
+			@include formatting-button-style__active();
 		}
 	}
 }

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -7,12 +7,12 @@
 		margin: 0;
 		padding: 4px;
 		border: $border-width solid transparent;
-		border-radius: 0;
 		display: flex;
 		flex-direction: row;
 
 		&.is-active,
 		&.is-active:hover {
+			box-shadow: none;
 			background-color: $dark-gray-500;
 			color: $white;
 		}
@@ -26,7 +26,7 @@
 
 		&:hover,
 		&:focus,
-		&:not(:disabled):hover {
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 			box-shadow: none;
 			outline: none;
 			color: $dark-gray-500;
@@ -45,9 +45,8 @@
 }
 
 .components-dropdown-menu__menu {
-	// note that left is set by react in a style attribute
 	width: 100%;
-	padding: 3px 3px 0;
+	padding: 9px;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	line-height: $default-line-height;
@@ -61,6 +60,25 @@
 
 		.dashicon {
 			margin-right: 8px;
+		}
+
+
+		&.has-separator {
+			margin-top: 6px;
+			position: relative;
+			overflow: visible;
+		}
+
+		&.has-separator::before {
+			display: block;
+			content: "";
+			box-sizing: content-box;
+			background-color: $light-gray-500;
+			position: absolute;
+			top: -3px;
+			left: 0;
+			right: 0;
+			height: 1px;
 		}
 	}
 }

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -27,16 +27,7 @@
 		&:hover,
 		&:focus,
 		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
-			box-shadow: none;
-			outline: none;
-			color: $dark-gray-500;
-			border-color: $dark-gray-500;
-		}
-
-		&.is-active > svg,
-		&.is-active:hover > svg {
-			background-color: $dark-gray-500;
-			color: $white;
+			@include formatting-button-style__hover();
 		}
 
 		.components-dropdown-menu__indicator {
@@ -65,9 +56,9 @@
 	.components-dropdown-menu__menu-item {
 		width: 100%;
 		padding: 6px;
-		border-radius: 0;
 		outline: none;
 		cursor: pointer;
+		margin-bottom: $grid-size-small;
 
 		&.has-separator {
 			margin-top: 6px;
@@ -87,9 +78,16 @@
 			height: 1px;
 		}
 
-		&:not(:disabled).is-active > svg {
-			@include formatting-button-style__active;
+		&:hover:not(:disabled):not([aria-disabled="true"]):not(.is-default) {
+			@include formatting-button-style__hover();
+		}
+
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default).is-active {
+			@include formatting-button-style__active();
+		}
+
+		&:focus:not(:disabled):not([aria-disabled="true"]):not(.is-default) {
+			@include formatting-button-style__focus();
 		}
 	}
 }
-

--- a/packages/components/src/toolbar/index.js
+++ b/packages/components/src/toolbar/index.js
@@ -8,6 +8,7 @@ import { flatMap } from 'lodash';
  * Internal dependencies
  */
 import IconButton from '../icon-button';
+import DropdownMenu from '../dropdown-menu';
 import ToolbarContainer from './toolbar-container';
 import ToolbarButtonContainer from './toolbar-button-container';
 
@@ -41,7 +42,7 @@ import ToolbarButtonContainer from './toolbar-button-container';
  *
  * @return {ReactElement} The rendered toolbar.
  */
-function Toolbar( { controls = [], children, className } ) {
+function Toolbar( { controls = [], children, className, isCollapsed, icon, label } ) {
 	if (
 		( ! controls || ! controls.length ) &&
 		! children
@@ -53,6 +54,17 @@ function Toolbar( { controls = [], children, className } ) {
 	let controlSets = controls;
 	if ( ! Array.isArray( controlSets[ 0 ] ) ) {
 		controlSets = [ controlSets ];
+	}
+
+	if ( isCollapsed ) {
+		return (
+			<DropdownMenu
+				icon={ icon }
+				label={ label }
+				controls={ controlSets }
+				className={ classnames( 'components-toolbar', className ) }
+			/>
+		);
 	}
 
 	return (

--- a/packages/editor/src/components/alignment-toolbar/index.js
+++ b/packages/editor/src/components/alignment-toolbar/index.js
@@ -72,8 +72,8 @@ export default compose(
 		const { getBlockRootClientId, getEditorSettings } = select( 'core/editor' );
 		return {
 			isCollapsed: isCollapsed || ! isLargeViewport || (
-				getBlockRootClientId( clientId ) &&
-				! getEditorSettings().hasFixedToolbar
+				! getEditorSettings().hasFixedToolbar &&
+				getBlockRootClientId( clientId )
 			),
 		};
 	} ),

--- a/packages/editor/src/components/alignment-toolbar/index.js
+++ b/packages/editor/src/components/alignment-toolbar/index.js
@@ -1,8 +1,14 @@
 /**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Toolbar } from '@wordpress/components';
+import { withViewportMatch } from '@wordpress/viewport';
 
 const ALIGNMENT_CONTROLS = [
 	{
@@ -22,13 +28,18 @@ const ALIGNMENT_CONTROLS = [
 	},
 ];
 
-export default function AlignmentToolbar( { value, onChange } ) {
+function AlignmentToolbar( { isCollapsed, isLargeViewport, value, onChange } ) {
 	function applyOrUnset( align ) {
 		return () => onChange( value === align ? undefined : align );
 	}
 
+	const activeAlignment = find( ALIGNMENT_CONTROLS, ( control ) => control.align === value );
+
 	return (
 		<Toolbar
+			isCollapsed={ isCollapsed || ! isLargeViewport }
+			icon={ activeAlignment ? activeAlignment.icon : 'editor-alignleft' }
+			label={ __( 'Change Text Alignment' ) }
 			controls={ ALIGNMENT_CONTROLS.map( ( control ) => {
 				const { align } = control;
 				const isActive = ( value === align );
@@ -42,3 +53,5 @@ export default function AlignmentToolbar( { value, onChange } ) {
 		/>
 	);
 }
+
+export default withViewportMatch( { isLargeViewport: 'medium' } )( AlignmentToolbar );

--- a/packages/editor/src/components/alignment-toolbar/index.js
+++ b/packages/editor/src/components/alignment-toolbar/index.js
@@ -35,7 +35,7 @@ const ALIGNMENT_CONTROLS = [
 	},
 ];
 
-function AlignmentToolbar( { isCollapsed, value, onChange } ) {
+export function AlignmentToolbar( { isCollapsed, value, onChange } ) {
 	function applyOrUnset( align ) {
 		return () => onChange( value === align ? undefined : align );
 	}

--- a/packages/editor/src/components/alignment-toolbar/index.js
+++ b/packages/editor/src/components/alignment-toolbar/index.js
@@ -9,6 +9,13 @@ import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Toolbar } from '@wordpress/components';
 import { withViewportMatch } from '@wordpress/viewport';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { withBlockEditContext } from '../block-edit/context';
 
 const ALIGNMENT_CONTROLS = [
 	{
@@ -28,7 +35,7 @@ const ALIGNMENT_CONTROLS = [
 	},
 ];
 
-function AlignmentToolbar( { isCollapsed, isLargeViewport, value, onChange } ) {
+function AlignmentToolbar( { isCollapsed, value, onChange } ) {
 	function applyOrUnset( align ) {
 		return () => onChange( value === align ? undefined : align );
 	}
@@ -37,7 +44,7 @@ function AlignmentToolbar( { isCollapsed, isLargeViewport, value, onChange } ) {
 
 	return (
 		<Toolbar
-			isCollapsed={ isCollapsed || ! isLargeViewport }
+			isCollapsed={ isCollapsed }
 			icon={ activeAlignment ? activeAlignment.icon : 'editor-alignleft' }
 			label={ __( 'Change Text Alignment' ) }
 			controls={ ALIGNMENT_CONTROLS.map( ( control ) => {
@@ -54,4 +61,20 @@ function AlignmentToolbar( { isCollapsed, isLargeViewport, value, onChange } ) {
 	);
 }
 
-export default withViewportMatch( { isLargeViewport: 'medium' } )( AlignmentToolbar );
+export default compose(
+	withBlockEditContext( ( { clientId } ) => {
+		return {
+			clientId,
+		};
+	} ),
+	withViewportMatch( { isLargeViewport: 'medium' } ),
+	withSelect( ( select, { clientId, isLargeViewport, isCollapsed } ) => {
+		const { getBlockRootClientId, getEditorSettings } = select( 'core/editor' );
+		return {
+			isCollapsed: isCollapsed || ! isLargeViewport || (
+				getBlockRootClientId( clientId ) &&
+				! getEditorSettings().hasFixedToolbar
+			),
+		};
+	} ),
+)( AlignmentToolbar );

--- a/packages/editor/src/components/alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/alignment-toolbar/test/__snapshots__/index.js.snap
@@ -27,5 +27,7 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
       },
     ]
   }
+  icon="editor-alignleft"
+  label="Change Text Alignment"
 />
 `;

--- a/packages/editor/src/components/alignment-toolbar/test/index.js
+++ b/packages/editor/src/components/alignment-toolbar/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import AlignmentToolbar from '../';
+import { AlignmentToolbar } from '../';
 
 describe( 'AlignmentToolbar', () => {
 	const alignment = 'left';

--- a/packages/editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/editor/src/components/block-alignment-toolbar/index.js
@@ -79,8 +79,8 @@ export default compose(
 		return {
 			wideControlsEnabled: select( 'core/editor' ).getEditorSettings().alignWide,
 			isCollapsed: isCollapsed || ! isLargeViewport || (
-				getBlockRootClientId( clientId ) &&
-				! getEditorSettings().hasFixedToolbar
+				! getEditorSettings().hasFixedToolbar &&
+				getBlockRootClientId( clientId )
 			),
 		};
 	} ),

--- a/packages/editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/editor/src/components/block-alignment-toolbar/index.js
@@ -53,7 +53,7 @@ export function BlockAlignmentToolbar( { isCollapsed, value, onChange, controls 
 		<Toolbar
 			isCollapsed={ isCollapsed }
 			icon={ activeAlignment ? activeAlignment.icon : 'align-left' }
-			label={ __( 'Change Text Alignment' ) }
+			label={ __( 'Change Alignment' ) }
 			controls={
 				enabledControls.map( ( control ) => {
 					return {

--- a/packages/editor/src/components/block-alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/block-alignment-toolbar/test/__snapshots__/index.js.snap
@@ -24,5 +24,7 @@ exports[`BlockAlignmentToolbar should match snapshot 1`] = `
       },
     ]
   }
+  icon="align-left"
+  label="Change Alignment"
 />
 `;

--- a/packages/editor/src/components/block-switcher/style.scss
+++ b/packages/editor/src/components/block-switcher/style.scss
@@ -36,17 +36,8 @@
 
 	// Add a dropdown arrow indicator.
 	.editor-block-icon::after {
-		content: "";
-		pointer-events: none;
-		display: block;
-		position: absolute;
+		@include dropdown-arrow();
 		top: $icon-button-size-small / 2 - 1px;
-		width: 0;
-		height: 0;
-		border-left: 3px solid transparent;
-		border-right: 3px solid transparent;
-		border-top: 5px solid currentColor;
-		right: 6px;
 	}
 
 	.editor-block-switcher__transform {


### PR DESCRIPTION
closes #9075

This PR adds 

 - Support for "collapsible" toolbars using the `isCollapsed` prop
 - Support for collapsing text alignment toolbars
 - Auto-collapse text alignment toolbars on mobile
 - Always Collapse text alignment for the paragraph block.

I tried adding auto computation on whether or not to collapse the toolbar segments based on the available space. It turns out it's more challenging than I expected originally and may not be achievable in a not fragile way, I'm instead suggesting it should be "opt-in" like the paragraph block here or more simple computations like "mobile" automatically triggering collapsed panels.