### PR TITLE
Extend allowed attributes for non-admin users

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -163,6 +163,9 @@ function gutenberg_pre_init() {
 	require_once dirname( __FILE__ ) . '/lib/load.php';
 
 	add_filter( 'replace_editor', 'gutenberg_init', 10, 2 );
+
+	// Include kses fixes so core blocks work for non-admin users.
+	require_once dirname( __FILE__ ) . '/lib/kses.php';
 }
 
 /**
@@ -481,20 +484,3 @@ function gutenberg_add_admin_body_class( $classes ) {
 		return "$classes gutenberg-editor-page is-fullscreen-mode";
 	}
 }
-
-/**
- * Adds attributes to kses allowed tags that aren't in the default list
- * and that Gutenberg needs to save blocks such as the Gallery block.
- *
- * @param array $tags Allowed HTML.
- * @return array (Maybe) modified allowed HTML.
- */
-function gutenberg_kses_allowedtags( $tags ) {
-	if ( isset( $tags['img'] ) ) {
-		$tags['img']['data-link'] = true;
-		$tags['img']['data-id']   = true;
-	}
-	return $tags;
-}
-
-add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2 );

--- a/lib/kses.php
+++ b/lib/kses.php
@@ -7,19 +7,12 @@
  * @return array (Maybe) modified allowed HTML.
  */
 function gutenberg_kses_allowedtags( $tags ) {
-	$tags['a']['download'] = true;
-	$tags['img']['data-link'] = true;
-	$tags['img']['data-id']   = true;
-	$tags['div']['style'] = true;
+	$tags['a']['download']      = true;
+	$tags['img']['data-link']   = true;
+	$tags['img']['data-id']     = true;
+	$tags['div']['style']       = true;
 	$tags['div']['aria-hidden'] = true;
 	return $tags;
 }
 
 add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2 );
-
-function gutenberg_kses_allowed_style_css( $attributes ) {
-	$attributes[] = 'background-image';
-	return $attributes;
-}
-
-add_filter( 'safe_style_css', 'gutenberg_kses_allowed_style_css', 10, 1 );

--- a/lib/kses.php
+++ b/lib/kses.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * KSES related functions for the Gutenberg plugin.
+ *
+ * @package gutenberg
+ */
+
+/**
  * Adds attributes to kses allowed tags that aren't in the default list
  * and that Gutenberg needs to save blocks such as the Gallery block.
  *

--- a/lib/kses.php
+++ b/lib/kses.php
@@ -13,11 +13,20 @@
  * @return array (Maybe) modified allowed HTML.
  */
 function gutenberg_kses_allowedtags( $tags ) {
-	$tags['a']['download']      = true;
-	$tags['img']['data-link']   = true;
-	$tags['img']['data-id']     = true;
-	$tags['div']['style']       = true;
-	$tags['div']['aria-hidden'] = true;
+	if ( isset( $tags['a'] ) ) {
+		$tags['a']['download'] = true;
+	}
+
+	if ( isset( $tags['img'] ) ) {
+		$tags['img']['data-link'] = true;
+		$tags['img']['data-id']   = true;
+	}
+
+	if ( isset( $tags['div'] ) ) {
+		$tags['div']['style']       = true;
+		$tags['div']['aria-hidden'] = true;
+	}
+
 	return $tags;
 }
 

--- a/lib/kses.php
+++ b/lib/kses.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Adds attributes to kses allowed tags that aren't in the default list
+ * and that Gutenberg needs to save blocks such as the Gallery block.
+ *
+ * @param array $tags Allowed HTML.
+ * @return array (Maybe) modified allowed HTML.
+ */
+function gutenberg_kses_allowedtags( $tags ) {
+	$tags['a']['download'] = true;
+	$tags['img']['data-link'] = true;
+	$tags['img']['data-id']   = true;
+	$tags['div']['style'] = true;
+	$tags['div']['aria-hidden'] = true;
+	return $tags;
+}
+
+add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2 );
+
+function gutenberg_kses_allowed_style_css( $attributes ) {
+	$attributes[] = 'background-image';
+	return $attributes;
+}
+
+add_filter( 'safe_style_css', 'gutenberg_kses_allowed_style_css', 10, 1 );

