### PR TITLE
Fix regression with appender.

### DIFF
--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -96,6 +96,10 @@
 	margin-right: auto;
 	position: relative;
 
+	.editor-default-block-appender__content {
+		height: $empty-paragraph-height / 2;
+	}
+
 	&[data-root-client-id=""] .editor-default-block-appender__content:hover {
 		// Outline on root-level default block appender is redundant with the
 		// WritingFlow click redirector.

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -89,26 +89,31 @@
 	}
 }
 
-.edit-post-visual-editor .editor-default-block-appender {
-	// Default to centered and content-width, like blocks
-	max-width: $content-width;
-	margin-left: auto;
-	margin-right: auto;
-	position: relative;
+.edit-post-visual-editor {
+	.editor-default-block-appender {
+		// Default to centered and content-width, like blocks
+		max-width: $content-width;
+		margin-left: auto;
+		margin-right: auto;
+		position: relative;
 
+		&[data-root-client-id=""] .editor-default-block-appender__content:hover {
+			// Outline on root-level default block appender is redundant with the
+			// WritingFlow click redirector.
+			outline: 1px solid transparent;
+		}
+
+		@include break-small() {
+			.editor-default-block-appender__content {
+				padding: 0 $block-padding;
+			}
+		}
+	}
+
+	// Ensure that the height of the first appender, and the one between blocks, is the same as text.
+	.editor-block-list__block[data-type="core/paragraph"] p[data-is-placeholder-visible="true"] + p,
 	.editor-default-block-appender__content {
 		height: $empty-paragraph-height / 2;
-	}
-
-	&[data-root-client-id=""] .editor-default-block-appender__content:hover {
-		// Outline on root-level default block appender is redundant with the
-		// WritingFlow click redirector.
-		outline: 1px solid transparent;
-	}
-
-	@include break-small() {
-		.editor-default-block-appender__content {
-			padding: 0 $block-padding;
-		}
+		line-height: $editor-line-height;
 	}
 }

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -138,8 +138,8 @@
 	}
 
 	// Adjust the spacing of the appender, or the first block, to sit near the title.
-	> .editor-default-block-appender > .editor-default-block-appender__content,
-	> .editor-block-list__block:first-child > .editor-block-list__block-edit {
+	.editor-default-block-appender > .editor-default-block-appender__content,
+	.editor-block-list__block:first-child > .editor-block-list__block-edit {
 		margin-top: $block-padding - $block-spacing / 2;
 	}
 


### PR DESCRIPTION
This PR is a hotfix for a small regression introduced in https://github.com/WordPress/gutenberg/pull/9735. Basically the empty "Write your story" placeholder had no top margin, and jumped when clicked. This PR fixes that.

Before:

<img width="701" alt="before" src="https://user-images.githubusercontent.com/1204802/45345291-3a2c9900-b5a6-11e8-8962-6a26a216c33d.png">

After:

<img width="706" alt="after" src="https://user-images.githubusercontent.com/1204802/45345298-3dc02000-b5a6-11e8-96d4-17fe790c5e9b.png">

Additionally it fixes an issue I think might have regressed with editor styles. The appender _height_ used to be the same as a paragraph height (28px, 56px with margins). But this regressed. This PR adds an explicit height to the appender input field to fix this, noting that a Paragraph is actually a paragraph, whereas the appender is an input field. 

![height](https://user-images.githubusercontent.com/1204802/45345359-6e07be80-b5a6-11e8-8cc3-dad40e6e6bf0.gif)

☝️ in that GIF I type in "Write your story", then delete the block, then use undo/redo to ensure they look identical