### PR TITLE
Meta Boxes: Remove dirty detection

### DIFF
--- a/docs/data/data-core-edit-post.md
+++ b/docs/data/data-core-edit-post.md
@@ -154,6 +154,32 @@ Returns the state of legacy meta boxes.
 
 State of meta boxes.
 
+### getActiveMetaBoxLocations
+
+Returns an array of active meta box locations.
+
+*Parameters*
+
+ * state: Post editor state.
+
+*Returns*
+
+Active meta box locations.
+
+### isMetaBoxLocationActive
+
+Returns true if there is an active meta box in the given location, or false
+otherwise.
+
+*Parameters*
+
+ * state: Post editor state.
+ * location: Meta box location to test.
+
+*Returns*
+
+Whether the meta box location is active.
+
 ### getMetaBox
 
 Returns the state of legacy meta boxes.
@@ -270,6 +296,15 @@ This indicates that the sidebar has a meta box but the normal area does not.
 *Parameters*
 
  * metaBoxes: Whether meta box locations are active.
+
+### setActiveMetaBoxLocations
+
+Returns an action object used in signaling that the active meta box
+locations have changed.
+
+*Parameters*
+
+ * locations: New active meta box locations.
 
 ### requestMetaBoxUpdates
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -15,6 +15,12 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 
 - Writing resolvers as async generators has been removed. Use the controls plugin instead.
 - `wp.components.AccessibleSVG` component has been removed. Please use `wp.components.SVG` instead.
+- The `wp.editor.UnsavedChangesWarning` component no longer accepts a `forceIsDirty` prop.
+- `initializeMetaBoxState` action (`core/edit-post`) has been removed. Use `setActiveMetaBoxLocations` action (`core/edit-post`) instead.
+- `wp.editPost.initializeEditor` no longer returns an object. Use the `setActiveMetaBoxLocations` action (`core/edit-post`) in place of the existing object's `initializeMetaBoxes` function.
+- `setMetaBoxSavedData` action (`core/edit-post`) has been removed.
+- `getMetaBoxes` selector (`core/edit-post`) has been removed. Use `getActiveMetaBoxLocations` selector (`core/edit-post`) instead.
+- `getMetaBox` selector (`core/edit-post`) has been removed. Use `isMetaBoxLocationActive` selector (`core/edit-post`) instead.
 
 ## 4.1.0
 

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -35,7 +34,6 @@ import VisualEditor from '../visual-editor';
 import EditorModeKeyboardShortcuts from '../keyboard-shortcuts';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
 import MetaBoxes from '../meta-boxes';
-import { getMetaBoxContainer } from '../../utils/meta-boxes';
 import Sidebar from '../sidebar';
 import PluginPostPublishPanel from '../sidebar/plugin-post-publish-panel';
 import PluginPrePublishPanel from '../sidebar/plugin-pre-publish-panel';
