### PR TITLE
Fix popover link repositioning

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -47,11 +47,13 @@ const LinkContainer = ( props ) => {
 
 	return (
 		<Fill name="RichText.Siblings">
-			<PositionedAtSelection className="editor-format-toolbar__link-container">
+			<PositionedAtSelection
+				className="editor-format-toolbar__link-container"
+				key={ selectedNodeId /* Used to force remount on change to ensure popover repositions */ }
+			>
 				<Popover
 					position="bottom center"
 					focusOnMount={ isEditing ? 'firstElement' : false }
-					key={ selectedNodeId /* Used to force rerender on change */ }
 				>
 					{ isEditing && (
 						// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar


### PR DESCRIPTION
## Description
Fixes #7992, specifically "Link Modal doesn't move when clicking on another link within Paragraph block" - the steps mentioned here https://github.com/WordPress/gutenberg/issues/7992#issuecomment-415218240

Other issues couldn't be reproduced.

**Problem**
The `PositionedAtSelection` component used in `LinkContainer` only calculates its position when mounting. When clicking between two existing links in the same paragraph, the component doesn't remount, so therefore the position also doesn't change.

**Fix**
The `Popover` being rendered in `LinkContainer` already had a `key` specified that forces it to re-mount whenever a selection is changed. This has now been moved to the parent `PositionedAtSelection` to force that and its children to remount, resulting in a recalculation of the position.

I did consider/try some other approaches, but none worked quite as well as this.

## How has this been tested?
1. Add two separate links to a paragraph block
2. Click on one, then click on the other.
3. Observed that the link popover correctly repositioned and updated

## Screenshots <!-- if applicable -->
**Before**
![popover-reposition-bug](https://user-images.githubusercontent.com/677833/45759887-d4cd4d80-bc20-11e8-9fd8-057568f7b8ff.gif)

**After**
![popover-reposition-fix](https://user-images.githubusercontent.com/677833/45759910-e0b90f80-bc20-11e8-9280-8c5c83765e23.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
