### PR TITLE
Try: Remove the sidebar close button on desktop breakpoints

### DIFF
--- a/edit-post/components/sidebar/sidebar-header/index.js
+++ b/edit-post/components/sidebar/sidebar-header/index.js
@@ -16,7 +16,6 @@ import { withDispatch, withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import './style.scss';
-import shortcuts from '../../../keyboard-shortcuts';
 
 const SidebarHeader = ( { children, className, closeLabel, closeSidebar, title } ) => {
 	return (
@@ -33,12 +32,6 @@ const SidebarHeader = ( { children, className, closeLabel, closeSidebar, title }
 			</div>
 			<div className={ classnames( 'components-panel__header edit-post-sidebar-header', className ) }>
 				{ children }
-				<IconButton
-					onClick={ closeSidebar }
-					icon="no-alt"
-					label={ closeLabel }
-					shortcut={ shortcuts.toggleSidebar.display }
-				/>
 			</div>
 		</Fragment>
 	);

--- a/edit-post/components/sidebar/sidebar-header/style.scss
+++ b/edit-post/components/sidebar/sidebar-header/style.scss
@@ -14,20 +14,3 @@
 		display: none;
 	}
 }
-
-.components-panel__header.edit-post-sidebar-header {
-	padding-right: $panel-padding / 2;
-
-	.components-icon-button {
-		display: none;
-		margin-left: auto;
-
-		~ .components-icon-button {
-			margin-left: 0;
-		}
-
-		@include break-medium() {
-			display: flex;
-		}
-	}
-}

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -151,15 +151,6 @@
 	padding-right: $panel-padding / 2;
 	border-top: 0;
 	margin-top: 0;
-
-	.components-icon-button {
-		display: none;
-		margin-left: auto;
-
-		@include break-medium() {
-			display: flex;
-		}
-	}
 }
 
 .edit-post-sidebar__panel-tab {


### PR DESCRIPTION
Why do this?

Right now the sidebar close button does the same as toggling the cog from the Editor Bar. Redundant UI is usually okay in situations like these, but given the overall complexity of the top right desktop breakpoint UI already — which features both the editor bar cogs, tabs in the sidebar.

By removing a single piece of UI, we keep the exact same functionality as before, but reduce the visual footprint just slightly.

Thoughts? Yay or nay?

Before:

<img width="614" alt="screen shot 2018-09-11 at 11 38 40" src="https://user-images.githubusercontent.com/1204802/45352623-33f3e800-b5b9-11e8-8d50-5556dc7166a2.png">

After:

<img width="594" alt="screen shot 2018-09-11 at 11 43 58" src="https://user-images.githubusercontent.com/1204802/45352629-36564200-b5b9-11e8-8da1-10e42a3dcff0.png">
