### PR TITLE
Fix dropzone issue in Edge - event.dataTransfer.types not being an array

### DIFF
--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual, find, some, filter, noop, throttle } from 'lodash';
+import { isEqual, find, some, filter, noop, throttle, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -88,11 +88,14 @@ class DropZoneProvider extends Component {
 
 	getDragEventType( event ) {
 		if ( event.dataTransfer ) {
-			if ( event.dataTransfer.types.indexOf( 'Files' ) !== -1 ) {
+			// Use lodash `includes` here as in the Edge browser `types` is implemented
+			// as a DomStringList, whereas in other browsers it's an array. `includes`
+			// happily works with both types.
+			if ( includes( event.dataTransfer.types, 'Files' ) ) {
 				return 'file';
 			}
 
-			if ( event.dataTransfer.types.indexOf( 'text/html' ) !== -1 ) {
+			if ( includes( event.dataTransfer.types, 'text/html' ) ) {
 				return 'html';
 			}
 		}


### PR DESCRIPTION
## Description
Fixes #9729

In Edge event.dataTransfer.types is implemented as a DomStringList instead of
an array. See Edge bug report:
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18164853/

Using Lodash includes ensures both arrays and DomStringList types are
supported.
<!-- Please describe what you have changed or added -->

## How has this been tested?
1. Loaded the gutenberg demo post (tested in both Edge and Chrome)
2. Attempted to drag and drop blocks
3. Observed that the drop zones are highighted when dragging a block into a different position.
4. Observed that the block is moved to the new position when the mouse button is released
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
