### PR TITLE
Fix minor punctuation typo in comment

### DIFF
--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -11,7 +11,7 @@
 	left: 0;
 	right: 0;
 
-	// Stick the toolbar to the top, because the admin bar is not fixed on mobile..
+	// Stick the toolbar to the top, because the admin bar is not fixed on mobile.
 	top: 0;
 	position: sticky;
 


### PR DESCRIPTION
This is a PR that fixes a punctuation typo in a comment where there were 2 periods instead of just 1 at the end of a sentence.