### PR TITLE
Data: Support adding and updating entities

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1749,4 +1749,13 @@ Returns an action object used to signal that post saving is unlocked.
 
  * lockName: The lock name.
 
+### addTermToEditedPost
+
+Returns an action object signaling that a new term is added to the edited post.
+
+*Parameters*
+
+ * slug: Taxonomy slug.
+ * term: Term object.
+
 ### createNotice

--- a/docs/data/data-core.md
+++ b/docs/data/data-core.md
@@ -183,3 +183,13 @@ a given URl has been received.
 
  * url: URL to preview the embed for.
  * preview: Preview data.
+
+### saveEntityRecord
+
+Action triggered to save an entity record.
+
+*Parameters*
+
+ * kind: Kind of the received entity.
+ * name: Name of the received entity.
+ * record: Record to be saved.

--- a/docs/data/data-core.md
+++ b/docs/data/data-core.md
@@ -165,6 +165,7 @@ Returns an action object used in signalling that entity records have been receiv
  * name: Name of the received entity.
  * records: Records received.
  * query: Query Object.
+ * invalidateCache: Should invalidate query caches
 
 ### receiveThemeSupports
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2168,12 +2168,6 @@
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.10",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"equivalent-key-map": {
-					"version": "0.2.2",
-					"bundled": true
-				}
 			}
 		},
 		"@wordpress/custom-templated-path-webpack-plugin": {
@@ -2196,12 +2190,6 @@
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.10",
 				"redux": "^4.0.0"
-			},
-			"dependencies": {
-				"equivalent-key-map": {
-					"version": "0.2.2",
-					"bundled": true
-				}
 			}
 		},
 		"@wordpress/date": {
@@ -7051,6 +7039,11 @@
 			"requires": {
 				"lodash": "^4.17.4"
 			}
+		},
+		"equivalent-key-map": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew=="
 		},
 		"errno": {
 			"version": "0.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2165,7 +2165,7 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/url": "file:packages/url",
-				"equivalent-key-map": "^0.2.1",
+				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.10",
 				"rememo": "^3.0.0"
 			}
@@ -2186,8 +2186,12 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/redux-routine": "file:packages/redux-routine",
+<<<<<<< HEAD
 				"equivalent-key-map": "^0.2.0",
 				"is-promise": "^2.1.0",
+=======
+				"equivalent-key-map": "^0.2.2",
+>>>>>>> Packages: Bump equivalent-key-map to 0.2.2
 				"lodash": "^4.17.10",
 				"redux": "^4.0.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2168,6 +2168,12 @@
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.10",
 				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"equivalent-key-map": {
+					"version": "0.2.2",
+					"bundled": true
+				}
 			}
 		},
 		"@wordpress/custom-templated-path-webpack-plugin": {
@@ -2186,14 +2192,16 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/redux-routine": "file:packages/redux-routine",
-<<<<<<< HEAD
-				"equivalent-key-map": "^0.2.0",
-				"is-promise": "^2.1.0",
-=======
 				"equivalent-key-map": "^0.2.2",
->>>>>>> Packages: Bump equivalent-key-map to 0.2.2
+				"is-promise": "^2.1.0",
 				"lodash": "^4.17.10",
 				"redux": "^4.0.0"
+			},
+			"dependencies": {
+				"equivalent-key-map": {
+					"version": "0.2.2",
+					"bundled": true
+				}
 			}
 		},
 		"@wordpress/date": {
@@ -7043,11 +7051,6 @@
 			"requires": {
 				"lodash": "^4.17.4"
 			}
-		},
-		"equivalent-key-map": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.1.tgz",
-			"integrity": "sha512-dmHJQuM7gMbZexuf9DfZdFUyeCUs2Srpa8Proo1TGC4YAF5UsLO+SNSFDvsf43kFJRLEKxpmGCAFNLOf6OjNPw=="
 		},
 		"errno": {
 			"version": "0.1.7",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -25,7 +25,7 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"@wordpress/url": "file:../url",
-		"equivalent-key-map": "^0.2.1",
+		"equivalent-key-map": "^0.2.2",
 		"lodash": "^4.17.10",
 		"rememo": "^3.0.0"
 	},

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -10,7 +10,7 @@ import {
 	receiveItems,
 	receiveQueriedItems,
 } from './queried-data';
-import { getKindEntities } from './entities';
+import { getKindEntities, DEFAULT_ENTITY_KEY } from './entities';
 import { apiFetch } from './controls';
 
 /**
@@ -116,7 +116,7 @@ export function* saveEntityRecord( kind, name, record ) {
 	if ( ! entity ) {
 		return;
 	}
-	const key = entity[ key ] || 'id';
+	const key = entity.key || DEFAULT_ENTITY_KEY;
 	const recordId = record[ key ];
 	const updatedRecord = yield apiFetch( {
 		path: `${ entity.baseURL }${ recordId ? '/' + recordId : '' }`,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -46,14 +46,15 @@ export function addEntities( entities ) {
 /**
  * Returns an action object used in signalling that entity records have been received.
  *
- * @param {string}       kind    Kind of the received entity.
- * @param {string}       name    Name of the received entity.
- * @param {Array|Object} records Records received.
- * @param {?Object}      query  Query Object.
+ * @param {string}       kind            Kind of the received entity.
+ * @param {string}       name            Name of the received entity.
+ * @param {Array|Object} records         Records received.
+ * @param {?Object}      query           Query Object.
+ * @param {?boolean}     invalidateCache Should invalidate query caches
  *
  * @return {Object} Action object.
  */
