### PR TITLE
Updates to the Font Size Picker

### DIFF
--- a/edit-post/components/sidebar/block-sidebar/style.scss
+++ b/edit-post/components/sidebar/block-sidebar/style.scss
@@ -4,9 +4,9 @@
 	margin: 0 -16px;
 
 	.components-base-control {
-		margin: 0 0 1em 0;
+		margin: 0 0 1.5em 0;
 		&:last-child {
-			margin-bottom: 0;
+			margin-bottom: 0.5em;
 		}
 	}
 

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -110,17 +110,17 @@
 }
 
 .has-small-font-size {
-	font-size: 14px;
+	font-size: 13px;
 }
 
 .has-regular-font-size {
-	font-size: 16px;
+	font-size: 18px;
 }
 
 .has-large-font-size {
-	font-size: 36px;
+	font-size: 22px;
 }
 
 .has-larger-font-size {
-	font-size: 48px;
+	font-size: 32px;
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -114,13 +114,13 @@
 }
 
 .has-regular-font-size {
-	font-size: 18px;
+	font-size: 20px;
 }
 
 .has-large-font-size {
-	font-size: 22px;
+	font-size: 36px;
 }
 
 .has-larger-font-size {
-	font-size: 32px;
+	font-size: 42px;
 }

--- a/packages/components/src/base-control/index.js
+++ b/packages/components/src/base-control/index.js
@@ -7,7 +7,8 @@ function BaseControl( { id, label, help, className, children } ) {
 	return (
 		<div className={ classnames( 'components-base-control', className ) }>
 			<div className="components-base-control__field">
-				{ label && <label className="components-base-control__label" htmlFor={ id }>{ label }</label> }
+				{ label && id && <label className="components-base-control__label" htmlFor={ id }>{ label }</label> }
+				{ label && ! id && <span className="components-base-control__label">{ label }</span> }
 				{ children }
 			</div>
 			{ !! help && <p id={ id + '__help' } className="components-base-control__help">{ help }</p> }

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -1,22 +1,23 @@
 .components-base-control {
 	font-family: $default-font;
 	font-size: $default-font-size;
-}
 
-.components-base-control__field {
-	margin-bottom: $grid-size;
+	.components-base-control__field {
+		margin-bottom: $grid-size;
 
-	.components-panel__row & {
-		margin-bottom: inherit;
+		.components-panel__row & {
+			margin-bottom: inherit;
+		}
 	}
-}
 
-.components-base-control__label {
-	display: block;
-	margin-bottom: $grid-size-small;
-}
+	.components-base-control__label {
+		display: block;
+		margin-bottom: $grid-size-small;
+	}
 
-.components-base-control__help {
-	font-style: italic;
-	margin-bottom: 0;
+	.components-base-control__help {
+		margin-top: -$grid-size;
+		font-style: italic;
+		margin-bottom: 0;
+	}
 }

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -6,12 +6,12 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import BaseControl from '../base-control';
 import Button from '../button';
 import ButtonGroup from '../button-group';
 import RangeControl from '../range-control';
@@ -27,7 +27,9 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 		onChange( Number( newValue ) );
 	};
 	return (
-		<Fragment>
+		<BaseControl
+			label={ __( 'Font Size' ) }
+		>
 			<div className="components-font-size-picker__buttons">
 				<ButtonGroup aria-label={ __( 'Font Size' ) }>
 					{ map( fontSizes, ( { name, size, shortName } ) => (
@@ -73,6 +75,6 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 					afterIcon="editor-textcolor"
 				/>
 			}
-		</Fragment>
+		</BaseControl>
 	);
 }

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -15,42 +15,64 @@ import { __ } from '@wordpress/i18n';
 import Button from '../button';
 import ButtonGroup from '../button-group';
 import RangeControl from '../range-control';
+import Tooltip from '../tooltip';
 
-export default function FontSizePicker( { fontSizes = [], fallbackFontSize, value, onChange } ) {
+export default function FontSizePicker( { fontSizes = [], fallbackFontSize, value, onChange, withSlider } ) {
+	const onChangeValue = ( event ) => {
+		const newValue = event.target.value;
+		if ( newValue === '' ) {
+			onChange( undefined );
+			return;
+		}
+		onChange( Number( newValue ) );
+	};
 	return (
 		<Fragment>
 			<div className="components-font-size-picker__buttons">
 				<ButtonGroup aria-label={ __( 'Font Size' ) }>
 					{ map( fontSizes, ( { name, size, shortName } ) => (
-						<Button
-							key={ size }
-							isLarge
-							isPrimary={ value === size }
-							aria-pressed={ value === size }
-							onClick={ () => onChange( size ) }
-						>
-							{ shortName || name }
-						</Button>
+						<Tooltip text={ name || shortName }>
+							<Button
+								key={ size }
+								isLarge
+								isPrimary={ value === size }
+								aria-pressed={ value === size }
+								onClick={ () => onChange( size ) }
+								style={ { fontSize: size } }
+							>
+								A
+							</Button>
+						</Tooltip>
 					) ) }
 				</ButtonGroup>
+				{ ! withSlider &&
+					<input
+						className="components-range-control__number"
+						type="number"
+						onChange={ onChangeValue }
+						aria-label={ __( 'Custom Size' ) }
+						value={ value }
+					/>
+				}
 				<Button
-					isLarge
 					onClick={ () => onChange( undefined ) }
 				>
 					{ __( 'Reset' ) }
 				</Button>
 			</div>
-			<RangeControl
-				className="components-font-size-picker__custom-input"
-				label={ __( 'Custom Size' ) }
-				value={ value || '' }
-				initialPosition={ fallbackFontSize }
-				onChange={ onChange }
-				min={ 12 }
-				max={ 100 }
-				beforeIcon="editor-textcolor"
-				afterIcon="editor-textcolor"
-			/>
+			{ withSlider &&
+				<RangeControl
+					className="components-font-size-picker__custom-input"
+					label={ __( 'Custom Size' ) }
+					value={ value || '' }
+					initialPosition={ fallbackFontSize }
+					onChange={ onChange }
+					min={ 12 }
+					max={ 100 }
+					beforeIcon="editor-textcolor"
+					afterIcon="editor-textcolor"
+				/>
+			}
 		</Fragment>
 	);
 }

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -26,6 +26,7 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 		}
 		onChange( Number( newValue ) );
 	};
+
 	return (
 		<BaseControl
 			label={ __( 'Font Size' ) }
@@ -53,12 +54,13 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 						type="number"
 						onChange={ onChangeValue }
 						aria-label={ __( 'Custom Size' ) }
-						value={ value }
+						value={ value || '' }
 					/>
 				}
 				<Button
 					className="components-color-palette__clear"
 					type="button"
+					disabled={ value === undefined }
 					onClick={ () => onChange( undefined ) }
 					isButton
 					isSmall

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -42,7 +42,7 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 								onClick={ () => onChange( size ) }
 								style={ { fontSize: size } }
 							>
-								A
+								<span>A</span>
 							</Button>
 						</Tooltip>
 					) ) }
