### PR TITLE
Docs: document `isDefault` option for block styles

### DIFF
--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -21,6 +21,8 @@ wp.blocks.registerBlockStyle( 'core/quote', {
 
 The example above registers a block style variation named `fancy-quote` to the `core/quote` block. When the user selects this block style variation from the styles selector, an `is-style-fancy-quote` className will be added to the block's wrapper.
 
+By adding `isDefault: true`, you can make registered style variation to be active by default when a block is inserted.
+
 ### Filters
 
 Extending blocks can involve more than just providing alternative styles, in this case, you can use one of the following filters to extend the block settings.


### PR DESCRIPTION

## Description
Documents `isDefault` option when adding block style variations with `wp.blocks.registerBlockStyle()`

[Example](https://github.com/WordPress/gutenberg/blob/3b6c167cab50e77c44b21c74e3dd2bdf8b890ff4/packages/block-library/src/separator/index.js#L20-L24).

I'm building a custom block with different styles and I wanted one of the styles to be active by default. I had to go searching from code if such a feature exists.

## How has this been tested?
N/A

## Types of changes
Documentation update.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
