### PR TITLE
Update @wordpress/api-fetch README.md

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -17,7 +17,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ```js
 import apiFetch from '@wordpress/api-fetch';
 
-apiFetch( { path: '/wp/v2/posts' } ).then( posts => {
+apiFetch( { path: '/wp-json/wp/v2/posts' } ).then( posts => {
 	console.log( posts );
 } );
 ```


### PR DESCRIPTION
## Description
This is a minor change, something that I just encountered when copying and pasting lines 20-22. 

Without prefixing the path with `/wp-json/` the following error is returned:

```
code: "invalid_json"
message: "The response is not a valid JSON response."
```

Prefixing with `/wp-json/` made a successful call and returned the expected data (posts array).

## How has this been tested?
I have tested this locally.

## Screenshots <!-- if applicable -->

## Types of changes
Documentation update.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
