### PR TITLE
Improve the reusable blocks "Export as JSON" link

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -257,13 +257,22 @@ add_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
  * @return array          Updated post actions.
  */
 function gutenberg_add_edit_link( $actions, $post ) {
+	// Build the classic edit action. See also: WP_Posts_List_Table::handle_row_actions().
+	$title = _draft_or_post_title( $post->ID );
+
 	if ( 'wp_block' === $post->post_type ) {
 		unset( $actions['edit'] );
 		unset( $actions['inline hide-if-no-js'] );
 		$actions['export'] = sprintf(
-			'<a class="wp-list-reusable-blocks__export" href="#" data-id="%s" aria-label="%s">%s</a>',
+			'<button type="button" class="wp-list-reusable-blocks__export button-link" data-id="%s" aria-label="%s">%s</button>',
 			$post->ID,
-			__( 'Export as JSON', 'gutenberg' ),
+			esc_attr(
+				sprintf(
+					/* translators: %s: post title */
+					__( 'Export &#8220;%s&#8221; as JSON', 'gutenberg' ),
+					$title
+				)
+			),
 			__( 'Export as JSON', 'gutenberg' )
 		);
 		return $actions;
@@ -276,8 +285,6 @@ function gutenberg_add_edit_link( $actions, $post ) {
 	$edit_url = get_edit_post_link( $post->ID, 'raw' );
 	$edit_url = add_query_arg( 'classic-editor', '', $edit_url );
 
-	// Build the classic edit action. See also: WP_Posts_List_Table::handle_row_actions().
-	$title       = _draft_or_post_title( $post->ID );
 	$edit_action = array(
 		'classic' => sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',


### PR DESCRIPTION
## Description

This PR improves the Export as JSON link by referencing the block title in the aria-label attribute (as it's standard in core) and changing the link to a button. For more details, please see #10002 

## How has this been tested?
- npm test gives a failing (unrelated?) test
- I've tested it with the fix from #10000 with Firefox and it works correctly, still have to test it with IE 11

/Cc @youknowriad 

Fixes #10002 