### PR TITLE
chore: Remove prop-type-like check in Popover component

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -136,11 +136,7 @@ class Popover extends Component {
 			// Focus the popover panel itself so items in the popover are easily
 			// accessed via keyboard navigation.
 			this.contentNode.current.focus();
-
-			return;
 		}
-
-		window.console.warn( `<Popover> component: focusOnMount argument "${ focusOnMount }" not recognized.` );
 	}
 
 	getAnchorRect( anchor ) {


### PR DESCRIPTION
Remove a warning that was basically a discount prop-type check from `Popover` component.

I've been meaning to do this since [July 30](
https://github.com/WordPress/gutenberg/pull/7503#discussion_r206153944) when @aduth pointed it out in a post-merge PR comment. 😅 