### PR TITLE
Have Travis run mobile tests that use the parent code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
       node_js: 8
       env:
         LANE='node'
+        GUTENBERG_AS_PARENT=true
         CHECK_CORRECTNESS='true'
       cache:
         yarn: true
@@ -86,6 +87,7 @@ jobs:
       node_js: 8
       env:
         LANE='node'
+        GUTENBERG_AS_PARENT=true
         CHECK_TESTS='true'
         TEST_RN_PLATFORM='android'
       cache:
@@ -99,6 +101,7 @@ jobs:
       node_js: 8
       env:
         LANE='node'
+        GUTENBERG_AS_PARENT=true
         CHECK_TESTS='true'
         TEST_RN_PLATFORM='ios'
       cache:


### PR DESCRIPTION
## Description
Until now, Travis was running the mobile tests but those were actually using the deeply nested Gutenberg filetree (a nested submodule inside the mobile submodule), resulting to false positive "green" runs.

This PR adds a flag to the mobile related Travis jobs to make them use the proper configuration where the mobile tests should assume to be running from inside the Gutenberg folder.

## How has this been tested?
This is a Travis change and the testing is done by looking at the Travis run on this PR.
In particular, when looking at the 2 mobile job outputs, one can see this:
```
$ ./.travis/travis-checks-js.sh
> gutenberg-mobile@0.1.0 test:inside-gb /home/travis/build/WordPress/gutenberg/gutenberg-mobile
> cross-env NODE_ENV=test node node_modules/jest/bin/jest.js --verbose --config jest_gb.config.js
```
where the important bit is the `jest_gb.config.js`. That's the Jest configuration that sets the Gutenberg package paths to point one directory up from the mobile submodule. That's what we need to have the mobile tests use the code/changes found in the parent folder.

## Types of changes
Adds a shell flag to the Travis configuration of the mobile jobs.

## To test:
Open the Travis output https://travis-ci.org/WordPress/gutenberg/jobs/430595120#L5410 and notice the `jest_gb.config.js` bit.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
