### PR TITLE
Use HTML Document for finding iframe in embed previews

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -144,7 +144,7 @@ export function getEmbedEdit( title, icon ) {
 		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
 		 */
 		maybeSetAspectRatioClassName( html ) {
-			const previewDocument = document.implementation.createHTMLDocument();
+			const previewDocument = document.implementation.createHTMLDocument( '' );
 			previewDocument.body.innerHTML = html;
 			const iframe = previewDocument.body.querySelector( 'iframe' );
 

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -144,9 +144,9 @@ export function getEmbedEdit( title, icon ) {
 		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
 		 */
 		maybeSetAspectRatioClassName( html ) {
-			const previewDom = document.createElement( 'div' );
-			previewDom.innerHTML = html;
-			const iframe = previewDom.querySelector( 'iframe' );
+			const previewDocument = document.implementation.createHTMLDocument();
+			previewDocument.body.innerHTML = html;
+			const iframe = previewDocument.body.querySelector( 'iframe' );
 
 			if ( ! iframe ) {
 				return;


### PR DESCRIPTION
## Description

Fix for concern highlighted in https://github.com/WordPress/gutenberg/pull/9500#discussion_r216456963

## How has this been tested?

Embed a tweet, embed a youtube video, and check the video has an aspect ratio CSS class applied, and the tweet does not.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)
