### PR TITLE
Suspected typo on theme documentation page

### DIFF
--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -1,6 +1,6 @@
 # Theme Support
 
-By default, blocks provide their styles to enable basic support for blocks in themes without any change. Themes can add/override these styles, or they can provide no styles at all, and rely fully on what the theme provides.
+By default, blocks provide their styles to enable basic support for blocks in themes without any change. Themes can add/override these styles, or they can provide no styles at all, and rely fully on what the blocks provide.
 
 Some advanced block features require opt-in support in the theme itself as it's difficult for the block to provide these styles, they may require some architecting of the theme itself, in order to work well.
 


### PR DESCRIPTION
The sentence here says "theme provides" but I believe the intent is to say that if a theme doesn't provide styles, it will rely on what the blocks provide.

## Description
Minor wording change on extensibility - theme page.

## Types of changes
Minor wording Change

## Checklist:
No code to test, text change only
