### PR TITLE
Fixed ESNext example code

### DIFF
--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -155,7 +155,7 @@ wp.hooks.addFilter( 'editor.BlockEdit', 'my-plugin/with-inspector-controls', wit
 {% ESNext %}
 ```js
 const { createHigherOrderComponent } = wp.compose;
-const { Fragment } = wp.Element;
+const { Fragment } = wp.element;
 const { InspectorControls } = wp.editor;
 const { PanelBody } = wp.components;
 
@@ -163,12 +163,12 @@ const withInspectorControls =  createHigherOrderComponent(BlockEdit => {
   return props => {
     return (
       <Fragment>
+        <BlockEdit { ...props } />
 		<InspectorControls>
 			<PanelBody>
 				My custom control
 			</PanelBody>
-		<InspectorControls />
-        <BlockEdit { ...props } />
+		</InspectorControls>
       </Fragment>
     );
   };

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -159,19 +159,19 @@ const { Fragment } = wp.element;
 const { InspectorControls } = wp.editor;
 const { PanelBody } = wp.components;
 
-const withInspectorControls =  createHigherOrderComponent(BlockEdit => {
-  return props => {
-    return (
-      <Fragment>
-        <BlockEdit { ...props } />
-		<InspectorControls>
-			<PanelBody>
-				My custom control
-			</PanelBody>
-		</InspectorControls>
-      </Fragment>
-    );
-  };
+const withInspectorControls =  createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					<PanelBody>
+						My custom control
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	};
 }, "withInspectorControl" );
 
 wp.hooks.addFilter( 'editor.BlockEdit', 'my-plugin/with-inspector-controls', withInspectorControls );


### PR DESCRIPTION
## Description
Fixed errors that prevented it from rendering and rearranged blocks to mirror ES5 example code.

## How has this been tested?
Tests ran in a local PHP environment. Used create-guten-block to bootstrap the block plugin, and tested inside the plugin to make sure the code worked in the local Wordpress.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
