### PR TITLE
Wrap cite with footer in saved markup for quote and pullquote blocks

### DIFF
--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -9,7 +9,7 @@
 }
 
 .wp-block-pullquote {
-	cite .editor-rich-text__tinymce[data-is-empty="true"]::before {
+	footer .editor-rich-text__tinymce[data-is-empty="true"]::before {
 		font-size: 14px;
 		font-family: $default-font;
 	}

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -29,7 +29,7 @@ const blockAttributes = {
 	citation: {
 		type: 'array',
 		source: 'children',
-		selector: 'cite',
+		selector: 'footer cite',
 	},
 };
 
@@ -70,6 +70,7 @@ export const settings = {
 				/>
 				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 					<RichText
+						tagName="footer"
 						value={ citation }
 						/* translators: the individual or entity quoted */
 						placeholder={ __( 'Write citation…' ) }
@@ -78,7 +79,6 @@ export const settings = {
 								citation: nextCitation,
 							} )
 						}
-						className="wp-block-pullquote__citation"
 					/>
 				) }
 			</blockquote>
@@ -91,34 +91,61 @@ export const settings = {
 		return (
 			<blockquote>
 				<RichText.Content value={ toRichTextValue( value ) } />
-				{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+				{ ! RichText.isEmpty( citation ) && (
+					<footer>
+						<RichText.Content tagName="cite" value={ citation } />
+					</footer>
+				) }
 			</blockquote>
 		);
 	},
 
-	deprecated: [ {
-		attributes: {
-			...blockAttributes,
-			citation: {
-				type: 'array',
-				source: 'children',
-				selector: 'footer',
+	deprecated: [
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					type: 'array',
+					source: 'children',
+					selector: 'footer',
+				},
+				align: {
+					type: 'string',
+					default: 'none',
+				},
 			},
-			align: {
-				type: 'string',
-				default: 'none',
+
+			save( { attributes } ) {
+				const { value, citation, align } = attributes;
+
+				return (
+					<blockquote className={ `align${ align }` }>
+						<RichText.Content value={ toRichTextValue( value ) } />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="footer" value={ citation } /> }
+					</blockquote>
+				);
 			},
 		},
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					type: 'array',
+					source: 'children',
+					selector: 'cite',
+				},
+			},
 
-		save( { attributes } ) {
-			const { value, citation, align } = attributes;
+			save( { attributes } ) {
+				const { value, citation } = attributes;
 
-			return (
-				<blockquote className={ `align${ align }` }>
-					<RichText.Content value={ toRichTextValue( value ) } />
-					{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="footer" value={ citation } /> }
-				</blockquote>
-			);
+				return (
+					<blockquote>
+						<RichText.Content value={ toRichTextValue( value ) } />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				);
+			},
 		},
-	} ],
+	],
 };

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -16,7 +16,6 @@
 		line-height: 1.6;
 	}
 
-	cite,
 	footer {
 		position: relative;
 	}

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -3,9 +3,7 @@
 	border-bottom: 4px solid $dark-gray-500;
 	color: $dark-gray-600;
 
