### PR TITLE
Editor package: fix block settings menu appearance

### DIFF
--- a/packages/editor/src/components/block-settings-menu/style.scss
+++ b/packages/editor/src/components/block-settings-menu/style.scss
@@ -10,7 +10,6 @@
 	}
 
 	.editor-block-settings-menu__content {
-		width: 100%;
 		padding: $item-spacing - $border-width;
 	}
 


### PR DESCRIPTION
## Description

This is an attempt to resolve the styling issue that's present in Gutenberg integration that rely on `@wordpress/editor` package and its CSS. The block settings menu was always shown with a horizontal scrollbar, and removing the `width: 100%` attribute from it resolved the issue, while at the same time preserving the existing look in `wp-admin`.

## How has this been tested?

I've verified that this fixes the issue in the Gutenberg integrations that we are working on: [wp-calypso](https://wpcalypso.wordpress.com/gutenberg) and [standalone repository](https://github.com/vindl/gutenberg-standalone) (to rule out the possibility of visual issues caused by Calypso shared styles). 

After that I've tested the change in Gutenberg local development environment and `wp-admin`, and made sure that the placeholder still looks the same.

## Screenshots

- In integrations that use `@wordpress/components`:

| Before | After |
| - | - |
| ![menu-scrollbar](https://user-images.githubusercontent.com/1182160/45332426-bd32fc80-b570-11e8-9b01-008229431916.png) | ![menu-fixed](https://user-images.githubusercontent.com/1182160/45332431-c2904700-b570-11e8-8f8d-a0602a5c1c76.png) |

- There should be no visual changes in `wp-admin` context.

## Types of changes

Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
