### PR TITLE
Make drag handle visible on hover in nested

### DIFF
--- a/packages/editor/src/components/block-mover/style.scss
+++ b/packages/editor/src/components/block-mover/style.scss
@@ -1,7 +1,6 @@
 .editor-block-mover {
 	min-height: $empty-paragraph-height;
-
-	opacity: 0;
+	//opacity: 0;
 
 	&.is-visible {
 		@include fade_in;
@@ -13,7 +12,7 @@
 	// Don't do this for wide, fullwide, or mobile.
 	@include break-small() {
 		.editor-block-list__block:not([data-align="wide"]):not([data-align="full"]) & {
-			margin-top: -8px;
+			margin-top: -$grid-size;
 		}
 	}
 }
@@ -92,7 +91,7 @@
 			background: $white;
 			box-shadow: inset 0 0 0 1px $light-gray-500;
 
-			&:first-child {
+			&:nth-child(-n+2) {
 				margin-bottom: -1px;
 			}
 

--- a/packages/editor/src/components/block-mover/style.scss
+++ b/packages/editor/src/components/block-mover/style.scss
@@ -58,6 +58,7 @@
 	cursor: move; // Fallback for IE/Edge < 14
 	cursor: grab;
 	fill: currentColor;
+	border-radius: $radius-round-rectangle;
 
 	&,
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,

--- a/packages/editor/src/components/block-mover/style.scss
+++ b/packages/editor/src/components/block-mover/style.scss
@@ -23,12 +23,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	border: none;
-	outline: none;
-	background: none;
 	cursor: pointer;
 	padding: 0;
-	border-radius: $radius-round-rectangle;
 
 	// Carefully adjust the size of the side UI to fit one paragraph of text (56px).
 	width: $block-side-ui-width;
@@ -55,38 +51,6 @@
 		.is-dark-theme & {
 			color: $light-opacity-light-300;
 		}
-	}
-
-	// Apply a background in nested contexts, only on desktop.
-	@include break-small() {
-		.editor-block-list__layout .editor-block-list__layout & {
-			background: $white;
-			box-shadow: inset 0 0 0 1px $light-gray-500;
-
-			&:first-child {
-				margin-bottom: -1px;
-			}
-
-			&:hover,
-			&:active,
-			&:focus {
-				// Buttons are stacked with overlapping border to look like a unit, so elevate on interactions.
-				z-index: z-index(".editor-block-mover__control");
-			}
-		}
-	}
-
-	// Hover, active and focus styles
-	&:not(:disabled):not([aria-disabled="true"]):hover {
-		@include button-style__hover;
-	}
-
-	&:not(:disabled):not([aria-disabled="true"]):active {
-		@include button-style__active;
-	}
-
-	&:not(:disabled):not([aria-disabled="true"]):focus {
-		@include button-style__focus-active;
 	}
 }
 
@@ -117,4 +81,26 @@
 
 .editor-block-mover__description {
 	display: none;
+}
+
+// Apply a background in nested contexts, only on desktop.
+.editor-block-mover__control-drag-handle:not(:disabled):not([aria-disabled="true"]):not(.is-default),
+.editor-block-mover__control {
+	@include break-small() {
+		.editor-block-list__layout .editor-block-list__layout & {
+			background: $white;
+			box-shadow: inset 0 0 0 1px $light-gray-500;
+
+			&:first-child {
+				margin-bottom: -1px;
+			}
+
+			&:hover,
+			&:active,
+			&:focus {
+				// Buttons are stacked with overlapping border to look like a unit, so elevate on interactions.
+				z-index: z-index(".editor-block-mover__control");
+			}
+		}
+	}
 }

--- a/packages/editor/src/components/block-mover/style.scss
+++ b/packages/editor/src/components/block-mover/style.scss
@@ -1,6 +1,6 @@
 .editor-block-mover {
 	min-height: $empty-paragraph-height;
-	//opacity: 0;
+	opacity: 0;
 
 	&.is-visible {
 		@include fade_in;


### PR DESCRIPTION
In nested contexts, the drag handle doesn't have a background on hover like the up/down arrows. This PR refactors things a bit and fixes it up.

Before:

<img width="272" alt="screen shot 2018-09-20 at 11 43 20" src="https://user-images.githubusercontent.com/1204802/45811579-bbcea600-bccd-11e8-8ab0-a357f7c9435c.png">

After:

<img width="304" alt="screen shot 2018-09-20 at 12 05 25" src="https://user-images.githubusercontent.com/1204802/45811583-bec99680-bccd-11e8-8f76-5302aec6ac3a.png">
