### PR TITLE
Removing wrapper div from the categories block

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -41,7 +41,7 @@ function render_block_core_categories( $attributes ) {
 			$wrapper_markup .= build_dropdown_script_block_core_categories( $id );
 		}
 	} else {
-		$wrapper_markup = '<div class="%1$s"><ul>%2$s</ul></div>';
+		$wrapper_markup = '<ul class="%1$s">%2$s</ul>';
 		$items_markup   = wp_list_categories( $args );
 		$type           = 'list';
 	}


### PR DESCRIPTION
Fixes #9411 

Previously, the categories block was rendered inside a div, while other list-based blocks (archives, latest posts, list, etc.) were not. This update removes the div wrapper for consistency.

Previously, this block would render like this:
```
<!-- Categories Block -->
<div class="wp-block-categories wp-block-categories-list aligncenter">
  <ul>
    <li class="cat-item cat-item-1"><a href="#">Category</a></li>
    <li class="cat-item cat-item-2"><a href="#">Category</a></li>
    <li class="cat-item cat-item-3"><a href="#">Category</a></li>
  </ul>
</div>
```

But this change updates that to:
```
<!-- Categories Block -->
<ul class="wp-block-categories wp-block-categories-list aligncenter">
  <li class="cat-item cat-item-1"><a href="#">Category</a></li>
  <li class="cat-item cat-item-2"><a href="#">Category</a></li>
  <li class="cat-item cat-item-3"><a href="#">Category</a></li>
</ul>
```

We still need the wrapper div if this is shown as a dropdown, so this doesn't effect that. Seems like a simple change, and doesn't seem to require any css updates.  