### PR TITLE
Ensure that the return value of apiFetch is always a valid Promise object in Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2187,6 +2187,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/redux-routine": "file:packages/redux-routine",
 				"equivalent-key-map": "^0.2.0",
+				"is-promise": "^2.1.0",
 				"lodash": "^4.17.10",
 				"redux": "^3.7.2"
 			}
@@ -2374,6 +2375,7 @@
 			"version": "file:packages/redux-routine",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
+				"is-promise": "^2.1.0",
 				"rungen": "^0.3.2"
 			},
 			"dependencies": {
@@ -10048,8 +10050,7 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-redirect": {
 			"version": "1.0.0",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Writing resolvers as async generators has been deprecated. Use the controls plugin instead.
 
+## Bug Fixes
+
+- Fix the promise middleware in Firefox.
+
 ## 2.0.0 (2018-09-05)
 
 ### Breaking Change

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -28,6 +28,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/redux-routine": "file:../redux-routine",
 		"equivalent-key-map": "^0.2.0",
+		"is-promise": "^2.1.0",
 		"lodash": "^4.17.10",
 		"redux": "^3.7.2"
 	},

--- a/packages/data/src/promise-middleware.js
+++ b/packages/data/src/promise-middleware.js
@@ -1,10 +1,15 @@
 /**
+ * External dependencies
+ */
+import isPromise from 'is-promise';
+
+/**
  * Simplest possible promise redux middleware.
  *
  * @return {function} middleware.
  */
 const promiseMiddleware = () => ( next ) => ( action ) => {
-	if ( action instanceof Promise ) {
+	if ( isPromise( action ) ) {
 		return action.then( ( resolvedAction ) => {
 			if ( resolvedAction ) {
 				return next( resolvedAction );

--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -5,6 +5,10 @@
 - The middleware returns a promise resolving once the runtime finishes iterating over the generator.
 - It's not possible to kill the execution of the runtime anymore by returning `undefined`
 
+## Bug Fixes
+
+- Fix running routines in Firefox.
+
 ## 2.0.0 (2018-09-05)
 
 ### Breaking Change

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -23,6 +23,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
+		"is-promise": "^2.1.0",
 		"rungen": "^0.3.2"
 	},
 	"devDependencies": {

--- a/packages/redux-routine/src/runtime.js
+++ b/packages/redux-routine/src/runtime.js
@@ -3,6 +3,7 @@
  */
 import { create } from 'rungen';
 import { map, isString } from 'lodash';
+import isPromise from 'is-promise';
 
 /**
  * Internal dependencies
@@ -23,7 +24,7 @@ export default function createRuntime( controls = {}, dispatch ) {
 			return false;
 		}
 		const routine = control( value );
-		if ( routine instanceof Promise ) {
+		if ( isPromise( routine ) ) {
 			// Async control routine awaits resolution.
 			routine.then(
 				yieldNext,


### PR DESCRIPTION
it looks like window.fetch in firefox don't return an object that is instance of Promise causing some weird issues down the road.

This PR ensures we always return a promise object.

closes #10208
fixes #10265

**Testing instructions**

 - Try embedding a tweet in Firefox, you should see the preview.