### PR TITLE
chore: Update Redux to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2189,7 +2189,7 @@
 				"equivalent-key-map": "^0.2.0",
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.10",
-				"redux": "^3.7.2"
+				"redux": "^4.0.0"
 			}
 		},
 		"@wordpress/date": {
@@ -2249,6 +2249,7 @@
 				"classnames": "^2.2.5",
 				"dom-scroll-into-view": "^1.2.1",
 				"inherits": "^2.0.3",
+				"jquery": "^3.3.1",
 				"lodash": "^4.17.10",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
@@ -2384,31 +2385,6 @@
 				"@babel/runtime": "^7.0.0",
 				"is-promise": "^2.1.0",
 				"rungen": "^0.3.2"
-			},
-			"dependencies": {
-				"js-tokens": {
-					"version": "4.0.0",
-					"bundled": true
-				},
-				"loose-envify": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"js-tokens": "^3.0.0 || ^4.0.0"
-					}
-				},
-				"redux": {
-					"version": "4.0.0",
-					"bundled": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"symbol-observable": "^1.2.0"
-					}
-				},
-				"symbol-observable": {
-					"version": "1.2.0",
-					"bundled": true
-				}
 			}
 		},
 		"@wordpress/rich-text": {
@@ -12975,11 +12951,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
 			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
-		"lodash-es": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
-		},
 		"lodash._baseisequal": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
@@ -16979,14 +16950,12 @@
 			}
 		},
 		"redux": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+			"integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
 			"requires": {
-				"lodash": "^4.2.1",
-				"lodash-es": "^4.2.1",
 				"loose-envify": "^1.1.0",
-				"symbol-observable": "^1.0.3"
+				"symbol-observable": "^1.2.0"
 			}
 		},
 		"redux-multi": {
@@ -20606,7 +20575,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
 		"prop-types": "15.5.10",
 		"react": "16.4.1",
 		"react-dom": "16.4.1",
-		"redux": "3.7.2",
 		"refx": "3.0.0"
 	},
 	"devDependencies": {

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Adding support for using controls in resolvers using the controls plugin.
 
+### Polish
+
+- Updated `redux` dependency to the latest version.
+
 ### Deprecations
 
 - Writing resolvers as async generators has been deprecated. Use the controls plugin instead.

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -30,7 +30,7 @@
 		"equivalent-key-map": "^0.2.0",
 		"is-promise": "^2.1.0",
 		"lodash": "^4.17.10",
-		"redux": "^3.7.2"
+		"redux": "^4.0.0"
 	},
 	"devDependencies": {
 		"deep-freeze": "^0.0.1",


### PR DESCRIPTION
## Description
I noticed that we use `redux@4.0.0` as a dependency for `@wordpress/redux-routine` but use `redux@3.7.2` for `@wordpress/data`. This PR fixes it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
