### PR TITLE
Fix issue with editor styles and fullscreen

### DIFF
--- a/edit-post/components/fullscreen-mode/style.scss
+++ b/edit-post/components/fullscreen-mode/style.scss
@@ -1,8 +1,11 @@
 body.is-fullscreen-mode {
 	// Reset the html.wp-topbar padding
+	// Because this uses negative margins, we have to compensate for the height.
 	margin-top: -$admin-bar-height-big;
+	height: calc(100% + #{ $admin-bar-height-big });
 	@include break-medium() {
 		margin-top: -$admin-bar-height;
+		height: calc(100% + #{ $admin-bar-height });
 	}
 
 	#adminmenumain,


### PR DESCRIPTION
This is a curious one.

The topbar in WordPress takes up some space in the editing canvas. When fullscreen mode is engaged, we invoke a negative vertical margin to offset this. But this means the _body_ element is no longer 100% tall, because 32px have been cropped off.

So what happens when an editor style colorizes the body element? Well normally even though the body element isn't as tall as the viewport, it floods the whole thing. See https://css-tricks.com/just-one-of-those-weird-things-about-css-background-on-body/ for all the details.

But in this case, we have a background color on the HTML element. And we need to have that, because otherwise we can't use mix-blend-mode when selecting multiple blocks. This is due to a bug in Chrome where this feature doesn't work unless a background color that isn't none or transparent is explicitly set on the html element.

So there we go — and that's why this PR uses calc to set the height on the body element.

Before:

<img width="1398" alt="screen shot 2018-09-19 at 09 38 29" src="https://user-images.githubusercontent.com/1204802/45739018-2c07f980-bbf2-11e8-9b64-1044724f677b.png">

After:

<img width="1527" alt="screen shot 2018-09-19 at 09 43 41" src="https://user-images.githubusercontent.com/1204802/45739022-2f02ea00-bbf2-11e8-9de4-31ab9840e278.png">
