### PR TITLE
[Fix] Gallery losing columns when alignments are applied

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -94,4 +94,12 @@
 		max-width: $content-width / 2;
 		width: 100%;
 	}
+
+	// Keep the display property consistent when alignments are applied
+	// to preserve columns
+	&.alignleft,
+	&.aligncenter,
+	&.alignright {
+		display: flex;
+	}
 }


### PR DESCRIPTION
## Description
This PR closes #9533 which reports that the "Gallery" block loses the assigned number of columns when alignments are applied.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the "Gallery" block and added 3 images.
3. Applied an alignment setting, e.g. "Center".
4. Made sure "Gallery" block doesn't lose the assigned number of columns. 

## Screenshots <!-- if applicable -->
![pull-9533-min](https://user-images.githubusercontent.com/20284937/45231398-a6c93e80-b2ed-11e8-8f64-87fd5a032b46.gif)

## Types of changes
This PR applies styles which keep the `display` property of the gallery block as `flex` (which makes the column functionality work) even if alignment settings are applied (which changes the value to `block` and `inline-block` in different cases).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