-export function receiveEntityRecords( kind, name, records, query ) {
+export function receiveEntityRecords( kind, name, records, query, invalidateCache = false ) {
 	let action;
 	if ( query ) {
 		action = receiveQueriedItems( records, query );
@@ -65,6 +66,7 @@ export function receiveEntityRecords( kind, name, records, query ) {
 		...action,
 		kind,
 		name,
+		invalidateCache,
 	};
 }
 
@@ -121,7 +123,7 @@ export function* saveEntityRecord( kind, name, record ) {
 		method: recordId ? 'PUT' : 'POST',
 		data: record,
 	} );
-	yield receiveEntityRecords( kind, name, updatedRecord );
+	yield receiveEntityRecords( kind, name, updatedRecord, undefined, true );
 
 	return updatedRecord;
 }

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -9,6 +9,8 @@ import { upperFirst, camelCase, map, find } from 'lodash';
 import { addEntities } from './actions';
 import { apiFetch, select } from './controls';
 
+export const DEFAULT_ENTITY_KEY = 'id';
+
 export const defaultEntities = [
 	{ name: 'postType', kind: 'root', key: 'slug', baseURL: '/wp/v2/types' },
 	{ name: 'media', kind: 'root', baseURL: '/wp/v2/media', plural: 'mediaItems' },

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { pick } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { registerStore } from '@wordpress/data';
@@ -21,20 +26,23 @@ const createEntityRecordSelector = ( source ) => defaultEntities.reduce( ( resul
 	return result;
 }, {} );
 
-const createEntityRecordResolver = ( source ) => defaultEntities.reduce( ( result, entity ) => {
+const createEntityRecordResolverOrAction = ( source ) => defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name ) ] = ( key ) => source.getEntityRecord( kind, name, key );
 	result[ getMethodName( kind, name, 'get', true ) ] = ( ...args ) => source.getEntityRecords( kind, name, ...args );
 	return result;
 }, {} );
 
-const entityResolvers = createEntityRecordResolver( resolvers );
+const entityActions = createEntityRecordResolverOrAction(
+	pick( actions, [ 'saveEntityRecord' ] )
+);
+const entityResolvers = createEntityRecordResolverOrAction( resolvers );
 const entitySelectors = createEntityRecordSelector( selectors );
 
 const store = registerStore( REDUCER_KEY, {
 	reducer,
-	actions,
 	controls,
+	actions: { ...actions, ...entityActions },
 	selectors: { ...selectors, ...entitySelectors },
 	resolvers: { ...resolvers, ...entityResolvers },
 } );

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -26,17 +26,26 @@ const createEntityRecordSelector = ( source ) => defaultEntities.reduce( ( resul
 	return result;
 }, {} );
 
-const createEntityRecordResolverOrAction = ( source ) => defaultEntities.reduce( ( result, entity ) => {
+const createEntityRecordAction = ( source ) => defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name ) ] = ( key ) => source.getEntityRecord( kind, name, key );
 	result[ getMethodName( kind, name, 'get', true ) ] = ( ...args ) => source.getEntityRecords( kind, name, ...args );
 	return result;
 }, {} );
 
