### PR TITLE
Build Tooling: Include block serialization default parser in plugin

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -122,6 +122,7 @@ zip -r gutenberg.zip \
 	lib/*.php \
 	block-library/*/*.php \
 	packages/block-library/src/*/*.php \
+	packages/block-serialization-default-parser/*.php \
 	post-content.php \
 	$vendor_scripts \
 	$build_files \


### PR DESCRIPTION
**This should be included in a final 3.8 release.**

Fixes #9791 
Related: #8083

This pull request seeks to resolve an issue where the new PHP parser introduced in #8083 was not included in the plugin distributable.

**Testing instructions:**

Run `npm run package-plugin`. Ensure that the generated ZIP includes `packages/block-serialization-default-parser/parser.php`.

Verify there are no other non-included PHP files contained in packages:

```
find packages -type f -name "*.php"
```