### PR TITLE
State: Set template validity on block reset

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,5 +1,9 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 4.1.0
+
+- `wp.data.dispatch( 'core/editor' ).checkTemplateValidity` has been removed. Validity is verified automatically upon block reset.
+
 ## 4.0.0
 
 - `wp.components.RichTextProvider` has been removed. Please use `wp.data.select( 'core/editor' )` methods instead.

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -8,6 +8,10 @@
 - `RichText` `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
 - `RichText` `onSetup` prop has been removed. The `unstableOnSetup` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
 
+### Deprecations
+
+- The `checkTemplateValidity` action has been deprecated. Validity is verified automatically upon block reset.
+
 ## 3.0.0 (2018-09-05)
 
 ### New Features

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -97,14 +97,13 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { editPost, resetBlocks, checkTemplateValidity } = dispatch( 'core/editor' );
+		const { editPost, resetBlocks } = dispatch( 'core/editor' );
 		return {
 			onChange( content ) {
 				editPost( { content } );
 			},
 			onPersist( content ) {
 				resetBlocks( parse( content ) );
-				checkTemplateValidity();
 			},
 		};
 	} ),

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -11,6 +11,7 @@ import {
 	getDefaultBlockName,
 	createBlock,
 } from '@wordpress/blocks';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Returns an action object used in signalling that editor has initialized with
@@ -373,6 +374,14 @@ export function setTemplateValidity( isValid ) {
  * @return {Object} Action object.
  */
 export function checkTemplateValidity() {
+	// TODO: Hello future deprecation remover. Please ensure also to remove all
+	// references to CHECK_TEMPLATE_VALIDITY, notably its effect handler.
+	deprecated( 'checkTemplateValidity action (`core/editor`)', {
+		version: '4.1',
+		plugin: 'Gutenberg',
+		hint: 'Validity is verified automatically upon block reset.',
+	} );
+
 	return {
 		type: 'CHECK_TEMPLATE_VALIDITY',
 	};


### PR DESCRIPTION
Extracted from #9403 

This pull request seeks to refactor block validity to perform as a side-effect of the `RESET_BLOCKS` action (and temporarily, the `SETUP_EDITOR` action). This better reflects that testing block validity is not intended as an explicit action, but rather a function of comparing blocks state and editor settings. Until now I did not realize there was an intended user action around overriding validity ("Keep as is" on invalid template), so this is not intended to become deprecated.

**Testing instructions:**

Verify there are no regressions in the use of templates and template locking.

Here's a dummy CPT if you need one:

```php
<?php

/**
 * Plugin Name: Demo CPT
 */

add_action( 'init', function() {
	register_post_type( 'book', [
		'label' => 'Book',
		'show_in_rest' => true,
		'public' => true,
		'show_ui' => true,
		'supports' => [ 'title', 'editor' ],
		'template' => [
			[ 'core/html', [
				'content' => '<p>Hello</p>',
			] ]
		],
		'template_lock' => 'all',
	] );
} );
```