### PR TITLE
Fix gallery margin while typing

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -118,7 +118,9 @@
 	.blocks-gallery-image:last-child,
 	.blocks-gallery-item:last-child,
 	.is-selected & .blocks-gallery-image:nth-last-child(2),
-	.is-selected & .blocks-gallery-item:nth-last-child(2) {
+	.is-selected & .blocks-gallery-item:nth-last-child(2),
+	.is-typing & .blocks-gallery-image:nth-last-child(2),
+	.is-typing & .blocks-gallery-item:nth-last-child(2) {
 		margin-right: 0;
 	}
 


### PR DESCRIPTION
#10027 introduced a small bug where the last item in a gallery sometimes jumps around when a user is in the process of adding a caption. 

This is due to a `:nth-last-child(2)` style rule that is applied to a gallery when it has an `is-selected` class, but not an `is-typing` class.

This PR modifies that rule to include the `is-typing` class and remove the jump.

**Before:**
![broken](https://user-images.githubusercontent.com/1202812/46169926-631d8100-c26a-11e8-99f0-af6e3558bfc6.gif)

**After**
![fixed](https://user-images.githubusercontent.com/1202812/46169935-66b10800-c26a-11e8-8a58-1328cbecaa32.gif)
