### PR TITLE
Fix Async Generator resolvers resolution

### DIFF
--- a/packages/data/src/plugins/controls/index.js
+++ b/packages/data/src/plugins/controls/index.js
@@ -32,7 +32,7 @@ export default function( registry ) {
 
 		async __experimentalFulfill( reducerKey, selectorName, ...args ) {
 			if ( ! registry.namespaces[ reducerKey ].supportControls ) {
-				registry.__experimentalFulfill( reducerKey, selectorName, ...args );
+				await registry.__experimentalFulfill( reducerKey, selectorName, ...args );
 				return;
 			}
 


### PR DESCRIPTION
closes #9962 regression of #9507 

**Testing instructions**

 - Create a reusable block
 - Create a new post
 - Open the inserter
 - The reusable block should show up there.