### PR TITLE
Parser (Fix): Output freeform content before void blocks

### DIFF
--- a/packages/block-serialization-default-parser/CHANGELOG.md
+++ b/packages/block-serialization-default-parser/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.1
+-   Fix: Include freeform content preceding void blocks (#9984)
+
 ## 1.0.0
 
 -   Initial release.

--- a/packages/block-serialization-default-parser/CHANGELOG.md
+++ b/packages/block-serialization-default-parser/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.1
+## 1.0.1 (unreleased)
 -   Fix: Include freeform content preceding void blocks (#9984)
 
 ## 1.0.0

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-serialization-default-parser",
-	"version": "1.0.1",
+	"version": "1.0.0-rc1",
 	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-serialization-default-parser",
-	"version": "1.0.0-rc.0",
+	"version": "1.0.1",
 	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-serialization-default-parser",
-	"version": "1.0.0-rc1",
+	"version": "1.0.0-rc.0",
 	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -197,12 +197,12 @@ class WP_Block_Parser {
 	 * @return bool
 	 */
     function proceed() {
-    	$next_token = $this->next_token();
+        $next_token = $this->next_token();
         list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $next_token;
         $stack_depth = count( $this->stack );
 
-		// we may have some HTML soup before the next block
-		$leading_html_start = $start_offset > $this->offset ? $this->offset : null;
+        // we may have some HTML soup before the next block
+        $leading_html_start = $start_offset > $this->offset ? $this->offset : null;
 
         switch ( $token_type ) {
             case 'no-more-tokens':
@@ -243,16 +243,16 @@ class WP_Block_Parser {
                  * in the top-level of the document
                  */
                 if ( 0 === $stack_depth ) {
-					if ( isset( $leading_html_start ) ) {
-						$this->output[] = array(
-							'attrs' => array(),
-							'innerHTML' => substr(
-								$this->document,
-								$leading_html_start,
-								$start_offset - $leading_html_start
-							),
-						);
-					}
+                    if ( isset( $leading_html_start ) ) {
+                        $this->output[] = array(
+                            'attrs' => array(),
+                            'innerHTML' => substr(
+                                $this->document,
+                                $leading_html_start,
+                                $start_offset - $leading_html_start
+                            ),
+                        );
+                    }
 
                     $this->output[] = new WP_Block_Parser_Block( $block_name, $attrs, array(), '' );
                     $this->offset = $start_offset + $token_length;

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -197,8 +197,12 @@ class WP_Block_Parser {
 	 * @return bool
 	 */
     function proceed() {
-        list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $this->next_token();
+    	$next_token = $this->next_token();
+        list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $next_token;
         $stack_depth = count( $this->stack );
+
+		// we may have some HTML soup before the next block
+		$leading_html_start = $start_offset > $this->offset ? $this->offset : null;
 
         switch ( $token_type ) {
             case 'no-more-tokens':
@@ -239,6 +243,17 @@ class WP_Block_Parser {
                  * in the top-level of the document
                  */
                 if ( 0 === $stack_depth ) {
+					if ( isset( $leading_html_start ) ) {
+						$this->output[] = array(
+							'attrs' => array(),
+							'innerHTML' => substr(
+								$this->document,
+								$leading_html_start,
+								$start_offset - $leading_html_start
+							),
+						);
+					}
+
                     $this->output[] = new WP_Block_Parser_Block( $block_name, $attrs, array(), '' );
                     $this->offset = $start_offset + $token_length;
                     return true;
@@ -254,9 +269,6 @@ class WP_Block_Parser {
                 return true;
 
             case 'block-opener':
-                // we may have some HTML soup before the next block
-                $leading_html_start = $start_offset > $this->offset ? $this->offset : null;
-
                 // track all newly-opened blocks on the stack
                 array_push( $this->stack, new WP_Block_Parser_Frame(
                     new WP_Block_Parser_Block( $block_name, $attrs, array(), '' ),

--- a/packages/block-serialization-default-parser/test/index.js
+++ b/packages/block-serialization-default-parser/test/index.js
@@ -24,4 +24,50 @@ describe( 'block-serialization-spec-parser', () => {
 			},
 		] );
 	} );
+
+	test( 'treats void blocks and empty blocks identically', () => {
+		expect( parse(
+			'<!-- wp:block /-->'
+		) ).toEqual( parse(
+			'<!-- wp:block --><!-- /wp:block -->'
+		) );
+
+		expect( parse(
+			'<!-- wp:my/bus { "is": "fast" } /-->'
+		) ).toEqual( parse(
+			'<!-- wp:my/bus { "is": "fast" } --><!-- /wp:my/bus -->'
+		) );
+	} );
+
+	test( 'should grab HTML soup before block openers', () => {
+		[
+			'<p>Break me</p><!-- wp:block /-->',
+			'<p>Break me</p><!-- wp:block --><!-- /wp:block -->',
+		].forEach( ( input ) => expect( parse( input ) ).toEqual( [
+			expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
+			expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ),
+		] ) );
+	} );
+
+	test( 'should grab HTML soup before inner block openers', () => {
+		[
+			'<!-- wp:outer --><p>Break me</p><!-- wp:block /--><!-- /wp:outer -->',
+			'<!-- wp:outer --><p>Break me</p><!-- wp:block --><!-- /wp:block --><!-- /wp:outer -->',
+		].forEach( ( input ) => expect( parse( input ) ).toEqual( [
+			expect.objectContaining( {
+				innerBlocks: [ expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ) ],
+				innerHTML: '<p>Break me</p>',
+			} ),
+		] ) );
+	} );
+
+	test( 'should grab HTML soup after blocks', () => {
+		[
+			'<!-- wp:block /--><p>Break me</p>',
+			'<!-- wp:block --><!-- /wp:block --><p>Break me</p>',
+		].forEach( ( input ) => expect( parse( input ) ).toEqual( [
+			expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ),
+			expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
+		] ) );
+	} );
 } );


### PR DESCRIPTION
Resolves #9968

It was noted that a classic block preceding a void block would
disappear in the editor while if that same classic block preceded
the long-form non-void representation of an empty block then things
would load as expected.

This behavior was determined to originate in the new default parser
in #8083 and the bug was that with void blocks we weren't sending
any preceding HTML soup/freeform content into the output list.

In this patch I've duplicated some code from the block-closing
function of the parser to spit out this content when a void block
is at the top-level of the document.

This bug did not appear when void blocks are nested because it's
the parent block that eats HTML soup. In the case of the top-level
void however we were immediately pushing that void block to the
output list and neglecting the freeform HTML.

I've added a few tests to verify and demonstrate this behavior.
Actually, since I wasn't sure what was wrong I wrote the tests first
to try and understand the behaviors and bugs. There are a few tests
that are thus not entirely essential but worthwhile to have in here.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. (N/A)
- [x] My code has proper inline documentation.