### PR TITLE
Add table dimension controls

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -23,6 +23,7 @@ import {
 	Button,
 	Toolbar,
 	DropdownMenu,
+	ResizableBox,
 } from '@wordpress/components';
 
 /**
@@ -35,7 +36,6 @@ import {
 	deleteRow,
 	insertColumn,
 	deleteColumn,
-	getTableStyles,
 	getStyleValue,
 	getStyleUnit,
 } from './state';
@@ -462,6 +462,8 @@ export class TableEdit extends Component {
 			className,
 			backgroundColor,
 			setBackgroundColor,
+			toggleSelection,
+			setAttributes,
 		} = this.props;
 		const { initialRowCount, initialColumnCount, widthUnit } = this.state;
 		const { hasFixedLayout, head, body, foot, width, height } = attributes;
@@ -565,11 +567,33 @@ export class TableEdit extends Component {
 						] }
 					/>
 				</InspectorControls>
-				<table className={ classes } style={ getTableStyles( attributes ) }>
-					<Section type="head" rows={ head } />
-					<Section type="body" rows={ body } />
-					<Section type="foot" rows={ foot } />
-				</table>
+				<ResizableBox
+					className="block-library-table__resizable-box"
+					size={ {
+						width,
+						height,
+					} }
+					enable={ {
+						right: true,
+						bottom: true,
+					} }
+					onResizeStart={ () => {
+						toggleSelection( false );
+					} }
+					onResizeStop={ ( event, direction, element ) => {
+						setAttributes( {
+							width: direction === 'right' ? element.style.width : width,
+							height: direction === 'bottom' ? element.style.height : height,
+						} );
+						toggleSelection( true );
+					} }
+				>
+					<table className={ classes }>
+						<Section type="head" rows={ head } />
+						<Section type="body" rows={ body } />
+						<Section type="foot" rows={ foot } />
+					</table>
+				</ResizableBox>
 			</Fragment>
 		);
 	}

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -426,7 +426,6 @@ export class TableEdit extends Component {
 									className={ cellClasses }
 								>
 									<RichText
-										className="wp-block-table__cell-content"
 										value={ content }
 										onChange={ this.onChange }
 										unstableOnFocus={ this.createOnFocus( cell ) }

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -424,6 +424,14 @@ export class TableEdit extends Component {
 								<CellTag
 									key={ columnIndex }
 									className={ cellClasses }
+									onClick={ ( event ) => {
+										// When a cell is selected, forward focus to the child contenteditable. This solves an issue where the
+										// user may click inside a cell, but outside of the contenteditable, resulting in nothing happening.
+										const contentEditable = event && event.target && event.target.querySelector( '[contenteditable=true]' );
+										if ( contentEditable ) {
+											contentEditable.focus();
+										}
+									} }
 								>
 									<RichText
 										value={ content }

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -19,11 +19,6 @@
 
 
 .wp-block-table {
-	table {
-		border-collapse: collapse;
-		width: 100%;
-	}
-
 	td,
 	th {
 		padding: 0;
@@ -41,3 +36,14 @@
 		padding: 0.5em;
 	}
 }
+
+.block-library-table__dimensions__row {
+	display: flex;
+}
+
+.block-library-table__dimensions__width {
+	flex: 1;
+	// Use padding since it's hard to override the margin of the base control.
+	padding-right: 5px;
+}
+

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -21,7 +21,7 @@
 .wp-block-table {
 	td,
 	th {
-		padding: 0;
+		padding: 0.5rem;
 		border: $border-width solid $black;
 	}
 
@@ -30,10 +30,6 @@
 		border-color: $blue-medium-500;
 		box-shadow: inset 0 0 0 1px $blue-medium-500;
 		border-style: double;
-	}
-
-	&__cell-content {
-		padding: 0.5em;
 	}
 }
 

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -17,8 +17,10 @@
 	}
 }
 
-
 .wp-block-table {
+	width: 100%;
+	height: 100%;
+
 	td,
 	th {
 		padding: 0.5rem;
@@ -31,6 +33,18 @@
 		box-shadow: inset 0 0 0 1px $blue-medium-500;
 		border-style: double;
 	}
+
+
+}
+
+.block-library-table__resizable-box {
+	// Using display table is a hack to ensure wrapping resizable box can't be resized to smaller than the content.
+	display: table;
+	min-width: $break-mobile / 2;
+
+	& .components-resizable-box__handle {
+		display: block;
+	}
 }
 
 .block-library-table__dimensions__row {
@@ -42,4 +56,3 @@
 	// Use padding since it's hard to override the margin of the base control.
 	padding-right: 5px;
 }
-

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -15,6 +15,7 @@ import { RichText, getColorClassName } from '@wordpress/editor';
  * Internal dependencies
  */
 import edit from './edit';
