### PR TITLE
Update/freeform embrace editor css styles

### DIFF
--- a/block-library/freeform/edit.js
+++ b/block-library/freeform/edit.js
@@ -135,8 +135,10 @@ export default class FreeformEdit extends Component {
 		editor.on( 'init', () => {
 			const rootNode = this.editor.getBody();
 
-			// Move wp-includes/css/editor.css as last in <head>,
-			// if editor is the first classic editor in Gutenberg edit-screen.
+			/*
+			 * Move wp-includes/css/editor.css as last in <head>,
+			 * if editor is the first classic editor in Gutenberg edit-screen.
+			 */
 			if ( 1 === window.tinymce.editors.length ) {
 				jQuery( '#editor-buttons-css' ).detach().appendTo( 'head' );
 			}

--- a/block-library/freeform/edit.js
+++ b/block-library/freeform/edit.js
@@ -135,6 +135,12 @@ export default class FreeformEdit extends Component {
 		editor.on( 'init', () => {
 			const rootNode = this.editor.getBody();
 
+			// Move wp-includes/css/editor.css as last in <head>,
+			// if editor is the first classic editor in Gutenberg edit-screen.
+			if ( 1 === window.tinymce.editors.length ) {
+				jQuery( '#editor-buttons-css' ).detach().appendTo( 'head' );
+			}
+
 			// Create the toolbar by refocussing the editor.
 			if ( document.activeElement === rootNode ) {
 				rootNode.blur();


### PR DESCRIPTION
This PR will fix #6485, which happens because styles in skin.css of TinyMCE will override styles in editor.css.

The issue is caused, because editor.css is loaded already in `wp_enqueue_editor()` -call in [here](https://github.com/WordPress/gutenberg/blob/master/lib/client-assets.php#L1515). This will cause execution of `wp_enqueue_style( 'editor-buttons' );` in [here](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-editor.php#L819)

Tinymce skin styles are added last to `<head>`, when user adds new classic editor: [See code reference](https://github.com/WordPress/gutenberg/blob/master/block-library/freeform/edit.js#L74) 

## Description
My first thought was to load editor.css as content_css like this:
```
wp.oldEditor.initialize( `editor-${ clientId }`, {
			tinymce: {
				...settings,
				inline: true,
				content_css: '/wp-includes/css/editor.css',
				fixed_toolbar_container: `#toolbar-${ clientId }`,
				setup: this.onSetup,
			},
		} );
```
But this caused editor.css to be included (and loaded) twice in DOM. Another option would have been to include the style definitions of editor.css to gutenberg/block-library/freeform/editor.scss, but then the style definitions would have been duplicated.

Moving the `<link` -element in DOM-tree in `init`-event of TinyMCE seems to me to be the best solution. I think because of this PR, it might be a good idea to revisit #9680 (by @jasmussen) and check, if all those `.mce-*` overrides are necessary.

## How has this been tested?
I have tested the solution manually in Chrome, Firefox and Safari on macOS.

I also run e2e-tests of Gutenberg (`npm run test-e2e`) and run both unit tests and code linting by `npm test`. There were two failing e2e-tests (undo.test.js and lists.test.js), but both of them failed also in master, so I assume that they are not related to this PR.

## Screenshots
**Before**
![before](https://user-images.githubusercontent.com/5536354/46308735-1ec01700-c5c3-11e8-826f-ec74e2268392.png)

**After**
![after](https://user-images.githubusercontent.com/5536354/46308747-22539e00-c5c3-11e8-9d5f-e991f83599f2.png)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
