### PR TITLE
Clean up event count setting.

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -93,7 +93,9 @@ export class RichText extends Component {
 	}
 
 	shouldComponentUpdate( nextProps ) {
-		if ( nextProps.content.forceUpdate ) {
+		if ( nextProps.content.forceUpdate || nextProps.tagName !== this.props.tagName ) {
+			this.lastEventCount = undefined;
+			this.lastContent = undefined;
 			return true;
 		}
 		// The check below allows us to avoid updating the content right after an `onChange` call
@@ -157,8 +159,7 @@ export class RichText extends Component {
 
 		// Save back to HTML from React tree
 		const html = '<' + tagName + '>' + renderToString( this.props.content.contentTree ) + '</' + tagName + '>';
-		// If we are rendering we can reset lastEventCount
-		this.lastEventCount = undefined;
+
 		return (
 			<View>
 				{ formatToolbar }
@@ -167,7 +168,7 @@ export class RichText extends Component {
 						this._editor = ref;
 					}
 					}
-					text={ { text: html } }
+					text={ { text: html, eventCount: this.lastEventCount } }
 					onChange={ this.onChange }
 					onContentSizeChange={ this.onContentSizeChange }
 					onActiveFormatsChange={ this.onActiveFormatsChange }

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -60,17 +60,18 @@ export class RichText extends Component {
 	 */
 
 	onChange( event ) {
+		// If we had a timer set to propagate a change, let's cancel it, because the user meanwhile typed something extra
 		if ( !! this.currentTimer ) {
 			clearTimeout( this.currentTimer );
 		}
 		this.lastEventCount = event.nativeEvent.eventCount;
-		// The following method just cleans up any <p> tags produced by aztec and replaces them with a br tag
+		// The following method just cleans up any root tags produced by aztec and replaces them with a br tag
 		// This should be removed on a later version when aztec doesn't return the top tag of the text being edited
 		const openingTagRegexp = RegExp( '^<' + this.props.tagName + '>', 'gim' );
 		const closingTagRegexp = RegExp( '</' + this.props.tagName + '>$', 'gim' );
 		const contentWithoutRootTag = event.nativeEvent.text.replace( openingTagRegexp, '' ).replace( closingTagRegexp, '' );
 		this.lastContent = contentWithoutRootTag;
-
+		// Set a time to call the onChange prop if nothing changes in the next second
 		this.currentTimer = setTimeout( function() {
 			this.props.onChange( {
 				content: this.lastContent,
@@ -92,10 +93,10 @@ export class RichText extends Component {
 	}
 
 	shouldComponentUpdate( nextProps ) {
-		// The check below allows us to avoid updating the content right after an `onChange` call
 		if ( nextProps.content.forceUpdate ) {
 			return true;
 		}
+		// The check below allows us to avoid updating the content right after an `onChange` call
 		// first time the component is drawn with empty content `lastContent` is undefined
 		if ( nextProps.content.contentTree &&
 			this.lastContent &&
@@ -156,8 +157,8 @@ export class RichText extends Component {
 
 		// Save back to HTML from React tree
 		const html = '<' + tagName + '>' + renderToString( this.props.content.contentTree ) + '</' + tagName + '>';
-		const eventCount = this.lastEventCount;
-
+		// If we are rendering we can reset lastEventCount
+		this.lastEventCount = undefined;
 		return (
 			<View>
 				{ formatToolbar }
@@ -166,7 +167,7 @@ export class RichText extends Component {
 						this._editor = ref;
 					}
 					}
-					text={ { text: html, eventCount: eventCount } }
+					text={ { text: html } }
 					onChange={ this.onChange }
 					onContentSizeChange={ this.onContentSizeChange }
 					onActiveFormatsChange={ this.onActiveFormatsChange }


### PR DESCRIPTION
## Description
This updates the setting of lastEventCount to be reseted every time there is a re render of the component. This way only when onChange events are set we stop a re render of the component.

## How has this been tested?

Using this [PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/142) on the mobile example try to do this:

Edit a Heading block by setting to H4, H3
Switch to HTML mode and back to Visual mode
Check that app doesn't crash.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
