### PR TITLE
Inserter: Respect block category when searching for blocks

### DIFF
--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -52,7 +52,7 @@ export const searchItems = ( items, searchTerm ) => {
 
 	return items.filter( ( item ) => {
 		const itemCategory = find( categories, { slug: item.category } );
-		return matchSearch( item.title ) || some( item.keywords, matchSearch ) || matchSearch( itemCategory.title );
+		return matchSearch( item.title ) || some( item.keywords, matchSearch ) || ( itemCategory && matchSearch( itemCategory.title ) );
 	} );
 };
 

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -48,10 +48,12 @@ const MAX_SUGGESTED_ITEMS = 9;
 export const searchItems = ( items, searchTerm ) => {
 	const normalizedSearchTerm = normalizeTerm( searchTerm );
 	const matchSearch = ( string ) => normalizeTerm( string ).indexOf( normalizedSearchTerm ) !== -1;
+	const categories = getCategories();
 
-	return items.filter( ( item ) =>
-		matchSearch( item.title ) || some( item.keywords, matchSearch )
-	);
+	return items.filter( ( item ) => {
+		const itemCategory = find( categories, { slug: item.category } );
+		return matchSearch( item.title ) || some( item.keywords, matchSearch ) || matchSearch( itemCategory.title );
+	} );
 };
 
 /**

--- a/packages/editor/src/components/inserter/test/menu.js
+++ b/packages/editor/src/components/inserter/test/menu.js
@@ -338,6 +338,12 @@ describe( 'searchItems', () => {
 		);
 	} );
 
+	it( 'should search items using the categories', () => {
+		expect( searchItems( items, 'LAYOUT' ) ).toEqual(
+			[ moreItem ]
+		);
+	} );
+
 	it( 'should ignore a leading slash on a search term', () => {
 		expect( searchItems( items, '/GOOGL' ) ).toEqual(
 			[ youtubeItem ]


### PR DESCRIPTION
## Description
Update the inserter search to respect block categories when filtering search results. 

To achieve this, in addition to what we currently do when filtering search results (comparing against the keywords and the block title), we compare against the title of the block's category.

Fixes https://github.com/WordPress/gutenberg/issues/9998.

## How has this been tested?
This has been tested manually with the following steps:
* Start a new post in the wp-admin.
* Open the inserter (+)
* Search for "layout", verify you see all the blocks from within the "Layout Elements" category.
* Search for "formatting", verify you see all the blocks from within the "Formatting" category".

I can work on adding a unit test if that makes sense.

## Screenshots

**Searching for "formatting"**
![](https://cldup.com/8PHL5VhpFh.png)

**Searching for "layout"**
![](https://cldup.com/wPurmHRbD6.png)

## Types of changes
* Now respecting block category when searching for blocks in the inserter.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