@@ -57,7 +57,12 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 					/>
 				}
 				<Button
+					className="components-color-palette__clear"
+					type="button"
 					onClick={ () => onChange( undefined ) }
+					isButton
+					isSmall
+					isDefault
 				>
 					{ __( 'Reset' ) }
 				</Button>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -33,7 +33,7 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 		>
 			<div className="components-font-size-picker__buttons">
 				<ButtonGroup aria-label={ __( 'Font Size' ) }>
-					{ map( fontSizes, ( { name, size, shortName } ) => (
+					{ map( fontSizes, ( { name, size, shortName, slug } ) => (
 						<Tooltip text={ name || shortName }>
 							<Button
 								key={ size }
@@ -41,7 +41,7 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 								isPrimary={ value === size }
 								aria-pressed={ value === size }
 								onClick={ () => onChange( size ) }
-								style={ { fontSize: size } }
+								className={ 'is-font-' + slug }
 							>
 								<span>A</span>
 							</Button>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -7,6 +7,7 @@ import { map } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -16,8 +17,16 @@ import BaseControl from '../base-control';
 import Button from '../button';
 import Dropdown from '../dropdown';
 import RangeControl from '../range-control';
+import { NavigableMenu } from '../navigable-container';
 
-export default function FontSizePicker( { fontSizes = [], fallbackFontSize, value, onChange, withSlider } ) {
+function FontSizePicker( {
+	fallbackFontSize,
+	fontSizes = [],
+	instanceId,
+	onChange,
+	value,
+	withSlider,
+} ) {
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;
 		if ( newValue === '' ) {
@@ -28,10 +37,12 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 	};
 
 	const currentFont = fontSizes.find( ( font ) => font.size === value );
+	const labelId = `components-font-size-picker-label-${ instanceId }`;
 
 	return (
 		<BaseControl
 			label={ __( 'Font Size' ) }
+			id={ labelId }
 		>
 			<div className="components-font-size-picker__buttons">
 				<Dropdown
@@ -43,19 +54,23 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 							{ ( currentFont && currentFont.name ) || ( ! value && 'Normal' ) || 'Custom' }
 						</Button>
 					) }
-					renderContent={ () => map( fontSizes, ( { name, size, slug } ) => (
-						<Button
-							key={ slug }
-							aria-pressed={ value === size }
-							onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
-							className={ 'is-font-' + slug }
-						>
-							{ ( value === size || ( ! value && slug === 'normal' ) ) &&	<Dashicon icon="saved" /> }
-							<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: size } }>
-								{ name }
-							</span>
-						</Button>
-					) )	}
+					renderContent={ () => (
+						<NavigableMenu aria-labelledby={ labelId }>
+							{ map( fontSizes, ( { name, size, slug } ) => (
+								<Button
+									key={ slug }
+									aria-pressed={ value === size }
+									onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
+									className={ 'is-font-' + slug }
+								>
+									{ ( value === size || ( ! value && slug === 'normal' ) ) &&	<Dashicon icon="saved" /> }
+									<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: size } }>
+										{ name }
+									</span>
+								</Button>
+							) ) }
+						</NavigableMenu>
+					) }
 				/>
 				{ ! withSlider &&
 					<input
@@ -94,3 +109,5 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 		</BaseControl>
 	);
 }
+
+export default withInstanceId( FontSizePicker );

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -11,11 +11,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import Dashicon from '../dashicon';
 import BaseControl from '../base-control';
 import Button from '../button';
-import ButtonGroup from '../button-group';
+import Dropdown from '../dropdown';
 import RangeControl from '../range-control';
-import Tooltip from '../tooltip';
 
 export default function FontSizePicker( { fontSizes = [], fallbackFontSize, value, onChange, withSlider } ) {
 	const onChangeValue = ( event ) => {
@@ -27,27 +27,36 @@ export default function FontSizePicker( { fontSizes = [], fallbackFontSize, valu
 		onChange( Number( newValue ) );
 	};
 
+	const currentFont = fontSizes.find( ( font ) => font.size === value );
+
 	return (
 		<BaseControl
 			label={ __( 'Font Size' ) }
 		>
 			<div className="components-font-size-picker__buttons">
-				<ButtonGroup aria-label={ __( 'Font Size' ) }>
-					{ map( fontSizes, ( { name, size, shortName, slug } ) => (
-						<Tooltip text={ name || shortName }>
-							<Button
-								key={ size }
-								isLarge
-								isPrimary={ value === size }
-								aria-pressed={ value === size }
-								onClick={ () => onChange( size ) }
-								className={ 'is-font-' + slug }
-							>
-								<span>A</span>
-							</Button>
-						</Tooltip>
-					) ) }
-				</ButtonGroup>
+				<Dropdown
+					className="components-font-size-picker__dropdown"
+					contentClassName="components-font-size-picker__dropdown-content"
+					position="bottom"
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button className="components-font-size-picker__selector" isLarge onClick={ onToggle } aria-expanded={ isOpen }>
+							{ ( currentFont && currentFont.name ) || ( ! value && 'Normal' ) || 'Custom' }
+						</Button>
+					) }
+					renderContent={ () => map( fontSizes, ( { name, size, slug } ) => (
+						<Button
+							key={ slug }
+							aria-pressed={ value === size }
+							onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
+							className={ 'is-font-' + slug }
+						>
+							{ ( value === size || ( ! value && slug === 'normal' ) ) &&	<Dashicon icon="saved" /> }
+							<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: size } }>
+								{ name }
+							</span>
+						</Button>
+					) )	}
+				/>
 				{ ! withSlider &&
 					<input
 						className="components-range-control__number"

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -22,7 +22,6 @@ import { NavigableMenu } from '../navigable-container';
 function FontSizePicker( {
 	fallbackFontSize,
 	fontSizes = [],
-	instanceId,
 	onChange,
 	value,
 	withSlider,
@@ -37,31 +36,33 @@ function FontSizePicker( {
 	};
 
 	const currentFont = fontSizes.find( ( font ) => font.size === value );
-	const labelId = `components-font-size-picker-label-${ instanceId }`;
 
 	return (
-		<BaseControl
-			label={ __( 'Font Size' ) }
-			id={ labelId }
-		>
+		<BaseControl label={ __( 'Font Size' ) }>
 			<div className="components-font-size-picker__buttons">
 				<Dropdown
 					className="components-font-size-picker__dropdown"
 					contentClassName="components-font-size-picker__dropdown-content"
 					position="bottom"
 					renderToggle={ ( { isOpen, onToggle } ) => (
-						<Button className="components-font-size-picker__selector" isLarge onClick={ onToggle } aria-expanded={ isOpen }>
+						<Button
+							className="components-font-size-picker__selector"
+							isLarge
+							onClick={ onToggle }
+							aria-expanded={ isOpen }
+							aria-label={ __( 'Custom font size' ) }
+						>
 							{ ( currentFont && currentFont.name ) || ( ! value && 'Normal' ) || 'Custom' }
 						</Button>
 					) }
 					renderContent={ () => (
-						<NavigableMenu aria-labelledby={ labelId }>
+						<NavigableMenu>
 							{ map( fontSizes, ( { name, size, slug } ) => (
 								<Button
 									key={ slug }
-									aria-pressed={ value === size }
 									onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
 									className={ 'is-font-' + slug }
+									role="menuitem"
 								>
 									{ ( value === size || ( ! value && slug === 'normal' ) ) &&	<Dashicon icon="saved" /> }
 									<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: size } }>
@@ -77,7 +78,7 @@ function FontSizePicker( {
 						className="components-range-control__number"
 						type="number"
 						onChange={ onChangeValue }
-						aria-label={ __( 'Custom Size' ) }
+						aria-label={ __( 'Custom font size' ) }
 						value={ value || '' }
 					/>
 				}
@@ -89,6 +90,7 @@ function FontSizePicker( {
 					isButton
 					isSmall
 					isDefault
+					aria-label={ __( 'Reset font size' ) }
 				>
 					{ __( 'Reset' ) }
 				</Button>

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -22,6 +22,14 @@
 		> span {
 			line-height: 1;
 		}
+
+		&.is-font-medium {
+			font-size: 18px;
+		}
+
+		&.is-font-large {
+			font-size: 22px;
+		}
 	}
 }
 

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -2,6 +2,10 @@
 	display: flex;
 	justify-content: space-between;
 	margin-bottom: 1em;
+
+	.components-button {
+		overflow: hidden;
+	}
 }
 
 .components-font-size-picker__custom-input {

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -1,10 +1,27 @@
 .components-font-size-picker__buttons {
 	display: flex;
 	justify-content: space-between;
-	margin-bottom: 1em;
+	align-items: center;
+
+	// Apply the same height as the isSmall Reset button.
+	.components-range-control__number {
+		height: 24px;
+		line-height: 22px;
+
+		// Show the reset button as disabled until a value is entered.
+		&[value=""] + .components-button {
+			cursor: default;
+			opacity: 0.3;
+			pointer-events: none;
+		}
+	}
 
 	.components-button {
 		overflow: hidden;
+
+		> span {
+			line-height: 1;
+		}
 	}
 }
 

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -15,22 +15,6 @@
 			pointer-events: none;
 		}
 	}
-
-	.components-button {
-		overflow: hidden;
-
-		> span {
-			line-height: 1;
-		}
-
-		&.is-font-medium {
-			font-size: 18px;
-		}
-
-		&.is-font-large {
-			font-size: 22px;
-		}
-	}
 }
 
 .components-font-size-picker__custom-input {

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -39,3 +39,37 @@
 		height: 30px;
 	}
 }
+
+.components-font-size-picker__dropdown-content .components-button {
+	display: block;
+	position: relative;
+	padding: 10px 20px 10px 40px;
+	width: 100%;
+	text-align: left;
+
+	.dashicon {
+		position: absolute;
+		top: calc(50% - 10px);
+		left: 10px;
+	}
+}
+
+.components-font-size-picker__buttons .components-font-size-picker__selector {
+	border: 1px solid;
+	background: none;
+	position: relative;
+	width: 110px;
+
+	@include input-style__neutral();
+
+	&:focus {
+		@include input-style__focus();
+	}
+
+	&::after {
+		@include dropdown-arrow();
+		right: 8px;
+		top: 12px;
+		position: absolute;
+	}
+}

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -81,21 +81,28 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	fontSizes: [
 		{
 			name: __( 'Small' ),
-			shortName: __( 'S' ),
 			size: 13,
 			slug: 'small',
 		},
 		{
+			name: __( 'Normal' ),
+			size: 16,
+			slug: 'normal',
+		},
+		{
 			name: __( 'Medium' ),
-			shortName: __( 'M' ),
 			size: 20,
 			slug: 'medium',
 		},
 		{
 			name: __( 'Large' ),
-			shortName: __( 'L' ),
 			size: 36,
 			slug: 'large',
+		},
+		{
+			name: __( 'Huge' ),
+			size: 48,
+			slug: 'huge',
 		},
 	],
 

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -82,26 +82,20 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 		{
 			name: __( 'Small' ),
 			shortName: __( 'S' ),
-			size: 14,
+			size: 13,
 			slug: 'small',
 		},
 		{
-			name: __( 'Regular' ),
+			name: __( 'Medium' ),
 			shortName: __( 'M' ),
-			size: 16,
-			slug: 'regular',
+			size: 18,
+			slug: 'medium',
 		},
 		{
 			name: __( 'Large' ),
 			shortName: __( 'L' ),
-			size: 36,
+			size: 22,
 			slug: 'large',
-		},
-		{
-			name: __( 'Larger' ),
-			shortName: __( 'XL' ),
-			size: 48,
-			slug: 'larger',
 		},
 	],
 

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -88,13 +88,13 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 		{
 			name: __( 'Medium' ),
 			shortName: __( 'M' ),
-			size: 18,
+			size: 20,
 			slug: 'medium',
 		},
 		{
 			name: __( 'Large' ),
 			shortName: __( 'L' ),
-			size: 22,
+			size: 36,
 			slug: 'large',
 		},
 	],

--- a/test/e2e/specs/editor-modes.test.js
+++ b/test/e2e/specs/editor-modes.test.js
@@ -73,7 +73,9 @@ describe( 'Editing modes (visual/HTML)', () => {
 		expect( htmlBlockContent ).toEqual( '<p>Hello world!</p>' );
 
 		// Change the font size using the sidebar.
-		const changeSizeButton = await page.waitForXPath( '//button[text()="L"]' );
+		const fontSizePicker = await page.waitForSelector( '.components-font-size-picker__selector' );
+		await fontSizePicker.click();
+		const changeSizeButton = await page.waitForSelector( '.components-button.is-font-large' );
 		await changeSizeButton.click();
 
 		// Make sure the HTML content updated.

--- a/test/e2e/specs/editor-modes.test.js
+++ b/test/e2e/specs/editor-modes.test.js
@@ -73,8 +73,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 		expect( htmlBlockContent ).toEqual( '<p>Hello world!</p>' );
 
 		// Change the font size using the sidebar.
-		const fontSizePicker = await page.waitForSelector( '.components-font-size-picker__selector' );
-		await fontSizePicker.click();
+		await page.click( '.components-font-size-picker__selector' );
 		const changeSizeButton = await page.waitForSelector( '.components-button.is-font-large' );
 		await changeSizeButton.click();
 

--- a/test/e2e/specs/font-size-picker.test.js
+++ b/test/e2e/specs/font-size-picker.test.js
@@ -17,8 +17,9 @@ describe( 'Font Size Picker', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "large"' );
 
-		const largeButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'L\']' ) )[ 0 ];
-		await largeButton.click();
+		await page.click( '.components-font-size-picker__selector' );
+		const changeSizeButton = await page.waitForSelector( '.components-button.is-font-large' );
+		await changeSizeButton.click();
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
@@ -31,7 +32,7 @@ describe( 'Font Size Picker', () => {
 		await page.keyboard.type( 'Paragraph to be made "small"' );
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
-		await page.keyboard.type( '14' );
+		await page.keyboard.type( '13' );
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
@@ -57,7 +58,10 @@ describe( 'Font Size Picker', () => {
 		await page.keyboard.type( 'Paragraph with font size reset using button' );
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
-		await page.keyboard.type( '14' );
+		await page.keyboard.type( '13' );
+
+		// Blur the range control
+		await page.click( '.components-base-control__label' );
 
 		const resetButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'Reset\']' ) )[ 0 ];
 		await resetButton.click();
@@ -72,8 +76,9 @@ describe( 'Font Size Picker', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph with font size reset using input field' );
 
-		const largeButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'L\']' ) )[ 0 ];
-		await largeButton.click();
+		await page.click( '.components-font-size-picker__selector' );
+		const changeSizeButton = await page.waitForSelector( '.components-button.is-font-large' );
+		await changeSizeButton.click();
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
 		await page.keyboard.press( 'Backspace' );


### PR DESCRIPTION
This PR aims to add a bit more clarity and simplify the font-size control. It removed the S M L XL denotations in favor of size reference. It also groups the custom size input with the reset and on the same line. Furthermore, it disabled the display of the slider by default.

Sizes are rendered at their correct value (as supplied by the theme). "Normal" is the same as "Reset".

![image](https://user-images.githubusercontent.com/548849/46211434-d17a4600-c333-11e8-94e0-0c9435c53fdb.png)

_In Progress_

To Do:
- [x] Use `NavigableMenu`?.
- [ ] Figure out what components should exist here (`Select` based on `Dropdown`?)