### PR TITLE
Add a hover state to sidebar panel headers

### DIFF
--- a/edit-post/components/sidebar/block-sidebar/style.scss
+++ b/edit-post/components/sidebar/block-sidebar/style.scss
@@ -11,7 +11,7 @@
 	}
 
 	.components-panel__body-toggle {
-		color: $dark-gray-500;
+		color: $dark-gray-900;
 	}
 
 	&:first-child {

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -28,6 +28,10 @@
 	&.is-opened {
 		padding: $panel-padding;
 	}
+
+	> .components-icon-button {
+		color: $dark-gray-900;
+	}
 }
 
 .components-panel__header {
@@ -71,11 +75,6 @@
 .components-panel__body:not(.is-opened) > .components-panel__body-title:hover,
 .edit-post-last-revision__panel > .components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 	background: $light-gray-100;
-
-	.components-button,
-	.components-panel__arrow {
-		color: $dark-gray-900;
-	}
 }
 
 .components-panel__body-toggle.components-button {
@@ -85,7 +84,7 @@
 	width: 100%;
 	font-weight: 600;
 	text-align: left;
-	color: $dark-gray-500;
+	color: $dark-gray-900;
 	@include menu-style__neutral;
 	transition: 0.1s background ease-in-out;
 
@@ -98,7 +97,7 @@
 		right: $item-spacing;
 		top: 50%;
 		transform: translateY(-50%);
-		color: $dark-gray-500;
+		color: $dark-gray-900;
 		fill: currentColor;
 		transition: 0.1s color ease-in-out;
 	}

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -60,10 +60,24 @@
 	font-size: inherit;
 	margin-top: 0;
 	margin-bottom: 0;
+	transition: 0.1s background ease-in-out;
+
+	&:hover {
+		background: $light-gray-100;
+
+		.components-button,
+		.components-panel__arrow {
+			color: $dark-gray-900;
+		}
+	}
 }
 .components-panel__body.is-opened > .components-panel__body-title {
 	margin: -1 * $panel-padding;
 	margin-bottom: 5px;
+
+	&:hover {
+		background: transparent;
+	}
 }
 
 .components-panel__body-toggle.components-button {
@@ -73,8 +87,9 @@
 	width: 100%;
 	font-weight: 600;
 	text-align: left;
-	color: $dark-gray-900;
+	color: $dark-gray-500;
 	@include menu-style__neutral;
+	transition: 0.1s background ease-in-out;
 
 	&:focus:not(:disabled):not([aria-disabled="true"]) {
 		@include menu-style__focus;
@@ -85,8 +100,9 @@
 		right: $item-spacing;
 		top: 50%;
 		transform: translateY(-50%);
-		color: $dark-gray-900;
+		color: $dark-gray-500;
 		fill: currentColor;
+		transition: 0.1s color ease-in-out;
 	}
 
 	// mirror the arrow horizontally in RTL languages

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -61,22 +61,20 @@
 	margin-top: 0;
 	margin-bottom: 0;
 	transition: 0.1s background ease-in-out;
-
-	&:hover {
-		background: $light-gray-100;
-
-		.components-button,
-		.components-panel__arrow {
-			color: $dark-gray-900;
-		}
-	}
 }
 .components-panel__body.is-opened > .components-panel__body-title {
 	margin: -1 * $panel-padding;
 	margin-bottom: 5px;
+}
 
-	&:hover {
-		background: transparent;
+// Hover States
+.components-panel__body:not(.is-opened) > .components-panel__body-title:hover,
+.edit-post-last-revision__panel > .components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+	background: $light-gray-100;
+
+	.components-button,
+	.components-panel__arrow {
+		color: $dark-gray-900;
 	}
 }
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -72,7 +72,7 @@
 }
 
 // Hover States
-.components-panel__body:not(.is-opened) > .components-panel__body-title:hover,
+.components-panel__body > .components-panel__body-title:hover,
 .edit-post-last-revision__panel > .components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 	background: $light-gray-100;
 }


### PR DESCRIPTION
This PR adds a hover state to sidebar panels. When a panel is closed:

- The background changes to a light gray on hover
- The text and icon change from $dark-gray-500 to $dark-gray-900

When a panel is already open, the text and icon color changes, but the background does not. 

This helps subtly differentiate collapsed panels from uncollapsed ones, and provides another visual cue reinforcement that these headers are interactive. 

This _does_ lighten the un-hovered color of these headers to our usual `$dark-gray-500` text color, but I don't think it effects their effectiveness as headers. 

## Screenshots

_Closed, default:_ 
<img width="284" alt="screen shot 2018-09-20 at 9 46 17 am" src="https://user-images.githubusercontent.com/1202812/45822747-2970d700-bcba-11e8-996c-a6f65022d490.png">

_Closed, hovered:_ 
<img width="284" alt="screen shot 2018-09-20 at 9 46 31 am" src="https://user-images.githubusercontent.com/1202812/45822791-3392d580-bcba-11e8-9e8c-b965d826ea43.png">

_Open, default:_
<img width="283" alt="screen shot 2018-09-20 at 9 46 39 am" src="https://user-images.githubusercontent.com/1202812/45822814-3b527a00-bcba-11e8-9d73-6042fc172107.png">

_Open, title is hovered:_
<img width="282" alt="screen shot 2018-09-20 at 9 46 50 am" src="https://user-images.githubusercontent.com/1202812/45822846-51f8d100-bcba-11e8-9128-df566002fb41.png">


## GIF

(The subtle background color isn't quite visible due to the compression 😕)

![sidebar](https://user-images.githubusercontent.com/1202812/45822903-7b196180-bcba-11e8-9687-912055fab180.gif)

This also works nicely alongside #10062:

![sidebar-white](https://user-images.githubusercontent.com/1202812/45822931-88365080-bcba-11e8-823a-6d01a3dc26ca.gif)