### PR TITLE
Fix(with-select): Rename parameter from `mapStateToProps` to `mapSelectToProps`.

### DIFF
--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -14,13 +14,13 @@ import { RegistryConsumer } from '../registry-provider';
  * Higher-order component used to inject state-derived props using registered
  * selectors.
  *
- * @param {Function} mapStateToProps Function called on every state change,
+ * @param {Function} mapSelectToProps Function called on every state change,
  *                                   expected to return object of props to
  *                                   merge with the component's own props.
  *
  * @return {Component} Enhanced component with merged state data props.
  */
-const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( WrappedComponent ) => {
+const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( WrappedComponent ) => {
 	/**
 	 * Default merge props. A constant value is used as the fallback since it
 	 * can be more efficiently shallow compared in case component is repeatedly
@@ -31,15 +31,15 @@ const withSelect = ( mapStateToProps ) => createHigherOrderComponent( ( WrappedC
 	const DEFAULT_MERGE_PROPS = {};
 
 	/**
-	 * Given a props object, returns the next merge props by mapStateToProps.
+	 * Given a props object, returns the next merge props by mapSelectToProps.
 	 *
-	 * @param {Object} props Props to pass as argument to mapStateToProps.
+	 * @param {Object} props Props to pass as argument to mapSelectToProps.
 	 *
 	 * @return {Object} Props to merge into rendered wrapped element.
 	 */
 	function getNextMergeProps( props ) {
 		return (
-			mapStateToProps( props.registry.select, props.ownProps ) ||
+			mapSelectToProps( props.registry.select, props.ownProps ) ||
 			DEFAULT_MERGE_PROPS
 		);
 	}

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -416,8 +416,8 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const childMapStateToProps = jest.fn();
-		const parentMapStateToProps = jest.fn().mockImplementation( ( _select ) => ( {
+		const childMapSelectToProps = jest.fn();
+		const parentMapSelectToProps = jest.fn().mockImplementation( ( _select ) => ( {
 			isRenderingChild: _select( 'childRender' ).getValue(),
 		} ) );
 
@@ -426,8 +426,8 @@ describe( 'withSelect', () => {
 			<div>{ props.isRenderingChild ? <Child /> : null }</div>
 		) );
 
-		const Child = withSelect( childMapStateToProps )( ChildOriginalComponent );
-		const Parent = withSelect( parentMapStateToProps )( ParentOriginalComponent );
+		const Child = withSelect( childMapSelectToProps )( ChildOriginalComponent );
+		const Parent = withSelect( parentMapSelectToProps )( ParentOriginalComponent );
 
 		TestRenderer.create(
 			<RegistryProvider value={ registry }>
@@ -435,15 +435,15 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( childMapStateToProps ).toHaveBeenCalledTimes( 1 );
-		expect( parentMapStateToProps ).toHaveBeenCalledTimes( 1 );
+		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		registry.dispatch( 'childRender' ).toggleRender();
 
-		expect( childMapStateToProps ).toHaveBeenCalledTimes( 1 );
-		expect( parentMapStateToProps ).toHaveBeenCalledTimes( 2 );
+		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );


### PR DESCRIPTION
## Description

`state` isn't available in this function and the current parameter name is confusing with Redux's parameter.
Moreover, in the guide it says `mapSelectToProps` ->
https://github.com/WordPress/gutenberg/blob/master/packages/data/README.md#withselect-mapselecttoprops-function--function
Also, discussed with @aduth 
![screenshot 2018-09-23 11 03 08](https://user-images.githubusercontent.com/379918/45924543-6a6a2500-bf20-11e8-820b-41884142dec4.png)


## How has this been tested?

Ran unit tests with `test-unit`. All 254 tests passed.

## Types of changes

- Function parameter name change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
