### PR TITLE
Use regex to extract iframe width and height

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -144,8 +144,7 @@ export function getEmbedEdit( title, icon ) {
 		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
 		 */
 		maybeSetAspectRatioClassName( html ) {
-			// Extract the first iframe's height and width. Uses a regex so we don't have to
-			// create the DOM and have potential security risks.
+			// Extract the first iframe's height and width without having to construct DOM elements.
 			const matches = html.toLowerCase().match( /<iframe[^>]+(height|width)=['"]?([0-9]+)["']?[^>]+(height|width)=['"]?([0-9]+)["']?.*?>/ );
 			let height;
 			let width;

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -144,7 +144,8 @@ export function getEmbedEdit( title, icon ) {
 		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
 		 */
 		maybeSetAspectRatioClassName( html ) {
-			// Extract the first iframe's height and width.
+			// Extract the first iframe's height and width. Uses a regex so we don't have to
+			// create the DOM and have potential security risks.
 			const matches = html.toLowerCase().match( /<iframe[^>]+(height|width)=['"]?([0-9]+)["']?[^>]+(height|width)=['"]?([0-9]+)["']?.*?>/ );
 			let height;
 			let width;

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -144,48 +144,64 @@ export function getEmbedEdit( title, icon ) {
 		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
 		 */
 		maybeSetAspectRatioClassName( html ) {
-			const previewDom = document.createElement( 'div' );
-			previewDom.innerHTML = html;
-			const iframe = previewDom.querySelector( 'iframe' );
+			// Extract the first iframe's height and width.
+			const matches = html.toLowerCase().match( /<iframe[^>]+(height|width)=['"]?([0-9]+)["']?[^>]+(height|width)=['"]?([0-9]+)["']?.*?>/ );
+			let height;
+			let width;
 
-			if ( ! iframe ) {
+			if ( ! matches ) {
 				return;
 			}
 
-			if ( iframe.height && iframe.width ) {
-				const aspectRatio = ( iframe.width / iframe.height ).toFixed( 2 );
-				let aspectRatioClassName;
+			if ( 'height' === matches[ 1 ] ) {
+				height = parseInt( matches[ 2 ] );
+			}
+			if ( 'height' === matches[ 3 ] ) {
+				height = parseInt( matches[ 4 ] );
+			}
+			if ( 'width' === matches[ 1 ] ) {
+				width = parseInt( matches[ 2 ] );
+			}
+			if ( 'width' === matches[ 3 ] ) {
+				width = parseInt( matches[ 4 ] );
+			}
 
-				switch ( aspectRatio ) {
-					// Common video resolutions.
-					case '2.33':
-						aspectRatioClassName = 'wp-embed-aspect-21-9';
-						break;
-					case '2.00':
-						aspectRatioClassName = 'wp-embed-aspect-18-9';
-						break;
-					case '1.78':
-						aspectRatioClassName = 'wp-embed-aspect-16-9';
-						break;
-					case '1.33':
-						aspectRatioClassName = 'wp-embed-aspect-4-3';
-						break;
-					// Vertical video and instagram square video support.
-					case '1.00':
-						aspectRatioClassName = 'wp-embed-aspect-1-1';
-						break;
-					case '0.56':
-						aspectRatioClassName = 'wp-embed-aspect-9-16';
-						break;
-					case '0.50':
-						aspectRatioClassName = 'wp-embed-aspect-1-2';
-						break;
-				}
+			if ( ! height && ! width ) {
+				return;
+			}
 
-				if ( aspectRatioClassName ) {
-					const className = classnames( this.props.attributes.className, 'wp-has-aspect-ratio', aspectRatioClassName );
-					this.props.setAttributes( { className } );
-				}
+			const aspectRatio = ( width / height ).toFixed( 2 );
+			let aspectRatioClassName;
+
+			switch ( aspectRatio ) {
+				// Common video resolutions.
+				case '2.33':
+					aspectRatioClassName = 'wp-embed-aspect-21-9';
+					break;
+				case '2.00':
+					aspectRatioClassName = 'wp-embed-aspect-18-9';
+					break;
+				case '1.78':
+					aspectRatioClassName = 'wp-embed-aspect-16-9';
+					break;
+				case '1.33':
+					aspectRatioClassName = 'wp-embed-aspect-4-3';
+					break;
+				// Vertical video and instagram square video support.
+				case '1.00':
+					aspectRatioClassName = 'wp-embed-aspect-1-1';
+					break;
+				case '0.56':
+					aspectRatioClassName = 'wp-embed-aspect-9-16';
+					break;
+				case '0.50':
+					aspectRatioClassName = 'wp-embed-aspect-1-2';
+					break;
+			}
+
+			if ( aspectRatioClassName ) {
+				const className = classnames( this.props.attributes.className, 'wp-has-aspect-ratio', aspectRatioClassName );
+				this.props.setAttributes( { className } );
 			}
 		}
 


### PR DESCRIPTION
## Description

Fix for concern highlighted in https://github.com/WordPress/gutenberg/pull/9500#discussion_r216456963

## How has this been tested?

Embed a tweet, embed a youtube video, and check the video has an aspect ratio CSS class applied, and the tweet does not.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)
