### PR TITLE
Fix: Prepublish text for scheduled posts

### DIFF
--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -23,12 +23,26 @@ import MaybePostFormatPanel from './maybe-post-format-panel';
 
 function PostPublishPanelPrepublish( {
 	hasPublishAction,
+	isBeingScheduled,
 	children,
 } ) {
+	let prePublishTitle, prePublishBodyText;
+
+	if ( ! hasPublishAction ) {
+		prePublishTitle = __( 'Are you ready to submit for review?' );
+		prePublishBodyText = __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' );
+	} else if ( isBeingScheduled ) {
+		prePublishTitle = __( 'Are you ready to schedule?' );
+		prePublishBodyText = __( 'Your post will be published at the specified date and time.' );
+	} else {
+		prePublishTitle = __( 'Are you ready to publish?' );
+		prePublishBodyText = __( 'Double-check your settings, then use the button to publish your post.' );
+	}
+
 	return (
 		<div className="editor-post-publish-panel__prepublish">
-			<div><strong>{ hasPublishAction ? __( 'Are you ready to publish?' ) : __( 'Are you ready to submit for review?' ) }</strong></div>
-			<p>{ hasPublishAction ? __( 'Double-check your settings, then use the button to publish your post.' ) : __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' ) }</p>
+			<div><strong>{ prePublishTitle }</strong></div>
+			<p>{ prePublishBodyText }</p>
 			{ hasPublishAction && (
 				<Fragment>
 					<PanelBody initialOpen={ false } title={ [
@@ -54,9 +68,13 @@ function PostPublishPanelPrepublish( {
 
 export default withSelect(
 	( select ) => {
-		const { getCurrentPost } = select( 'core/editor' );
+		const {
+			getCurrentPost,
+			isEditedPostBeingScheduled,
+		} = select( 'core/editor' );
 		return {
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			isBeingScheduled: isEditedPostBeingScheduled(),
 		};
 	}
 )( PostPublishPanelPrepublish );


### PR DESCRIPTION
## Description
Fixes #9960. 
When scheduling a new post, the text displayed in the prepublish panel was a little misleading to the user:
![1](https://user-images.githubusercontent.com/43263346/45669201-eed73500-bb27-11e8-9ee7-0210d3ff32d7.PNG)

This fix adds a more appropriate message:
![2](https://user-images.githubusercontent.com/43263346/45668858-e2061180-bb26-11e8-91dc-2518f3ab1c55.PNG)

## How has this been tested?
I created a new post, scheduled it at a later date and clicked the 'Schedule' button: the above message appears.

## Types of changes
It introduces two variables `prePublishTitle` and `prePublishBodyText` which get assigned depending on the publish date or if the user is a contributor. 
