### PR TITLE
CSS BUGFIX:  Inspector Controls Dashicon vertical center correction

### DIFF
--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -15,6 +15,12 @@
 	border-bottom: 1px solid $light-gray-500;
 	margin: -16px -16px 16px -16px;
 	padding: 16px;
+
+	.editor-block-icon {
+		svg {
+			vertical-align: middle; 
+		}
+	}
 }
 
 .editor-block-inspector__card-icon {


### PR DESCRIPTION
## Description
Inspector Controls Dashicons are no Center in the Y-axis. I have fix it now. 

## How has this been tested?
Now it works fine and correctly. 

## Screenshots <!-- if applicable -->
Before:  https://www.imagebanana.com/s/big/1180/1keuVorY.png
After FIX:  https://www.imagebanana.com/s/big/1180/i3uIdqr2.png

## Types of changes
- Add new CSS Code in file "editor/components/block-inspector/style.scss" @ Line 19  
- Dashicons now vert. correctly 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->