### PR TITLE
Try a white sidebar

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -11,6 +11,7 @@ $z-layers: (
 	".freeform-toolbar": 10,
 	".editor-block-list__breadcrumb": 1,
 	".components-form-toggle__input": 1,
+	".components-panel__header.edit-post-sidebar__panel-tabs": 1,
 	".editor-inserter__tabs": 1,
 	".editor-inserter__tab.is-active": 1,
 	".components-panel__header": 1,

--- a/edit-post/components/sidebar/settings-header/style.scss
+++ b/edit-post/components/sidebar/settings-header/style.scss
@@ -3,6 +3,8 @@
 	padding-left: 0;
 	padding-right: $grid-size-small;
 	border-top: 0;
+	background: $light-gray-200;
+	position: sticky;
 }
 
 .edit-post-sidebar__panel-tab {

--- a/edit-post/components/sidebar/settings-header/style.scss
+++ b/edit-post/components/sidebar/settings-header/style.scss
@@ -5,6 +5,8 @@
 	border-top: 0;
 	background: $light-gray-200;
 	position: sticky;
+	z-index: z-index(".components-panel__header.edit-post-sidebar__panel-tabs");
+	top: 0;
 }
 
 .edit-post-sidebar__panel-tab {
@@ -12,7 +14,7 @@
 	border: none;
 	border-radius: 0;
 	cursor: pointer;
-	height: 50px;
+	height: $grid-size * 6;
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 400;

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -6,7 +6,7 @@
 	bottom: 0;
 	width: $sidebar-width;
 	border-left: $border-width solid $light-gray-500;
-	background: $light-gray-300;
+	background: $white;
 	color: $dark-gray-500;
 	height: 100vh;
 	overflow: hidden;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -34,7 +34,6 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	background: $light-gray-300;
 	padding: 0 $panel-padding;
 	height: 50px;
 	border-top: $border-width solid $light-gray-500;


### PR DESCRIPTION
This PR extracts an idea from #9784, a white sidebar.

This looks a little jarring at first, but can grow on you. Because it's sort of a jarring change, I think it needs to be tested in a PR, rather than be discussed. That way people can actually _feel_ it, rather than look at screenshots.

What do you think?

Before:

<img width="1192" alt="screen shot 2018-09-20 at 11 21 01" src="https://user-images.githubusercontent.com/1204802/45809323-2b419700-bcc8-11e8-9826-adda036240fe.png">

After:

<img width="1201" alt="screen shot 2018-09-20 at 11 24 18" src="https://user-images.githubusercontent.com/1204802/45809327-2d0b5a80-bcc8-11e8-9813-1602db76bfe2.png">

Especially in fullscreen mode this works:

<img width="1325" alt="screen shot 2018-09-20 at 11 26 06" src="https://user-images.githubusercontent.com/1204802/45809338-35639580-bcc8-11e8-98fd-49f8a7b27614.png">
