### PR TITLE
Try: Improve floats UI.

### DIFF
--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -1,7 +1,8 @@
 .wp-block-embed {
 	margin: 0;
-	clear: both; // Necessary because we use responsive trickery to set width/height, and therefore the video doesn't intrinsically clear floats like an image does.
-
+	// Necessary because we use responsive trickery to set width/height,
+	// therefore the video doesn't intrinsically clear floats like an image does.
+	clear: both;
 	// Apply a min-width, or the embed can collapse when floated.
 	min-width: $break-mobile / 2;
 

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -1,6 +1,9 @@
 .wp-block-embed {
 	margin: 0;
-	clear: both; // necessary because we use responsive trickery to set width/height, and therefore the video doesn't intrinsically clear floats like an img does
+	clear: both; // Necessary because we use responsive trickery to set width/height, and therefore the video doesn't intrinsically clear floats like an image does.
+
+	// Apply a min-width, or the embed can collapse when floated.
+	min-width: $break-mobile / 2;
 
 	&.is-loading {
 		display: flex;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -287,28 +287,62 @@
 		.editor-block-contextual-toolbar {
 			margin-bottom: $border-width;
 		}
+
+		// Hide all additional UI on floats.
+		.editor-block-mover,
+		.editor-block-list__block-mobile-toolbar {
+			display: none;
+		}
+
+		// Position toolbar better on mobile.
+		.editor-block-contextual-toolbar {
+			border-bottom: 1px solid $light-gray-500;
+			bottom: $block-padding;
+			left: auto;
+			right: auto;
+		}
 	}
 
-	// Left: This is in the editor only; the image should be floated on the frontend.
-	&[data-align="left"] > .editor-block-list__block-edit {
-		/*!rtl:begin:ignore*/
-		float: left;
-		margin-right: 2em;
-		/*!rtl:end:ignore*/
+	// Left
+	&[data-align="left"] {
+		// This is in the editor only; the image should be floated on the frontend.
+		.editor-block-list__block-edit {
+			/*!rtl:begin:ignore*/
+			float: left;
+			margin-right: 2em;
+			/*!rtl:end:ignore*/
+		}
+
+		// Align block toolbar to floated content.
+		@include break-small() {
+			.editor-block-toolbar {
+				/*!rtl:begin:ignore*/
+				left: $block-padding;
+				right: auto;
+				/*!rtl:end:ignore*/
+			}
+		}
 	}
 
-	// Right: This is in the editor only; the image should be floated on the frontend.
-	&[data-align="right"] > .editor-block-list__block-edit {
-		/*!rtl:begin:ignore*/
-		float: right;
-		margin-left: 2em;
-		/*!rtl:end:ignore*/
-	}
+	// Right
+	&[data-align="right"] {
+		// Right: This is in the editor only; the image should be floated on the frontend.
+		> .editor-block-list__block-edit {
+			/*!rtl:begin:ignore*/
+			float: right;
+			margin-left: 2em;
+			/*!rtl:end:ignore*/
+		}
 
-	&[data-align="right"] > .editor-block-contextual-toolbar > .editor-block-toolbar {
-		/*!rtl:begin:ignore*/
-		float: right;
-		/*!rtl:end:ignore*/
+		// Align block toolbar to floated content.
+		@include break-small() {
+			.editor-block-toolbar {
+				/*!rtl:begin:ignore*/
+				right: $block-padding;
+				left: auto;
+				/*!rtl:end:ignore*/
+			}
+		}
 	}
 
 	// Wide and full-wide
@@ -801,21 +835,6 @@
 		position: absolute;
 		left: 0;
 	}
-
-	.editor-block-list__block[data-align="right"] & {
-		/*!rtl:begin:ignore*/
-		left: auto;
-		right: 0;
-		/*!rtl:end:ignore*/
-	}
-
-	.editor-block-list__block[data-align="left"] & {
-		/*!rtl:begin:ignore*/
-		right: auto;
-		left: 0;
-		/*!rtl:end:ignore*/
-	}
-
 
 	@include break-small() {
 		width: auto;


### PR DESCRIPTION
This PR tries to improve the block UI on floated elements. It does a few things:

- It hides the side UI entirely. Because this is now just the ellipsis and drag handle, this is not the end of the world. The argument being, that when you need to move an image up or down, you do it before you float. And the side UI overlapped with parents anyway, so the only alternative was to use the mobile UI (buttons below the block), for floats. This was not as compelling as initially thought.
- Because the block outline is hidden on floated UI anyway (it has to be, because it doesn't know how tall the floated content is due to the nature of floats), the toolbar looked offset to the side. This PR positions the block toolbar to better align with the float.
- Improves the mobile UI for floats, it was quite broken.
- It adds a min-width to embeds, which after the most recent responsive feature would collapse completely when floated.

Screenshot. No side UI:

<img width="552" alt="no side ui" src="https://user-images.githubusercontent.com/1204802/45871354-9acd8a00-bd8d-11e8-8bcd-7f05c87c33d2.png">

Improved mobile UI:

<img width="476" alt="improved mobile positioning" src="https://user-images.githubusercontent.com/1204802/45871361-9f923e00-bd8d-11e8-8a35-5409754089fa.png">

Min width for embeds:

<img width="565" alt="min width for embeds" src="https://user-images.githubusercontent.com/1204802/45871372-a456f200-bd8d-11e8-943c-2afa6f55eb15.png">

Right floated toolbar positioning:

<img width="658" alt="positioning for right floated" src="https://user-images.githubusercontent.com/1204802/45871377-a91ba600-bd8d-11e8-97fa-1bcf5a67193e.png">

Left floated toolbar positioning:

<img width="473" alt="positioning for left floated" src="https://user-images.githubusercontent.com/1204802/45871395-b2a50e00-bd8d-11e8-9dd3-7886725b7d28.png">
