### PR TITLE
Fix wide regression

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -14,6 +14,10 @@
 		width: 100%;
 	}
 
+	// This resets the intrinsic margin on the figure in non-floated, wide, and full-wide alignments.
+	margin-left: 0;
+	margin-right: 0;
+
 	// Floats get an extra wrapping <aside> element, so the <figure> becomes a child.
 	.alignleft,
 	.alignright,

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -361,6 +361,12 @@
 				display: inline-flex;
 			}
 		}
+
+		// This resets the intrinsic margin on the figure in wide and full-wide alignments.
+		figure {
+			margin-left: 0;
+			margin-right: 0;
+		}
 	}
 
 	// Wide
@@ -373,7 +379,6 @@
 
 	// Full-wide
 	&[data-align="full"] {
-
 		// Position hover label on the right
 		> .editor-block-list__breadcrumb {
 			right: -$border-width;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -361,12 +361,6 @@
 				display: inline-flex;
 			}
 		}
-
-		// This resets the intrinsic margin on the figure in wide and full-wide alignments.
-		figure {
-			margin-left: 0;
-			margin-right: 0;
-		}
 	}
 
 	// Wide


### PR DESCRIPTION
This fixes a regression where wide images would cause horizontal scrollbars. Try the demo content in master, note that there are horizontal scrollbars. Then try this branch, note that they are gone.

The issue: the margins on the figure weren't being reset left and right on wide image. 

I will investigate why this regression happened, I suspect it was related to the side-padding normalization.