### PR TITLE
Adjust gallery caption flex alignment

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -16,9 +16,13 @@
 
 .blocks-gallery-item {
 
+	// Hide the focus outline that otherwise briefly appears when selecting a block.
+	figure:not(.is-selected):focus {
+		outline: none;
+	}
+
 	.is-selected {
 		outline: 4px solid theme(primary);
-		outline-offset: -4px;
 	}
 
 	&.is-transient img {
@@ -41,8 +45,8 @@
 	.is-selected .editor-rich-text {
 		// IE calculates this incorrectly, so leave it to modern browsers.
 		@supports (position: sticky) {
-			width: calc(100% - 8px);
-			left: 4px;
+			right: 0;
+			left: 0;
 			margin-top: -4px;
 		}
 
@@ -96,8 +100,8 @@
 .block-library-gallery-item__inline-menu {
 	padding: 2px;
 	position: absolute;
-	top: 0;
-	right: 0;
+	top: -2px;
+	right: -2px;
 	background-color: theme(primary);
 	display: inline-flex;
 	z-index: z-index(".block-library-gallery-item__inline-menu");

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -27,6 +27,7 @@
 
 	.editor-rich-text {
 		position: absolute;
+		bottom: 0;
 		width: 100%;
 		max-height: 100%;
 		overflow-y: auto;
@@ -38,9 +39,12 @@
 	}
 
 	.is-selected .editor-rich-text {
-		width: calc(100% - 8px);
-		left: 4px;
-		margin-top: -4px;
+		// IE calculates this incorrectly, so leave it to modern browsers.
+		@supports (position: sticky) {
+			width: calc(100% - 8px);
+			left: 4px;
+			margin-top: -4px;
+		}
 
 		// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
 		.editor-rich-text__inline-toolbar {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -19,8 +19,13 @@
 		figure {
 			margin: 0;
 			height: 100%;
-			display: flex;
-			align-items: flex-end;
+
+			// IE doesn't support flex so omit that.
+			@supports (position: sticky) {
+				display: flex;
+				align-items: flex-end;
+				justify-content: flex-start;
+			}
 		}
 
 		img {
@@ -32,6 +37,7 @@
 		// IE doesn't handle cropping, so we need an explicit width here.
 		img {
 			width: 100%;
+
 			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
 			@supports (position: sticky) {
 				width: auto;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -20,7 +20,7 @@
 			margin: 0;
 			height: 100%;
 			display: flex;
-			align-items: center;
+			align-items: flex-end;
 		}
 
 		img {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -29,6 +29,15 @@
 			height: auto;
 		}
 
+		// IE doesn't handle cropping, so we need an explicit width here.
+		img {
+			width: 100%;
+			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+			@supports (position: sticky) {
+				width: auto;
+			}
+		}
+
 		figcaption {
 			position: absolute;
 			width: 100%;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -46,6 +46,7 @@
 
 		figcaption {
 			position: absolute;
+			bottom: 0;
 			width: 100%;
 			max-height: 100%;
 			overflow: auto;


### PR DESCRIPTION
Gallery captions are meant to appear at the bottom of gallery items, but a recent change in #9622 changed that and introduced a visual bug (#9752). This sets things back to the way they were before.

---

_Before:_

![screen shot 2018-09-10 at 1 17 12 pm](https://user-images.githubusercontent.com/1202812/45313103-d9488680-b4fb-11e8-93cb-1799f165953b.png)


_After:_
![screen shot 2018-09-10 at 1 14 16 pm](https://user-images.githubusercontent.com/1202812/45312988-95ee1800-b4fb-11e8-9c8d-ca9711ae812d.png)

---

Fixes #9752