### PR TITLE
Fix: Mobile: Space block layout on small screens < 600px

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,10 +1,12 @@
 .editor-block-list__block[data-type="core/spacer"].is-selected .editor-block-list__block-edit {
-	background: $light-gray-200;
-
 	.block-library-spacer__resize-handler-top,
 	.block-library-spacer__resize-handler-bottom {
 		display: block;
 	}
+}
+
+.editor-block-list__block[data-type="core/spacer"].is-selected .block-library-spacer__resize-container {
+	background: $light-gray-200;
 }
 
 .block-library-spacer__resize-handler-top,

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -38,6 +38,7 @@ export const settings = {
 			return (
 				<Fragment>
 					<ResizableBox
+						className="block-library-spacer__resize-container"
 						size={ {
 							height,
 						} }


### PR DESCRIPTION
## Description
This PR just applies a simple CSS change to make sure the space blocks works correctly on small screens (< 600px).

Fixes: https://github.com/WordPress/gutenberg/issues/8853

## How has this been tested?
I checked space blocks works correctly on small screens and that on other screens the design was unchanged.

## Screenshots <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/11271197/45572586-88b98c00-b861-11e8-95ae-57657b5dda27.png)


After:
<img width="401" alt="screen shot 2018-09-14 at 20 46 15" src="https://user-images.githubusercontent.com/11271197/45571981-ec42ba00-b85f-11e8-9aa3-d654978cce44.png">


