### PR TITLE
Taxonomies: Fix error when a taxonomy has no attached post type

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -63,7 +68,7 @@ export default compose(
 		const tags = tagsTaxonomy && select( 'core/editor' ).getEditedPostAttribute( tagsTaxonomy.rest_base );
 		return {
 			areTagsFetched: tagsTaxonomy !== undefined,
-			isPostTypeSupported: tagsTaxonomy && tagsTaxonomy.types.some( ( type ) => type === postType ),
+			isPostTypeSupported: tagsTaxonomy && some( tagsTaxonomy.types, ( type ) => type === postType ),
 			hasTags: tags && tags.length,
 		};
 	} ),


### PR DESCRIPTION
Just a small tweak to ensure we don't thrown an error when the "types" assigned for a given taxonomy is null (instead of an empty array)

closes #9693

The problem here though is while I'm certain this will fix the issue in #9693 I was not able to reproduce on my own and I'm still not certain if it's valid to have a taxonomy without types.
