### PR TITLE
Fix: Image Block: Link Settings - None has a redundant URL field

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -350,13 +350,15 @@ class ImageEdit extends Component {
 						options={ this.getLinkDestinationOptions() }
 						onChange={ this.onSetLinkDestination }
 					/>
-					<TextControl
-						label={ __( 'Link URL' ) }
-						value={ href || '' }
-						onChange={ this.onSetCustomHref }
-						placeholder={ ! isLinkURLInputDisabled ? 'https://' : undefined }
-						disabled={ isLinkURLInputDisabled }
-					/>
+					{ linkDestination !== 'none' && (
+						<TextControl
+							label={ __( 'Link URL' ) }
+							value={ href || '' }
+							onChange={ this.onSetCustomHref }
+							placeholder={ ! isLinkURLInputDisabled ? 'https://' : undefined }
+							disabled={ isLinkURLInputDisabled }
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 		);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -350,7 +350,7 @@ class ImageEdit extends Component {
 						options={ this.getLinkDestinationOptions() }
 						onChange={ this.onSetLinkDestination }
 					/>
-					{ linkDestination !== 'none' && (
+					{ linkDestination !== LINK_DESTINATION_NONE && (
 						<TextControl
 							label={ __( 'Link URL' ) }
 							value={ href || '' }


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/8851

Simple PR to conditionally render the URL input field.

## How has this been tested?
I added an image block, I went to the link settings in the block sidebar and I checked that when 'Link To' is 'None' the URL input field is not displayed when 'Link To' is not 'None' the URL input field is correctly displayed. 

