### PR TITLE
Fix raw transforms not working in Edge when pasting content

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -9,6 +9,7 @@ import {
 	forEach,
 	identity,
 	isEqual,
+	isNil,
 	merge,
 	noop,
 } from 'lodash';
@@ -230,7 +231,13 @@ export class RichText extends Component {
 	 */
 	onPaste( event ) {
 		const clipboardData = event.clipboardData;
-		const { items = [], files = [] } = clipboardData;
+		let { items, files } = clipboardData;
+
+		// In Edge these properties can be null instead of undefined, so a more
+		// rigorous test is required over using default values.
+		items = isNil( items ) ? [] : items;
+		files = isNil( files ) ? [] : files;
+
 		const item = find( [ ...items, ...files ], ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
 		let plainText = '';
 		let html = '';


### PR DESCRIPTION
## Description
I noticed raw transforms weren't being triggered in MS Edge when pasting markup.

**Diagnosis**
This error is being thrown
```
Invalid attempt to spread non-iterable instance
```

that's being thrown on line 234 here:
https://github.com/WordPress/gutenberg/blob/e5d77bd5e7dea2147a503cdad1e89945648753e1/packages/editor/src/components/rich-text/index.js#L233-L234

`items` is a DataTransferItemList and `files` is null. Because files is null a default value of `[]` is not being set (in the destructuring on line 233). 

**Fix**
I've added a check for both null and undefined using lodash `isNil`.

## How has this been tested?
In Edge:
- Paste some markup that will trigger a raw transform:
```
<table>
	<tbody>
		<tr>
			<td>1</td>
			<td>2</td>
		</tr>
		<tr>
			<td>3</td>
			<td>4</td>
		</tr>
	</tbody>
</table>
```
- Observe that a table block is created and no errors are thrown.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
