### PR TITLE
Docs: new intro, principles, and "block as interface"

### DIFF
--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,0 +1,17 @@
+# Principles
+
+First, let’s look at the big picture. If the architectural and UX principles described here are activated at scale, how will Gutenberg improve and transform both users and creators experiences?
+
+How Gutenberg can transform the *user experience*:
+
+* Users can focus on conveying their ideas and information in the way they want without having to understand the underlying technical / semantic distinctions.
+* Users can add and edit functionality more easily via the unified mechanism of blocks.
+* Everything on a user’s site can be directly manipulated and edited in place without having to rely on traversing complex navigation menus and disparate sections.
+* Users only have to learn a single interface — the block — and a single way to add new elements. They will gain the confidence that comes from using a system that feels unified and clear, where everything works in a consistent manner.
+
+How Gutenberg can transform the *developer and designer experience*:
+
+* A powerful and expressive toolkit that allows crafting first-class experiences through standardized design and development processes.
+* This standardization allows for interoperability — developers can create components that seamlessly connect with components from other developers.
+* Relying on consistent UX patterns means developers can be confident their work will be immediately familiar and usable to users and that they don’t have to reinvent interaction patterns. They can focus on their product.
+* With one modern, flexible interface, the block, but many ways to bend it, makers have an opportunity to extend WordPress in many new ways.

