### PR TITLE
Do not assume that singular form in _n() is used just for single item

### DIFF
--- a/edit-post/components/sidebar/settings-header/index.js
+++ b/edit-post/components/sidebar/settings-header/index.js
@@ -32,7 +32,11 @@ const SettingsHeader = ( { count, openDocumentSettings, openBlockSettings, sideb
 				className={ `edit-post-sidebar__panel-tab ${ sidebarName === 'edit-post/block' ? 'is-active' : '' }` }
 				aria-label={ __( 'Block settings' ) }
 			>
-				{ 1 === count ? __( 'Block' ) : sprintf( _n( '%d Block', '%d Blocks', count ), count ) }
+				{ (
+					1 === count ?
+						__( 'Block' ) :
+						sprintf( _n( '%d Block', '%d Blocks', count ), count )
+				) }
 			</button>
 		</SidebarHeader>
 	);

--- a/edit-post/components/sidebar/settings-header/index.js
+++ b/edit-post/components/sidebar/settings-header/index.js
@@ -32,7 +32,7 @@ const SettingsHeader = ( { count, openDocumentSettings, openBlockSettings, sideb
 				className={ `edit-post-sidebar__panel-tab ${ sidebarName === 'edit-post/block' ? 'is-active' : '' }` }
 				aria-label={ __( 'Block settings' ) }
 			>
-				{ sprintf( _n( 'Block', '%d Blocks', count ), count ) }
+				{ 1 === count ? __( 'Block' ) : sprintf( _n( '%d Block', '%d Blocks', count ), count ) }
 			</button>
 		</SidebarHeader>
 	);

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -74,7 +74,7 @@ export class BlockSwitcher extends Component {
 							onToggle();
 						}
 					};
-					const label = sprintf( _n( 'Change block type', 'Change type of %d blocks', blocks.length ), blocks.length );
+					const label = 1 === blocks.length ? __( 'Change block type' ) : sprintf( _n( 'Change type of %d block', 'Change type of %d blocks', blocks.length ), blocks.length );
 
 					return (
 						<Toolbar>

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -74,7 +74,18 @@ export class BlockSwitcher extends Component {
 							onToggle();
 						}
 					};
-					const label = 1 === blocks.length ? __( 'Change block type' ) : sprintf( _n( 'Change type of %d block', 'Change type of %d blocks', blocks.length ), blocks.length );
+					const label = (
+						1 === blocks.length ?
+							__( 'Change block type' ) :
+							sprintf(
+								_n(
+									'Change type of %d block',
+									'Change type of %d blocks',
+									blocks.length
+								),
+								blocks.length
+							)
+					);
 
 					return (
 						<Toolbar>


### PR DESCRIPTION
## Description
As explained in [this comment](https://developer.wordpress.org/reference/functions/_n/#comment-2397) (and linked pages), in languages other than English, singular form in `_n()` can be used when there is more than one item, not just for one item. 

In two cases, we use placeholder in plural form in `_n()` but not in singular form, because we assume that it’ll be used for just one item. 

This PR splits those strings so that we have separate strings when there is just one item and for more than one item, and always include placeholder in `_n()` singular forms.

## How has this been tested?
By selecting different number of blocks after running `npm run build`. Also `npm run test`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
