### PR TITLE
Docs: Fix code tabs in Extending Blocks 

### DIFF
--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -169,6 +169,7 @@ const withInspectorControls =  createHigherOrderComponent(BlockEdit => {
 
 wp.hooks.addFilter( 'editor.BlockEdit', 'my-plugin/with-inspector-controls', withInspectorControls );
 ```
+{% end %}
 
 #### `editor.BlockListBlock`
 
@@ -223,6 +224,7 @@ const withDataAlign = createHigherOrderComponent( ( BlockListBlock ) => {
 
 wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-data-align', withDataAlign );
 ```
+{% end %}
 
 ## Removing Blocks
 

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -20,7 +20,7 @@ The example above registers a block style variation called `fancy-quote` to the 
 
 ### Filters
 
-Extensing blocks can involve more than just providing alternative styles, in this case, you can use one of the following filters to extend the block settings.
+Extending blocks can involve more than just providing alternative styles, in this case, you can use one of the following filters to extend the block settings.
 
 #### `blocks.registerBlockType`
 


### PR DESCRIPTION
## Description
This PR repairs the code tabs in [Extending Blocks](https://wordpress.org/gutenberg/handbook/extensibility/extending-blocks/) and fixes a typo. 
