### PR TITLE
Fix: Paragraph: Link colors

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -200,6 +200,7 @@ class ParagraphBlock extends Component {
 				<RichText
 					tagName="p"
 					className={ classnames( 'wp-block-paragraph', className, {
+						'has-text-color': textColor.color,
 						'has-background': backgroundColor.color,
 						'has-drop-cap': dropCap,
 						[ backgroundColor.class ]: backgroundColor.class,

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -245,6 +245,7 @@ export const settings = {
 		const fontSizeClass = getFontSizeClass( fontSize );
 
 		const className = classnames( {
+			'has-text-color': textColor || customTextColor,
 			'has-background': backgroundColor || customBackgroundColor,
 			'has-drop-cap': dropCap,
 			[ fontSizeClass ]: fontSizeClass,

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -33,3 +33,7 @@ p {
 p.has-background {
 	padding: 20px 30px;
 }
+
+p.has-text-color a {
+	color: inherit;
+}


### PR DESCRIPTION
## Description
If a paragraph block contained a custom text color that color was not applied to hyperlinks inside it.

This PR's fixes that. In order to fix the problem, a new class 'has-text-color' was added to every paragraph that has a custom text color (set using a class or an inline style). The allows us to target paragraphs with a color which until now was not possible.


## How has this been tested?
Add the following block:
```
<!-- wp:paragraph {"textColor":"pale-pink"} -->
<p class="has-text-color has-pale-pink-color">link: <a href="http://www.wordpress.org">WordPress</a></p>
<!-- /wp:paragraph -->
```

Verify the link appears in pale pink in both the front end and the editor.

## Screenshots
Before:

<img width="619" alt="screen shot 2018-09-25 at 18 12 04" src="https://user-images.githubusercontent.com/11271197/46030638-8fac8e00-c0ee-11e8-80b7-d3a8a22c91a0.png">

After:

<img width="726" alt="screen shot 2018-09-25 at 18 11 47" src="https://user-images.githubusercontent.com/11271197/46030644-94714200-c0ee-11e8-9275-509866f148a5.png">

