### PR TITLE
Modal: Prevent onMouseDown events propagating beyond the modal overlay

### DIFF
--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -26,7 +26,7 @@ class Modal extends Component {
 		super( props );
 
 		this.prepareDOM();
-		this.onModalOnly = this.onModalOnly.bind( this );
+		this.stopEventPropagationOutsideModal = this.stopEventPropagationOutsideModal.bind( this );
 	}
 
 	/**
@@ -102,8 +102,11 @@ class Modal extends Component {
 		ariaHelper.showApp();
 	}
 
-	onModalOnly( ev ) {
-		// Stop all onMouseDown events propagating further - they should only go to the modal
+	/**
+	 * Stop all onMouseDown events propagating further - they should only go to the modal
+ 	 * @param {string} ev Event object
+	 */
+	stopEventPropagationOutsideModal( ev ) {
 		ev.stopPropagation();
 	}
 
@@ -136,7 +139,7 @@ class Modal extends Component {
 		return createPortal(
 			<div
 				className={ classnames( 'components-modal__screen-overlay', overlayClassName ) }
-				onMouseDown={ this.onModalOnly }
+				onMouseDown={ this.stopEventPropagationOutsideModal }
 			>
 				<ModalFrame
 					className={ classnames(

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -26,6 +26,7 @@ class Modal extends Component {
 		super( props );
 
 		this.prepareDOM();
+		this.onModalOnly = this.onModalOnly.bind( this );
 	}
 
 	/**
@@ -101,6 +102,11 @@ class Modal extends Component {
 		ariaHelper.showApp();
 	}
 
+	onModalOnly( ev ) {
+		// Stop all onMouseDown events propagating further - they should only go to the modal
+		ev.stopPropagation();
+	}
+
 	/**
 	 * Renders the modal.
 	 *
@@ -125,11 +131,13 @@ class Modal extends Component {
 			'components-modal-header-' + instanceId
 		);
 
+		// Disable reason: this stops mouse events from triggering tooltips and other elements underneath the modal overlay
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return createPortal(
-			<div className={ classnames(
-				'components-modal__screen-overlay',
-				overlayClassName
-			) }>
+			<div
+				className={ classnames( 'components-modal__screen-overlay', overlayClassName ) }
+				onMouseDown={ this.onModalOnly }
+			>
 				<ModalFrame
 					className={ classnames(
 						'components-modal__frame',
@@ -155,6 +163,7 @@ class Modal extends Component {
 			</div>,
 			this.node
 		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
 

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -50,7 +50,6 @@ export class BlockInvalidWarning extends Component {
 					title={ __( 'Compare Block Conversion' ) }
 					onRequestClose={ this.onCompareClose }
 					className="editor-block-compare"
-					focusOnMount={ false }
 				>
 					<BlockCompare
 						block={ block }


### PR DESCRIPTION
Prevent `onMouseDown` events propagating up beyond the modal overlay.

This prevents blocks being triggered when a modal that is in the block's DOM is shown. This happens when an invalid block warning is trigger and the user picks 'compare block convert'.

An example is shown below. Here I am double-clicking where the next block is, and it is making the block blue as well as triggering the ellipsis menu tooltip.

![modal trigger](https://user-images.githubusercontent.com/1277682/45543089-9e9c6200-b80b-11e8-955b-a6eade7cf9e2.gif)

It also removes the `focusOnMount={ false }` from the invalid block warning modal as this was incorrectly used to help with this, but was actually making it worse. Here the `tab` key is pressed several times when the modal appears, tabbing between block tooltips:

![modal focus](https://user-images.githubusercontent.com/1277682/45543145-c7bcf280-b80b-11e8-89ae-81d29d8da345.gif)

## How has this been tested?

1. Create several blocks
2. Invalidate the first block (edit as HTML and remove the trailing tag)
3. Without the PR applied, click the ellipsis menu inside the block warning and pick 'Compare conversion'. Click around where the next block might be and try and get it to trigger as above
4. Close the modal and re-open, then press tab several times and note that the focus goes to the block tooltips under the modal
4. Apply PR and repeat. Note that the block under the modal is not triggered, and pressing tab just focuses on the modal
5. Verify that the modal continues to function - buttons work, as does the close button and close button tooltip appears
6. Verify that the keyboard shortcut modal continues to work

## Types of changes
Changes the `<Modal />` component event handling, and will only affect modals (block comparison and keyboard shortcuts)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
