### PR TITLE
Fix custom classNames for dynamic blocks

### DIFF
--- a/packages/editor/src/hooks/custom-class-name.js
+++ b/packages/editor/src/hooks/custom-class-name.js
@@ -55,7 +55,6 @@ export function addAttribute( settings ) {
 export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
 		const hasCustomClassName = hasBlockSupport( props.name, 'customClassName', true );
-
 		if ( hasCustomClassName && props.isSelected ) {
 			return (
 				<Fragment>
@@ -145,7 +144,7 @@ export function addParsedDifference( blockAttributes, blockType, innerHTML ) {
 
 		if ( customClasses.length ) {
 			blockAttributes.className = customClasses.join( ' ' );
-		} else {
+		} else if ( serialized ) {
 			delete blockAttributes.className;
 		}
 	}

--- a/packages/editor/src/hooks/test/custom-class-name.js
+++ b/packages/editor/src/hooks/test/custom-class-name.js
@@ -15,6 +15,12 @@ describe( 'custom className', () => {
 		title: 'block title',
 	};
 
+	const dynamicBlockSettings = {
+		save: () => null,
+		category: 'common',
+		title: 'block title',
+	};
+
 	describe( 'addAttribute()', () => {
 		const addAttribute = applyFilters.bind( null, 'blocks.registerBlockType' );
 
@@ -149,6 +155,16 @@ describe( 'custom className', () => {
 			);
 
 			expect( attributes.className ).toBe( 'custom1 custom3' );
+		} );
+
+		it( 'should not remove the custom classes for dynamic blocks', () => {
+			const attributes = addParsedDifference(
+				{ className: 'custom1' },
+				dynamicBlockSettings,
+				null,
+			);
+
+			expect( attributes.className ).toBe( 'custom1' );
 		} );
 	} );
 } );


### PR DESCRIPTION
closes #9991 and closes #9929

This PR fixes a small regression where custom classes for dynamic blocks were not parsed properly after a save. 

This was a conflict with a behavior considering removal of custom classes from markup as a valid operation even if the block comment includes a custom className. But blocks returning `null` don't have a wrapper to which the custom className is added which means we shouldn't remove the `className` property in that case.

**Testing instructions**

 - Repeat instructions in #9991 