### PR TITLE
Show "Publish: Immediately" for new drafts by inferring floating date

### DIFF
--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -5,9 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { dateI18n, getSettings } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
-export function PostScheduleLabel( { date, floating } ) {
+export function PostScheduleLabel( { date, isFloating } ) {
 	const settings = getSettings();
-	return date && ! floating ?
+	return date && ! isFloating ?
 		dateI18n( settings.formats.datetime, date ) :
 		__( 'Immediately' );
 }
@@ -15,6 +15,6 @@ export function PostScheduleLabel( { date, floating } ) {
 export default withSelect( ( select ) => {
 	return {
 		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
-		floating: select( 'core/editor' ).isEditedPostDateFloating(),
+		isFloating: select( 'core/editor' ).isEditedPostDateFloating(),
 	};
 } )( PostScheduleLabel );

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -5,21 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { dateI18n, getSettings } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
-// Unlike in the PHP backend, in the REST API response draft posts for which a
-// date has not yet been set return a full gmt date string instead of the empty
-// 0000-00-00 00:00:00 placeholder used in the database. To infer that a post
-// is set to publish "immediately" we check whether the date and modified date
-// are matching values.
-function isFloatingDate( { date, modified, status } ) {
-	if ( status === 'draft' || status === 'auto-draft' ) {
-		return date === modified;
-	}
-	return false;
-}
-
-export function PostScheduleLabel( props ) {
-	const { date } = props;
-	const floating = isFloatingDate( props );
+export function PostScheduleLabel( { date, floating } ) {
 	const settings = getSettings();
 	return date && ! floating ?
 		dateI18n( settings.formats.datetime, date ) :
@@ -29,7 +15,6 @@ export function PostScheduleLabel( props ) {
 export default withSelect( ( select ) => {
 	return {
 		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
-		modified: select( 'core/editor' ).getEditedPostAttribute( 'modified' ),
-		status: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
+		floating: select( 'core/editor' ).isEditedPostDateFloating(),
 	};
 } )( PostScheduleLabel );

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -5,9 +5,23 @@ import { __ } from '@wordpress/i18n';
 import { dateI18n, getSettings } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
-function PostScheduleLabel( { date } ) {
+// Unlike in the PHP backend, in the REST API response draft posts for which a
+// date has not yet been set return a full gmt date string instead of the empty
+// 0000-00-00 00:00:00 placeholder used in the database. To infer that a post
+// is set to publish "immediately" we check whether the date and modified date
+// are matching values.
+function isFloatingDate( { date, modified, status } ) {
+	if ( status === 'draft' || status === 'auto-draft' ) {
+		return date === modified;
+	}
+	return false;
+}
+
+export function PostScheduleLabel( props ) {
+	const { date } = props;
+	const floating = isFloatingDate( props );
 	const settings = getSettings();
-	return date ?
+	return date && ! floating ?
 		dateI18n( settings.formats.datetime, date ) :
 		__( 'Immediately' );
 }
@@ -15,5 +29,7 @@ function PostScheduleLabel( { date } ) {
 export default withSelect( ( select ) => {
 	return {
 		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
+		modified: select( 'core/editor' ).getEditedPostAttribute( 'modified' ),
+		status: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
 	};
 } )( PostScheduleLabel );

--- a/packages/editor/src/components/post-schedule/test/label.js
+++ b/packages/editor/src/components/post-schedule/test/label.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostScheduleLabel } from '../label';
+
+describe( 'PostScheduleLabel', () => {
+	it( 'should show the post will be published immediately if no publish date is set', () => {
+		const wrapper = shallow( <PostScheduleLabel date={ undefined } /> );
+		expect( wrapper.text() ).toBe( 'Immediately' );
+	} );
+
+	it( 'should show the post will be published immediately if in draft status and the date and modified date match', () => {
+		const date = '2018-09-17T01:23:45.678Z';
+		const wrapper = shallow( <PostScheduleLabel date={ date } modified={ date } status={ 'draft' } /> );
+		expect( wrapper.text() ).toBe( 'Immediately' );
+	} );
+
+	it( 'should show the post will be published immediately if in auto-draft status and the date and modified date match', () => {
+		const date = '2018-09-17T01:23:45.678Z';
+		const wrapper = shallow( <PostScheduleLabel date={ date } modified={ date } status={ 'auto-draft' } /> );
+		expect( wrapper.text() ).toBe( 'Immediately' );
+	} );
+
+	it( 'should show the scheduled publish date if a date has been set', () => {
+		const date = '2018-09-17T01:23:45.678Z';
+		const modified = '2018-08-01T00:00:00.000Z';
+		const wrapper = shallow( <PostScheduleLabel date={ date } modified={ modified } status={ 'draft' } /> );
+		expect( wrapper.text() ).not.toBe( 'Immediately' );
+	} );
+} );

--- a/packages/editor/src/components/post-schedule/test/label.js
+++ b/packages/editor/src/components/post-schedule/test/label.js
@@ -14,22 +14,15 @@ describe( 'PostScheduleLabel', () => {
 		expect( wrapper.text() ).toBe( 'Immediately' );
 	} );
 
-	it( 'should show the post will be published immediately if in draft status and the date and modified date match', () => {
+	it( 'should show the post will be published immediately if it has a floating date', () => {
 		const date = '2018-09-17T01:23:45.678Z';
-		const wrapper = shallow( <PostScheduleLabel date={ date } modified={ date } status={ 'draft' } /> );
-		expect( wrapper.text() ).toBe( 'Immediately' );
-	} );
-
-	it( 'should show the post will be published immediately if in auto-draft status and the date and modified date match', () => {
-		const date = '2018-09-17T01:23:45.678Z';
-		const wrapper = shallow( <PostScheduleLabel date={ date } modified={ date } status={ 'auto-draft' } /> );
+		const wrapper = shallow( <PostScheduleLabel date={ date } floating={ true } /> );
 		expect( wrapper.text() ).toBe( 'Immediately' );
 	} );
 
 	it( 'should show the scheduled publish date if a date has been set', () => {
 		const date = '2018-09-17T01:23:45.678Z';
-		const modified = '2018-08-01T00:00:00.000Z';
-		const wrapper = shallow( <PostScheduleLabel date={ date } modified={ modified } status={ 'draft' } /> );
+		const wrapper = shallow( <PostScheduleLabel date={ date } floating={ false } /> );
 		expect( wrapper.text() ).not.toBe( 'Immediately' );
 	} );
 } );

--- a/packages/editor/src/components/post-schedule/test/label.js
+++ b/packages/editor/src/components/post-schedule/test/label.js
@@ -16,13 +16,13 @@ describe( 'PostScheduleLabel', () => {
 
 	it( 'should show the post will be published immediately if it has a floating date', () => {
 		const date = '2018-09-17T01:23:45.678Z';
-		const wrapper = shallow( <PostScheduleLabel date={ date } floating={ true } /> );
+		const wrapper = shallow( <PostScheduleLabel date={ date } isFloating={ true } /> );
 		expect( wrapper.text() ).toBe( 'Immediately' );
 	} );
 
 	it( 'should show the scheduled publish date if a date has been set', () => {
 		const date = '2018-09-17T01:23:45.678Z';
-		const wrapper = shallow( <PostScheduleLabel date={ date } floating={ false } /> );
+		const wrapper = shallow( <PostScheduleLabel date={ date } isFloating={ false } /> );
 		expect( wrapper.text() ).not.toBe( 'Immediately' );
 	} );
 } );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -428,6 +428,29 @@ export function isEditedPostBeingScheduled( state ) {
 }
 
 /**
+ * Returns whether the current post should be considered to have a "floating"
+ * date (i.e. that it would publish "Immediately" rather than at a set time).
+ *
+ * Unlike in the PHP backend, the REST API returns a full date string for posts
+ * where the 0000-00-00T00:00:00 placeholder is present in the database. To
+ * infer that a post is set to publish "Immediately" we check whether the date
+ * and modified date are the same.
+ *
+ * @param  {Object}  state Editor state.
+ *
+ * @return {boolean} Whether the edited post has a floating date value.
+ */
+export function isEditedPostDateFloating( state ) {
+	const date = getEditedPostAttribute( state, 'date' );
+	const modified = getEditedPostAttribute( state, 'modified' );
+	const status = getEditedPostAttribute( state, 'status' );
+	if ( status === 'draft' || status === 'auto-draft' ) {
+		return date === modified;
+	}
+	return false;
+}
+
+/**
  * Returns a new reference when the inner blocks of a given block client ID
  * change. This is used exclusively as a memoized selector dependant, relying
  * on this selector's shared return value and recursively those of its inner

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -38,6 +38,7 @@ const {
 	hasAutosave,
 	isEditedPostEmpty,
 	isEditedPostBeingScheduled,
+	isEditedPostDateFloating,
 	getBlockDependantsCacheBust,
 	getBlockName,
 	getBlock,
@@ -1218,6 +1219,83 @@ describe( 'selectors', () => {
 			};
 
 			expect( isEditedPostBeingScheduled( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isEditedPostDateFloating', () => {
+		let editor;
+
+		beforeEach( () => {
+			editor = {
+				present: {
+					edits: {},
+				},
+			};
+		} );
+
+		it( 'should return true for draft posts where the date matches the modified date', () => {
+			const state = {
+				currentPost: {
+					date: '2018-09-27T01:23:45.678Z',
+					modified: '2018-09-27T01:23:45.678Z',
+					status: 'draft',
+				},
+				editor,
+			};
+
+			expect( isEditedPostDateFloating( state ) ).toBe( true );
+		} );
+
+		it( 'should return true for auto-draft posts where the date matches the modified date', () => {
+			const state = {
+				currentPost: {
+					date: '2018-09-27T01:23:45.678Z',
+					modified: '2018-09-27T01:23:45.678Z',
+					status: 'auto-draft',
+				},
+				editor,
+			};
+
+			expect( isEditedPostDateFloating( state ) ).toBe( true );
+		} );
+
+		it( 'should return false for draft posts where the date does not match the modified date', () => {
+			const state = {
+				currentPost: {
+					date: '2018-09-27T01:23:45.678Z',
+					modified: '1970-01-01T00:00:00.000Z',
+					status: 'draft',
+				},
+				editor,
+			};
+
+			expect( isEditedPostDateFloating( state ) ).toBe( false );
+		} );
+
+		it( 'should return false for auto-draft posts where the date does not match the modified date', () => {
+			const state = {
+				currentPost: {
+					date: '2018-09-27T01:23:45.678Z',
+					modified: '1970-01-01T00:00:00.000Z',
+					status: 'auto-draft',
+				},
+				editor,
+			};
+
+			expect( isEditedPostDateFloating( state ) ).toBe( false );
+		} );
+
+		it( 'should return false for published posts', () => {
+			const state = {
+				currentPost: {
+					date: '2018-09-27T01:23:45.678Z',
+					modified: '2018-09-27T01:23:45.678Z',
+					status: 'publish',
+				},
+				editor,
+			};
+
+			expect( isEditedPostDateFloating( state ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
This addresses the post date label issue described in #7195 with an alternative to the previously-proposed solution in PR #8395.

Rather than forcing a new property into the API to work around the nuances of how dates are stored in the database, we can use what @earnjam and @TimothyBJacobs proposed in https://core.trac.wordpress.org/ticket/39953 and infer that a post's date is "floating" (_i.e._ that it should be published immediately) by comparing the date modified to the listed publish date. In that Trac thread @TimothyBJacobs explained,

> If the date and the modified date are the same, then we're still working on the post because those are both updated at every write. As mentioned we don't have an actual `created_at` date. This would save us having to add the new field. We couldn't figure out a time when those two dates wouldn't match, and in testing it looked like it would work to fulfill Gutenberg's needs.

Note that this works in Gutenberg because on save, we only send back values which have been edited. To fully address this issue throughout WordPress, changes will be needed in Trac to ensure that we apply the same logic when preparing posts to be saved to the database.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I created this patch with @earnjam at the WCNYC contributor day, and I have tested it by creating several posts to ensure various combinations of draft and auto-draft correctly reflect manually-specified dates and the Immediately placeholder. To reproduce these tests,

1. Create a new post and look at the date label. It should display "Immediately."
2. Update the title (or any other non-date field) and save a draft. Post should still display Publish: "Immediately."
3. Test publish _vs_ manually-specify date:
  - To test that date is set properly when publishing, publish the post and ensure the date that is displayed on the front-end and when reloading the post in the editor reflects the time at which the post was published.
  - To test that the date is set properly when manually specifying a date, click "Immediately" and set a manual date at which the post should be published. Reload the page and ensure the provided date still displays.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/442115/45627438-ef0bfd80-ba5f-11e8-8b40-472c701ba2d3.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for PostScheduleLabel component.
Adds unit tests for PostScheduleLabel component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
