### PR TITLE
chore: Bump 3.9.0 RC version

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 3.9.0-rc.1
+ * Version: 3.9.0-rc.2
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "3.9.0-rc.1",
+	"version": "3.9.0-rc.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "3.9.0-rc.1",
+	"version": "3.9.0-rc.2",
 	"private": true,
 	"description": "A new WordPress editor experience",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
This PR is to bump our RC version. I'll cherry-pick this commit after:

* 41cb78b2ae1b47a2e0e94f7fe4df3718b08655d4
* 38e1ae01d7240a9f716606ee048e844b9eff6a35
* 99ca7ea54f0ee5d0fea044b3a829147b3f7bd190
* 2b42db51dd1a6c100d22190669a14a7873af6a44
* 7edf243ae22cae05402be42138b5f62b09120ce3