### PR TITLE
Documentation: fix registerBlockStyle arguments, clarify getSaveElement filter args

### DIFF
--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -13,10 +13,13 @@ Block Style Variations allow providing alternative styles to existing blocks. Th
 _Example:_
 
 ```js
-wp.blocks.registerBlockStyle( 'core/quote', 'fancy-quote' );
+wp.blocks.registerBlockStyle( 'core/quote', {
+	name: 'fancy-quote',
+	label: 'Fancy Quote'
+} );
 ```
 
-The example above registers a block style variation called `fancy-quote` to the `core/quote` block. When the user selects this block style variation from the styles selector, an `is-style-fancy-quote` className will be added to the block's wrapper.
+The example above registers a block style variation named `fancy-quote` to the `core/quote` block. When the user selects this block style variation from the styles selector, an `is-style-fancy-quote` className will be added to the block's wrapper.
 
 ### Filters
 
@@ -54,9 +57,13 @@ wp.hooks.addFilter(
 
 A filter that applies to the result of a block's `save` function. This filter is used to replace or extend the element, for example using `wp.element.cloneElement` to modify the element's props or replace its children, or returning an entirely new element.
 
+The filter's callback receives an element, a block type and the block attributes as arguments. It should return an element.
+
 #### `blocks.getSaveContent.extraProps`
 
-A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block type and the block attributes as arguments.
+A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element.
+
+The filter receives the current `save` element's props, a block type and the block attributes as arguments. It should return a props object.
 
 _Example:_
 
@@ -179,6 +186,7 @@ _Example:_
 
 {% codetabs %}
 {% ES5 %}
+
 ```js
 var el = wp.element.createElement;
 
@@ -206,6 +214,7 @@ var withDataAlign = wp.compose.createHigherOrderComponent( function( BlockListBl
 }, 'withAlign' );
 
 wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-data-align', withDataAlign );
+
 ```
 {% ESNext %}
 ```js
@@ -224,6 +233,7 @@ const withDataAlign = createHigherOrderComponent( ( BlockListBlock ) => {
 
 wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-data-align', withDataAlign );
 ```
+
 {% end %}
 
 ## Removing Blocks
@@ -285,7 +295,7 @@ On the server, you can filter the list of blocks shown in the inserter using the
 
 function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
 	if ( $post->post_type !== 'post' ) {
-	    return $allowed_block_types;
+		return $allowed_block_types;
 	}
 	return array( 'core/paragraph' );
 }


### PR DESCRIPTION
## Description
Update arguments for `wp.blocks.registerBlockStyle`. The current example doesn't do anything because the hook expects an object with `name` and `label` keys.

## How has this been tested?
This is a documentation fix. 

## Types of changes
Non-breaking change, documentation update.

## Checklist:
(n/a? no changes to non-documentation files)
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
