### PR TITLE
Docs: Fix grammar.md manifest entry; (chore) update data docs

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -259,7 +259,8 @@ Whether the post can be saved.
 ### isEditedPostEmpty
 
 Returns true if the edited post has content. A post has content if it has at
-least one block or otherwise has a non-empty content property assigned.
+least one saveable block or otherwise has a non-empty content property
+assigned.
 
 *Parameters*
 
@@ -988,6 +989,19 @@ default post format. Returns null if the format cannot be determined.
 *Returns*
 
 Suggested post format.
+
+### getBlocksForSerialization
+
+Returns a set of blocks which are to be used in consideration of the post's
+generated save content.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+Filtered set of blocks for save.
 
 ### getEditedPostContent
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -12,6 +12,12 @@
 		"parent": null
 	},
 	{
+		"title": "The Gutenberg block grammar",
+		"slug": "grammar",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/grammar.md",
+		"parent": "language"
+	},
+	{
 		"title": "Block API",
 		"slug": "block-api",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/block-api.md",

--- a/docs/root-manifest.json
+++ b/docs/root-manifest.json
@@ -12,6 +12,12 @@
 		"parent": null
 	},
 	{
+		"title": "The Gutenberg block grammar",
+		"slug": "grammar",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/grammar.md",
+		"parent": "language"
+	},
+	{
 		"title": "Block API",
 		"slug": "block-api",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/block-api.md",


### PR DESCRIPTION
## Description

Follow-up on https://github.com/WordPress/gutenberg/pull/9837#issuecomment-421390823. I'd mistakenly updated `docs/manifest.json`, which is auto-generated from other sources, including `docs/root-manifest.json`.

## Testing

Run `npm run docs:build`, make sure that `docs/manifest.json` is kept intact (that the entry for `grammar.md` isn't removed).