--- a/docs/principles/the-block.md
+++ b/docs/principles/the-block.md
@@ -1,0 +1,27 @@
+# Blocks are the Interface
+
+At the core of Gutenberg lies the concept of the block. From a technical point of view, blocks both raise the level of abstraction from a single document to a collection of meaningful elements, and they replace ambiguity—inherent in HTML—with explicit structure.
+
+From a user perspective, blocks allow any kind of content, media, or functionality to be directly added to their site in a more consistent and usable way. The “add block” button gives the user access to an entire library of options all in one place, rather than having to hunt through menus or know shortcodes.
+
+But most importantly, Gutenberg is built on the principle of *direct manipulation*, which means that the primary options for how an element is displayed are controlled *in the context of the block itself*. This is a big shift from the traditional WordPress model, where options that were often buried deep in layers of navigation menus controlled the elements on a page through indirect mechanisms.
+
+So, for example, a user can add an image, write its caption, change its width and layout, add a link around it, all from within the block interface in the canvas. The same principle should apply to more complex blocks, like a "navigation menu", with the user being able to add, edit, move, and finalize the full presentation of their navigation.
+
+* Users only need to learn one interface — the block — to add and edit everything on their site. Users shouldn’t have to write shortcodes, custom HTML, or understand hidden mechanisms to embed content.
+* Gutenberg makes core features more discoverable, reducing hard-to-find “Mystery meat.” WordPress supports a large number of blocks and 30+ embeds. Let’s increase their visibility.
+
+## Building Blocks
+
+What does this mean for designers and developers? The block structure plus the principle of direct manipulation mean thinking differently about how to design and develop WordPress components. Let’s take another look at the architecture of a block:
+
+![Gutenberg Blueprint](https://cldup.com/LQrPNubkJY.png)
+
+### The primary interface for a block is the content area of the block.
+The placeholder content in the content area of the block can be thought of as a guide or interface for users to follow a set of instructions or “fill in the blanks” (more on placeholders later). Since the content area represents what will actually appear on the site, interaction here hews closest to the principle of direct manipulation and will be most intuitive to the user. This should be thought of as the primary interface for adding and manipulating content and adjusting how it is displayed.
+
+### The block toolbar is the place for critical options that can’t be incorporated into placeholder UI.
+Basic block settings won’t always make sense in the context of the placeholder / content UI. As a secondary option, options that are critical to the functionality of a block can live in the block toolbar. The block toolbar is one step removed from direct manipulation, but is still highly contextual and visible on all screen sizes, so it is a great secondary option.
+
+### The block sidebar should only be used for advanced, tertiary controls.
+The sidebar is not visible by default on a small / mobile screen, and may also be collapsed even in a desktop view. Therefore, it should not be relied on for anything that is necessary for the basic operation of the block. Pick good defaults, make important actions available in the block toolbar, and think of the sidebar as something that only power users may discover.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,24 +1,11 @@
 # Introduction
 
-"Gutenberg" is the codename for the new WordPress editor focus. The goal of this focus is to create a new post and page editing experience that makes it easy for anyone to create rich post layouts. This was the kickoff goal:
+Gutenberg began as a transformation of the WordPress editor — a new interface for adding, editing, and manipulating content. It seeks to make it easy for anyone to create rich, flexible content layouts with a block-based UI. All types of page components are represented as modular blocks, which means they can be accessed from a unified block menu, dropped anywhere on a page, and directly edited to create the custom presentation the user wants.
 
-> The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.
+It is a fundamental modernization and transformation of how the WordPress experience works, creating new opportunities for both users and developers. Gutenberg introduces new frameworks, interaction patterns, functionality, and user experiences for WordPress. And similar to a new Mac OS version, we will talk about "Gutenberg", and all the new possibilities it enables, until eventually the idea of Gutenberg as a separate entity will fade and it will simply be WordPress.
 
-Key take-aways from parsing that paragraph:
+![Gutenberg Demo](https://cldup.com/kZXGDcGPMU.gif)
 
-- Authoring richly laid out posts is a key strength of WordPress.
-- By embracing "the block", we can potentially unify multiple different interfaces into one. Instead of learning how to write shortcodes, custom HTML, or paste URLs to embed, you should do with just learning the block, and all the pieces should fall in place.
-- "Mystery meat" refers to hidden features in software, features that you have to discover. WordPress already supports a large number of blocks and 30+ embeds, so let's surface them.
+Gutenberg brings many changes to WordPress, but the biggest impact comes from the way it can enable a much clearer product architecture — one which enables modularity, consistency, and interoperability — and the positive impact that can have on the end user experience of WordPress. This handbook will describe the scope of those architectural and user experience (UX) changes, including the central “block as the interface” principle — the most crucial conceptual change to understand about Gutenberg.
 
-Gutenberg is being developed on [GitHub](https://github.com/WordPress/gutenberg), and you can try [an early beta version today from the plugin repository](https://wordpress.org/plugins/gutenberg/). Though keep in mind it's not fully functional, feature complete, or production ready.
-
-## Logo
-<img width="200px" src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/final-g-wapuu-black.svg?sanitize=true" alt="Gutenberg Logo" />
-
-Released under GPL license, made by [Cristel Rossignol](https://twitter.com/cristelrossi).
-
-[Download the SVG logo](https://github.com/WordPress/gutenberg/blob/master/docs/final-g-wapuu-black.svg).
-
-## Mockups
-
-Mockup Sketch files are available in <a href="https://wordpress.org/gutenberg/handbook/reference/design-principles/#more-resources">the Design section</a>.
+Here you can also find design guidelines, API documentation, and tutorials about getting started with Gutenberg development.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,7 +6,7 @@
 - [Frequently Asked Questions](../docs/reference/faq.md)
 
 ## Logo
-<img width="200px" src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/final-g-wapuu-black.svg?sanitize=true" alt="Gutenberg Logo" />
+<img width="200" src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/final-g-wapuu-black.svg?sanitize=true" alt="Gutenberg Logo" />
 
 Released under GPL license, made by [Cristel Rossignol](https://twitter.com/cristelrossi).
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,3 +4,14 @@
 - [Coding Guidelines](../docs/reference/coding-guidelines.md)
 - [Testing Overview](../docs/reference/testing-overview.md)
 - [Frequently Asked Questions](../docs/reference/faq.md)
+
+## Logo
+<img width="200px" src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/final-g-wapuu-black.svg?sanitize=true" alt="Gutenberg Logo" />
+
+Released under GPL license, made by [Cristel Rossignol](https://twitter.com/cristelrossi).
+
+[Download the SVG logo](https://github.com/WordPress/gutenberg/blob/master/docs/final-g-wapuu-black.svg).
+
+## Mockups
+
+Mockup Sketch files are available in <a href="https://wordpress.org/gutenberg/handbook/reference/design-principles/#more-resources">the Design section</a>.


### PR DESCRIPTION
This is the start of some reorganization of the handbook documents to encompass a more living resource spanning project vision, interface guidelines, all the way down to the API documentation, references, and tutorials.

Kudos to @alexislloyd for the help in getting these started.

A rethinking of the IA of the handbook navigation will also be required separately to give some better hierarchy and clarity to the now quite huge sidebar.

I'm also moving the logo and design resources to the "references" document as it didn't seem worth the front-page.

Let's discuss!

cc @jasmussen @karmatosed @kjellr @chrisvanpatten 