### PR TITLE
Fix guided tour popup margins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2415,7 +2415,6 @@
 			"version": "file:packages/rich-text",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
-				"@wordpress/escape-html": "file:packages/escape-html",
 				"lodash": "^4.17.10"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -2415,6 +2415,7 @@
 			"version": "file:packages/rich-text",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
+				"@wordpress/escape-html": "file:packages/escape-html",
 				"lodash": "^4.17.10"
 			}
 		},

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -171,7 +171,7 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-right & {
 		/*!rtl:ignore*/
-		margin-left: -24px;
+		margin-left: 0;
 	}
 
 	.components-popover:not(.is-mobile).is-left & {
@@ -182,7 +182,7 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-left & {
 		/*!rtl:ignore*/
-		margin-right: -24px;
+		margin-right: 0;
 	}
 }
 

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -174,6 +174,11 @@ $arrow-size: 8px;
 		margin-left: 0;
 	}
 
+	.components-popover.edit-post-more-menu__content:not(.is-mobile):not(.is-middle).is-right & {
+		/*!rtl:ignore*/
+		margin-left: -12px;
+	}
+
 	.components-popover:not(.is-mobile).is-left & {
 		position: absolute;
 		/*!rtl:ignore*/
@@ -184,6 +189,11 @@ $arrow-size: 8px;
 		/*!rtl:ignore*/
 		margin-right: 0;
 	}
+	.components-popover.edit-post-more-menu__content:not(.is-mobile):not(.is-middle).is-left & {
+		/*!rtl:ignore*/
+		margin-right: -12px;
+	}
+
 }
 
 // The withFocusReturn div

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -189,11 +189,11 @@ $arrow-size: 8px;
 		/*!rtl:ignore*/
 		margin-right: 0;
 	}
+
 	.components-popover.edit-post-more-menu__content:not(.is-mobile):not(.is-middle).is-left & {
 		/*!rtl:ignore*/
 		margin-right: -12px;
 	}
-
 }
 
 // The withFocusReturn div


### PR DESCRIPTION
## Description

Removed negative left and right margins from guided tour popup when scrolling on mobile devices.

## How has this been tested?

Fix had been tested using iPhone 7 Plus with iOS 11.4.1 in both English (LTR) and Hebrew (RTL).

## Screenshots

### Before

<img src="https://user-images.githubusercontent.com/3323310/46375658-fcc9a180-c661-11e8-8459-84b2f794c27f.png" width="150" title="Unfixed English 01"> <img src="https://user-images.githubusercontent.com/3323310/46375659-fcc9a180-c661-11e8-99b1-31c1e59b9957.png" width="150" title="Unfixed English 02"> <img src="https://user-images.githubusercontent.com/3323310/46375674-06eba000-c662-11e8-8311-5401e53eeef2.png" width="150" title="Unfixed Hebrew 01"> <img src="https://user-images.githubusercontent.com/3323310/46375675-06eba000-c662-11e8-86de-e5679ee9095f.png" width="150" title="Unfixed Hebrew 02">

### After

<img src="https://user-images.githubusercontent.com/3323310/46375668-0226ec00-c662-11e8-98c5-03d2e3e549e1.png" width="150" title="Fixed English 01"> <img src="https://user-images.githubusercontent.com/3323310/46375670-0226ec00-c662-11e8-865a-855d7486acbc.png" width="150" title="Fixed English 02"> <img src="https://user-images.githubusercontent.com/3323310/46375678-09e69080-c662-11e8-9f77-8c1f08c744bb.png" width="150" title="Fixed Hebrew 01"> <img src="https://user-images.githubusercontent.com/3323310/46375679-09e69080-c662-11e8-9431-eba935d654a2.png" width="150" title="Fixed Hebrew 02">

## Types of changes

Removed two negative margins (LTR & RTL) within `gutenberg/packages/components/src/popover/style.scss`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
