### PR TITLE
wp.data: Split store implementation out from registry.

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -7,6 +7,11 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - The following editor store actions have been removed: `createNotice`, `removeNotice`, `createSuccessNotice`, `createInfoNotice`, `createErrorNotice`, `createWarningNotice`. Use the equivalent actions by the same name from the `@wordpress/notices` module.
 - The id prop of wp.nux.DotTip has been removed. Please use the tipId prop instead.
 - `wp.blocks.isValidBlock` has been removed. Please use `wp.blocks.isValidBlockContent` instead but keep in mind that the order of params has changed.
+- `wp.data` `registry.registerReducer` has been deprecated. Use `registry.registerStore` instead.
+- `wp.data` `registry.registerSelectors` has been deprecated. Use `registry.registerStore` instead.
+- `wp.data` `registry.registerActions` has been deprecated. Use `registry.registerStore` instead.
+- `wp.data` `registry.registerResolvers` has been deprecated. Use `registry.registerStore` instead.
+- `wp.data` `registry.use` has been deprecated. Implement with `registry.registerGenericStore` instead.
 
 ## 4.3.0
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -11,7 +11,6 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - `wp.data` `registry.registerSelectors` has been deprecated. Use `registry.registerStore` instead.
 - `wp.data` `registry.registerActions` has been deprecated. Use `registry.registerStore` instead.
 - `wp.data` `registry.registerResolvers` has been deprecated. Use `registry.registerStore` instead.
