### PR TITLE
Change the URL Input label to match Classic

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -34,7 +34,8 @@
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 
-	$blocks-button__link-input-width: 280px;
+	// the width of input box plus two icon buttons plus a padding
+	$blocks-button__link-input-width: 300px + 2 * $icon-button-size + 8px;
 	width: $blocks-button__link-input-width;
 
 	.editor-url-input {

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -196,7 +196,7 @@ class URLInput extends Component {
 						value={ value }
 						onChange={ this.onChange }
 						onInput={ stopEventPropagation }
-						placeholder={ __( 'Paste URL or type' ) }
+						placeholder={ __( 'Paste URL or type to search' ) }
 						onKeyDown={ this.onKeyDown }
 						role="combobox"
 						aria-expanded={ showSuggestions }

--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -1,6 +1,6 @@
 // Link input
 $input-padding: 9px 8px;
-$input-size: 230px;
+$input-size: 300px;
 
 .editor-block-list__block .editor-url-input,
 .components-popover .editor-url-input,
@@ -11,7 +11,7 @@ $input-size: 230px;
 	padding: 1px;
 
 	input[type="text"] {
-		width: 100%;
+		width: $input-size;
 		padding: $input-padding;
 		border: none;
 		border-radius: 0;

--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -37,6 +37,7 @@ $input-size: 300px;
 	transition: all 0.15s ease-in-out;
 	list-style: none;
 	padding: 4px 0;
+	width: $input-size + 2 * $icon-button-size;
 }
 
 // Hide suggestions on mobile until we @todo find a better way to show them

--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -11,7 +11,10 @@ $input-size: 300px;
 	padding: 1px;
 
 	input[type="text"] {
-		width: $input-size;
+		width: 100%;
+		@include break-small() {
+			width: $input-size;
+		}
 		padding: $input-padding;
 		border: none;
 		border-radius: 0;


### PR DESCRIPTION
## Description

The current URL input label "Paste URL or type" doesn't actually say what typing does, and it hides the ability to search for posts/pages to link to.

Changing it to match the label in Classic, "Paste URL or type to search" tells the author what it is that typing will do, and makes the search functionality more discoverable.

In order to make the longer label fit, this change increases the width of the URL input box.

## Screenshots

<img width="549" alt="url input in Gutenberg" src="https://user-images.githubusercontent.com/352291/45534131-77f71f00-b83d-11e8-810c-1340f1d4ff45.png">

<img width="655" alt="url input in classic" src="https://user-images.githubusercontent.com/352291/45534132-788fb580-b83d-11e8-9403-fdb5afd4de66.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.