--- a/phpunit/class-kses-test.php
+++ b/phpunit/class-kses-test.php
@@ -25,7 +25,7 @@ class KSES_Test extends WP_UnitTestCase {
 		$node_list = $document->getElementsByTagName( '*' );
 		foreach ( $node_list as $node ) {
 			$node_repr = array(
-				'tag_name'    => $node->tagName,
+				'tag_name'   => $node->tagName, // @codingStandardsIgnoreLine WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar 
 				'attributes' => array(),
 			);
 			foreach ( $node->attributes as $attr ) {

--- a/phpunit/class-kses-test.php
+++ b/phpunit/class-kses-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests that serialized HTML is not altered by KSES
+ * Tests that serialized HTML is not altered by KSES.
  *
  * @package Gutenberg
  */
@@ -14,19 +14,19 @@ class KSES_Test extends WP_UnitTestCase {
 	 * Generates a normalized array of tag names and attributes.
 	 * Takes into account how kses alters CSS.
 	 *
-	 * @param string $html HTML
-	 * @return array Normalized list of tags and attributes
+	 * @param string $html HTML.
+	 * @return array Normalized list of tags and attributes.
 	 */
 	function get_normalized_dom( $html ) {
 		$normalized = array();
-		$document = new DOMDocument();
-		libxml_use_internal_errors( true ); // Avoid errors with HTML5 elements
+		$document   = new DOMDocument();
+		libxml_use_internal_errors( true ); // Avoid errors with HTML5 elements.
 		$document->loadHTML( $html );
 		$node_list = $document->getElementsByTagName( '*' );
 		foreach ( $node_list as $node ) {
 			$node_repr = array(
 				'tagName'    => $node->tagName,
-				'attributes' => array()
+				'attributes' => array(),
 			);
 			foreach ( $node->attributes as $attr ) {
 				$name  = $attr->name;
@@ -71,12 +71,12 @@ class KSES_Test extends WP_UnitTestCase {
 		$admin_only = array(
 			// Freeform HTML.
 			'core__html.serialized.html',
-			// Currently broken for non-admin users, tracked at https://github.com/WordPress/gutenberg/issues/2539
-			'core__cover-image.serialized.html'
+			// Currently broken for non-admin users, https://github.com/WordPress/gutenberg/issues/2539 .
+			'core__cover-image.serialized.html',
 		);
 
 		foreach ( $admin_only as $excluded ) {
-			if ( $excluded === substr( $filename, -strlen( $excluded ) ) ) {
+			if ( substr( $filename, -strlen( $excluded ) ) === $excluded ) {
 				return false;
 			}
 		}

--- a/phpunit/class-kses-test.php
+++ b/phpunit/class-kses-test.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Tests that serialized HTML is not altered by KSES
+ *
+ * @package Gutenberg
+ */
+
+require_once dirname( __FILE__ ) . '/../lib/kses.php';
+
+class KSES_Test extends WP_UnitTestCase {
+	protected static $fixtures_dir;
+
+	/**
+	 * Generates a normalized array of tag names and attributes.
+	 * Takes into account how kses alters CSS.
+	 *
+	 * @param string $html HTML
+	 * @return array Normalized list of tags and attributes
+	 */
+	function get_normalized_dom( $html ) {
+		$normalized = array();
+		$document = new DOMDocument();
+		libxml_use_internal_errors( true ); // Avoid errors with HTML5 elements
+		$document->loadHTML( $html );
+		$node_list = $document->getElementsByTagName( '*' );
+		foreach ( $node_list as $node ) {
+			$node_repr = array(
+				'tagName'    => $node->tagName,
+				'attributes' => array()
+			);
+			foreach ( $node->attributes as $attr ) {
+				$name  = $attr->name;
+				$value = $attr->value;
+
+				// Normalise css.
+				if ( 'style' === $name && ';' === substr( $value, -1 ) ) {
+					$value = substr( $value, 0, -1 );
+				}
+
+				$node_repr['attributes'][ $name ] = $value;
+			}
+			$normalized[] = $node_repr;
+		}
+		libxml_clear_errors();
+		return $normalized;
+	}
+
+	function assert_html_is_equivalent( $expected_html, $actual_html, $message ) {
+		$expected = $this->get_normalized_dom( $expected_html );
+		$actual   = $this->get_normalized_dom( $actual_html );
+		$this->assertEquals( $expected, $actual, $message );
+	}
+
+	function kses_test_filenames() {
+		self::$fixtures_dir = dirname( dirname( __FILE__ ) ) . '/test/integration/full-content/fixtures';
+
+		require_once dirname( dirname( __FILE__ ) ) . '/lib/parser.php';
+
+		// Exclude fixtures that would require admin to save,
+		// and so wouldn't go through kses.
+		$fixture_files = array_filter(
+			glob( self::$fixtures_dir . '/*.serialized.html' ),
+			array( $this, 'is_saved_through_kses' )
+		);
+
+		return array_map(
+			array( $this, 'filename_to_args' ),
+			$fixture_files
+		);
+	}
+
+	function is_saved_through_kses( $filename ) {
+		return 'core__html.serialized.html' !== substr( $filename, -26 );
+	}
+
+	function filename_to_args( $filename ) {
+		return array( $filename );
+	}
+
+	function strip_r( $input ) {
+		return str_replace( "\r", '', $input );
+	}
+
+	/**
+	 * @dataProvider kses_test_filenames
+	 */
+	function test_kses_does_not_alter_output( $html_path ) {
+		$html      = self::strip_r( file_get_contents( $html_path ) );
+		$kses_html = wp_unslash( wp_filter_post_kses( $html ) );
+
+		$this->assert_html_is_equivalent(
+			$html,
+			$kses_html,
+			"File '$html_path' was altered by kses"
+		);
+	}
+}

--- a/phpunit/class-kses-test.php
+++ b/phpunit/class-kses-test.php
@@ -68,7 +68,20 @@ class KSES_Test extends WP_UnitTestCase {
 	}
 
 	function is_saved_through_kses( $filename ) {
-		return 'core__html.serialized.html' !== substr( $filename, -26 );
+		$admin_only = array(
+			// Freeform HTML.
+			'core__html.serialized.html',
+			// Currently broken for non-admin users, tracked at https://github.com/WordPress/gutenberg/issues/2539
+			'core__cover-image.serialized.html'
+		);
+
+		foreach ( $admin_only as $excluded ) {
+			if ( $excluded === substr( $filename, -strlen( $excluded ) ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	function filename_to_args( $filename ) {

--- a/phpunit/class-kses-test.php
+++ b/phpunit/class-kses-test.php
@@ -25,7 +25,7 @@ class KSES_Test extends WP_UnitTestCase {
 		$node_list = $document->getElementsByTagName( '*' );
 		foreach ( $node_list as $node ) {
 			$node_repr = array(
-				'tagName'    => $node->tagName,
+				'tag_name'    => $node->tagName,
 				'attributes' => array(),
 			);
 			foreach ( $node->attributes as $attr ) {

--- a/phpunit/class-kses-test.php
+++ b/phpunit/class-kses-test.php
@@ -54,8 +54,6 @@ class KSES_Test extends WP_UnitTestCase {
 	function kses_test_filenames() {
 		self::$fixtures_dir = dirname( dirname( __FILE__ ) ) . '/test/integration/full-content/fixtures';
 
-		require_once dirname( dirname( __FILE__ ) ) . '/lib/parser.php';
-
 		// Exclude fixtures that would require admin to save,
 		// and so wouldn't go through kses.
 		$fixture_files = array_filter(


### PR DESCRIPTION
## Description

Adds a test and alters allowed kses attributes so that users with the author role can save the current blocks without having attributes removed.

## How has this been tested?

New test runs the serialized fixtures through kses and makes sure the resulting HTML is equivalent.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
