### PR TITLE
Add "Exit Code Editor" toolbar.

### DIFF
--- a/edit-post/components/text-editor/index.js
+++ b/edit-post/components/text-editor/index.js
@@ -3,6 +3,7 @@
  */
 import { PostTextEditor, PostTitle } from '@wordpress/editor';
 import { IconButton } from '@wordpress/components';
+import { withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { displayShortcut } from '@wordpress/keycodes';
 
@@ -11,13 +12,13 @@ import { displayShortcut } from '@wordpress/keycodes';
  */
 import './style.scss';
 
-function TextEditor() {
+function TextEditor( { onExit } ) {
 	return (
 		<div className="edit-post-text-editor">
 			<div className="edit-post-text-editor__toolbar">
 				<h2>{ __( 'Editing Code' ) }</h2>
 				<IconButton
-					//onClick={ onSave }
+					onClick={ onExit }
 					icon="no-alt"
 					shortcut={ displayShortcut.secondary( 'm' ) }
 				>
@@ -32,4 +33,10 @@ function TextEditor() {
 	);
 }
 
-export default TextEditor;
+export default withDispatch( ( dispatch ) => {
+	return {
+		onExit() {
+			dispatch( 'core/edit-post' ).switchEditorMode( 'visual' );
+		},
+	};
+} )( TextEditor );

--- a/edit-post/components/text-editor/index.js
+++ b/edit-post/components/text-editor/index.js
@@ -2,6 +2,9 @@
  * WordPress dependencies
  */
 import { PostTextEditor, PostTitle } from '@wordpress/editor';
+import { IconButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { displayShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -11,6 +14,16 @@ import './style.scss';
 function TextEditor() {
 	return (
 		<div className="edit-post-text-editor">
+			<div className="edit-post-text-editor__toolbar">
+				<h2>{ __( 'Editing Code' ) }</h2>
+				<IconButton
+					//onClick={ onSave }
+					icon="no-alt"
+					shortcut={ displayShortcut.secondary( 'm' ) }
+				>
+					{ __( 'Exit Code Editor' ) }
+				</IconButton>
+			</div>
 			<div className="edit-post-text-editor__body">
 				<PostTitle />
 				<PostTextEditor />

--- a/edit-post/components/text-editor/style.scss
+++ b/edit-post/components/text-editor/style.scss
@@ -1,37 +1,31 @@
 .edit-post-text-editor__body {
-	padding-top: 40px;
+	padding-top: $grid-size * 5;
 
 	@include break-small() {
-		padding-top: 40px + $admin-bar-height-big;
+		padding-top: ($grid-size * 5) + $admin-bar-height-big;
 
 		body.is-fullscreen-mode & {
-			padding-top: 40px;
+			padding-top: $grid-size * 5;
 		}
 	}
 
 	@include break-medium() {
-		padding-top: 40px;
+		padding-top: $grid-size * 5;
 
 		body.is-fullscreen-mode & {
-			padding-top: 40px;
+			padding-top: $grid-size * 5;
 		}
 	}
 }
 
-// Use padding to center text in the textarea, this allows you to click anywhere to focus it
 .edit-post-text-editor {
-	padding-left: 20px;
-	padding-right: 20px;
+	margin-left: $grid-size-large;
+	margin-right: $grid-size-large;
 
-	@include break-large() {
-		padding-left: calc(50% - #{ $content-width / 2 });
-		padding-right: calc(50% - #{ $content-width / 2 });
-	}
-
-	.edit-post-post-text-editor__toolbar {
-		width: 100%;
+	@include break-small() {
 		max-width: $content-width;
-		margin: 0 auto;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	// Always show outlines in code editor
@@ -39,6 +33,7 @@
 		textarea {
 			border: $border-width solid $light-gray-500;
 			margin-bottom: 4px;
+			padding: $block-padding;
 		}
 
 		textarea:hover,
@@ -64,5 +59,30 @@
 		padding: $block-padding;
 		min-height: 200px;
 		line-height: 1.8;
+	}
+
+	// Make room for toolbar.
+	padding-top: $block-controls-height + $grid-size;
+
+	// Exit Code Editor toolbar.
+	.edit-post-text-editor__toolbar {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: $block-controls-height;
+		line-height: $block-controls-height;
+		padding: 0 $grid-size 0 $grid-size-large;
+		display: flex;
+
+		h2 {
+			margin: 0 auto 0 0;
+			font-size: $default-font-size;
+			color: $dark-gray-500;
+		}
+
+		.components-icon-button svg {
+			order: 1;
+		}
 	}
 }


### PR DESCRIPTION
This PR intends to fix #9445. It adds a toolbar to the code editor with a label showing what you are doing, as well as an "Exit Code Editor" button that takes you back to the visual editor.

I hope the space between this label and the close button can be used, in the future, to add a slot fill so a plugin could add quicktags here.

Screenshot:

<img width="1414" alt="screen shot 2018-09-20 at 11 08 43" src="https://user-images.githubusercontent.com/1204802/45808220-99d12580-bcc5-11e8-9af7-194f0fa27b58.png">

The PR also cleans up a few things, removes some redundant rules, refactors the centering stuff. It is tested for all breakpoints. However, it is not yet wired up, and I could use some help here. Essentially the button doesn't do anything yet. @tofumatt or @gziolo can you help me wire this up? Thanks. 