### PR TITLE
Function call should not use trailing comma

### DIFF
--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -78,7 +78,7 @@ const spawnScript = ( scriptName, args = [] ) => {
 			fromScriptsRoot( scriptName ),
 			...args,
 		],
-		{ stdio: 'inherit' },
+		{ stdio: 'inherit' }
 	);
 
 	if ( signal ) {


### PR DESCRIPTION
Can throw error during build.