### PR TITLE
Update Dashicons component.

### DIFF
--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -104,6 +104,12 @@ export default class Dashicon extends Component {
 			case 'align-none':
 				path = 'M3 5h14V3H3v2zm10 8V7H3v6h10zM3 17h14v-2H3v2z';
 				break;
+			case 'align-pull-left':
+				path = 'M9 16V4H3v12h6zm2-7h6V7h-6v2zm0 4h6v-2h-6v2z';
+				break;
+			case 'align-pull-right':
+				path = 'M17 16V4h-6v12h6zM9 7H3v2h6V7zm0 4H3v2h6v-2z';
+				break;
 			case 'align-right':
 				path = 'M3 5h14V3H3v2zm0 4h3V7H3v2zm14 4V7H8v6h9zM3 13h3v-2H3v2zm0 4h14v-2H3v2z';
 				break;
@@ -433,6 +439,9 @@ export default class Dashicon extends Component {
 				break;
 			case 'excerpt-view':
 				path = 'M19 18V2c0-.55-.45-1-1-1H2c-.55 0-1 .45-1 1v16c0 .55.45 1 1 1h16c.55 0 1-.45 1-1zM4 3c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm13 0v6H6V3h11zM4 11c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm13 0v6H6v-6h11z';
+				break;
+			case 'exit':
+				path = 'M13 3v2h2v10h-2v2h4V3h-4zm0 8V9H5.4l4.3-4.3-1.4-1.4L1.6 10l6.7 6.7 1.4-1.4L5.4 11H13z';
 				break;
 			case 'external':
 				path = 'M9 3h8v8l-2-1V6.92l-5.6 5.59-1.41-1.41L14.08 5H10zm3 12v-3l2-2v7H3V6h8L9 8H5v7h7z';


### PR DESCRIPTION
This updates the Dashicons component with recent additions, two which are in a PR that's yet to be merged, and one that's needed to exit fullscreen.

Some of the changes in this PR haven't yet been merged into upstream Dashicons, we are waiting for https://github.com/WordPress/dashicons/pull/316 to settle. But in the mean time, this copies the new paths.

