### PR TITLE
Fix notice styling regression

### DIFF
--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -26,8 +26,7 @@
 }
 
 .components-notice__content {
-	font-size: 13px;
-	line-height: 1.5;
+	margin: 1em 0;
 }
 
 .components-notice__dismiss {


### PR DESCRIPTION
Just a tiny PR aligning notices properly.

closes #9725  and closes #9422

I suspect this being a regression of #8856