### PR TITLE
Fix post-publish close button in other locales

### DIFF
--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -128,7 +128,17 @@
 }
 
 .edit-post-layout .editor-post-publish-panel__header-publish-button {
-	margin-right: 52px; // This number is approximative to keep the publish button at the same position when opening the panel
+	// Match the size of the Publish... button.
+	.components-button.is-large {
+		height: 33px;
+		line-height: 32px;
+	}
+
+	// Size the spacer flexibly to allow for different button lengths.
+	.editor-post-publish-panel__spacer {
+		display: inline-flex;
+		flex: 0 1 52px; // This number is approximative to keep the publish button at the same position when opening the panel
+	}
 }
 
 .edit-post-toggle-publish-panel {

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -70,6 +70,7 @@ class PostPublishPanel extends Component {
 					{ ! submitted && (
 						<div className="editor-post-publish-panel__header-publish-button">
 							<PostPublishButton focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
+							<span className="editor-post-publish-panel__spacer"></span>
 						</div>
 					) }
 					{ submitted && (

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -22,8 +22,11 @@
 }
 
 .editor-post-publish-panel__header-publish-button {
+	display: flex;
+	justify-content: flex-end;
 	flex-grow: 1;
 	text-align: right;
+	flex-wrap: nowrap;
 }
 
 .editor-post-publish-panel__header-published {


### PR DESCRIPTION
Fixes #9972.

This PR makes it so the spacing that sits between the final confirm "Publish" button and the close button is a flex spacer. That means it behaves as an autosizing elastic element that has no minimum width, has a max width, and wants to be as big as it can.

In these screenshots I've painted the spacer red, but it's invisible in the actual PR. 

<img width="313" alt="screen shot 2018-09-18 at 09 37 50" src="https://user-images.githubusercontent.com/1204802/45671857-e7fbf280-bb26-11e8-8b60-a1fa874e9990.png">

<img width="331" alt="screen shot 2018-09-18 at 09 38 05" src="https://user-images.githubusercontent.com/1204802/45671860-e9c5b600-bb26-11e8-9bc3-bd6d8a167278.png">

The width the spacer _desires_ is 52px, which is about the space it takes to overlay the confirm publish button on top of the pre-publish button, so if you like you can "double-click" to publish.