### PR TITLE
Remove glob and just include necessary files

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -33,19 +33,9 @@ require dirname( __FILE__ ) . '/register.php';
 
 
 // Register server-side code for individual blocks.
-$paths = array(
-	dirname( __FILE__ ) . '/../block-library/*/index.php',
-	dirname( __FILE__ ) . '/../packages/block-library/src/*/index.php',
-);
-
-foreach ( $paths as $path ) {
-	$block_logic_files = glob( $path );
-	// glob() can sometimes return false if there's an error, or it couldn't find any files.
-	if ( ! $block_logic_files ) {
-		continue;
-	}
-
-	foreach ( $block_logic_files as $block_logic ) {
-		require $block_logic;
-	}
-}
+require dirname( __FILE__ ) . '/../packages/block-library/src/archives/index.php';
+require dirname( __FILE__ ) . '/../packages/block-library/src/block/index.php';
+require dirname( __FILE__ ) . '/../packages/block-library/src/categories/index.php';
+require dirname( __FILE__ ) . '/../packages/block-library/src/latest-comments/index.php';
+require dirname( __FILE__ ) . '/../packages/block-library/src/latest-posts/index.php';
+require dirname( __FILE__ ) . '/../packages/block-library/src/shortcode/index.php';


### PR DESCRIPTION
## Description
Remove the use of glob to require files, simply hard code the necessary files.
This improves performance and simplifies the code.

Fixes #10052 


## How has this been tested?
Confirmed block library includes still work as expected.

## Types of changes

Removes the glob(*) in favor of hard coding.
You can confirm the proper files are included by checking the following directory paths which it was searching to include the files.

```
> ls -1 ./block-library/**/index.php
ls: cannot access './block-library/**/index.php': No such file or directory

> ls -1 ./packages/block-library/src/**/index.php
./packages/block-library/src/archives/index.php
./packages/block-library/src/block/index.php
./packages/block-library/src/categories/index.php
./packages/block-library/src/latest-comments/index.php
./packages/block-library/src/latest-posts/index.php
./packages/block-library/src/shortcode/index.php
```


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
