### PR TITLE
Fix faulty Jed state after setLocaleData

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## 3.0.0 (Unreleased)
 
-### Braking Change
+### Breaking Changes
 
-- `wp.i18n.getI18n` has been removed. Use `__`, `_x`, `_n`, or `_nx` instead.
-- `wp.i18n.dcnpgettext` has been removed. Use `__`, `_x`, `_n`, or `_nx` instead.
+- `getI18n` has been removed. Use `__`, `_x`, `_n`, or `_nx` instead.
+- `dcnpgettext` has been removed. Use `__`, `_x`, `_n`, or `_nx` instead.
+
+### Bug Fixes
+
+- The initialization of the internal Jed instance now correctly assigns its default data.
 
 ## 2.0.0 (2018-09-05)
 

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -29,7 +29,7 @@ export function setLocaleData( localeData = { '': {} }, domain = 'default' ) {
 		i18n = new Jed( {
 			domain: 'default',
 			locale_data: {
-				default: {},
+				default: { '': {} },
 			},
 		} );
 	}


### PR DESCRIPTION
## Description

When calling `setLocaleData` with a custom textdomain in a non-Gutenberg environment the default textdomain ends up in a state that is not ok with Jed resulting in the error: "Error: No locale meta information provided." In Gutenberg this is not a problem because `setLocaleData` is always called first with the default textdomain.

## How has this been tested?

Using `hotfix/8.3.1` of Yoast SEO we found this bug. After the removal of `getI18n` from our code we uncovered this.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
