### PR TITLE
Fix broken button dimensions in IE11

### DIFF
--- a/packages/block-library/src/block/edit-panel/style.scss
+++ b/packages/block-library/src/block/edit-panel/style.scss
@@ -40,6 +40,11 @@
 
 	.components-button.reusable-block-edit-panel__button {
 		margin: 0 5px 0 0;
+
+		// Prevent button shrinking in IE11 when other items have a 100% flex basis.
+		// This should be safe to apply in all browsers because we don't want these
+		// buttons to shrink anyway.
+		flex-shrink: 0;
 	}
 
 	@include break-large() {

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -19,6 +19,13 @@
 		margin-left: -$border-width;
 		margin-right: -$border-width;
 	}
+
+	button {
+		// Prevent button shrinking in IE11 when other items have a 100% flex basis.
+		// This should be safe to apply in all browsers because we don't want these
+		// buttons to shrink anyway.
+		flex-shrink: 0;
+	}
 }
 
 .editor-post-permalink__copy {
@@ -76,7 +83,6 @@
 	// Higher specificity required to override core margin styles.
 	.editor-post-permalink-editor__save {
 		margin-left: auto;
-		flex: 0 1 auto;
 	}
 }
 


### PR DESCRIPTION
## Description
This is a PR to fix shrunken buttons seen when editing permalinks and reusable blocks.

<img src="https://user-images.githubusercontent.com/530877/45796947-e716ae00-bc57-11e8-839a-e21706fea8e9.png" alt="image" style="max-width:100%;">

In both cases, IE11 appears to be shrinking the buttons based on a sibling flex item with `width` or `flex-basis` of 100%. I played with changing the basis of those items to auto but later realized we actually want to use 100%, at least in the reusable blocks case, because it nicely wraps to new flex lines on mobile.

This fix simply sets `flex-shrink: 0` on those buttons and does so for all browsers because I'm not aware of cases where we'd want the buttons to shrink. Please correct me if I'm wrong. : )

Fixes #7481.

## How has this been tested?
I loaded Gutenberg in the following browsers and observed expected rendering of the permalink and reusable block buttons and surrounding UI:
* IE11
* Edge
* Firefox 63
* Chrome 69
* Safari 11.1
* iOS Safari latest
* Android WebView latest