### PR TITLE
Fix/docs links

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1253,6 +1253,19 @@ Returns whether or not the user has the unfiltered_html capability.
 
 Whether the user can or can't post unfiltered HTML.
 
+### isPublishSidebarEnabled
+
+Returns whether the pre-publish panel should be shown
+or skipped when the user clicks the "publish" button.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the pre-publish panel should be shown or not.
+
 ## Actions
 
 ### setupEditor
@@ -1634,3 +1647,11 @@ Returns an action object used in signalling that the editor settings have been u
 *Parameters*
 
  * settings: Updated settings
+
+### enablePublishSidebar
+
+Returns an action object used in signalling that the user has enabled the publish sidebar.
+
+### disablePublishSidebar
+
+Returns an action object used in signalling that the user has disabled the publish sidebar.

--- a/edit-post/README.md
+++ b/edit-post/README.md
@@ -2,7 +2,7 @@
 
 Extending the editor UI can be accomplished with the `registerPlugin` API, allowing you to define all your plugin's UI elements in one place.
 
-Refer to [the plugins module documentation](../plugins/) for more information.
+Refer to [the plugins module documentation](../packages/plugins/) for more information.
 
 ## Plugin Components
 
@@ -49,7 +49,7 @@ const doOnClick = ( ) => {
 };
 
 const MyPluginBlockSettingsMenuItem = () => (
-    <PluginBlockSettingsMenuItem 
+    <PluginBlockSettingsMenuItem
 		allowedBlockNames=[ 'core/paragraph' ]
 		icon='dashicon-name'
 		label=__( 'Menu item text' )
@@ -424,7 +424,7 @@ Title displayed at the top of the panel.
 
 ##### initialOpen
 
-Whether to have the panel initially opened. When no title is provided it is always opened. 
+Whether to have the panel initially opened. When no title is provided it is always opened.
 
 - Type: `Boolean`
 - Required: No

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -29,7 +29,7 @@ This method takes two arguments:
       or an element (or function returning an element) if you choose to render your own SVG.
     - `render`: A component containing the UI elements to be rendered.
 
-See [the edit-post module documentation](../edit-post/) for available components.
+See [the edit-post module documentation](../../edit-post/) for available components.
 
 _Example:_
 {% codetabs %}


### PR DESCRIPTION
This PR fixes:

- link to `plugins` in **edit-post** readme
- and link to `edit-post` in **packages/plugins** readme.


