### PR TITLE
Pass feature image id to media upload component

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -63,6 +63,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 								{ ! media && <Spinner /> }
 							</Button>
 						) }
+						value={ featuredImageId }
 					/>
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&


### PR DESCRIPTION
## Description
Fixes: #9982 

The feature image id was not being passed to MediaUpload component in the feature image component, so clicking on the image would open the media library but wouldn't select the image correctly.


## How has this been tested?
Create a new post. Add a featured image. Save the post reload the editor and click the Feature Image. Verify it was correctly selected in the media library.

In collaboration with @pento.