### PR TITLE
Add needed attributes to kses allowed tags for the Gallery block

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -475,3 +475,20 @@ function gutenberg_add_admin_body_class( $classes ) {
 		return "$classes gutenberg-editor-page is-fullscreen-mode";
 	}
 }
+
+/**
+ * Adds attributes to kses allowed tags that aren't in the default list
+ * and that Gutenberg needs to save blocks such as the Gallery block.
+ *
+ * @param array $allowed_html Allowed HTML.
+ * @return array (Maybe) modified allowed HTML.
+ */
+function gutenberg_kses_allowedtags( $tags ) {
+	if ( isset( $tags['img'] ) ) {
+		$tags['img']['data-link'] = true;
+		$tags['img']['data-id']   = true;
+	}
+	return $tags;
+}
+
+add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2);

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -480,7 +480,7 @@ function gutenberg_add_admin_body_class( $classes ) {
  * Adds attributes to kses allowed tags that aren't in the default list
  * and that Gutenberg needs to save blocks such as the Gallery block.
  *
- * @param array $allowed_html Allowed HTML.
+ * @param array $tags Allowed HTML.
  * @return array (Maybe) modified allowed HTML.
  */
 function gutenberg_kses_allowedtags( $tags ) {
@@ -491,4 +491,4 @@ function gutenberg_kses_allowedtags( $tags ) {
 	return $tags;
 }
 
-add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2);
+add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2 );


### PR DESCRIPTION
## Description

The Gallery block uses `data-id` and `data-link` on the images,
and for non-admin users, `kses` strips these out, which makes Gutenberg
error when loading a post with a Gallery that's been authored by a non-admin
user.

This PR adds a filter function that adds the attributes we need.

## How has this been tested?

Log in with a user with the author role.
Make a new post, add a gallery block.
Save the post.
Reload the editor.

The gallery block should load and be editable as expected.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
