### PR TITLE
Add inlineStyle matcher for sourcing block attributes

### DIFF
--- a/docs/block-api/attributes.md
+++ b/docs/block-api/attributes.md
@@ -77,6 +77,26 @@ _Example_: Extract child nodes from a paragraph of rich text.
 // }
 ```
 
+### `styleProperty`
+
+Use `inlineStyle` to extract a value from the inline style declaration of the matched element.
+
+_Example_: Extract the width value from the an inline style
+
+```js
+{
+	width: {
+		type: 'string',
+		source: 'inlineStyle',
+		selector: 'div',
+		styleProperty: 'width'
+	}
+}
+// {
+//   "width": "20px" 
+// }
+```
+
 ### `query`
 
 Use `query` to extract an array of values from markup. Entries of the array are determined by the selector argument, where each matched element within the block will have an entry structured corresponding to the second argument, an object of attribute sources.

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -112,6 +112,11 @@ export function matcherFromSource( sourceConfig ) {
 			return children( sourceConfig.selector );
 		case 'node':
 			return node( sourceConfig.selector );
+		case 'inlineStyle':
+			return flow( [
+				prop( sourceConfig.selector, `style.${ sourceConfig.styleProperty }` ),
+				( value ) => value !== '' ? value : undefined,
+			] );
 		case 'query':
 			const subMatchers = mapValues( sourceConfig.query, matcherFromSource );
 			return query( sourceConfig.selector, subMatchers );
@@ -164,6 +169,7 @@ export function getBlockAttribute( attributeKey, attributeSchema, innerHTML, com
 		case 'text':
 		case 'children':
 		case 'node':
+		case 'inlineStyle':
 		case 'query':
 		case 'tag':
 			value = parseWithAttributeSchema( innerHTML, attributeSchema );

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -137,7 +137,7 @@ describe( 'block parser', () => {
 	} );
 
 	describe( 'parseWithAttributeSchema', () => {
-		it( 'should return the matcher’s attribute value', () => {
+		it( 'should return the matcher’s text content value', () => {
 			const value = parseWithAttributeSchema(
 				'<div>chicken</div>',
 				{
@@ -147,6 +147,19 @@ describe( 'block parser', () => {
 				},
 			);
 			expect( value ).toBe( 'chicken' );
+		} );
+
+		it( 'should return the matcher’s style property value', () => {
+			const value = parseWithAttributeSchema(
+				'<div style="width: 10px">chicken</div>',
+				{
+					type: 'string',
+					source: 'inlineStyle',
+					selector: 'div',
+					styleProperty: 'width',
+				},
+			);
+			expect( value ).toBe( '10px' );
 		} );
 
 		it( 'should return the matcher’s string attribute value', () => {
@@ -216,7 +229,7 @@ describe( 'block parser', () => {
 			expect( value ).toBe( 10 );
 		} );
 
-		it( "should return the matcher's attribute value", () => {
+		it( "should return the matcher's text content value", () => {
 			const value = getBlockAttribute(
 				'content',
 				{
@@ -228,6 +241,21 @@ describe( 'block parser', () => {
 				{}
 			);
 			expect( value ).toBe( 'chicken' );
+		} );
+
+		it( "returns the matcher's style property value", () => {
+			const value = getBlockAttribute(
+				'content',
+				{
+					type: 'string',
+					source: 'inlineStyle',
+					selector: 'div',
+					styleProperty: 'width',
+				},
+				'<div style="width:10px">chicken</div>',
+				{}
+			);
+			expect( value ).toBe( '10px' );
 		} );
 
 		it( 'should return undefined for meta attributes', () => {


### PR DESCRIPTION
Allows sourcing of a block attribute from an inline style

## Description
I added this as part of #9801, but thought I'd break it out into a separate PR so that it can undergo a bit more scrutiny (and to make that PR a bit smaller).

#9801 adds width and height controls for tables in a table block and I wanted to be able to source the height and width directly from the inline styles. When pasting markup, the attributes can then be sourced directly from the styles instead of the json object, as demonstrated by this gif:
![pasting-table](https://user-images.githubusercontent.com/677833/45374186-484fd900-b5e9-11e8-82f9-2b6542c177f0.gif)

I think its also advantageous to encode attributes in the markup when possible for portability. It might also be possible to use this matcher in other existing blocks (e.g. image) that also have width and height attributes that result in inline styles.

This is the first time I've touched matchers, so it'd be good to know if there are any downsides to this approach.

## How has this been tested?
I tested across all supported desktop browsers and this seems to work everywhere. MS Edge has a separate bug that I discovered in testing and there's a fix for that here:
https://github.com/WordPress/gutenberg/pull/10077

I did manage to verify that this works when the edge fix was applied to this branch.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
