### PR TITLE
Fix shortcode package dependencies

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -304,7 +304,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-shortcode',
 		gutenberg_url( 'build/shortcode/index.js' ),
-		array( 'wp-polyfill' ),
+		array( 'wp-polyfill', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/shortcode/index.js' ),
 		true
 	);

--- a/packages/shortcode/CHANGELOG.md
+++ b/packages/shortcode/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.1 (Unreleased)
+
+### Bug Fixes
+
+- Fix missing memize dependency in package.json
+
 ## 2.0.0 (2018-09-05)
 
 ### Breaking Change

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -20,7 +20,8 @@
 	"module": "build-module/index.js",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
-		"lodash": "^4.17.10"
+		"lodash": "^4.17.10",
+		"memize": "^1.0.5"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Installing the shortcode package using npm leads to an unresolved dependency (memize).