### PR TITLE
[Try] Make gallery block resilient against the removal of data attributes

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { filter, pick } from 'lodash';
+import { compact, filter, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -171,7 +171,7 @@ class GalleryEdit extends Component {
 							type="image"
 							multiple
 							gallery
-							value={ images.map( ( img ) => img.id ) }
+							value={ compact( images.map( ( img ) => img.id ) ) }
 							render={ ( { open } ) => (
 								<IconButton
 									className="components-toolbar__control"


### PR DESCRIPTION
## Description
The gallery block relies on data-link and data-id attributes being present on the HTML of the block. As we found in the past some security rules may remove this attributes from the dom depending on user role. Although this attributes should not be removed some security plugins/systems may still be removing this attributes and take time to stop doing that. This PR makes sure the gallery block is not invalidated if data-* attributes are removed.

Removing this attributes still affects the block. As the id is removed the user can not see which images were selected when opening the media library again (although images load just fine on the block shown in the editor). If the gallery was not linking to the attachment page, then the data-link, and data-id, attributes are removed and then we change the gallery to link to the attachment page, no links are going to be created because the attachment page links are not known.

The attributes link and id besides being used to store data-link, data-id on the dom are used to compute a class and the href attribute. In order to make the block resilient again data-* removal we add two more attributes that contain the previous class and the previous href value. Then if the data-* attributes are not available we use some rules to check if the previous attributes could be used.

As a bonus feature users can now add classes to individual gallery images via the code editor and the block will not become invalid because of that.

## How has this been tested?
I added some galleries with different link to options, I removed the data-* attributes and checked the blocks continue to be valid.
