### PR TITLE
Token field: remove the placeholder and make the label visible

### DIFF
--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -500,7 +500,7 @@ class FormTokenField extends Component {
 	}
 
 	renderInput() {
-		const { autoCapitalize, autoComplete, maxLength, value, placeholder, instanceId } = this.props;
+		const { autoCapitalize, autoComplete, maxLength, value, instanceId } = this.props;
 
 		let props = {
 			instanceId,
@@ -515,10 +515,6 @@ class FormTokenField extends Component {
 			selectedSuggestionIndex: this.state.selectedSuggestionIndex,
 		};
 
-		if ( value.length === 0 && placeholder ) {
-			props.placeholder = placeholder;
-		}
-
 		if ( ! ( maxLength && value.length >= maxLength ) ) {
 			props = { ...props, onChange: this.onInputChange };
 		}
@@ -531,18 +527,18 @@ class FormTokenField extends Component {
 	render() {
 		const {
 			disabled,
-			placeholder = __( 'Add item.' ),
+			label = __( 'Add item' ),
 			instanceId,
 			className,
 		} = this.props;
 		const { isExpanded } = this.state;
-		const classes = classnames( className, 'components-form-token-field', {
+		const classes = classnames( className, 'components-form-token-field__input-container', {
 			'is-active': this.state.isActive,
 			'is-disabled': disabled,
 		} );
 
 		let tokenFieldProps = {
-			className: classes,
+			className: 'components-form-token-field',
 			tabIndex: '-1',
 		};
 		const matchingSuggestions = this.getMatchingSuggestions();
@@ -560,31 +556,33 @@ class FormTokenField extends Component {
 		// TODO: Refactor click detection to use blur to stop propagation.
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
-			<div { ...tokenFieldProps } >
-				<label htmlFor={ `components-form-token-input-${ instanceId }` } className="screen-reader-text">
-					{ placeholder }
+			<div { ...tokenFieldProps }>
+				<label
+					htmlFor={ `components-form-token-input-${ instanceId }` }
+					className="components-form-token-field__label"
+				>
+					{ label }
 				</label>
 				<div ref={ this.bindTokensAndInput }
-					className="components-form-token-field__input-container"
+					className={ classes }
 					tabIndex="-1"
 					onMouseDown={ this.onContainerTouched }
 					onTouchStart={ this.onContainerTouched }
 				>
 					{ this.renderTokensAndInput() }
+					{ isExpanded && (
+						<SuggestionsList
+							instanceId={ instanceId }
+							match={ this.props.saveTransform( this.state.incompleteTokenValue ) }
+							displayTransform={ this.props.displayTransform }
+							suggestions={ matchingSuggestions }
+							selectedIndex={ this.state.selectedSuggestionIndex }
+							scrollIntoView={ this.state.selectedSuggestionScroll }
+							onHover={ this.onSuggestionHovered }
+							onSelect={ this.onSuggestionSelected }
+						/>
+					) }
 				</div>
-
-				{ isExpanded && (
-					<SuggestionsList
-						instanceId={ instanceId }
-						match={ this.props.saveTransform( this.state.incompleteTokenValue ) }
-						displayTransform={ this.props.displayTransform }
-						suggestions={ matchingSuggestions }
-						selectedIndex={ this.state.selectedSuggestionIndex }
-						scrollIntoView={ this.state.selectedSuggestionScroll }
-						onHover={ this.onSuggestionHovered }
-						onSelect={ this.onSuggestionSelected }
-					/>
-				) }
 				<div id={ `components-form-token-suggestions-howto-${ instanceId }` } className="screen-reader-text">
 					{ __( 'Separate with commas' ) }
 				</div>
@@ -598,7 +596,6 @@ FormTokenField.defaultProps = {
 	suggestions: Object.freeze( [] ),
 	maxSuggestions: 100,
 	value: Object.freeze( [] ),
-	placeholder: '',
 	displayTransform: identity,
 	saveTransform: ( token ) => token.trim(),
 	onChange: () => {},

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -4,7 +4,7 @@
 	align-items: flex-start;
 	width: 100%;
 	margin: 0;
-	padding: 4px;
+	padding: $grid-size-small;
 	background-color: $white;
 	border: $border-width solid $light-gray-700;
 	color: $dark-gray-700;
@@ -162,7 +162,7 @@
 	transition: all 0.15s ease-in-out;
 	list-style: none;
 	border-top: $border-width solid $dark-gray-300;
-	margin: 4px -4px -4px -4px;
+	margin: $grid-size-small -$grid-size-small -$grid-size-small -$grid-size-small;
 	padding-top: 3px;
 }
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -162,7 +162,7 @@
 	transition: all 0.15s ease-in-out;
 	list-style: none;
 	border-top: $border-width solid $dark-gray-300;
-	margin: $grid-size-small -$grid-size-small -$grid-size-small -$grid-size-small;
+	margin: $grid-size-small (-$grid-size-small) (-$grid-size-small);
 	padding-top: 3px;
 }
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -1,7 +1,10 @@
-.components-form-token-field {
+.components-form-token-field__input-container {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
 	width: 100%;
 	margin: 0;
-	padding: 0;
+	padding: 4px;
 	background-color: $white;
 	border: $border-width solid $light-gray-700;
 	color: $dark-gray-700;
@@ -17,13 +20,6 @@
 	&.is-active {
 		@include input-style__focus();
 	}
-}
-
-.components-form-token-field__input-container {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: flex-start;
-	padding: 4px;
 
 	// Token input
 	input[type="text"].components-form-token-field__input {
@@ -48,6 +44,11 @@
 	.components-form-token-field__token + input[type="text"].components-form-token-field__input {
 		width: auto;
 	}
+}
+
+.components-form-token-field__label {
+	display: inline-block;
+	margin-bottom: $grid-size-small;
 }
 
 // Tokens
@@ -154,13 +155,14 @@
 
 // Suggestion list
 .components-form-token-field__suggestions-list {
-	background: $white;
+	flex: 1 0 100%;
+	min-width: 100%;
 	max-height: 9em;
 	overflow-y: scroll;
 	transition: all 0.15s ease-in-out;
 	list-style: none;
 	border-top: $border-width solid $dark-gray-300;
-	margin: 0;
+	margin: 4px -4px -4px -4px;
 	padding-top: 3px;
 }
 

--- a/packages/components/src/form-token-field/token-input.js
+++ b/packages/components/src/form-token-field/token-input.js
@@ -29,8 +29,8 @@ class TokenInput extends Component {
 	}
 
 	render() {
-		const { value, placeholder, isExpanded, instanceId, selectedSuggestionIndex, ...props } = this.props;
-		const size = ( ( value.length === 0 && placeholder && placeholder.length ) || value.length ) + 1;
+		const { value, isExpanded, instanceId, selectedSuggestionIndex, ...props } = this.props;
+		const size = value.length + 1;
 
 		return (
 			<input
@@ -39,7 +39,6 @@ class TokenInput extends Component {
 				type="text"
 				{ ...props }
 				value={ value }
-				placeholder={ placeholder }
 				onChange={ this.onChange }
 				size={ size }
 				className="components-form-token-field__input"

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -173,7 +173,7 @@ class FlatTermSelector extends Component {
 
 		const { loading, availableTerms, selectedTerms } = this.state;
 		const termNames = availableTerms.map( ( term ) => term.name );
-		const newTermPlaceholderLabel = get(
+		const newTermLabel = get(
 			taxonomy,
 			[ 'data', 'labels', 'add_new_item' ],
 			slug === 'post_tag' ? __( 'Add New Tag' ) : __( 'Add New Term' )
@@ -196,7 +196,7 @@ class FlatTermSelector extends Component {
 				onInputChange={ this.searchTerms }
 				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
 				disabled={ loading }
-				placeholder={ newTermPlaceholderLabel }
+				label={ newTermLabel }
 				messages={ {
 					added: termAddedLabel,
 					removed: termRemovedLabel,


### PR DESCRIPTION
This PR seeks to address the considerations made in #10125 

Placeholders shouldn't be used as replacement for labels. This design trend creates more problem than it solves, while a visible `<label>` element benefits everyone. Please refer to the considerations made on the issue and in the core Trac ticket https://core.trac.wordpress.org/ticket/40331. I'd strongly recommend to go through all the resources and articles linked in the Trac ticket to get a good grasp of what the nature of the issue is.

- removes the placeholder
- makes the existing label visible
- refactors markup and CSS a bit to keep the styling unchanged

before:

<img width="600" alt="screen shot 2018-09-23 at 15 18 01" src="https://user-images.githubusercontent.com/1682452/45928690-08251a80-bf48-11e8-9757-30fe231ff379.png">

after:

<img width="600" alt="screen shot 2018-09-23 at 12 14 49" src="https://user-images.githubusercontent.com/1682452/45928702-386cb900-bf48-11e8-99b9-68f9718ce499.png">

As mentioned in the issue, this way it's also easier to reuse this component in different contexts, as there will always be a visible label while the current implementation in the sidebar relies on the sidebar panel title.

Fixes #10125 

Aside: unrelated, but the readme should be updated as it still says pressing Tab will insert a new token: this is no longer true since a few months:
```- `tab` / `enter` - if suggestion selected, insert suggestion as a new token; otherwise, insert value typed into input as new token```