### PR TITLE
Placeholder: Consistent input field width

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -35,7 +35,7 @@
 	flex-direction: row;
 	justify-content: center;
 	width: 100%;
-	max-width: 280px;
+	max-width: 400px;
 	flex-wrap: wrap;
 	z-index: z-index(".components-placeholder__fieldset");
 


### PR DESCRIPTION
## Description
To make the Placeholder form width consistent with the MediaPlaceholder form and to show the full input placeholder with the german translation, this PR sets the max-width to 400px.

Fixes #8107

## Screenshots
**Before**
<img width="671" alt="bildschirmfoto 2018-09-21 um 12 35 55" src="https://user-images.githubusercontent.com/695201/45876707-af188380-bd9b-11e8-9afd-514f4e7862c1.png">

**After**
<img width="709" alt="bildschirmfoto 2018-09-21 um 12 35 32" src="https://user-images.githubusercontent.com/695201/45876712-b17add80-bd9b-11e8-9a08-80f228c3e21e.png">

