### PR TITLE
Categories block: fix alignment

### DIFF
--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -20,9 +20,8 @@ export const settings = {
 	category: 'widgets',
 
 	attributes: {
-		showPostCounts: {
-			type: 'boolean',
-			default: false,
+		align: {
+			type: 'string',
 		},
 		displayAsDropdown: {
 			type: 'boolean',
@@ -32,8 +31,9 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
-		align: {
-			type: 'string',
+		showPostCounts: {
+			type: 'boolean',
+			default: false,
 		},
 	},
 
@@ -43,7 +43,7 @@ export const settings = {
 
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
-		if ( 'left' === align || 'right' === align || 'full' === align ) {
+		if ( [ 'left', 'center', 'right', 'full' ].includes( align ) ) {
 			return { 'data-align': align };
 		}
 	},

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -16,11 +16,6 @@ function render_block_core_categories( $attributes ) {
 	static $block_id = 0;
 	$block_id++;
 
-	$align = 'center';
-	if ( isset( $attributes['align'] ) && in_array( $attributes['align'], array( 'left', 'right', 'full' ), true ) ) {
-		$align = $attributes['align'];
-	}
-
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
@@ -46,10 +41,14 @@ function render_block_core_categories( $attributes ) {
 		$type           = 'list';
 	}
 
-	$class = "wp-block-categories wp-block-categories-{$type} align{$align}";
+	$class = "wp-block-categories wp-block-categories-{$type}";
+
+	if ( isset( $attributes['align'] ) ) {
+		$class .= " align{$attributes['align']}";
+	}
 
 	if ( isset( $attributes['className'] ) ) {
-		$class .= ' ' . $attributes['className'];
+		$class .= " {$attributes['className']}";
 	}
 
 	$block_content = sprintf(


### PR DESCRIPTION
## Description
This PR fixes an issue where the Categories block would always use the `aligncenter` class regardless of what alignment you set. It also cleans up some of the code to make it more readable and consistent.

Fixes #7910.