### PR TITLE
Data Module: update the resolvers to rely on controls instead of async generators

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,5 +1,9 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 4.2.0
+
+- Writing resolvers as async generators has been removed. Use the controls plugin instead.
+
 ## 4.1.0
 
 - `wp.data.dispatch( 'core/editor' ).checkTemplateValidity` has been removed. Validity is verified automatically upon block reset.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -248,6 +248,7 @@ function gutenberg_register_scripts_and_styles() {
 		array(
 			'lodash',
 			'wp-compose',
+			'wp-deprecated',
 			'wp-element',
 			'wp-is-shallow-equal',
 			'wp-polyfill',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2182,6 +2182,7 @@
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/redux-routine": "file:packages/redux-routine",

--- a/packages/core-data/src/controls.js
+++ b/packages/core-data/src/controls.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { default as triggerApiFetch } from '@wordpress/api-fetch';
+import { select as selectData } from '@wordpress/data';
+
+/**
+ * Trigger an API Fetch request.
+ *
+ * @param {Object} request API Fetch Request Object.
+ * @return {Object} control descriptor.
+ */
+export function apiFetch( request ) {
+	return {
+		type: 'API_FETCH',
+		request,
+	};
+}
+
+/**
+ * Calls a selector using the current state.
+ * @param {string} selectorName Selector name.
+ * @param  {Array} args         Selector arguments.
+ *
+ * @return {Object} control descriptor.
+ */
+export function select( selectorName, ...args ) {
+	return {
+		type: 'SELECT',
+		selectorName,
+		args,
+	};
+}
+
+const controls = {
+	API_FETCH( { request } ) {
+		return triggerApiFetch( request );
+	},
+
+	SELECT( { selectorName, args } ) {
+		return selectData( 'core' )[ selectorName ]( ...args );
+	},
+};
+
+export default controls;

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -4,15 +4,10 @@
 import { upperFirst, camelCase, map, find } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import apiFetch from '@wordpress/api-fetch';
-
-/**
  * Internal dependencies
  */
-import { getEntitiesByKind } from './selectors';
 import { addEntities } from './actions';
+import { apiFetch, select } from './controls';
 
 export const defaultEntities = [
 	{ name: 'postType', kind: 'root', key: 'slug', baseURL: '/wp/v2/types' },
@@ -30,8 +25,8 @@ export const kinds = [
  *
  * @return {Promise} Entities promise
  */
-async function loadPostTypeEntities() {
-	const postTypes = await apiFetch( { path: '/wp/v2/types?context=edit' } );
+function * loadPostTypeEntities() {
+	const postTypes = yield apiFetch( { path: '/wp/v2/types?context=edit' } );
 	return map( postTypes, ( postType, name ) => {
 		return {
 			kind: 'postType',
@@ -46,8 +41,8 @@ async function loadPostTypeEntities() {
  *
  * @return {Promise} Entities promise
  */
-async function loadTaxonomyEntities() {
-	const taxonomies = await apiFetch( { path: '/wp/v2/taxonomies?context=edit' } );
+function * loadTaxonomyEntities() {
+	const taxonomies = yield apiFetch( { path: '/wp/v2/taxonomies?context=edit' } );
 	return map( taxonomies, ( taxonomy, name ) => {
 		return {
 			kind: 'taxonomy',
@@ -78,14 +73,12 @@ export const getMethodName = ( kind, name, prefix = 'get', usePlural = false ) =
 /**
  * Loads the kind entities into the store.
  *
- * @param {Object} state Global state
  * @param {string} kind  Kind
  *
  * @return {Array} Entities
  */
-export async function* getKindEntities( state, kind ) {
-	let entities = getEntitiesByKind( state, kind );
-
+export function* getKindEntities( kind ) {
+	let entities = yield select( 'getEntitiesByKind', kind );
 	if ( entities && entities.length !== 0 ) {
 		return entities;
 	}
@@ -95,7 +88,7 @@ export async function* getKindEntities( state, kind ) {
 		return [];
 	}
 
-	entities = await kindConfig.loadEntities();
+	entities = yield kindConfig.loadEntities();
 	yield addEntities( entities );
 
 	return entities;

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -25,7 +25,7 @@ export const kinds = [
  *
  * @return {Promise} Entities promise
  */
-function * loadPostTypeEntities() {
+function* loadPostTypeEntities() {
 	const postTypes = yield apiFetch( { path: '/wp/v2/types?context=edit' } );
 	return map( postTypes, ( postType, name ) => {
 		return {
@@ -41,7 +41,7 @@ function * loadPostTypeEntities() {
  *
  * @return {Promise} Entities promise
  */
-function * loadTaxonomyEntities() {
+function* loadTaxonomyEntities() {
 	const taxonomies = yield apiFetch( { path: '/wp/v2/taxonomies?context=edit' } );
 	return map( taxonomies, ( taxonomy, name ) => {
 		return {

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -7,25 +7,34 @@ import { registerStore } from '@wordpress/data';
  * Internal dependencies
  */
 import reducer from './reducer';
+import controls from './controls';
 import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import { defaultEntities, getMethodName } from './entities';
 import { REDUCER_KEY } from './name';
 
-const createEntityRecordGetter = ( source ) => defaultEntities.reduce( ( result, entity ) => {
+const createEntityRecordSelector = ( source ) => defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name ) ] = ( state, key ) => source.getEntityRecord( state, kind, name, key );
 	result[ getMethodName( kind, name, 'get', true ) ] = ( state, ...args ) => source.getEntityRecords( state, kind, name, ...args );
 	return result;
 }, {} );
 
-const entityResolvers = createEntityRecordGetter( resolvers );
-const entitySelectors = createEntityRecordGetter( selectors );
+const createEntityRecordResolver = ( source ) => defaultEntities.reduce( ( result, entity ) => {
+	const { kind, name } = entity;
+	result[ getMethodName( kind, name ) ] = ( key ) => source.getEntityRecord( kind, name, key );
+	result[ getMethodName( kind, name, 'get', true ) ] = ( ...args ) => source.getEntityRecords( kind, name, ...args );
+	return result;
+}, {} );
+
+const entityResolvers = createEntityRecordResolver( resolvers );
+const entitySelectors = createEntityRecordSelector( selectors );
 
 const store = registerStore( REDUCER_KEY, {
 	reducer,
 	actions,
+	controls,
 	selectors: { ...selectors, ...entitySelectors },
 	resolvers: { ...resolvers, ...entityResolvers },
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -6,7 +6,6 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -19,43 +18,42 @@ import {
 	receiveEmbedPreview,
 } from './actions';
 import { getKindEntities } from './entities';
+import { apiFetch } from './controls';
 
 /**
  * Requests authors from the REST API.
  */
-export async function* getAuthors() {
-	const users = await apiFetch( { path: '/wp/v2/users/?who=authors&per_page=-1' } );
+export function* getAuthors() {
+	const users = yield apiFetch( { path: '/wp/v2/users/?who=authors&per_page=-1' } );
 	yield receiveUserQuery( 'authors', users );
 }
 
 /**
  * Requests an entity's record from the REST API.
  *
- * @param {Object} state  State tree
  * @param {string} kind   Entity kind.
  * @param {string} name   Entity name.
  * @param {number} key    Record's key
  */
-export async function* getEntityRecord( state, kind, name, key ) {
-	const entities = yield* await getKindEntities( state, kind );
+export function* getEntityRecord( kind, name, key ) {
+	const entities = yield getKindEntities( kind );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity ) {
 		return;
 	}
-	const record = await apiFetch( { path: `${ entity.baseURL }/${ key }?context=edit` } );
+	const record = yield apiFetch( { path: `${ entity.baseURL }/${ key }?context=edit` } );
 	yield receiveEntityRecords( kind, name, record );
 }
 
 /**
  * Requests the entity's records from the REST API.
  *
- * @param {Object}  state  State tree
  * @param {string}  kind   Entity kind.
  * @param {string}  name   Entity name.
  * @param {Object?} query  Query Object.
  */
-export async function* getEntityRecords( state, kind, name, query = {} ) {
-	const entities = yield* await getKindEntities( state, kind );
+export function* getEntityRecords( kind, name, query = {} ) {
+	const entities = yield getKindEntities( kind );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity ) {
 		return;
@@ -64,27 +62,26 @@ export async function* getEntityRecords( state, kind, name, query = {} ) {
 		...query,
 		context: 'edit',
 	} );
-	const records = await apiFetch( { path } );
+	const records = yield apiFetch( { path } );
 	yield receiveEntityRecords( kind, name, Object.values( records ), query );
 }
 
 /**
  * Requests theme supports data from the index.
  */
-export async function* getThemeSupports() {
-	const index = await apiFetch( { path: '/' } );
+export function* getThemeSupports() {
+	const index = yield apiFetch( { path: '/' } );
 	yield receiveThemeSupportsFromIndex( index );
 }
 
 /**
  * Requests a preview from the from the Embed API.
  *
- * @param {Object} state State tree
  * @param {string} url   URL to get the preview for.
  */
-export async function* getEmbedPreview( state, url ) {
+export function* getEmbedPreview( url ) {
 	try {
-		const embedProxyResponse = await apiFetch( { path: addQueryArgs( '/oembed/1.0/proxy', { url } ) } );
+		const embedProxyResponse = yield apiFetch( { path: addQueryArgs( '/oembed/1.0/proxy', { url } ) } );
 		yield receiveEmbedPreview( url, embedProxyResponse );
 	} catch ( error ) {
 		// Embed API 404s if the URL cannot be embedded, so we have to catch the error from the apiRequest here.

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -1,67 +1,23 @@
 /**
- * WordPress dependencies
- */
-import apiFetch from '@wordpress/api-fetch';
-
-/**
- * External dependencies
- */
-import { addQueryArgs } from '@wordpress/url';
-
-/**
  * Internal dependencies
  */
 import { getEntityRecord, getEntityRecords, getEmbedPreview } from '../resolvers';
-import { receiveEntityRecords, addEntities, receiveEmbedPreview } from '../actions';
-
-jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+import { receiveEntityRecords, receiveEmbedPreview } from '../actions';
 
 describe( 'getEntityRecord', () => {
 	const POST_TYPE = { slug: 'post' };
-	const POST_TYPES = {
-		post: {
-			rest_base: 'posts',
-		},
-	};
-	const POST = { id: 10, title: 'test' };
-
-	beforeAll( () => {
-		apiFetch.mockImplementation( ( options ) => {
-			if ( options.path === '/wp/v2/types/post?context=edit' ) {
-				return Promise.resolve( POST_TYPE );
-			}
-			if ( options.path === '/wp/v2/posts/10?context=edit' ) {
-				return Promise.resolve( POST );
-			}
-			if ( options.path === '/wp/v2/types?context=edit' ) {
-				return Promise.resolve( POST_TYPES );
-			}
-		} );
-	} );
 
 	it( 'yields with requested post type', async () => {
-		const state = {
-			entities: {
-				config: [
-					{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
-				],
-			},
-		};
-		const fulfillment = getEntityRecord( state, 'root', 'postType', 'post' );
-		const received = ( await fulfillment.next() ).value;
+		const entities = [ { name: 'postType', kind: 'root', baseURL: '/wp/v2/types' } ];
+		const fulfillment = getEntityRecord( 'root', 'postType', 'post' );
+		// Trigger generator
+		fulfillment.next();
+		// Provide entities and trigger apiFetch
+		const { value: apiFetchAction } = fulfillment.next( entities );
+		expect( apiFetchAction.request ).toEqual( { path: '/wp/v2/types/post?context=edit' } );
+		// Provide response and trigger action
+		const { value: received } = fulfillment.next( POST_TYPE );
 		expect( received ).toEqual( receiveEntityRecords( 'root', 'postType', POST_TYPE ) );
-	} );
-
-	it( 'loads the kind entities and yields with requested post type', async () => {
-		const fulfillment = getEntityRecord( { entities: {} }, 'postType', 'post', 10 );
-		const receivedEntities = ( await fulfillment.next() ).value;
-		expect( receivedEntities ).toEqual( addEntities( [ {
-			baseURL: '/wp/v2/posts',
-			kind: 'postType',
-			name: 'post',
-		} ] ) );
-		const received = ( await fulfillment.next() ).value;
-		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', POST ) );
 	} );
 } );
 
@@ -71,24 +27,19 @@ describe( 'getEntityRecords', () => {
 		page: { slug: 'page' },
 	};
 
-	beforeAll( () => {
-		apiFetch.mockImplementation( ( options ) => {
-			if ( options.path === '/wp/v2/types?context=edit' ) {
-				return Promise.resolve( POST_TYPES );
-			}
-		} );
-	} );
-
 	it( 'yields with requested post type', async () => {
-		const state = {
-			entities: {
-				config: [
-					{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
-				],
-			},
-		};
-		const fulfillment = getEntityRecords( state, 'root', 'postType' );
-		const received = ( await fulfillment.next() ).value;
+		const entities = [
+			{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
+		];
+		const fulfillment = getEntityRecords( 'root', 'postType' );
+
+		// Trigger generator
+		fulfillment.next();
+		// Provide entities and trigger apiFetch
+		const { value: apiFetchAction } = fulfillment.next( entities );
+		expect( apiFetchAction.request ).toEqual( { path: '/wp/v2/types?context=edit' } );
+		// Provide response and trigger action
+		const { value: received } = fulfillment.next( POST_TYPES );
 		expect( received ).toEqual( receiveEntityRecords( 'root', 'postType', Object.values( POST_TYPES ), {} ) );
 	} );
 } );
@@ -99,24 +50,21 @@ describe( 'getEmbedPreview', () => {
 	const EMBEDDABLE_URL = 'http://twitter.com/notnownikki';
 	const UNEMBEDDABLE_URL = 'http://example.com/';
 
-	beforeAll( () => {
-		apiFetch.mockImplementation( ( options ) => {
-			if ( options.path === addQueryArgs( '/oembed/1.0/proxy', { url: EMBEDDABLE_URL } ) ) {
-				return Promise.resolve( SUCCESSFUL_EMBED_RESPONSE );
-			}
-			throw 404;
-		} );
-	} );
-
 	it( 'yields with fetched embed preview', async () => {
-		const fulfillment = getEmbedPreview( {}, EMBEDDABLE_URL );
-		const received = ( await fulfillment.next() ).value;
+		const fulfillment = getEmbedPreview( EMBEDDABLE_URL );
+		// Trigger generator
+		fulfillment.next();
+		// Provide apiFetch response and trigger Action
+		const received = ( await fulfillment.next( SUCCESSFUL_EMBED_RESPONSE ) ).value;
 		expect( received ).toEqual( receiveEmbedPreview( EMBEDDABLE_URL, SUCCESSFUL_EMBED_RESPONSE ) );
 	} );
 
 	it( 'yields false if the URL cannot be embedded', async () => {
-		const fulfillment = getEmbedPreview( {}, UNEMBEDDABLE_URL );
-		const received = ( await fulfillment.next() ).value;
+		const fulfillment = getEmbedPreview( UNEMBEDDABLE_URL );
+		// Trigger generator
+		fulfillment.next();
+		// Provide invalid response and trigger Action
+		const received = ( await fulfillment.throw( { status: 404 } ) ).value;
 		expect( received ).toEqual( receiveEmbedPreview( UNEMBEDDABLE_URL, UNEMBEDDABLE_RESPONSE ) );
 	} );
 } );

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.1.0 (Unreleased)
+
+## New Features
+
+- Adding support for using controls in resolvers using the controls plugin.
+
+### Deprecations
+
+- Writing resolvers as async generators has been deprecated. Use the controls plugin instead.
+
 ## 2.0.0 (2018-09-05)
 
 ### Breaking Change

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -23,6 +23,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/redux-routine": "file:../redux-routine",

--- a/packages/data/src/plugins/async-generator/middleware.js
+++ b/packages/data/src/plugins/async-generator/middleware.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Returns true if the given argument appears to be a dispatchable action.
  *
  * @param {*} action Object to test.
@@ -50,6 +55,11 @@ function isIterable( object ) {
  */
 export function toAsyncIterable( object ) {
 	if ( isAsyncIterable( object ) ) {
+		deprecated( 'Writing Resolvers as async generators', {
+			alternative: 'resolvers as generators with controls',
+			plugin: 'Gutenberg',
+			version: 4.2,
+		} );
 		return object;
 	}
 

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -360,6 +360,8 @@ describe( 'createRegistry', () => {
 
 			registry.select( 'counter' ).getCount();
 
+			expect( console ).toHaveWarned();
+
 			return promise;
 		} );
 	} );

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -36,7 +36,7 @@
 - `wp.editor.DocumentTitle` component has been removed.
 - `getDocumentTitle` selector (`core/editor`) has been removed.
 
-### Deprecation
+### Deprecations
 
 - `wp.editor.RichTextProvider` flagged for deprecation. Please use `wp.data.select( 'core/editor' )` methods instead.
 

--- a/packages/editor/src/store/effects/test/utils.js
+++ b/packages/editor/src/store/effects/test/utils.js
@@ -22,7 +22,7 @@ describe( 'resolveSelector', () => {
 		resolvers: {
 			selectAll: () => {
 				return new Promise( ( resolve ) => {
-					process.nextTick( () => resolve( { type: 'resolve' } ) );
+					resolve( { type: 'resolve' } );
 				} );
 			},
 		},

--- a/packages/redux-routine/src/runtime.js
+++ b/packages/redux-routine/src/runtime.js
@@ -26,7 +26,7 @@ export default function createRuntime( controls = {}, dispatch ) {
 		if ( routine instanceof Promise ) {
 			// Async control routine awaits resolution.
 			routine.then(
-				next,
+				yieldNext,
 				( error ) => yieldError( castError( error ) ),
 			);
 		} else {

--- a/test/unit/__mocks__/@wordpress/data.js
+++ b/test/unit/__mocks__/@wordpress/data.js
@@ -1,3 +1,3 @@
 import { use, plugins } from '../../../../packages/data/src';
-use( plugins.asyncGenerator );
+use( plugins.controls );
 export * from '../../../../packages/data/src';


### PR DESCRIPTION
Follow up to #9507 

This PR refactors the current Gutenberg resolvers to use controls instead of async generator.

**Testing instructions**

 - Unit and e2e tests pass.

**Todo**

 - [x] Deprecate the async generators plugin