### PR TITLE
Fix package lock and typos after #7890

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2415,6 +2415,7 @@
 			"version": "file:packages/rich-text",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
+				"@wordpress/escape-html": "file:packages/escape-html",
 				"lodash": "^4.17.10"
 			}
 		},

--- a/packages/rich-text/src/apply-format.js
+++ b/packages/rich-text/src/apply-format.js
@@ -9,12 +9,12 @@ import { normaliseFormats } from './normalise-formats';
  * given `endIndex`. Indices are retrieved from the selection if none are
  * provided.
  *
- * @param {Object} record     Record to modify.
+ * @param {Object} value      Value to modify.
  * @param {Object} format     Format to apply.
  * @param {number} startIndex Start index.
  * @param {number} endIndex   End index.
  *
- * @return {Object} A new record with the format applied.
+ * @return {Object} A new value with the format applied.
  */
 export function applyFormat(
 	{ formats, text, start, end },

--- a/test/e2e/test-plugins/deprecated-node-matcher/index.js
+++ b/test/e2e/test-plugins/deprecated-node-matcher/index.js
@@ -32,13 +32,13 @@
 		},
 	} );
 
-	function torichText( value ) {
+	function toRichTextValue( value ) {
 		return _.map( value, function( subValue ) {
 			return subValue.children;
 		} );
 	}
 
-	function fromrichText( value ) {
+	function fromRichTextValue( value ) {
 		return _.map( value, function( subValue ) {
 			return {
 				children: subValue,
@@ -65,10 +65,10 @@
 			return el( 'blockquote', {},
 				el( RichText, {
 					multiline: 'p',
-					value: torichText( attributes.value ),
+					value: toRichTextValue( attributes.value ),
 					onChange: function( nextValue ) {
 						setAttributes( {
-							value: fromrichText( nextValue ),
+							value: fromRichTextValue( nextValue ),
 						} );
 					},
 				} )
@@ -77,7 +77,7 @@
 		save: function( { attributes } ) {
 			return el( 'blockquote', {},
 				el( RichText.Content, {
-					value: torichText( attributes.value ),
+					value: toRichTextValue( attributes.value ),
 				} )
 			);
 		},


### PR DESCRIPTION
## Description

1) Fixes the package lock. No idea why it changed here: https://github.com/WordPress/gutenberg/commit/94352e7cfadc20a4df4585ff7165385dcea0602e#diff-32607347f8126e6534ebc7ebaec4853d
2) Search-replace typo: https://github.com/WordPress/gutenberg/commit/94352e7cfadc20a4df4585ff7165385dcea0602e#r30727710
3) Adjust instance of "record" where we otherwise refer to the object as "value" in the rest of the package.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->