-- `wp.data` `registry.use` has been deprecated. Implement with `registry.registerGenericStore` instead.
 
 ## 4.3.0
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -299,6 +299,7 @@ function gutenberg_register_scripts_and_styles() {
 		array(
 			'lodash',
 			'wp-compose',
+			'wp-deprecated',
 			'wp-element',
 			'wp-is-shallow-equal',
 			'wp-polyfill',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,6 +2183,7 @@
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/redux-routine": "file:packages/redux-routine",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 3.1.0 (Unreleased)
+
+### New Features
+
+- `registry.registerGenericStore` has been added to support integration with existing data systems.
+
+### Deprecations
+
+- `registry.registerReducer` has been deprecated. Use `registry.registerStore` instead.
+- `registry.registerSelectors` has been deprecated. Use `registry.registerStore` instead.
+- `registry.registerActions` has been deprecated. Use `registry.registerStore` instead.
+- `registry.registerResolvers` has been deprecated. Use `registry.registerStore` instead.
+- `registry.use` has been deprecated. Implement with `registry.registerGenericStore` instead.
+
 ## 3.0.1 (2018-10-30)
 
 ### Internal

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -10,7 +10,6 @@
 - `registry.registerSelectors` has been deprecated. Use `registry.registerStore` instead.
 - `registry.registerActions` has been deprecated. Use `registry.registerStore` instead.
 - `registry.registerResolvers` has been deprecated. Use `registry.registerStore` instead.
-- `registry.use` has been deprecated. Implement with `registry.registerGenericStore` instead.
 
 ## 3.0.1 (2018-10-30)
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -322,10 +322,10 @@ const mappedActions = existingActions.map( ( action ) => {
 } );
 
 const genericStore = {
-	getSelectors(): {
+	getSelectors() {
 		return mappedSelectors;
 	},
-	getActions(): {
+	getActions() {
 		return mappedActions;
 	},
 	subscribe: reduxStore.subscribe;
@@ -334,7 +334,7 @@ const genericStore = {
 registry.registerGenericStore( 'existing-app', genericStore );
 ```
 
-It is also possible to impelement a completely custom store from scratch:
+It is also possible to implement a completely custom store from scratch:
 
 _Example:_
 
@@ -357,19 +357,19 @@ function createCustomStore() {
 	};
 
 	return {
-		getSelectors(): {
+		getSelectors() {
 			return selectors;
 		},
-		getActions(): {
+		getActions() {
 			return actions;
 		},
-		subscribe( listener ): {
+		subscribe( listener ) {
 			storeChanged = listener;
 		}
 	};
 }
 
-registry.registerGenericStore( 'custom-data', customStore );
+registry.registerGenericStore( 'custom-data', createCustomStore() );
 ```
 
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -286,6 +286,93 @@ const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 //  <SaleButton>Start Sale!</SaleButton>
 ```
 
+## Generic Stores
+
+The `@wordpress/data` module offers a more advanced and generic interface for the purposes of integrating other data systems and situations where more direct control over a data system is needed. In this case, a data store will need to be implemented outside of `@wordpress/data` and then plugged in via three functions:
+
+- `getSelectors()`: Returns an object of selector functions, pre-mapped to the store.
+- `getActions()`: Returns an object of action functions, pre-mapped to the store.
+- `subscribe( listener: Function )`: Registers a function called any time the value of state changes.
+   - Behaves as Redux [`subscribe`](https://redux.js.org/api-reference/store#subscribe(listener))
+   with the following differences:
+      - Doesn't have to implement an unsubscribe, since the registry never uses it.
+	  - Only has to support one listener (the registry).
+
+By implementing the above interface for your custom store, you gain the benefits of using the registry and the `withSelect` and `withDispatch` higher order components in your application code. This provides seamless integration with existing and alternative data systems.
+
+Integrating an existing redux store with its own reducers, store enhancers and middleware can be accomplished as follows:
+
+_Example:_
+
+```js
+import existingSelectors from './existing-app/selectors';
+import existingActions from './existing-app/actions';
+import createStore from './existing-app/store';
+
+const reduxStore = createStore();
+
+const mappedSelectors = existingSelectors.map( ( selector ) => {
+	return ( ...args ) => selector( reduxStore.getState(), ...args );
+} );
+
+const mappedActions = existingActions.map( ( action ) => {
+	return actions.map( ( action ) => {
+		return ( ...args ) => reduxStore.dispatch( action( ...args ) );
+	} );
+} );
+
+const genericStore = {
+	getSelectors(): {
+		return mappedSelectors;
+	},
+	getActions(): {
+		return mappedActions;
+	},
+	subscribe: reduxStore.subscribe;
+};
+
+registry.registerGenericStore( 'existing-app', genericStore );
+```
+
+It is also possible to impelement a completely custom store from scratch:
+
+_Example:_
+
+```js
+function createCustomStore() {
+	let storeChanged = () => {};
+	const prices = { hammer: 7.50 };
+
+	const selectors = {
+		getPrice( itemName ): {
+			return prices[ itemName ];
+		},
+	};
+
+	const actions = {
+		setPrice( itemName, price ): {
+			prices[ itemName ] = price;
+			storeChanged();
+		},
+	};
+
+	return {
+		getSelectors(): {
+			return selectors;
+		},
+		getActions(): {
+			return actions;
+		},
+		subscribe( listener ): {
+			storeChanged = listener;
+		}
+	};
+}
+
+registry.registerGenericStore( 'custom-data', customStore );
+```
+
+
 ## Comparison with Redux
 
 The data module shares many of the same [core principles](https://redux.js.org/introduction/three-principles) and [API method naming](https://redux.js.org/api-reference) of [Redux](https://redux.js.org/). In fact, it is implemented atop Redux. Where it differs is in establishing a modularization pattern for creating separate but interdependent stores, and in codifying conventions such as selector functions as the primary entry point for data access.

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -23,6 +23,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/redux-routine": "file:../redux-routine",

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -30,6 +30,7 @@ export { combineReducers };
 export const select = defaultRegistry.select;
 export const dispatch = defaultRegistry.dispatch;
 export const subscribe = defaultRegistry.subscribe;
+export const registerGenericStore = defaultRegistry.registerGenericStore;
 export const registerStore = defaultRegistry.registerStore;
 export const registerReducer = defaultRegistry.registerReducer;
 export const registerActions = defaultRegistry.registerActions;

--- a/packages/data/src/namespace-store.js
+++ b/packages/data/src/namespace-store.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { createStore as createReduxStore } from 'redux';
+import {
+	flowRight,
+} from 'lodash';
+
+/**
+ * Creates a namespace object with a store derived from the reducer given.
+ *
+ * @param {Object} reducer Reducer function.
+ * @param {Array} enhancers Array of enhancer functions to be added to the store.
+ * @param {function} globalListener TODO: Remove this after subscribe is passed correctly.
+ *
+ * @return {Object} Store Object.
+ */
+export function createNamespace( reducer, enhancers, globalListener ) {
+	const store = createReduxStore( reducer, flowRight( enhancers ) );
+	const namespace = { store, reducer };
+
+	// TODO: Move this to a subscribe function instead of referencing globalListener.
+	// Customize subscribe behavior to call listeners only on effective change,
+	// not on every dispatch.
+	let lastState = store.getState();
+	store.subscribe( () => {
+		const state = store.getState();
+		const hasChanged = state !== lastState;
+		lastState = state;
+
+		if ( hasChanged ) {
+			globalListener();
+		}
+	} );
+
+	return namespace;
+}

--- a/packages/data/src/namespace-store.js
+++ b/packages/data/src/namespace-store.js
@@ -4,6 +4,7 @@
 import { createStore as createReduxStore } from 'redux';
 import {
 	flowRight,
+	mapValues,
 } from 'lodash';
 
 /**
@@ -34,4 +35,30 @@ export function createNamespace( reducer, enhancers, globalListener ) {
 	} );
 
 	return namespace;
+}
+
+/**
+ * Sets selectors for given namespace.
+ *
+ * @param {Object} namespace  The namespace object to modify.
+ * @param {Object} selectors  Selectors to register. Keys will be used as the
+ *                            public facing API. Selectors will get passed the
+ *                            state as first argument.
+ */
+export function setSelectors( namespace, selectors ) {
+	const { store } = namespace;
+	const createStateSelector = ( selector ) => ( ...args ) => selector( store.getState(), ...args );
+	namespace.selectors = mapValues( selectors, createStateSelector );
+}
+
+/**
+ * Sets actions for given namespace.
+ *
+ * @param {Object} namespace  The namespace object to modify.
+ * @param {Object} actions    Actions to register.
+ */
+export function setActions( namespace, actions ) {
+	const { store } = namespace;
+	const createBoundAction = ( action ) => ( ...args ) => store.dispatch( action( ...args ) );
+	namespace.actions = mapValues( actions, createBoundAction );
 }

--- a/packages/data/src/plugins/persistence/test/index.js
+++ b/packages/data/src/plugins/persistence/test/index.js
@@ -34,9 +34,6 @@ describe( 'persistence', () => {
 		const options = Object.freeze( { persist: true, reducer() {} } );
 
 		registry.registerStore( 'test', options );
-
-		// use is a deprecated function and will produce a warning.
-		expect( console ).toHaveWarned();
 	} );
 
 	it( 'override values passed to registerStore', () => {

--- a/packages/data/src/plugins/persistence/test/index.js
+++ b/packages/data/src/plugins/persistence/test/index.js
@@ -21,6 +21,7 @@ describe( 'persistence', () => {
 
 		// Since the exposed `registerStore` is a proxying function, mimic
 		// intercept of original call by adding an initial plugin.
+		// TODO: Remove the `use` function in favor of `registerGenericStore`
 		registry = createRegistry()
 			.use( ( originalRegistry ) => {
 				originalRegisterStore = jest.spyOn( originalRegistry, 'registerStore' );
@@ -33,6 +34,9 @@ describe( 'persistence', () => {
 		const options = Object.freeze( { persist: true, reducer() {} } );
 
 		registry.registerStore( 'test', options );
+
+		// use is a deprecated function and will produce a warning.
+		expect( console ).toHaveWarned();
 	} );
 
 	it( 'override values passed to registerStore', () => {

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -133,7 +133,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 * @return {Object} Store Object.
 	 */
 	registry.registerReducer = ( reducerKey, reducer ) => {
-		const namespace = createNamespace( reducerKey, { reducer }, registry, globalListener );
+		const namespace = createNamespace( reducerKey, { reducer }, registry );
 		registerGenericStore( reducerKey, namespace );
 		return namespace.store;
 	};
@@ -146,7 +146,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 * @param {Object} actions   Actions to register.
 	 */
 	registry.registerActions = ( reducerKey, actions ) => {
-		const namespace = createNamespace( reducerKey, { actions }, registry, globalListener );
+		const namespace = createNamespace( reducerKey, { actions }, registry );
 		registerGenericStore( reducerKey, namespace );
 	};
 
@@ -160,7 +160,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 *                              state as first argument.
 	 */
 	registry.registerSelectors = ( reducerKey, selectors ) => {
-		const namespace = createNamespace( reducerKey, { selectors }, registry, globalListener );
+		const namespace = createNamespace( reducerKey, { selectors }, registry );
 		registerGenericStore( reducerKey, namespace );
 	};
 
@@ -174,7 +174,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 * @param {Object} resolvers Resolvers to register.
 	 */
 	registry.registerResolvers = ( reducerKey, resolvers ) => {
-		const namespace = createNamespace( reducerKey, { resolvers }, registry, globalListener );
+		const namespace = createNamespace( reducerKey, { resolvers }, registry );
 		registerGenericStore( reducerKey, namespace );
 	};
 
@@ -191,7 +191,7 @@ export function createRegistry( storeConfigs = {} ) {
 			throw new TypeError( 'Must specify store reducer' );
 		}
 
-		const namespace = createNamespace( reducerKey, options, registry, globalListener );
+		const namespace = createNamespace( reducerKey, options, registry );
 		registerGenericStore( reducerKey, namespace );
 		return namespace.store;
 	};
@@ -213,6 +213,7 @@ export function createRegistry( storeConfigs = {} ) {
 			throw new TypeError( 'config.subscribe must be a function' );
 		}
 		stores[ key ] = config;
+		config.subscribe( globalListener );
 	}
 
 	/**

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -7,6 +7,11 @@ import {
 } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import createNamespace from './namespace-store.js';
@@ -17,15 +22,11 @@ import dataStore from './store';
  *
  * @typedef {WPDataRegistry}
  *
- * @property {Function} registerReducer
- * @property {Function} registerSelectors
- * @property {Function} registerResolvers
- * @property {Function} registerActions
+ * @property {Function} registerGenericStore
  * @property {Function} registerStore
  * @property {Function} subscribe
  * @property {Function} select
  * @property {Function} dispatch
- * @property {Function} use
  */
 
 /**
@@ -94,16 +95,10 @@ export function createRegistry( storeConfigs = {} ) {
 		return store && store.getActions();
 	}
 
-	/**
-	 * Maps an object of function values to proxy invocation through to the
-	 * current internal representation of the registry, which may be enhanced
-	 * by plugins.
-	 * TODO: Consider deprecating and removing this after plugins are no longer needed.
-	 *
-	 * @param {Object<string,Function>} attributes Object of function values.
-	 *
-	 * @return {Object<string,Function>} Object enhanced with plugin proxying.
-	 */
+	//
+	// Deprecated
+	// TODO: Remove this after `use()` is removed.
+	//
 	function withPlugins( attributes ) {
 		return mapValues( attributes, ( attribute, key ) => {
 			if ( typeof attribute !== 'function' ) {
@@ -145,61 +140,59 @@ export function createRegistry( storeConfigs = {} ) {
 		use,
 	};
 
-	/**
-	 * Registers a new sub-reducer to the global state and returns a Redux-like
-	 * store object.
-	 * TODO: Deprecate and remove this function in favor of registerStore
-	 *
-	 * @param {string} reducerKey Reducer key.
-	 * @param {Object} reducer    Reducer function.
-	 *
-	 * @return {Object} Store Object.
-	 */
+	//
+	// Deprecated
+	//
 	registry.registerReducer = ( reducerKey, reducer ) => {
+		deprecated( 'registry.registerReducer', {
+			alternative: 'registry.registerStore',
+			plugin: 'Gutenberg',
+			version: '3.1.0',
+		} );
+
 		const namespace = createNamespace( reducerKey, { reducer }, registry );
 		registerGenericStore( reducerKey, namespace );
 		return namespace.store;
 	};
 
-	/**
-	 * Registers actions for external usage.
-	 * TODO: Deprecate and remove this function in favor of registerStore
-	 *
-	 * @param {string} reducerKey   Part of the state shape to register the
-	 *                              selectors for.
-	 * @param {Object} actions   Actions to register.
-	 */
+	//
+	// Deprecated
+	//
 	registry.registerActions = ( reducerKey, actions ) => {
+		deprecated( 'registry.registerActions', {
+			alternative: 'registry.registerStore',
+			plugin: 'Gutenberg',
+			version: '3.1.0',
+		} );
+
 		const namespace = createNamespace( reducerKey, { actions }, registry );
 		registerGenericStore( reducerKey, namespace );
 	};
 
-	/**
-	 * Registers selectors for external usage.
-	 * TODO: Deprecate and remove this function in favor of registerStore
-	 *
-	 * @param {string} reducerKey   Part of the state shape to register the
-	 *                              selectors for.
-	 * @param {Object} selectors    Selectors to register. Keys will be used as the
-	 *                              public facing API. Selectors will get passed the
-	 *                              state as first argument.
-	 */
+	//
+	// Deprecated
+	//
 	registry.registerSelectors = ( reducerKey, selectors ) => {
+		deprecated( 'registry.registerSelectors', {
+			alternative: 'registry.registerStore',
+			plugin: 'Gutenberg',
+			version: '3.1.0',
+		} );
+
 		const namespace = createNamespace( reducerKey, { selectors }, registry );
 		registerGenericStore( reducerKey, namespace );
 	};
 
-	/**
-	 * Registers resolvers for a given reducer key. Resolvers are side effects
-	 * invoked once per argument set of a given selector call, used in ensuring
-	 * that the data needs for the selector are satisfied.
-	 * TODO: Deprecate and remove this function in favor of registerStore
-	 *
-	 * @param {string} reducerKey   Part of the state shape to register the
-	 *                              resolvers for.
-	 * @param {Object} resolvers Resolvers to register.
-	 */
+	//
+	// Deprecated
+	//
 	registry.registerResolvers = ( reducerKey, resolvers ) => {
+		deprecated( 'registry.registerResolvers', {
+			alternative: 'registry.registerStore',
+			plugin: 'Gutenberg',
+			version: '3.1.0',
+		} );
+
 		const namespace = createNamespace( reducerKey, { resolvers }, registry );
 		registerGenericStore( reducerKey, namespace );
 	};
@@ -222,17 +215,16 @@ export function createRegistry( storeConfigs = {} ) {
 		return namespace.store;
 	};
 
-	/**
-	 * Enhances the registry with the prescribed set of overrides. Returns the
-	 * enhanced registry to enable plugin chaining.
-	 * TODO: Consider deprecating and removing this after plugins are no longer needed.
-	 *
-	 * @param {WPDataPlugin} plugin  Plugin by which to enhance.
-	 * @param {?Object}      options Optional options to pass to plugin.
-	 *
-	 * @return {WPDataRegistry} Enhanced registry.
-	 */
+	//
+	// Deprecated
+	//
 	function use( plugin, options ) {
+		deprecated( 'registry.use', {
+			alternative: 'registry.registerGenericStore',
+			plugin: 'Gutenberg',
+			version: '3.1.0',
+		} );
+
 		registry = {
 			...registry,
 			...plugin( registry, options ),

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -216,15 +216,10 @@ export function createRegistry( storeConfigs = {} ) {
 	};
 
 	//
-	// Deprecated
+	// TODO:
+	// This function will be deprecated as soon as it is no longer internally referenced.
 	//
 	function use( plugin, options ) {
-		deprecated( 'registry.use', {
-			alternative: 'registry.registerGenericStore',
-			plugin: 'Gutenberg',
-			version: '4.4.0',
-		} );
-
 		registry = {
 			...registry,
 			...plugin( registry, options ),

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -98,6 +98,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 * Maps an object of function values to proxy invocation through to the
 	 * current internal representation of the registry, which may be enhanced
 	 * by plugins.
+	 * TODO: Consider deprecating and removing this after plugins are no longer needed.
 	 *
 	 * @param {Object<string,Function>} attributes Object of function values.
 	 *
@@ -114,7 +115,28 @@ export function createRegistry( storeConfigs = {} ) {
 		} );
 	}
 
+	/**
+	 * Registers a generic store.
+	 *
+	 * @param {string} key    Store registry key.
+	 * @param {Object} config Configuration (getSelectors, getActions, subscribe).
+	 */
+	function registerGenericStore( key, config ) {
+		if ( typeof config.getSelectors !== 'function' ) {
+			throw new TypeError( 'config.getSelectors must be a function' );
+		}
+		if ( typeof config.getActions !== 'function' ) {
+			throw new TypeError( 'config.getActions must be a function' );
+		}
+		if ( typeof config.subscribe !== 'function' ) {
+			throw new TypeError( 'config.subscribe must be a function' );
+		}
+		stores[ key ] = config;
+		config.subscribe( globalListener );
+	}
+
 	let registry = {
+		registerGenericStore,
 		stores,
 		namespaces: stores, // TODO: Deprecate/remove this.
 		subscribe,
@@ -126,6 +148,7 @@ export function createRegistry( storeConfigs = {} ) {
 	/**
 	 * Registers a new sub-reducer to the global state and returns a Redux-like
 	 * store object.
+	 * TODO: Deprecate and remove this function in favor of registerStore
 	 *
 	 * @param {string} reducerKey Reducer key.
 	 * @param {Object} reducer    Reducer function.
@@ -140,6 +163,7 @@ export function createRegistry( storeConfigs = {} ) {
 
 	/**
 	 * Registers actions for external usage.
+	 * TODO: Deprecate and remove this function in favor of registerStore
 	 *
 	 * @param {string} reducerKey   Part of the state shape to register the
 	 *                              selectors for.
@@ -152,6 +176,7 @@ export function createRegistry( storeConfigs = {} ) {
 
 	/**
 	 * Registers selectors for external usage.
+	 * TODO: Deprecate and remove this function in favor of registerStore
 	 *
 	 * @param {string} reducerKey   Part of the state shape to register the
 	 *                              selectors for.
@@ -168,6 +193,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 * Registers resolvers for a given reducer key. Resolvers are side effects
 	 * invoked once per argument set of a given selector call, used in ensuring
 	 * that the data needs for the selector are satisfied.
+	 * TODO: Deprecate and remove this function in favor of registerStore
 	 *
 	 * @param {string} reducerKey   Part of the state shape to register the
 	 *                              resolvers for.
@@ -197,28 +223,9 @@ export function createRegistry( storeConfigs = {} ) {
 	};
 
 	/**
-	 * Registers a generic store.
-	 *
-	 * @param {string} key    Store registry key.
-	 * @param {Object} config Configuration (getSelectors, getActions, subscribe).
-	 */
-	function registerGenericStore( key, config ) {
-		if ( typeof config.getSelectors !== 'function' ) {
-			throw new TypeError( 'config.getSelectors must be a function' );
-		}
-		if ( typeof config.getActions !== 'function' ) {
-			throw new TypeError( 'config.getActions must be a function' );
-		}
-		if ( ! config.subscribe ) {
-			throw new TypeError( 'config.subscribe must be a function' );
-		}
-		stores[ key ] = config;
-		config.subscribe( globalListener );
-	}
-
-	/**
 	 * Enhances the registry with the prescribed set of overrides. Returns the
 	 * enhanced registry to enable plugin chaining.
+	 * TODO: Consider deprecating and removing this after plugins are no longer needed.
 	 *
 	 * @param {WPDataPlugin} plugin  Plugin by which to enhance.
 	 * @param {?Object}      options Optional options to pass to plugin.

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -147,7 +147,7 @@ export function createRegistry( storeConfigs = {} ) {
 		deprecated( 'registry.registerReducer', {
 			alternative: 'registry.registerStore',
 			plugin: 'Gutenberg',
-			version: '3.1.0',
+			version: '4.4.0',
 		} );
 
 		const namespace = createNamespace( reducerKey, { reducer }, registry );
@@ -162,7 +162,7 @@ export function createRegistry( storeConfigs = {} ) {
 		deprecated( 'registry.registerActions', {
 			alternative: 'registry.registerStore',
 			plugin: 'Gutenberg',
-			version: '3.1.0',
+			version: '4.4.0',
 		} );
 
 		const namespace = createNamespace( reducerKey, { actions }, registry );
@@ -176,7 +176,7 @@ export function createRegistry( storeConfigs = {} ) {
 		deprecated( 'registry.registerSelectors', {
 			alternative: 'registry.registerStore',
 			plugin: 'Gutenberg',
-			version: '3.1.0',
+			version: '4.4.0',
 		} );
 
 		const namespace = createNamespace( reducerKey, { selectors }, registry );
@@ -190,7 +190,7 @@ export function createRegistry( storeConfigs = {} ) {
 		deprecated( 'registry.registerResolvers', {
 			alternative: 'registry.registerStore',
 			plugin: 'Gutenberg',
-			version: '3.1.0',
+			version: '4.4.0',
 		} );
 
 		const namespace = createNamespace( reducerKey, { resolvers }, registry );
@@ -222,7 +222,7 @@ export function createRegistry( storeConfigs = {} ) {
 		deprecated( 'registry.use', {
 			alternative: 'registry.registerGenericStore',
 			plugin: 'Gutenberg',
-			version: '3.1.0',
+			version: '4.4.0',
 		} );
 
 		registry = {

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -11,7 +11,11 @@ import { applyMiddleware } from 'redux';
 /**
  * Internal dependencies
  */
-import { createNamespace } from './namespace-store.js';
+import {
+	createNamespace,
+	setActions,
+	setSelectors,
+} from './namespace-store.js';
 import dataStore from './store';
 import promise from './promise-middleware';
 import createResolversCacheMiddleware from './resolvers-cache-middleware';
@@ -89,9 +93,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 *                              state as first argument.
 	 */
 	function registerSelectors( reducerKey, newSelectors ) {
-		const store = namespaces[ reducerKey ].store;
-		const createStateSelector = ( selector ) => ( ...args ) => selector( store.getState(), ...args );
-		namespaces[ reducerKey ].selectors = mapValues( newSelectors, createStateSelector );
+		setSelectors( namespaces[ reducerKey ], newSelectors );
 	}
 
 	/**
@@ -147,9 +149,7 @@ export function createRegistry( storeConfigs = {} ) {
 	 * @param {Object} newActions   Actions to register.
 	 */
 	function registerActions( reducerKey, newActions ) {
-		const store = namespaces[ reducerKey ].store;
-		const createBoundAction = ( action ) => ( ...args ) => store.dispatch( action( ...args ) );
-		namespaces[ reducerKey ].actions = mapValues( newActions, createBoundAction );
+		setActions( namespaces[ reducerKey ], newActions );
 	}
 
 	/**

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -561,9 +561,6 @@ describe( 'createRegistry', () => {
 			registry.use( plugin, expectedOptions );
 
 			expect( actualOptions ).toBe( expectedOptions );
-
-			// This uses deprecated functions and will produce a warning.
-			expect( console ).toHaveWarned();
 		} );
 
 		it( 'should override base method', () => {

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -40,6 +40,18 @@ describe( 'createRegistry', () => {
 		}
 	} );
 
+	describe( 'registerGenericStore', () => {
+		it( 'should throw if not all required config elements are present', () => {
+			const getSelectors = () => ( {} );
+			const getActions = () => ( {} );
+			const subscribe = () => ( {} );
+
+			expect( () => registry.registerStore( 'grocer', {} ) ).toThrow();
+			expect( () => registry.registerStore( 'grocer', { getSelectors, getActions } ) ).toThrow();
+			expect( () => registry.registerStore( 'grocer', { getActions, subscribe } ) ).toThrow();
+		} );
+	} );
+
 	describe( 'registerStore', () => {
 		it( 'should be shorthand for reducer, actions, selectors registration', () => {
 			const store = registry.registerStore( 'butcher', {
@@ -424,8 +436,12 @@ describe( 'createRegistry', () => {
 				// function proxying.
 				expect( _registry ).toMatchObject(
 					mapValues( registry, ( value, key ) => {
-						if ( key === 'namespaces' ) {
+						if ( key === 'stores' ) {
 							return expect.any( Object );
+						}
+						// TODO: Remove this after namsespaces is removed.
+						if ( key === 'namespaces' ) {
+							return registry.stores;
 						}
 						return expect.any( Function );
 					} )

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -180,6 +180,7 @@ describe( 'createRegistry', () => {
 		} );
 	} );
 
+	// TODO: Refactor this into registerStore tests after this function is removed.
 	describe( 'registerReducer', () => {
 		it( 'Should append reducers to the state', () => {
 			const reducer1 = () => 'chicken';
@@ -190,9 +191,13 @@ describe( 'createRegistry', () => {
 
 			const store2 = registry.registerReducer( 'red2', reducer2 );
 			expect( store2.getState() ).toEqual( 'ribs' );
+
+			// This uses deprecated functions and will produce a warning.
+			expect( console ).toHaveWarned();
 		} );
 	} );
 
+	// TODO: Refactor this into registerStore tests after this function is removed.
 	describe( 'registerResolvers', () => {
 		it( 'should not do anything for selectors which do not have resolvers', () => {
 			registry.registerReducer( 'demo', ( state = 'OK' ) => state );
@@ -202,6 +207,9 @@ describe( 'createRegistry', () => {
 			registry.registerResolvers( 'demo', {} );
 
 			expect( registry.select( 'demo' ).getValue() ).toBe( 'OK' );
+
+			// This uses deprecated functions and will produce a warning.
+			expect( console ).toHaveWarned();
 		} );
 
 		it( 'should behave as a side effect for the given selector, with arguments', () => {
@@ -516,6 +524,9 @@ describe( 'createRegistry', () => {
 			registry.dispatch( 'counter' ).increment(); // state = 1
 			registry.dispatch( 'counter' ).increment( 4 ); // state = 5
 			expect( store.getState() ).toBe( 5 );
+
+			// This uses deprecated functions and will produce a warning.
+			expect( console ).toHaveWarned();
 		} );
 	} );
 
@@ -550,6 +561,9 @@ describe( 'createRegistry', () => {
 			registry.use( plugin, expectedOptions );
 
 			expect( actualOptions ).toBe( expectedOptions );
+
+			// This uses deprecated functions and will produce a warning.
+			expect( console ).toHaveWarned();
 		} );
 
 		it( 'should override base method', () => {


### PR DESCRIPTION
## Description
The goal of this PR is to split out the implementation of `@wordpress/data` store implementations to be separate from the registry, opening up the registry for alternative data implementations that can all share a common interface. The ethos behind this is to allow `@worpdress/data` to be a universal interface for data within Gutenberg and WordPress core, regardless of the implementation of the data system backing it. The benefit of doing this is so existing data systems can be integrated with `@wordpress/data` for interoperation or transition purposes.

The common interface for data to be registered will be:

```
registry.registerGenericStore( key, { getSelectors, getActions, subscribe } );
```

* `getSelectors()` will return an object of pre-bound named selector functions.
* `getActions()` will return an object of pre-bound functions.
* `subscribe()` will behave as a redux store subscribe.

Note: This deprecates the following functions on the registry in favor of using `registerStore` and `registerGenericStore`.

* `registerReducer` (use `registerStore` instead)
* `registerSelectors` (use `registerStore` instead)
* `registerActions` (use `registerStore` instead)
* `registerResolvers` (use `registerStore` instead)
* `use` (implement using `registerGenericStore` instead)

## How has this been tested?

I purposely left existing tests alone in this PR to ensure that they all run the exact same way as before.
I also added a few tests to verify expectations of `registerGenericStore` parameter types. No difference in operation should be perceptible.

## Types of changes

This is a refactor of the registry, to remove the implicit store implementation from it.
All code and tests should still behave the same for `@wordpress/data` and the Gutenberg editor.

After the initial interface here is settled, I plan on creating at least one example PR in another repo to validate the operation of using another implementation via `registerGenericStore`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
