### PR TITLE
Fix: CSS rule affecting nested paragraphs placeholder

### DIFF
--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -117,7 +117,7 @@
 	// Ensure that the height of the first appender, and the one between blocks, is the same as text.
 	.editor-block-list__block[data-type="core/paragraph"] p[data-is-placeholder-visible="true"] + p,
 	.editor-default-block-appender__content {
-		height: $empty-paragraph-height / 2;
+		min-height: $empty-paragraph-height / 2;
 		line-height: $editor-line-height;
 	}
 }


### PR DESCRIPTION
## Description
We were forcing a height of 28px for paragraph placeholders but the paragraph may have a huge font size so 28px may not be enough for the placeholder.
This PR replaces the usage of height with min-height in the problematic rule.

I guess this was a recent regression because I noticed this bug after rebasing https://github.com/WordPress/gutenberg/pull/9416.
 
## How has this been tested?
I checked the following test block appears as expected https://gist.github.com/jorgefilipecosta/7f0a54193f9d8d28c1514aa2e57a00fc.

## Screenshots <!-- if applicable -->
Before:
<img width="635" alt="screen shot 2018-09-26 at 16 44 45" src="https://user-images.githubusercontent.com/11271197/46092287-7a963480-c1ac-11e8-9d31-66fa471ddbf9.png">

After:
<img width="633" alt="screen shot 2018-09-26 at 16 44 04" src="https://user-images.githubusercontent.com/11271197/46092301-7ff37f00-c1ac-11e8-86e3-40d632dbffc2.png">

