### PR TITLE
Don't build twice for e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
 		"publish:dev": "npm run build:packages && lerna publish --npm-tag next",
 		"publish:prod": "npm run build:packages && lerna publish",
 		"test": "npm run lint && npm run test-unit",
-		"pretest-e2e": "concurrently \"./bin/reset-e2e-tests.sh\" \"npm run build\"",
+		"pretest-e2e": "concurrently \"./bin/reset-e2e-tests.sh\"",
 		"test-e2e": "cross-env JEST_PUPPETEER_CONFIG=test/e2e/puppeteer.config.js wp-scripts test-unit-js --config test/e2e/jest.config.json --runInBand",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
 		"test-php": "npm run lint-php && npm run test-unit-php",


### PR DESCRIPTION
CI scripts already build Gutenberg, so remove the build
step from the pre script. Saves minutes on the CI job.
