### PR TITLE
Editor: Changed createObjectUrl to createBlobURL

### DIFF
--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -7,7 +7,7 @@ import { compact, flatMap, forEach, get, has, includes, map, noop, startsWith } 
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { createBlobURL } from '@wordpress/blob';
+import { createBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -63,6 +63,7 @@ export function mediaUpload( {
 
 	const filesSet = [];
 	const setAndUpdateFiles = ( idx, value ) => {
+		revokeBlobURL( get( filesSet, [ idx, 'url' ] ) );
 		filesSet[ idx ] = value;
 		onFileChange( compact( filesSet ) );
 	};

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -7,6 +7,7 @@ import { compact, flatMap, forEach, get, has, includes, map, noop, startsWith } 
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { createBlobURL } from '@wordpress/blob';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -131,7 +132,7 @@ export function mediaUpload( {
 
 		// Set temporary URL to create placeholder media file, this is replaced
 		// with final file from media gallery when upload is `done` below
-		filesSet.push( { url: window.URL.createObjectURL( mediaFile ) } );
+		filesSet.push( { url: createBlobURL( mediaFile ) } );
 		onFileChange( filesSet );
 
 		return createMediaFromFile( mediaFile, additionalData )


### PR DESCRIPTION
Follow-up for the work started by @caxco93 in #7734.

## Description
Changed createObjectUrl to createBlobURL from the `@wordpress/editor` package.

## How has this been tested?
Included tests and manually

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
