### PR TITLE
Update for MediaPlaceholder component: don't stack error messages when re-uploading

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -115,6 +115,7 @@ class AudioEdit extends Component {
 					value={ this.props.attributes }
 					notices={ noticeUI }
 					onError={ noticeOperations.createErrorNotice }
+					clearPreviousNotices={ noticeOperations.removeAllNotices }
 				/>
 			);
 		}

--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -221,6 +221,7 @@ export const settings = {
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						notices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }
+						clearPreviousNotices={ noticeOperations.removeAllNotices }
 					/>
 				</Fragment>
 			);

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -147,6 +147,7 @@ class FileEdit extends Component {
 					onSelect={ this.onSelectFile }
 					notices={ noticeUI }
 					onError={ noticeOperations.createErrorNotice }
+					clearPreviousNotices={ noticeOperations.removeAllNotices }
 					accept="*"
 				/>
 			);

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -140,6 +140,7 @@ class GalleryEdit extends Component {
 				} );
 			},
 			onError: noticeOperations.createErrorNotice,
+			clearPreviousNotices: noticeOperations.removeAllNotices,
 		} );
 	}
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -204,6 +204,7 @@ class GalleryEdit extends Component {
 						multiple
 						notices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }
+						clearPreviousNotices={ noticeOperations.removeAllNotices }
 					/>
 				</Fragment>
 			);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -251,6 +251,7 @@ class ImageEdit extends Component {
 						onSelect={ this.onSelectImage }
 						notices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }
+						clearPreviousNotices={ noticeOperations.removeAllNotices }
 						accept="image/*"
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 					/>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -144,6 +144,7 @@ class VideoEdit extends Component {
 					value={ this.props.attributes }
 					notices={ noticeUI }
 					onError={ noticeOperations.createErrorNotice }
+					clearPreviousNotices={ noticeOperations.removeAllNotices }
 				/>
 			);
 		}

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -90,7 +90,7 @@ class MediaPlaceholder extends Component {
 	}
 
 	onFilesUpload( files ) {
-		const { onSelect, multiple, onError } = this.props;
+		const { onSelect, multiple, onError, clearPreviousNotices } = this.props;
 		const allowedTypes = this.getAllowedTypes();
 		const setMedia = multiple ? onSelect : ( [ media ] ) => onSelect( media );
 		mediaUpload( {
@@ -98,6 +98,7 @@ class MediaPlaceholder extends Component {
 			filesList: files,
 			onFileChange: setMedia,
 			onError,
+			clearPreviousNotices,
 		} );
 	}
 

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -30,6 +30,7 @@ export default function( {
 	filesList,
 	maxUploadFileSize,
 	onError = noop,
+	clearPreviousNotices = noop,
 	onFileChange,
 	allowedType,
 } ) {
@@ -61,6 +62,7 @@ export default function( {
 		},
 		maxUploadFileSize,
 		onError: ( { message } ) => onError( message ),
+		clearPreviousNotices,
 		wpAllowedMimeTypes,
 	} );
 }

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -66,6 +66,7 @@ export function mediaUpload( {
 	filesList,
 	maxUploadFileSize,
 	onError = noop,
+	clearPreviousNotices = noop,
 	onFileChange,
 	wpAllowedMimeTypes = null,
 } ) {
@@ -113,6 +114,11 @@ export function mediaUpload( {
 
 		onError( error );
 	};
+
+	// Clear previous notices, before trying to upload new media files
+	if ( files.length > 0 ) {
+		clearPreviousNotices();
+	}
 
 	files.forEach( ( mediaFile, idx ) => {
 		// verify if user is allowed to upload this mime type


### PR DESCRIPTION
## Description
Maybe fixes #6106? I'm not sure, if the original screenshot by @karmatosed is taken from WordPress Core Media Uploader Modal (it seems to be) or some previous version of Gutenberg. Stacking of error messages truly happens in WordPress Media Uploader Modal even with Gutenberg disabled. But the same seems to be true also in all Gutenberg media blocks.

So this PR relates to Image, Gallery, Cover Image, Video, File and Audio blocks. Issue happens when something went wrong in uploading files and one tries to upload another file: new error message is stacked on top of old ones, which is not optimal.

Steps to replicate the issue:
1. Add Image block
2. Click Upload -button and try to add too big image file. You get error message: `"FILENAME_A: This file exceeds the maximum upload size for this site."`
3. Click Upload -button again and try to add another too big image file. You have now two error messages: 
`"FILENAME_B: This file exceeds the maximum upload size for this site."`
`"FILENAME_A: This file exceeds the maximum upload size for this site."`

## How has this been tested?
I tested in my VVV2 local environment by running `npm test`. All tests passed.

I also tested manually by following the steps mentioned earlier for each blocks (Image, Gallery, Cover Image, Video, File and Audio) to see, if issue is solved.

I also tested the situation where one uploads multiple images to Gallery block and some of them are too large. User gets notice from each file, as they should get. When he/she tries to upload again, only the new error messages are shown and the old ones are removed.

## Screenshots
**Before**
![before](https://user-images.githubusercontent.com/5536354/46249120-78420d80-c42c-11e8-92cd-ff4aa8a070bc.png)

**After**
![after](https://user-images.githubusercontent.com/5536354/46249133-c7883e00-c42c-11e8-8692-a729f3f4f224.png)

**Error notices when uploading two too large images and one image with appropriate image size**
![gallery](https://user-images.githubusercontent.com/5536354/46249425-c4dc1780-c431-11e8-91ab-7955e4374a6f.png)

## Types of changes
Bug fix for MediaPlaceholder component and especially for `mediaUpload()`. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
