### PR TITLE
Add the React Native entrypoint to more packages

### DIFF
--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -18,6 +18,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0"
 	},

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -18,6 +18,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0"
 	},

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -18,6 +18,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
 		"@wordpress/hooks": "file:../hooks"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,6 +18,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0"
 	},

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -18,6 +18,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"bin": {
 		"pot-to-php": "./tools/pot-to-php.js"
 	},


### PR DESCRIPTION
## Description
This PR adds the React Native entrypoints to some more WordPress packages.

## How has this been tested?
Using the mobile side PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/154

## Types of changes
Adds the `react-native` field in the packages' `package.json`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
