### PR TITLE
Fix: Block alignment css rules affecting nested blocks

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -309,31 +309,26 @@
 		}
 	}
 
-	// Left
-	&[data-align="left"] {
-		// This is in the editor only; the image should be floated on the frontend.
-		.editor-block-list__block-edit {
-			/*!rtl:begin:ignore*/
-			float: left;
-			margin-right: 2em;
-			/*!rtl:end:ignore*/
-		}
+	// Left: This is in the editor only; the image should be floated on the frontend.
+	&[data-align="left"] > .editor-block-list__block-edit {
+		/*!rtl:begin:ignore*/
+		float: left;
+		margin-right: 2em;
+		/*!rtl:end:ignore*/
 	}
 
-	// Right
-	&[data-align="right"] {
-		// This is in the editor only; the image should be floated on the frontend.
-		.editor-block-list__block-edit {
-			/*!rtl:begin:ignore*/
-			float: right;
-			margin-left: 2em;
-			/*!rtl:end:ignore*/
-		}
+	// Right: This is in the editor only; the image should be floated on the frontend.
+	&[data-align="right"] > .editor-block-list__block-edit {
+		/*!rtl:begin:ignore*/
+		float: right;
+		margin-left: 2em;
+		/*!rtl:end:ignore*/
+	}
 
-		.editor-block-toolbar {
-			/*!rtl:ignore*/
-			float: right;
-		}
+	&[data-align="right"] > .editor-block-contextual-toolbar > .editor-block-toolbar {
+		/*!rtl:begin:ignore*/
+		float: right;
+		/*!rtl:end:ignore*/
 	}
 
 	// Wide and full-wide


### PR DESCRIPTION
## Description
Some CSS rules to apply left and right alignment used the CSS children selector instead of direct children selector. This caused some bugs on nested blocks.
It was discovered during the PR https://github.com/WordPress/gutenberg/pull/10141 where the bug caused some troubles.
Note that for wide alignment direct children selector was being correctly used. 

## How has this been tested?
I added the test block available in https://gist.github.com/jorgefilipecosta/78f206b7c5a28458b54b2abce04787e8 ( pasted it in the console).
I made the block right aligned and verified the block kept its shape.

## Screenshots
Before:
<img width="447" alt="screen shot 2018-09-24 at 19 49 20" src="https://user-images.githubusercontent.com/11271197/45972805-98d92480-c034-11e8-908b-c384f2f0f532.png">

After:
<img width="359" alt="screen shot 2018-09-24 at 19 52 26" src="https://user-images.githubusercontent.com/11271197/45972791-91198000-c034-11e8-909e-3b29991091e6.png">
