### PR TITLE
Block API: Add `pre_render` and `post_render` block filters

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -134,7 +134,7 @@ if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
  *
  * @since 1.9.0
  * @since 4.4.0 renders full nested tree of blocks before reassembling into HTML string
- * @since 4.6.0 filters blocks structurally before rendering and as text afterwards
+ * @since 4.7.0 filters blocks structurally before rendering and as text afterwards
  * @global WP_Post $post The post to edit.
  *
  * @param  array $source_block A single parsed block object.
@@ -210,7 +210,7 @@ function gutenberg_render_block( $source_block ) {
 	 *     add_filter( 'block_pre_render', 'un_markdownify_block' );
 	 * }
 	 *
-	 * @since 4.6.0
+	 * @since 4.7.0
 	 *
 	 * @param array|null $prev transformed block from previous filter or null
 	 * @param array $source_block original block passed through all filters
@@ -299,7 +299,7 @@ function gutenberg_render_block( $source_block ) {
 	 * add_filter( 'block_post_render', array( $matcher, 'block_post_render' ) );
 	 * add_filter( 'the_content', array( $matcher, 'the_content' ), 10 );
 	 *
-	 * @since 4.6.0
+	 * @since 4.7.0
 	 *
 	 * @param string $output rendered HTML from block or previous filters
 	 * @param array $block original block that was rendered

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -134,7 +134,7 @@ if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
  *
  * @since 1.9.0
  * @since 4.4.0 renders full nested tree of blocks before reassembling into HTML string
- * @since 4.7.0 filters blocks structurally before rendering and as text afterwards
+ * @since 4.8.0 filters blocks structurally before rendering and as text afterwards
  * @global WP_Post $post The post to edit.
  *
  * @param  array $source_block A single parsed block object.
@@ -210,7 +210,7 @@ function gutenberg_render_block( $source_block ) {
 	 *     add_filter( 'block_pre_render', 'un_markdownify_block' );
 	 * }
 	 *
-	 * @since 4.7.0
+	 * @since 4.8.0
 	 *
 	 * @param array|null $prev transformed block from previous filter or null
 	 * @param array $source_block original block passed through all filters
@@ -299,7 +299,7 @@ function gutenberg_render_block( $source_block ) {
 	 * add_filter( 'block_post_render', array( $matcher, 'block_post_render' ) );
 	 * add_filter( 'the_content', array( $matcher, 'the_content' ), 10 );
 	 *
-	 * @since 4.7.0
+	 * @since 4.8.0
 	 *
 	 * @param string $output rendered HTML from block or previous filters
 	 * @param array $block original block that was rendered

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -137,7 +137,7 @@ if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
  * @since 4.6.0 filters blocks structurally before rendering and as text afterwards
  * @global WP_Post $post The post to edit.
  *
- * @param  array $block A single parsed block object.
+ * @param  array $source_block A single parsed block object.
  * @return string String of rendered HTML.
  */
 function gutenberg_render_block( $source_block ) {
@@ -217,9 +217,9 @@ function gutenberg_render_block( $source_block ) {
 	 *
 	 * @return array|null transformed version of block or previous $block if not transformation is needed
 	 */
-	$pre_render  = apply_filters( 'block_pre_render', null, $source_block );
-	$post        = $global_post;
-	$block       = isset( $pre_render ) ? $pre_render : $source_block;
+	$pre_render = apply_filters( 'block_pre_render', null, $source_block );
+	$post       = $global_post;
+	$block      = isset( $pre_render ) ? $pre_render : $source_block;
 
 	$block_type    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$is_dynamic    = $block['blockName'] && null !== $block_type && $block_type->is_dynamic();


### PR DESCRIPTION
There are numerous needs to process posts at the block level without
demanding that plugin authors implement their own parsing systems.
Some needs involve structural processing - knowing the block type or
specific attributes on the block - while others are simply needing to
process the output HTML from a given block.

In this patch I'm adding an API to allow extending `do_blocks`
and `gutenberg_render_block` with a _pre-processing_ and a
_post-processing_ filter.

The main distinction between _pre_ and _post_ filtering is that _pre_
filtering gives us the chance to control or change _how a block is rendered_
while the _post_ filtering gives us a chance to change a block's output.

One use case is in #8760 where we want to replace the HTML parts of
blocks while preserving other structure. Another use case could be
removing specific inner blocks or content based on the current user
requesting a post.

See the docblock comments in the patch itself for examples.