### PR TITLE
Refactor richtext content prop

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -33,6 +33,7 @@ class HeadingEdit extends Component {
 		const {
 			level,
 			placeholder,
+			content,
 		} = attributes;
 
 		const tagName = 'h' + level;
@@ -42,7 +43,7 @@ class HeadingEdit extends Component {
 				<HeadingToolbar minLevel={ 2 } maxLevel={ 5 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 				<RichText
 					tagName={ tagName }
-					content={ { contentTree: attributes.content } }
+					value={ content }
 					style={ {
 						minHeight: Math.max( minHeight, typeof attributes.aztecHeight === 'undefined' ? 0 : attributes.aztecHeight ),
 					} }

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -23,13 +23,14 @@ class ParagraphEdit extends Component {
 
 		const {
 			placeholder,
+			content,
 		} = attributes;
 
 		return (
 			<View>
 				<RichText
 					tagName="p"
-					content={ { contentTree: attributes.content } }
+					value={ content }
 					style={ {
 						...style,
 						minHeight: Math.max( minHeight, typeof attributes.aztecHeight === 'undefined' ? 0 : attributes.aztecHeight ),

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -1,0 +1,6 @@
+
+function DropdownMenu() {
+	return null;
+}
+
+export default DropdownMenu;

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -151,6 +151,7 @@ export class RichText extends Component {
 			style,
 			formattingControls,
 			formatters,
+			value,
 		} = this.props;
 
 		const formatToolbar = (
@@ -163,7 +164,7 @@ export class RichText extends Component {
 		);
 
 		// Save back to HTML from React tree
-		const html = '<' + tagName + '>' + renderToString( this.props.content.contentTree ) + '</' + tagName + '>';
+		const html = '<' + tagName + '>' + renderToString( value ) + '</' + tagName + '>';
 
 		return (
 			<View>

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -98,14 +98,14 @@ export class RichText extends Component {
 	}
 
 	shouldComponentUpdate( nextProps ) {
-		if ( nextProps.content.forceUpdate || nextProps.tagName !== this.props.tagName ) {
+		if ( nextProps.tagName !== this.props.tagName ) {
 			this.lastEventCount = undefined;
 			this.lastContent = undefined;
 			return true;
 		}
 		// The check below allows us to avoid updating the content right after an `onChange` call
 		// first time the component is drawn with empty content `lastContent` is undefined
-		if ( nextProps.content.contentTree &&
+		if ( nextProps.value &&
 			this.lastContent &&
 			this.lastEventCount ) {
 			return false;


### PR DESCRIPTION
## Description
This PR updates the RN RichText implementation by renaming the `content` prop to `value` and have the same interface as the Web counterpart.

It also fixes some compatibility issues with the Web project by implementing a stub DropDownMenu.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
