### PR TITLE
Replace TinyMCE decode entities

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -40,6 +40,7 @@ import {
 	isEmptyLine,
 	unstableToDom,
 } from '@wordpress/rich-text';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -329,7 +330,7 @@ export class RichText extends Component {
 				this.onChange( applyFormat( this.getRecord(), {
 					type: 'a',
 					attributes: {
-						href: this.editor.dom.decode( pastedText ),
+						href: decodeEntities( pastedText ),
 					},
 				} ) );
 


### PR DESCRIPTION


## Description

Replace TinyMCE function to decode entities with existing Gutenberg package.

## How has this been tested?

Copy paste for example `http://example.com/path/to/page?name=gutenberg&color=black` on top of a selection. A link should be created and the "&" character should be decoded.

I was looking at adding an e2e test but didn't find anything useful right away to do pasting.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->