### PR TITLE
utils: mediaUpload: Pass all available properties in the media object

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -22,6 +22,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - `getMetaBoxes` selector (`core/edit-post`) has been removed. Use `getActiveMetaBoxLocations` selector (`core/edit-post`) instead.
 - `getMetaBox` selector (`core/edit-post`) has been removed. Use `isMetaBoxLocationActive` selector (`core/edit-post`) instead.
 - Attribute type coercion has been removed. Omit the source to preserve type via serialized comment demarcation.
+- `mediaDetails` in object passed to `onFileChange` callback of `wp.editor.mediaUpload`. Please use `media_details` property instead.
 
 ## 4.1.0
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -44,6 +44,8 @@ export function defaultColumnsNumber( attributes ) {
 	return Math.min( 3, attributes.images.length );
 }
 
+export const RELEVANT_MEDIA_FIELDS = [ 'alt', 'caption', 'id', 'link', 'url' ];
+
 class GalleryEdit extends Component {
 	constructor() {
 		super( ...arguments );
@@ -87,7 +89,7 @@ class GalleryEdit extends Component {
 
 	onSelectImages( images ) {
 		this.props.setAttributes( {
-			images: images.map( ( image ) => pick( image, [ 'alt', 'caption', 'id', 'link', 'url' ] ) ),
+			images: images.map( ( image ) => pick( image, RELEVANT_MEDIA_FIELDS ) ),
 		} );
 	}
 
@@ -135,8 +137,9 @@ class GalleryEdit extends Component {
 			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList: files,
 			onFileChange: ( images ) => {
+				const imagesNormalized = images.map( ( image ) => pick( image, RELEVANT_MEDIA_FIELDS ) );
 				setAttributes( {
-					images: currentImages.concat( images ),
+					images: currentImages.concat( imagesNormalized ),
 				} );
 			},
 			onError: noticeOperations.createErrorNotice,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -44,7 +44,10 @@ export function defaultColumnsNumber( attributes ) {
 	return Math.min( 3, attributes.images.length );
 }
 
-export const RELEVANT_MEDIA_FIELDS = [ 'alt', 'caption', 'id', 'link', 'url' ];
+const RELEVANT_MEDIA_FIELDS = [ 'alt', 'caption', 'id', 'link', 'url' ];
+export const pickRelevantMediaFiles = ( image ) => {
+	return pick( image, RELEVANT_MEDIA_FIELDS );
+};
 
 class GalleryEdit extends Component {
 	constructor() {
@@ -89,7 +92,7 @@ class GalleryEdit extends Component {
 
 	onSelectImages( images ) {
 		this.props.setAttributes( {
-			images: images.map( ( image ) => pick( image, RELEVANT_MEDIA_FIELDS ) ),
+			images: images.map( ( image ) => pickRelevantMediaFiles( image ) ),
 		} );
 	}
 
@@ -137,7 +140,7 @@ class GalleryEdit extends Component {
 			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList: files,
 			onFileChange: ( images ) => {
-				const imagesNormalized = images.map( ( image ) => pick( image, RELEVANT_MEDIA_FIELDS ) );
+				const imagesNormalized = images.map( ( image ) => pickRelevantMediaFiles( image ) );
 				setAttributes( {
 					images: currentImages.concat( imagesNormalized ),
 				} );

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, every } from 'lodash';
+import { filter, every, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,7 +14,7 @@ import { createBlobURL } from '@wordpress/blob';
 /**
  * Internal dependencies
  */
-import { default as edit, defaultColumnsNumber } from './edit';
+import { default as edit, defaultColumnsNumber, RELEVANT_MEDIA_FIELDS } from './edit';
 
 const blockAttributes = {
 	images: {
@@ -134,7 +134,9 @@ export const settings = {
 					} );
 					mediaUpload( {
 						filesList: files,
-						onFileChange: ( images ) => onChange( block.clientId, { images } ),
+						onFileChange: ( images ) => onChange( block.clientId, {
+							images: images.map( ( image ) => pick( image, RELEVANT_MEDIA_FIELDS ) ),
+						} ),
 						allowedTypes: [ 'image' ],
 					} );
 					return block;

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, every, pick } from 'lodash';
+import { filter, every } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,7 +14,7 @@ import { createBlobURL } from '@wordpress/blob';
 /**
  * Internal dependencies
  */
-import { default as edit, defaultColumnsNumber, RELEVANT_MEDIA_FIELDS } from './edit';
+import { default as edit, defaultColumnsNumber, pickRelevantMediaFiles } from './edit';
 
 const blockAttributes = {
 	images: {
@@ -135,7 +135,7 @@ export const settings = {
 					mediaUpload( {
 						filesList: files,
 						onFileChange: ( images ) => onChange( block.clientId, {
-							images: images.map( ( image ) => pick( image, RELEVANT_MEDIA_FIELDS ) ),
+							images: images.map( ( image ) => pickRelevantMediaFiles( image ) ),
 						} ),
 						allowedTypes: [ 'image' ],
 					} );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -55,6 +55,7 @@ const LINK_DESTINATION_MEDIA = 'media';
 const LINK_DESTINATION_ATTACHMENT = 'attachment';
 const LINK_DESTINATION_CUSTOM = 'custom';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
+export const RELEVANT_MEDIA_FIELDS = [ 'alt', 'caption', 'id', 'url' ];
 
 class ImageEdit extends Component {
 	constructor() {
@@ -87,7 +88,7 @@ class ImageEdit extends Component {
 				mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ image ] ) => {
-						setAttributes( { ...image } );
+						setAttributes( { ...pick( image, RELEVANT_MEDIA_FIELDS ) } );
 					},
 					allowedTypes: ALLOWED_MEDIA_TYPES,
 				} );
@@ -121,7 +122,7 @@ class ImageEdit extends Component {
 			return;
 		}
 		this.props.setAttributes( {
-			...pick( media, [ 'alt', 'id', 'caption', 'url' ] ),
+			...pick( media, RELEVANT_MEDIA_FIELDS ),
 			width: undefined,
 			height: undefined,
 		} );

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -33,6 +33,11 @@ export default function( {
 	onFileChange,
 	allowedType,
 } ) {
+	deprecated( 'mediaDetails in object passed to onFileChange callback of wp.editor.mediaUpload', {
+		version: '4.2',
+		alternative: 'media_details property containing exactly the property as returned by the rest api',
+	} );
+
 	const {
 		getCurrentPostId,
 		getEditorSettings,

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -10,6 +10,7 @@ import {
 	includes,
 	map,
 	noop,
+	omit,
 	some,
 	startsWith,
 } from 'lodash';
@@ -163,10 +164,9 @@ export function mediaUpload( {
 		return createMediaFromFile( mediaFile, additionalData )
 			.then( ( savedMedia ) => {
 				const mediaObject = {
+					...omit( savedMedia, [ 'alt_text', 'source_url' ] ),
 					alt: savedMedia.alt_text,
 					caption: get( savedMedia, [ 'caption', 'raw' ], '' ),
-					id: savedMedia.id,
-					link: savedMedia.link,
 					title: savedMedia.title.raw,
 					url: savedMedia.source_url,
 					mediaDetails: {},


### PR DESCRIPTION
## Description
Initially, mediaUpload util only passed to the callback function of the invoker a simple object with the URL of the file, a caption, and an alt. With time needs for other props appeared and the function was changed to add the missing props. The most recent need was mediaDetails.sizes.
Now with the most recent updates in https://github.com/WordPress/gutenberg/pull/9416 I discovered I need yet another property the media type.
I thought a little bit and I think the function should return all the available properties. Omitting props will limit the things blocks can do and will probably force them to use their own media upload if they really need a prop we are omitting.




## How has this been tested?
I checked that blocks where we upload files (image, gallery, video, audio and file) the uploads still work as before.


Required for: https://github.com/WordPress/gutenberg/pull/9416