### PR TITLE
Don't focus close button on modal open/Try a modal appear animation

### DIFF
--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -62,3 +62,17 @@
 @mixin animate_rotation($speed: 1s) {
 	animation: rotation $speed infinite linear;
 }
+
+@keyframes modal-appear {
+	from {
+		transform: translate(-50%, -20%);
+	}
+	to {
+		transform: translate(-50%, -30%); // Matches the starting state of the Modal.
+	}
+}
+
+@mixin modal_appear() {
+	animation: modal-appear 0.1s ease-out;
+	animation-fill-mode: forwards;
+}

--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -65,10 +65,10 @@
 
 @keyframes modal-appear {
 	from {
-		transform: translate(-50%, -20%);
+		margin-top: $grid-size * 4;
 	}
 	to {
-		transform: translate(-50%, -30%); // Matches the starting state of the Modal.
+		margin-top: 0;
 	}
 }
 

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -278,12 +278,3 @@ body.gutenberg-editor-page {
 .ephox-snooker-resizer-bar-dragging {
 	background: $blue-medium-500;
 }
-
-// This style is defined here instead of the modal component
-// because the modal should be context agnostic.
-.components-modal__content {
-	height: calc(100% - #{ $header-height } - #{ $admin-bar-height });
-	body.is-fullscreen-mode & {
-		height: calc(100% - #{ $header-height });
-	}
-}

--- a/edit-post/components/keyboard-shortcut-help-modal/index.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/index.js
@@ -91,11 +91,9 @@ export function KeyboardShortcutHelpModal( { isModalActive, toggleModal } ) {
 					closeLabel={ __( 'Close' ) }
 					onRequestClose={ toggleModal }
 				>
-
 					{ shortcutConfig.map( ( config, index ) => (
 						<ShortcutSection key={ index } { ...config } />
 					) ) }
-
 				</Modal>
 			) }
 		</Fragment>

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -9,7 +9,6 @@ import { noop } from 'lodash';
  */
 import { Component, createPortal } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -105,10 +104,10 @@ class Modal extends Component {
 
 	/**
 	 * Stop all onMouseDown events propagating further - they should only go to the modal
- 	 * @param {string} ev Event object
+ 	 * @param {string} event Event object
 	 */
-	stopEventPropagationOutsideModal( ev ) {
-		ev.stopPropagation();
+	stopEventPropagationOutsideModal( event ) {
+		event.stopPropagation();
 	}
 
 	/**
@@ -131,10 +130,7 @@ class Modal extends Component {
 			...otherProps
 		} = this.props;
 
-		const headingId = (
-			aria.labelledby ||
-			'components-modal-header-' + instanceId
-		);
+		const headingId = aria.labelledby || `components-modal-header-${ instanceId }`;
 
 		// Disable reason: this stops mouse events from triggering tooltips and
 		// other elements underneath the modal overlay.
@@ -156,12 +152,7 @@ class Modal extends Component {
 					} }
 					{ ...otherProps }
 				>
-					<div
-						className={ 'components-modal__content' }
-						role="region"
-						aria-label={ __( 'Dialog Contents' ) }
-						tabIndex="0"
-					>
+					<div className={ 'components-modal__content' } tabIndex="0">
 						<ModalHeader
 							closeLabel={ closeButtonLabel }
 							headingId={ headingId }

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -9,6 +9,7 @@ import { noop } from 'lodash';
  */
 import { Component, createPortal } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -135,7 +136,8 @@ class Modal extends Component {
 			'components-modal-header-' + instanceId
 		);
 
-		// Disable reason: this stops mouse events from triggering tooltips and other elements underneath the modal overlay
+		// Disable reason: this stops mouse events from triggering tooltips and
+		// other elements underneath the modal overlay.
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return createPortal(
 			<div
@@ -152,17 +154,22 @@ class Modal extends Component {
 						labelledby: title ? headingId : null,
 						describedby: aria.describedby,
 					} }
-					{ ...otherProps } >
-					<ModalHeader
-						closeLabel={ closeButtonLabel }
-						isDismissable={ isDismissable }
-						onClose={ onRequestClose }
-						title={ title }
-						headingId={ headingId }
-						icon={ icon }
-					/>
+					{ ...otherProps }
+				>
 					<div
-						className={ 'components-modal__content' }>
+						className={ 'components-modal__content' }
+						role="region"
+						aria-label={ __( 'Dialog Contents' ) }
+						tabIndex="0"
+					>
+						<ModalHeader
+							closeLabel={ closeButtonLabel }
+							headingId={ headingId }
+							icon={ icon }
+							isDismissable={ isDismissable }
+							onClose={ onRequestClose }
+							title={ title }
+						/>
 						{ children }
 					</div>
 				</ModalFrame>

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -7,10 +7,16 @@
 	left: 0;
 	background-color: rgba($white, 0.4);
 	z-index: z-index(".components-modal__screen-overlay");
+
+	// Animate appearance.
+	@include fade-in();
 }
 
 // The modal window element.
 .components-modal__frame {
+	// Animate appearance.
+	@include modal_appear();
+
 	// In small screens the content needs to be full width.
 	position: fixed;
 	top: 0;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -14,8 +14,10 @@
 
 // The modal window element.
 .components-modal__frame {
-	// Animate appearance.
-	@include modal_appear();
+	border: $border-width solid $light-gray-500;
+	background-color: $white;
+	box-shadow: $shadow-modal;
+	outline: none;
 
 	// In small screens the content needs to be full width.
 	position: fixed;
@@ -36,6 +38,9 @@
 		top: $panel-padding;
 		left: 50%;
 		height: 90%;
+
+		// Animate appearance.
+		@include modal_appear();
 	}
 
 	// Show pretty big on desktop breakpoints.
@@ -46,50 +51,61 @@
 		left: 50%;
 		height: 70%;
 	}
-
-	border: $border-width solid $light-gray-500;
-	background-color: $white;
-	box-shadow: $shadow-modal;
-	outline: none;
 }
 
+// Fix heading to the top.
 .components-modal__header {
 	box-sizing: border-box;
-	height: $header-height;
 	border-bottom: $border-width solid $light-gray-500;
-	padding: $item-spacing $item-spacing $item-spacing $panel-padding;
+	padding: 0 0 $grid-size 0;
 	display: flex;
 	flex-direction: row;
 	align-items: stretch;
 	justify-content: space-between;
-}
+	position: fixed;
+	top: 0;
+	background: $white;
+	width: calc(100% - #{$panel-padding + $panel-padding});
+	height: $header-height;
+	padding: $item-spacing 0;
 
-.components-modal__header-heading-container {
-	align-items: center;
-	flex-grow: 1;
-	display: flex;
-	flex-direction: row;
-	justify-content: left;
-}
+	.components-modal__header-heading {
+		font-size: 1em;
+		font-weight: normal;
+	}
 
-.components-modal__header-heading {
-	font-size: 1em;
-	font-weight: normal;
-}
+	.components-modal__header-heading-container {
+		align-items: center;
+		flex-grow: 1;
+		display: flex;
+		flex-direction: row;
+		justify-content: left;
+	}
 
-.components-modal__header-icon-container {
-	display: inline-block;
+	.components-modal__header-icon-container {
+		display: inline-block;
 
-	svg {
-		max-width: $icon-button-size;
-		max-height: $icon-button-size;
-		padding: 8px;
+		svg {
+			max-width: $icon-button-size;
+			max-height: $icon-button-size;
+			padding: 8px;
+		}
+	}
+
+	h1 {
+		line-height: 1;
+		margin: 0;
 	}
 }
 
+// Modal contents.
 .components-modal__content {
-	// The height of the content is the height of it's parent, minus the header. after that, the offset was 3px.
-	height: 100%;
+	box-sizing: border-box;
 	overflow: auto;
-	padding: $panel-padding;
+	height: 100%;
+	padding: ($header-height+$panel-padding) $panel-padding $panel-padding $panel-padding;
+
+	&:focus {
+		outline: $border-width solid $dark-gray-500;
+	}
 }

--- a/test/e2e/specs/a11y.test.js
+++ b/test/e2e/specs/a11y.test.js
@@ -31,17 +31,17 @@ describe( 'a11y', () => {
 	} );
 
 	it( 'constrains focus to a modal when tabbing', async () => {
-		// Open help modal
+		// Open keyboard help modal.
 		await pressWithModifier( ACCESS_MODIFIER_KEYS, 'h' );
 
-		// Test that the Close button of the modal is focused when the
-		// latter is opened.
-		expect( await isCloseButtonFocused() ).toBe( true );
+		// The close button should not be focused by default; this is a strange UX
+		// experience.
+		// See: https://github.com/WordPress/gutenberg/issues/9410
+		expect( await isCloseButtonFocused() ).toBe( false );
 
 		await page.keyboard.press( 'Tab' );
 
-		// Test that the Close button of the modal is focused when the
-		// latter is opened.
+		// Ensure the Close button of the modal is focused after tabbing.
 		expect( await isCloseButtonFocused() ).toBe( true );
 	} );
 


### PR DESCRIPTION
This is the first in a series of tiny micro interaction animations I hope to add across the UI. It adds a "fade & appear" animation to any modal you open. It's fast, but it's smooth, and it's non intrusive.

![sep-14-2018 11-57-10](https://user-images.githubusercontent.com/1204802/45543865-0a83c800-b816-11e8-9015-c33b88d3fc2f.gif)

Please try checking out the branch — the framerate of this GIF doesn't do it justice, so _please don't give your animation feedback based solely on this GIF, please please try it first_.

The animation includes movement, downwards up, because this helps suggest that the modal is a card that always exists at this elevation, it just sits outside the viewport, in this case below the screen and it's literally brought _up_ when you ask for it. 

However this animation also brings with us a challenge that needs solving — right now the "Close dialog" tooltip shows every time a modal is opened. This is a problem on its own because it sends mixed signals to the user: I just opened this dialog, should I close it again?

But specifically in this case, the tooltip appears mid-animation which means it's not correctly aligned.

How do we fix this? Here are some thoughts:

- Don't focus the close button. Focus the header, or the modal itself instead, so a single press of the "Tab" button focuses it. I volunteer to make a giant in-your-face focus style for the modal, a dashed line inside the entire thing, if we can do this.
- Don't show the tooltip when the close button is focused on modals.

What other solutions can you think of? It really is a bad experience for sighted users as it is.
