### PR TITLE
Add a filter to preload paths.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1284,14 +1284,18 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	 * @param array $preload_paths Array of paths to preload
 	 * @param object $post         The post resource data.
 	 */
-	$preload_paths = apply_filters( 'editor_preload_paths', array(
-		'/',
-		'/wp/v2/types?context=edit',
-		'/wp/v2/taxonomies?per_page=-1&context=edit',
-		sprintf( '/wp/v2/%s/%s?context=edit', $rest_base, $post->ID ),
-		sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
-		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
-	), $post );
+	$preload_paths = apply_filters(
+		'editor_preload_paths',
+		array(
+			'/',
+			'/wp/v2/types?context=edit',
+			'/wp/v2/taxonomies?per_page=-1&context=edit',
+			sprintf( '/wp/v2/%s/%s?context=edit', $rest_base, $post->ID ),
+			sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
+			sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
+		),
+		$post
+	);
 
 	// Ensure the global $post remains the same after
 	// API data is preloaded. Because API preloading

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1276,15 +1276,22 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$post_type_object = get_post_type_object( $post_type );
 	$rest_base        = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
 
-	// Preload common data.
-	$preload_paths = array(
+	/**
+	 * Preload common data by specifying an array of REST API paths that will be preloaded.
+	 *
+	 * Filters the array of paths that will be preloaded.
+	 *
+	 * @param array $preload_paths Array of paths to preload
+	 * @param object $post         The post resource data.
+	 */
+	$preload_paths = apply_filters( 'editor_preload_paths', array(
 		'/',
 		'/wp/v2/types?context=edit',
 		'/wp/v2/taxonomies?per_page=-1&context=edit',
 		sprintf( '/wp/v2/%s/%s?context=edit', $rest_base, $post->ID ),
 		sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
 		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
-	);
+	), $post );
 
 	// Ensure the global $post remains the same after
 	// API data is preloaded. Because API preloading


### PR DESCRIPTION
## Description
Preload paths is an array of local API paths that are preloaded. The response data for these paths are populated in PHP and then the preload middleware ensures that the data is returned immediately when fetched, without needing to make an external request. 

This PR adds a filter to preload paths, which means developers can add additional paths. 

See https://github.com/WordPress/gutenberg/issues/10268

## How has this been tested?

* Add the following code in PHP (e.g. in your theme functions.php file)

```
add_filter( 'editor_preload_paths', function( $paths, $post ) {
	if ( $post->post_type === 'page' ) {
		$paths[] = '/wp/v2/types/post?context=edit';
	}
	return $paths;
}, 10, 2 );
```

* Then create a new Page. (Our filter only works on post type page!) 
* Open developer tools and from the console enter the following: 

```
wp.apiFetch({ path: '/wp/v2/types/post?context=edit' });
```

* You will see that the returned value is a promise that is already resolved. 
* If you remove the filter you added in PHP, and retry, the response is a promise that is pending. When it does resolve, the data will be the same. 
 
## Screenshots <!-- if applicable -->
NA

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
