### PR TITLE
chore: Use snapshots for #9454 conversion tests

### DIFF
--- a/test/e2e/specs/__snapshots__/convert-block-type.test.js.snap
+++ b/test/e2e/specs/__snapshots__/convert-block-type.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Code block should convert to a preformatted block 1`] = `
+"<!-- wp:code -->
+<pre class=\\"wp-block-code\\"><code>print \\"Hello Dolly!\\"</code></pre>
+<!-- /wp:code -->"
+`;
+
+exports[`Code block should convert to a preformatted block 2`] = `
+"<!-- wp:preformatted -->
+<pre class=\\"wp-block-preformatted\\">print \\"Hello Dolly!\\"</pre>
+<!-- /wp:preformatted -->"
+`;

--- a/test/e2e/specs/convert-block-type.test.js
+++ b/test/e2e/specs/convert-block-type.test.js
@@ -19,11 +19,9 @@ describe( 'Code block', () => {
 
 		await page.type( '.editor-block-list__block textarea', code );
 
-		// Verify the content starts as a Code block.
+		// Verify the content starts out as a Code block.
 		const originalPostContent = await getEditedPostContent();
-		const codeRegex = new RegExp( `<!-- wp:code -->\\s*<pre class="wp-block-code"><code>${ code }<\\/code><\\/pre>\\s*<!-- \\/wp:code -->` );
-
-		expect( originalPostContent ).toMatch( codeRegex );
+		expect( originalPostContent ).toMatchSnapshot();
 
 		// Hover over this block to show its toolbar so we can click on the block
 		// conversion button.
@@ -37,8 +35,6 @@ describe( 'Code block', () => {
 
 		// The content should now be a Preformatted block with no data loss.
 		const convertedPostContent = await getEditedPostContent();
-		const preformattedRegex = new RegExp( `<!-- wp:preformatted -->\\s*<pre class="wp-block-preformatted">${ code }<\\/pre>\\s*<!-- \\/wp:preformatted -->` );
-
-		expect( convertedPostContent ).toMatch( preformattedRegex );
+		expect( convertedPostContent ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
Use snapshots for tests added in #9454, as requested in 
https://github.com/WordPress/gutenberg/pull/9454#discussion_r220090944