### PR TITLE
Add another pullquote style

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { includes, map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	Component,
+	Fragment,
+} from '@wordpress/element';
+import {
+	RichText,
+	ContrastChecker,
+	InspectorControls,
+	withColors,
+	PanelColorSettings,
+} from '@wordpress/editor';
+
+export const SOLID_COLOR_STYLE_NAME = 'solid-color';
+export const SOLID_COLOR_CLASS = `is-style-${ SOLID_COLOR_STYLE_NAME }`;
+
+export const toRichTextValue = ( value ) => map( value, ( ( subValue ) => subValue.children ) );
+export const fromRichTextValue = ( value ) => map( value, ( subValue ) => ( {
+	children: subValue,
+} ) );
+
+class PullQuoteEdit extends Component {
+	render() {
+		const {
+			attributes,
+			mainColor,
+			textColor,
+			setAttributes,
+			isSelected,
+			className,
+			setMainColor,
+			setTextColor,
+		} = this.props;
+
+		const { value, citation } = attributes;
+
+		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+		const figureStyle = isSolidColorStyle ?
+			{ backgroundColor: mainColor.color } :
+			{ borderColor: mainColor.color };
+		const blockquoteStyle = {
+			color: textColor.color,
+		};
+		const blockquoteClass = textColor.class;
+		return (
+			<Fragment>
+				<figure style={ figureStyle } className={ classnames(
+					className, {
+						[ mainColor.class ]: isSolidColorStyle && mainColor.class,
+					} ) }>
+					<blockquote style={ blockquoteStyle } className={ blockquoteClass }>
+						<RichText
+							multiline="p"
+							value={ toRichTextValue( value ) }
+							onChange={
+								( nextValue ) => setAttributes( {
+									value: fromRichTextValue( nextValue ),
+								} )
+							}
+							/* translators: the text of the quotation */
+							placeholder={ __( 'Write quote…' ) }
+							wrapperClassName="block-library-pullquote__content"
+						/>
+						{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
+							<RichText
+								value={ citation }
+								/* translators: the individual or entity quoted */
+								placeholder={ __( 'Write citation…' ) }
+								onChange={
+									( nextCitation ) => setAttributes( {
+										citation: nextCitation,
+									} )
+								}
+								className="wp-block-pullquote__citation"
+							/>
+						) }
+					</blockquote>
+				</figure>
+				<InspectorControls>
+					<PanelColorSettings
+						title={ __( 'Color Settings' ) }
+						colorSettings={ [
+							{
+								value: mainColor.color,
+								onChange: setMainColor,
+								label: __( 'Main Color' ),
+							},
+							{
+								value: textColor.color,
+								onChange: setTextColor,
+								label: __( 'Text Color' ),
+							},
+						] }
+					>
+						{ isSolidColorStyle && (
+							<ContrastChecker
+								{ ...{
+									textColor: textColor.color,
+									backgroundColor: mainColor.color,
+								} }
+								isLargeText={ false }
+							/>
+						) }
+					</PanelColorSettings>
+				</InspectorControls>
+			</Fragment>
+		);
+	}
+}
+
+export default withColors( { mainColor: 'background-color', textColor: 'color' } )(
+	PullQuoteEdit
+);

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -71,14 +71,16 @@ class PullQuoteEdit extends Component {
 		const blockquoteStyle = {
 			color: textColor.color,
 		};
-		const blockquoteClass = textColor.class;
+		const blockquoteClasses = textColor.color ? classnames( 'has-text-color', {
+			[ textColor.class ]: textColor.class,
+		} ) : undefined;
 		return (
 			<Fragment>
 				<figure style={ figureStyle } className={ classnames(
 					className, {
 						[ mainColor.class ]: isSolidColorStyle && mainColor.class,
 					} ) }>
-					<blockquote style={ blockquoteStyle } className={ blockquoteClass }>
+					<blockquote style={ blockquoteStyle } className={ blockquoteClasses }>
 						<RichText
 							multiline="p"
 							value={ toRichTextValue( value ) }

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -29,6 +29,29 @@ export const fromRichTextValue = ( value ) => map( value, ( subValue ) => ( {
 } ) );
 
 class PullQuoteEdit extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.wasTextColorAutomaticallyComputed = false;
+		this.pullQuoteMainColorSetter = this.pullQuoteMainColorSetter.bind( this );
+		this.pullQuoteTextColorSetter = this.pullQuoteTextColorSetter.bind( this );
+	}
+
+	pullQuoteMainColorSetter( colorValue ) {
+		const { colorUtils, textColor, setTextColor, setMainColor } = this.props;
+		setMainColor( colorValue );
+		if ( ! textColor.color || this.wasTextColorAutomaticallyComputed ) {
+			this.wasTextColorAutomaticallyComputed = true;
+			setTextColor( colorUtils.getMostReadableColor( colorValue ) );
+		}
+	}
+
+	pullQuoteTextColorSetter( colorValue ) {
+		const { setTextColor } = this.props;
+		setTextColor( colorValue );
+		this.wasTextColorAutomaticallyComputed = false;
+	}
+
 	render() {
 		const {
 			attributes,
@@ -37,8 +60,6 @@ class PullQuoteEdit extends Component {
 			setAttributes,
 			isSelected,
 			className,
-			setMainColor,
-			setTextColor,
 		} = this.props;
 
 		const { value, citation } = attributes;
@@ -91,12 +112,12 @@ class PullQuoteEdit extends Component {
 						colorSettings={ [
 							{
 								value: mainColor.color,
-								onChange: setMainColor,
+								onChange: this.pullQuoteMainColorSetter,
 								label: __( 'Main Color' ),
 							},
 							{
 								value: textColor.color,
-								onChange: setTextColor,
+								onChange: this.pullQuoteTextColorSetter,
 								label: __( 'Text Color' ),
 							},
 						] }

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -26,3 +26,8 @@
 		line-height: 1.6;
 	}
 }
+
+.wp-block-pullquote.is-style-stylized {
+	margin-left: 0;
+	margin-right: 0;
+}

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -27,7 +27,11 @@
 	}
 }
 
