### PR TITLE
Try a simpler spacing setup for gallery items

### DIFF
--- a/packages/block-library/src/cover-image/editor.scss
+++ b/packages/block-library/src/cover-image/editor.scss
@@ -1,6 +1,4 @@
 .wp-block-cover-image {
-	margin: 0;
-
 	.editor-rich-text__tinymce[data-is-empty="true"]::before {
 		position: inherit;
 	}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -1,9 +1,5 @@
-.wp-block-gallery.components-placeholder {
-	margin: 0;
-}
-
 // Allow gallery items to go edge to edge.
-.gutenberg .wp-block-gallery:not(.components-placeholder) {
+/*.gutenberg .wp-block-gallery:not(.components-placeholder) {
 	margin-left: -8px;
 	margin-right: -8px;
 }
@@ -13,6 +9,7 @@
 	margin-left: auto;
 	margin-right: auto;
 }
+*/
 
 .blocks-gallery-item {
 

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -1,16 +1,3 @@
-// Allow gallery items to go edge to edge.
-/*.gutenberg .wp-block-gallery:not(.components-placeholder) {
-	margin-left: -8px;
-	margin-right: -8px;
-}
-
-// Don't use negative margins when full-wide.
-.gutenberg [data-align="full"] .wp-block-gallery:not(.components-placeholder) {
-	margin-left: auto;
-	margin-right: auto;
-}
-*/
-
 .blocks-gallery-item {
 
 	// Hide the focus outline that otherwise briefly appears when selecting a block.

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -81,7 +81,7 @@
 	// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
 	& .blocks-gallery-image,
 	& .blocks-gallery-item {
-		width: calc((100% / 2) - (#{ $grid-size-large } * 2));
+		width: calc((100% / 2) - #{ $grid-size-large });
 	}
 
 	&.columns-1 .blocks-gallery-image,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -81,12 +81,17 @@
 	// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
 	& .blocks-gallery-image,
 	& .blocks-gallery-item {
-		width: calc((100% / 2) - #{ $grid-size-large });
+		width: calc((100% - #{ $grid-size-large }) / 2);
+
+		&:nth-child(odd) {
+			margin-right: 0;
+		}
 	}
 
 	&.columns-1 .blocks-gallery-image,
 	&.columns-1 .blocks-gallery-item {
 		width: 100%;
+		margin-right: 0;
 	}
 
 	// Beyond mobile viewports, we allow up to 8 columns.
@@ -94,16 +99,17 @@
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
 			&.columns-#{ $i } .blocks-gallery-item {
-				width: calc((100% / #{ $i }) - #{ $grid-size-large });
+				width: calc((100% - #{ $grid-size-large } * #{ $i - 1 }) / #{ $i });
+				margin-right: 16px;
 			}
 		}
-	}
 
-	// Unset the right margin on every rightmost gallery item to ensure center balance.
-	@for $column-count from 1 through 8 {
-		&.columns-#{ $column-count } .blocks-gallery-image:nth-of-type(#{ $column-count }n),
-		&.columns-#{ $column-count } .blocks-gallery-item:nth-of-type(#{ $column-count }n) {
-			margin-right: 0;
+		// Unset the right margin on every rightmost gallery item to ensure center balance.
+		@for $column-count from 1 through 8 {
+			&.columns-#{ $column-count } .blocks-gallery-image:nth-of-type(#{ $column-count }n),
+			&.columns-#{ $column-count } .blocks-gallery-item:nth-of-type(#{ $column-count }n) {
+				margin-right: 0;
+			}
 		}
 	}
 

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -82,10 +82,6 @@
 	& .blocks-gallery-image,
 	& .blocks-gallery-item {
 		width: calc((100% - #{ $grid-size-large }) / 2);
-
-		&:nth-child(odd) {
-			margin-right: 0;
-		}
 	}
 
 	&.columns-1 .blocks-gallery-image,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -82,6 +82,10 @@
 	& .blocks-gallery-image,
 	& .blocks-gallery-item {
 		width: calc((100% - #{ $grid-size-large }) / 2);
+
+		&:nth-of-type(even) {
+			margin-right: 0;
+		}
 	}
 
 	&.columns-1 .blocks-gallery-image,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -4,12 +4,9 @@
 	list-style-type: none;
 	padding: 0;
 
-	// Allow gallery items to go edge to edge.
-	//margin: 0 -8px 0 -8px;
-
 	.blocks-gallery-image,
 	.blocks-gallery-item {
-		// Add space between thumbnails, and unset the nth-child and last-child later
+		// Add space between thumbnails, and unset right most thumbnails later.
 		margin: 0 $grid-size-large $grid-size-large 0;
 		display: flex;
 		flex-grow: 1;
@@ -81,7 +78,7 @@
 		}
 	}
 
-	// Responsive fallback value, 2 columns
+	// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
 	& .blocks-gallery-image,
 	& .blocks-gallery-item {
 		width: calc((100% / 2) - (#{ $grid-size-large } * 2));
@@ -92,6 +89,7 @@
 		width: calc(100% / 1);
 	}
 
+	// Beyond mobile viewports, we allow up to 8 columns.
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
@@ -101,17 +99,16 @@
 		}
 	}
 
-	// Unset right margins.
+	// Unset the right margin on every rightmost gallery item to ensure center balance.
 	@for $j from 1 through 8 {
 		&.columns-#{ $j } .blocks-gallery-image:nth-of-type(#{ $j }n),
 		&.columns-#{ $j } .blocks-gallery-item:nth-of-type(#{ $j }n) {
 			margin-right: 0;
-			//border: 10px solid red;
 		}
 	}
 
 	// Last item always needs margins reset.
-	// When block is selected, only reset the right margin of the 2nd to last child.
+	// When block is selected, only reset the right margin of the 2nd to last item.
 	.blocks-gallery-image:last-child,
 	.blocks-gallery-item:last-child,
 	.is-selected & .blocks-gallery-image:nth-last-child(2),
@@ -127,7 +124,7 @@
 		}
 	}
 
-	// Apply max-width to floated items that have no intrinsic width
+	// Apply max-width to floated items that have no intrinsic width.
 	[data-align="left"] &,
 	[data-align="right"] &,
 	&.alignleft,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -5,11 +5,12 @@
 	padding: 0;
 
 	// Allow gallery items to go edge to edge.
-	margin: 0 -8px 0 -8px;
+	//margin: 0 -8px 0 -8px;
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {
-		margin: 8px;
+		// Add space between thumbnails, and unset the nth-child and last-child later
+		margin: 0 $grid-size-large $grid-size-large 0;
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;
@@ -83,21 +84,39 @@
 	// Responsive fallback value, 2 columns
 	& .blocks-gallery-image,
 	& .blocks-gallery-item {
-		width: calc(100% / 2 - 16px);
+		width: calc((100% / 2) - (#{ $grid-size-large } * 2));
 	}
 
 	&.columns-1 .blocks-gallery-image,
 	&.columns-1 .blocks-gallery-item {
-		width: calc(100% / 1 - 16px);
+		width: calc(100% / 1);
 	}
 
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
 			&.columns-#{ $i } .blocks-gallery-item {
-				width: calc(100% / #{ $i } - 16px);
+				width: calc((100% / #{ $i }) - (#{ $grid-size-large } * #{ $i }));
 			}
 		}
+	}
+
+	// Unset right margins.
+	@for $j from 1 through 8 {
+		&.columns-#{ $j } .blocks-gallery-image:nth-of-type(#{ $j }n),
+		&.columns-#{ $j } .blocks-gallery-item:nth-of-type(#{ $j }n) {
+			margin-right: 0;
+			//border: 10px solid red;
+		}
+	}
+
+	// Last item always needs margins reset.
+	// When block is selected, only reset the right margin of the 2nd to last child.
+	.blocks-gallery-image:last-child,
+	.blocks-gallery-item:last-child,
+	.is-selected & .blocks-gallery-image:nth-last-child(2),
+	.is-selected & .blocks-gallery-item:nth-last-child(2) {
+		margin-right: 0;
 	}
 
 	// Make the "Add new Gallery item" button full-width (so it always appears

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -86,7 +86,7 @@
 
 	&.columns-1 .blocks-gallery-image,
 	&.columns-1 .blocks-gallery-item {
-		width: calc(100% / 1);
+		width: 100%;
 	}
 
 	// Beyond mobile viewports, we allow up to 8 columns.

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -94,15 +94,15 @@
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
 			&.columns-#{ $i } .blocks-gallery-item {
-				width: calc((100% / #{ $i }) - (#{ $grid-size-large } * #{ $i }));
+				width: calc((100% / #{ $i }) - #{ $grid-size-large });
 			}
 		}
 	}
 
 	// Unset the right margin on every rightmost gallery item to ensure center balance.
-	@for $j from 1 through 8 {
-		&.columns-#{ $j } .blocks-gallery-image:nth-of-type(#{ $j }n),
-		&.columns-#{ $j } .blocks-gallery-item:nth-of-type(#{ $j }n) {
+	@for $column-count from 1 through 8 {
+		&.columns-#{ $column-count } .blocks-gallery-image:nth-of-type(#{ $column-count }n),
+		&.columns-#{ $column-count } .blocks-gallery-item:nth-of-type(#{ $column-count }n) {
 			margin-right: 0;
 		}
 	}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,6 +1,5 @@
 .wp-block-image {
 	position: relative;
-	margin: 0;
 
 	&.is-transient img {
 		@include loading_fade;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -1,4 +1,5 @@
 .components-placeholder {
+	margin: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: center;


### PR DESCRIPTION
The stock gallery features white gutters between items. Currently in `master`, every item has an even 8px margin all around. We then compensate for this, left and right, of the gallery, to make sure items in the gallery align correctly with text width above and below the gallery.

This PR attempts a different approach. It sets only the right and bottom margin on gallery items, and then unsets the right margin on the rightmost item in each row.

This is a little more complex in the rules that are output, but it solves the issue presented here: https://github.com/WordPress/gutenberg/pull/9670#issuecomment-419388164

Let me know your thoughts. The columns markup itself is a little more complex, but the gallery itself is easier to style for themes, as it no longer uses negative margins.

![alternate gallery](https://user-images.githubusercontent.com/1204802/45743575-a2a9f480-bbfc-11e8-9d85-e3f75b254233.gif)

If we like this, we'll need to test for IE as well.

By the way I noticed this:

<img width="522" alt="screen shot 2018-09-19 at 10 25 18" src="https://user-images.githubusercontent.com/1204802/45743598-b2c1d400-bbfc-11e8-8a1e-7dae42e49d1b.png">

It looks like when the gallery block has no alignment, an "alignundefined" is applied.

CC: @SofiaSousa 
