### PR TITLE
chore: Add E2E tests for list creation (see #7890)

### DIFF
--- a/test/e2e/specs/__snapshots__/lists.test.js.snap
+++ b/test/e2e/specs/__snapshots__/lists.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Lists can be created by typing "/list" 1`] = `
+"<!-- wp:list -->
+<ul><li>I’m a list</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`Lists can be created by using a hyphen at the start of a RichText block 1`] = `
+"<!-- wp:list -->
+<ul><li>A list item</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`Lists can be created by using an asterisk at the start of a RichText block 1`] = `
+"<!-- wp:list -->
+<ul><li>A list item</li><li>Another list item</li></ul>
+<!-- /wp:list -->"
+`;

--- a/test/e2e/specs/lists.test.js
+++ b/test/e2e/specs/lists.test.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	newPost,
+} from '../support/utils';
+
+describe( 'Lists', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'can be created by using an asterisk at the start of a RichText block', async () => {
+		// Create a block with some text that will trigger a list creation.
+		await clickBlockAppender();
+		await page.keyboard.type( '* A list item' );
+
+		// Create a second list item.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Another list item' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by using a hyphen at the start of a RichText block', async () => {
+		// Create a block with some text that will trigger a list creation.
+		await clickBlockAppender();
+		await page.keyboard.type( '- A list item' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by typing "/list"', async () => {
+		// Create a list with the slash block shortcut.
+		await clickBlockAppender();
+		await page.keyboard.type( '/list' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'I’m a list' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Adds tests for list creation after regressions were found in #7890.

Would be good to get these in and then use them for #7890. 😄 