### PR TITLE
Try Edge toolbar position fix

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -866,6 +866,9 @@
 				// Move the block toolbar upwards using margin, as translate doesn't work.
 				margin-top: -$block-toolbar-height -$block-padding -$border-width;
 
+				// Disable the technique used to move the block toolbar upwards in non-edge browsers.
+				transform: translateY(0);
+
 				// Stick to the top which is different because of using margins instead of translate.
 				top: -$border-width;
 			}

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -860,6 +860,16 @@
 				top: $block-toolbar-height + $block-padding;
 			}
 
+			// Rules inside this query are only run by Microsoft Edge.
+			// Edge has bugs around position: sticky; combined with transform, so create different rules.
+			@supports (-ms-ime-align:auto) {
+				// Move the block toolbar upwards using margin, as translate doesn't work.
+				margin-top: -$block-toolbar-height -$block-padding -$border-width;
+
+				// Stick to the top which is different because of using margins instead of translate.
+				top: -$border-width;
+			}
+
 			// This is an important one. Because the toolbar is sticky, it's part of the flow.
 			// It behaves as relative, in other words, until it reaches an edge and then behaves as fixed.
 			// But by applying a float, we take it out of this flow. The benefit is that we don't need to compensate for margins.


### PR DESCRIPTION
Currently in Edge, the block-docked toolbar is pushed downwards 51px and overlaps content.

This PR adds a hack to fix that. The hack is from https://browserstrangeness.github.io/css_hacks.html, and in my testing runs _only_ in Edge, and doesn't bleed into either Chrome, Firefox, Safari or IE11.

Chrome (unchanged):

<img width="783" alt="screen shot 2018-09-20 at 09 51 13" src="https://user-images.githubusercontent.com/1204802/45804075-74d7b500-bcbb-11e8-9bf0-d2b2319eb628.png">

Edge:

<img width="937" alt="screen shot 2018-09-20 at 09 51 30" src="https://user-images.githubusercontent.com/1204802/45804084-7a34ff80-bcbb-11e8-9bde-3bdbd0a371a5.png">

Edge scrolled:

<img width="787" alt="screen shot 2018-09-20 at 09 52 05" src="https://user-images.githubusercontent.com/1204802/45804101-85882b00-bcbb-11e8-86e9-67ed1b1ae9e4.png">

IE11 (fixed, not sticky):

<img width="1227" alt="screen shot 2018-09-20 at 09 52 26" src="https://user-images.githubusercontent.com/1204802/45804116-8d47cf80-bcbb-11e8-8a0c-d4930fc63fd2.png">

I would appreciate a sanity check on the hack, as well as testing of lots of different post layouts. The reason we combined _float_ with _translate_ in modern browsers is that it allows the toolbar to stay where it needs to in any layout, despite collapsing margins. 

This doesn't seem to be an issue in Edge, but worth looking at both different zoom rates, and small viewports in Edge. 
