### PR TITLE
Fix regression with Button placeholder text

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -18,10 +18,15 @@
 		cursor: text;
 		line-height: 1;
 	}
+
+	&:not(.has-text-color) .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
+		color: $white;
+		opacity: 0.8;
+	}
 }
 
 .block-library-button__inline-link {
-	background: #fff;
+	background: $white;
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;


### PR DESCRIPTION
A recent change to placeholder text contrast caused this to regress. This PR fixes that.

Before:

![screen shot 2018-09-25 at 14 05 14](https://user-images.githubusercontent.com/1204802/46013632-308a5180-c0cd-11e8-800e-3b6889a72734.png)

After:

![screen shot 2018-09-25 at 14 12 05](https://user-images.githubusercontent.com/1204802/46013640-32ecab80-c0cd-11e8-8543-1e6ba44769bc.png)
