### PR TITLE
Fix button alignment

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -10,7 +10,7 @@
 }
 
 .wp-block-button {
-	display: inline-block;
+	display: block;
 	margin-bottom: 0;
 	position: relative;
 


### PR DESCRIPTION
## Description
.wp-block-button needs to be a 'block' element for 'aligncenter' to work on actual inner 'button' elements using 'text-align: centre' to centre.
Use case (From Gutenberg demo post) : 

```
<div class="wp-block-button aligncenter">
   <a class="wp-block-button__link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a>
</div>

```

## How has this been tested?
Standard WordPress installation with demo posts and pages, Gutenberg installed and enabled alongside Woocommerce and Jetpack plugin. 
Browser : Safari 12, Firefox Quantum 62, Google Chrome 69.0.3497.100 

## Types of changes
Changing CSS display type for 'wp-block-button' from 'inline-block' to 'block' level element.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->