### PR TITLE
Issue/9785 - Remove isButton prop

### DIFF
--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -84,7 +84,6 @@ export default function ColorPalette( { colors, disableCustomColors = false, val
 				className="components-color-palette__clear"
 				type="button"
 				onClick={ () => onChange( undefined ) }
-				isButton
 				isSmall
 				isDefault
 			>

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -127,7 +127,6 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
   </div>
   <Button
     className="components-color-palette__clear"
-    isButton={true}
     isDefault={true}
     isSmall={true}
     onClick={[Function]}
@@ -213,7 +212,6 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   />
   <Button
     className="components-color-palette__clear"
-    isButton={true}
     isDefault={true}
     isSmall={true}
     onClick={[Function]}


### PR DESCRIPTION
Fixes #9785

## Description
Removed the isButton prop

## How has this been tested?
Removed prop, recompiled, opened color settings panel and there was no error.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
