### PR TITLE
Fix table header and body column misalignment (responsiveness using word-break: break-all)

### DIFF
--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -1,9 +1,6 @@
 .wp-block-table {
 	// Fixed layout toggle
-	&.has-fixed-layout thead,
-	&.has-fixed-layout tbody,
-	&.has-fixed-layout tfoot {
-		display: table;
+	&.has-fixed-layout {
 		table-layout: fixed;
 		width: 100%;
 	}

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -1,16 +1,7 @@
 .wp-block-table {
-	overflow-x: auto;
-	display: block; // Necessary in order for this table to be mobile responsive.
-	border-collapse: collapse;
 	width: 100%;
-
-	thead,
-	tbody,
-	tfoot {
-		width: 100%;
-		min-width: $break-mobile / 2;
-		display: table;
-	}
+	min-width: $break-mobile / 2;
+	border-collapse: collapse;
 
 	td,
 	th {

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -7,5 +7,6 @@
 	th {
 		padding: 0.5em;
 		border: 1px solid currentColor;
+		word-break: break-all;
 	}
 }


### PR DESCRIPTION
## Description
Fixes #9779 - table header misalignment issue. This PR takes a different approach to that originally proposed in #10011, opting to wrap text instead of using a container `div` to handle an overflowing table.

Changes:
1. The issue was caused by `thead`, `tbody` and `tfoot` elements being given the `display: table` property (SO explanation - https://stackoverflow.com/a/12153220). This styling has now been removed so that the elements have their default display property.
2. `table-layout: fixed;` was previously applied on the `thead`, `tbody` and `tfoot` elements, but since they're no longer `display: table` that was no longer working. This style is now applied to the `table` element and the `table` element has been changed from `display: block` to `display: table`
3. The above changes break the `overflow-x: auto` style that was applied to the `table` element. One option to solve this would have been to apply a wrapping div around the table. This was attempted on #10011, but ultimately the introduction of a wrapping element was decided against. This PR tries an alternative approach using `word-break: break-all` to ensure content in a table cannot overflow.

## How has this been tested?
**Column alignment**
1. Paste a table with a `thead` directly into the editor - e.g: 
```
<table><thead><tr><td><strong>Column One</strong></td><td><strong>Column Two</strong></td></tr></thead><tbody><tr><td>one</td><td>two</td></tr><tr><td>three</td><td>four</td></tr></tbody></table>
```
2. Observed in the editor that the table header columns are aligned with the body regardless of whether the 'Fixed width table cells' option is enabled.
3. Observed in the preview that everything is aligned. 

**Overflow**
1. Enter long content without spaces or line breaks in a cell.
2. Observed that the text wraps onto a new line and columns are sized according to the amount of content in a column.
3. Observed that the the same behaviour is also present in the preview. (To test this, `add_theme_support( 'wp-block-styles' );` needs to be added somewhere (e.g. in client-assets.php)).

**Fixed width table cells**
1. Toggle fixed width table cells
2. Ensured that table cells are equal spaced and that long content wraps in both the editor and preview

## Screenshots <!-- if applicable -->
**Before**
<img width="837" alt="screen shot 2018-09-18 at 6 09 04 pm" src="https://user-images.githubusercontent.com/677833/45704114-076a3e00-bb6e-11e8-82d6-6db8541c4e73.png">

**After**
<img width="837" alt="screen shot 2018-09-18 at 5 57 30 pm" src="https://user-images.githubusercontent.com/677833/45703477-5a42f600-bb6c-11e8-9d7b-1f53fc830f51.png">

**Wrapping content**
<img width="546" alt="screen shot 2018-09-28 at 12 17 14 pm" src="https://user-images.githubusercontent.com/677833/46205453-8acb2280-c318-11e8-9afb-d25e21f6fe3a.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
