### PR TITLE
Fix qs dependency typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2436,7 +2436,7 @@
 			"version": "file:packages/url",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
-				"qs": "^6.5.2s"
+				"qs": "^6.5.2"
 			}
 		},
 		"@wordpress/viewport": {
@@ -20576,7 +20576,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.1 (Unreleased)
+
+### Bug Fixes
+
+- Fix typo in the `qs` dependency definition in the `package.json`
+
 ## 2.0.0 (2018-09-05)
 
 ### Breaking Change

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -21,7 +21,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
-		"qs": "^6.5.2s"
+		"qs": "^6.5.2"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/8300#discussion_r215993271