### PR TITLE
Fix: More block to handle Enter

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -5,11 +5,14 @@ import { __ } from '@wordpress/i18n';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
+import { ENTER } from '@wordpress/keycodes';
+import { createBlock } from '@wordpress/blocks';
 
 export default class MoreEdit extends Component {
 	constructor() {
 		super( ...arguments );
 		this.onChangeInput = this.onChangeInput.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
 
 		this.state = {
 			defaultText: __( 'Read more' ),
@@ -24,6 +27,14 @@ export default class MoreEdit extends Component {
 
 		const value = event.target.value.length === 0 ? undefined : event.target.value;
 		this.props.setAttributes( { customText: value } );
+	}
+
+	onKeyDown( event ) {
+		const { keyCode } = event;
+		const { insertBlocksAfter } = this.props;
+		if ( keyCode === ENTER ) {
+			insertBlocksAfter( [ createBlock( 'core/paragraph' ) ] );
+		}
 	}
 
 	render() {
@@ -52,6 +63,7 @@ export default class MoreEdit extends Component {
 						value={ value }
 						size={ inputLength }
 						onChange={ this.onChangeInput }
+						onKeyDown={ this.onKeyDown }
 					/>
 				</div>
 			</Fragment>

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -6,7 +6,10 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
 import { ENTER } from '@wordpress/keycodes';
-import { createBlock } from '@wordpress/blocks';
+import {
+	getDefaultBlockName,
+	createBlock,
+} from '@wordpress/blocks';
 
 export default class MoreEdit extends Component {
 	constructor() {
@@ -33,7 +36,7 @@ export default class MoreEdit extends Component {
 		const { keyCode } = event;
 		const { insertBlocksAfter } = this.props;
 		if ( keyCode === ENTER ) {
-			insertBlocksAfter( [ createBlock( 'core/paragraph' ) ] );
+			insertBlocksAfter( [ createBlock( getDefaultBlockName() ) ] );
 		}
 	}
 

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -16,6 +16,7 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
   >
     <input
       onChange={[Function]}
+      onKeyDown={[Function]}
       size={1}
       type="text"
       value=""
@@ -40,6 +41,7 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
   >
     <input
       onChange={[Function]}
+      onKeyDown={[Function]}
       size={1}
       type="text"
       value=""


### PR DESCRIPTION
## Description

Pressing enter in the Read More should behave like other blocks and simply create a new block and make all keyboard access a bit smoother.

Fixes #7324


## How has this been tested?

Tested adding a Read More block and pressing enter.

## Screenshots 

![read-more-results](https://user-images.githubusercontent.com/45363/46044707-6250e780-c0d0-11e8-8054-16c2cb6f3cad.gif)


## Types of changes

Adds a `onKeyDown` listener to the More block which when checks for ENTER, when pressed will insert a new block below.

Updates unittest with new snapshot.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
