### PR TITLE
Framework: Pass editor initial settings as direct argument

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1316,41 +1316,32 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'after'
 	);
 
-	// Prepopulate with some test content in demo.
+	// Assign initial edits, if applicable. These are not initially assigned
+	// to the persisted post, but should be included in its save payload.
 	if ( $is_new_post && $is_demo ) {
+		// Prepopulate with some test content in demo.
 		ob_start();
 		include gutenberg_dir_path() . 'post-content.php';
 		$demo_content = ob_get_clean();
 
-		wp_add_inline_script(
-			'wp-edit-post',
-			sprintf(
-				'window._wpGutenbergDefaultPost = { title: %s, content: %s };',
-				wp_json_encode(
-					array(
-						'raw' => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
-					)
-				),
-				wp_json_encode(
-					array(
-						'raw' => $demo_content,
-					)
-				)
-			)
+		$initial_edits = array(
+			'title'   => array(
+				'raw' => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
+			),
+			'content' => array(
+				'raw' => $demo_content,
+			),
 		);
 	} elseif ( $is_new_post ) {
-		wp_add_inline_script(
-			'wp-edit-post',
-			sprintf(
-				'window._wpGutenbergDefaultPost = { title: %s };',
-				wp_json_encode(
-					array(
-						'raw'      => '',
-						'rendered' => apply_filters( 'the_title', '', $post->ID ),
-					)
-				)
-			)
+		// Override "(Auto Draft)" new post default title with empty string,
+		// or filtered value.
+		$initial_edits = array(
+			'title' => array(
+				'raw' => apply_filters( 'the_title', '', $post->ID ),
+			),
 		);
+	} else {
+		$initial_edits = null;
 	}
 
 	// Prepare Jed locale data.
@@ -1488,10 +1479,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	$init_script = <<<JS
 	( function() {
-		var editorSettings = %s;
 		window._wpLoadGutenbergEditor = new Promise( function( resolve ) {
 			wp.domReady( function() {
-				resolve( wp.editPost.initializeEditor( 'editor', "%s", %d, editorSettings, window._wpGutenbergDefaultPost ) );
+				resolve( wp.editPost.initializeEditor( 'editor', "%s", %d, %s, %s ) );
 			} );
 		} );
 } )();
@@ -1507,7 +1497,13 @@ JS;
 	 */
 	$editor_settings = apply_filters( 'block_editor_settings', $editor_settings, $post );
 
-	$script = sprintf( $init_script, wp_json_encode( $editor_settings ), $post->post_type, $post->ID );
+	$script = sprintf(
+		$init_script,
+		$post->post_type,
+		$post->ID,
+		wp_json_encode( $editor_settings ),
+		wp_json_encode( $initial_edits )
+	);
 	wp_add_inline_script( 'wp-edit-post', $script );
 
 	/**


### PR DESCRIPTION
Extracted from #9403

This pull request refactors server-side editor initialization to pass initial edits as a setting directly to the editor initialization, rather than by proxy through a `window._wpGutenbergDefaultPost` global. In doing so, it resolves a yet-undiscovered issue where our filtering of `the_title` was effectively disregarded, since we never used the `rendered` property of the title populating the editor. This will be further separately improved by efforts in #9403.

Related to these future efforts, I think we should consider demo content as an external influencer, exposing filters necessary to provide these initial edits, in a similar fashion to what exists already with the `block_editor_settings` filter. [Here's a patch](https://gist.github.com/aduth/bd19a020a01fd40b58242d45b4bdfd94) which, when applied to this branch, would achieve this. However, I am choosing to defer this to after #9403, as it is not my desire for the `raw` / `rendered` distinction of content attributes persist, and thus be exposed into a public interface for extending initial edits.

**Testing instructions:**

Verify there are no regressions in the behavior of initial edits, notably:

- Demo post title and content
- Editing an existing post
- New post with and without `the_title` filter

Here's a small plugin for testing `the_title`:

```php
<?php

/**
 * Plugin Name: Filter The Title
 */

add_filter( 'the_title', function() {
	return 'My default title';
} );
```

(Note: `the_title` is not an editor-specific filter, so it will have additional side-effects to leave the above plugin activated after testing)