### PR TITLE
Add media button to classic block

### DIFF
--- a/block-library/freeform/edit.js
+++ b/block-library/freeform/edit.js
@@ -132,6 +132,12 @@ export default class FreeformEdit extends Component {
 			},
 		} );
 
+		editor.addButton( 'wp_add_media', {
+			tooltip: __( 'Insert Media' ),
+			icon: 'dashicon dashicons-admin-media',
+			cmd: 'WP_Medialib',
+		} );
+
 		editor.on( 'init', () => {
 			const rootNode = this.editor.getBody();
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -540,6 +540,7 @@ function gutenberg_register_scripts_and_styles() {
 							'unlink',
 							'wp_more',
 							'spellchecker',
+							'wp_add_media',
 						),
 						'editor'
 					),


### PR DESCRIPTION
## Description
Fixes #7762.

## How has this been tested?
Insert a classic block, observe media button on the right side of the toolbar. Try to insert images.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->