### PR TITLE
Move the reusable UI to the top

### DIFF
--- a/packages/block-library/src/block/edit-panel/style.scss
+++ b/packages/block-library/src/block/edit-panel/style.scss
@@ -7,14 +7,14 @@
 	font-family: $default-font;
 	font-size: $default-font-size;
 	position: relative;
-	top: $block-padding;
-	margin: 0 (-$parent-block-padding);
-	padding: 10px $parent-block-padding;
+	top: -$block-padding;
+	margin: 0 (-$parent-block-padding) (-$block-padding) (-$parent-block-padding);
+	padding: $grid-size $parent-block-padding;
 
 	// Show a smaller padding when nested.
 	.editor-block-list__layout & {
 		margin: 0 (-$block-padding);
-		padding: 10px $block-padding;
+		padding: $grid-size $block-padding;
 	}
 
 	.reusable-block-edit-panel__spinner {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -125,7 +125,6 @@ class ReusableBlockEdit extends Component {
 
 		return (
 			<Fragment>
-				{ element }
 				{ ( isSelected || isEditing ) && (
 					<ReusableBlockEditPanel
 						isEditing={ isEditing }
@@ -138,6 +137,7 @@ class ReusableBlockEdit extends Component {
 					/>
 				) }
 				{ ! isSelected && ! isEditing && <ReusableBlockIndicator title={ reusableBlock.title } /> }
+				{ element }
 			</Fragment>
 		);
 	}

--- a/packages/block-library/src/block/indicator/style.scss
+++ b/packages/block-library/src/block/indicator/style.scss
@@ -2,10 +2,10 @@
 	background: $white;
 	border-left: $border-width dashed $light-gray-500;
 	color: $dark-gray-500;
-	border-top: $border-width dashed $light-gray-500;
-	bottom: -$block-padding;
+	border-bottom: $border-width dashed $light-gray-500;
+	top: -$block-padding;
 	height: 30px;
-	padding: 5px;
+	padding: $grid-size-small;
 	position: absolute;
 	width: 30px;
 	right: -$parent-block-padding;

--- a/test/e2e/specs/reusable-blocks.test.js
+++ b/test/e2e/specs/reusable-blocks.test.js
@@ -127,8 +127,12 @@ describe( 'Reusable Blocks', () => {
 		// Change the block's title
 		await page.keyboard.type( 'Surprised greeting block' );
 
+		// Tab three times to navigate to the block's content
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+
 		// Change the block's content
-		await pressWithModifier( 'Shift', 'Tab' );
 		await page.keyboard.type( 'Oh! ' );
 
 		// Save the reusable block
@@ -154,7 +158,7 @@ describe( 'Reusable Blocks', () => {
 			'.editor-block-list__block[data-type="core/block"] .editor-rich-text',
 			( element ) => element.innerText
 		);
-		expect( text ).toMatch( 'Hello there!' );
+		expect( text ).toMatch( 'Oh! Hello there!' );
 	} );
 
 	it( 'can be converted to a regular block', async () => {
@@ -177,7 +181,7 @@ describe( 'Reusable Blocks', () => {
 			'.editor-block-list__block[data-type="core/paragraph"] .editor-rich-text',
 			( element ) => element.innerText
 		);
-		expect( text ).toMatch( 'Hello there!' );
+		expect( text ).toMatch( 'Oh! Hello there!' );
 	} );
 
 	it( 'can be deleted', async () => {

--- a/test/e2e/specs/reusable-blocks.test.js
+++ b/test/e2e/specs/reusable-blocks.test.js
@@ -154,7 +154,7 @@ describe( 'Reusable Blocks', () => {
 			'.editor-block-list__block[data-type="core/block"] .editor-rich-text',
 			( element ) => element.innerText
 		);
-		expect( text ).toMatch( 'Oh! Hello there!' );
+		expect( text ).toMatch( 'Hello there!' );
 	} );
 
 	it( 'can be converted to a regular block', async () => {
@@ -177,7 +177,7 @@ describe( 'Reusable Blocks', () => {
 			'.editor-block-list__block[data-type="core/paragraph"] .editor-rich-text',
 			( element ) => element.innerText
 		);
-		expect( text ).toMatch( 'Oh! Hello there!' );
+		expect( text ).toMatch( 'Hello there!' );
 	} );
 
 	it( 'can be deleted', async () => {


### PR DESCRIPTION
Now that you can create very long blocks, the UI for entering the name of a reusable block fits better at the top.

GIF:

![reusable ui near top](https://user-images.githubusercontent.com/1204802/45420091-7edd3080-b689-11e8-86c3-5f5d682a6a8b.gif)
