### PR TITLE
Fix draghandle color

### DIFF
--- a/packages/editor/src/components/block-mover/style.scss
+++ b/packages/editor/src/components/block-mover/style.scss
@@ -93,6 +93,7 @@
 .editor-block-mover__control-drag-handle {
 	cursor: move; // Fallback for IE/Edge < 14
 	cursor: grab;
+	fill: currentColor;
 
 	&,
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,


### PR DESCRIPTION
Fixes design nitpick from https://github.com/WordPress/gutenberg/pull/9569#issuecomment-421442554.

Before:

![before](https://user-images.githubusercontent.com/1204802/45612549-8f175600-ba63-11e8-87ed-01b0b96130f9.png)

After:

![after](https://user-images.githubusercontent.com/1204802/45612506-668f5c00-ba63-11e8-80d4-f9e6b822b481.png)

