### PR TITLE
Try: Hide gallery crop option from IE.

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -221,6 +221,7 @@ class GalleryEdit extends Component {
 							max={ Math.min( MAX_COLUMNS, images.length ) }
 						/> }
 						<ToggleControl
+							className="components-toggle-control__crop"
 							label={ __( 'Crop Images' ) }
 							checked={ !! imageCrop }
 							onChange={ this.toggleImageCrop }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -130,3 +130,12 @@
 	left: 50%;
 	transform: translate(-50%, -50%);
 }
+
+// Because IE doesn't handle cropping, we hide the control entirely.
+.components-toggle-control__crop {
+	display: none;
+
+	@supports (position: sticky) {
+		display: inherit;
+	}
+}

--- a/packages/components/src/toggle-control/index.js
+++ b/packages/components/src/toggle-control/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { isFunction } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -29,8 +30,12 @@ class ToggleControl extends Component {
 	}
 
 	render() {
-		const { label, checked, help, instanceId } = this.props;
+		const { label, checked, help, instanceId, className } = this.props;
 		const id = `inspector-toggle-control-${ instanceId }`;
+		const classes = classnames(
+			'components-toggle-control',
+			className,
+		);
 
 		let describedBy, helpLabel;
 		if ( help ) {
@@ -43,7 +48,7 @@ class ToggleControl extends Component {
 				label={ label }
 				id={ id }
 				help={ helpLabel }
-				className="components-toggle-control"
+				className={ classes }
 			>
 				<FormToggle
 					id={ id }


### PR DESCRIPTION
IE doesn't support object-fit for cropping using CSS.

This PR adds the ability to give a CSS classname to the toggle control, then proceeds to use that CSS class to hide it for all browsers including IE, then unhide it for modern browsers.

I wish it could be the other way around — show it for all browsers, hide it for IE. But alas there doesn't seem to be a solid CSS hack for this.

What do you think?

Screenshots. Chrome:

<img width="975" alt="screen shot 2018-09-21 at 11 26 10" src="https://user-images.githubusercontent.com/1204802/45872971-aae76880-bd91-11e8-9f6d-083aa4766a88.png">

IE:

<img width="1474" alt="screen shot 2018-09-21 at 11 26 31" src="https://user-images.githubusercontent.com/1204802/45872979-af138600-bd91-11e8-8305-4734767a2270.png">

Edge:

<img width="1500" alt="screen shot 2018-09-21 at 11 26 59" src="https://user-images.githubusercontent.com/1204802/45872983-b20e7680-bd91-11e8-9e13-d374bf9df683.png">
