### PR TITLE
Docs: Add simplified block grammar spec to handbook

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -12,6 +12,12 @@
 		"parent": null
 	},
 	{
+		"title": "The Gutenberg block grammar",
+		"slug": "grammar",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/grammar.md",
+		"parent": "language"
+	},
+	{
 		"title": "Block API",
 		"slug": "block-api",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/block-api.md",

--- a/packages/block-serialization-default-parser/README.md
+++ b/packages/block-serialization-default-parser/README.md
@@ -1,6 +1,6 @@
 # Block Serialization Default Parser
 
-This library contains the default block serialization parser implementations for WordPress documents. It provides native PHP and JavaScript parsers that implement the specification from `@wordpress/block-serialization-spec-parser` and which normally operates on the document stored in `post_content`.
+This library contains the default block serialization parser implementations for WordPress documents. It provides native PHP and JavaScript parsers that implement the [specification](../../docs/grammar.md) from [`@wordpress/block-serialization-spec-parser`](../block-serialization-spec-parser/README.md) and which normally operates on the document stored in `post_content`.
 
 ## Installation
 

--- a/packages/block-serialization-spec-parser/README.md
+++ b/packages/block-serialization-spec-parser/README.md
@@ -1,10 +1,11 @@
 # Block Serialization Spec Parser
 
-This library contains the grammar file (`grammar.pegjs`) for WordPress posts which is a block serialization _specification_ which is used to generate the actual _parser_ which is also bundled in this package.
+This library contains the grammar file (`grammar.pegjs`) for WordPress posts which is a block serialization [_specification_](../../docs/grammar.md) which is used to generate the actual _parser_ which is also bundled in this package.
 
 PEG parser generators are available in many languages, though different libraries may require some translation of this grammar into their syntax. For more information see:
-* https://pegjs.org
-* https://en.wikipedia.org/wiki/Parsing_expression_grammar
+
+* [PEG.js](https://pegjs.org)
+* [Parsing expression grammar](https://en.wikipedia.org/wiki/Parsing_expression_grammar)
 
 ## Installation
 


### PR DESCRIPTION
## Description

Add `docs/grammar.md`, a document auto-generated since #6116 containing a simplified specification of the Gutenberg block grammar, to the Gutenberg Handbook.

## How has this been tested?

Changes to the handbook aren't very testable beforehand. Once these changes are merged and applies, the expectation is that:
- The document renders properly at https://wordpress.org/gutenberg/handbook/language/grammar
- The links added in this PR between the simplified spec and the parsing packages work both in the Handbook and in GitHub.

## Types of changes

Documentation.
