### PR TITLE
Add greater than symbol to attribute escaping

### DIFF
--- a/packages/element/src/test/index.js
+++ b/packages/element/src/test/index.js
@@ -53,7 +53,7 @@ describe( 'element', () => {
 			}, '<"WordPress" & Friends>' ) );
 
 			expect( result ).toBe(
-				'<a href="/index.php?foo=bar&amp;qux=<&quot;scary&quot;>" style="background-color:red">' +
+				'<a href="/index.php?foo=bar&amp;qux=<&quot;scary&quot;&gt;" style="background-color:red">' +
 				'&lt;"WordPress" &amp; Friends>' +
 				'</a>'
 			);

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -528,7 +528,7 @@ describe( 'renderAttributes()', () => {
 				href: '/index.php?foo=bar&qux=<"scary">',
 			} );
 
-			expect( result ).toBe( ' style="background:url(&quot;foo.png&quot;)" href="/index.php?foo=bar&amp;qux=<&quot;scary&quot;>"' );
+			expect( result ).toBe( ' style="background:url(&quot;foo.png&quot;)" href="/index.php?foo=bar&amp;qux=<&quot;scary&quot;&gt;"' );
 		} );
 
 		it( 'should render numeric attributes', () => {

--- a/packages/escape-html/CHANGELOG.md
+++ b/packages/escape-html/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1 (Unreleased)
+
+- Add fix for WordPress wptexturize greater-than tokenize bug (see https://core.trac.wordpress.org/ticket/45387)
+
 ## 1.0.1 (2018-10-19)
 
 ## 1.0.0 (2018-10-18)

--- a/packages/escape-html/README.md
+++ b/packages/escape-html/README.md
@@ -18,7 +18,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ### escapeAmpersand
 
-[src/index.js#L28-L30](src/index.js#L28-L30)
+[src/index.js#L33-L35](src/index.js#L33-L35)
 
 Returns a string with ampersands escaped. Note that this is an imperfect
 implementation, where only ampersands which do not appear as a pattern of
@@ -41,7 +41,7 @@ named references (i.e. ambiguous ampersand) are are still permitted.
 
 ### escapeAttribute
 
-[src/index.js#L66-L68](src/index.js#L66-L68)
+[src/index.js#L79-L81](src/index.js#L79-L81)
 
 Returns an escaped attribute value.
 
@@ -51,6 +51,14 @@ Returns an escaped attribute value.
 
 "[...] the text cannot contain an ambiguous ampersand [...] must not contain
 any literal U+0022 QUOTATION MARK characters (")"
+
+Note we also escape the greater than symbol, as this is used by wptexturize to
+split HTML strings. This is a WordPress specific fix
+
+Note that if a resolution for Trac#45387 comes to fruition, it is no longer
+necessary for `__unstableEscapeGreaterThan` to be used.
+
+See: <https://core.trac.wordpress.org/ticket/45387>
 
 **Parameters**
 
@@ -62,7 +70,7 @@ any literal U+0022 QUOTATION MARK characters (")"
 
 ### escapeHTML
 
-[src/index.js#L82-L84](src/index.js#L82-L84)
+[src/index.js#L95-L97](src/index.js#L95-L97)
 
 Returns an escaped HTML element value.
 
@@ -83,7 +91,7 @@ ambiguous ampersand."
 
 ### escapeLessThan
 
-[src/index.js#L50-L52](src/index.js#L50-L52)
+[src/index.js#L55-L57](src/index.js#L55-L57)
 
 Returns a string with less-than sign replaced.
 
@@ -97,7 +105,7 @@ Returns a string with less-than sign replaced.
 
 ### escapeQuotationMark
 
-[src/index.js#L39-L41](src/index.js#L39-L41)
+[src/index.js#L44-L46](src/index.js#L44-L46)
 
 Returns a string with quotation marks replaced.
 
@@ -111,7 +119,7 @@ Returns a string with quotation marks replaced.
 
 ### isValidAttributeName
 
-[src/index.js#L93-L95](src/index.js#L93-L95)
+[src/index.js#L106-L108](src/index.js#L106-L108)
 
 Returns true if the given attribute name is valid, or false otherwise.
 

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/escape-html",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Escape HTML utils.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/escape-html/src/escape-greater.js
+++ b/packages/escape-html/src/escape-greater.js
@@ -1,0 +1,15 @@
+/**
+ * Returns a string with greater-than sign replaced.
+ *
+ * Note that if a resolution for Trac#45387 comes to fruition, it is no longer
+ * necessary for `__unstableEscapeGreaterThan` to exist.
+ *
+ * See: https://core.trac.wordpress.org/ticket/45387
+ *
+ * @param {string} value Original string.
+ *
+ * @return {string} Escaped string.
+ */
+export default function __unstableEscapeGreaterThan( value ) {
+	return value.replace( />/g, '&gt;' );
+}

--- a/packages/escape-html/src/index.js
+++ b/packages/escape-html/src/index.js
@@ -52,7 +52,7 @@ export function escapeLessThan( value ) {
 }
 
 /**
- * Returns a string with grater-than sign replaced.
+ * Returns a string with greater-than sign replaced.
  *
  * @param {string} value Original string.
  *
@@ -69,6 +69,9 @@ export function escapeGreaterThan( value ) {
  *
  * "[...] the text cannot contain an ambiguous ampersand [...] must not contain
  * any literal U+0022 QUOTATION MARK characters (")"
+ *
+ * Note we also escape the greater than symbol, as this is used by wptexturize to
+ * split HTML strings. This is a WordPress specific fix
  *
  * @param {string} value Attribute value.
  *

--- a/packages/escape-html/src/index.js
+++ b/packages/escape-html/src/index.js
@@ -52,6 +52,17 @@ export function escapeLessThan( value ) {
 }
 
 /**
+ * Returns a string with grater-than sign replaced.
+ *
+ * @param {string} value Original string.
+ *
+ * @return {string} Escaped string.
+ */
+export function escapeGreaterThan( value ) {
+	return value.replace( />/g, '&gt;' );
+}
+
+/**
  * Returns an escaped attribute value.
  *
  * @link https://w3c.github.io/html/syntax.html#elements-attributes
@@ -64,7 +75,7 @@ export function escapeLessThan( value ) {
  * @return {string} Escaped attribute value.
  */
 export function escapeAttribute( value ) {
-	return escapeQuotationMark( escapeAmpersand( value ) );
+	return escapeGreaterThan( escapeQuotationMark( escapeAmpersand( value ) ) );
 }
 
 /**

--- a/packages/escape-html/src/index.js
+++ b/packages/escape-html/src/index.js
@@ -58,7 +58,7 @@ export function escapeLessThan( value ) {
  *
  * @return {string} Escaped string.
  */
-export function escapeGreaterThan( value ) {
+export function __unstableEscapeGreaterThan( value ) {
 	return value.replace( />/g, '&gt;' );
 }
 
@@ -74,7 +74,7 @@ export function escapeGreaterThan( value ) {
  * split HTML strings. This is a WordPress specific fix
  *
  * Note that if a resolution for Trac#45387 comes to fruition, it is no longer
- * necessary for `escapeGreaterThan` to exist in this module.
+ * necessary for `__unstableEscapeGreaterThan` to exist in this module.
  *
  * See: https://core.trac.wordpress.org/ticket/45387
  * @param {string} value Attribute value.
@@ -82,7 +82,7 @@ export function escapeGreaterThan( value ) {
  * @return {string} Escaped attribute value.
  */
 export function escapeAttribute( value ) {
-	return escapeGreaterThan( escapeQuotationMark( escapeAmpersand( value ) ) );
+	return __unstableEscapeGreaterThan( escapeQuotationMark( escapeAmpersand( value ) ) );
 }
 
 /**

--- a/packages/escape-html/src/index.js
+++ b/packages/escape-html/src/index.js
@@ -73,6 +73,10 @@ export function escapeGreaterThan( value ) {
  * Note we also escape the greater than symbol, as this is used by wptexturize to
  * split HTML strings. This is a WordPress specific fix
  *
+ * Note that if a resolution for Trac#45387 comes to fruition, it is no longer
+ * necessary for `escapeGreaterThan` to exist in this module.
+ *
+ * See: https://core.trac.wordpress.org/ticket/45387
  * @param {string} value Attribute value.
  *
  * @return {string} Escaped attribute value.

--- a/packages/escape-html/src/index.js
+++ b/packages/escape-html/src/index.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import __unstableEscapeGreaterThan from './escape-greater';
+
+/**
  * Regular expression matching invalid attribute names.
  *
  * "Attribute names must consist of one or more characters other than controls,
@@ -52,17 +57,6 @@ export function escapeLessThan( value ) {
 }
 
 /**
- * Returns a string with greater-than sign replaced.
- *
- * @param {string} value Original string.
- *
- * @return {string} Escaped string.
- */
-export function __unstableEscapeGreaterThan( value ) {
-	return value.replace( />/g, '&gt;' );
-}
-
-/**
  * Returns an escaped attribute value.
  *
  * @link https://w3c.github.io/html/syntax.html#elements-attributes
@@ -74,9 +68,10 @@ export function __unstableEscapeGreaterThan( value ) {
  * split HTML strings. This is a WordPress specific fix
  *
  * Note that if a resolution for Trac#45387 comes to fruition, it is no longer
- * necessary for `__unstableEscapeGreaterThan` to exist in this module.
+ * necessary for `__unstableEscapeGreaterThan` to be used.
  *
  * See: https://core.trac.wordpress.org/ticket/45387
+ *
  * @param {string} value Attribute value.
  *
  * @return {string} Escaped attribute value.

--- a/packages/escape-html/src/test/index.js
+++ b/packages/escape-html/src/test/index.js
@@ -5,10 +5,18 @@ import {
 	escapeAmpersand,
 	escapeQuotationMark,
 	escapeLessThan,
+	escapeGreaterThan,
 	escapeAttribute,
 	escapeHTML,
 	isValidAttributeName,
 } from '../';
+
+function testEscapeGreaterThan( implementation ) {
+	it( 'should escape greater than', () => {
+		const result = implementation( 'Chicken > Ribs' );
+		expect( result ).toBe( 'Chicken &gt; Ribs' );
+	} );
+}
 
 function testEscapeAmpersand( implementation ) {
 	it( 'should escape ampersand', () => {
@@ -46,9 +54,14 @@ describe( 'escapeLessThan', () => {
 	testEscapeLessThan( escapeLessThan );
 } );
 
+describe( 'escapeGreaterThan', () => {
+	testEscapeGreaterThan( escapeGreaterThan );
+} );
+
 describe( 'escapeAttribute', () => {
 	testEscapeAmpersand( escapeAttribute );
 	testEscapeQuotationMark( escapeAttribute );
+	testEscapeGreaterThan( escapeAttribute );
 } );
 
 describe( 'escapeHTML', () => {

--- a/packages/escape-html/src/test/index.js
+++ b/packages/escape-html/src/test/index.js
@@ -5,13 +5,13 @@ import {
 	escapeAmpersand,
 	escapeQuotationMark,
 	escapeLessThan,
-	escapeGreaterThan,
+	__unstableEscapeGreaterThan,
 	escapeAttribute,
 	escapeHTML,
 	isValidAttributeName,
 } from '../';
 
-function testEscapeGreaterThan( implementation ) {
+function testUnstableEscapeGreaterThan( implementation ) {
 	it( 'should escape greater than', () => {
 		const result = implementation( 'Chicken > Ribs' );
 		expect( result ).toBe( 'Chicken &gt; Ribs' );
@@ -55,13 +55,13 @@ describe( 'escapeLessThan', () => {
 } );
 
 describe( 'escapeGreaterThan', () => {
-	testEscapeGreaterThan( escapeGreaterThan );
+	testUnstableEscapeGreaterThan( __unstableEscapeGreaterThan );
 } );
 
 describe( 'escapeAttribute', () => {
 	testEscapeAmpersand( escapeAttribute );
 	testEscapeQuotationMark( escapeAttribute );
-	testEscapeGreaterThan( escapeAttribute );
+	testUnstableEscapeGreaterThan( escapeAttribute );
 } );
 
 describe( 'escapeHTML', () => {

--- a/packages/escape-html/src/test/index.js
+++ b/packages/escape-html/src/test/index.js
@@ -5,11 +5,11 @@ import {
 	escapeAmpersand,
 	escapeQuotationMark,
 	escapeLessThan,
-	__unstableEscapeGreaterThan,
 	escapeAttribute,
 	escapeHTML,
 	isValidAttributeName,
 } from '../';
+import __unstableEscapeGreaterThan from '../escape-greater';
 
 function testUnstableEscapeGreaterThan( implementation ) {
 	it( 'should escape greater than', () => {


### PR DESCRIPTION
Although `>` is a [valid attribute character](https://www.w3.org/TR/html5/syntax.html#elements-attributes), it is used by `wptexturize` in WordPress to split HTML tokens. Without escaping `wptexturize` will incorrectly tokenize a string, [causing problems](https://github.com/WordPress/gutenberg/issues/991). 

For example, add `test > thing` as the `alt` tag for an image in Gutenberg, and then view the post:

```html
<img src="kirby.jpg" alt="test > thing" class="wp-image-10"/>
```

Results in this HTML rendered in WordPress:

```html
<img src="kirby.jpg" alt="test > thing&#8221; class=&#8221;wp-image-10&#8243;/>
```

Encoding in Gutenberg prevents this problem while being transparent to the Gutenberg visual UI. It does have the effect that if you add a `>` into a block's attribute in HTML mode it will be replaced by `&gt;`, and this matches the same behaviour of `&` being replaced with `&amp;`.

The problem likely exists for other block types where an attribute is output directly based on user input. For example, custom class names.

Fixes #9915 
Fixes #8779

Note this won't fix any existing posts that have a `>` in an attribute. Re-saving these in Gutenberg should resolve the problem.

## How has this been tested?
Additional unit test added for the `>` symbol, and existing unit tests modified.

It can also be manually verified that adding `test > thing` to an image's `alt` tag is displayed as-is in the Gutenberg UI, and results in `test &gt; thing` appearing in the HTML.

```html
<img src="kirby.jpg" alt="test &gt; thing" class="wp-image-10"/>
```

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
