### PR TITLE
Update: Docs: chore: Update doc blocks after changes to the blocks API

### DIFF
--- a/docs/data/data-core-blocks.md
+++ b/docs/data/data-core-blocks.md
@@ -72,6 +72,38 @@ Returns an array with the child blocks of a given block.
 
 Array of child block names.
 
+### getBlockSupport
+
+Returns the block support value for a feature, if defined.
+
+*Parameters*
+
+ * state: Data state.
+ * nameOrType: Block name or type object
+ * feature: Feature to retrieve
+ * defaultSupports: Default value to return if not
+                                          explicitly defined
+
+*Returns*
+
+Block support value
+
+### hasBlockSupport
+
+Returns true if the block defines support for a feature, or false otherwise.
+
+*Parameters*
+
+ * state: Data state.
+ * nameOrType: Block name or type object.
+ * feature: Feature to test.
+ * defaultSupports: Whether feature is supported by
+                                         default if not explicitly defined.
+
+*Returns*
+
+Whether block supports feature.
+
 ### hasChildBlocks
 
 Returns a boolean indicating if a block has child blocks or not.
@@ -84,6 +116,20 @@ Returns a boolean indicating if a block has child blocks or not.
 *Returns*
 
 True if a block contains child blocks and false otherwise.
+
+### hasChildBlocksWithInserterSupport
+
+Returns a boolean indicating if a block has at least one child block with inserter support.
+
+*Parameters*
+
+ * state: Data state.
+ * blockName: Block type name.
+
+*Returns*
+
+True if a block contains at least one child blocks with inserter support
+                  and false otherwise.
 
 ## Actions
 

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1589,7 +1589,7 @@ Returns an action object used to convert a static block into a reusable block.
 
 *Parameters*
 
- * clientId: The client ID of the block to detach.
+ * clientIds: The client IDs of the block to detach.
 
 ### insertDefaultBlock
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -12,12 +12,6 @@
 		"parent": null
 	},
 	{
-		"title": "The Gutenberg block grammar",
-		"slug": "grammar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/grammar.md",
-		"parent": "language"
-	},
-	{
 		"title": "Block API",
 		"slug": "block-api",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/block-api.md",


### PR DESCRIPTION
## Description
Simple PR that just updates the doc blocks after the automation execution of `npm run docs:build`.
This should have been part of https://github.com/WordPress/gutenberg/pull/9337, but I missed it during that PR.
Thank you for catching this problem @aduth 
