### PR TITLE
Build: Add support for Webpack bundle analyzer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2499,6 +2499,16 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"accepts": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"dev": true,
+			"requires": {
+				"mime-types": "~2.1.18",
+				"negotiator": "0.6.1"
+			}
+		},
 		"acorn": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
@@ -2735,6 +2745,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
+		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
 			"dev": true
 		},
 		"array-ify": {
@@ -4123,6 +4139,18 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bfj": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.1.tgz",
+			"integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.5.1",
+				"check-types": "^7.3.0",
+				"hoopy": "^0.1.2",
+				"tryer": "^1.0.0"
+			}
+		},
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -4178,6 +4206,91 @@
 				"error": "^7.0.0",
 				"raw-body": "~1.1.0",
 				"safe-json-parse": "~1.0.1"
+			}
+		},
+		"body-parser": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"dev": true,
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "~1.1.1",
+				"http-errors": "~1.6.2",
+				"iconv-lite": "0.4.19",
+				"on-finished": "~2.3.0",
+				"qs": "6.5.1",
+				"raw-body": "2.3.2",
+				"type-is": "~1.6.15"
+			},
+			"dependencies": {
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+					"dev": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+					"dev": true
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"dev": true,
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"depd": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+							"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+							"dev": true
+						},
+						"http-errors": {
+							"version": "1.6.2",
+							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+							"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+							"dev": true,
+							"requires": {
+								"depd": "1.1.1",
+								"inherits": "2.0.3",
+								"setprototypeof": "1.0.3",
+								"statuses": ">= 1.3.1 < 2"
+							}
+						}
+					}
+				},
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+					"dev": true
+				}
 			}
 		},
 		"boolbase": {
@@ -4659,6 +4772,12 @@
 					"dev": true
 				}
 			}
+		},
+		"check-types": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
+			"integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
+			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.2",
@@ -5377,6 +5496,18 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+			"dev": true
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
+		},
 		"continuable-cache": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
@@ -5723,6 +5854,18 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
 			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+			"dev": true
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
 			"dev": true
 		},
 		"copy-concurrently": {
@@ -6410,6 +6553,12 @@
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"dev": true
 		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
+		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -6419,6 +6568,12 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
 			}
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+			"dev": true
 		},
 		"detect-conflict": {
 			"version": "1.0.1",
@@ -6604,6 +6759,12 @@
 			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
 			"dev": true
 		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
+		},
 		"ejs": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
@@ -6647,6 +6808,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true
 		},
 		"encoding": {
@@ -6852,6 +7019,12 @@
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -7124,6 +7297,12 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
 		},
 		"event-stream": {
@@ -7446,6 +7625,67 @@
 			"integrity": "sha1-tMMi4ouG6edPXG1jb7Hg3eXEpVk=",
 			"dev": true
 		},
+		"express": {
+			"version": "4.16.3",
+			"resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "~1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "1.1.1",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.3",
+				"qs": "6.5.1",
+				"range-parser": "~1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.2",
+				"serve-static": "1.13.2",
+				"setprototypeof": "1.1.0",
+				"statuses": "~1.4.0",
+				"type-is": "~1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+					"dev": true
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+					"dev": true
+				}
+			}
+		},
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -7743,6 +7983,12 @@
 				"minimatch": "^3.0.3"
 			}
 		},
+		"filesize": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+			"dev": true
+		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -7762,6 +8008,32 @@
 					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"statuses": "~1.4.0",
+				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
 					}
 				}
 			}
@@ -7986,6 +8258,12 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+			"dev": true
+		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -7994,6 +8272,12 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+			"dev": true
 		},
 		"from": {
 			"version": "0.1.7",
@@ -9271,6 +9555,24 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
 		},
+		"gzip-size": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
+			"integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+			"dev": true,
+			"requires": {
+				"duplexer": "^0.1.1",
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
 		"handlebars": {
 			"version": "4.0.11",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -9474,6 +9776,12 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
+		"hoopy": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+			"dev": true
+		},
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -9537,6 +9845,18 @@
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
 			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
 			"dev": true
+		},
+		"http-errors": {
+			"version": "1.6.3",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"dev": true,
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.0",
+				"statuses": ">= 1.4.0 < 2"
+			}
 		},
 		"http-parser-js": {
 			"version": "0.4.13",
@@ -9750,6 +10070,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"ipaddr.js": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+			"dev": true
 		},
 		"irregular-plurals": {
 			"version": "2.0.0",
@@ -13381,6 +13707,12 @@
 			"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
 			"dev": true
 		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+			"dev": true
+		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -13577,6 +13909,12 @@
 			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
 			"dev": true
 		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+			"dev": true
+		},
 		"merge-stream": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -13590,6 +13928,12 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
 			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
+			"dev": true
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
 			"dev": true
 		},
 		"micromatch": {
@@ -13862,6 +14206,12 @@
 				"randexp": "0.4.6",
 				"semver": "^5.4.1"
 			}
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+			"dev": true
 		},
 		"neo-async": {
 			"version": "2.5.1",
@@ -14506,6 +14856,15 @@
 				"has": "^1.0.1"
 			}
 		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -14523,6 +14882,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"opener": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"dev": true
 		},
 		"optimist": {
 			"version": "0.6.1",
@@ -14863,6 +15228,12 @@
 				"@types/node": "*"
 			}
 		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+			"dev": true
+		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -14907,6 +15278,12 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
 			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
 		"path-type": {
@@ -16348,6 +16725,16 @@
 			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
 		},
