### PR TITLE
Fix regression with placeholder text color.

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -79,7 +79,7 @@
 			color: rgba(0, 0, 0, 0.2);
 		}
 
-		// Caption placeholder text.
+		// Increase opacity for placeholder text as the gray is lighter.
 		&[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
 			opacity: 0.8;
 		}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -78,11 +78,6 @@
 		&:focus a[data-mce-selected] {
 			color: rgba(0, 0, 0, 0.2);
 		}
-
-		// Increase opacity for placeholder text as the gray is lighter.
-		&[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
-			opacity: 0.8;
-		}
 	}
 }
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -8,11 +8,6 @@
 	figcaption img {
 		display: inline;
 	}
-
-	// Increase opacity for placeholder text as the gray is lighter.
-	.editor-rich-text .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
-		opacity: 0.8;
-	}
 }
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -8,6 +8,11 @@
 	figcaption img {
 		display: inline;
 	}
+
+	// Increase opacity for placeholder text as the gray is lighter.
+	.editor-rich-text .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
+		opacity: 0.8;
+	}
 }
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.

--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -94,12 +94,10 @@
 		pointer-events: none;
 
 		// Use opacity to work in various editor styles.
+		// We don't specify the color here, because blocks or editor styles might provide their own.
 		&,
 		p {
-			color: $dark-opacity-300;
-			.is-dark-theme & {
-				color: $light-opacity-300;
-			}
+			opacity: 0.62;
 		}
 	}
 

--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -90,7 +90,7 @@
 	}
 
 	// Placeholder text.
-	& + .editor-rich-text__tinymce, {
+	& + .editor-rich-text__tinymce {
 		pointer-events: none;
 
 		// Use opacity to work in various editor styles.
@@ -99,6 +99,12 @@
 		p {
 			opacity: 0.62;
 		}
+	}
+
+	// Captions may have lighter (gray) text, or be shown on a range of different background luminosites.
+	// To ensure legibility, we increase the default placeholder opacity to ensure contrast.
+	&[data-is-placeholder-visible="true"] + figcaption.editor-rich-text__tinymce {
+		opacity: 0.8;
 	}
 
 	&.mce-content-body {


### PR DESCRIPTION
Recently we increased the contrast of text color in placeholder text.

As part of this, we changed from using opacity, to using rgba, to provide not-fully-opaque placeholder text. This caused a regression in contexts that did not have a light background, because the RGBA obviously adds a color, it doesn't just change the opacity.

For example placeholder text in a Cover Image block was suddenly dark, and if you added a dark editor style, placeholder text was not legible.

This PR changes that back, with a few tweaks, so it relies on opacity again. The benefit to this is that any block or editor style that provides its own text color for elements can use the placeholder aspect without having to also worry about the placeholder text color in various background environments.

This PR ensures there is sufficient (4.7+ contrast ratios) for placeholder text in:

- Cover Image
- Image captions
- Empty paragraphs in dark editor styles

<img width="626" alt="screen shot 2018-10-02 at 10 58 37" src="https://user-images.githubusercontent.com/1204802/46357687-67171d80-c633-11e8-98fc-b1dd61038e6b.png">

<img width="666" alt="screen shot 2018-10-02 at 11 01 47" src="https://user-images.githubusercontent.com/1204802/46357692-6aaaa480-c633-11e8-9bf7-75851110716a.png">

<img width="715" alt="screen shot 2018-10-02 at 10 58 32" src="https://user-images.githubusercontent.com/1204802/46357699-6da59500-c633-11e8-9ef1-e57f53c5d2c1.png">
