### PR TITLE
HeaderToolbar: Pluralize "kind" to fix typo.

### DIFF
--- a/edit-post/components/header/header-toolbar/index.js
+++ b/edit-post/components/header/header-toolbar/index.js
@@ -35,7 +35,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport } ) {
 			<div>
 				<Inserter position="bottom right" />
 				<DotTip id="core/editor.inserter">
-					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kind of content: you can insert text, headings, images, lists, and lots more!' ) }
+					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kinds of content: you can insert text, headings, images, lists, and lots more!' ) }
 				</DotTip>
 			</div>
 			<EditorHistoryUndo />


### PR DESCRIPTION
The word "kind" should be pluralized in the string, `There are blocks available for all kind of content`.

Reported at https://wordpress.org/support/topic/just-a-typo-2/

