### PR TITLE
Hierarchical terms sorted by name and filterable

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -279,7 +279,7 @@ class HierarchicalTermSelector extends Component {
 			_n( '%d result found.', '%d results found.', resultCount, 'term' ),
 			resultCount
 		);
-		this.props.speak( resultsFoundMessage, 'assertive' );
+		this.props.debouncedSpeak( resultsFoundMessage, 'assertive' );
 	}
 
 	getFilterMatcher( filterValue ) {

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -287,7 +287,7 @@ class HierarchicalTermSelector extends Component {
 		/* eslint-disable jsx-a11y/no-onchange */
 		return [
 			<input
-				type="text"
+				type="search"
 				id={ filterInputId }
 				value={ filterValue }
 				onChange={ ( event ) => this.setState( { filterValue: event.target.value } ) }

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -1,3 +1,8 @@
+.editor-post-taxonomies__hierarchical-terms-list {
+	max-height: 14em;
+	overflow: auto;
+}
+
 .editor-post-taxonomies__hierarchical-terms-choice {
 	margin-bottom: 8px;
 }
@@ -23,5 +28,9 @@
 
 .editor-post-taxonomies__hierarchical-terms-input {
 	margin-top: 8px;
+	width: 100%;
+}
+.editor-post-taxonomies__hierarchical-terms-filter {
+	margin-bottom: 8px;
 	width: 100%;
 }


### PR DESCRIPTION
## Description

Fix for https://github.com/WordPress/gutenberg/issues/2607

Limits the height of the list so that sites with a lot of categories don't have lists that cause the page to grow a lot.

Adds a filter field to do simple substring matching on the list.

Changes the default ordering to name ascending.

## How has this been tested?

Load a post, check the categories are there. Try filtering the list of categories to find the one you want.

## Screenshots <!-- if applicable -->

![newcategoryui](https://user-images.githubusercontent.com/3314354/45958198-b72c2980-c00e-11e8-8532-ed00a5f2d688.gif)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
