### PR TITLE
Try a full screen mode appear animation

### DIFF
--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -26,6 +26,11 @@
 	animation: slide_in_right 0.1s forwards;
 }
 
+@mixin slide_in_top {
+	transform: translateY(-100%);
+	animation: slide_in_top 0.1s forwards;
+}
+
 @mixin fade_in($speed: 0.2s, $delay: 0s) {
 	animation: fade-in $speed ease-out $delay;
 	animation-fill-mode: forwards;

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -37,6 +37,12 @@
 	}
 }
 
+@keyframes slide_in_top {
+	100% {
+		transform: translateY(0%);
+	}
+}
+
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations
 html.wp-toolbar {

--- a/edit-post/components/fullscreen-mode/style.scss
+++ b/edit-post/components/fullscreen-mode/style.scss
@@ -14,4 +14,11 @@ body.is-fullscreen-mode {
 	#wpfooter {
 		margin-left: 0;
 	}
+
+	// Animations
+	@include fade_in(0.3s);
+
+	.edit-post-header {
+		@include slide_in_top();
+	}
 }


### PR DESCRIPTION
This PR tries out a slight animation to full screen mode when it's loaded:

- The body does a quick 0-100% fade animation.
- The toolbar slides in from the top.

This is subtle (and due to frame rates, _it cannot be observed in the GIF — so please give this PR a spin before weighing in_) but helps the transition feel little more smooth. 

A couple notes:

- This appears _every_ time the `body.is-fullscreen-mode` loads, so if you activate full screen, navigate away from the page, and come back, it'll animate again on the initial editor load. This actually seems just fine to me in practice.
- The fade in animation is 0.3s long, which is a little slower than I'd usually do. But since this fades in the whole page content, it has a larger chance of seeming jarring. I think the extra 0.1-0.2s helps make this feel snappy but still calm. 

**GIFs**

_Old (no animation):_ 

![old](https://user-images.githubusercontent.com/1202812/45552337-a43f7b00-b7fe-11e8-9a14-c8af39536977.gif)

_New:_

![new-animation](https://user-images.githubusercontent.com/1202812/45552344-aa355c00-b7fe-11e8-9365-4d2750c9255f.gif)
