### PR TITLE
chore: Embed block: remove unnecessary class from a placeholder

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -237,7 +237,7 @@ export function getEmbedEdit( title, icon ) {
 				<figure className={ classnames( className, 'wp-block-embed', { 'is-video': 'video' === type } ) }>
 					{ controls }
 					{ ( cannotPreview ) ? (
-						<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label } className="wp-block-embed">
+						<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label }>
 							<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>
 							<p className="components-placeholder__error">{ __( 'Previews for this are unavailable in the editor, sorry!' ) }</p>
 						</Placeholder>


### PR DESCRIPTION
Caused in https://github.com/WordPress/gutenberg/pull/9466.
## Description
The class wp-block-embed was repeated on the placeholder and the figure. This PR just removes the class from the placeholder.

## How has this been tested?
I verified there were no design changes when adding an embed with a preview not available e.g: https://github.com/WordPress/gutenberg/pull/9466.

