### PR TITLE
Try: Always show movers on selected blocks (except during typing)

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -501,7 +501,7 @@ export class BlockListBlock extends Component {
 						layout={ layout }
 						isFirst={ isFirst }
 						isLast={ isLast }
-						isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' }
+						isHidden={ ( ! isHovered || hoverArea !== 'left' ) && ! isSelected }
 						isDraggable={ ( isDraggable !== false ) && ( ! isPartOfMultiSelection && isMovable ) }
 						onDragStart={ this.onDragStart }
 						onDragEnd={ this.onDragEnd }


### PR DESCRIPTION
This tries to fix #6272 by always showing movers on selected blocks, unless `isTypingWithinBlock` is true. This solves some accessibility issues as detailed in the original ticket, but also brings greater consistency between all block tools and less "flickeryness" (new word) for fast-paced mouse users.

It also partially impacts #10090 (but doesn't solve the underlying problem, just makes it less apparent).

Here's a visual:

![kapture 2018-09-21 at 8 35 22](https://user-images.githubusercontent.com/1231306/45881652-c8a8d380-bd79-11e8-9af6-f62ce86c2a04.gif)

Now that the block mover is taller, this exposes an overlap issue when hovering a block immediately following a selected short block. I don't have a great answer for that unfortunately, but I think in this case the benefits outweigh that cost (at least for now).