### PR TITLE
Fix camelCase and cross-component class name

### DIFF
--- a/packages/editor/src/components/block-compare/block-view.js
+++ b/packages/editor/src/components/block-compare/block-view.js
@@ -7,7 +7,7 @@ const BlockView = ( { title, rawContent, renderedContent, action, actionText, cl
 	return (
 		<div className={ className }>
 			<div className="editor-block-compare__content">
-				<h1 className="components-modal__header-heading">{ title }</h1>
+				<h1 className="editor-block-compare__heading">{ title }</h1>
 
 				<div className="editor-block-compare__html">
 					{ rawContent }
@@ -19,7 +19,7 @@ const BlockView = ( { title, rawContent, renderedContent, action, actionText, cl
 			</div>
 
 			<div className="editor-block-compare__action">
-				<Button isLarge tabindex="0" onClick={ action }>{ actionText }</Button>
+				<Button isLarge tabIndex="0" onClick={ action }>{ actionText }</Button>
 			</div>
 		</div>
 	);

--- a/packages/editor/src/components/block-compare/style.scss
+++ b/packages/editor/src/components/block-compare/style.scss
@@ -74,4 +74,9 @@
 	.editor-block-compare__action {
 		margin-top: $block-padding;
 	}
+
+	.editor-block-compare__heading {
+		font-size: 1em;
+		font-weight: normal;
+	}
 }

--- a/packages/editor/src/components/block-compare/test/__snapshots__/block-view.js.snap
+++ b/packages/editor/src/components/block-compare/test/__snapshots__/block-view.js.snap
@@ -8,7 +8,7 @@ exports[`BlockView should match snapshot 1`] = `
     className="editor-block-compare__content"
   >
     <h1
-      className="components-modal__header-heading"
+      className="editor-block-compare__heading"
     >
       title
     </h1>
@@ -29,7 +29,7 @@ exports[`BlockView should match snapshot 1`] = `
     <[object Object]
       isLarge={true}
       onClick={[Function]}
-      tabindex="0"
+      tabIndex="0"
     >
       action
     </[object Object]>


### PR DESCRIPTION
Fixes camel case typo in `tabIndex` in the block comparison modal, and use a class name local to the component.

This fixes the points raised https://github.com/WordPress/gutenberg/pull/7995#discussion_r217395351

## How has this been tested?
Existing tests updated for new names.

Trigger an invalid block and pick 'compare block conversion' from the ellipsis menu. Verify that the modal title looks the same:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/45538740-c8e82280-b7ff-11e8-9912-6f4488ab1d6b.jpg)

As it looked before:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/45538697-ac4bea80-b7ff-11e8-9566-9912c3e54640.jpg)

## Types of changes
Minor class and attribute change

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
