### PR TITLE
Toggle responsiveness for embed blocks

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -153,9 +153,10 @@ export function getEmbedEdit( title, icon ) {
 		 * if the HTML has an iframe with width and height set.
 		 *
 		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
-		 * @return {Object} Object with classnames set to true, for use with `classnames`.
+		 * @param {boolean} add If the classes should be added, or removed.
+		 * @return {Object} Object with classnames set for use with `classnames`.
 		 */
-		getAspectRatioClassNames( html ) {
+		getAspectRatioClassNames( html, add = true ) {
 			const previewDocument = document.implementation.createHTMLDocument( '' );
 			previewDocument.body.innerHTML = html;
 			const iframe = previewDocument.body.querySelector( 'iframe' );
@@ -192,8 +193,8 @@ export function getEmbedEdit( title, icon ) {
 
 				if ( aspectRatioClassName ) {
 					return {
-						[ aspectRatioClassName ]: true,
-						'wp-has-aspect-ratio': true,
+						[ aspectRatioClassName ]: add,
+						'wp-has-aspect-ratio': add,
 					};
 				}
 			}
@@ -252,15 +253,7 @@ export function getEmbedEdit( title, icon ) {
 		toggleResponsive() {
 			const { allowResponsive, className } = this.props.attributes;
 			const { html } = this.props.preview;
-			const responsiveClassNames = this.getAspectRatioClassNames( html );
-
-			if ( allowResponsive ) {
-				// Before toggling, we were allowing responsiveness, so
-				// this will remove the responsive classes from the className attribute.
-				for ( const property in responsiveClassNames ) {
-					responsiveClassNames[ property ] = false;
-				}
-			}
+			const responsiveClassNames = this.getAspectRatioClassNames( html, ! allowResponsive );
 
 			this.props.setAttributes(
 				{

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -248,7 +248,7 @@ export function getEmbedEdit( title, icon ) {
 		}
 
 		getResponsiveHelp( checked ) {
-			return checked ? __( 'Videos automatically resize.' ) : __( 'Videos are fixed size.' );
+			return checked ? __( 'Videos and other content automatically resizes.' ) : __( 'Content is fixed size.' );
 		}
 
 		toggleResponsive() {

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -52,7 +52,7 @@ export function getEmbedEdit( title, icon ) {
 			this.setUrl = this.setUrl.bind( this );
 			this.maybeSwitchBlock = this.maybeSwitchBlock.bind( this );
 			this.setAttributesFromPreview = this.setAttributesFromPreview.bind( this );
-			this.maybeSetAspectRatioClassName = this.maybeSetAspectRatioClassName.bind( this );
+			this.setAspectRatioClassNames = this.setAspectRatioClassNames.bind( this );
 			this.getResponsiveHelp = this.getResponsiveHelp.bind( this );
 			this.toggleResponsive = this.toggleResponsive.bind( this );
 
@@ -197,17 +197,15 @@ export function getEmbedEdit( title, icon ) {
 					};
 				}
 			}
-
-			return {};
 		}
 
 		/**
-		 * Maybe sets the appropriate CSS class names to enforce an aspect ratio when the embed
-		 * is resized if the HTML has an iframe with width and height set.
+		 * Sets the aspect ratio related class names returned by `getAspectRatioClassNames`
+		 * if `allowResponsive` is truthy.
 		 *
-		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
+		 * @param {string} html The preview HTML.
 		 */
-		maybeSetAspectRatioClassName( html ) {
+		setAspectRatioClassNames( html ) {
 			const { allowResponsive } = this.props.attributes;
 			if ( ! allowResponsive ) {
 				return;
@@ -240,7 +238,7 @@ export function getEmbedEdit( title, icon ) {
 				setAttributes( { type, providerNameSlug } );
 			}
 
-			this.maybeSetAspectRatioClassName( html );
+			this.setAspectRatioClassNames( html );
 		}
 
 		switchBackToURLInput() {

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -271,12 +271,14 @@ export function getEmbedEdit( title, icon ) {
 				<Fragment>
 					<BlockControls>
 						<Toolbar>
-							{ ( preview && ! previewIsFallback && <IconButton
-								className="components-toolbar__control"
-								label={ __( 'Edit URL' ) }
-								icon="edit"
-								onClick={ this.switchBackToURLInput }
-							/> ) }
+							{ preview && ! previewIsFallback && (
+								<IconButton
+									className="components-toolbar__control"
+									label={ __( 'Edit URL' ) }
+									icon="edit"
+									onClick={ this.switchBackToURLInput }
+								/>
+							) }
 						</Toolbar>
 					</BlockControls>
 					<InspectorControls>

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -257,7 +257,8 @@ export function getEmbedEdit( title, icon ) {
 			const responsiveClassNames = this.getAspectRatioClassNames( html );
 
 			if ( allowResponsive ) {
-				// This will remove the responsive classes from the className attribute.
+				// Before toggling, we were allowing responsiveness, so
+				// this will remove the responsive classes from the className attribute.
 				for ( const property in responsiveClassNames ) {
 					responsiveClassNames[ property ] = false;
 				}

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -10,10 +10,19 @@ import classnames from 'classnames/dedupe';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
-import { Component, renderToString } from '@wordpress/element';
-import { Button, Placeholder, Spinner, SandBox, IconButton, Toolbar } from '@wordpress/components';
+import { Component, renderToString, Fragment } from '@wordpress/element';
+import {
+	Button,
+	Placeholder,
+	Spinner,
+	SandBox,
+	IconButton,
+	Toolbar,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
-import { RichText, BlockControls, BlockIcon } from '@wordpress/editor';
+import { RichText, BlockControls, BlockIcon, InspectorControls } from '@wordpress/editor';
 import { withSelect } from '@wordpress/data';
 
 // These embeds do not work in sandboxes
@@ -44,6 +53,8 @@ export function getEmbedEdit( title, icon ) {
 			this.maybeSwitchBlock = this.maybeSwitchBlock.bind( this );
 			this.setAttributesFromPreview = this.setAttributesFromPreview.bind( this );
 			this.maybeSetAspectRatioClassName = this.maybeSetAspectRatioClassName.bind( this );
+			this.getResponsiveHelp = this.getResponsiveHelp.bind( this );
+			this.toggleResponsive = this.toggleResponsive.bind( this );
 
 			this.state = {
 				editingURL: false,
@@ -138,21 +149,18 @@ export function getEmbedEdit( title, icon ) {
 		}
 
 		/**
-		 * Sets the appropriate CSS class to enforce an aspect ratio when the embed is resized
+		 * Gets the appropriate CSS class names to enforce an aspect ratio when the embed is resized
 		 * if the HTML has an iframe with width and height set.
 		 *
 		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
+		 * @return {Object} Object with classnames set to true, for use with `classnames`.
 		 */
-		maybeSetAspectRatioClassName( html ) {
+		getAspectRatioClassNames( html ) {
 			const previewDocument = document.implementation.createHTMLDocument( '' );
 			previewDocument.body.innerHTML = html;
 			const iframe = previewDocument.body.querySelector( 'iframe' );
 
-			if ( ! iframe ) {
-				return;
-			}
-
-			if ( iframe.height && iframe.width ) {
+			if ( iframe && iframe.height && iframe.width ) {
 				const aspectRatio = ( iframe.width / iframe.height ).toFixed( 2 );
 				let aspectRatioClassName;
 
@@ -183,10 +191,32 @@ export function getEmbedEdit( title, icon ) {
 				}
 
 				if ( aspectRatioClassName ) {
-					const className = classnames( this.props.attributes.className, 'wp-has-aspect-ratio', aspectRatioClassName );
-					this.props.setAttributes( { className } );
+					return {
+						[ aspectRatioClassName ]: true,
+						'wp-has-aspect-ratio': true,
+					};
 				}
 			}
+
+			return {};
+		}
+
+		/**
+		 * Maybe sets the appropriate CSS class names to enforce an aspect ratio when the embed
+		 * is resized if the HTML has an iframe with width and height set.
+		 *
+		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
+		 */
+		maybeSetAspectRatioClassName( html ) {
+			const { allowResponsive } = this.props.attributes;
+			if ( ! allowResponsive ) {
+				return;
+			}
+			const className = classnames(
+				this.props.attributes.className,
+				this.getAspectRatioClassNames( html )
+			);
+			this.props.setAttributes( { className } );
 		}
 
 		/***
@@ -217,21 +247,57 @@ export function getEmbedEdit( title, icon ) {
 			this.setState( { editingURL: true } );
 		}
 
+		getResponsiveHelp( checked ) {
+			return checked ? __( 'Videos are responsive.' ) : __( 'Toggle to make videos responsive.' );
+		}
+
+		toggleResponsive() {
+			const { allowResponsive, className } = this.props.attributes;
+			const { html } = this.props.preview;
+			const responsiveClassNames = this.getAspectRatioClassNames( html );
+
+			if ( allowResponsive ) {
+				// This will remove the responsive classes from the className attribute.
+				for ( const property in responsiveClassNames ) {
+					responsiveClassNames[ property ] = false;
+				}
+			}
+
+			this.props.setAttributes(
+				{
+					allowResponsive: ! allowResponsive,
+					className: classnames( className, responsiveClassNames ),
+				}
+			);
+		}
+
 		render() {
 			const { url, editingURL } = this.state;
-			const { caption, type } = this.props.attributes;
+			const { caption, type, allowResponsive } = this.props.attributes;
 			const { fetching, setAttributes, isSelected, className, preview, previewIsFallback } = this.props;
 			const controls = (
-				<BlockControls>
-					<Toolbar>
-						{ ( preview && ! previewIsFallback && <IconButton
-							className="components-toolbar__control"
-							label={ __( 'Edit URL' ) }
-							icon="edit"
-							onClick={ this.switchBackToURLInput }
-						/> ) }
-					</Toolbar>
-				</BlockControls>
+				<Fragment>
+					<BlockControls>
+						<Toolbar>
+							{ ( preview && ! previewIsFallback && <IconButton
+								className="components-toolbar__control"
+								label={ __( 'Edit URL' ) }
+								icon="edit"
+								onClick={ this.switchBackToURLInput }
+							/> ) }
+						</Toolbar>
+					</BlockControls>
+					<InspectorControls>
+						<PanelBody title={ __( 'Media Settings' ) } className="blocks-responsive">
+							<ToggleControl
+								label={ __( 'Responsive' ) }
+								checked={ allowResponsive }
+								help={ this.getResponsiveHelp }
+								onChange={ this.toggleResponsive }
+							/>
+						</PanelBody>
+					</InspectorControls>
+				</Fragment>
 			);
 
 			if ( fetching ) {
@@ -330,6 +396,10 @@ const embedAttributes = {
 	},
 	providerNameSlug: {
 		type: 'string',
+	},
+	allowResponsive: {
+		type: 'boolean',
+		default: true,
 	},
 };
 

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -248,7 +248,7 @@ export function getEmbedEdit( title, icon ) {
 		}
 
 		getResponsiveHelp( checked ) {
-			return checked ? __( 'Videos are responsive.' ) : __( 'Toggle to make videos responsive.' );
+			return checked ? __( 'Videos automatically resize.' ) : __( 'Videos are fixed size.' );
 		}
 
 		toggleResponsive() {

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -153,10 +153,10 @@ export function getEmbedEdit( title, icon ) {
 		 * if the HTML has an iframe with width and height set.
 		 *
 		 * @param {string} html The preview HTML that possibly contains an iframe with width and height set.
-		 * @param {boolean} add If the classes should be added, or removed.
+		 * @param {boolean} allowResponsive If the classes should be added, or removed.
 		 * @return {Object} Object with classnames set for use with `classnames`.
 		 */
-		getAspectRatioClassNames( html, add = true ) {
+		getAspectRatioClassNames( html, allowResponsive = true ) {
 			const previewDocument = document.implementation.createHTMLDocument( '' );
 			previewDocument.body.innerHTML = html;
 			const iframe = previewDocument.body.querySelector( 'iframe' );
@@ -193,8 +193,8 @@ export function getEmbedEdit( title, icon ) {
 
 				if ( aspectRatioClassName ) {
 					return {
-						[ aspectRatioClassName ]: add,
-						'wp-has-aspect-ratio': add,
+						[ aspectRatioClassName ]: allowResponsive,
+						'wp-has-aspect-ratio': allowResponsive,
 					};
 				}
 			}
@@ -284,7 +284,7 @@ export function getEmbedEdit( title, icon ) {
 					<InspectorControls>
 						<PanelBody title={ __( 'Media Settings' ) } className="blocks-responsive">
 							<ToggleControl
-								label={ __( 'Responsive' ) }
+								label={ __( 'Automatically scale content' ) }
 								checked={ allowResponsive }
 								help={ this.getResponsiveHelp }
 								onChange={ this.toggleResponsive }

--- a/test/integration/full-content/fixtures/core__embed.json
+++ b/test/integration/full-content/fixtures/core__embed.json
@@ -7,7 +7,8 @@
             "url": "https://example.com/",
             "caption": [
                 "Embedded content from an example URL"
-            ]
+            ],
+            "allowResponsive": true
         },
         "innerBlocks": [],
         "originalContent": "<figure class=\"wp-block-embed\">\n    <div class=\"wp-block-embed__wrapper\">\n        https://example.com/\n    </div>\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>"


### PR DESCRIPTION
## Description

Added an inspector control to toggle responsive classes on a per block basis.

## How has this been tested?

Start a post, embed a youtube video.
Publish the post.
Edit the post, toggle responsiveness to off. Check the responsive classes are removed.
Publish the post. Edit it, and check the classes are still removed.
Toggle the responsiveness back on, publish the post.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
