### PR TITLE
Adjust margin rules for nested blocks.

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -39,10 +39,6 @@
 .editor-block-list__layout .editor-block-list__block[data-type="core/column"] > .editor-block-list__block-edit {
 	margin-top: 0;
 	margin-bottom: 0;
-
-	// This uncollapses margins on this parent container.
-	padding-top: 0.1px;
-	padding-bottom: 0.1px;
 }
 
 .wp-block-columns {

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -126,7 +126,7 @@
 		padding-right: $block-container-side-padding;
 	}
 
-	// Don't add side padding for nested blocks, and compensate for block padding
+	// Don't add side padding for nested blocks.
 	.editor-block-list__block & {
 		// Compensate for side UI.
 		padding-left: 0;
@@ -135,24 +135,19 @@
 		// Compensate for block padding horizontally.
 		margin-left: -$block-padding;
 		margin-right: -$block-padding;
-
-		// Compensate for block padding.
-		margin-top: -$block-padding;
-		margin-bottom: -$block-padding;
 	}
 
 	// Adjust the spacing of the appender, or the first block, to sit near the title.
-	.editor-default-block-appender .editor-default-block-appender__content,
-	.editor-block-list__block:first-child .editor-block-list__block-edit {
+	> .editor-default-block-appender > .editor-default-block-appender__content,
+	> .editor-block-list__block:first-child > .editor-block-list__block-edit {
 		margin-top: $block-padding - $block-spacing / 2;
 	}
 
 	// Space every block, and the default appender, using margins.
 	// This allows margins to collapse, which gives a better representation of how it looks on the frontend.
-	.editor-default-block-appender__content,
-	.editor-block-list__block .editor-block-list__block-edit,
-	.editor-block-list__layout .editor-block-list__block .editor-block-list__block-edit,
-	.editor-block-list__layout .editor-default-block-appender .editor-default-block-appender__content { // Explicitly target nested blocks, as those need to override the preceding rule.
+	> .editor-default-block-appender__content,
+	> .editor-block-list__block > .editor-block-list__block-edit,
+	> .editor-block-list__layout > .editor-block-list__block > .editor-block-list__block-edit {
 		margin-top: $block-padding * 2 + $block-spacing;
 		margin-bottom: $block-padding * 2 + $block-spacing;
 	}


### PR DESCRIPTION
This PR one one hand fixes #9730, and on the other hand simplifies some of the column wrangling code to be simpler.

It does visualy regress it slightly: previously we'd use negative margins to make it so text inside columns looked to be spaced the same as text before and after the columns.

However this greatly complexified the CSS, which caused #9730 in the first place. The thing is — the columns block itself has a margin. This margin collapses correctly to adjacent blocks. But given it also has children, those margins don't also collapse. Possibly we could make this happen, I'm unsure, flex containers are supposed to prevent margin collapsing by creating their own contexts, but it seems like the negative margins added complexity where it wasn't helpful.

Before:

<img width="825" alt="screen shot 2018-09-10 at 12 38 17" src="https://user-images.githubusercontent.com/1204802/45292747-67ba0980-b4f6-11e8-9262-b655a596dc9a.png">

After:

<img width="780" alt="screen shot 2018-09-10 at 12 33 20" src="https://user-images.githubusercontent.com/1204802/45292758-6ee11780-b4f6-11e8-88cf-58400e2ea2cc.png">

The difference is subtle. But look how the margin between text inside and outside the columns block used to be the same. This is no longer the case, but perhaps worth it as a simplification fix, and then possibly something to revisit separately.