### PR TITLE
Fix typo: "attribute" to "attributes" in docs

### DIFF
--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -6,7 +6,7 @@ Our example block is still not very interesting because it lacks options to cust
 
 Until now, the `edit` and `save` functions have returned a simple representation of a paragraph element. We also learned how these functions are responsible for _describing_ the structure of the block's appearance. If the user changes a block, this structure may need to change. To achieve this, the state of a block is maintained throughout the editing session as a plain JavaScript object, and when an update occurs, the `edit` function is invoked again. Put another way: __the output of a block is a function of its attributes__.
 
-One challenge of maintaining the representation of a block as a JavaScript object is that we must be able to extract this object again from the saved content of a post. This is achieved with the block type's `attribute` property:
+One challenge of maintaining the representation of a block as a JavaScript object is that we must be able to extract this object again from the saved content of a post. This is achieved with the block type's `attributes` property:
 
 {% codetabs %}
 {% ES5 %}


### PR DESCRIPTION
## Description
Fixing typo. It's correctly referred to as "attributes" later in the doc, but not here.