### PR TITLE
Parser: Normalize data types and fix default implementation

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -60,7 +60,7 @@ function gutenberg_parse_blocks( $content ) {
 	if ( ! has_blocks( $content ) ) {
 		return array(
 			array(
-				'blockName'   => 'core/freeform',
+				'blockName'   => null,
 				'attrs'       => array(),
 				'innerBlocks' => array(),
 				'innerHTML'   => $content,

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -60,8 +60,10 @@ function gutenberg_parse_blocks( $content ) {
 	if ( ! has_blocks( $content ) ) {
 		return array(
 			array(
-				'attrs'     => array(),
-				'innerHTML' => $content,
+				'blockName'   => 'core/freeform',
+				'attrs'       => array(),
+				'innerBlocks' => array(),
+				'innerHTML'   => $content,
 			),
 		);
 	}

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -259,26 +259,26 @@ class Gutenberg_PEG_Parser {
     private function peg_f2($blockName, $a) { return $a; }
     private function peg_f3($blockName, $attrs) {
         return array(
-          'blockName'  => $blockName,
-          'attrs'      => $attrs,
+          'blockName'   => $blockName,
+          'attrs'       => isset( $attrs ) ? $attrs : array(),
           'innerBlocks' => array(),
-          'innerHTML' => '',
+          'innerHTML'   => '',
         );
         }
     private function peg_f4($s, $children, $e) {
         list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
 
         return array(
-          'blockName'  => $s['blockName'],
-          'attrs'      => $s['attrs'],
+          'blockName'    => $s['blockName'],
+          'attrs'        => $s['attrs'],
           'innerBlocks'  => $innerBlocks,
-          'innerHTML'  => implode( '', $innerHTML ),
+          'innerHTML'    => implode( '', $innerHTML ),
         );
         }
     private function peg_f5($blockName, $attrs) {
         return array(
           'blockName' => $blockName,
-          'attrs'     => $attrs,
+          'attrs'     => isset( $attrs ) ? $attrs : array(),
         );
         }
     private function peg_f6($blockName) {
@@ -1461,7 +1461,12 @@ class Gutenberg_PEG_Parser {
             $blocks = array();
 
             if ( ! empty( $pre ) ) {
-                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+                $blocks[] = array(
+                    'blockName' => 'core/freeform',
+                    'attrs' => array(),
+                    'innerBlocks' => array(),
+                    'innerHTML' => $pre
+                );
             }
 
             foreach ( $tokens as $token ) {
@@ -1470,12 +1475,22 @@ class Gutenberg_PEG_Parser {
                 $blocks[] = $token;
 
                 if ( ! empty( $html ) ) {
-                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                    $blocks[] = array(
+                        'blockName' => 'core/freeform',
+                        'attrs' => array(),
+                        'innerBlocks' => array(),
+                        'innerHTML' => $html
+                    );
                 }
             }
 
             if ( ! empty( $post ) ) {
-                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+                $blocks[] = array(
+                    'blockName' => 'core/freeform',
+                    'attrs' => array(),
+                    'innerBlocks' => array(),
+                    'innerHTML' => $post
+                );
             }
 
             return $blocks;

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -1462,7 +1462,7 @@ class Gutenberg_PEG_Parser {
 
             if ( ! empty( $pre ) ) {
                 $blocks[] = array(
-                    'blockName' => 'core/freeform',
+                    'blockName' => null,
                     'attrs' => array(),
                     'innerBlocks' => array(),
                     'innerHTML' => $pre
@@ -1476,7 +1476,7 @@ class Gutenberg_PEG_Parser {
 
                 if ( ! empty( $html ) ) {
                     $blocks[] = array(
-                        'blockName' => 'core/freeform',
+                        'blockName' => null,
                         'attrs' => array(),
                         'innerBlocks' => array(),
                         'innerHTML' => $html
@@ -1486,7 +1486,7 @@ class Gutenberg_PEG_Parser {
 
             if ( ! empty( $post ) ) {
                 $blocks[] = array(
-                    'blockName' => 'core/freeform',
+                    'blockName' => null,
                     'attrs' => array(),
                     'innerBlocks' => array(),
                     'innerHTML' => $post

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -121,6 +121,7 @@ class WP_Block_Parser_Frame {
  * Parses a document and constructs a list of parsed block objects
  *
  * @since 3.8.0
+ * @since 4.0.0 returns arrays not objects, all attributes are arrays
  */
 class WP_Block_Parser {
 	/**
@@ -244,17 +245,14 @@ class WP_Block_Parser {
                  */
                 if ( 0 === $stack_depth ) {
                     if ( isset( $leading_html_start ) ) {
-                        $this->output[] = array(
-                            'attrs' => array(),
-                            'innerHTML' => substr(
-                                $this->document,
-                                $leading_html_start,
-                                $start_offset - $leading_html_start
-                            ),
-                        );
+                        $this->output[] = (array) self::freeform( substr(
+                            $this->document,
+                            $leading_html_start,
+                            $start_offset - $leading_html_start
+                        ) );
                     }
 
-                    $this->output[] = new WP_Block_Parser_Block( $block_name, $attrs, array(), '' );
+                    $this->output[] = (array) new WP_Block_Parser_Block( $block_name, $attrs, array(), '' );
                     $this->offset = $start_offset + $token_length;
                     return true;
                 }
@@ -370,7 +368,7 @@ class WP_Block_Parser {
         $namespace  = ( isset( $namespace ) && -1 !== $namespace[ 1 ] ) ? $namespace[ 0 ] : 'core/';
         $name       = $namespace . $matches[ 'name' ][ 0 ];
         $has_attrs  = isset( $matches[ 'attrs' ] ) && -1 !== $matches[ 'attrs' ][ 1 ];
-        $attrs      = $has_attrs ? json_decode( $matches[ 'attrs' ][ 0 ] ) : null;
+        $attrs      = $has_attrs ? json_decode( $matches[ 'attrs' ][ 0 ], /* as-associative */ true ) : array();
 
         /*
          * This state isn't allowed
@@ -391,6 +389,19 @@ class WP_Block_Parser {
         return array( 'block-opener', $name, $attrs, $started_at, $length );
     }
 
+    /**
+     * Returns a new block object for freeform HTML
+     *
+     * @internal
+     * @since 3.9.0
+     *
+     * @param string $innerHTML HTML content of block
+     * @return WP_Block_Parser_Block freeform block object
+     */
+    static function freeform( $innerHTML ) {
+        return new WP_Block_Parser_Block( 'core/freeform', array(), array(), $innerHTML );
+    }
+
 	/**
 	 * Pushes a length of text from the input document
 	 * to the output list as a freeform block
@@ -406,10 +417,7 @@ class WP_Block_Parser {
             return;
         }
 
-        $this->output[] = array(
-            'attrs'     => new stdClass(),
-            'innerHTML' => substr( $this->document, $this->offset, $length ),
-        );
+        $this->output[] = (array) self::freeform( substr( $this->document, $this->offset, $length ) );
     }
 
 	/**
@@ -423,7 +431,7 @@ class WP_Block_Parser {
 	 * @param int $token_length byte length of entire block from start of opening token to end of closing token
 	 * @param int|null $last_offset last byte offset into document if continuing form earlier output
 	 */
-    function add_inner_block(WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
+    function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
         $parent = $this->stack[ count( $this->stack ) - 1 ];
         $parent->block->innerBlocks[] = $block;
         $parent->block->innerHTML .= substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
@@ -446,16 +454,13 @@ class WP_Block_Parser {
             : substr( $this->document, $prev_offset );
 
         if ( isset( $stack_top->leading_html_start ) ) {
-            $this->output[] = array(
-                'attrs' => array(),
-                'innerHTML' => substr(
-                    $this->document,
-                    $stack_top->leading_html_start,
-                    $stack_top->token_start - $stack_top->leading_html_start
-                ),
-            );
+            $this->output[] = (array) self::freeform( substr(
+                $this->document,
+                $stack_top->leading_html_start,
+                $stack_top->token_start - $stack_top->leading_html_start
+            ) );
         }
 
-        $this->output[] = $stack_top->block;
+        $this->output[] = (array) $stack_top->block;
     }
 }

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -368,7 +368,14 @@ class WP_Block_Parser {
         $namespace  = ( isset( $namespace ) && -1 !== $namespace[ 1 ] ) ? $namespace[ 0 ] : 'core/';
         $name       = $namespace . $matches[ 'name' ][ 0 ];
         $has_attrs  = isset( $matches[ 'attrs' ] ) && -1 !== $matches[ 'attrs' ][ 1 ];
-        $attrs      = $has_attrs ? json_decode( $matches[ 'attrs' ][ 0 ], /* as-associative */ true ) : array();
+
+        /*
+         * Fun fact! It's not trivial in PHP to create "an empty associative array" since all arrays
+         * are associative arrays. If we use `array()` we get a JSON `[]`
+         */
+        $attrs = $has_attrs
+			? json_decode( $matches[ 'attrs' ][ 0 ], /* as-associative */ true )
+			: json_decode( '{}', /* don't ask why, just verify in PHP */ false );
 
         /*
          * This state isn't allowed

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -399,7 +399,7 @@ class WP_Block_Parser {
      * @return WP_Block_Parser_Block freeform block object
      */
     static function freeform( $innerHTML ) {
-        return new WP_Block_Parser_Block( 'core/freeform', array(), array(), $innerHTML );
+        return new WP_Block_Parser_Block( null, array(), array(), $innerHTML );
     }
 
 	/**

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -13,6 +13,10 @@ function Block( blockName, attrs, innerBlocks, innerHTML ) {
 	};
 }
 
+function Freeform( innerHTML ) {
+	return Block( 'core/freeform', {}, [], innerHTML );
+}
+
 function Frame( block, tokenStart, tokenLength, prevOffset, leadingHtmlStart ) {
 	return {
 		block,
@@ -78,10 +82,7 @@ function proceed() {
 			// in the top-level of the document
 			if ( 0 === stackDepth ) {
 				if ( null !== leadingHtmlStart ) {
-					output.push( {
-						attrs: {},
-						innerHTML: document.substr( leadingHtmlStart, startOffset - leadingHtmlStart ),
-					} );
+					output.push( Freeform( document.substr( leadingHtmlStart, startOffset - leadingHtmlStart ) ) );
 				}
 				output.push( Block( blockName, attrs, [], '' ) );
 				offset = startOffset + tokenLength;
@@ -196,7 +197,7 @@ function nextToken() {
 	const namespace = namespaceMatch || 'core/';
 	const name = namespace + nameMatch;
 	const hasAttrs = !! attrsMatch;
-	const attrs = hasAttrs ? parseJSON( attrsMatch ) : null;
+	const attrs = hasAttrs ? parseJSON( attrsMatch ) : {};
 
 	// This state isn't allowed
 	// This is an error
@@ -223,14 +224,7 @@ function addFreeform( rawLength ) {
 		return;
 	}
 
-	// why is this not a Frame? it's because the current grammar
-	// specifies an object that's different. we can update the
-	// specification and change here if we want to but for now we
-	// want this parser to be spec-compliant
-	output.push( {
-		attrs: {},
-		innerHTML: document.substr( offset, length ),
-	} );
+	output.push( Freeform( document.substr( offset, length ) ) );
 }
 
 function addInnerBlock( block, tokenStart, tokenLength, lastOffset ) {
@@ -253,10 +247,7 @@ function addBlockFromStack( endOffset ) {
 	}
 
 	if ( null !== leadingHtmlStart ) {
-		output.push( {
-			attrs: {},
-			innerHTML: document.substr( leadingHtmlStart, tokenStart - leadingHtmlStart ),
-		} );
+		output.push( Freeform( document.substr( leadingHtmlStart, tokenStart - leadingHtmlStart ) ) );
 	}
 
 	output.push( block );

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -14,7 +14,7 @@ function Block( blockName, attrs, innerBlocks, innerHTML ) {
 }
 
 function Freeform( innerHTML ) {
-	return Block( 'core/freeform', {}, [], innerHTML );
+	return Block( null, {}, [], innerHTML );
 }
 
 function Frame( block, tokenStart, tokenLength, prevOffset, leadingHtmlStart ) {

--- a/packages/block-serialization-spec-parser/grammar.pegjs
+++ b/packages/block-serialization-spec-parser/grammar.pegjs
@@ -72,7 +72,7 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
         if ( ! empty( $pre ) ) {
             $blocks[] = array(
-                'blockName' => 'core/freeform',
+                'blockName' => null,
                 'attrs' => array(),
                 'innerBlocks' => array(),
                 'innerHTML' => $pre
@@ -86,7 +86,7 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
             if ( ! empty( $html ) ) {
                 $blocks[] = array(
-                    'blockName' => 'core/freeform',
+                    'blockName' => null,
                     'attrs' => array(),
                     'innerBlocks' => array(),
                     'innerHTML' => $html
@@ -96,7 +96,7 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
         if ( ! empty( $post ) ) {
             $blocks[] = array(
-                'blockName' => 'core/freeform',
+                'blockName' => null,
                 'attrs' => array(),
                 'innerBlocks' => array(),
                 'innerHTML' => $post
@@ -111,7 +111,7 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
 function freeform( s ) {
     return s.length && {
-        blockName: 'core/freeform',
+        blockName: null,
         attrs: {},
         innerBlocks: [],
         innerHTML: s,

--- a/packages/block-serialization-spec-parser/grammar.pegjs
+++ b/packages/block-serialization-spec-parser/grammar.pegjs
@@ -71,7 +71,12 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
         $blocks = array();
 
         if ( ! empty( $pre ) ) {
-            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+            $blocks[] = array(
+                'blockName' => 'core/freeform',
+                'attrs' => array(),
+                'innerBlocks' => array(),
+                'innerHTML' => $pre
+            );
         }
 
         foreach ( $tokens as $token ) {
@@ -80,12 +85,22 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
             $blocks[] = $token;
 
             if ( ! empty( $html ) ) {
-                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                $blocks[] = array(
+                    'blockName' => 'core/freeform',
+                    'attrs' => array(),
+                    'innerBlocks' => array(),
+                    'innerHTML' => $html
+                );
             }
         }
 
         if ( ! empty( $post ) ) {
-            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+            $blocks[] = array(
+                'blockName' => 'core/freeform',
+                'attrs' => array(),
+                'innerBlocks' => array(),
+                'innerHTML' => $post
+            );
         }
 
         return $blocks;
@@ -96,8 +111,10 @@ if ( ! function_exists( 'peg_join_blocks' ) ) {
 
 function freeform( s ) {
     return s.length && {
+        blockName: 'core/freeform',
         attrs: {},
-        innerHTML: s
+        innerBlocks: [],
+        innerHTML: s,
     };
 }
 
@@ -180,16 +197,16 @@ Block_Void
   {
     /** <?php
     return array(
-      'blockName'  => $blockName,
-      'attrs'      => $attrs,
+      'blockName'   => $blockName,
+      'attrs'       => isset( $attrs ) ? $attrs : array(),
       'innerBlocks' => array(),
-      'innerHTML' => '',
+      'innerHTML'   => '',
     );
     ?> **/
 
     return {
       blockName: blockName,
-      attrs: attrs,
+      attrs: attrs || {},
       innerBlocks: [],
       innerHTML: ''
     };
@@ -202,10 +219,10 @@ Block_Balanced
     list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
 
     return array(
-      'blockName'  => $s['blockName'],
-      'attrs'      => $s['attrs'],
+      'blockName'    => $s['blockName'],
+      'attrs'        => $s['attrs'],
       'innerBlocks'  => $innerBlocks,
-      'innerHTML'  => implode( '', $innerHTML ),
+      'innerHTML'    => implode( '', $innerHTML ),
     );
     ?> **/
 
@@ -230,13 +247,13 @@ Block_Start
     /** <?php
     return array(
       'blockName' => $blockName,
-      'attrs'     => $attrs,
+      'attrs'     => isset( $attrs ) ? $attrs : array(),
     );
     ?> **/
 
     return {
       blockName: blockName,
-      attrs: attrs
+      attrs: attrs || {}
     };
   }
 

--- a/packages/block-serialization-spec-parser/index.js
+++ b/packages/block-serialization-spec-parser/index.js
@@ -1499,7 +1499,7 @@
 
             if ( ! empty( $pre ) ) {
                 $blocks[] = array(
-                    'blockName' => 'core/freeform',
+                    'blockName' => null,
                     'attrs' => array(),
                     'innerBlocks' => array(),
                     'innerHTML' => $pre
@@ -1513,7 +1513,7 @@
 
                 if ( ! empty( $html ) ) {
                     $blocks[] = array(
-                        'blockName' => 'core/freeform',
+                        'blockName' => null,
                         'attrs' => array(),
                         'innerBlocks' => array(),
                         'innerHTML' => $html
@@ -1523,7 +1523,7 @@
 
             if ( ! empty( $post ) ) {
                 $blocks[] = array(
-                    'blockName' => 'core/freeform',
+                    'blockName' => null,
                     'attrs' => array(),
                     'innerBlocks' => array(),
                     'innerHTML' => $post
@@ -1538,7 +1538,7 @@
 
     function freeform( s ) {
         return s.length && {
-            blockName: 'core/freeform',
+            blockName: null,
             attrs: {},
             innerBlocks: [],
             innerHTML: s,

--- a/packages/block-serialization-spec-parser/index.js
+++ b/packages/block-serialization-spec-parser/index.js
@@ -165,16 +165,16 @@
         peg$c10 = function(blockName, attrs) {
             /** <?php
             return array(
-              'blockName'  => $blockName,
-              'attrs'      => $attrs,
+              'blockName'   => $blockName,
+              'attrs'       => isset( $attrs ) ? $attrs : array(),
               'innerBlocks' => array(),
-              'innerHTML' => '',
+              'innerHTML'   => '',
             );
             ?> **/
 
             return {
               blockName: blockName,
-              attrs: attrs,
+              attrs: attrs || {},
               innerBlocks: [],
               innerHTML: ''
             };
@@ -184,10 +184,10 @@
             list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
 
             return array(
-              'blockName'  => $s['blockName'],
-              'attrs'      => $s['attrs'],
+              'blockName'    => $s['blockName'],
+              'attrs'        => $s['attrs'],
               'innerBlocks'  => $innerBlocks,
-              'innerHTML'  => implode( '', $innerHTML ),
+              'innerHTML'    => implode( '', $innerHTML ),
             );
             ?> **/
 
@@ -208,13 +208,13 @@
             /** <?php
             return array(
               'blockName' => $blockName,
-              'attrs'     => $attrs,
+              'attrs'     => isset( $attrs ) ? $attrs : array(),
             );
             ?> **/
 
             return {
               blockName: blockName,
-              attrs: attrs
+              attrs: attrs || {}
             };
           },
         peg$c15 = "/wp:",
@@ -1498,7 +1498,12 @@
             $blocks = array();
 
             if ( ! empty( $pre ) ) {
-                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+                $blocks[] = array(
+                    'blockName' => 'core/freeform',
+                    'attrs' => array(),
+                    'innerBlocks' => array(),
+                    'innerHTML' => $pre
+                );
             }
 
             foreach ( $tokens as $token ) {
@@ -1507,12 +1512,22 @@
                 $blocks[] = $token;
 
                 if ( ! empty( $html ) ) {
-                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                    $blocks[] = array(
+                        'blockName' => 'core/freeform',
+                        'attrs' => array(),
+                        'innerBlocks' => array(),
+                        'innerHTML' => $html
+                    );
                 }
             }
 
             if ( ! empty( $post ) ) {
-                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+                $blocks[] = array(
+                    'blockName' => 'core/freeform',
+                    'attrs' => array(),
+                    'innerBlocks' => array(),
+                    'innerHTML' => $post
+                );
             }
 
             return $blocks;
@@ -1523,8 +1538,10 @@
 
     function freeform( s ) {
         return s.length && {
+            blockName: 'core/freeform',
             attrs: {},
-            innerHTML: s
+            innerBlocks: [],
+            innerHTML: s,
         };
     }
 

--- a/packages/block-serialization-spec-parser/test/__snapshots__/index.js.snap
+++ b/packages/block-serialization-spec-parser/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`block-serialization-spec-parser parse() works properly 1`] = `
 Array [
   Object {
-    "attrs": null,
+    "attrs": Object {},
     "blockName": "core/more",
     "innerBlocks": Array [],
     "innerHTML": "<!--more-->",

--- a/test/integration/full-content/fixtures/core__4-invalid-starting-letter.parsed.json
+++ b/test/integration/full-content/fixtures/core__4-invalid-starting-letter.parsed.json
@@ -1,6 +1,8 @@
 [
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "<!-- wp:core/4-invalid /-->\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__audio.parsed.json
+++ b/test/integration/full-content/fixtures/core__audio.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__block.parsed.json
+++ b/test/integration/full-content/fixtures/core__block.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": ""
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__button__center.parsed.json
+++ b/test/integration/full-content/fixtures/core__button__center.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<div class=\"wp-block-button aligncenter\"><a class=\"wp-block-button__link\" href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__categories.parsed.json
+++ b/test/integration/full-content/fixtures/core__categories.parsed.json
@@ -10,7 +10,9 @@
         "innerHTML": ""
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__code.parsed.json
+++ b/test/integration/full-content/fixtures/core__code.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/code",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<pre class=\"wp-block-code\"><code>export default function MyButton() {\n\treturn &lt;Button&gt;Click Me!&lt;/Button&gt;;\n}</code></pre>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__column.parsed.json
+++ b/test/integration/full-content/fixtures/core__column.parsed.json
@@ -1,17 +1,17 @@
 [
     {
         "blockName": "core/column",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [
             {
                 "blockName": "core/paragraph",
-                "attrs": null,
+                "attrs": {},
                 "innerBlocks": [],
                 "innerHTML": "\n\t<p>Column One, Paragraph One</p>\n\t"
             },
             {
                 "blockName": "core/paragraph",
-                "attrs": null,
+                "attrs": {},
                 "innerBlocks": [],
                 "innerHTML": "\n\t<p>Column One, Paragraph Two</p>\n\t"
             }
@@ -19,7 +19,9 @@
         "innerHTML": "\n<div class=\"wp-block-column\">\n\t\n\t\n</div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__columns.parsed.json
+++ b/test/integration/full-content/fixtures/core__columns.parsed.json
@@ -7,17 +7,17 @@
         "innerBlocks": [
             {
                 "blockName": "core/column",
-                "attrs": null,
+                "attrs": {},
                 "innerBlocks": [
                     {
                         "blockName": "core/paragraph",
-                        "attrs": null,
+                        "attrs": {},
                         "innerBlocks": [],
                         "innerHTML": "\n\t\t<p>Column One, Paragraph One</p>\n\t\t"
                     },
                     {
                         "blockName": "core/paragraph",
-                        "attrs": null,
+                        "attrs": {},
                         "innerBlocks": [],
                         "innerHTML": "\n\t\t<p>Column One, Paragraph Two</p>\n\t\t"
                     }
@@ -26,17 +26,17 @@
             },
             {
                 "blockName": "core/column",
-                "attrs": null,
+                "attrs": {},
                 "innerBlocks": [
                     {
                         "blockName": "core/paragraph",
-                        "attrs": null,
+                        "attrs": {},
                         "innerBlocks": [],
                         "innerHTML": "\n\t\t<p>Column Two, Paragraph One</p>\n\t\t"
                     },
                     {
                         "blockName": "core/paragraph",
-                        "attrs": null,
+                        "attrs": {},
                         "innerBlocks": [],
                         "innerHTML": "\n\t\t<p>Column Three, Paragraph One</p>\n\t\t"
                     }
@@ -47,7 +47,9 @@
         "innerHTML": "\n<div class=\"wp-block-columns has-3-columns\">\n\t\n\t\n</div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__cover-image.parsed.json
+++ b/test/integration/full-content/fixtures/core__cover-image.parsed.json
@@ -9,7 +9,9 @@
         "innerHTML": "\n<div class=\"wp-block-cover-image has-background-dim-40 has-background-dim\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <p class=\"wp-block-cover-image-text\">Guten Berg!</p>\n</div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__embed.parsed.json
+++ b/test/integration/full-content/fixtures/core__embed.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<figure class=\"wp-block-embed\">\n    <div class=\"wp-block-embed__wrapper\">\n        https://example.com/\n    </div>\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__file__new-window.parsed.json
+++ b/test/integration/full-content/fixtures/core__file__new-window.parsed.json
@@ -10,7 +10,9 @@
         "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"6546\">Download</a></div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__file__no-download-button.parsed.json
+++ b/test/integration/full-content/fixtures/core__file__no-download-button.parsed.json
@@ -10,7 +10,9 @@
         "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/?attachment_id=176\">lkjfijwef</a></div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__file__no-text-link.parsed.json
+++ b/test/integration/full-content/fixtures/core__file__no-text-link.parsed.json
@@ -10,7 +10,9 @@
         "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__freeform.parsed.json
+++ b/test/integration/full-content/fixtures/core__freeform.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/freeform",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__freeform__undelimited.parsed.json
+++ b/test/integration/full-content/fixtures/core__freeform__undelimited.parsed.json
@@ -1,6 +1,8 @@
 [
     {
         "attrs": {},
+        "blockName": null,
+        "innerBlocks": [],
         "innerHTML": "Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__gallery.parsed.json
+++ b/test/integration/full-content/fixtures/core__gallery.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/gallery",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<ul class=\"wp-block-gallery columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__gallery__columns.parsed.json
+++ b/test/integration/full-content/fixtures/core__gallery__columns.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<ul class=\"wp-block-gallery columns-1 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__heading__h2-em.parsed.json
+++ b/test/integration/full-content/fixtures/core__heading__h2-em.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/heading",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<h2>The <em>Inserter</em> Tool</h2>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__heading__h2.parsed.json
+++ b/test/integration/full-content/fixtures/core__heading__h2.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/heading",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<h2>A picture is worth a thousand words, or so the saying goes</h2>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__html.parsed.json
+++ b/test/integration/full-content/fixtures/core__html.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/html",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<h1>Some HTML code</h1>\n<marquee>This text will scroll from right to left</marquee>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__image.parsed.json
+++ b/test/integration/full-content/fixtures/core__image.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/image",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"\" /></figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__image__attachment-link.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__attachment-link.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"http://localhost:8888/?attachment_id=7\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"\" /></a></figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__image__center-caption.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__center-caption.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<div class=\"wp-block-image\"><figure class=\"aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__image__custom-link.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__custom-link.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"\" /></a></figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__image__media-link.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__media-link.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"https://cldup.com/uuUqE_dXzy.jpg\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"\" /></a></figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__invalid-Capitals.parsed.json
+++ b/test/integration/full-content/fixtures/core__invalid-Capitals.parsed.json
@@ -1,6 +1,8 @@
 [
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "<!-- wp:core/invalid-Capitals /-->\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__invalid-special.parsed.json
+++ b/test/integration/full-content/fixtures/core__invalid-special.parsed.json
@@ -1,6 +1,8 @@
 [
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "<!-- wp:core/invalid-$special /-->\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__latest-comments.parsed.json
+++ b/test/integration/full-content/fixtures/core__latest-comments.parsed.json
@@ -10,7 +10,9 @@
         "innerHTML": ""
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__latest-posts.parsed.json
+++ b/test/integration/full-content/fixtures/core__latest-posts.parsed.json
@@ -9,7 +9,9 @@
         "innerHTML": ""
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__latest-posts__displayPostDate.parsed.json
+++ b/test/integration/full-content/fixtures/core__latest-posts__displayPostDate.parsed.json
@@ -9,7 +9,9 @@
         "innerHTML": ""
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__list__ul.parsed.json
+++ b/test/integration/full-content/fixtures/core__list__ul.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/list",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__more.parsed.json
+++ b/test/integration/full-content/fixtures/core__more.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/more",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<!--more-->\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__more__custom-text-teaser.parsed.json
+++ b/test/integration/full-content/fixtures/core__more__custom-text-teaser.parsed.json
@@ -9,7 +9,9 @@
         "innerHTML": "\n<!--more Continue Reading-->\n<!--noteaser-->\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__nextpage.parsed.json
+++ b/test/integration/full-content/fixtures/core__nextpage.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/nextpage",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<!--nextpage-->\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__paragraph__align-right.parsed.json
+++ b/test/integration/full-content/fixtures/core__paragraph__align-right.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__paragraph__deprecated.parsed.json
+++ b/test/integration/full-content/fixtures/core__paragraph__deprecated.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/paragraph",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\nUnwrapped is <em>still</em> valid.\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__preformatted.parsed.json
+++ b/test/integration/full-content/fixtures/core__preformatted.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/preformatted",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<pre class=\"wp-block-preformatted\">Some <em>preformatted</em> text...<br>And more!</pre>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__pullquote.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/pullquote",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/pullquote",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n        <p>Paragraph <strong>one</strong></p>\n        <p>Paragraph two</p>\n        <cite>by whomever</cite>\n\t</blockquote>\n</figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__quote__style-1.parsed.json
+++ b/test/integration/full-content/fixtures/core__quote__style-1.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/quote",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__quote__style-2.parsed.json
+++ b/test/integration/full-content/fixtures/core__quote__style-2.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__separator.parsed.json
+++ b/test/integration/full-content/fixtures/core__separator.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/separator",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<hr class=\"wp-block-separator\" />\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__shortcode.parsed.json
+++ b/test/integration/full-content/fixtures/core__shortcode.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/shortcode",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n[gallery ids=\"238,338\"]\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__spacer.parsed.json
+++ b/test/integration/full-content/fixtures/core__spacer.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/spacer",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__subhead.parsed.json
+++ b/test/integration/full-content/fixtures/core__subhead.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/subhead",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<p class=\"wp-block-subhead\">This is a <em>subhead</em>.</p>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__table.parsed.json
+++ b/test/integration/full-content/fixtures/core__table.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/table",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<table class=\"wp-block-table\"><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__text-columns.parsed.json
+++ b/test/integration/full-content/fixtures/core__text-columns.parsed.json
@@ -8,7 +8,9 @@
         "innerHTML": "\n<div class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-column\">\n        <p>Two</p>\n    </div>\n</div>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__text__converts-to-paragraph.parsed.json
+++ b/test/integration/full-content/fixtures/core__text__converts-to-paragraph.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/text",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<p>This is an old-style text block.  Changed to <code>paragraph</code> in #2135.</p>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__verse.parsed.json
+++ b/test/integration/full-content/fixtures/core__verse.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/verse",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]

--- a/test/integration/full-content/fixtures/core__video.parsed.json
+++ b/test/integration/full-content/fixtures/core__video.parsed.json
@@ -1,12 +1,14 @@
 [
     {
         "blockName": "core/video",
-        "attrs": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "\n<figure class=\"wp-block-video\"><video controls src=\"https://awesome-fake.video/file.mp4\"></video></figure>\n"
     },
     {
+        "blockName": null,
         "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]


### PR DESCRIPTION
Resolves #10041
Resolves #10047

A few inconsistencies have remained in the grammar specification
concerning freeform blocks and blocks without attributes in the
block delimiters. Freeform blocks were returned without block
names and blocks without attributes returned `null` instead of
an empty set of attributes.

Further, the default parser implementation (from #8083) was
returning an array of block objects instead of an array of
generic arrays. This resulted in mismatches in PHP of accessing
properties with `$block[ 'attrs' ]` syntax vs `$block->attrs`
syntax.

In this patch I've updatd the specification to remove all of
the type ambiguity and have updated the default parser to match
it. After this patch every block should be accessible as a normal
array in PHP and have all properties: `blockName`, `attrs`,
`innerBlocks`, and `innerHTML`. If no attributes are specified
then `attrs` will be an empty set (in JavaScript `{}` and in
PHP `array()`).

## Status

I haven't tested this yet. I'd like some feedback on the design change
though. My plan is to run the tests through the parser comparator and
make sure that the spec and the default parsers remain consistent.

If you look at the automated test results you can see what the impact is
of making HTML soup turn implicitly into a freeform block. I'd appreciate
some feedback on what you think of that. Personally I think it's a reasonable
change: at the time we _didn't_ do that we weren't as sure of what would 
happen with the "HTML soup" but it seems like we've locked down the idea
of the classic block which is `core/freeform` - maybe I'm wrong 🤷‍♂️ 

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards
- [x] My code has proper inline documentation.