### PR TITLE
Allow block HTML validation to be disabled

### DIFF
--- a/block-library/html/index.js
+++ b/block-library/html/index.js
@@ -30,6 +30,7 @@ export const settings = {
 		customClassName: false,
 		className: false,
 		html: false,
+		htmlValidation: false,
 	},
 
 	attributes: {

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -449,6 +449,13 @@ className: false,
 html: false,
 ```
 
+- `htmlValidation` (default `true`): By default, all blocks will validate their HTML. To disable this behaviour, set `htmlValidation` to `false`.
+
+```js
+// Remove support for HTML validation.
+htmlValidation: false,
+```
+
 - `inserter` (default `true`): By default, all blocks will appear in the Gutenberg inserter. To hide a block so that it can only be inserted programatically, set `inserter` to `false`.
 
 ```js

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -519,5 +519,22 @@ describe( 'validation', () => {
 
 			expect( isValid ).toBe( true );
 		} );
+
+		it( 'returns true if block is invalid and htmlValidation is disabled block', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				supports: {
+					htmlValidation: false,
+				},
+			} );
+
+			const isValid = isValidBlock(
+				'Bananas',
+				getBlockType( 'core/test-block' ),
+				{ fruit: 'Not bananas' }
+			);
+
+			expect( isValid ).toBe( true );
+		} );
 	} );
 } );

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -8,6 +8,7 @@ import { xor, fromPairs, isEqual, includes, stubTrue } from 'lodash';
  * Internal dependencies
  */
 import { getSaveContent } from './serializer';
+import { hasBlockSupport } from './registration';
 
 /**
  * Globally matches any consecutive whitespace
@@ -464,6 +465,11 @@ export function isEquivalentHTML( actual, expected ) {
  * @return {boolean} Whether block is valid.
  */
 export function isValidBlock( innerHTML, blockType, attributes ) {
+	// Validate blocks that support it, otherwise assume it is valid
+	if ( ! hasBlockSupport( blockType.name, 'htmlValidation', true ) ) {
+		return true;
+	}
+
 	let saveContent;
 	try {
 		saveContent = getSaveContent( blockType, attributes );


### PR DESCRIPTION
Adds a block support flag to allow HTML validation to be disabled (`htmlValidation`).

The flag is enabled by default, but disabled for the HTML block. This allows the HTML block to support any content, not just what Gutenberg can validate.

This does allow invalid HTML to be entered, and it could be argued that if a user wants to do this via a custom HTML block then we shouldn't stop them. Additionally, what Gutenberg thinks of as valid HTML and what a browser does may not be the same, so being less controlling should allow for a smoother transition for people with existing custom HTML.

Fixes part of #9198
Fixes #9898

Note that custom HTML will still run through `hpq`, and this is likely to transform it in some way. Ideally this can be changed to make Gutenberg less opinionated about custom HTML. I'll look at this separately.

## How has this been tested?
Additional unit tests added for validation with the `htmlValidation` flag enabled.

## Types of changes
Changes HTML validation.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
