### PR TITLE
Use nesting in cover image take 2

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -29,7 +29,8 @@ $z-layers: (
 	".edit-post-header": 30,
 	".block-library-button__inline-link .editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
 	".block-library-image__resize-handlers": 1, // Resize handlers above sibling inserter
-	".wp-block-cover-image__inner-container": 0, // InnerBlocks area inside cover image block
+	".wp-block-cover-image__inner-container": 1, // InnerBlocks area inside cover image block
+	".wp-block-cover-image__video-background": 0, // Video background inside cover image block
 
 	// Side UI active buttons
 	".editor-block-mover__control": 1,

--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -29,6 +29,7 @@ $z-layers: (
 	".edit-post-header": 30,
 	".block-library-button__inline-link .editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
 	".block-library-image__resize-handlers": 1, // Resize handlers above sibling inserter
+	".wp-block-cover-image__inner-container": 0, // InnerBlocks area inside cover image block
 
 	// Side UI active buttons
 	".editor-block-mover__control": 1,

--- a/packages/block-library/src/cover-image/editor.scss
+++ b/packages/block-library/src/cover-image/editor.scss
@@ -19,11 +19,28 @@
 		color: inherit;
 	}
 
+	&.has-right-content .editor-rich-text__inline-toolbar,
 	&.has-left-content .editor-rich-text__inline-toolbar {
-		justify-content: flex-start;
+		display: inline-block;
 	}
 
-	&.has-right-content .editor-rich-text__inline-toolbar {
-		justify-content: flex-end;
+	.editor-block-list__layout {
+		width: 100%;
+	}
+
+	.editor-block-list__block {
+		color: $light-gray-100;
 	}
 }
+
+// wp-block-cover-image class is used just to increase selector specificity
+.wp-block-cover-image .wp-block-cover-image__inner-container {
+	// avoid text align inherit from cover image align.
+	text-align: left;
+}
+
+.wp-block-cover-image__inner-container > .editor-inner-blocks > .editor-block-list__layout {
+	margin-left: 0;
+	margin-right: 0;
+}
+

--- a/packages/block-library/src/cover-image/style.scss
+++ b/packages/block-library/src/cover-image/style.scss
@@ -71,6 +71,7 @@
 		right: 0;
 		background-color: inherit;
 		opacity: 0.5;
+		z-index: z-index(".wp-block-cover-image__inner-container");
 	}
 
 	@for $i from 1 through 10 {
@@ -108,4 +109,15 @@
 	.wp-block-subhead {
 		color: inherit;
 	}
+}
+
+.wp-block-cover-image__video-background {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translateX(-50%) translateY(-50%);
+	width: 100%;
+	height: 100%;
+	z-index: z-index(".wp-block-cover-image__video-background");
+	object-fit: fill;
 }

--- a/packages/block-library/src/cover-image/style.scss
+++ b/packages/block-library/src/cover-image/style.scss
@@ -1,3 +1,12 @@
+.wp-block-cover-image,
+.wp-block-cover-image.alignleft,
+.wp-block-cover-image.aligncenter,
+.wp-block-cover-image.alignright,
+.wp-block-cover-image.alignwide,
+.wp-block-cover-image.alignfull {
+	display: flex;
+}
+
 .wp-block-cover-image {
 	position: relative;
 	background-color: $black;
@@ -6,7 +15,7 @@
 	min-height: 430px;
 	width: 100%;
 	margin: 0 0 1.5em 0;
-	display: flex;
+
 	justify-content: center;
 	align-items: center;
 
@@ -81,5 +90,22 @@
 	&.alignright {
 		max-width: $content-width / 2;
 		width: 100%;
+	}
+
+	.wp-block-cover-image__inner-container {
+		width: calc(100% - 70px);
+		z-index: z-index(".wp-block-cover-image__inner-container");
+		color: $light-gray-100;
+	}
+
+	p,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	.wp-block-subhead {
+		color: inherit;
 	}
 }

--- a/post-content.php
+++ b/post-content.php
@@ -1,5 +1,11 @@
 <!-- wp:cover-image {"url":"https://cldup.com/Fz-ASbo2s3.jpg","align":"wide"} -->
-<div class="wp-block-cover-image has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><p class="wp-block-cover-image-text"><?php _e( 'Of Mountains &amp; Printing Presses', 'gutenberg' ); ?></p></div>
+<div class="wp-block-cover-image has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)">
+   <div class="wp-block-cover-image__inner-container">
+      <!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+      <p style="text-align:center" class="has-large-font-size">Of Mountains &amp; Printing Presses</p>
+      <!-- /wp:paragraph -->
+   </div>
+</div>
 <!-- /wp:cover-image -->
 
 <!-- wp:paragraph -->

--- a/test/integration/full-content/fixtures/core__cover-image.html
+++ b/test/integration/full-content/fixtures/core__cover-image.html
@@ -1,5 +1,9 @@
-<!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
-<div class="wp-block-cover-image has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)">
-    <p class="wp-block-cover-image-text">Guten Berg!</p>
+<!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","id":8398,"dimRatio": 40} -->
+<div class="wp-block-cover-image has-background-dim has-background-dim-40" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)">
+    <div class="wp-block-cover-image__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p style="text-align:center" class="has-large-font-size">Paragraph 1</p>
+		<!-- /wp:paragraph -->
+    </div>
 </div>
-<!-- /wp:core/cover-image -->
+<!-- /wp:cover-image -->

--- a/test/integration/full-content/fixtures/core__cover-image.parsed.json
+++ b/test/integration/full-content/fixtures/core__cover-image.parsed.json
@@ -3,10 +3,22 @@
         "blockName": "core/cover-image",
         "attrs": {
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
+            "id": 8398,
             "dimRatio": 40
         },
-        "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-cover-image has-background-dim-40 has-background-dim\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <p class=\"wp-block-cover-image-text\">Guten Berg!</p>\n</div>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "center",
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p style=\"text-align:center\" class=\"has-large-font-size\">Paragraph 1</p>\n\t\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-cover-image has-background-dim has-background-dim-40\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <div class=\"wp-block-cover-image__inner-container\">\n\t\t\n    </div>\n</div>\n"
     },
     {
         "blockName": null,

--- a/test/integration/full-content/fixtures/core__cover-image.serialized.html
+++ b/test/integration/full-content/fixtures/core__cover-image.serialized.html
@@ -1,3 +1,5 @@
-<!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
-<div class="wp-block-cover-image has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)"><p class="wp-block-cover-image-text">Guten Berg!</p></div>
+<!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","id":8398,"dimRatio":40} -->
+<div class="wp-block-cover-image has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)"><div class="wp-block-cover-image__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p style="text-align:center" class="has-large-font-size">Paragraph 1</p>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:cover-image -->


### PR DESCRIPTION
PR https://github.com/WordPress/gutenberg/pull/5452 was created a long time ago and meanwhile, our nesting mechanism evolved a lot. Some PR's were extracted from it and were already merged. At the time we decided to not migrate yet nesting to cover image because the mechanism did not offer a good experience.

This PR is a take two to use nesting in the cover image so we can check if the nesting mechanism now is ready.

This is a first step in the following set of enhancements:
Rename cover image block to cover, add video/color background functionality.

## How has this been tested?
I verified the cover image block works as expected, and existing cover images are automatically migrated.
