### PR TITLE
Fix calculation of new block index on drop

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -387,6 +387,20 @@ on each call
 
 Post blocks.
 
+### getClientIdsOfDescendants
+
+Returns an array containing the clientIds of all descendants
+of the blocks given.
+
+*Parameters*
+
+ * state: Global application state.
+ * clientIds: Array of blocks to inspect.
+
+*Returns*
+
+ids of descendants.
+
 ### getClientIdsWithDescendants
 
 Returns an array containing the clientIds of the top-level blocks

--- a/packages/editor/src/components/block-draggable/index.js
+++ b/packages/editor/src/components/block-draggable/index.js
@@ -7,9 +7,9 @@ import { withSelect } from '@wordpress/data';
 const BlockDraggable = ( { children, clientId, rootClientId, blockElementId, index, onDragStart, onDragEnd } ) => {
 	const transferData = {
 		type: 'block',
-		fromIndex: index,
-		rootClientId,
-		clientId,
+		srcIndex: index,
+		srcRootClientId: rootClientId,
+		srcClientId: clientId,
 	};
 
 	return (

--- a/packages/editor/src/components/block-draggable/index.js
+++ b/packages/editor/src/components/block-draggable/index.js
@@ -4,13 +4,12 @@
 import { Draggable } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
-const BlockDraggable = ( { children, clientId, rootClientId, blockElementId, index, layout, onDragStart, onDragEnd } ) => {
+const BlockDraggable = ( { children, clientId, rootClientId, blockElementId, index, onDragStart, onDragEnd } ) => {
 	const transferData = {
 		type: 'block',
 		fromIndex: index,
 		rootClientId,
 		clientId,
-		layout,
 	};
 
 	return (

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -60,10 +60,11 @@ class BlockDropZone extends Component {
 			return;
 		}
 
-		let clientId, type, rootClientId, fromIndex;
+		const { index: dstIndex, rootClientId: dstRootClientId } = this.props;
 
+		let type, srcClientId, srcRootClientId, srcIndex;
 		try {
-			( { clientId, type, rootClientId, fromIndex } = JSON.parse( event.dataTransfer.getData( 'text' ) ) );
+			( { type, srcClientId, srcRootClientId, srcIndex } = JSON.parse( event.dataTransfer.getData( 'text' ) ) );
 		} catch ( err ) {
 			return;
 		}
@@ -71,15 +72,15 @@ class BlockDropZone extends Component {
 		if ( type !== 'block' ) {
 			return;
 		}
-		const { index } = this.props;
+
 		const positionIndex = this.getInsertIndex( position );
 
 		// If the block is kept at the same level and moved downwards,
 		// subtract to account for blocks shifting upward to occupy its old position.
 		// Note that rootClientId can be undefined or a void string if the block is at the top-level.
-		const isSameLevel = ( src, dst ) => ( src === dst ) || ( ! src === true && ! dst === true );
-		const insertIndex = index && fromIndex < index && isSameLevel( rootClientId, this.props.rootClientId ) ? positionIndex - 1 : positionIndex;
-		this.props.moveBlockToPosition( clientId, rootClientId, insertIndex );
+		const isSameLevel = ( ) => ( srcRootClientId === dstRootClientId ) || ( ! srcRootClientId === true && ! dstRootClientId === true );
+		const insertIndex = dstIndex && srcIndex < dstIndex && isSameLevel() ? positionIndex - 1 : positionIndex;
+		this.props.moveBlockToPosition( srcClientId, srcRootClientId, insertIndex );
 	}
 
 	render() {
@@ -111,7 +112,7 @@ export default compose(
 		} = dispatch( 'core/editor' );
 
 		return {
-			insertBlocks( blocks, insertIndex ) {
+			insertBlocks( blocks, index ) {
 				const { rootClientId, layout } = ownProps;
 
 				if ( layout ) {
@@ -124,14 +125,14 @@ export default compose(
 					) );
 				}
 
-				insertBlocks( blocks, insertIndex, rootClientId );
+				insertBlocks( blocks, index, rootClientId );
 			},
 			updateBlockAttributes( ...args ) {
 				updateBlockAttributes( ...args );
 			},
-			moveBlockToPosition( clientId, fromRootClientId, index ) {
-				const { rootClientId, layout } = ownProps;
-				moveBlockToPosition( clientId, fromRootClientId, rootClientId, layout, index );
+			moveBlockToPosition( srcClientId, srcRootClientId, dstIndex ) {
+				const { rootClientId: dstRootClientId, layout } = ownProps;
+				moveBlockToPosition( srcClientId, srcRootClientId, dstRootClientId, layout, dstIndex );
 			},
 		};
 	} ),

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -60,7 +60,7 @@ class BlockDropZone extends Component {
 			return;
 		}
 
-		const { index: dstIndex, rootClientId: dstRootClientId } = this.props;
+		const { index: dstIndex, rootClientId: dstRootClientId, clientId: dstClientId } = this.props;
 
 		let type, srcClientId, srcRootClientId, srcIndex;
 		try {
@@ -73,13 +73,17 @@ class BlockDropZone extends Component {
 			return;
 		}
 
-		const positionIndex = this.getInsertIndex( position );
-
-		// If the block is kept at the same level and moved downwards,
-		// subtract to account for blocks shifting upward to occupy its old position.
-		// Note that rootClientId can be undefined or a void string if the block is at the top-level.
 		const isSameLevel = ( ) => ( srcRootClientId === dstRootClientId ) || ( ! srcRootClientId === true && ! dstRootClientId === true );
-		const insertIndex = dstIndex && srcIndex < dstIndex && isSameLevel() ? positionIndex - 1 : positionIndex;
+		const isSameBlock = ( ) => srcClientId === dstClientId;
+
+		let insertIndex = dstIndex;
+		if ( ! isSameBlock() ) {
+			// If the block is kept at the same level and moved downwards,
+			// subtract to account for blocks shifting upward to occupy its old position.
+			// Note that rootClientId can be undefined or a void string if the block is at the top-level.
+			const positionIndex = this.getInsertIndex( position );
+			insertIndex = dstIndex && srcIndex < dstIndex && isSameLevel() ? positionIndex - 1 : positionIndex;
+		}
 		this.props.moveBlockToPosition( srcClientId, srcRootClientId, insertIndex );
 	}
 

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -74,9 +74,11 @@ class BlockDropZone extends Component {
 		const { index } = this.props;
 		const positionIndex = this.getInsertIndex( position );
 
-		// If the block is kept at the same level and moved downwards, subtract
-		// to account for blocks shifting upward to occupy its old position.
-		const insertIndex = index && fromIndex < index && rootClientId === this.props.rootClientId ? positionIndex - 1 : positionIndex;
+		// If the block is kept at the same level and moved downwards,
+		// subtract to account for blocks shifting upward to occupy its old position.
+		// Note that rootClientId can be undefined or a void string if the block is at the top-level.
+		const isSameLevel = ( src, dst ) => ( src === dst ) || ( ! src === true && ! dst === true );
+		const insertIndex = index && fromIndex < index && isSameLevel( rootClientId, this.props.rootClientId ) ? positionIndex - 1 : positionIndex;
 		this.props.moveBlockToPosition( clientId, rootClientId, insertIndex );
 	}
 

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -491,6 +491,7 @@ export class BlockListBlock extends Component {
 				) }
 				<BlockDropZone
 					index={ order }
+					clientId={ clientId }
 					rootClientId={ rootClientId }
 					layout={ layout }
 				/>

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -498,7 +498,6 @@ export class BlockListBlock extends Component {
 					<BlockMover
 						clientIds={ clientId }
 						blockElementId={ blockElementId }
-						layout={ layout }
 						isFirst={ isFirst }
 						isLast={ isLast }
 						isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' }

--- a/packages/editor/src/components/block-mover/drag-handle.js
+++ b/packages/editor/src/components/block-mover/drag-handle.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import BlockDraggable from '../block-draggable';
 
-export const IconDragHandle = ( { isVisible, className, icon, onDragStart, onDragEnd, blockElementId, clientId, layout } ) => {
+export const IconDragHandle = ( { isVisible, className, icon, onDragStart, onDragEnd, blockElementId, clientId } ) => {
 	if ( ! isVisible ) {
 		return null;
 	}
@@ -19,7 +19,6 @@ export const IconDragHandle = ( { isVisible, className, icon, onDragStart, onDra
 		<BlockDraggable
 			clientId={ clientId }
 			blockElementId={ blockElementId }
-			layout={ layout }
 			onDragStart={ onDragStart }
 			onDragEnd={ onDragEnd }
 		>

--- a/packages/editor/src/components/block-mover/index.js
+++ b/packages/editor/src/components/block-mover/index.js
@@ -44,7 +44,7 @@ export class BlockMover extends Component {
 	}
 
 	render() {
-		const { onMoveUp, onMoveDown, isFirst, isLast, isDraggable, onDragStart, onDragEnd, clientIds, blockElementId, layout, blockType, firstIndex, isLocked, instanceId, isHidden } = this.props;
+		const { onMoveUp, onMoveDown, isFirst, isLast, isDraggable, onDragStart, onDragEnd, clientIds, blockElementId, blockType, firstIndex, isLocked, instanceId, isHidden } = this.props;
 		const { isFocused } = this.state;
 		const blocksCount = castArray( clientIds ).length;
 		if ( isLocked || ( isFirst && isLast ) ) {
@@ -72,7 +72,6 @@ export class BlockMover extends Component {
 					icon={ dragHandle }
 					clientId={ clientIds }
 					blockElementId={ blockElementId }
-					layout={ layout }
 					isVisible={ isDraggable }
 					onDragStart={ onDragStart }
 					onDragEnd={ onDragEnd }

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -566,6 +566,20 @@ export const getBlocks = createSelector(
 );
 
 /**
+ * Returns an array containing the clientIds of all descendants
+ * of the blocks given.
+ *
+ * @param {Object} state Global application state.
+ * @param {Array} clientIds Array of blocks to inspect.
+ *
+ * @return {Array} ids of descendants.
+ */
+export const getDescendants = ( state, clientIds ) => flatMap( clientIds, ( clientId ) => {
+	const descendants = getBlockOrder( state, clientId );
+	return [ ...descendants, ...getDescendants( state, descendants ) ];
+} );
+
+/**
  * Returns an array containing the clientIds of the top-level blocks
  * and their descendants of any depth (for nested blocks).
  *
@@ -575,12 +589,8 @@ export const getBlocks = createSelector(
  */
 export const getClientIdsWithDescendants = createSelector(
 	( state ) => {
-		const getDescendants = ( clientIds ) => flatMap( clientIds, ( clientId ) => {
-			const descendants = getBlockOrder( state, clientId );
-			return [ ...descendants, ...getDescendants( descendants ) ];
-		} );
 		const topLevelIds = getBlockOrder( state );
-		return [ ...topLevelIds, ...getDescendants( topLevelIds ) ];
+		return [ ...topLevelIds, ...getDescendants( state, topLevelIds ) ];
 	},
 	( state ) => [
 		state.editor.present.blockOrder,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -574,9 +574,9 @@ export const getBlocks = createSelector(
  *
  * @return {Array} ids of descendants.
  */
-export const getDescendants = ( state, clientIds ) => flatMap( clientIds, ( clientId ) => {
+export const getClientIdsOfDescendants = ( state, clientIds ) => flatMap( clientIds, ( clientId ) => {
 	const descendants = getBlockOrder( state, clientId );
-	return [ ...descendants, ...getDescendants( state, descendants ) ];
+	return [ ...descendants, ...getClientIdsOfDescendants( state, descendants ) ];
 } );
 
 /**
@@ -590,7 +590,7 @@ export const getDescendants = ( state, clientIds ) => flatMap( clientIds, ( clie
 export const getClientIdsWithDescendants = createSelector(
 	( state ) => {
 		const topLevelIds = getBlockOrder( state );
-		return [ ...topLevelIds, ...getDescendants( state, topLevelIds ) ];
+		return [ ...topLevelIds, ...getClientIdsOfDescendants( state, topLevelIds ) ];
 	},
 	( state ) => [
 		state.editor.present.blockOrder,

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -55,7 +55,7 @@ const {
 	getBlocks,
 	getBlockCount,
 	getClientIdsWithDescendants,
-	getDescendants,
+	getClientIdsOfDescendants,
 	hasSelectedBlock,
 	getSelectedBlock,
 	getSelectedBlockClientId,
@@ -1652,7 +1652,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getDescendants', () => {
+	describe( 'getClientIdsOfDescendants', () => {
 		it( 'should return the ids of any descendants, given an array of clientIds', () => {
 			const state = {
 				currentPost: {},
@@ -1696,7 +1696,7 @@ describe( 'selectors', () => {
 					},
 				},
 			};
-			expect( getDescendants( state, [ 'uuid-10' ] ) ).toEqual( [
+			expect( getClientIdsOfDescendants( state, [ 'uuid-10' ] ) ).toEqual( [
 				'uuid-12',
 				'uuid-14',
 				'uuid-16',

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -55,6 +55,7 @@ const {
 	getBlocks,
 	getBlockCount,
 	getClientIdsWithDescendants,
+	getDescendants,
 	hasSelectedBlock,
 	getSelectedBlock,
 	getSelectedBlockClientId,
@@ -1647,6 +1648,63 @@ describe( 'selectors', () => {
 			expect( getBlocks( state ) ).toEqual( [
 				{ clientId: 123, name: 'core/paragraph', attributes: {}, innerBlocks: [] },
 				{ clientId: 23, name: 'core/heading', attributes: {}, innerBlocks: [] },
+			] );
+		} );
+	} );
+
+	describe( 'getDescendants', () => {
+		it( 'should return the ids of any descendants, given an array of clientIds', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocksByClientId: {
+							'uuid-2': { clientId: 'uuid-2', name: 'core/image', attributes: {} },
+							'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
+							'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
+							'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: {} },
+							'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: {} },
+							'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: {} },
+							'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: {} },
+							'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: {} },
+							'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: {} },
+							'uuid-20': { clientId: 'uuid-20', name: 'core/gallery', attributes: {} },
+							'uuid-22': { clientId: 'uuid-22', name: 'core/block', attributes: {} },
+							'uuid-24': { clientId: 'uuid-24', name: 'core/columns', attributes: {} },
+							'uuid-26': { clientId: 'uuid-26', name: 'core/column', attributes: {} },
+							'uuid-28': { clientId: 'uuid-28', name: 'core/column', attributes: {} },
+							'uuid-30': { clientId: 'uuid-30', name: 'core/paragraph', attributes: {} },
+						},
+						blockOrder: {
+							'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
+							'uuid-2': [ ],
+							'uuid-4': [ ],
+							'uuid-6': [ ],
+							'uuid-8': [ ],
+							'uuid-10': [ 'uuid-12', 'uuid-14' ],
+							'uuid-12': [ 'uuid-16' ],
+							'uuid-14': [ 'uuid-18' ],
+							'uuid-16': [ ],
+							'uuid-18': [ 'uuid-24' ],
+							'uuid-20': [ ],
+							'uuid-22': [ ],
+							'uuid-24': [ 'uuid-26', 'uuid-28' ],
+							'uuid-26': [ ],
+							'uuid-28': [ 'uuid-30' ],
+						},
+						edits: {},
+					},
+				},
+			};
+			expect( getDescendants( state, [ 'uuid-10' ] ) ).toEqual( [
+				'uuid-12',
+				'uuid-14',
+				'uuid-16',
+				'uuid-18',
+				'uuid-24',
+				'uuid-26',
+				'uuid-28',
+				'uuid-30',
 			] );
 		} );
 	} );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/9823, https://github.com/WordPress/gutenberg/issues/10202 and https://github.com/WordPress/gutenberg/issues/9303.

### Testing

- Drag any block and drop it at the place you want. Check that it behaves as expected.
- Drag any block and drop it ot its own top/bottom zones ([see](https://github.com/WordPress/gutenberg/issues/10202)).
- Drag a columns block and drop it within one of its columns ([see](https://github.com/WordPress/gutenberg/issues/9303#issuecomment-420563076)).
- Drag a block and drop it in the top zone of any block below it ([see](https://github.com/WordPress/gutenberg/issues/9823)).