### PR TITLE
Image Block: Convert back and forth from a cover image block

### DIFF
--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -74,6 +74,18 @@ export const settings = {
 					createBlock( 'core/cover-image', { title: content } )
 				),
 			},
+			{
+				type: 'block',
+				blocks: [ 'core/image' ],
+				transform: ( { caption, url, align, id } ) => (
+					createBlock( 'core/cover-image', {
+						title: caption,
+						url,
+						align,
+						id,
+					} )
+				),
+			},
 		],
 		to: [
 			{
@@ -81,6 +93,18 @@ export const settings = {
 				blocks: [ 'core/heading' ],
 				transform: ( { title } ) => (
 					createBlock( 'core/heading', { content: title } )
+				),
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/image' ],
+				transform: ( { title, url, align, id } ) => (
+					createBlock( 'core/image', {
+						caption: title,
+						url,
+						align,
+						id,
+					} )
 				),
 			},
 		],


### PR DESCRIPTION
closes #6475

PR making it possible to convert cover images to images and vice versa.

**Testing instructions**

 - Try converting images to cover images (and convert back)
 - Notice most of the attributes are kept.