### PR TITLE
Framework: Pin fetch polyfill to 3.0 UMD distributable

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -832,7 +832,7 @@ function gutenberg_register_vendor_scripts() {
 	wp_add_inline_script( 'lodash', 'window.lodash = _.noConflict();' );
 	gutenberg_register_vendor_script(
 		'wp-polyfill-fetch',
-		'https://unpkg.com/whatwg-fetch/fetch.js'
+		'https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js'
 	);
 	gutenberg_register_vendor_script(
 		'wp-polyfill-promise',


### PR DESCRIPTION
**This should be included in a 3.8 final release.**

This pull request seeks to resolve an issue where the `fetch` polyfill is no longer usable in Internet Explorer 11. This was due to the fact that we had never pinned the version of polyfill we consume, thus when its latest [3.0.0 release](https://github.com/github/fetch/releases/tag/v3.0.0) included breaking changes to the default build targetting [JavaScript modules](https://caniuse.com/#feat=es6-module), not supportable in IE11.

The changes here target the IE-compatible UMD build, and also pin to the 3.0.0 version to avoid future issues.

**Testing instructions:**

Verify that saving works as expected in Internet Explorer and your preferred browser.

Based on our hashing of vendor scripts, I do not expect that an existing downloaded/cached copy should need to be deleted.