### PR TITLE
Use a pseudo element to prevent inspector tab width from changing when selected

### DIFF
--- a/edit-post/components/sidebar/settings-header/index.js
+++ b/edit-post/components/sidebar/settings-header/index.js
@@ -24,6 +24,7 @@ const SettingsHeader = ( { count, openDocumentSettings, openBlockSettings, sideb
 				onClick={ openDocumentSettings }
 				className={ `edit-post-sidebar__panel-tab ${ sidebarName === 'edit-post/document' ? 'is-active' : '' }` }
 				aria-label={ __( 'Document settings' ) }
+				data-label={ __( 'Document' ) }
 			>
 				{ __( 'Document' ) }
 			</button>
@@ -31,6 +32,11 @@ const SettingsHeader = ( { count, openDocumentSettings, openBlockSettings, sideb
 				onClick={ openBlockSettings }
 				className={ `edit-post-sidebar__panel-tab ${ sidebarName === 'edit-post/block' ? 'is-active' : '' }` }
 				aria-label={ __( 'Block settings' ) }
+				data-label={ (
+					1 === count ?
+						__( 'Block' ) :
+						sprintf( _n( '%d Block', '%d Blocks', count ), count )
+				) }
 			>
 				{ (
 					1 === count ?

--- a/edit-post/components/sidebar/settings-header/index.js
+++ b/edit-post/components/sidebar/settings-header/index.js
@@ -13,7 +13,10 @@ import SidebarHeader from '../sidebar-header';
 
 const SettingsHeader = ( { count, openDocumentSettings, openBlockSettings, sidebarName } ) => {
 	// Do not display "0 Blocks".
-	count = count === 0 ? 1 : count;
+	const blockCount = count === 0 ? 1 : count;
+	const blockLabel = blockCount === 1 ?
+		__( 'Block' ) :
+		sprintf( _n( '%d Block', '%d Blocks', blockCount ), blockCount );
 
 	return (
 		<SidebarHeader
@@ -32,17 +35,9 @@ const SettingsHeader = ( { count, openDocumentSettings, openBlockSettings, sideb
 				onClick={ openBlockSettings }
 				className={ `edit-post-sidebar__panel-tab ${ sidebarName === 'edit-post/block' ? 'is-active' : '' }` }
 				aria-label={ __( 'Block settings' ) }
-				data-label={ (
-					1 === count ?
-						__( 'Block' ) :
-						sprintf( _n( '%d Block', '%d Blocks', count ), count )
-				) }
+				data-label={ blockLabel }
 			>
-				{ (
-					1 === count ?
-						__( 'Block' ) :
-						sprintf( _n( '%d Block', '%d Blocks', count ), count )
-				) }
+				{ blockLabel }
 			</button>
 		</SidebarHeader>
 	);

--- a/edit-post/components/sidebar/settings-header/style.scss
+++ b/edit-post/components/sidebar/settings-header/style.scss
@@ -1,7 +1,7 @@
 .components-panel__header.edit-post-sidebar__panel-tabs {
 	justify-content: flex-start;
 	padding-left: 0;
-	padding-right: $grid-size-small;
+	padding-right: $panel-padding / 2;
 	border-top: 0;
 }
 

--- a/edit-post/components/sidebar/settings-header/style.scss
+++ b/edit-post/components/sidebar/settings-header/style.scss
@@ -17,6 +17,17 @@
 	color: $dark-gray-900;
 	@include square-style__neutral;
 
+	// This pseudo-element "duplicates" the tab label and sets the text to bold.
+	// This ensures that the tab doesn't change width when selected.
+	&::after {
+		display: block;
+		content: attr(data-label);
+		font-weight: 600;
+		overflow: hidden;
+		visibility: hidden;
+		height: 0;
+	}
+
 	&.is-active {
 		padding-bottom: 0;
 		border-bottom: 3px solid theme(primary);

--- a/edit-post/components/sidebar/settings-header/style.scss
+++ b/edit-post/components/sidebar/settings-header/style.scss
@@ -22,6 +22,7 @@
 	&::after {
 		display: block;
 		content: attr(data-label);
+		speak: none;
 		font-weight: 600;
 		overflow: hidden;
 		visibility: hidden;

--- a/edit-post/components/sidebar/settings-header/style.scss
+++ b/edit-post/components/sidebar/settings-header/style.scss
@@ -1,7 +1,7 @@
 .components-panel__header.edit-post-sidebar__panel-tabs {
 	justify-content: flex-start;
 	padding-left: 0;
-	padding-right: $panel-padding / 2;
+	padding-right: $grid-size-small;
 	border-top: 0;
 }
 
@@ -19,14 +19,15 @@
 
 	// This pseudo-element "duplicates" the tab label and sets the text to bold.
 	// This ensures that the tab doesn't change width when selected.
+	// See: https://github.com/WordPress/gutenberg/pull/9793
 	&::after {
-		display: block;
 		content: attr(data-label);
-		speak: none;
+		display: block;
 		font-weight: 600;
-		overflow: hidden;
-		visibility: hidden;
 		height: 0;
+		overflow: hidden;
+		speak: none;
+		visibility: hidden;
 	}
 
 	&.is-active {


### PR DESCRIPTION
This is a very small tweak, but it's one of those little things that makes me crazy ;-)

It adds a pseudo element to the inspector tabs, with the content set to match the tab label. The psuedo-element is bolded, so the width of the tab is always the same. It's sort of hard to explain in text so here's an example:

**Before:**
![tab-normal](https://user-images.githubusercontent.com/1231306/45365184-f5a2fc80-b5a9-11e8-9dd8-b6ddf9e84ed1.gif)

**After:**
![tab-fixed](https://user-images.githubusercontent.com/1231306/45365200-fe93ce00-b5a9-11e8-8eb9-27fa95581076.gif)

And to help make it a bit clearer what's happening under-the-hood, here's how it looks if the pseudo element is visible (it's the 2nd line of labels):

![tab-example](https://user-images.githubusercontent.com/1231306/45365239-15d2bb80-b5aa-11e8-9389-a7e49d7c7294.png)

That second label is pre-bolded, so when the focus changes and the visible label changes to bold, the width is unchanged.

There's probably a better way to have the data attribute on the JS side (on the Block tab in particular, since there's some logic around selected block count that I just duplicated) but I'm not sure what's most appropriate there.