### PR TITLE
Fix export block as JSON in IE11 and Firefox

### DIFF
--- a/packages/list-reusable-blocks/src/utils/file.js
+++ b/packages/list-reusable-blocks/src/utils/file.js
@@ -6,11 +6,22 @@
  * @param {string} contentType File mime type.
  */
 export function download( fileName, content, contentType ) {
-	const a = document.createElement( 'a' );
 	const file = new window.Blob( [ content ], { type: contentType } );
-	a.href = URL.createObjectURL( file );
-	a.download = fileName;
-	a.click();
+
+	// IE11 can't use the click to download technique
+	// we use a specific IE11 technique instead.
+	if ( window.navigator.msSaveOrOpenBlob ) {
+		window.navigator.msSaveOrOpenBlob( file, fileName );
+	} else {
+		const a = document.createElement( 'a' );
+		a.href = URL.createObjectURL( file );
+		a.download = fileName;
+
+		a.style.display = 'none';
+		document.body.appendChild( a );
+		a.click();
+		document.body.removeChild( a );
+	}
 }
 
 /**


### PR DESCRIPTION
closes #9919

 - Firefox requires the link to be inserter in the DOM to perform the "click"
 - IE11 throws a "Access denied" error when clicking the link so we're using a dedication function only available in IE

**Testing instructions**

 * Try exporting reusable blocks in all browsers.
