### PR TITLE
Apply consistent spacing on the post visibility popover

### DIFF
--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -75,7 +75,7 @@ export class PostVisibility extends Component {
 		};
 
 		return [
-			<fieldset key="visibility-selector" className="editor-post-visibility">
+			<fieldset key="visibility-selector" className="editor-post-visibility__dialog-fieldset">
 				<legend className="editor-post-visibility__dialog-legend">
 					{ __( 'Post Visibility' ) }
 				</legend>

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -1,6 +1,6 @@
 .edit-post-post-visibility__dialog {
 	.editor-post-visibility__dialog-fieldset {
-		padding: 3px;
+		padding: $grid-size-small;
 		padding-top: 0;
 	}
 

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -1,19 +1,34 @@
 .edit-post-post-visibility__dialog {
+	.editor-post-visibility__dialog-fieldset {
+		padding: 3px;
+		padding-top: 0;
+	}
+
 	.editor-post-visibility__dialog-legend {
 		font-weight: 600;
 		margin-bottom: 1em;
 		margin-top: 0.5em;
+		padding: 0;
 	}
+
 	.editor-post-visibility__dialog-radio {
 		margin-top: 2px;
 	}
+
 	.editor-post-visibility__dialog-label {
 		font-weight: 600;
 	}
+
 	.editor-post-visibility__dialog-info {
 		margin-top: 0;
 		margin-left: 28px;
 	}
+
+	// Remove bottom margin on the last label only.
+	.editor-post-visibility__choice:last-child .editor-post-visibility__dialog-info {
+		margin-bottom: 0;
+	}
+
 	.editor-post-visibility__dialog-password-input {
 		margin-left: 28px;
 	}


### PR DESCRIPTION
This is a small tweak to the padding/spacing on the post visibility popover.

**Before:**

![visibility-before](https://user-images.githubusercontent.com/1231306/45370500-6c45f700-b5b6-11e8-8dd1-9b612b22bd4a.png)

**After:**

![visibility-after](https://user-images.githubusercontent.com/1231306/45370513-710aab00-b5b6-11e8-9b01-01e73940dfb7.png)

I also tweaked the class for the `<fieldset>` to be more consistent with the other BEM classes.

Note that @aduth had a question about the nested CSS classes on the original PR #9138 which I have not resolved here. It's a totally fair point, but should probably be part of a bigger discussion on CSS standards, as there are many cases of nested CSS rulesets (that probably don't need to be nested) around the Gutenberg code base.