### PR TITLE
Blocks: Handle block category addition and removal in store

### DIFF
--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -72,3 +72,33 @@ export function setCategories( categories ) {
 		categories,
 	};
 }
+
+/**
+ * Returns an action object used to add a new block category.
+ *
+ * @param {string} title Title of the block category.
+ * @param {string} slug  Slug of the block category.
+ *
+ * @return {Object} Action object.
+ */
+export function addCategory( title, slug ) {
+	return {
+		type: 'ADD_CATEGORY',
+		title,
+		slug,
+	};
+}
+
+/**
+ * Returns an action object used to remove an existing block category.
+ *
+ * @param {string} slug Slug of the category to remove.
+ *
+ * @return {Object} Action object.
+ */
+export function removeCategory( slug ) {
+	return {
+		type: 'REMOVE_CATEGORY',
+		slug,
+	};
+}

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, omit } from 'lodash';
+import { filter, keyBy, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -80,8 +80,19 @@ export const fallbackBlockName = createBlockNameSetterReducer( 'SET_FALLBACK_BLO
  * @return {Object} Updated state.
  */
 export function categories( state = DEFAULT_CATEGORIES, action ) {
-	if ( action.type === 'SET_CATEGORIES' ) {
-		return action.categories || [];
+	switch ( action.type ) {
+		case 'SET_CATEGORIES':
+			return action.categories || [];
+		case 'ADD_CATEGORY':
+			return [
+				...filter( state, ( category ) => category.slug !== action.slug ),
+				{
+					title: action.title,
+					slug: action.slug,
+				},
+			];
+		case 'REMOVE_CATEGORY':
+			return filter( state, ( category ) => category.slug !== action.slug );
 	}
 
 	return state;

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -131,10 +131,11 @@ describe( 'categories', () => {
 		] );
 	} );
 
-	it( 'should override previous match when adding a category', () => {
+	it( 'should append and remove previous match when adding a category', () => {
 		const original = deepFreeze( [
 			{ slug: 'chicken', title: 'Chicken' },
 			{ slug: 'wings', title: 'Original wings' },
+			{ slug: 'strips', title: 'Strips' },
 		] );
 
 		const state = categories( original, {
@@ -145,6 +146,7 @@ describe( 'categories', () => {
 
 		expect( state ).toEqual( [
 			{ slug: 'chicken', title: 'Chicken' },
+			{ slug: 'strips', title: 'Strips' },
 			{ slug: 'wings', title: 'Wings' },
 		] );
 	} );

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -113,4 +113,70 @@ describe( 'categories', () => {
 			{ slug: 'wings', title: 'Wings' },
 		] );
 	} );
+
+	it( 'should add a new category', () => {
+		const original = deepFreeze( [
+			{ slug: 'chicken', title: 'Chicken' },
+		] );
+
+		const state = categories( original, {
+			type: 'ADD_CATEGORY',
+			title: 'Wings',
+			slug: 'wings',
+		} );
+
+		expect( state ).toEqual( [
+			{ slug: 'chicken', title: 'Chicken' },
+			{ slug: 'wings', title: 'Wings' },
+		] );
+	} );
+
+	it( 'should override previous match when adding a category', () => {
+		const original = deepFreeze( [
+			{ slug: 'chicken', title: 'Chicken' },
+			{ slug: 'wings', title: 'Original wings' },
+		] );
+
+		const state = categories( original, {
+			type: 'ADD_CATEGORY',
+			title: 'Wings',
+			slug: 'wings',
+		} );
+
+		expect( state ).toEqual( [
+			{ slug: 'chicken', title: 'Chicken' },
+			{ slug: 'wings', title: 'Wings' },
+		] );
+	} );
+
+	it( 'should remove a category', () => {
+		const original = deepFreeze( [
+			{ slug: 'chicken', title: 'Chicken' },
+			{ slug: 'wings', title: 'Wings' },
+		] );
+
+		const state = categories( original, {
+			type: 'REMOVE_CATEGORY',
+			slug: 'wings',
+		} );
+
+		expect( state ).toEqual( [
+			{ slug: 'chicken', title: 'Chicken' },
+		] );
+	} );
+
+	it( 'should return original state when removing a non-existing category', () => {
+		const original = deepFreeze( [
+			{ slug: 'chicken', title: 'Chicken' },
+		] );
+
+		const state = categories( original, {
+			type: 'REMOVE_CATEGORY',
+			slug: 'wings',
+		} );
+
+		expect( state ).toEqual( [
+			{ slug: 'chicken', title: 'Chicken' },
+		] );
+	} );
 } );


### PR DESCRIPTION
## Description
This PR introduces actions and the corresponding reducer for registering new block categories and removing existing ones. 

Rationale behind the suggested actions is to allow block/extension developers to manage block categories with less effort. See https://github.com/Automattic/wp-calypso/pull/27190#issuecomment-422050034 for more details on the rationale.

## How has this been tested?
This PR includes several new unit tests to cover the additional reducer functionality. 

To run the tests, run `npm test packages/blocks/src/store`.

## Types of changes
* New feature: `addCategory()` action to allow easy registration of new categories.
* New feature: `removeCategory()` action to allow easy unregistration of existing categories.
* Reducer additions to handle store changes from the above actions, along with tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
