### PR TITLE
Fix: Spacer Block: Make block work on  unified toolbar and spotlight mode

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,11 +1,11 @@
-.editor-block-list__block[data-type="core/spacer"].is-selected .editor-block-list__block-edit {
+.block-library-spacer__resize-container.is-selected {
 	.block-library-spacer__resize-handler-top,
 	.block-library-spacer__resize-handler-bottom {
 		display: block;
 	}
 }
 
-.editor-block-list__block[data-type="core/spacer"].is-selected .block-library-spacer__resize-container {
+.block-library-spacer__resize-container.is-selected {
 	background: $light-gray-200;
 }
 

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import ResizableBox from 're-resizable';
+import classnames from 'classnames';
 
 /**
  * WordPress
@@ -31,14 +32,17 @@ export const settings = {
 	},
 
 	edit: withInstanceId(
-		( { attributes, setAttributes, toggleSelection, instanceId } ) => {
+		( { attributes, isSelected, setAttributes, toggleSelection, instanceId } ) => {
 			const { height } = attributes;
 			const id = `block-spacer-height-input-${ instanceId }`;
 
 			return (
 				<Fragment>
 					<ResizableBox
-						className="block-library-spacer__resize-container"
+						className={ classnames(
+							'block-library-spacer__resize-container',
+							{ 'is-selected': isSelected }
+						) }
 						size={ {
 							height,
 						} }


### PR DESCRIPTION
The blocks relied on is-selected class being present in block edit div. I just checked that when unified toolbar or spotlight modes are enabled the editor does not add this classes to the BlockEdit, this made it impossible to resize the spacer block.

This seems to be an old problem and not a recent regression as the block seems to always relied on the selector ".editor-block-list__block[data-type="core/spacer"].is-selected" which is not valid in this modes.

This PR reads the prop isSelected and in that case, adds an internal class is-selected that we can safely rely on.

## How has this been tested?
I checked that if spotlight mode or unified toolbar options are enabled in master it is not possible to resize the block and in this branch, the problem got fixed.