-	cite,
-	footer,
-	&__citation {
+	footer {
 		color: $dark-gray-600;
 		text-transform: uppercase;
 		font-size: $default-font-size;

--- a/packages/block-library/src/quote/editor.scss
+++ b/packages/block-library/src/quote/editor.scss
@@ -1,7 +1,7 @@
 .wp-block-quote {
 	margin: 0;
 
-	&__citation {
+	footer {
 		font-size: $default-font-size;
 	}
 }

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -35,7 +35,7 @@ const blockAttributes = {
 	citation: {
 		type: 'array',
 		source: 'children',
-		selector: 'cite',
+		selector: 'footer cite',
 	},
 	align: {
 		type: 'string',
@@ -205,6 +205,7 @@ export const settings = {
 					/>
 					{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 						<RichText
+							tagName="footer"
 							value={ citation }
 							onChange={
 								( nextCitation ) => setAttributes( {
@@ -213,7 +214,6 @@ export const settings = {
 							}
 							/* translators: the individual or entity quoted */
 							placeholder={ __( 'Write citation…' ) }
-							className="wp-block-quote__citation"
 						/>
 					) }
 				</blockquote>
@@ -227,7 +227,11 @@ export const settings = {
 		return (
 			<blockquote style={ { textAlign: align ? align : null } }>
 				<RichText.Content value={ toRichTextValue( value ) } />
-				{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+				{ ! RichText.isEmpty( citation ) && (
+					<footer>
+						<RichText.Content tagName="cite" value={ citation } />
+					</footer>
+				) }
 			</blockquote>
 		);
 	},
@@ -291,6 +295,27 @@ export const settings = {
 					>
 						<RichText.Content value={ toRichTextValue( value ) } />
 						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="footer" value={ citation } /> }
+					</blockquote>
+				);
+			},
+		},
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					type: 'array',
+					source: 'children',
+					selector: 'cite',
+				},
+			},
+
+			save( { attributes } ) {
+				const { align, value, citation } = attributes;
+
+				return (
+					<blockquote style={ { textAlign: align ? align : null } }>
+						<RichText.Content value={ toRichTextValue( value ) } />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
 					</blockquote>
 				);
 			},

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -10,7 +10,6 @@
 			line-height: 1.6;
 		}
 
-		cite,
 		footer {
 			font-size: 18px;
 			text-align: right;

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -1,9 +1,7 @@
 .wp-block-quote {
 	margin: 20px 0;
 
-	cite,
-	footer,
-	&__citation {
+	footer {
 		color: $dark-gray-300;
 		font-size: $default-font-size;
 		margin-top: 1em;

--- a/test/integration/full-content/fixtures/core__pullquote.html
+++ b/test/integration/full-content/fixtures/core__pullquote.html
@@ -1,5 +1,6 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote">
-<p>Testing pullquote block...</p><cite>...with a caption</cite>
+<p>Testing pullquote block...</p>
+<footer><cite>...with a caption</cite></footer>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote.json
+++ b/test/integration/full-content/fixtures/core__pullquote.json
@@ -21,6 +21,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p>\n<footer><cite>...with a caption</cite></footer>\n</blockquote>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__pullquote.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/pullquote",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p>\n<footer><cite>...with a caption</cite></footer>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/test/integration/full-content/fixtures/core__pullquote.serialized.html
+++ b/test/integration/full-content/fixtures/core__pullquote.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:pullquote -->
-<blockquote class="wp-block-pullquote"><p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote>
+<blockquote class="wp-block-pullquote"><p>Testing pullquote block...</p><footer><cite>...with a caption</cite></footer></blockquote>
 <!-- /wp:pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.html
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.html
@@ -2,6 +2,8 @@
 <blockquote class="wp-block-pullquote">
     <p>Paragraph <strong>one</strong></p>
     <p>Paragraph two</p>
-    <cite>by whomever</cite>
+    <footer>
+        <cite>by whomever</cite>
+    </footer>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.json
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.json
@@ -39,6 +39,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-pullquote\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-pullquote\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>\n        <cite>by whomever</cite>\n    </footer>\n</blockquote>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/pullquote",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-pullquote\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>\n        <cite>by whomever</cite>\n    </footer>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:pullquote -->
-<blockquote class="wp-block-pullquote"><p>Paragraph <strong>one</strong></p><p>Paragraph two</p><cite>by whomever</cite></blockquote>
+<blockquote class="wp-block-pullquote"><p>Paragraph <strong>one</strong></p><p>Paragraph two</p><footer><cite>by whomever</cite></footer></blockquote>
 <!-- /wp:pullquote -->

--- a/test/integration/full-content/fixtures/core__quote__style-1.html
+++ b/test/integration/full-content/fixtures/core__quote__style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote -->
-<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>
 <!-- /wp:core/quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-1.json
+++ b/test/integration/full-content/fixtures/core__quote__style-1.json
@@ -21,6 +21,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__quote__style-1.parsed.json
+++ b/test/integration/full-content/fixtures/core__quote__style-1.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/quote",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>\n"
     },
     {
         "attrs": {},

--- a/test/integration/full-content/fixtures/core__quote__style-1.serialized.html
+++ b/test/integration/full-content/fixtures/core__quote__style-1.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:quote -->
-<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>
 <!-- /wp:quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-2.html
+++ b/test/integration/full-content/fixtures/core__quote__style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"className":"is-style-large"} -->
-<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>
 <!-- /wp:core/quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-2.json
+++ b/test/integration/full-content/fixtures/core__quote__style-2.json
@@ -22,6 +22,6 @@
             "className": "is-style-large"
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__quote__style-2.parsed.json
+++ b/test/integration/full-content/fixtures/core__quote__style-2.parsed.json
@@ -5,7 +5,7 @@
             "className": "is-style-large"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>\n"
     },
     {
         "attrs": {},

--- a/test/integration/full-content/fixtures/core__quote__style-2.serialized.html
+++ b/test/integration/full-content/fixtures/core__quote__style-2.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:quote {"className":"is-style-large"} -->
-<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>
 <!-- /wp:quote -->


### PR DESCRIPTION
## Description
This PR changes the Quote and Pullquote blocks to wrap their `<cite>`s with `<footer>`s. The reason for this is that `<cite>` tags can be used within a quote but not be the citation of a quote, e.g. using a `<cite>` element to refer to a book or ship. The use of a `<footer>` improves the semantics to show that the contained `<cite>` is the citation of the entire `<blockquote>`, and makes it easier for themes to style inline `<cite>`s differently from the one in the `<footer>`.

In the editor, the RichText field for the citation is a `<footer>` element, where previously it was a `<div>` due to #8785 and before that it was a `<cite>`.

## How has this been tested?
I have tested to make sure that old Quote and Pullquote blocks are automatically converted properly. Some errors appear in the JavaScript console the first time a post is opened containing the deprecated forms of the blocks, but I am guessing that is due to the deprecated forms not matching the other even older deprecated forms before matching the last one in the list. **The content is preserved and automatically converted as expected and no blocks are made invalid. After saving, no errors appear in the JavaScript console.**

(I would say that the failed matches of deprecated forms should not be called out in the JavaScript console as errors, but I am not sure of the history of this functionality or how it works, and that is out-of-scope for this PR anyway.)

## Additional info
- https://www.w3.org/TR/html52/grouping-content.html#the-blockquote-element (Specifically example 15.)
- https://www.w3.org/TR/html52/textlevel-semantics.html#the-cite-element