### PR TITLE
chore: Don't allow string literals in IDs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -155,7 +155,9 @@ module.exports = {
 				message: 'Prefer page.waitForSelector instead.',
 			},
 			{
-				selector: 'JSXAttribute[name.name="id"][value.type="Literal"]',
+				// The <DotTip> component uses the `id` prop for something that does not require an
+				// instanceId; maybe we should change its key.
+				selector: 'JSXOpeningElement[name.name!="DotTip"] JSXAttribute[name.name="id"][value.type="Literal"]',
 				message: 'Do not use string literals for IDs; use withInstanceId instead.',
 			},
 		],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -160,6 +160,13 @@ module.exports = {
 				selector: 'JSXOpeningElement[name.name!="DotTip"] JSXAttribute[name.name="id"][value.type="Literal"]',
 				message: 'Do not use string literals for IDs; use withInstanceId instead.',
 			},
+			{
+				// Discourage the usage of `Math.random()` as it's a code smell
+				// for UUID generation, for which we already have a higher-order
+				// component: `withInstanceId`.
+				selector: 'CallExpression[callee.object.name="Math"][callee.property.name="random"]',
+				message: 'Do not use Math.random() to generate unique IDs; use withInstanceId instead. (If you’re not generating unique IDs: ignore this message.)',
+			},
 		],
 	},
 	overrides: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -152,8 +152,12 @@ module.exports = {
 			},
 			{
 				selector: 'CallExpression[callee.object.name="page"][callee.property.name="waitFor"]',
-				message: 'Prefer page.waitForSelector instead.'
-			}
+				message: 'Prefer page.waitForSelector instead.',
+			},
+			{
+				selector: 'JSXAttribute[name.name="id"][value.type="Literal"]',
+				message: 'Do not use string literals for IDs; use withInstanceId instead.',
+			},
 		],
 	},
 	overrides: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -157,6 +157,7 @@ module.exports = {
 			{
 				// The <DotTip> component uses the `id` prop for something that does not require an
 				// instanceId; maybe we should change its key.
+				// See: https://github.com/WordPress/gutenberg/issues/10305
 				selector: 'JSXOpeningElement[name.name!="DotTip"] JSXAttribute[name.name="id"][value.type="Literal"]',
 				message: 'Do not use string literals for IDs; use withInstanceId instead.',
 			},

--- a/packages/components/src/form-toggle/test/index.js
+++ b/packages/components/src/form-toggle/test/index.js
@@ -30,6 +30,9 @@ describe( 'FormToggle', () => {
 		} );
 
 		it( 'should render an id prop for the input checkbox', () => {
+			// Disabled because of our rule restricting literal IDs, preferring
+			// `withInstanceId`. In this case, it's fine to use literal IDs.
+			// eslint-disable-next-line no-restricted-syntax
 			const formToggle = shallow( <FormToggle id="test" /> );
 			expect( formToggle.find( '.components-form-toggle__input' ).prop( 'id' ) ).toBe( 'test' );
 		} );

--- a/packages/components/src/navigable-container/test/index.js
+++ b/packages/components/src/navigable-container/test/index.js
@@ -45,6 +45,11 @@ describe( 'NavigableMenu', () => {
 	it( 'vertical: should navigate by up and down', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
+			/*
+				Disabled because of our rule restricting literal IDs, preferring
+				`withInstanceId`. In this case, it's fine to use literal IDs.
+			*/
+			/* eslint-disable no-restricted-syntax */
 			<NavigableMenu orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
 				<span tabIndex="-1" id="btn1">One</span>
 				<span tabIndex="-1" id="btn2">Two</span>
@@ -53,6 +58,7 @@ describe( 'NavigableMenu', () => {
 				</span>
 				<span tabIndex="-1" id="btn3">Three</span>
 			</NavigableMenu>
+			/* eslint-enable no-restricted-syntax */
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -83,11 +89,17 @@ describe( 'NavigableMenu', () => {
 	it( 'vertical: should navigate by up and down, and stop at edges', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
+			/*
+				Disabled because of our rule restricting literal IDs, preferring
+				`withInstanceId`. In this case, it's fine to use literal IDs.
+			*/
+			/* eslint-disable no-restricted-syntax */
 			<NavigableMenu cycle={ false } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
 				<span tabIndex="-1" id="btn1">One</span>
 				<span tabIndex="-1" id="btn2">Two</span>
 				<span tabIndex="-1" id="btn3">Three</span>
 			</NavigableMenu>
+			/* eslint-enable no-restricted-syntax */
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -116,6 +128,11 @@ describe( 'NavigableMenu', () => {
 	it( 'horizontal: should navigate by left and right', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
+			/*
+				Disabled because of our rule restricting literal IDs, preferring
+				`withInstanceId`. In this case, it's fine to use literal IDs.
+			*/
+			/* eslint-disable no-restricted-syntax */
 			<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
 				<span tabIndex="-1" id="btn1">One</span>
 				<span tabIndex="-1" id="btn2">Two</span>
@@ -124,6 +141,7 @@ describe( 'NavigableMenu', () => {
 				</span>
 				<span tabIndex="-1" id="btn3">Three</span>
 			</NavigableMenu>
+			/* eslint-enable no-restricted-syntax */
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -154,11 +172,17 @@ describe( 'NavigableMenu', () => {
 	it( 'horizontal: should navigate by left and right, and stop at edges', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
+			/*
+				Disabled because of our rule restricting literal IDs, preferring
+				`withInstanceId`. In this case, it's fine to use literal IDs.
+			*/
+			/* eslint-disable no-restricted-syntax */
 			<NavigableMenu cycle={ false } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
 				<span tabIndex="-1" id="btn1">One</span>
 				<span tabIndex="-1" id="btn2">Two</span>
 				<span tabIndex="-1" id="btn3">Three</span>
 			</NavigableMenu>
+			/* eslint-enable no-restricted-syntax */
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -187,11 +211,17 @@ describe( 'NavigableMenu', () => {
 	it( 'both: should navigate by up/down and left/right', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
+			/*
+				Disabled because of our rule restricting literal IDs, preferring
+				`withInstanceId`. In this case, it's fine to use literal IDs.
+			*/
+			/* eslint-disable no-restricted-syntax */
 			<NavigableMenu orientation="both" onNavigate={ ( index ) => currentIndex = index }>
 				<button id="btn1">One</button>
 				<button id="btn2">Two</button>
 				<button id="btn3">Three</button>
 			</NavigableMenu>
+			/* eslint-enable no-restricted-syntax */
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -226,6 +256,11 @@ describe( 'TabbableContainer', () => {
 	it( 'should navigate by keypresses', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
+			/*
+				Disabled because of our rule restricting literal IDs, preferring
+				`withInstanceId`. In this case, it's fine to use literal IDs.
+			*/
+			/* eslint-disable no-restricted-syntax */
 			<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
 				<div className="section" id="section1" tabIndex="0">Section One</div>
 				<div className="section" id="section2" tabIndex="0">Section Two</div>
@@ -234,6 +269,7 @@ describe( 'TabbableContainer', () => {
 				</div>
 				<div className="section" id="section3" tabIndex="0">Section Three</div>
 			</TabbableContainer>
+			/* eslint-enable no-restricted-syntax */
 		) );
 
 		simulateVisible( wrapper, '*' );
@@ -262,11 +298,17 @@ describe( 'TabbableContainer', () => {
 	it( 'should navigate by keypresses and stop at edges', () => {
 		let currentIndex = 0;
 		const wrapper = mount( (
+			/*
+				Disabled because of our rule restricting literal IDs, preferring
+				`withInstanceId`. In this case, it's fine to use literal IDs.
+			*/
+			/* eslint-disable no-restricted-syntax */
 			<TabbableContainer cycle={ false } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
 				<div className="section" id="section1" tabIndex="0">Section One</div>
 				<div className="section" id="section2" tabIndex="0">Section Two</div>
 				<div className="section" id="section3" tabIndex="0">Section Three</div>
 			</TabbableContainer>
+			/* eslint-enable no-restricted-syntax */
 		) );
 
 		simulateVisible( wrapper, '*' );


### PR DESCRIPTION
This adds a rule about hard-coding IDs to our eslint rules. We may also want to add a rule around `Math.random()` because we don't use it anywhere and it's a warning sign to someone trying to create UUIDs.