### PR TITLE
Pass ‘rel’ tag to richtext links

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -811,7 +811,7 @@ export class RichText extends Component {
 					return;
 				}
 
-				const { isAdding, value: href, target } = formatValue;
+				const { isAdding, value: href, target, rel } = formatValue;
 				const isSelectionCollapsed = this.editor.selection.isCollapsed();
 
 				// Are we creating a new link?
@@ -846,7 +846,7 @@ export class RichText extends Component {
 				if ( isSelectionCollapsed && ! isActive ) {
 					this.editor.insertContent( this.editor.dom.createHTML(
 						'a',
-						{ href, target },
+						{ href, target, rel },
 						this.editor.dom.encode( href )
 					) );
 					return;
@@ -857,6 +857,7 @@ export class RichText extends Component {
 				this.editor.execCommand( 'mceInsertLink', false, {
 					href,
 					target,
+					rel,
 					'data-wp-placeholder': null,
 					'data-mce-bogus': null,
 				} );


### PR DESCRIPTION
Fixes a problem with RichText links where the `rel` attribute isn't passed when the link format is changed, meaning that it doesn't immediately update the HTML for the block.

Fixes #9731

## How has this been tested?
Run the steps in #9731 and verify that `rel="noopener noreferrer"` is added to the HTML for the block.

Also verify that `rel` is added if you add a link without selecting any text.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
