### PR TITLE
Align the close, chevrons, and ellipsis icons

### DIFF
--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -1,6 +1,6 @@
 .edit-post-header {
 	height: $header-height;
-	padding: $item-spacing 2px;
+	padding: $grid-size-small 2px;
 	border-bottom: $border-width solid $light-gray-500;
 	background: $white;
 	display: flex;
@@ -19,7 +19,7 @@
 	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
 	@include break-small {
 		position: fixed;
-		padding: $item-spacing;
+		padding: $grid-size;
 		top: $admin-bar-height-big;
 
 		body.is-fullscreen-mode & {

--- a/edit-post/components/sidebar/settings-header/style.scss
+++ b/edit-post/components/sidebar/settings-header/style.scss
@@ -1,7 +1,7 @@
 .components-panel__header.edit-post-sidebar__panel-tabs {
 	justify-content: flex-start;
 	padding-left: 0;
-	padding-right: $panel-padding / 2;
+	padding-right: $grid-size-small;
 	border-top: 0;
 }
 

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -148,7 +148,7 @@
 .components-panel__header.edit-post-sidebar__panel-tabs {
 	justify-content: flex-start;
 	padding-left: 0;
-	padding-right: $panel-padding / 2;
+	padding-right: $grid-size-small;
 	border-top: 0;
 	margin-top: 0;
 


### PR DESCRIPTION
This applies the beginnings of a grid to the icons in the right side of the editor.

This is either a complement to, or a replacement for #9784. 

Before:

<img width="432" alt="screen shot 2018-09-12 at 11 29 05" src="https://user-images.githubusercontent.com/1204802/45415954-15f0bb00-b67f-11e8-8d6c-ebc5e232569c.png">

After:

<img width="414" alt="screen shot 2018-09-12 at 11 28 58" src="https://user-images.githubusercontent.com/1204802/45415958-18531500-b67f-11e8-9864-765e3270f682.png">

Look closely. Closelier. The ellipsis, x and down chevron are aligned.