### PR TITLE
Pass name of the block to render_callback

### DIFF
--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -105,7 +105,7 @@ class WP_Block_Type {
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return (string) call_user_func( $this->render_callback, $attributes, $content );
+		return (string) call_user_func( $this->render_callback, $attributes, $content, $this->name );
 	}
 
 	/**

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -109,6 +109,36 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, json_decode( $output, true ) );
 	}
 
+	function test_render_callback_params() {
+
+		$block_type = 'core/dummy';
+		$attributes = array(
+			'foo' => 'bar',
+			'bar' => 'foo',
+		);
+
+		$content = 'baz';
+
+		$mock = $this->getMockBuilder( 'stdClass' )
+		             ->setMethods( [ 'render' ] )->getMock();
+		$mock->expects( $this->once( ) )
+		     ->method( 'render' )
+		     ->with(
+		     	$this->equalTo( $attributes ),
+		        $this->equalTo( $content ),
+		        $this->equalTo($block_type)
+		     );
+
+		$block_type  = new WP_Block_Type(
+			$block_type,
+			array(
+				'render_callback' => array( $mock, 'render' ),
+			)
+		);
+
+		$block_type->render( $attributes, $content );
+	}
+
 	function test_render_for_static_block() {
 		$block_type = new WP_Block_Type( 'core/dummy', array() );
 		$output     = $block_type->render();


### PR DESCRIPTION
Key/name of the block type is required when parsing multiple blocks with the same render callback, 
also when WordPress fire shortcode callback, pass shortcode tag as third parameter and the render_callback should be similar.
