### PR TITLE
Try fixing the embed scrollbar.

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -148,9 +148,10 @@ class Sandbox extends Component {
 			body.wp-has-aspect-ratio > div,
 			body.wp-has-aspect-ratio > div > iframe {
 				height: 100%;
+				overflow: hidden; /* If it has an aspect ratio, it shouldn't scroll. */
 			}
 			body > div > * {
-				margin-top: 0 !important;	/* has to have !important to override inline styles */
+				margin-top: 0 !important; /* Has to have !important to override inline styles. */
 				margin-bottom: 0 !important;
 			}
 		`;


### PR DESCRIPTION
Fixes #9920.

This PR hides overflow on any embedded iframe that has an aspect ratio. I.e. it's a video.

<img width="760" alt="screen shot 2018-09-19 at 09 32 05" src="https://user-images.githubusercontent.com/1204802/45737782-09281600-bbef-11e8-8d37-d46093a70e4f.png">

Can I have a sanity check on this please?