+import { getTableStyles } from './state';
 
 const tableContentPasteSchema = {
 	tr: {
@@ -31,6 +32,7 @@ const tableContentPasteSchema = {
 
 const tablePasteSchema = {
 	table: {
+		attributes: [ 'style' ],
 		children: {
 			thead: {
 				children: tableContentPasteSchema,
@@ -87,6 +89,13 @@ export const settings = {
 			default: false,
 		},
 		backgroundColor: {
+			type: 'string',
+		},
+		width: {
+			type: 'string',
+			default: '100%',
+		},
+		height: {
 			type: 'string',
 		},
 		head: getTableSectionAttributeSchema( 'head' ),
@@ -161,7 +170,7 @@ export const settings = {
 		};
 
 		return (
-			<table className={ classes }>
+			<table className={ classes } style={ getTableStyles( attributes ) }>
 				<Section type="head" rows={ head } />
 				<Section type="body" rows={ body } />
 				<Section type="foot" rows={ foot } />

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -157,3 +157,56 @@ export function deleteColumn( state, {
 		} ) ).filter( ( row ) => row.cells.length ),
 	};
 }
+
+/**
+ * Get the integer value of a style property.
+ *
+ * @param {?string} rawValue The style's raw value (e.g. 100%, 25px).
+ *
+ * @return {?number} The integer value (e.g. 100, 25).
+ */
+export function getStyleValue( rawValue ) {
+	const parsedValue = parseInt( rawValue, 10 );
+
+	if ( isNaN( parsedValue ) ) {
+		return;
+	}
+
+	return parsedValue;
+}
+
+/**
+ * Get the px or % unit from a style value.
+ *
+ * @param {?string} value The style's value (e.g. 100px, 25%).
+ *
+ * @return {?string} The unit (e.g. px, %).
+ */
+export function getStyleUnit( value ) {
+	const match = /(px|%)/i.exec( value );
+
+	if ( ! match ) {
+		return;
+	}
+
+	return match[ 1 ].toLowerCase();
+}
+
+/**
+ * Given the table block attributes, return the style properties.
+ *
+ * @param {?string} attributes.width  The width value.
+ * @param {?string} attributes.height The height value.
+ *
+ * @return {?Object} The style properties.
+ */
+export function getTableStyles( { width, height } ) {
+	if ( ! width && ! height ) {
+		return;
+	}
+
+	return {
+		width: width ? width : undefined,
+		height: height ? height : undefined,
+	};
+}

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -206,7 +206,7 @@ export function getTableStyles( { width, height } ) {
 	}
 
 	return {
-		width: width ? width : undefined,
+		width: width && width !== '100%' ? width : undefined,
 		height: height ? height : undefined,
 	};
 }

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -13,6 +13,9 @@ import {
 	deleteRow,
 	insertColumn,
 	deleteColumn,
+	getStyleValue,
+	getStyleUnit,
+	getTableStyles,
 } from '../state';
 
 const table = deepFreeze( {
@@ -284,5 +287,54 @@ describe( 'deleteColumn', () => {
 		};
 
 		expect( state ).toEqual( expected );
+	} );
+} );
+
+describe( 'getStyleValue', () => {
+	it( 'returns 50 for a style value with the numerical value of 50', () => {
+		expect( getStyleValue( '50%' ) ).toBe( 50 );
+		expect( getStyleValue( '50px' ) ).toBe( 50 );
+		expect( getStyleValue( 50 ) ).toBe( 50 );
+	} );
+
+	it( 'returns undefined when unable to find a numerical value', () => {
+		expect( getStyleValue() ).toBeUndefined();
+		expect( getStyleValue( '' ) ).toBeUndefined();
+		expect( getStyleValue( 'px' ) ).toBeUndefined();
+		expect( getStyleValue( null ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'getStyleUnit', () => {
+	it( 'returns % for a style value with the % suffix', () => {
+		expect( getStyleUnit( '50%' ) ).toBe( '%' );
+	} );
+
+	it( 'returns px for a style value with the px suffix', () => {
+		expect( getStyleUnit( '50px' ) ).toBe( 'px' );
+	} );
+
+	it( 'returns px for a style value with the PX suffix (case insensitivity)', () => {
+		expect( getStyleUnit( '50PX' ) ).toBe( 'px' );
+	} );
+
+	it( 'returns undefined when unable to find a px or % value', () => {
+		expect( getStyleUnit( '50' ) ).toBeUndefined();
+		expect( getStyleUnit( '' ) ).toBeUndefined();
+		expect( getStyleUnit( 50 ) ).toBeUndefined();
+		expect( getStyleUnit( null ) ).toBeUndefined();
+		expect( getStyleUnit() ).toBeUndefined();
+	} );
+} );
+
+describe( 'getTableStyles', () => {
+	it( 'returns undefined when height and width are falsey values', () => {
+		expect( getTableStyles( {} ) ).toBeUndefined();
+		expect( getTableStyles( { width: '', height: '' } ) ).toBeUndefined();
+	} );
+
+	it( 'returns the width and height attributes in an object when defined', () => {
+		const attributes = { width: '50%', height: '200px', somethingElse: 'ignored' };
+		expect( getTableStyles( attributes ) ).toEqual( { width: '50%', height: '200px' } );
 	} );
 } );


### PR DESCRIPTION
## Description
Fixes #9327
Fixes #9114
Fixes #8325
Related #6923

This PR adds width and height controls to the table block. Summarised:
- Add new width/height attributes to the table block
- Add width/height controls to table block sidebar - changing these adjusts the table element's width & height inline styles

## How has this been tested?
- Test deprecation by creating a table block on `master`, saving and loading post on this branch.
- Test pasting a table that has width and height style properties
- Test unsetting table width/height values - table reverts to full width horizontally and content size vertically
- Added unit and integration tests
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
**Using width/height controls**
![table-width-height](https://user-images.githubusercontent.com/677833/45374156-39692680-b5e9-11e8-8a4e-af304ec44067.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
