### PR TITLE
Fix incorrect unlink shortcut

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -154,6 +154,7 @@ class FormatToolbar extends Component {
 					const isActive = isFormatActive || isAddingLink;
 					return {
 						...control,
+						shortcut: isFormatActive ? control.activeShortcut : control.shortcut,
 						icon: isFormatActive ? 'editor-unlink' : 'admin-links', // TODO: Need proper unlink icon
 						title: isFormatActive ? __( 'Unlink' ) : __( 'Link' ),
 						onClick: isActive ? this.dropLink : this.addLink,

--- a/packages/editor/src/components/rich-text/formatting-controls.js
+++ b/packages/editor/src/components/rich-text/formatting-controls.js
@@ -21,6 +21,7 @@ export const FORMATTING_CONTROLS = [
 		icon: 'admin-links',
 		title: __( 'Link' ),
 		shortcut: displayShortcut.primary( 'k' ),
+		activeShortcut: displayShortcut.access( 's' ),
 		format: 'link',
 	},
 	{


### PR DESCRIPTION
## Description
I spotted that the shortcut displayed on the tooltip for unlinking is incorrect. It displays the tooltip for linking instead of unlinking

## How has this been tested?
- Manual testing - add a shortcut in various blocks that implement the RichText component (paragraph, table, list). Hover over the unlink icon, the shortcut should be displayed as ^⌥S on a Mac

## Screenshots <!-- if applicable -->
**Before**
<img width="71" alt="screen shot 2018-09-14 at 11 21 14 am" src="https://user-images.githubusercontent.com/677833/45545338-e1f9cf00-b811-11e8-960c-057f11ca5ca0.png">

**After**
<img width="96" alt="screen shot 2018-09-14 at 11 16 54 am" src="https://user-images.githubusercontent.com/677833/45545318-da3a2a80-b811-11e8-8e07-d5316d38f380.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