+		"proxy-addr": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"dev": true,
+			"requires": {
+				"forwarded": "~0.1.2",
+				"ipaddr.js": "1.8.0"
+			}
+		},
 		"proxy-from-env": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -16553,6 +16940,12 @@
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
 			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+			"dev": true
 		},
 		"raw-body": {
 			"version": "1.1.7",
@@ -17835,11 +18228,61 @@
 			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
 			"dev": true
 		},
+		"send": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "~1.6.2",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.0",
+				"statuses": "~1.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+					"dev": true
+				}
+			}
+		},
 		"serialize-javascript": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
 			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
 			"dev": true
+		},
+		"serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"dev": true,
+			"requires": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.2",
+				"send": "0.16.2"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -17879,6 +18322,12 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+			"dev": true
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -18356,6 +18805,12 @@
 					}
 				}
 			}
+		},
+		"statuses": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+			"dev": true
 		},
 		"stdout-stream": {
 			"version": "1.4.0",
@@ -19422,6 +19877,12 @@
 				}
 			}
 		},
+		"tryer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+			"dev": true
+		},
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -19457,6 +19918,16 @@
 			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
+			}
+		},
+		"type-is": {
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"dev": true,
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.18"
 			}
 		},
 		"typedarray": {
@@ -19768,6 +20239,12 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
+		},
 		"unquote": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -19915,6 +20392,12 @@
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
+		},
 		"uuid": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
@@ -19949,6 +20432,12 @@
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/validator/-/validator-10.5.0.tgz",
 			"integrity": "sha512-6OOi+eV2mOxCFLq0f2cJDrdB6lrtLXEUxabhNRGjgOLT/l3SSll9J49Cl+LIloUqkWWTPraK/mucEQ3dc2jStQ==",
+			"dev": true
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
 			"dev": true
 		},
 		"vendors": {
@@ -20428,6 +20917,40 @@
 						"imurmurhash": "^0.1.4",
 						"slide": "^1.1.5"
 					}
+				}
+			}
+		},
+		"webpack-bundle-analyzer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.2.tgz",
+			"integrity": "sha512-cZG4wSQtKrSpk5RJ33dxiaAyo8bP0V+JvycAyIDFEiDIhw4LHhhVKhn40YT1w6TR9E4scHA00LnIoBtTA13Mow==",
+			"dev": true,
+			"requires": {
+				"acorn": "^5.7.3",
+				"bfj": "^6.1.1",
+				"chalk": "^2.4.1",
+				"commander": "^2.18.0",
+				"ejs": "^2.6.1",
+				"express": "^4.16.3",
+				"filesize": "^3.6.1",
+				"gzip-size": "^5.0.0",
+				"lodash": "^4.17.10",
+				"mkdirp": "^0.5.1",
+				"opener": "^1.5.1",
+				"ws": "^6.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+					"dev": true
+				},
+				"commander": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+					"integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==",
+					"dev": true
 				}
 			}
 		},
@@ -21310,6 +21833,15 @@
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"
+			}
+		},
+		"ws": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.0.0.tgz",
+			"integrity": "sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"x-is-string": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
 		"symlink-or-copy": "1.2.0",
 		"uuid": "3.1.0",
 		"webpack": "4.8.3",
+		"webpack-bundle-analyzer": "3.0.2",
 		"webpack-cli": "2.1.3",
 		"webpack-livereload-plugin": "2.1.1",
 		"webpack-rtl-plugin": "github:yoavf/webpack-rtl-plugin#develop",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -217,7 +217,7 @@ const config = {
 				to: `./build/${ packageName }/`,
 				flatten: true,
 				transform: ( content ) => {
-					if ( isProduction ) {
+					if ( config.mode === 'production' ) {
 						return postcss( [
 							require( 'cssnano' )( {
 								preset: 'default',
@@ -230,7 +230,11 @@ const config = {
 				},
 			} ) )
 		),
+		// GUTENBERG_BUNDLE_ANALYZER global variable enables utility that represents bundle content
+		// as convenient interactive zoomable treemap.
 		process.env.GUTENBERG_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
+		// GUTENBERG_LIVE_RELOAD_PORT global variable changes port on which live reload works
+		// when running watch mode.
 		! isProduction && new LiveReloadPlugin( { port: process.env.GUTENBERG_LIVE_RELOAD_PORT || 35729 } ),
 	].filter( Boolean ),
 	stats: {
@@ -239,6 +243,8 @@ const config = {
 };
 
 if ( ! isProduction ) {
+	// GUTENBERG_DEVTOOL global variable controls how source maps are generated.
+	// See: https://webpack.js.org/configuration/devtool/#devtool.
 	config.devtool = process.env.GUTENBERG_DEVTOOL || 'source-map';
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -230,7 +230,7 @@ const config = {
 				},
 			} ) )
 		),
-		process.env.BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
+		process.env.GUTENBERG_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
 		! isProduction && new LiveReloadPlugin( { port: process.env.GUTENBERG_LIVE_RELOAD_PORT || 35729 } ),
 	].filter( Boolean ),
 	stats: {
@@ -239,7 +239,7 @@ const config = {
 };
 
 if ( ! isProduction ) {
-	config.devtool = process.env.SOURCEMAP || 'source-map';
+	config.devtool = process.env.GUTENBERG_DEVTOOL || 'source-map';
 }
 
 module.exports = config;


### PR DESCRIPTION
## Description
This PR enabled support for Webpack bundle analyzer hidden behind the environment flag `BUNDLE_ANALYZER`.

We still need to document this and other env flags we use in the Webpack config.

## How has this been tested?
`BUNDLE_ANALYZER=1 npm run dev`

## Screenshots <!-- if applicable -->

![screen shot 2018-09-26 at 10 48 37](https://user-images.githubusercontent.com/699132/46068569-c11e6b80-c179-11e8-995c-ef764b0bf5e4.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
