### PR TITLE
Fix typo: delimieters -> delimiters

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -38,7 +38,7 @@ class WP_Block_Parser_Block {
     public $innerBlocks;
 
 	/**
-	 * Resultant HTML from inside block comment delimieters
+	 * Resultant HTML from inside block comment delimiters
 	 * after removing inner blocks
 	 *
 	 * @example "...Just <!-- wp:test /--> testing..." -> "Just testing..."


### PR DESCRIPTION
Fixes a typo in `packages/block-serialization-default-parser/parser.php`:

`delimieters` -> `delimiters`