### PR TITLE
Check the return value of glob()

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -33,9 +33,18 @@ require dirname( __FILE__ ) . '/register.php';
 
 
 // Register server-side code for individual blocks.
-foreach ( glob( dirname( __FILE__ ) . '/../block-library/*/index.php' ) as $block_logic ) {
-	require $block_logic;
-}
-foreach ( glob( dirname( __FILE__ ) . '/../packages/block-library/src/*/index.php' ) as $block_logic ) {
-	require $block_logic;
+$paths = array(
+	dirname( __FILE__ ) . '/../block-library/*/index.php',
+	dirname( __FILE__ ) . '/../packages/block-library/src/*/index.php',
+);
+
+foreach ( $paths as $path ) {
+	$block_logic_files = glob( $path );
+	if ( ! $block_logic_files ) {
+		continue;
+	}
+
+	foreach ( $block_logic_files as $block_logic ) {
+		require $block_logic;
+	}
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -40,6 +40,7 @@ $paths = array(
 
 foreach ( $paths as $path ) {
 	$block_logic_files = glob( $path );
+	// glob() can sometimes return false if there's an error, or it couldn't find any files.
 	if ( ! $block_logic_files ) {
 		continue;
 	}


### PR DESCRIPTION
## Description

When `glob()` doesn't find any files, it's supposed to return an empty array, but some versions of PHP seem to return `false`, instead. I've seen a few reports along the lines of #9213, it can also be observed [here](https://3v4l.org/jX14F).

As a side note, OSes that rely on musl libc (notably, Alpine Linux) may have a bug where `glob()` fails to find files when the search pattern includes both `.` and `*` (ref: [Alpine](https://bugs.alpinelinux.org/issues/8009), [musl](http://git.musl-libc.org/cgit/musl/commit/?id=ec04d122f1182aeb91f39b0e80ae40c68e4d9605)). I don't think we need to work around this, just something to be aware of.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.