### PR TITLE
Block Toolbar: Hide the block toolbar if no block is selected

### DIFF
--- a/packages/editor/src/components/block-toolbar/index.js
+++ b/packages/editor/src/components/block-toolbar/index.js
@@ -44,6 +44,11 @@ class BlockToolbar extends Component {
 
 	render() {
 		const { blockClientIds, isValid, mode } = this.props;
+
+		if ( blockClientIds.length === 0 ) {
+			return null;
+		}
+
 		if ( blockClientIds.length > 1 ) {
 			return (
 				<div className="editor-block-toolbar" ref={ this.container }>


### PR DESCRIPTION
closes #9797

**Testing instructions**

 - Toggle the "unified toolbar mode" 
 - Unselect all the blocks
 - The block settings menu should not appear in the toolbar