### PR TITLE
Components: Exporting CategorySelect component

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -8,6 +8,7 @@ export { default as Button } from './button';
 export { default as ButtonGroup } from './button-group';
 export { default as CheckboxControl } from './checkbox-control';
 export { default as ClipboardButton } from './clipboard-button';
+export { default as CategorySelect } from './query-controls/category-select';
 export { default as ColorIndicator } from './color-indicator';
 export { default as ColorPalette } from './color-palette';
 export { default as Dashicon } from './dashicon';


### PR DESCRIPTION
This is a simple PR to export **CategorySelect** component in **components** package.

I believe **CategorySelect** is a usefull component and would be nice if we could include it in our custom plugins for example.

````js
const { CategorySelect } = wp.components;
````

