### PR TITLE
Fix menu item hover colors.

### DIFF
--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -199,6 +199,12 @@
 	box-shadow: none;
 }
 
+@mixin menu-style__hover() {
+	color: $dark-gray-900;
+	border: none;
+	box-shadow: none;
+}
+
 @mixin menu-style__focus() {
 	color: $dark-gray-900;
 	border: none;

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -23,7 +23,7 @@
 	}
 
 	&:hover:not(:disabled):not([aria-disabled="true"]) {
-		@include menu-style__neutral;
+		@include menu-style__hover;
 	}
 
 	&:focus:not(:disabled):not([aria-disabled="true"]) {

--- a/packages/editor/src/components/block-settings-menu/style.scss
+++ b/packages/editor/src/components/block-settings-menu/style.scss
@@ -45,7 +45,10 @@
 		cursor: pointer;
 		@include menu-style__neutral;
 
-		&:hover:not(:disabled):not([aria-disabled="true"]),
+		&:hover:not(:disabled):not([aria-disabled="true"]) {
+			@include menu-style__hover;
+		}
+
 		&:focus:not(:disabled):not([aria-disabled="true"]) {
 			@include menu-style__focus;
 		}


### PR DESCRIPTION
This fixes an issue where the "Manage Reusable Blocks" menu item had a blue hover color as the only item in the menu.

It also adds a consistent hover color for the rest.

Why was it blue, you ask? Because it's the first menu item that's a hyperlink to a separate page, the others are buttons. 

Before:

<img width="381" alt="screen shot 2018-09-18 at 09 45 18" src="https://user-images.githubusercontent.com/1204802/45672096-97d16000-bb27-11e8-8047-b8a754a74d08.png">

After:

<img width="332" alt="screen shot 2018-09-18 at 09 44 00" src="https://user-images.githubusercontent.com/1204802/45672078-87b98080-bb27-11e8-96b2-818ed7e9bb7c.png">
