### PR TITLE
Support reusable blocks for multi-selection

### DIFF
--- a/block-library/index.js
+++ b/block-library/index.js
@@ -36,12 +36,12 @@ import * as nextpage from '../packages/block-library/src/nextpage';
 import * as preformatted from '../packages/block-library/src/preformatted';
 import * as pullquote from '../packages/block-library/src/pullquote';
 import * as reusableBlock from '../packages/block-library/src/block';
-import * as reusableTemplate from '../packages/block-library/src/template';
 import * as separator from '../packages/block-library/src/separator';
 import * as shortcode from '../packages/block-library/src/shortcode';
 import * as spacer from '../packages/block-library/src/spacer';
 import * as subhead from '../packages/block-library/src/subhead';
 import * as table from '../packages/block-library/src/table';
+import * as template from '../packages/block-library/src/template';
 import * as textColumns from '../packages/block-library/src/text-columns';
 import * as verse from '../packages/block-library/src/verse';
 import * as video from '../packages/block-library/src/video';
@@ -87,10 +87,10 @@ export const registerCoreBlocks = () => {
 		pullquote,
 		separator,
 		reusableBlock,
-		reusableTemplate,
 		spacer,
 		subhead,
 		table,
+		template,
 		textColumns,
 		verse,
 		video,

--- a/block-library/index.js
+++ b/block-library/index.js
@@ -36,6 +36,7 @@ import * as nextpage from '../packages/block-library/src/nextpage';
 import * as preformatted from '../packages/block-library/src/preformatted';
 import * as pullquote from '../packages/block-library/src/pullquote';
 import * as reusableBlock from '../packages/block-library/src/block';
+import * as reusableTemplate from '../packages/block-library/src/template';
 import * as separator from '../packages/block-library/src/separator';
 import * as shortcode from '../packages/block-library/src/shortcode';
 import * as spacer from '../packages/block-library/src/spacer';
@@ -86,6 +87,7 @@ export const registerCoreBlocks = () => {
 		pullquote,
 		separator,
 		reusableBlock,
+		reusableTemplate,
 		spacer,
 		subhead,
 		table,

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -33,6 +33,7 @@ import * as nextpage from './nextpage';
 import * as preformatted from './preformatted';
 import * as pullquote from './pullquote';
 import * as reusableBlock from './block';
+import * as reusableTemplate from './template';
 import * as separator from './separator';
 import * as shortcode from './shortcode';
 import * as spacer from './spacer';
@@ -75,6 +76,7 @@ export const registerCoreBlocks = () => {
 		pullquote,
 		separator,
 		reusableBlock,
+		reusableTemplate,
 		spacer,
 		subhead,
 		table,

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -33,12 +33,12 @@ import * as nextpage from './nextpage';
 import * as preformatted from './preformatted';
 import * as pullquote from './pullquote';
 import * as reusableBlock from './block';
-import * as reusableTemplate from './template';
 import * as separator from './separator';
 import * as shortcode from './shortcode';
 import * as spacer from './spacer';
 import * as subhead from './subhead';
 import * as table from './table';
+import * as template from './template';
 import * as textColumns from './text-columns';
 import * as verse from './verse';
 import * as video from './video';
@@ -76,10 +76,10 @@ export const registerCoreBlocks = () => {
 		pullquote,
 		separator,
 		reusableBlock,
-		reusableTemplate,
 		spacer,
 		subhead,
 		table,
+		template,
 		textColumns,
 		verse,
 		video,

--- a/packages/block-library/src/template/index.js
+++ b/packages/block-library/src/template/index.js
@@ -13,6 +13,8 @@ export const settings = {
 
 	description: __( 'Template block used as a container.' ),
 
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24" /><g><path d="M19 3H5c-1.105 0-2 .895-2 2v14c0 1.105.895 2 2 2h14c1.105 0 2-.895 2-2V5c0-1.105-.895-2-2-2zM6 6h5v5H6V6zm4.5 13C9.12 19 8 17.88 8 16.5S9.12 14 10.5 14s2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5zm3-6l3-5 3 5h-6z" /></g></svg>,
+
 	supports: {
 		customClassName: false,
 		html: false,

--- a/packages/block-library/src/template/index.js
+++ b/packages/block-library/src/template/index.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/editor';
+
+export const name = 'core/template';
+
+export const settings = {
+	title: __( 'Reusable Template' ),
+
+	category: 'reusable',
+
+	description: __( 'Template block used as a container.' ),
+
+	supports: {
+		customClassName: false,
+		html: false,
+		inserter: false,
+	},
+
+	edit() {
+		return <InnerBlocks />;
+	},
+
+	save() {
+		return <InnerBlocks.Content />;
+	},
+};

--- a/packages/editor/src/components/block-settings-menu/index.js
+++ b/packages/editor/src/components/block-settings-menu/index.js
@@ -106,12 +106,10 @@ export function BlockSettingsMenu( { clientIds, onSelect } ) {
 									onToggle={ onClose }
 								/>
 							) }
-							{ count === 1 && (
-								<ReusableBlockConvertButton
-									clientId={ firstBlockClientId }
-									onToggle={ onClose }
-								/>
-							) }
+							<ReusableBlockConvertButton
+								clientIds={ clientIds }
+								onToggle={ onClose }
+							/>
 							<_BlockSettingsMenuPluginsExtension.Slot fillProps={ { clientIds, onClose } } />
 							<div className="editor-block-settings-menu__separator" />
 							{ count === 1 && (

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -691,14 +691,14 @@ export function convertBlockToStatic( clientId ) {
 /**
  * Returns an action object used to convert a static block into a reusable block.
  *
- * @param {string} clientId The client ID of the block to detach.
+ * @param {string} clientIds The client IDs of the block to detach.
  *
  * @return {Object} Action object.
  */
-export function convertBlockToReusable( clientId ) {
+export function convertBlockToReusable( clientIds ) {
 	return {
 		type: 'CONVERT_BLOCK_TO_REUSABLE',
-		clientId,
+		clientIds: castArray( clientIds ),
 	};
 }
 /**

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -508,7 +508,7 @@ describe( 'actions', () => {
 			const clientId = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
 			expect( convertBlockToReusable( clientId ) ).toEqual( {
 				type: 'CONVERT_BLOCK_TO_REUSABLE',
-				clientId,
+				clientIds: [ clientId ],
 			} );
 		} );
 	} );

--- a/test/e2e/specs/__snapshots__/reusable-blocks.test.js.snap
+++ b/test/e2e/specs/__snapshots__/reusable-blocks.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reusable Blocks multi-selection reusable block can be converted back to regular blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>Hello there!</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/integration/full-content/full-content.spec.js
+++ b/test/integration/full-content/full-content.spec.js
@@ -223,7 +223,7 @@ describe( 'full post content fixture', () => {
 			.map( ( block ) => block.name )
 			// We don't want tests for each oembed provider, which all have the same
 			// `save` functions and attributes.
-			.filter( ( name ) => name.indexOf( 'core-embed' ) !== 0 )
+			.filter( ( name ) => name.indexOf( 'core-embed' ) !== 0 && name !== 'core/template' )
 			.forEach( ( name ) => {
 				const nameToFilename = name.replace( /\//g, '__' );
 				const foundFixtures = fileBasenames

--- a/test/integration/full-content/full-content.spec.js
+++ b/test/integration/full-content/full-content.spec.js
@@ -223,6 +223,7 @@ describe( 'full post content fixture', () => {
 			.map( ( block ) => block.name )
 			// We don't want tests for each oembed provider, which all have the same
 			// `save` functions and attributes.
+			// The `core/template` is not worth testing here because it's never saved, it's covered better in e2e tests.
 			.filter( ( name ) => name.indexOf( 'core-embed' ) !== 0 && name !== 'core/template' )
 			.forEach( ( name ) => {
 				const nameToFilename = name.replace( /\//g, '__' );


### PR DESCRIPTION
This PR adds the possibility to save a multiselection as a reusable block. To do so we create a hidden block called `core/template` serving as a container for the multi-selection and when converting back to a regular block, we drop the `core/template` container.

**Testing instructions**

 - Try playing with reusable blocks and multiselection

**Notes**

The `core/template` block is a temporary block never saved to post content or to the `wp_block` CPT. After we land #7453 we will be able to get rid of it completely.

Right now the assumption in the state is that a reusable block holds a unique block. We don't make this assumption server side and we will be able to get rid of this assumption after #7453 as well.