### PR TITLE
Framework: Add wp-polyfill as central polyfill

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -100,65 +100,83 @@ function gutenberg_register_scripts_and_styles() {
 	register_tinymce_scripts();
 
 	wp_register_script(
+		'wp-polyfill',
+		null,
+		array(
+			'wp-polyfill-ecmascript',
+		)
+	);
+	wp_script_add_data(
+		'wp-polyfill',
+		'data',
+		gutenberg_get_script_polyfill(
+			array(
+				'\'fetch\' in window' => 'wp-polyfill-fetch',
+				'document.contains'   => 'wp-polyfill-node-contains',
+				'window.FormData && window.FormData.prototype.keys' => 'wp-polyfill-formdata',
+			)
+		)
+	);
+	wp_register_script(
 		'wp-url',
 		gutenberg_url( 'build/url/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/url/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-autop',
 		gutenberg_url( 'build/autop/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/autop/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-wordcount',
 		gutenberg_url( 'build/wordcount/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/wordcount/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-dom-ready',
 		gutenberg_url( 'build/dom-ready/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/dom-ready/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-a11y',
 		gutenberg_url( 'build/a11y/index.js' ),
-		array( 'wp-dom-ready', 'wp-polyfill-ecmascript' ),
+		array( 'wp-dom-ready', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/a11y/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-hooks',
 		gutenberg_url( 'build/hooks/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/hooks/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-i18n',
 		gutenberg_url( 'build/i18n/index.js' ),
-		array( 'wp-deprecated', 'wp-polyfill-ecmascript' ),
+		array( 'wp-deprecated', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/i18n/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-is-shallow-equal',
 		gutenberg_url( 'build/is-shallow-equal/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/is-shallow-equal/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-token-list',
 		gutenberg_url( 'build/token-list/index.js' ),
-		array( 'lodash', 'wp-polyfill-ecmascript' ),
+		array( 'lodash', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/token-list/index.js' ),
 		true
 	);
@@ -167,18 +185,9 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-api-fetch',
 		gutenberg_url( 'build/api-fetch/index.js' ),
-		array( 'wp-polyfill-ecmascript', 'wp-hooks', 'wp-i18n' ),
+		array( 'wp-polyfill', 'wp-hooks', 'wp-i18n' ),
 		filemtime( gutenberg_dir_path() . 'build/api-fetch/index.js' ),
 		true
-	);
-	wp_add_inline_script(
-		'wp-api-fetch',
-		gutenberg_get_script_polyfill(
-			array(
-				'\'fetch\' in window' => 'wp-polyfill-fetch',
-			)
-		),
-		'before'
 	);
 	wp_add_inline_script(
 		'wp-api-fetch',
@@ -200,35 +209,35 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-deprecated',
 		gutenberg_url( 'build/deprecated/index.js' ),
-		array( 'wp-polyfill-ecmascript', 'wp-hooks' ),
+		array( 'wp-polyfill', 'wp-hooks' ),
 		filemtime( gutenberg_dir_path() . 'build/deprecated/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-blob',
 		gutenberg_url( 'build/blob/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/blob/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-compose',
 		gutenberg_url( 'build/compose/index.js' ),
-		array( 'lodash', 'wp-element', 'wp-is-shallow-equal', 'wp-polyfill-ecmascript' ),
+		array( 'lodash', 'wp-element', 'wp-is-shallow-equal', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/compose/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-keycodes',
 		gutenberg_url( 'build/keycodes/index.js' ),
-		array( 'lodash', 'wp-polyfill-ecmascript' ),
+		array( 'lodash', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/keycodes/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-html-entities',
 		gutenberg_url( 'build/html-entities/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/html-entities/index.js' ),
 		true
 	);
@@ -240,7 +249,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-compose',
 			'wp-element',
 			'wp-is-shallow-equal',
-			'wp-polyfill-ecmascript',
+			'wp-polyfill',
 			'wp-redux-routine',
 		),
 		filemtime( gutenberg_dir_path() . 'build/data/index.js' ),
@@ -264,14 +273,14 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-core-data',
 		gutenberg_url( 'build/core-data/index.js' ),
-		array( 'wp-data', 'wp-api-fetch', 'wp-polyfill-ecmascript', 'wp-url', 'lodash' ),
+		array( 'wp-data', 'wp-api-fetch', 'wp-polyfill', 'wp-url', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/core-data/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-dom',
 		gutenberg_url( 'build/dom/index.js' ),
-		array( 'lodash', 'wp-polyfill-ecmascript', 'wp-tinymce' ),
+		array( 'lodash', 'wp-polyfill', 'wp-tinymce' ),
 		filemtime( gutenberg_dir_path() . 'build/dom/index.js' ),
 		true
 	);
@@ -285,37 +294,28 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-block-serialization-spec-parser',
 		gutenberg_url( 'build/block-serialization-spec-parser/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/block-serialization-spec-parser/index.js' ),
 		true
-	);
-	wp_add_inline_script(
-		'wp-dom',
-		gutenberg_get_script_polyfill(
-			array(
-				'document.contains' => 'wp-polyfill-node-contains',
-			)
-		),
-		'before'
 	);
 	wp_register_script(
 		'wp-shortcode',
 		gutenberg_url( 'build/shortcode/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/shortcode/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-redux-routine',
 		gutenberg_url( 'build/redux-routine/index.js' ),
-		array( 'wp-polyfill-ecmascript' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/redux-routine/index.js' ),
 		true
 	);
 	wp_register_script(
 		'wp-date',
 		gutenberg_url( 'build/date/index.js' ),
-		array( 'moment', 'wp-polyfill-ecmascript' ),
+		array( 'moment', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/date/index.js' ),
 		true
 	);
@@ -357,7 +357,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-element',
 		gutenberg_url( 'build/element/index.js' ),
-		array( 'wp-polyfill-ecmascript', 'react', 'react-dom', 'lodash' ),
+		array( 'wp-polyfill', 'react', 'react-dom', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/element/index.js' ),
 		true
 	);
@@ -378,7 +378,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-i18n',
 			'wp-is-shallow-equal',
 			'wp-keycodes',
-			'wp-polyfill-ecmascript',
+			'wp-polyfill',
 			'wp-url',
 		),
 		filemtime( gutenberg_dir_path() . 'build/components/index.js' ),
@@ -402,7 +402,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-hooks',
 			'wp-i18n',
 			'wp-is-shallow-equal',
-			'wp-polyfill-ecmascript',
+			'wp-polyfill',
 			'wp-shortcode',
 			'lodash',
 		),
@@ -412,7 +412,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-viewport',
 		gutenberg_url( 'build/viewport/index.js' ),
-		array( 'wp-polyfill-ecmascript', 'wp-element', 'wp-data', 'wp-compose', 'lodash' ),
+		array( 'wp-polyfill', 'wp-element', 'wp-data', 'wp-compose', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/viewport/index.js' ),
 		true
 	);
@@ -436,7 +436,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-html-entities',
 			'wp-i18n',
 			'wp-keycodes',
-			'wp-polyfill-ecmascript',
+			'wp-polyfill',
 			'wp-url',
 			'wp-viewport',
 		),
@@ -452,7 +452,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-compose',
 			'wp-data',
 			'wp-i18n',
-			'wp-polyfill-ecmascript',
+			'wp-polyfill',
 			'lodash',
 		),
 		filemtime( gutenberg_dir_path() . 'build/nux/index.js' ),
@@ -461,7 +461,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-plugins',
 		gutenberg_url( 'build/plugins/index.js' ),
-		array( 'lodash', 'wp-compose', 'wp-element', 'wp-hooks', 'wp-polyfill-ecmascript' ),
+		array( 'lodash', 'wp-compose', 'wp-element', 'wp-hooks', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/plugins/index.js' )
 	);
 	// Loading the old editor and its config to ensure the classic block works as expected.
@@ -592,7 +592,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-is-shallow-equal',
 			'wp-keycodes',
 			'wp-nux',
-			'wp-polyfill-ecmascript',
+			'wp-polyfill',
 			'wp-tinymce',
 			'wp-token-list',
 			'wp-url',
@@ -625,16 +625,11 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-i18n',
 			'wp-keycodes',
 			'wp-plugins',
-			'wp-polyfill-ecmascript',
+			'wp-polyfill',
 			'wp-viewport',
 		),
 		filemtime( gutenberg_dir_path() . 'build/edit-post/index.js' ),
 		true
-	);
-	wp_add_inline_script(
-		'wp-edit-post',
-		gutenberg_get_script_polyfill( array( 'window.FormData && window.FormData.prototype.keys' => 'wp-polyfill-formdata' ) ),
-		'before'
 	);
 
 	// Editor Styles.


### PR DESCRIPTION
Related (will require changes to): #9750

This pull request seeks to refactor our polyfills, introducing a new central `wp-polyfill` handle which includes polyfills for both JavaScript language features (`Promise`, etc) _and_ modern browser features (currently `window.fetch`, `Node#contains`, `FormData`, soon `Element#closest`).

**Implementation notes:**

It does not remove or deprecate `wp-polyfill-ecmascript`, but rather acts as a superset, where the intended contract of "ecmascript" would be for language features, regardless of whether the underlying `babel-polyfill` / `core-js` provides browser polyfills.

**Testing instructions:**

Verify there are no regressions in the behavior of polyfills, particularly in Internet Explorer 11.

Note that there is currently a separate issue with saving in IE11, not addressed here.