### PR TITLE
Fix typo in import

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -19,7 +19,7 @@ follow to add your own custom blocks to WordPress's editor interfaces.
 Install the module
 
 ```bash
-npm install @wordpress/bocks --save
+npm install @wordpress/blocks --save
 ```
 
 _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._


### PR DESCRIPTION
## Description
Just a lil typo :)

## How has this been tested?
I looked at the markdown

## Screenshots
N/A

## Types of changes
N/A

## Checklist:
- [ N/A] My code is tested.
- [ N/A] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
