### PR TITLE
Writing Flow: Ensure default block on removal / replacement

### DIFF
--- a/test/e2e/specs/reusable-blocks.test.js
+++ b/test/e2e/specs/reusable-blocks.test.js
@@ -194,8 +194,7 @@ describe( 'Reusable Blocks', () => {
 		await Promise.all( [ waitForAndAcceptDialog(), convertButton.click() ] );
 
 		// Check that we have an empty post again
-		const block = await page.$$( '.editor-block-list__block' );
-		expect( block ).toHaveLength( 0 );
+		expect( await getEditedPostContent() ).toBe( '' );
 
 		// Search for the block in the inserter
 		await searchForBlock( 'Surprised greeting block' );

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -198,5 +198,17 @@ describe( 'splitting and merging blocks', () => {
 
 		// But the effective saved content is still empty:
 		expect( await getEditedPostContent() ).toBe( '' );
+
+		// And focus is retained:
+		const isInDefaultBlock = await page.evaluate( () => {
+			const activeBlockName = document.activeElement
+				.closest( '[data-type]' )
+				.getAttribute( 'data-type' );
+			const defaultBlockName = window.wp.blocks.getDefaultBlockName();
+
+			return activeBlockName === defaultBlockName;
+		} );
+
+		expect( isInDefaultBlock ).toBe( true );
 	} );
 } );

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -181,4 +181,22 @@ describe( 'splitting and merging blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should ensure always a default block', async () => {
+		// Feature: To avoid focus loss, removal of all blocks will result in a
+		// default block insertion at the root. Pressing backspace in a new
+		// paragraph should not effectively allow removal. This is counteracted
+		// with pre-save content processing to save post consisting of only the
+		// unmodified default block as an empty string.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/9626
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.press( 'Backspace' );
+
+		// There is a default block:
+		expect( await page.$$( '.editor-block-list__block' ) ).toHaveLength( 1 );
+
+		// But the effective saved content is still empty:
+		expect( await getEditedPostContent() ).toBe( '' );
+	} );
 } );


### PR DESCRIPTION
Closes #9626 

This pull request seeks to ensure that a default block is inserted (and selected) when all other blocks are removed. This helps assure there is no focus loss, and preserves expected native behavior of typing within an editable field, where pressing backspace from the beginning of an otherwise empty field should not incur a focus loss.

Note that as of #9808, in these cases where only a default empty paragraph exists, the saved content will not effectively include the paragraph, but will instead fall back to an empty string, as it's inferred now that a post containing only the default unmodified block is equivalent to being empty.

**Testing instructions:**

Verify that if all blocks are removed, a default block is inserted at the beginning of the post and that focus is preserved.

1. Navigate to Posts > Add New
2. Click the Writing Prompt to insert a new paragraph
3. Press Backspace
4. Note that the caret is still focused within a paragraph

Ensure end-to-end tests pass:

```
npm run test-e2e
```