-const entityActions = createEntityRecordResolverOrAction(
+const createEntityRecordResolver = ( source ) => defaultEntities.reduce( ( result, entity ) => {
+	const { kind, name } = entity;
+	result[ getMethodName( kind, name ) ] = ( key ) => source.getEntityRecord( kind, name, key );
+	const pluralMethodName = getMethodName( kind, name, 'get', true );
+	result[ pluralMethodName ] = ( ...args ) => source.getEntityRecords( kind, name, ...args );
+	result[ pluralMethodName ].shouldInvalidate = ( action, ...args ) => source.getEntityRecords.shouldInvalidate( action, kind, name, ...args );
+	return result;
+}, {} );
+
+const entityActions = createEntityRecordAction(
 	pick( actions, [ 'saveEntityRecord' ] )
 );
-const entityResolvers = createEntityRecordResolverOrAction( resolvers );
+const entityResolvers = createEntityRecordResolver( resolvers );
 const entitySelectors = createEntityRecordSelector( selectors );
 
 const store = registerStore( REDUCER_KEY, {

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { pick } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { registerStore } from '@wordpress/data';
@@ -19,34 +14,32 @@ import * as resolvers from './resolvers';
 import { defaultEntities, getMethodName } from './entities';
 import { REDUCER_KEY } from './name';
 
-const createEntityRecordSelector = ( source ) => defaultEntities.reduce( ( result, entity ) => {
+// The entity selectors/resolvers and actions are shortcuts to their generic equivalents
+// (getEntityRecord, getEntityRecords, updateEntityRecord, updateEntityRecordss)
+// Instead of getEntityRecord, the consumer could use more user-frieldly named selector: getPostType, getTaxonomy...
+// The "kind" and the "name" of the entity are combined to generate these shortcuts.
+
+const entitySelectors = defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
-	result[ getMethodName( kind, name ) ] = ( state, key ) => source.getEntityRecord( state, kind, name, key );
-	result[ getMethodName( kind, name, 'get', true ) ] = ( state, ...args ) => source.getEntityRecords( state, kind, name, ...args );
+	result[ getMethodName( kind, name ) ] = ( state, key ) => selectors.getEntityRecord( state, kind, name, key );
+	result[ getMethodName( kind, name, 'get', true ) ] = ( state, ...args ) => selectors.getEntityRecords( state, kind, name, ...args );
 	return result;
 }, {} );
 
-const createEntityRecordAction = ( source ) => defaultEntities.reduce( ( result, entity ) => {
+const entityResolvers = defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
-	result[ getMethodName( kind, name ) ] = ( key ) => source.getEntityRecord( kind, name, key );
-	result[ getMethodName( kind, name, 'get', true ) ] = ( ...args ) => source.getEntityRecords( kind, name, ...args );
-	return result;
-}, {} );
-
-const createEntityRecordResolver = ( source ) => defaultEntities.reduce( ( result, entity ) => {
-	const { kind, name } = entity;
-	result[ getMethodName( kind, name ) ] = ( key ) => source.getEntityRecord( kind, name, key );
+	result[ getMethodName( kind, name ) ] = ( key ) => resolvers.getEntityRecord( kind, name, key );
 	const pluralMethodName = getMethodName( kind, name, 'get', true );
-	result[ pluralMethodName ] = ( ...args ) => source.getEntityRecords( kind, name, ...args );
-	result[ pluralMethodName ].shouldInvalidate = ( action, ...args ) => source.getEntityRecords.shouldInvalidate( action, kind, name, ...args );
+	result[ pluralMethodName ] = ( ...args ) => resolvers.getEntityRecords( kind, name, ...args );
+	result[ pluralMethodName ].shouldInvalidate = ( action, ...args ) => resolvers.getEntityRecords.shouldInvalidate( action, kind, name, ...args );
 	return result;
 }, {} );
 
-const entityActions = createEntityRecordAction(
-	pick( actions, [ 'saveEntityRecord' ] )
-);
-const entityResolvers = createEntityRecordResolver( resolvers );
-const entitySelectors = createEntityRecordSelector( selectors );
+const entityActions = defaultEntities.reduce( ( result, entity ) => {
+	const { kind, name } = entity;
+	result[ getMethodName( kind, name, 'save' ) ] = ( key ) => actions.saveEntityRecord( kind, name, key );
+	return result;
+}, {} );
 
 const store = registerStore( REDUCER_KEY, {
 	reducer,

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -12,6 +12,7 @@ import {
 	replaceAction,
 	onSubKey,
 } from '../utils';
+import { DEFAULT_ENTITY_KEY } from '../entities';
 import getQueryParts from './get-query-parts';
 
 /**
@@ -67,7 +68,7 @@ function items( state = {}, action ) {
 		case 'RECEIVE_ITEMS':
 			return {
 				...state,
-				...keyBy( action.items, action.key || 'id' ),
+				...keyBy( action.items, action.key || DEFAULT_ENTITY_KEY ),
 			};
 	}
 
@@ -107,7 +108,7 @@ const queries = flowRight( [
 	// reducer tracks only a single query object.
 	onSubKey( 'stableKey' ),
 ] )( ( state = null, action ) => {
-	const { type, page, perPage, key = 'id' } = action;
+	const { type, page, perPage, key = DEFAULT_ENTITY_KEY } = action;
 
 	if ( type !== 'RECEIVE_ITEMS' ) {
 		return state;

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -13,7 +13,7 @@ import { combineReducers } from '@wordpress/data';
  */
 import { ifMatchingAction, replaceAction } from './utils';
 import { reducer as queriedDataReducer } from './queried-data';
-import { defaultEntities } from './entities';
+import { defaultEntities, DEFAULT_ENTITY_KEY } from './entities';
 
 /**
  * Reducer managing terms state. Keyed by taxonomy slug, the value is either
@@ -125,7 +125,7 @@ function entity( entityConfig ) {
 		replaceAction( ( action ) => {
 			return {
 				...action,
-				key: entityConfig.key || 'id',
+				key: entityConfig.key || DEFAULT_ENTITY_KEY,
 			};
 		} ),
 	] )( queriedDataReducer );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -66,6 +66,15 @@ export function* getEntityRecords( kind, name, query = {} ) {
 	yield receiveEntityRecords( kind, name, Object.values( records ), query );
 }
 
+getEntityRecords.shouldInvalidate = ( action, kind, name ) => {
+	return (
+		action.type === 'RECEIVE_ITEMS' &&
+		action.invalidateCache &&
+		kind === action.kind &&
+		name === action.name
+	);
+};
+
 /**
  * Requests theme supports data from the index.
  */

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -19,7 +19,7 @@ describe( 'saveEntityRecord', () => {
 		} );
 		// Provide response and trigger action
 		const { value: received } = fulfillment.next( { ...post, id: 10 } );
-		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', { ...post, id: 10 } ) );
+		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', { ...post, id: 10 }, undefined, true ) );
 	} );
 
 	it( 'triggers a PUT request for an existing record', async () => {
@@ -37,6 +37,6 @@ describe( 'saveEntityRecord', () => {
 		} );
 		// Provide response and trigger action
 		const { value: received } = fulfillment.next( post );
-		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', post ) );
+		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', post, undefined, true ) );
 	} );
 } );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import { saveEntityRecord, receiveEntityRecords } from '../actions';
+
+describe( 'saveEntityRecord', () => {
+	it( 'triggers a POST request for a new record', async () => {
+		const post = { title: 'new post' };
+		const entities = [ { name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' } ];
+		const fulfillment = saveEntityRecord( 'postType', 'post', post );
+		// Trigger generator
+		fulfillment.next();
+		// Provide entities and trigger apiFetch
+		const { value: apiFetchAction } = fulfillment.next( entities );
+		expect( apiFetchAction.request ).toEqual( {
+			path: '/wp/v2/posts',
+			method: 'POST',
+			data: post,
+		} );
+		// Provide response and trigger action
+		const { value: received } = fulfillment.next( { ...post, id: 10 } );
+		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', { ...post, id: 10 } ) );
+	} );
+
+	it( 'triggers a PUT request for an existing record', async () => {
+		const post = { id: 10, title: 'new post' };
+		const entities = [ { name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' } ];
+		const fulfillment = saveEntityRecord( 'postType', 'post', post );
+		// Trigger generator
+		fulfillment.next();
+		// Provide entities and trigger apiFetch
+		const { value: apiFetchAction } = fulfillment.next( entities );
+		expect( apiFetchAction.request ).toEqual( {
+			path: '/wp/v2/posts/10',
+			method: 'PUT',
+			data: post,
+		} );
+		// Provide response and trigger action
+		const { value: received } = fulfillment.next( post );
+		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', post ) );
+	} );
+} );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -39,4 +39,22 @@ describe( 'saveEntityRecord', () => {
 		const { value: received } = fulfillment.next( post );
 		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', post, undefined, true ) );
 	} );
+
+	it( 'triggers a PUT request for an existing record with a custom key', async () => {
+		const postType = { slug: 'page', title: 'Pages' };
+		const entities = [ { name: 'postType', kind: 'root', baseURL: '/wp/v2/types', key: 'slug' } ];
+		const fulfillment = saveEntityRecord( 'root', 'postType', postType );
+		// Trigger generator
+		fulfillment.next();
+		// Provide entities and trigger apiFetch
+		const { value: apiFetchAction } = fulfillment.next( entities );
+		expect( apiFetchAction.request ).toEqual( {
+			path: '/wp/v2/types/page',
+			method: 'PUT',
+			data: postType,
+		} );
+		// Provide response and trigger action
+		const { value: received } = fulfillment.next( postType );
+		expect( received ).toEqual( receiveEntityRecords( 'root', 'postType', postType, undefined, true ) );
+	} );
 } );

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/redux-routine": "file:../redux-routine",
-		"equivalent-key-map": "^0.2.0",
+		"equivalent-key-map": "^0.2.2",
 		"is-promise": "^2.1.0",
 		"lodash": "^4.17.10",
 		"redux": "^4.0.0"

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -44,7 +44,7 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 
 				proxyDispatch( propName, ...args ) {
 					// Original dispatcher is a pre-bound (dispatching) action creator.
-					return mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps )[ propName ]( ...args );
+					mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps )[ propName ]( ...args );
 				}
 
 				setProxyProps( props ) {

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -44,7 +44,7 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 
 				proxyDispatch( propName, ...args ) {
 					// Original dispatcher is a pre-bound (dispatching) action creator.
-					mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps )[ propName ]( ...args );
+					return mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps )[ propName ]( ...args );
 				}
 
 				setProxyProps( props ) {

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -33,7 +33,10 @@ describe( 'withDispatch', () => {
 			const { count } = ownProps;
 
 			return {
-				increment: () => _dispatch( 'counter' ).increment( count ),
+				increment: () => {
+					const actionReturnedFromDispatch = _dispatch( 'counter' ).increment( count );
+					expect( actionReturnedFromDispatch ).toBe( undefined );
+				},
 			};
 		} )( ( props ) => <button onClick={ props.increment } /> );
 

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -7,7 +7,6 @@ import {
 	without,
 	mapValues,
 	get,
-	pick,
 } from 'lodash';
 
 /**
@@ -119,9 +118,8 @@ export function createRegistry( storeConfigs = {} ) {
 	 */
 	function registerResolvers( reducerKey, newResolvers ) {
 		namespaces[ reducerKey ].resolvers = mapValues( newResolvers, ( resolver ) => {
-			const normalizedResolver = pick( resolver, [ 'shouldInvalidate', 'isFulfilled' ] );
-			normalizedResolver.fulfill = resolver.fulfill ? resolver.fulfill : resolver;
-			return normalizedResolver;
+			const { fulfill: resolverFulfill = resolver } = resolver;
+			return { ...resolver, fulfill: resolverFulfill };
 		} );
 
 		namespaces[ reducerKey ].selectors = mapValues( namespaces[ reducerKey ].selectors, ( selector, selectorName ) => {

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * creates a middleware handling resolvers cache invalidation.
+ *
+ * @param {Object} registry
+ * @param {string} reducerKey
+ *
+ * @return {function} middleware
+ */
+const createResolversCacheMiddleware = ( registry, reducerKey ) => () => ( next ) => ( action ) => {
+	const resolvers = registry.select( 'core/data' ).getCachedResolvers( reducerKey );
+	Object.entries( resolvers ).forEach( ( [ selectorName, resolversByArgs ] ) => {
+		const resolver = get( registry.namespaces, [ reducerKey, 'resolvers', selectorName ] );
+		if ( ! resolver || ! resolver.shouldInvalidate ) {
+			return;
+		}
+		resolversByArgs.forEach( ( value, args ) => {
+			if ( value !== false || ! resolver.shouldInvalidate( action, ...args ) ) {
+				return;
+			}
+
+			// Trigger cache invalidation
+			registry.dispatch( 'core/data' ).invalidateCache( reducerKey, selectorName, args );
+		} );
+	} );
+	next( action );
+};
+
+export default createResolversCacheMiddleware;

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -19,6 +19,9 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => ( next 
 			return;
 		}
 		resolversByArgs.forEach( ( value, args ) => {
+			// resolversByArgs is the map Map([ args ] => boolean) storing the cache resolution status for a given selector.
+			// If the value is false it means this resolver has finished its resolution which means we need to invalidate it,
+			// if it's true it means it's inflight and the invalidation is not necessary.
 			if ( value !== false || ! resolver.shouldInvalidate( action, ...args ) ) {
 				return;
 			}

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -24,7 +24,7 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => ( next 
 			}
 
 			// Trigger cache invalidation
-			registry.dispatch( 'core/data' ).invalidateCache( reducerKey, selectorName, args );
+			registry.dispatch( 'core/data' ).invalidateResolution( reducerKey, selectorName, args );
 		} );
 	} );
 	next( action );

--- a/packages/data/src/store/actions.js
+++ b/packages/data/src/store/actions.js
@@ -45,9 +45,9 @@ export function finishResolution( reducerKey, selectorName, args ) {
  *
  * @return {Object} Action object.
  */
-export function invalidateCache( reducerKey, selectorName, args ) {
+export function invalidateResolution( reducerKey, selectorName, args ) {
 	return {
-		type: 'INVALIDATE_CACHE',
+		type: 'INVALIDATE_RESOLUTION',
 		reducerKey,
 		selectorName,
 		args,

--- a/packages/data/src/store/actions.js
+++ b/packages/data/src/store/actions.js
@@ -35,3 +35,21 @@ export function finishResolution( reducerKey, selectorName, args ) {
 		args,
 	};
 }
+
+/**
+ * Returns an action object used in signalling that we should invalidate the resolution cache.
+ *
+ * @param {string} reducerKey   Registered store reducer key.
+ * @param {string} selectorName Name of selector for which resolver should be invalidated.
+ * @param {...*}   args         Arguments to associate for uniqueness.
+ *
+ * @return {Object} Action object.
+ */
+export function invalidateCache( reducerKey, selectorName, args ) {
+	return {
+		type: 'INVALIDATE_CACHE',
+		reducerKey,
+		selectorName,
+		args,
+	};
+}

--- a/packages/data/src/store/actions.js
+++ b/packages/data/src/store/actions.js
@@ -41,7 +41,7 @@ export function finishResolution( reducerKey, selectorName, args ) {
  *
  * @param {string} reducerKey   Registered store reducer key.
  * @param {string} selectorName Name of selector for which resolver should be invalidated.
- * @param {...*}   args         Arguments to associate for uniqueness.
+ * @param {Array}  args         Arguments to associate for uniqueness.
  *
  * @return {Object} Action object.
  */

--- a/packages/data/src/store/reducer.js
+++ b/packages/data/src/store/reducer.js
@@ -33,7 +33,7 @@ const isResolved = flowRight( [
 		}
 		case 'INVALIDATE_CACHE': {
 			const nextState = new EquivalentKeyMap( state );
-			nextState.set( action.args, undefined );
+			nextState.delete( action.args );
 			return nextState;
 		}
 	}

--- a/packages/data/src/store/reducer.js
+++ b/packages/data/src/store/reducer.js
@@ -31,7 +31,7 @@ const isResolved = flowRight( [
 			nextState.set( action.args, isStarting );
 			return nextState;
 		}
-		case 'INVALIDATE_CACHE': {
+		case 'INVALIDATE_RESOLUTION': {
 			const nextState = new EquivalentKeyMap( state );
 			nextState.delete( action.args );
 			return nextState;

--- a/packages/data/src/store/reducer.js
+++ b/packages/data/src/store/reducer.js
@@ -25,11 +25,17 @@ const isResolved = flowRight( [
 ] )( ( state = new EquivalentKeyMap(), action ) => {
 	switch ( action.type ) {
 		case 'START_RESOLUTION':
-		case 'FINISH_RESOLUTION':
+		case 'FINISH_RESOLUTION': {
 			const isStarting = action.type === 'START_RESOLUTION';
 			const nextState = new EquivalentKeyMap( state );
 			nextState.set( action.args, isStarting );
 			return nextState;
+		}
+		case 'INVALIDATE_CACHE': {
+			const nextState = new EquivalentKeyMap( state );
+			nextState.set( action.args, undefined );
+			return nextState;
+		}
 	}
 
 	return state;

--- a/packages/data/src/store/selectors.js
+++ b/packages/data/src/store/selectors.js
@@ -79,5 +79,5 @@ export function isResolving( state, reducerKey, selectorName, args = [] ) {
  * @return {Object} Resolvers mapped by args and selectorName.
  */
 export function getCachedResolvers( state, reducerKey ) {
-	return get( state, reducerKey, {} );
+	return state.hasOwnProperty( reducerKey ) ? state[ reducerKey ] : {};
 }

--- a/packages/data/src/store/selectors.js
+++ b/packages/data/src/store/selectors.js
@@ -69,3 +69,15 @@ export function hasFinishedResolution( state, reducerKey, selectorName, args = [
 export function isResolving( state, reducerKey, selectorName, args = [] ) {
 	return getIsResolving( state, reducerKey, selectorName, args ) === true;
 }
+
+/**
+ * Returns the list of the cached resolvers.
+ *
+ * @param {Object} state      Data state.
+ * @param {string} reducerKey Registered store reducer key.
+ *
+ * @return {Object} Resolvers mapped by args and selectorName.
+ */
+export function getCachedResolvers( state, reducerKey ) {
+	return get( state, reducerKey, {} );
+}

--- a/packages/data/src/store/test/reducer.js
+++ b/packages/data/src/store/test/reducer.js
@@ -45,6 +45,30 @@ describe( 'reducer', () => {
 		expect( state.test.getFoo.get( [] ) ).toBe( false );
 	} );
 
+	it( 'should remove invalidations', () => {
+		let state = reducer( undefined, {
+			type: 'START_RESOLUTION',
+			reducerKey: 'test',
+			selectorName: 'getFoo',
+			args: [],
+		} );
+		state = reducer( deepFreeze( state ), {
+			type: 'FINISH_RESOLUTION',
+			reducerKey: 'test',
+			selectorName: 'getFoo',
+			args: [],
+		} );
+		state = reducer( deepFreeze( state ), {
+			type: 'INVALIDATE_CACHE',
+			reducerKey: 'test',
+			selectorName: 'getFoo',
+			args: [],
+		} );
+
+		// { test: { getFoo: EquivalentKeyMap( [] => undefined ) } }
+		expect( state.test.getFoo.get( [] ) ).toBe( undefined );
+	} );
+
 	it( 'different arguments should not conflict', () => {
 		const original = reducer( undefined, {
 			type: 'START_RESOLUTION',

--- a/packages/data/src/store/test/reducer.js
+++ b/packages/data/src/store/test/reducer.js
@@ -59,7 +59,7 @@ describe( 'reducer', () => {
 			args: [],
 		} );
 		state = reducer( deepFreeze( state ), {
-			type: 'INVALIDATE_CACHE',
+			type: 'INVALIDATE_RESOLUTION',
 			reducerKey: 'test',
 			selectorName: 'getFoo',
 			args: [],

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -205,7 +205,7 @@ class HierarchicalTermSelector extends Component {
 
 		const resultCount = getResultCount( filteredTermsTree );
 		const resultsFoundMessage = sprintf(
-			_n( '%d result found.', '%d results found.', resultCount, 'term' ),
+			_n( '%d result found.', '%d results found.', resultCount ),
 			resultCount
 		);
 		this.props.debouncedSpeak( resultsFoundMessage, 'assertive' );
@@ -321,7 +321,7 @@ class HierarchicalTermSelector extends Component {
 				slug === 'category' ? __( 'Categories' ) : __( 'Terms' )
 			)
 		);
-		const showFilter = availableTerms.length >= MIN_TERMS_COUNT_FOR_FILTER;
+		const showFilter = availableTerms && ( availableTerms.length >= MIN_TERMS_COUNT_FOR_FILTER );
 
 		return [
 			showFilter && <label

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -24,7 +24,6 @@ const DEFAULT_QUERY = {
 	per_page: -1,
 	orderby: 'name',
 	order: 'asc',
-	_fields: 'id,name,parent',
 };
 
 const MIN_TERMS_COUNT_FOR_FILTER = 8;

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -39,17 +39,12 @@ class HierarchicalTermSelector extends Component {
 		this.onToggleForm = this.onToggleForm.bind( this );
 		this.setFilterValue = this.setFilterValue.bind( this );
 		this.state = {
-			adding: false,
 			formName: '',
 			formParent: '',
 			showForm: false,
 			filterValue: '',
 			filteredTermsTree: [],
 		};
-	}
-
-	componentWillUnmount() {
-		this.addRequest = null;
 	}
 
 	onChange( event ) {
@@ -86,9 +81,9 @@ class HierarchicalTermSelector extends Component {
 
 	onAddTerm( event ) {
 		event.preventDefault();
-		const { onUpdateTerms, onSaveTerm, terms, slug, availableTerms, taxonomy } = this.props;
-		const { formName, formParent, adding } = this.state;
-		if ( formName === '' || adding ) {
+		const { onUpdateTerms, addTermToEditedPost, terms, availableTerms } = this.props;
+		const { formName, formParent } = this.state;
+		if ( formName === '' ) {
 			return;
 		}
 
@@ -106,45 +101,14 @@ class HierarchicalTermSelector extends Component {
 			return;
 		}
 
-		this.setState( {
-			adding: true,
-		} );
-
-		this.addRequest = onSaveTerm( {
+		addTermToEditedPost( {
 			name: formName,
 			parent: formParent ? formParent : undefined,
 		} );
-
-		this.addRequest
-			.then( ( term ) => {
-				if ( this.addRequest === null ) {
-					return;
-				}
-				const termAddedMessage = sprintf(
-					_x( '%s added', 'term' ),
-					get(
-						taxonomy,
-						[ 'data', 'labels', 'singular_name' ],
-						slug === 'category' ? __( 'Category' ) : __( 'Term' )
-					)
-				);
-				this.props.speak( termAddedMessage, 'assertive' );
-				this.addRequest = null;
-				this.setState( {
-					adding: false,
-					formName: '',
-					formParent: '',
-				} );
-				onUpdateTerms( [ ...terms, term.id ] );
-			}, () => {
-				if ( this.addRequest === null ) {
-					return;
-				}
-				this.addRequest = null;
-				this.setState( {
-					adding: false,
-				} );
-			} );
+		this.setState( {
+			formName: '',
+			formParent: '',
+		} );
 	}
 
 	sortBySelected( termsTree ) {
@@ -418,8 +382,8 @@ export default compose( [
 		onUpdateTerms( terms ) {
 			dispatch( 'core/editor' ).editPost( { [ taxonomy.rest_base ]: terms } );
 		},
-		onSaveTerm( term ) {
-			return dispatch( 'core' ).saveEntityRecord( 'taxonomy', slug, term );
+		addTermToEditedPost( term ) {
+			return dispatch( 'core/editor' ).addTermToEditedPost( slug, term );
 		},
 	} ) ),
 	withSpokenMessages,

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, unescape as unescapeString, without, find, some, invoke } from 'lodash';
+import { get, unescape as unescapeString, without, find, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,8 +11,6 @@ import { Component } from '@wordpress/element';
 import { TreeSelect, withSpokenMessages, withFilters, Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
-import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -41,11 +39,7 @@ class HierarchicalTermSelector extends Component {
 		this.onAddTerm = this.onAddTerm.bind( this );
 		this.onToggleForm = this.onToggleForm.bind( this );
 		this.setFilterValue = this.setFilterValue.bind( this );
-		this.sortBySelected = this.sortBySelected.bind( this );
 		this.state = {
-			loading: true,
-			availableTermsTree: [],
-			availableTerms: [],
 			adding: false,
 			formName: '',
 			formParent: '',
@@ -55,14 +49,18 @@ class HierarchicalTermSelector extends Component {
 		};
 	}
 
+	componentWillUnmount() {
+		this.addRequest = null;
+	}
+
 	onChange( event ) {
-		const { onUpdateTerms, terms = [], taxonomy } = this.props;
+		const { onUpdateTerms, terms = [] } = this.props;
 		const termId = parseInt( event.target.value, 10 );
 		const hasTerm = terms.indexOf( termId ) !== -1;
 		const newTerms = hasTerm ?
 			without( terms, termId ) :
 			[ ...terms, termId ];
-		onUpdateTerms( newTerms, taxonomy.rest_base );
+		onUpdateTerms( newTerms );
 	}
 
 	onChangeFormName( event ) {
@@ -89,8 +87,8 @@ class HierarchicalTermSelector extends Component {
 
 	onAddTerm( event ) {
 		event.preventDefault();
-		const { onUpdateTerms, taxonomy, terms, slug } = this.props;
-		const { formName, formParent, adding, availableTerms } = this.state;
+		const { onUpdateTerms, onSaveTerm, terms, slug, availableTerms, taxonomy } = this.props;
+		const { formName, formParent, adding } = this.state;
 		if ( formName === '' || adding ) {
 			return;
 		}
@@ -100,7 +98,7 @@ class HierarchicalTermSelector extends Component {
 		if ( existingTerm ) {
 			// if the term we are adding exists but is not selected select it
 			if ( ! some( terms, ( term ) => term === existingTerm.id ) ) {
-				onUpdateTerms( [ ...terms, existingTerm.id ], taxonomy.rest_base );
+				onUpdateTerms( [ ...terms, existingTerm.id ] );
 			}
 			this.setState( {
 				formName: '',
@@ -112,41 +110,21 @@ class HierarchicalTermSelector extends Component {
 		this.setState( {
 			adding: true,
 		} );
-		this.addRequest = apiFetch( {
-			path: `/wp/v2/${ taxonomy.rest_base }`,
-			method: 'POST',
-			data: {
-				name: formName,
-				parent: formParent ? formParent : undefined,
-			},
+
+		this.addRequest = onSaveTerm( {
+			name: formName,
+			parent: formParent ? formParent : undefined,
 		} );
-		// Tries to create a term or fetch it if it already exists
-		const findOrCreatePromise = this.addRequest
-			.catch( ( error ) => {
-				const errorCode = error.code;
-				if ( errorCode === 'term_exists' ) {
-					// search the new category created since last fetch
-					this.addRequest = apiFetch( {
-						path: addQueryArgs(
-							`/wp/v2/${ taxonomy.rest_base }`,
-							{ ...DEFAULT_QUERY, parent: formParent || 0, search: formName }
-						),
-					} );
-					return this.addRequest
-						.then( ( searchResult ) => {
-							return this.findTerm( searchResult, formParent, formName );
-						} );
-				}
-				return Promise.reject( error );
-			} );
-		findOrCreatePromise
+
+		this.addRequest
 			.then( ( term ) => {
-				const hasTerm = !! find( this.state.availableTerms, ( availableTerm ) => availableTerm.id === term.id );
-				const newAvailableTerms = hasTerm ? this.state.availableTerms : [ term, ...this.state.availableTerms ];
+				if ( this.addRequest === null ) {
+					return;
+				}
 				const termAddedMessage = sprintf(
 					_x( '%s added', 'term' ),
 					get(
-						this.props.taxonomy,
+						taxonomy,
 						[ 'data', 'labels', 'singular_name' ],
 						slug === 'category' ? __( 'Category' ) : __( 'Term' )
 					)
@@ -157,12 +135,10 @@ class HierarchicalTermSelector extends Component {
 					adding: false,
 					formName: '',
 					formParent: '',
-					availableTerms: newAvailableTerms,
-					availableTermsTree: this.sortBySelected( buildTermsTree( newAvailableTerms ) ),
 				} );
-				onUpdateTerms( [ ...terms, term.id ], taxonomy.rest_base );
-			}, ( xhr ) => {
-				if ( xhr.statusText === 'abort' ) {
+				onUpdateTerms( [ ...terms, term.id ] );
+			}, () => {
+				if ( this.addRequest === null ) {
 					return;
 				}
 				this.addRequest = null;
@@ -170,52 +146,6 @@ class HierarchicalTermSelector extends Component {
 					adding: false,
 				} );
 			} );
-	}
-
-	componentDidMount() {
-		this.fetchTerms();
-	}
-
-	componentWillUnmount() {
-		invoke( this.fetchRequest, [ 'abort' ] );
-		invoke( this.addRequest, [ 'abort' ] );
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( this.props.taxonomy !== prevProps.taxonomy ) {
-			this.fetchTerms();
-		}
-	}
-
-	fetchTerms() {
-		const { taxonomy } = this.props;
-		if ( ! taxonomy ) {
-			return;
-		}
-		this.fetchRequest = apiFetch( {
-			path: addQueryArgs( `/wp/v2/${ taxonomy.rest_base }`, DEFAULT_QUERY ),
-		} );
-		this.fetchRequest.then(
-			( terms ) => { // resolve
-				const availableTermsTree = this.sortBySelected( buildTermsTree( terms ) );
-
-				this.fetchRequest = null;
-				this.setState( {
-					loading: false,
-					availableTermsTree,
-					availableTerms: terms,
-				} );
-			},
-			( xhr ) => { // reject
-				if ( xhr.statusText === 'abort' ) {
-					return;
-				}
-				this.fetchRequest = null;
-				this.setState( {
-					loading: false,
-				} );
-			}
-		);
 	}
 
 	sortBySelected( termsTree ) {
@@ -256,7 +186,7 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	setFilterValue( event ) {
-		const { availableTermsTree } = this.state;
+		const { availableTermsTree } = this.props;
 		const filterValue = event.target.value;
 		const filteredTermsTree = availableTermsTree.map( this.getFilterMatcher( filterValue ) ).filter( ( term ) => term );
 		const getResultCount = ( terms ) => {
@@ -269,12 +199,10 @@ class HierarchicalTermSelector extends Component {
 			}
 			return count;
 		};
-		this.setState(
-			{
-				filterValue,
-				filteredTermsTree,
-			}
-		);
+		this.setState( {
+			filterValue,
+			filteredTermsTree,
+		} );
 
 		const resultCount = getResultCount( filteredTermsTree );
 		const resultsFoundMessage = sprintf(
@@ -339,13 +267,21 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	render() {
-		const { slug, taxonomy, instanceId, hasCreateAction, hasAssignAction } = this.props;
+		const {
+			slug,
+			taxonomy,
+			instanceId,
+			hasCreateAction,
+			hasAssignAction,
+			availableTermsTree,
+			availableTerms,
+		} = this.props;
 
 		if ( ! hasAssignAction ) {
 			return null;
 		}
 
-		const { availableTermsTree, availableTerms, filteredTermsTree, formName, formParent, loading, showForm, filterValue } = this.state;
+		const { filteredTermsTree, formName, formParent, isRequestingTerms, showForm, filterValue } = this.state;
 		const labelWithFallback = ( labelProperty, fallbackIsCategory, fallbackIsNotCategory ) => get(
 			taxonomy,
 			[ 'data', 'labels', labelProperty ],
@@ -409,9 +345,9 @@ class HierarchicalTermSelector extends Component {
 				role="group"
 				aria-label={ groupLabel }
 			>
-				{ this.renderTerms( '' !== filterValue ? filteredTermsTree : availableTermsTree ) }
+				{ this.renderTerms( '' !== filterValue ? filteredTermsTree : this.sortBySelected( availableTermsTree ) ) }
 			</div>,
-			! loading && hasCreateAction && (
+			! isRequestingTerms && hasCreateAction && (
 				<Button
 					key="term-add-button"
 					onClick={ this.onToggleForm }
@@ -464,18 +400,27 @@ class HierarchicalTermSelector extends Component {
 export default compose( [
 	withSelect( ( select, { slug } ) => {
 		const { getCurrentPost } = select( 'core/editor' );
-		const { getTaxonomy } = select( 'core' );
+		const { getTaxonomy, getEntityRecords } = select( 'core' );
+		const { isResolving } = select( 'core/data' );
 		const taxonomy = getTaxonomy( slug );
+		const availableTerms = getEntityRecords( 'taxonomy', slug, DEFAULT_QUERY );
+		const availableTermsTree = buildTermsTree( availableTerms );
 		return {
 			hasCreateAction: taxonomy ? get( getCurrentPost(), [ '_links', 'wp:action-create-' + taxonomy.rest_base ], false ) : false,
 			hasAssignAction: taxonomy ? get( getCurrentPost(), [ '_links', 'wp:action-assign-' + taxonomy.rest_base ], false ) : false,
 			terms: taxonomy ? select( 'core/editor' ).getEditedPostAttribute( taxonomy.rest_base ) : [],
+			isRequestingTerms: isResolving( 'core', 'getEntityRecords', [ 'taxonomy', slug, DEFAULT_QUERY ] ),
 			taxonomy,
+			availableTerms,
+			availableTermsTree,
 		};
 	} ),
-	withDispatch( ( dispatch ) => ( {
-		onUpdateTerms( terms, restBase ) {
-			dispatch( 'core/editor' ).editPost( { [ restBase ]: terms } );
+	withDispatch( ( dispatch, { slug, taxonomy } ) => ( {
+		onUpdateTerms( terms ) {
+			dispatch( 'core/editor' ).editPost( { [ taxonomy.rest_base ]: terms } );
+		},
+		onSaveTerm( term ) {
+			return dispatch( 'core' ).saveEntityRecord( 'taxonomy', slug, term );
 		},
 	} ) ),
 	withSpokenMessages,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -753,6 +753,22 @@ export function unlockPostSaving( lockName ) {
 	};
 }
 
+/**
+ * Returns an action object signaling that a new term is added to the edited post.
+ *
+ * @param {string} slug  Taxonomy slug.
+ * @param {Object} term  Term object.
+ *
+ * @return {Object} Action object.
+ */
+export function addTermToEditedPost( slug, term ) {
+	return {
+		type: 'ADD_TERM_TO_EDITED_POST',
+		slug,
+		term,
+	};
+}
+
 //
 // Deprecated
 //

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -52,6 +52,9 @@ import {
 	trashPostFailure,
 	refreshPost,
 } from './effects/posts';
+import {
+	addTermToEditedPost,
+} from './effects/terms';
 
 /**
  * Block validity is a function of blocks state (at the point of a
@@ -258,4 +261,7 @@ export default {
 	REPLACE_BLOCKS: [
 		ensureDefaultBlock,
 	],
+	ADD_TERM_TO_EDITED_POST: ( action ) => {
+		addTermToEditedPost( action );
+	},
 };

--- a/packages/editor/src/store/effects/terms.js
+++ b/packages/editor/src/store/effects/terms.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch, select } from '@wordpress/data';
+import { _x, sprintf, __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import { resolveSelector } from './utils';
+
+/**
+ * Effect handler adding a new term to currently edited post.
+ *
+ * @param {Object} action  action object.
+ * @param {Object} store   Redux Store.
+ */
+export async function addTermToEditedPost( { slug, term } ) {
+	const taxonomy = await resolveSelector( 'core', 'getTaxonomy', slug );
+	const savedTerm = await dispatch( 'core' ).saveEntityRecord( 'taxonomy', slug, term );
+	const terms = select( 'core/editor' ).getEditedPostAttribute( taxonomy.rest_base );
+
+	const termAddedMessage = sprintf(
+		_x( '%s added', 'term' ),
+		get(
+			taxonomy,
+			[ 'data', 'labels', 'singular_name' ],
+			slug === 'category' ? __( 'Category' ) : __( 'Term' )
+		)
+	);
+	speak( termAddedMessage, 'assertive' );
+	dispatch( 'core/editor' ).editPost( { [ taxonomy.rest_base ]: [ ...terms, savedTerm.id ] } );
+}


### PR DESCRIPTION
As an example: This PR refactors the HierarchicalTaxonomySelector component to use the data module instead of apiFetch.

This PR is very interesting in several aspects because it shows where we fall shart currently in Async Flow in the Data module and hopefully will allow us to solve this issue.

**Notes**:

1- First thing to note is that it's not fully functional yet because we need to solve a fundamental problem first: The list of categories is not being refreshed once we add a new category. That's because the queried-data state doest't invalidate the query resolvers/selectors when we add new records.

Options I can think of:

 - Invalidate all the resolvers performing queries. The difficulty is that it's not possible to gather automatically all these resolvers. Not sure there's a technical solution with this approach.

 - Rewrite the queried-data selectors to avoid relying on the IDs returned by the API request but perform the filtering client-side: Doesn't seem great neither because it's not always possible to recreate the filters client side especially since this is extensible by plugins server-side.

Which is to say, I'm not certain how to move forward with this, I need some insights/help @aduth 

2- This PR also shows that to create an action composed of two actions:

 - Save category
 - Add the saved category to the categories of the post

we need to know when the first composed action finishes and we need to know its return value (the ID created).

This is solved in this PR by using the return value of the generators. For me it seems an ok compromise and it works well. but I know this can be considered a "bad" practice 