### PR TITLE
Serialized code block is only half escaped

### DIFF
--- a/test/integration/full-content/fixtures/core__code.serialized.html
+++ b/test/integration/full-content/fixtures/core__code.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:code -->
 <pre class="wp-block-code"><code>export default function MyButton() {
-	return &lt;Button>Click Me!&lt;/Button>;
+	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
 }</code></pre>
 <!-- /wp:code -->


### PR DESCRIPTION
## Description

While fixing errors related to `kses` stripping out attributes and tags for non-admin users, I found that the seralized HTML fixture for the code block contains characters that should be htmlentities, but aren't "Fixing" the fixture makes the test fail. Unfortunately, kses does the right thing and converts to entities, so the saved version of the block doesn't match the version the serializer produces.

This branch _should_ pass, shouldn't it?