### PR TITLE
Try different title/appender margin fix.

### DIFF
--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -74,6 +74,10 @@
 	margin-right: auto;
 	max-width: $content-width;
 
+	// Space title similarly to other blocks.
+	// This uses negative margins so as to not affect the default block margins.
+	margin-bottom: -$block-padding - $block-spacing - $border-width - $border-width;
+
 	// Stack borders.
 	> div {
 		margin-left: 0;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -58,10 +58,9 @@
 		margin-right: -$block-padding;
 	}
 
-	// Adjust the spacing of the appender, or the first block, to sit near the title.
-	.editor-default-block-appender > .editor-default-block-appender__content,
-	.editor-block-list__block:first-child > .editor-block-list__block-edit {
-		margin-top: $block-padding - $block-spacing / 2;
+	// Adjust the spacing of the appender to match text blocks.
+	.editor-default-block-appender > .editor-default-block-appender__content {
+		margin-top: $block-padding * 2 + $block-spacing;
 	}
 
 	// Space every block, and the default appender, using margins.


### PR DESCRIPTION
This PR hopes to address feedback in https://github.com/WordPress/gutenberg/pull/9782#issuecomment-423726486.

The Title is not a _block_. It's a textarea, and has different metrics and margins that the actual text blocks. But visually and to ensure simplicity, we style it to look like a block, and have the right margins.

Right now in `master`, we do this by applying first-child margins, to any item that comes after the title. This can bleed into nesting contexts, which is not ideal.

This PR removes that, and applies the same margin to the default block appender that text blocks has. It then provides a negative margin to the title block itself, so that "pulls upwards" any first block below it.

Screenshots showing the margin in this PR:

![screen shot 2018-09-24 at 11 13 30](https://user-images.githubusercontent.com/1204802/45944703-5dfece80-bfeb-11e8-9074-8d5866807929.png)

Compare to text:

![screen shot 2018-09-24 at 11 13 38](https://user-images.githubusercontent.com/1204802/45944710-61925580-bfeb-11e8-90eb-b7ab421d5182.png)

To test, please verify there are no margin-related issues with any content, notably content inside nested block contexts like the Columns block. 