### PR TITLE
Add support for shortcode embeds that enqueue scripts

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -87,9 +87,17 @@ function gutenberg_filter_oembed_result( $response, $handler, $request ) {
 				global $wp_embed;
 				$html = $wp_embed->shortcode( array(), $_GET['url'] );
 				if ( $html ) {
+					global $wp_scripts;
+					// Check if any scripts were enqueued by the shortcode, and
+					// include them in the response.
+					$enqueued_scripts = array();
+					foreach ( $wp_scripts->queue as $script ) {
+						$enqueued_scripts[] = $wp_scripts->registered[ $script ]->src;
+					}
 					return array(
 						'provider_name' => __( 'Embed Handler', 'gutenberg' ),
 						'html'          => $html,
+						'scripts'       => $enqueued_scripts,
 					);
 				}
 			}

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -214,6 +214,7 @@ export function getEmbedEdit( title, icon ) {
 			}
 
 			const html = 'photo' === type ? this.getPhotoHtml( preview ) : preview.html;
+			const { scripts } = preview;
 			const parsedUrl = parse( url );
 			const cannotPreview = includes( HOSTS_NO_PREVIEWS, parsedUrl.host.replace( /^www\./, '' ) );
 			// translators: %s: host providing embed content e.g: www.youtube.com
@@ -227,6 +228,7 @@ export function getEmbedEdit( title, icon ) {
 				<div className="wp-block-embed__wrapper">
 					<SandBox
 						html={ html }
+						scripts={ scripts }
 						title={ iframeTitle }
 						type={ type }
 					/>

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -172,7 +172,6 @@ class Sandbox extends Component {
 				margin-bottom: 0 !important;
 			}
 		`;
-
 		// put the html snippet into a html document, and then write it to the iframe's document
 		// we can use this in the future to inject custom styles or scripts
 		const htmlDoc = (
@@ -180,6 +179,9 @@ class Sandbox extends Component {
 				<head>
 					<title>{ this.props.title }</title>
 					<style dangerouslySetInnerHTML={ { __html: style } } />
+					{ ( this.props.scripts ? this.props.scripts.map(
+						( src ) => <script key={ src } src={ src } />
+					) : null ) }
 				</head>
 				<body data-resizable-iframe-connected="data-resizable-iframe-connected" className={ this.props.type }>
 					<div dangerouslySetInnerHTML={ { __html: this.props.html } } />

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -172,6 +172,7 @@ class Sandbox extends Component {
 				margin-bottom: 0 !important;
 			}
 		`;
+
 		// put the html snippet into a html document, and then write it to the iframe's document
 		// we can use this in the future to inject custom styles or scripts
 		const htmlDoc = (
@@ -179,9 +180,9 @@ class Sandbox extends Component {
 				<head>
 					<title>{ this.props.title }</title>
 					<style dangerouslySetInnerHTML={ { __html: style } } />
-					{ ( this.props.scripts ? this.props.scripts.map(
+					{ ( this.props.scripts && this.props.scripts.map(
 						( src ) => <script key={ src } src={ src } />
-					) : null ) }
+					) ) }
 				</head>
 				<body data-resizable-iframe-connected="data-resizable-iframe-connected" className={ this.props.type }>
 					<div dangerouslySetInnerHTML={ { __html: this.props.html } } />


### PR DESCRIPTION
## Description

If the embed preview is handled by a shortcode, it might enqueue scripts to make it work.
This change returns the enqueued scripts as part of the embed response, and has
the Sandbox component put them into the preview document.

## How has this been tested?

Install Jetpack and activate the shortcodes module.
Try to embed https://www.pinterest.co.uk/heald0081/hair-ideas/

The preview should appear as expected. Without this fix, only the caption appears.

## Types of changes
Bug fix

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
