### PR TITLE
Components package: fix component placeholder styling

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -3,7 +3,6 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	padding: 1em;
 	min-height: 200px;
 	width: 100%;
 	text-align: center;


### PR DESCRIPTION
## Description

This is an attempt to resolve the styling issue that's present in Gutenberg integration that rely on `@wordpress/components` package and its CSS. The component placeholder is rendered incorrectly in those cases, and removing the `padding` from it fixes the issue, while at the same time preserving the expected look in `wp-admin`.

## How has this been tested?

I've verified that this fixes the issue in the Gutenberg integrations that we are working on: [wp-calypso](https://wpcalypso.wordpress.com/gutenberg) and [standalone repository](https://github.com/vindl/gutenberg-standalone) (to rule out the possibility of visual issues caused by Calypso shared styles). 

After that I've tested the change in Gutenberg local development environment and `wp-admin`, and made sure that the placeholder still looks the same.

## Screenshots

- In integrations that use `@wordpress/components`:

| Before | After |
| - | - |
|![image-misaligned](https://user-images.githubusercontent.com/1182160/45331778-eea9c900-b56c-11e8-8e79-49534aae928e.png)|![image-aligned](https://user-images.githubusercontent.com/1182160/45331786-f5d0d700-b56c-11e8-8f6f-66dc8fb14be5.png)|

- There should be no visual changes in `wp-admin` context.

## Types of changes

Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
