### PR TITLE
Fix focused header layout for IE11

### DIFF
--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -54,6 +54,11 @@
 	// where it is no longer noticeable.
 	> .edit-post-header__settings {
 		order: 1;
+
+		// Restore default order for all other browsers
+		@supports (position: sticky) {
+			order: initial;
+		}
 	}
 }
 

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -42,6 +42,19 @@
 			display: inline-flex;
 		}
 	}
+
+	// Some browsers, most notably IE11, honor an older version of the flexbox spec
+	// which takes absolutely positioned items into account when calculating `space-between`.
+	// https://www.w3.org/TR/2012/WD-css3-flexbox-20120612/#abspos-flex-items
+	//
+	// This difference is causing our header layout to break when focused in IE11.
+	// Our focused region styles use an absolutely positioned :after pseudo element to draw an outline,
+	// and IE11 is adding space between it and our last real child, shifting righthand UI elements
+	// to the left. For a workaround, we change the flex order to move the undesired spacing to the middle
+	// where it is no longer noticeable.
+	> .edit-post-header__settings {
+		order: 1;
+	}
 }
 
 @include editor-left(".edit-post-header");


### PR DESCRIPTION
## Description
This PR addresses a layout bug in IE11 which occurs when using `Ctrl + backtick` to navigate regions and focusing the header region.

![screenshot 34](https://user-images.githubusercontent.com/1682452/42831355-69efdd48-89ee-11e8-8b82-dbf6ec97aa90.png)

Closes #8008.

## How has this been tested?
Manually tested by navigating to the header region in IE11, Edge, Chrome, Firefox, and Safari and observing no undesired layout changes.

## Types of changes
The layout issue is caused by a combination of:
* IE11 implementing an [earlier version of the flexbox spec](https://www.w3.org/TR/2012/WD-css3-flexbox-20120612/#abspos-flex-items) which considers absolutely positioned items when calculating flexbox layout.
* Our focused region styles which add an `:after` pseudo element to draw the focused region outline.

The focused region outline is absolutely positioned, but IE11 adds space between it and the last header element, shifting the UI to the left. This PR adds a workaround that moves the pseudo element in the flex order where the undesired extra space does not visibly affect the layout.
