### PR TITLE
Change keyboard shortcut to access + z

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -70,7 +70,7 @@ This is the canonical list of keyboard shortcuts:
 ### Block shortcuts
 
 * <kbd>Shift</kbd>+<kbd>⌘D</kbd> Duplicate the selected block(s).
-* <kbd>Option</kbd>+<kbd>⌘Backspace</kbd> Remove the selected block(s).
+* <kbd>Ctrl</kbd>+<kbd>Option</kbd>+<kbd>z</kbd> Remove the selected block(s).
 * <kbd>Option</kbd>+<kbd>⌘T</kbd> Insert a new block before the selected block(s).
 * <kbd>Option</kbd>+<kbd>⌘Y</kbd> Insert a new block after the selected block(s).
 * <kbd>/</kbd> Change the block type after adding a new paragraph.

--- a/edit-post/components/keyboard-shortcut-help-modal/config.js
+++ b/edit-post/components/keyboard-shortcut-help-modal/config.js
@@ -93,7 +93,7 @@ const blockShortcuts = {
 			description: __( 'Duplicate the selected block(s).' ),
 		},
 		{
-			keyCombination: primaryAlt( 'backspace' ),
+			keyCombination: access( 'z' ),
 			description: __( 'Remove the selected block(s).' ),
 		},
 		{

--- a/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/edit-post/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -167,11 +167,11 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
           Object {
             "description": "Remove the selected block(s).",
             "keyCombination": Array [
-              "Ctrl",
+              "Shift",
               "+",
               "Alt",
               "+",
-              "Backspace",
+              "Z",
             ],
           },
           Object {

--- a/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
@@ -28,8 +28,8 @@ export const shortcuts = {
 		display: displayShortcut.primaryShift( 'd' ),
 	},
 	removeBlock: {
-		raw: rawShortcut.primaryAlt( 'backspace' ),
-		display: displayShortcut.primaryAlt( 'Backspace' ),
+		raw: rawShortcut.access( 'z' ),
+		display: displayShortcut.access( 'z' ),
 	},
 	insertBefore: {
 		raw: rawShortcut.primaryAlt( 't' ),

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -23,7 +23,7 @@ import {
 	getScrollContainer,
 } from '@wordpress/dom';
 import { createBlobURL } from '@wordpress/blob';
-import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, rawShortcut, isKeyboardEvent } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, rawShortcut } from '@wordpress/keycodes';
 import { Slot } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { rawHandler, children } from '@wordpress/blocks';
@@ -415,12 +415,6 @@ export class RichText extends Component {
 
 		const { keyCode } = event;
 		const isReverse = keyCode === BACKSPACE;
-
-		// User is using the Remove Block shortcut, so allow the event to bubble
-		// up to the BlockSettingsMenu component
-		if ( isKeyboardEvent.primaryAlt( event, 'Backspace' ) ) {
-			return;
-		}
 
 		const { isCollapsed } = getSelection();
 

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -6,7 +6,7 @@ import {
 	getEditedPostContent,
 	newPost,
 	pressWithModifier,
-	META_KEY,
+	ACCESS_MODIFIER_KEYS,
 } from '../support/utils';
 
 const addThreeParagraphsToNewPost = async () => {
@@ -50,7 +50,7 @@ describe( 'block deletion -', () => {
 		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
 			// Type some text to assert that the shortcut also deletes block content.
 			await page.keyboard.type( 'this is block 2' );
-			await pressWithModifier( [ 'Alt', META_KEY ], 'Backspace' );
+			await pressWithModifier( ACCESS_MODIFIER_KEYS, 'z' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 
 			// Type additional text and assert that caret position is correct by comparing to snapshot.


### PR DESCRIPTION
## Description
Fixes #9940
Fixes #9036

Second attempt at this after #9190 had to be reverted.

Changes the shortcut for remove block to access + z (ctrl + option + z on a Mac / shift + alt + z elsewhere).

Changes:
- change the shortcut in the editor-global-shortcuts
- change the shortcut in the keyboard shortcuts modal
- change the shortcut in the docs
- change the shortcut in the e2e tests
- remove some now unused code in RichText.

This requires some cross browser testing. Please help if you can 😄 

## How has this been tested?
- Tested various keyboard shortcuts documented in this spreadsheet to ensure there are no clashing browser or os shortcuts.
https://docs.google.com/spreadsheets/d/1nK1frKawxV7aboWOJbbslbIqBGoLY7gqKvfwqENj2yE/edit?usp=sharing

## Screenshots <!-- if applicable -->
<img width="278" alt="screen shot 2018-09-18 at 3 50 45 pm" src="https://user-images.githubusercontent.com/677833/45696184-eba96c80-bb5a-11e8-9fa3-ad6ca22348fc.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
