### PR TITLE
Plugin: Remove deprecations slated for 3.9 removal

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 4.0.0 (Unreleased)
+
+### Breaking Changes
+
+- `getDefaultBlockForPostFormat` has been removed.
+
 ## 3.0.0 (2018-09-05)
 
-### Breaking Change
+### Breaking Changes
 
 - The `isSharedBlock` function is removed. Use `isReusableBlock` instead.
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -32,7 +32,6 @@ export {
 	getUnknownTypeHandlerName,
 	setDefaultBlockName,
 	getDefaultBlockName,
-	getDefaultBlockForPostFormat,
 	getBlockType,
 	getBlockTypes,
 	getBlockSupport,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -10,7 +10,6 @@ import { get, isFunction, some } from 'lodash';
  */
 import { applyFilters, addFilter } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -41,19 +40,6 @@ import { isValidIcon, normalizeIconObject } from './utils';
  * @property {WPComponent}               edit       Component rendering element to be
  *                                                  interacted with in an editor.
  */
-
-/**
- * Constant mapping post formats to the expected default block.
- *
- * @type {Object}
- */
-const POST_FORMAT_BLOCK_MAP = {
-	audio: 'core/audio',
-	gallery: 'core/gallery',
-	image: 'core/image',
-	quote: 'core/quote',
-	video: 'core/video',
-};
 
 let serverSideBlockDefinitions = {};
 
@@ -220,25 +206,6 @@ export function setDefaultBlockName( name ) {
  */
 export function getDefaultBlockName() {
 	return select( 'core/blocks' ).getDefaultBlockName();
-}
-
-/**
- * Retrieves the expected default block for the post format.
- *
- * @param	{string} postFormat Post format
- * @return {string}            Block name.
- */
-export function getDefaultBlockForPostFormat( postFormat ) {
-	deprecated( 'getDefaultBlockForPostFormat', {
-		plugin: 'Gutenberg',
-		version: '3.9',
-	} );
-
-	const blockName = POST_FORMAT_BLOCK_MAP[ postFormat ];
-	if ( blockName && getBlockType( blockName ) ) {
-		return blockName;
-	}
-	return null;
 }
 
 /**

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Breaking Changes
 
 - `getColorName` has been removed. Use `getColorObjectByColorValue` instead.
-- `getColorClass` has been renamed. Use `wp.editor.getColorClassName` instead.
+- `getColorClass` has been renamed. Use `getColorClassName` instead.
 - The `value` property in color objects passed by `withColors` has been removed. Use `color` property instead.
 - `RichText` `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
 - `RichText` `onSetup` prop has been removed. The `unstableOnSetup` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.0.0 (Unreleased)
+
+### Breaking Changes
+
+- `getColorName` has been removed. Use `getColorObjectByColorValue` instead.
+- `getColorClass` has been renamed. Use `wp.editor.getColorClassName` instead.
+- The `value` property in color objects passed by `withColors` has been removed. Use `color` property instead.
+- `RichText` `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
+- `RichText` `onSetup` prop has been removed. The `unstableOnSetup` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
+
 ## 3.0.0 (2018-09-05)
 
 ### New Features

--- a/packages/editor/src/components/colors/index.js
+++ b/packages/editor/src/components/colors/index.js
@@ -1,7 +1,5 @@
 export {
-	getColorClass,
 	getColorClassName,
-	getColorName,
 	getColorObjectByAttributeValues,
 	getColorObjectByColorValue,
 } from './utils';

--- a/packages/editor/src/components/colors/utils.js
+++ b/packages/editor/src/components/colors/utils.js
@@ -4,11 +4,6 @@
 import { find, kebabCase } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import deprecated from '@wordpress/deprecated';
-
-/**
  * Provided an array of color objects as set by the theme or by the editor defaults,
  * and the values of the defined color or custom color returns a color object describing the color.
  *
@@ -47,24 +42,6 @@ export const getColorObjectByColorValue = ( colors, colorValue ) => {
 };
 
 /**
-* Provided an array of named colors and a color value returns the color name.
-*
-* @param {Array}   colors      Array of color objects containing the "name" and "color" value as properties.
-* @param {?string} colorValue  A string containing the color value.
-*
-* @return {?string} If colorValue is defined and matches a color part of the colors array, it returns the color name for that color.
-*/
-export const getColorName = ( colors, colorValue ) => {
-	deprecated( 'getColorName function', {
-		version: '3.9',
-		alternative: '`getColorObjectByColorValue` function',
-		plugin: 'Gutenberg',
-	} );
-	const colorObj = getColorObjectByColorValue( colors, colorValue );
-	return colorObj ? colorObj.name : undefined;
-};
-
-/**
  * Returns a class based on the context a color is being used and its slug.
  *
  * @param {string} colorContextName Context/place where color is being used e.g: background, text etc...
@@ -78,13 +55,4 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	}
 
 	return `has-${ kebabCase( colorSlug ) }-${ colorContextName }`;
-}
-
-export function getColorClass( colorContextName, colorSlug ) {
-	deprecated( 'getColorClass function', {
-		version: '3.9',
-		alternative: '`getColorClassName` function',
-		plugin: 'Gutenberg',
-	} );
-	return getColorClassName( colorContextName, colorSlug );
 }

--- a/packages/editor/src/components/colors/with-colors.js
+++ b/packages/editor/src/components/colors/with-colors.js
@@ -8,7 +8,6 @@ import { get, isString, kebabCase, reduce, upperFirst } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
-import deprecated from '@wordpress/deprecated';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -17,13 +16,6 @@ import { compose, createHigherOrderComponent } from '@wordpress/compose';
 import { getColorClassName, getColorObjectByColorValue, getColorObjectByAttributeValues } from './utils';
 
 const DEFAULT_COLORS = [];
-
-deprecated( 'value prop in color objects passed by withColors HOC', {
-	version: '3.9',
-	alternative: '`color` prop passed in the object',
-	plugin: 'Gutenberg',
-	hint: 'This is a global warning, shown regardless of whether value prop is used.',
-} );
 
 /**
  * Higher-order component, which handles color logic for class generation
@@ -95,19 +87,18 @@ export default ( ...args ) => {
 							);
 
 							const previousColorObject = previousState[ colorAttributeName ];
-							const previousColorValue = get( previousColorObject, [ 'value' ] );
+							const previousColor = get( previousColorObject, [ 'color' ] );
 							/**
 							* The "and previousColorObject" condition checks that a previous color object was already computed.
 							* At the start previousColorObject and colorValue are both equal to undefined
 							* bus as previousColorObject does not exist we should compute the object.
 							*/
-							if ( previousColorValue === colorObject.color && previousColorObject ) {
+							if ( previousColor === colorObject.color && previousColorObject ) {
 								newState[ colorAttributeName ] = previousColorObject;
 							} else {
 								newState[ colorAttributeName ] = {
 									...colorObject,
 									class: getColorClassName( colorContext, colorObject.slug ),
-									value: colorObject.color,
 								};
 							}
 							return newState;

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -29,7 +29,6 @@ import { Slot } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { rawHandler, children } from '@wordpress/blocks';
 import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
-import deprecated from '@wordpress/deprecated';
 import { isURL } from '@wordpress/url';
 
 /**
@@ -129,18 +128,6 @@ export class RichText extends Component {
 	 * @return {Object} The settings for this block.
 	 */
 	getSettings( settings ) {
-		let { unstableGetSettings: getSettings } = this.props;
-		if ( ! getSettings && typeof this.props.getSettings === 'function' ) {
-			deprecated( 'RichText getSettings prop', {
-				alternative: 'unstableGetSettings',
-				plugin: 'Gutenberg',
-				version: '3.9',
-				hint: 'Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.',
-			} );
-
-			getSettings = this.props.getSettings;
-		}
-
 		settings = {
 			...settings,
 			forced_root_block: this.props.multiline || false,
@@ -149,8 +136,9 @@ export class RichText extends Component {
 			custom_undo_redo_levels: 1,
 		};
 
-		if ( getSettings ) {
-			settings = getSettings( settings );
+		const { unstableGetSettings } = this.props;
+		if ( unstableGetSettings ) {
+			settings = unstableGetSettings( settings );
 		}
 
 		return settings;
@@ -179,20 +167,9 @@ export class RichText extends Component {
 
 		patterns.apply( this, [ editor ] );
 
-		let { unstableOnSetup: onSetup } = this.props;
-		if ( ! onSetup && typeof this.props.onSetup === 'function' ) {
-			deprecated( 'RichText onSetup prop', {
-				alternative: 'unstableOnSetup',
-				plugin: 'Gutenberg',
-				version: '3.9',
-				hint: 'Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.',
-			} );
-
-			onSetup = this.props.onSetup;
-		}
-
-		if ( onSetup ) {
-			onSetup( editor );
+		const { unstableOnSetup } = this.props;
+		if ( unstableOnSetup ) {
+			unstableOnSetup( editor );
 		}
 	}
 

--- a/packages/editor/src/components/rich-text/test/index.js
+++ b/packages/editor/src/components/rich-text/test/index.js
@@ -4,11 +4,6 @@
 import { shallow } from 'enzyme';
 
 /**
- * WordPress dependencies
- */
-import deprecated from '@wordpress/deprecated';
-
-/**
  * Internal dependencies
  */
 import {
@@ -16,8 +11,6 @@ import {
 	getFormatValue,
 } from '../';
 import { diffAriaProps, pickAriaProps } from '../aria';
-
-jest.mock( '@wordpress/deprecated', () => jest.fn() );
 
 describe( 'getFormatValue', () => {
 	function createMockNode( nodeName, attributes = {} ) {
@@ -121,13 +114,6 @@ describe( 'RichText', () => {
 					forced_root_block: false,
 					custom_undo_redo_levels: 1,
 				} );
-			} );
-
-			test( 'should be overriden (deprecated)', () => {
-				const mock = jest.fn().mockImplementation( () => 'mocked' );
-
-				expect( shallow( <RichText value={ value } multiline={ true } getSettings={ mock } /> ).instance().getSettings( settings ) ).toEqual( 'mocked' );
-				expect( deprecated ).toHaveBeenCalled();
 			} );
 
 			test( 'should be overriden', () => {


### PR DESCRIPTION
This PR removes all deprecations scheduled for removal with 3.9 release:

- RichText `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.
- RichText `onSetup` prop has been removed. The `unstableOnSetup` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice.
- `wp.editor.getColorName` has been removed. Please use `wp.editor.getColorObjectByColorValue` instead.
- `wp.editor.getColorClass` has been renamed. Please use `wp.editor.getColorClassName` instead.
- `value` property in color objects passed by `wp.editor.withColors` has been removed. Please use color property instead.
- The Subheading block has been removed. Please use the Paragraph block instead.
- `wp.blocks.getDefaultBlockForPostFormat` has been removed.