-.wp-block-pullquote.is-style-stylized {
+.wp-block-pullquote.is-style-solid-color {
 	margin-left: 0;
 	margin-right: 0;
+}
+
+.wp-block-pullquote .wp-block-pullquote__citation {
+	color: inherit;
 }

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -22,7 +22,7 @@
 
 	& blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
 	& blockquote > .editor-rich-text p {
-		font-size: 24px;
+		font-size: 28px;
 		line-height: 1.6;
 	}
 }
@@ -30,6 +30,15 @@
 .wp-block-pullquote.is-style-solid-color {
 	margin-left: 0;
 	margin-right: 0;
+
+	& blockquote > .editor-rich-text p {
+		font-size: 32px;
+	}
+
+	.wp-block-pullquote__citation {
+		text-transform: none;
+		font-style: normal;
+	}
 }
 
 .wp-block-pullquote .wp-block-pullquote__citation {

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { get, includes } from 'lodash';
 
 /**
@@ -106,11 +107,14 @@ export const settings = {
 			};
 		}
 
-		const blockquoteClass = getColorClassName( 'color', textColor );
-		const blockquoteStyle = blockquoteClass ? undefined : { color: customTextColor };
+		const blockquoteTextColorClass = getColorClassName( 'color', textColor );
+		const blockquoteClasses = textColor || customTextColor ? classnames( 'has-text-color', {
+			[ blockquoteTextColorClass ]: blockquoteTextColorClass,
+		} ) : undefined;
+		const blockquoteStyle = blockquoteTextColorClass ? undefined : { color: customTextColor };
 		return (
 			<figure className={ figureClass } style={ figureStyles }>
-				<blockquote className={ blockquoteClass } style={ blockquoteStyle } >
+				<blockquote className={ blockquoteClasses } style={ blockquoteStyle } >
 					<RichText.Content value={ toRichTextValue( value ) } />
 					{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
 				</blockquote>

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -74,7 +74,7 @@ export const settings = {
 	],
 
 	supports: {
-		align: true,
+		align: [ 'left', 'right', 'wide', 'full' ],
 	},
 
 	edit,

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -21,3 +21,29 @@
 		position: relative;
 	}
 }
+
+.wp-block-pullquote:not(.is-style-stylized) {
+	background: none;
+}
+
+.wp-block-pullquote.is-style-stylized {
+	border: none;
+	blockquote {
+		margin-left: auto;
+		margin-right: auto;
+		text-align: left;
+
+		max-width: 60%;
+
+		p {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+
+		cite {
+			text-transform: none;
+			font-style: normal;
+		}
+	}
+
+}

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -22,11 +22,11 @@
 	}
 }
 
-.wp-block-pullquote:not(.is-style-stylized) {
+.wp-block-pullquote:not(.is-style-solid-color) {
 	background: none;
 }
 
-.wp-block-pullquote.is-style-stylized {
+.wp-block-pullquote.is-style-solid-color {
 	border: none;
 	blockquote {
 		margin-left: auto;
@@ -45,5 +45,8 @@
 			font-style: normal;
 		}
 	}
+}
 
+.wp-block-pullquote cite {
+	color: inherit;
 }

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -20,6 +20,9 @@
 	footer {
 		position: relative;
 	}
+	.has-text-color a {
+		color: inherit;
+	}
 }
 
 .wp-block-pullquote:not(.is-style-solid-color) {

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	p {
-		font-size: 24px;
+		font-size: 28px;
 		line-height: 1.6;
 	}
 
@@ -38,6 +38,7 @@
 		p {
 			margin-top: 0;
 			margin-bottom: 0;
+			font-size: 32px;
 		}
 
 		cite {

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -9,6 +9,6 @@
 		color: $dark-gray-600;
 		text-transform: uppercase;
 		font-size: $default-font-size;
-		font-style: italic;
+		font-style: normal;
 	}
 }

--- a/packages/editor/src/components/colors/utils.js
+++ b/packages/editor/src/components/colors/utils.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { find, kebabCase } from 'lodash';
+import { find, kebabCase, map } from 'lodash';
+import tinycolor from 'tinycolor2';
 
 /**
  * Provided an array of color objects as set by the theme or by the editor defaults,
@@ -55,4 +56,19 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	}
 
 	return `has-${ kebabCase( colorSlug ) }-${ colorContextName }`;
+}
+
+/**
+* Given an array of color objects and a color value returns the color value of the most readable color in the array.
+*
+* @param {Array}   colors     Array of color objects as set by the theme or by the editor defaults.
+* @param {?string} colorValue A string containing the color value.
+*
+* @return {string} String with the color value of the most readable color.
+*/
+export function getMostReadableColor( colors, colorValue ) {
+	return tinycolor.mostReadable(
+		colorValue,
+		map( colors, 'color' )
+	).toHexString();
 }

--- a/packages/editor/src/components/colors/with-colors.js
+++ b/packages/editor/src/components/colors/with-colors.js
@@ -13,7 +13,7 @@ import { compose, createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { getColorClassName, getColorObjectByColorValue, getColorObjectByAttributeValues } from './utils';
+import { getColorClassName, getColorObjectByColorValue, getColorObjectByAttributeValues, getMostReadableColor } from './utils';
 
 const DEFAULT_COLORS = [];
 
@@ -54,8 +54,16 @@ export default ( ...args ) => {
 						super( props );
 
 						this.setters = this.createSetters();
+						this.colorUtils = {
+							getMostReadableColor: this.getMostReadableColor.bind( this ),
+						};
 
 						this.state = {};
+					}
+
+					getMostReadableColor( colorValue ) {
+						const { colors } = this.props;
+						return getMostReadableColor( colors, colorValue );
 					}
 
 					createSetters() {
@@ -113,6 +121,7 @@ export default ( ...args ) => {
 									colors: undefined,
 									...this.state,
 									...this.setters,
+									colorUtils: this.colorUtils,
 								} }
 							/>
 						);


### PR DESCRIPTION
The PR adds a new style variation (whose name is yet to be decided) to the Pull Quote block.

This style has an additional feature that allows users to choose a background color.

This PR depends on https://github.com/WordPress/gutenberg/pull/9599.

The design is open for feedback maybe we can improve the look of the block.

## How has this been tested?
I used the new style and converted between styles and did not notice any problem.
I checked that we are compatible with pull quotes created on the previous WordPress version e.g: by pasting the following code block in the code editor.
```
<!-- wp:pullquote {"align":"left"} -->
<figure class="wp-block-pullquote alignleft"><blockquote><p>AAA</p><cite>BBB</cite></blockquote></figure>
<!-- /wp:pullquote -->
```
## Screenshots <!-- if applicable -->
<img width="1256" alt="screen shot 2018-09-12 at 19 39 36" src="https://user-images.githubusercontent.com/11271197/45446050-db5d4180-b6c3-11e8-8e43-a8e783e9c82b.png">
<img width="1266" alt="screen shot 2018-09-12 at 19 38 57" src="https://user-images.githubusercontent.com/11271197/45446051-db5d4180-b6c3-11e8-87ae-3cff29058965.png">


