### PR TITLE
Rename the Speaker block to Speaker Deck

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -694,6 +694,7 @@ export const others = [
 		patterns: [ /^https?:\/\/(www\.)?smugmug\.com\/.+/i ],
 	},
 	{
+		// Deprecated in favour of the core-embed/speaker-deck block.
 		name: 'core-embed/speaker',
 		settings: getEmbedBlockSettings( {
 			title: 'Speaker',
@@ -701,6 +702,14 @@ export const others = [
 			supports: {
 				inserter: false,
 			},
+		} ),
+		patterns: [],
+	},
+	{
+		name: 'core-embed/speaker-deck',
+		settings: getEmbedBlockSettings( {
+			title: 'Speaker Deck',
+			icon: embedContentIcon,
 			transform: [ {
 				type: 'block',
 				blocks: [ 'core-embed/speaker' ],
@@ -710,14 +719,6 @@ export const others = [
 					} );
 				},
 			} ],
-		} ),
-		patterns: [ /^https?:\/\/(www\.)?speakerdeck\.com\/.+/i ],
-	},
-	{
-		name: 'core-embed/speaker-deck',
-		settings: getEmbedBlockSettings( {
-			title: 'Speaker Deck',
-			icon: embedContentIcon,
 		} ),
 		patterns: [ /^https?:\/\/(www\.)?speakerdeck\.com\/.+/i ],
 	},

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -331,7 +331,7 @@ const embedAttributes = {
 	},
 };
 
-function getEmbedBlockSettings( { title, description, icon, category = 'embed', transforms, keywords = [] } ) {
+function getEmbedBlockSettings( { title, description, icon, category = 'embed', transforms, keywords = [], supports = {} } ) {
 	// translators: %s: Name of service (e.g. VideoPress, YouTube)
 	const blockDescription = description || sprintf( __( 'Add a block that displays content pulled from other sites, like Twitter, Instagram or YouTube.' ), title );
 	return {
@@ -344,6 +344,7 @@ function getEmbedBlockSettings( { title, description, icon, category = 'embed', 
 
 		supports: {
 			align: true,
+			...supports,
 		},
 
 		transforms,
@@ -697,6 +698,26 @@ export const others = [
 		settings: getEmbedBlockSettings( {
 			title: 'Speaker',
 			icon: embedAudioIcon,
+			supports: {
+				inserter: false,
+			},
+			transform: [ {
+				type: 'block',
+				blocks: [ 'core-embed/speaker' ],
+				transform: ( content ) => {
+					return createBlock( 'core-embed/speaker-deck', {
+						content,
+					} );
+				},
+			} ],
+		} ),
+		patterns: [ /^https?:\/\/(www\.)?speakerdeck\.com\/.+/i ],
+	},
+	{
+		name: 'core-embed/speaker-deck',
+		settings: getEmbedBlockSettings( {
+			title: 'Speaker Deck',
+			icon: embedContentIcon,
 		} ),
 		patterns: [ /^https?:\/\/(www\.)?speakerdeck\.com\/.+/i ],
 	},


### PR DESCRIPTION
For some reason the Speaker Deck block is called "Speaker", this PR replaces it with a new "Speaker Deck" block, and transforms the old blocks into new blocks.

Fixes #7850.

## How has this been tested?

* Create a post with a Speaker block
* Switch to this PR
* Observe the block being silently upgraded to the Speaker Deck block.

Also, check that there's no way to insert an old Speaker block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.