### PR TITLE
Media: Refactor MediaUpload, MediaPlaceholder and mediaUpload to support arrays with multiple supported types.

### DIFF
--- a/edit-post/hooks/components/media-upload/index.js
+++ b/edit-post/hooks/components/media-upload/index.js
@@ -9,6 +9,7 @@ import { castArray, pick } from 'lodash';
 import { parseWithAttributeSchema } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import deprecated from '@wordpress/deprecated';
 
 // Getter for the sake of unit tests.
 const getGalleryDetailsMediaFrame = () => {
@@ -75,7 +76,15 @@ const getAttachmentsCollection = ( ids ) => {
 };
 
 class MediaUpload extends Component {
-	constructor( { multiple = false, type, gallery = false, title = __( 'Select or Upload Media' ), modalClass, value } ) {
+	constructor( {
+		allowedTypes,
+		type: deprecatedType,
+		multiple = false,
+		gallery = false,
+		title = __( 'Select or Upload Media' ),
+		modalClass,
+		value,
+	} ) {
 		super( ...arguments );
 		this.openModal = this.openModal.bind( this );
 		this.onOpen = this.onOpen.bind( this );
@@ -83,6 +92,19 @@ class MediaUpload extends Component {
 		this.onUpdate = this.onUpdate.bind( this );
 		this.onClose = this.onClose.bind( this );
 		this.processMediaCaption = this.processMediaCaption.bind( this );
+
+		let allowedTypesToUse = allowedTypes;
+		if ( ! allowedTypes && deprecatedType ) {
+			deprecated( 'type property of wp.editor.MediaUpload', {
+				version: '4.2',
+				alternative: 'allowedTypes property containing an array with the allowedTypes or do not pass any property if all types are allowed',
+			} );
+			if ( deprecatedType === '*' ) {
+				allowedTypesToUse = undefined;
+			} else {
+				allowedTypesToUse = [ deprecatedType ];
+			}
+		}
 
 		if ( gallery ) {
 			const currentState = value ? 'gallery-edit' : 'gallery';
@@ -93,7 +115,7 @@ class MediaUpload extends Component {
 				multiple,
 			} );
 			this.frame = new GalleryDetailsMediaFrame( {
-				mimeType: type,
+				mimeType: allowedTypesToUse,
 				state: currentState,
 				multiple,
 				selection,
@@ -108,8 +130,8 @@ class MediaUpload extends Component {
 				},
 				multiple,
 			};
-			if ( !! type ) {
-				frameConfig.library = { type };
+			if ( !! allowedTypesToUse ) {
+				frameConfig.library = { type: allowedTypesToUse };
 			}
 
 			this.frame = wp.media( frameConfig );

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -21,6 +21,8 @@ import {
 } from '@wordpress/editor';
 import { getBlobByURL } from '@wordpress/blob';
 
+const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+
 class AudioEdit extends Component {
 	constructor() {
 		super( ...arguments );
@@ -52,7 +54,7 @@ class AudioEdit extends Component {
 						this.setState( { editing: true } );
 						noticeOperations.createErrorNotice( e );
 					},
-					allowedType: 'audio',
+					allowedTypes: ALLOWED_MEDIA_TYPES,
 				} );
 			}
 		}
@@ -109,7 +111,7 @@ class AudioEdit extends Component {
 					onSelect={ onSelectAudio }
 					onSelectURL={ this.onSelectURL }
 					accept="audio/*"
-					type="audio"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ this.props.attributes }
 					notices={ noticeUI }
 					onError={ noticeOperations.createErrorNotice }

--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -54,6 +54,8 @@ const blockAttributes = {
 
 export const name = 'core/cover-image';
 
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
 export const settings = {
 	title: __( 'Cover Image' ),
 
@@ -157,7 +159,7 @@ export const settings = {
 					<Toolbar>
 						<MediaUpload
 							onSelect={ onSelectImage }
-							type="image"
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							value={ id }
 							render={ ( { open } ) => (
 								<IconButton
@@ -216,7 +218,7 @@ export const settings = {
 						} }
 						onSelect={ onSelectImage }
 						accept="image/*"
-						type="image"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						notices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }
 					/>

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -56,7 +56,6 @@ class FileEdit extends Component {
 			const file = getBlobByURL( href );
 
 			mediaUpload( {
-				allowedType: '*',
 				filesList: [ file ],
 				onFileChange: ( [ media ] ) => this.onSelectFile( media ),
 				onError: ( message ) => {
@@ -149,7 +148,6 @@ class FileEdit extends Component {
 					notices={ noticeUI }
 					onError={ noticeOperations.createErrorNotice }
 					accept="*"
-					type="*"
 				/>
 			);
 		}
@@ -174,7 +172,6 @@ class FileEdit extends Component {
 					<Toolbar>
 						<MediaUpload
 							onSelect={ this.onSelectFile }
-							type="*"
 							value={ id }
 							render={ ( { open } ) => (
 								<IconButton

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -38,6 +38,7 @@ const linkOptions = [
 	{ value: 'media', label: __( 'Media File' ) },
 	{ value: 'none', label: __( 'None' ) },
 ];
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 export function defaultColumnsNumber( attributes ) {
 	return Math.min( 3, attributes.images.length );
@@ -131,7 +132,7 @@ class GalleryEdit extends Component {
 		const currentImages = this.props.attributes.images || [];
 		const { noticeOperations, setAttributes } = this.props;
 		mediaUpload( {
-			allowedType: 'image',
+			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList: files,
 			onFileChange: ( images ) => {
 				setAttributes( {
@@ -168,7 +169,7 @@ class GalleryEdit extends Component {
 					<Toolbar>
 						<MediaUpload
 							onSelect={ this.onSelectImages }
-							type="image"
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							multiple
 							gallery
 							value={ images.map( ( img ) => img.id ) }
@@ -199,7 +200,7 @@ class GalleryEdit extends Component {
 						} }
 						onSelect={ this.onSelectImages }
 						accept="image/*"
-						type="image"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						multiple
 						notices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -136,7 +136,7 @@ export const settings = {
 					mediaUpload( {
 						filesList: files,
 						onFileChange: ( images ) => onChange( block.clientId, { images } ),
-						allowedType: 'image',
+						allowedTypes: [ 'image' ],
 					} );
 					return block;
 				},

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -54,6 +54,7 @@ const LINK_DESTINATION_NONE = 'none';
 const LINK_DESTINATION_MEDIA = 'media';
 const LINK_DESTINATION_ATTACHMENT = 'attachment';
 const LINK_DESTINATION_CUSTOM = 'custom';
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 class ImageEdit extends Component {
 	constructor() {
@@ -88,7 +89,7 @@ class ImageEdit extends Component {
 					onFileChange: ( [ image ] ) => {
 						setAttributes( { ...image } );
 					},
-					allowedType: 'image',
+					allowedTypes: ALLOWED_MEDIA_TYPES,
 				} );
 			}
 		}
@@ -221,7 +222,7 @@ class ImageEdit extends Component {
 				<Toolbar>
 					<MediaUpload
 						onSelect={ this.onSelectImage }
-						type="image"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						value={ id }
 						render={ ( { open } ) => (
 							<IconButton
@@ -251,7 +252,7 @@ class ImageEdit extends Component {
 						notices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }
 						accept="image/*"
-						type="image"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
 					/>
 				</Fragment>
 			);

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -24,6 +24,8 @@ import {
 } from '@wordpress/editor';
 import { getBlobByURL } from '@wordpress/blob';
 
+const ALLOWED_MEDIA_TYPES = [ 'video' ];
+
 class VideoEdit extends Component {
 	constructor() {
 		super( ...arguments );
@@ -55,7 +57,7 @@ class VideoEdit extends Component {
 						this.setState( { editing: true } );
 						noticeOperations.createErrorNotice( message );
 					},
-					allowedType: 'video',
+					allowedTypes: ALLOWED_MEDIA_TYPES,
 				} );
 			}
 		}
@@ -138,7 +140,7 @@ class VideoEdit extends Component {
 					onSelect={ onSelectVideo }
 					onSelectURL={ this.onSelectURL }
 					accept="video/*"
-					type="video"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ this.props.attributes }
 					notices={ noticeUI }
 					onError={ noticeOperations.createErrorNotice }
@@ -198,7 +200,7 @@ class VideoEdit extends Component {
 							<MediaUpload
 								title={ __( 'Select Poster Image' ) }
 								onSelect={ this.onSelectPoster }
-								type="image"
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
 								render={ ( { open } ) => (
 									<Button isDefault onClick={ open }>
 										{ ! this.props.attributes.poster ? __( 'Select Poster Image' ) : __( 'Replace image' ) }

--- a/packages/editor/src/components/media-upload/README.md
+++ b/packages/editor/src/components/media-upload/README.md
@@ -29,11 +29,13 @@ You can check how this component is implemented for the edit post page using `wp
 import { Button } from '@wordpress/components';
 import { MediaUpload } from '@wordpress/editor';
 
+const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+
 function MyMediaUploader() {
 	return (
 		<MediaUpload
 			onSelect={ ( media ) => console.log( 'selected ' + media.length ) }
-			type="image"
+			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			value={ mediaId }
 			render={ ( { open } ) => (
 				<Button onClick={ open }>
@@ -49,11 +51,14 @@ function MyMediaUploader() {
 
 The component accepts the following props. Props not included in this set will be applied to the element wrapping Popover content.
 
-### type
+### allowedTypes
 
-Type of the media to upload/select from the media library (image, video, audio).
+Array withe the types of the media to upload/select from the media library.
+Each type is a string that can contain the general mime type e.g: 'image', 'audio', 'text',
+or the complete mime type e.g: 'audio/mpeg', 'image/gif'.
+If allowedTypes is unset all mime types should be allowed.
 
-- Type: `String`
+- Type: `Array`
 - Required: No
 
 ### multiple

--- a/packages/editor/src/components/media-upload/README.md
+++ b/packages/editor/src/components/media-upload/README.md
@@ -53,7 +53,7 @@ The component accepts the following props. Props not included in this set will b
 
 ### allowedTypes
 
-Array withe the types of the media to upload/select from the media library.
+Array with the types of the media to upload/select from the media library.
 Each type is a string that can contain the general mime type e.g: 'image', 'audio', 'text',
 or the complete mime type e.g: 'audio/mpeg', 'image/gif'.
 If allowedTypes is unset all mime types should be allowed.

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -18,6 +18,8 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import PostFeaturedImageCheck from './check';
 import MediaUpload from '../media-upload';
 
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
 // Used when labels from post type were not yet loaded or when they are not present.
 const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
 const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
@@ -46,7 +48,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 					<MediaUpload
 						title={ __( 'Set featured image' ) }
 						onSelect={ onUpdateImage }
-						type="image"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						modalClass="editor-post-featured-image__media-modal"
 						render={ ( { open } ) => (
 							<Button className="editor-post-featured-image__preview" onClick={ open }>
@@ -67,7 +69,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 				<MediaUpload
 					title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
 					onSelect={ onUpdateImage }
-					type="image"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					modalClass="editor-post-featured-image__media-modal"
 					render={ ( { open } ) => (
 						<Button onClick={ open } isDefault isLarge>
@@ -81,7 +83,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 						<MediaUpload
 							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
-							type="image"
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button className="editor-post-featured-image__toggle" onClick={ open }>

--- a/packages/editor/src/components/rich-text/core-tokens/image/index.js
+++ b/packages/editor/src/components/rich-text/core-tokens/image/index.js
@@ -10,6 +10,8 @@ import MediaUpload from '../../../media-upload';
 
 export const name = 'core/image';
 
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
 export const settings = {
 	id: 'image',
 
@@ -22,7 +24,7 @@ export const settings = {
 	edit( { onSave } ) {
 		return (
 			<MediaUpload
-				type="image"
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				onSelect={ ( media ) => onSave( media ) }
 				onClose={ () => onSave( null ) }
 				render={ ( { open } ) => {

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -1,7 +1,18 @@
 /**
  * External Dependencies
  */
-import { compact, flatMap, forEach, get, has, includes, map, noop, startsWith } from 'lodash';
+import {
+	compact,
+	flatMap,
+	forEach,
+	get,
+	has,
+	includes,
+	map,
+	noop,
+	some,
+	startsWith,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -40,23 +51,23 @@ export function getMimeTypesArray( wpMimeTypesObject ) {
  *
  *	TODO: future enhancement to add an upload indicator.
  *
- * @param   {Object}   $0                   Parameters object passed to the function.
- * @param   {string}   $0.allowedType       The type of media that can be uploaded, or '*' to allow all.
- * @param   {?Object}  $0.additionalData    Additional data to include in the request.
- * @param   {Array}    $0.filesList         List of files.
- * @param   {?number}  $0.maxUploadFileSize Maximum upload size in bytes allowed for the site.
- * @param   {Function} $0.onError           Function called when an error happens.
- * @param   {Function} $0.onFileChange      Function called each time a file or a temporary representation of the file is available.
- * @param   {?Object} $0.allowedMimeTypes   List of allowed mime types and file extensions.
+ * @param   {Object}   $0                    Parameters object passed to the function.
+ * @param   {?Array}   $0.allowedTypes       Array with the types of media that can be uploaded, if unset all types are allowed.
+ * @param   {?Object}  $0.additionalData     Additional data to include in the request.
+ * @param   {Array}    $0.filesList          List of files.
+ * @param   {?number}  $0.maxUploadFileSize  Maximum upload size in bytes allowed for the site.
+ * @param   {Function} $0.onError            Function called when an error happens.
+ * @param   {Function} $0.onFileChange       Function called each time a file or a temporary representation of the file is available.
+ * @param   {?Object}  $0.wpAllowedMimeTypes List of allowed mime types and file extensions.
  */
 export function mediaUpload( {
-	allowedType,
+	allowedTypes,
 	additionalData = {},
 	filesList,
 	maxUploadFileSize,
 	onError = noop,
 	onFileChange,
-	allowedMimeTypes = null,
+	wpAllowedMimeTypes = null,
 } ) {
 	// Cast filesList to array
 	const files = [ ...filesList ];
@@ -70,11 +81,24 @@ export function mediaUpload( {
 
 	// Allowed type specified by consumer
 	const isAllowedType = ( fileType ) => {
-		return ( allowedType === '*' ) || startsWith( fileType, `${ allowedType }/` );
+		if ( ! allowedTypes ) {
+			return true;
+		}
+		return some(
+			allowedTypes,
+			( allowedType ) => {
+				// If a complete mimetype is specified verify if it matches exactly the mime type of the file.
+				if ( includes( allowedType, '/' ) ) {
+					return allowedType === fileType;
+				}
+				// Otherwise a general mime type is used and we should verify if the file mimetype starts with it.
+				return startsWith( fileType, `${ allowedType }/` );
+			}
+		);
 	};
 
 	// Allowed types for the current WP_User
-	const allowedMimeTypesForUser = getMimeTypesArray( allowedMimeTypes );
+	const allowedMimeTypesForUser = getMimeTypesArray( wpAllowedMimeTypes );
 	const isAllowedMimeTypeForUser = ( fileType ) => {
 		return includes( allowedMimeTypesForUser, fileType );
 	};

--- a/packages/editor/src/utils/media-upload/test/media-upload.js
+++ b/packages/editor/src/utils/media-upload/test/media-upload.js
@@ -69,9 +69,8 @@ describe( 'mediaUpload', () => {
 	it( 'should work as expected if allowedTypes contains a complete mime type string and the validation has success', () => {
 		// When the upload has success we get errors because we don't have available on the test environment
 		// all the functions required by mediaUpload.
-		// We know that when a validation success the function tries to creat a temporary url for the file
+		// We know that when a validation success the function tries to create a temporary url for the file
 		// so we use that function to test the validation success.
-
 		const onError = jest.fn();
 		const testFile = {
 			url: 'https://cldup.com/uuUqE_dXzy.mp3',
@@ -90,6 +89,7 @@ describe( 'mediaUpload', () => {
 		expect( createObjectURL ).not.toHaveBeenCalled();
 		expect( onError ).not.toHaveBeenCalled();
 	} );
+
 	it( 'should error if allowedTypes contains multiple types and the validation fails', () => {
 		const onError = jest.fn();
 		const testFile = {
@@ -115,9 +115,8 @@ describe( 'mediaUpload', () => {
 	it( 'should work as expected if allowedTypes contains multiple types and the validation has success', () => {
 		// When the upload has success we get errors because we don't have available on the test environment
 		// all the functions required by mediaUpload.
-		// We know that when a validation success the function tries to creat a temporary url for the file
+		// We know that when a validation success the function tries to create a temporary url for the file
 		// so we use that function to test the validation success.
-
 		const onError = jest.fn();
 		const testFile = {
 			url: 'https://cldup.com/uuUqE_dXzy.mp3',


### PR DESCRIPTION
mediaUpload util only allowed the uploads of a single type or all types. That makes impossible for a block to accept just the upload of images and videos.

This PR enhances the mediaUpload util and related components ( MediaUpload, MediaPlaceholder) to accept an allowedTypes prop with an array of all the supported types.

## Testing
I tried to upload to each media block and verified no error occurred.
I used the Test Media Upload block available in https://gist.github.com/jorgefilipecosta/7a925ac31448832f00fceb0b0caed423, and checked I can correctly upload images and videos using the button and drag&drop. I checked that on the media library only images and videos are listed and that we can correctly select items of this types. The type string passed by MediaPlaceholder is the same for the media library and the mediaUpload function. 

Required for: https://github.com/WordPress/gutenberg/pull/9416