### PR TITLE
Adjust unified block toolbar padding at medium breakpoints.

### DIFF
--- a/edit-post/components/header/header-toolbar/style.scss
+++ b/edit-post/components/header/header-toolbar/style.scss
@@ -23,14 +23,9 @@
 	min-height: $block-toolbar-height;
 	border-bottom: $border-width solid $light-gray-500;
 
-	.editor-block-toolbar {
-		margin: -9px 0;
-	}
-
 	.editor-block-toolbar .components-toolbar {
 		border-top: none;
 		border-bottom: none;
-		padding: 9px;
 	}
 
 	.is-sidebar-opened & {
@@ -56,6 +51,14 @@
 
 		.is-sidebar-opened & {
 			right: auto;
+		}
+
+		.editor-block-toolbar {
+			margin: -9px 0;
+		}
+
+		.editor-block-toolbar .components-toolbar {
+			padding: 9px;
 		}
 	}
 }


### PR DESCRIPTION
Fixes a visual bug where the block controls in Unified Toolbar are larger than their container bar on screens that are between 781px and 960px wide.

Fixes #9657.

## To Test:

1. Activate `Unified Toolbar` mode from the ellipsis menu. 
2. Scale your screen down so it's in between 781px and 960px wide.
3. Select a block, and observe the way the block toolbar looks at the top of the screen.

## Screenshots

_Before:_
<img width="766" alt="screen shot 2018-09-10 at 9 22 28 am" src="https://user-images.githubusercontent.com/1202812/45299959-194b4180-b4db-11e8-99fc-093b87485dde.png">

_After:_
<img width="767" alt="screen shot 2018-09-10 at 9 20 36 am" src="https://user-images.githubusercontent.com/1202812/45299970-1f412280-b4db-11e8-8eef-109cfddf5ebd.png">