### PR TITLE
Need to define isRichTextValueEmpty for mobile too

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -43,7 +43,7 @@ import patterns from './patterns';
 import { withBlockEditContext } from '../block-edit/context';
 import { domToFormat, valueToString } from './format';
 import TokenUI from './tokens/ui';
-import isRichTextValueEmpty from './utils';
+import { isRichTextValueEmpty } from './utils';
 
 /**
  * Browser dependencies

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -43,6 +43,7 @@ import patterns from './patterns';
 import { withBlockEditContext } from '../block-edit/context';
 import { domToFormat, valueToString } from './format';
 import TokenUI from './tokens/ui';
+import isRichTextValueEmpty from './utils';
 
 /**
  * Browser dependencies
@@ -59,17 +60,6 @@ const { Node, getSelection } = window;
  * @type {string}
  */
 const TINYMCE_ZWSP = '\uFEFF';
-
-/**
- * Check if the given `RichText` value is empty on not.
- *
- * @param {Array} value `RichText` value.
- *
- * @return {boolean} True if empty, false if not.
- */
-const isRichTextValueEmpty = ( value ) => {
-	return ! value || ! value.length;
-};
 
 export function getFormatValue( formatName, parents ) {
 	if ( formatName === 'link' ) {

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -20,6 +20,7 @@ import { children } from '@wordpress/blocks';
  */
 import FormatToolbar from './format-toolbar';
 import { FORMATTING_CONTROLS } from './formatting-controls';
+import isRichTextValueEmpty from './utils';
 
 export function getFormatValue( formatName ) {
 	if ( 'link' === formatName ) {
@@ -216,6 +217,8 @@ RichTextContainer.Content = ( { value, format, tagName: Tag, ...props } ) => {
 
 	return content;
 };
+
+RichTextContainer.isEmpty = isRichTextValueEmpty;
 
 RichTextContainer.Content.defaultProps = {
 	format: 'children',

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -20,7 +20,7 @@ import { children } from '@wordpress/blocks';
  */
 import FormatToolbar from './format-toolbar';
 import { FORMATTING_CONTROLS } from './formatting-controls';
-import isRichTextValueEmpty from './utils';
+import { isRichTextValueEmpty } from './utils';
 
 export function getFormatValue( formatName ) {
 	if ( 'link' === formatName ) {

--- a/packages/editor/src/components/rich-text/utils.js
+++ b/packages/editor/src/components/rich-text/utils.js
@@ -5,8 +5,6 @@
  *
  * @return {boolean} True if empty, false if not.
  */
-const isRichTextValueEmpty = ( value ) => {
+export const isRichTextValueEmpty = ( value ) => {
 	return ! value || ! value.length;
 };
-
-export default isRichTextValueEmpty;

--- a/packages/editor/src/components/rich-text/utils.js
+++ b/packages/editor/src/components/rich-text/utils.js
@@ -1,0 +1,12 @@
+/**
+ * Check if the given `RichText` value is empty on not.
+ *
+ * @param {Array} value `RichText` value.
+ *
+ * @return {boolean} True if empty, false if not.
+ */
+const isRichTextValueEmpty = ( value ) => {
+	return ! value || ! value.length;
+};
+
+export default isRichTextValueEmpty;


### PR DESCRIPTION
## Description
This PR moves the definition of the `isRichTextValueEmpty` function into a common module and uses it for the mobile `rich-text/index.native.js` implementation too. This fixes the breakage of `npm test` in current `master`.

## How has this been tested?
`npm install`, `npm test` now succeeds on the mobile tests.

## Types of changes
* Code refactoring to move `isRichTextValueEmpty()` in a common module (`./utils.js`)
* `rich-text/index.native.js` using the new `./utils.js`

To Test:
1. npm install
2. npm test
3. tests should pass

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
