### PR TITLE
Update columns editor styles to prevent overflowing text

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -59,6 +59,7 @@
 		}
 	}
 
+	// These max-widths constrain columns so long words do not cause overflow issues in the editor.
 	&.has-2-columns .editor-block-list__layout > .editor-block-list__block-edit {
 		max-width: 50%;
 	}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -58,4 +58,24 @@
 			}
 		}
 	}
+
+	&.has-2-columns .editor-block-list__layout > .editor-block-list__block-edit {
+		max-width: 50%;
+	}
+
+	&.has-3-columns .editor-block-list__layout > .editor-block-list__block-edit {
+		max-width: 33.3333%;
+	}
+
+	&.has-4-columns .editor-block-list__layout > .editor-block-list__block-edit {
+		max-width: 25%;
+	}
+
+	&.has-5-columns .editor-block-list__layout > .editor-block-list__block-edit {
+		max-width: 20%;
+	}
+
+	&.has-6-columns .editor-block-list__layout > .editor-block-list__block-edit {
+		max-width: 16.6666%;
+	}
 }

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -59,24 +59,24 @@
 		}
 	}
 
-	// These max-widths constrain columns so long words do not cause overflow issues in the editor.
-	&.has-2-columns .editor-block-list__layout > .editor-block-list__block-edit {
+	// These max-widths constrain columns so long content does not cause overflow issues in the editor.
+	&.has-2-columns > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block {
 		max-width: 50%;
 	}
 
-	&.has-3-columns .editor-block-list__layout > .editor-block-list__block-edit {
+	&.has-3-columns > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block {
 		max-width: 33.3333%;
 	}
 
-	&.has-4-columns .editor-block-list__layout > .editor-block-list__block-edit {
+	&.has-4-columns > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block {
 		max-width: 25%;
 	}
 
-	&.has-5-columns .editor-block-list__layout > .editor-block-list__block-edit {
+	&.has-5-columns > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block {
 		max-width: 20%;
 	}
 
-	&.has-6-columns .editor-block-list__layout > .editor-block-list__block-edit {
+	&.has-6-columns > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block {
 		max-width: 16.6666%;
 	}
 }

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -55,6 +55,7 @@
 
 			.editor-block-list__block-edit {
 				flex-basis: 100%;
+				word-wrap: break-word;
 			}
 		}
 	}


### PR DESCRIPTION
## Description
As per #7921 - on editor screen, adding long-words / unbroken text into column pushes additional columns off-screen.

To replicate:
1. Add column container block
2. Add paragraph to block 1
3. Keep typing (no spaces) and watch editor push columns off screen.

To prevent this, max-width rules have been added for (2, 3, 4, 5, and 6) columns to ensure long content does not cause overflow problems in the editor screen.

## How has this been tested?
Tested across browsers on Chrome, Firefox, Safari, IE and Edge on Mac High Sierra 10.13.6, Mac Sierra 10.12.6, IE 10

The width of the column is fixed on all, and an extra style has been added to fix the overflow issue on Edge.

## Screenshots
Issue
<img width="1217" alt="screen shot 2018-09-28 at 16 14 52" src="https://user-images.githubusercontent.com/7941932/46217370-bd394780-c339-11e8-9b39-eebfa40e840b.png">

Fixed
<img width="1021" alt="screen shot 2018-09-28 at 16 15 07" src="https://user-images.githubusercontent.com/7941932/46217375-c1656500-c339-11e8-8a36-a0f7bcea56a9.png">

## Types of changes
Bug fix, SCSS update: Adds multiple max-width rules in `packages/block-library/src/columns/editor.scss`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
