### PR TITLE
Use best fitting embed aspect ratio if exact match doesn't exist

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -28,6 +28,18 @@ import { withSelect } from '@wordpress/data';
 // These embeds do not work in sandboxes
 const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 
+const ASPECT_RATIOS = [
+	// Common video resolutions.
+	{ ratio: '2.33', className: 'wp-embed-aspect-21-9' },
+	{ ratio: '2.00', className: 'wp-embed-aspect-18-9' },
+	{ ratio: '1.78', className: 'wp-embed-aspect-16-9' },
+	{ ratio: '1.33', className: 'wp-embed-aspect-4-3' },
+	// Vertical video and instagram square video support.
+	{ ratio: '1.00', className: 'wp-embed-aspect-1-1' },
+	{ ratio: '0.56', className: 'wp-embed-aspect-9-16' },
+	{ ratio: '0.50', className: 'wp-embed-aspect-1-2' },
+];
+
 const matchesPatterns = ( url, patterns = [] ) => {
 	return patterns.some( ( pattern ) => {
 		return url.match( pattern );
@@ -166,20 +178,9 @@ export function getEmbedEdit( title, icon ) {
 
 			if ( iframe && iframe.height && iframe.width ) {
 				const aspectRatio = ( iframe.width / iframe.height ).toFixed( 2 );
-				const aspectRatios = [
-					// Common video resolutions.
-					{ ratio: '2.33', className: 'wp-embed-aspect-21-9' },
-					{ ratio: '2.00', className: 'wp-embed-aspect-18-9' },
-					{ ratio: '1.78', className: 'wp-embed-aspect-16-9' },
-					{ ratio: '1.33', className: 'wp-embed-aspect-4-3' },
-					// Vertical video and instagram square video support.
-					{ ratio: '1.00', className: 'wp-embed-aspect-1-1' },
-					{ ratio: '0.56', className: 'wp-embed-aspect-9-16' },
-					{ ratio: '0.50', className: 'wp-embed-aspect-1-2' },
-				];
 				// Given the actual aspect ratio, find the widest ratio to support it.
-				for ( let idx = 0; idx < aspectRatios.length; idx++ ) {
-					const potentialRatio = aspectRatios[ idx ];
+				for ( let ratioIndex = 0; ratioIndex < ASPECT_RATIOS.length; ratioIndex++ ) {
+					const potentialRatio = ASPECT_RATIOS[ ratioIndex ];
 					if ( aspectRatio >= potentialRatio.ratio ) {
 						return {
 							[ potentialRatio.className ]: allowResponsive,

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -67,7 +67,7 @@ export function getEmbedEdit( title, icon ) {
 			this.setAspectRatioClassNames = this.setAspectRatioClassNames.bind( this );
 			this.getResponsiveHelp = this.getResponsiveHelp.bind( this );
 			this.toggleResponsive = this.toggleResponsive.bind( this );
-			this.receivePreview = this.receivePreview.bind( this );
+			this.handleIncomingPreview = this.handleIncomingPreview.bind( this );
 
 			this.state = {
 				editingURL: false,
@@ -75,11 +75,11 @@ export function getEmbedEdit( title, icon ) {
 			};
 
 			if ( this.props.preview ) {
-				this.receivePreview();
+				this.handleIncomingPreview();
 			}
 		}
 
-		receivePreview() {
+		handleIncomingPreview() {
 			this.setAttributesFromPreview();
 			this.maybeSwitchBlock();
 		}
@@ -100,7 +100,7 @@ export function getEmbedEdit( title, icon ) {
 					this.setState( { editingURL: true } );
 					return;
 				}
-				this.receivePreview();
+				this.handleIncomingPreview();
 			}
 		}
 


### PR DESCRIPTION
## Description

This picks the best fit of the common aspect ratios if an exact fit does not appear in our list, for responsive content.

Fixes: https://github.com/WordPress/gutenberg/issues/8383#issuecomment-424998603

## How has this been tested?

Embed https://www.youtube.com/watch?v=XT13ijUfSts and check it has the 16-9 style.

Embed https://www.youtube.com/watch?v=uAE6Il6OTcs and check it has the 4-3 style.

Embed https://vimeo.com/139290912 and check it has the 21-9 style.

Embed https://vimeo.com/139290912 again in the same post, and check the new embed has the 21-9 style.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