@@ -49,7 +47,6 @@ function Layout( {
 	hasFixedToolbar,
 	closePublishSidebar,
 	togglePublishSidebar,
-	metaBoxes,
 	hasActiveMetaboxes,
 	isSaving,
 	isMobileViewport,
@@ -71,12 +68,7 @@ function Layout( {
 		<div className={ className }>
 			<FullscreenMode />
 			<BrowserURL />
-			<UnsavedChangesWarning forceIsDirty={ () => {
-				return some( metaBoxes, ( metaBox, location ) => {
-					return metaBox.isActive &&
-						jQuery( getMetaBoxContainer( location ) ).serialize() !== metaBox.data;
-				} );
-			} } />
+			<UnsavedChangesWarning />
 			<AutosaveMonitor />
 			<Header />
 			<div
@@ -142,7 +134,6 @@ export default compose(
 		pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
 		publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
-		metaBoxes: select( 'core/edit-post' ).getMetaBoxes(),
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 	} ) ),

--- a/edit-post/components/meta-boxes/index.js
+++ b/edit-post/components/meta-boxes/index.js
@@ -16,8 +16,10 @@ function MetaBoxes( { location, isActive } ) {
 	return <MetaBoxesArea location={ location } />;
 }
 
-export default withSelect(
-	( select, ownProps ) => ( {
-		isActive: select( 'core/edit-post' ).getMetaBox( ownProps.location ).isActive,
-	} ),
-)( MetaBoxes );
+export default withSelect( ( select, ownProps ) => {
+	const { isMetaBoxLocationActive } = select( 'core/edit-post' );
+
+	return {
+		isActive: isMetaBoxLocationActive( ownProps.location ),
+	};
+} )( MetaBoxes );

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -8,6 +8,7 @@ import '@wordpress/viewport';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -74,6 +75,12 @@ export function initializeEditor( id, postType, postId, settings, overridePost )
 
 	return {
 		initializeMetaBoxes( metaBoxes ) {
+			deprecated( 'editor.initializeMetaBoxes', {
+				alternative: 'setActiveMetaBoxLocations action (`core/edit-post`)',
+				plugin: 'Gutenberg',
+				version: '4.2',
+			} );
+
 			store.dispatch( initializeMetaBoxState( metaBoxes ) );
 		},
 	};

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -1,4 +1,14 @@
 /**
+ * External dependencies
+ */
+import { reduce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Returns an action object used in signalling that the user opened an editor sidebar.
  *
  * @param {string} name Sidebar name to be opened.
@@ -147,9 +157,35 @@ export function togglePinnedPluginItem( pluginName ) {
  * @return {Object} Action object.
  */
 export function initializeMetaBoxState( metaBoxes ) {
+	deprecated( 'initializeMetaBoxState action (`core/edit-post`)', {
+		alternative: 'setActiveMetaBoxLocations',
+		plugin: 'Gutenberg',
+		version: '4.2',
+	} );
+
+	const locations = reduce( metaBoxes, ( result, isActive, location ) => {
+		if ( isActive ) {
+			result = result.concat( location );
+		}
+
+		return result;
+	}, [] );
+
+	return setActiveMetaBoxLocations( locations );
+}
+
+/**
+ * Returns an action object used in signaling that the active meta box
+ * locations have changed.
+ *
+ * @param {string[]} locations New active meta box locations.
+ *
+ * @return {Object} Action object.
+ */
+export function setActiveMetaBoxLocations( locations ) {
 	return {
-		type: 'INITIALIZE_META_BOX_STATE',
-		metaBoxes,
+		type: 'SET_ACTIVE_META_BOX_LOCATIONS',
+		locations,
 	};
 }
 
@@ -184,6 +220,11 @@ export function metaBoxUpdatesSuccess() {
  * @return {Object} Action object.
  */
 export function setMetaBoxSavedData( dataPerLocation ) {
+	deprecated( 'setMetaBoxSavedData action (`core/edit-post`)', {
+		plugin: 'Gutenberg',
+		version: '4.2',
+	} );
+
 	return {
 		type: 'META_BOX_SET_SAVED_DATA',
 		dataPerLocation,

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -145,20 +145,6 @@ export function publishSidebarActive( state = false, action ) {
 	return state;
 }
 
-const locations = [
-	'normal',
-	'side',
-	'advanced',
-];
-
-const defaultMetaBoxState = locations.reduce( ( result, key ) => {
-	result[ key ] = {
-		isActive: false,
-	};
-
-	return result;
-}, {} );
-
 /**
  * Reducer keeping track of the meta boxes isSaving state.
  * A "true" value means the meta boxes saving request is in-flight.
@@ -181,39 +167,21 @@ export function isSavingMetaBoxes( state = false, action ) {
 }
 
 /**
- * Reducer keeping track of the state of each meta box location.
- * This includes:
- *  - isActive: Whether the location is active or not.
- *  - data: The last saved form data for this location.
- *    This is used to check whether the form is dirty
- *    before leaving the page.
+ * Reducer returning an array of active meta box locations after the given
+ * action.
  *
- * @param {boolean}  state   Previous state.
- * @param {Object}   action  Action Object.
+ * @param {boolean} state  Previous state.
+ * @param {Object}  action Action Object.
  *
- * @return {Object} Updated state.
+ * @return {string[]} Updated state.
  */
-export function metaBoxes( state = defaultMetaBoxState, action ) {
+export function activeMetaBoxLocations( state = [], action ) {
 	switch ( action.type ) {
-		case 'INITIALIZE_META_BOX_STATE':
-			return locations.reduce( ( newState, location ) => {
-				newState[ location ] = {
-					...state[ location ],
-					isActive: action.metaBoxes[ location ],
-				};
-				return newState;
-			}, { ...state } );
-		case 'META_BOX_SET_SAVED_DATA':
-			return locations.reduce( ( newState, location ) => {
-				newState[ location ] = {
-					...state[ location ],
-					data: action.dataPerLocation[ location ],
-				};
-				return newState;
-			}, { ...state } );
-		default:
-			return state;
+		case 'SET_ACTIVE_META_BOX_LOCATIONS':
+			return action.locations;
 	}
+
+	return state;
 }
 
 export default combineReducers( {
@@ -222,6 +190,6 @@ export default combineReducers( {
 	panel,
 	activeModal,
 	publishSidebarActive,
-	metaBoxes,
+	activeMetaBoxLocations,
 	isSavingMetaBoxes,
 } );

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -1,8 +1,12 @@
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * External dependencies
  */
-import createSelector from 'rememo';
-import { get, includes, some } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Returns the current editing mode.
@@ -154,12 +158,52 @@ export function isPluginItemPinned( state, pluginName ) {
 /**
  * Returns the state of legacy meta boxes.
  *
- * @param   {Object} state Global application state.
+ * @param {Object} state Global application state.
  *
  * @return {Object} State of meta boxes.
  */
 export function getMetaBoxes( state ) {
-	return state.metaBoxes;
+	deprecated( 'getMetaBox selector (`core/edit-post`)', {
+		alternative: 'getActiveMetaBoxLocations selector',
+		plugin: 'Gutenberg',
+		version: '4.2',
+	} );
+
+	return [
+		'normal',
+		'side',
+		'advanced',
+	].reduce( ( result, location ) => {
+		result[ location ] = {
+			isActive: isMetaBoxLocationActive( state, location ),
+		};
+
+		return result;
+	}, {} );
+}
+
+/**
+ * Returns an array of active meta box locations.
+ *
+ * @param {Object} state Post editor state.
+ *
+ * @return {string[]} Active meta box locations.
+ */
+export function getActiveMetaBoxLocations( state ) {
+	return state.activeMetaBoxLocations;
+}
+
+/**
+ * Returns true if there is an active meta box in the given location, or false
+ * otherwise.
+ *
+ * @param {Object} state    Post editor state.
+ * @param {string} location Meta box location to test.
+ *
+ * @return {boolean} Whether the meta box location is active.
+ */
+export function isMetaBoxLocationActive( state, location ) {
+	return getActiveMetaBoxLocations( state ).includes( location );
 }
 
 /**
@@ -171,6 +215,12 @@ export function getMetaBoxes( state ) {
  * @return {Object} State of meta box at specified location.
  */
 export function getMetaBox( state, location ) {
+	deprecated( 'getMetaBox selector (`core/edit-post`)', {
+		alternative: 'isMetaBoxLocationActive selector',
+		plugin: 'Gutenberg',
+		version: '4.2',
+	} );
+
 	return getMetaBoxes( state )[ location ];
 }
 
@@ -181,16 +231,9 @@ export function getMetaBox( state, location ) {
  *
  * @return {boolean} Whether there are metaboxes or not.
  */
-export const hasMetaBoxes = createSelector(
-	( state ) => {
-		return some( getMetaBoxes( state ), ( metaBox ) => {
-			return metaBox.isActive;
-		} );
-	},
-	( state ) => [
-		state.metaBoxes,
-	],
-);
+export function hasMetaBoxes( state ) {
+	return getActiveMetaBoxLocations( state ).length > 0;
+}
 
 /**
  * Returns true if the Meta Boxes are being saved.

--- a/edit-post/store/test/actions.js
+++ b/edit-post/store/test/actions.js
@@ -13,7 +13,6 @@ import {
 	toggleFeature,
 	togglePinnedPluginItem,
 	requestMetaBoxUpdates,
-	initializeMetaBoxState,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -112,21 +111,6 @@ describe( 'actions', () => {
 		it( 'should return the REQUEST_META_BOX_UPDATES action', () => {
 			expect( requestMetaBoxUpdates() ).toEqual( {
 				type: 'REQUEST_META_BOX_UPDATES',
-			} );
-		} );
-	} );
-
-	describe( 'initializeMetaBoxState', () => {
-		it( 'should return the META_BOX_STATE_CHANGED action with a hasChanged flag', () => {
-			const metaBoxes = {
-				side: true,
-				normal: true,
-				advanced: false,
-			};
-
-			expect( initializeMetaBoxState( metaBoxes ) ).toEqual( {
-				type: 'INITIALIZE_META_BOX_STATE',
-				metaBoxes,
 			} );
 		} );
 	} );

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -12,7 +12,7 @@ import {
 	activeGeneralSidebar,
 	activeModal,
 	isSavingMetaBoxes,
-	metaBoxes,
+	activeMetaBoxLocations,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -191,66 +191,22 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'metaBoxes()', () => {
+	describe( 'activeMetaBoxLocations()', () => {
 		it( 'should return default state', () => {
-			const actual = metaBoxes( undefined, {} );
-			const expected = {
-				normal: {
-					isActive: false,
-				},
-				side: {
-					isActive: false,
-				},
-				advanced: {
-					isActive: false,
-				},
-			};
+			const state = activeMetaBoxLocations( undefined, {} );
 
-			expect( actual ).toEqual( expected );
+			expect( state ).toEqual( [] );
 		} );
 
-		it( 'should set the sidebar to active', () => {
-			const theMetaBoxes = {
-				normal: false,
-				advanced: false,
-				side: true,
-			};
-
+		it( 'should set the active meta box locations', () => {
 			const action = {
-				type: 'INITIALIZE_META_BOX_STATE',
-				metaBoxes: theMetaBoxes,
+				type: 'SET_ACTIVE_META_BOX_LOCATIONS',
+				locations: [ 'normal' ],
 			};
 
-			const actual = metaBoxes( undefined, action );
-			const expected = {
-				normal: {
-					isActive: false,
-				},
-				side: {
-					isActive: true,
-				},
-				advanced: {
-					isActive: false,
-				},
-			};
+			const state = activeMetaBoxLocations( undefined, action );
 
-			expect( actual ).toEqual( expected );
-		} );
-
-		it( 'should set the meta boxes saved data', () => {
-			const action = {
-				type: 'META_BOX_SET_SAVED_DATA',
-				dataPerLocation: {
-					side: 'a=b',
-				},
-			};
-
-			const theMetaBoxes = metaBoxes( { normal: { isActive: true }, side: { isActive: false } }, action );
-			expect( theMetaBoxes ).toEqual( {
-				advanced: { data: undefined },
-				normal: { isActive: true, data: undefined },
-				side: { isActive: false, data: 'a=b' },
-			} );
+			expect( state ).toEqual( [ 'normal' ] );
 		} );
 	} );
 } );

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import {
@@ -15,9 +20,17 @@ import {
 	hasMetaBoxes,
 	isSavingMetaBoxes,
 	getMetaBox,
+	getActiveMetaBoxLocations,
+	isMetaBoxLocationActive,
 } from '../selectors';
 
+jest.mock( '@wordpress/deprecated', () => jest.fn() );
+
 describe( 'selectors', () => {
+	beforeEach( () => {
+		deprecated.mockClear();
+	} );
+
 	describe( 'getEditorMode', () => {
 		it( 'should return the selected editor mode', () => {
 			const state = {
@@ -283,14 +296,7 @@ describe( 'selectors', () => {
 	describe( 'hasMetaBoxes', () => {
 		it( 'should return true if there are active meta boxes', () => {
 			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: false,
-					},
-					side: {
-						isActive: true,
-					},
-				},
+				activeMetaBoxLocations: [ 'side' ],
 			};
 
 			expect( hasMetaBoxes( state ) ).toBe( true );
@@ -298,14 +304,7 @@ describe( 'selectors', () => {
 
 		it( 'should return false if there are no active meta boxes', () => {
 			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: false,
-					},
-					side: {
-						isActive: false,
-					},
-				},
+				activeMetaBoxLocations: [],
 			};
 
 			expect( hasMetaBoxes( state ) ).toBe( false );
@@ -333,19 +332,18 @@ describe( 'selectors', () => {
 	describe( 'getMetaBoxes', () => {
 		it( 'should return the state of all meta boxes', () => {
 			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: true,
-					},
-					side: {
-						isActive: true,
-					},
-				},
+				activeMetaBoxLocations: [ 'normal', 'side' ],
 			};
 
-			expect( getMetaBoxes( state ) ).toEqual( {
+			const result = getMetaBoxes( state );
+
+			expect( deprecated ).toHaveBeenCalled();
+			expect( result ).toEqual( {
 				normal: {
 					isActive: true,
+				},
+				advanced: {
+					isActive: false,
 				},
 				side: {
 					isActive: true,
@@ -357,19 +355,49 @@ describe( 'selectors', () => {
 	describe( 'getMetaBox', () => {
 		it( 'should return the state of selected meta box', () => {
 			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: false,
-					},
-					side: {
-						isActive: true,
-					},
-				},
+				activeMetaBoxLocations: [ 'side' ],
 			};
 
-			expect( getMetaBox( state, 'side' ) ).toEqual( {
+			const result = getMetaBox( state, 'side' );
+
+			expect( deprecated ).toHaveBeenCalled();
+			expect( result ).toEqual( {
 				isActive: true,
 			} );
+		} );
+	} );
+
+	describe( 'getActiveMetaBoxLocations', () => {
+		it( 'should return the active meta boxes', () => {
+			const state = {
+				activeMetaBoxLocations: [ 'side' ],
+			};
+
+			const result = getActiveMetaBoxLocations( state, 'side' );
+
+			expect( result ).toEqual( [ 'side' ] );
+		} );
+	} );
+
+	describe( 'isMetaBoxLocationActive', () => {
+		it( 'should return false if not active', () => {
+			const state = {
+				activeMetaBoxLocations: [],
+			};
+
+			const result = isMetaBoxLocationActive( state, 'side' );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return true if active', () => {
+			const state = {
+				activeMetaBoxLocations: [ 'side' ],
+			};
+
+			const result = isMetaBoxLocationActive( state, 'side' );
+
+			expect( result ).toBe( true );
 		} );
 	} );
 } );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -639,6 +639,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-block-library',
 			'wp-date',
 			'wp-data',
+			'wp-deprecated',
 			'wp-dom-ready',
 			'wp-editor',
 			'wp-element',

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -289,9 +289,9 @@ function the_gutenberg_metaboxes() {
 	 *
 	 * @param array $wp_meta_boxes Global meta box state.
 	 */
-	$wp_meta_boxes = apply_filters( 'filter_gutenberg_meta_boxes', $wp_meta_boxes );
-	$locations     = array( 'side', 'normal', 'advanced' );
-	$meta_box_data = array();
+	$wp_meta_boxes             = apply_filters( 'filter_gutenberg_meta_boxes', $wp_meta_boxes );
+	$locations                 = array( 'side', 'normal', 'advanced' );
+	$active_meta_box_locations = array();
 	// Render meta boxes.
 	?>
 	<form class="metabox-base-form">
@@ -302,13 +302,15 @@ function the_gutenberg_metaboxes() {
 			<div id="poststuff" class="sidebar-open">
 				<div id="postbox-container-2" class="postbox-container">
 					<?php
-					$number_metaboxes = do_meta_boxes(
+					$number_of_meta_boxes = do_meta_boxes(
 						$current_screen,
 						$location,
 						$post
 					);
 
-					$meta_box_data[ $location ] = $number_metaboxes > 0;
+					if ( $number_of_meta_boxes > 0 ) {
+						$active_meta_box_locations[] = $location;
+					}
 					?>
 				</div>
 			</div>
@@ -324,7 +326,9 @@ function the_gutenberg_metaboxes() {
 	 * editor instance. If a cleaner solution can be imagined, please change
 	 * this, and try to get this data to load directly into the editor settings.
 	 */
-	$script = 'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );';
+	$script = 'window._wpLoadGutenbergEditor.then( function() {
+		wp.data.dispatch( \'core/edit-post\' ).setActiveMetaBoxLocations( ' . wp_json_encode( $active_meta_box_locations ) . ' );
+	} );';
 
 	wp_add_inline_script( 'wp-edit-post', $script );
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -216,8 +216,6 @@ function gutenberg_collect_meta_box_data() {
 	 */
 	$_meta_boxes_copy = apply_filters( 'filter_gutenberg_meta_boxes', $_meta_boxes_copy );
 
-	$meta_box_data = array();
-
 	// Redirect to classic editor if a meta box is incompatible.
 	foreach ( $locations as $location ) {
 		if ( ! isset( $_meta_boxes_copy[ $post->post_type ][ $location ] ) ) {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
 		"react": "16.4.1",
 		"react-dom": "16.4.1",
 		"redux": "3.7.2",
-		"refx": "3.0.0",
-		"rememo": "3.0.0"
+		"refx": "3.0.0"
 	},
 	"devDependencies": {
 		"@babel/core": "7.0.0",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Deprecations
 
 - The `checkTemplateValidity` action has been deprecated. Validity is verified automatically upon block reset.
+- The `UnsavedChangesWarning` component `forceIsDirty` prop has been deprecated.
 
 ## 3.0.0 (2018-09-05)
 

--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -1,29 +1,26 @@
 /**
+ * External dependencies
+ */
+import { stubFalse } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 class UnsavedChangesWarning extends Component {
-	/**
-	 * @inheritdoc
-	 */
 	constructor() {
 		super( ...arguments );
 		this.warnIfUnsavedChanges = this.warnIfUnsavedChanges.bind( this );
 	}
 
-	/**
-	 * @inheritdoc
-	 */
 	componentDidMount() {
 		window.addEventListener( 'beforeunload', this.warnIfUnsavedChanges );
 	}
 
-	/**
-	 * @inheritdoc
-	 */
 	componentWillUnmount() {
 		window.removeEventListener( 'beforeunload', this.warnIfUnsavedChanges );
 	}
@@ -31,20 +28,28 @@ class UnsavedChangesWarning extends Component {
 	/**
 	 * Warns the user if there are unsaved changes before leaving the editor.
 	 *
-	 * @param   {Event}   event Event Object.
-	 * @return {string?}       Warning message.
+	 * @param {Event} event `beforeunload` event.
+	 *
+	 * @return {?string} Warning prompt message, if unsaved changes exist.
 	 */
 	warnIfUnsavedChanges( event ) {
-		const { isDirty, forceIsDirty = () => false } = this.props;
+		const { isDirty, forceIsDirty = stubFalse } = this.props;
+
+		// For deprecation, infer explicitly provided if not assigned to
+		// fallback value.
+		if ( forceIsDirty !== stubFalse ) {
+			deprecated( 'UnsavedChangesWarning forceIsDirty prop', {
+				plugin: 'Gutenberg',
+				version: '4.2',
+			} );
+		}
+
 		if ( isDirty || forceIsDirty() ) {
 			event.returnValue = __( 'You have unsaved changes. If you proceed, they will be lost.' );
 			return event.returnValue;
 		}
 	}
 
-	/**
-	 * @inheritdoc
-	 */
 	render() {
 		return null;
 	}


### PR DESCRIPTION
This pull request seeks to remove dirty detection for meta boxes. This is a feature which never existed in the classic editor but was introduced to Gutenberg as a proposed enhancement in an effort to avoid content loss. In practice, it has been shown to be very unreliable, very often prompting the user about unsaved changes when not exist, degrading the user experience.

In most cases, this occurs because plugins programmatically manipulate the values of inputs in the DOM after the editor has loaded. This conflicts with the dirty detection, which operates as a diff of input values between the initial load (or last save) and when the user attempts to leave the page. To my knowledge, it is not possible to differentiate between user initiated input changes and those incurred programmatically, nor is it possible to identify a point in time where it can be definitively determined that plugins are truly initialized so far as their post-initialization behaviors.

**Testing instructions**

Normally, this would be very easy to observe and test in the Yoast plugin, which assigns a hidden input value after initial load as the result of an AJAX request initiated after page load. However, with deprecations removed in the latest version of the master branch, the Yoast meta box does not currently load.

Instead, consider including the following plugin in `wp-content/mu-plugins` or `wp-content/plugins`:

```php
<?php

/**
 * Plugin name: Demo Meta
 */

function demo_meta_box_add() {
	add_meta_box(
		'my-meta-box-id',
		'My First Meta Box',
		'demo_meta_box_callback',
		'post',
		'normal',
		'high'
	);
}
add_action( 'add_meta_boxes', 'demo_meta_box_add' );

function demo_meta_box_callback() {
    echo '<input name=foo>';   
}
```

Verify both:

- the reloading the page after entering text in the input does not trigger a prompt
- that a network request sending meta box input values is triggered upon saving the post †

_† In this very naïve test plug-in, there is no persistence of the meta input value. Therefore, it is not expected that the value be restored after the page is reloaded, even if the post is saved._