### PR TITLE
DotTip: Rename `id` attribute to `tipId`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -155,10 +155,7 @@ module.exports = {
 				message: 'Prefer page.waitForSelector instead.',
 			},
 			{
-				// The <DotTip> component uses the `id` prop for something that does not require an
-				// instanceId; maybe we should change its key.
-				// See: https://github.com/WordPress/gutenberg/issues/10305
-				selector: 'JSXOpeningElement[name.name!="DotTip"] JSXAttribute[name.name="id"][value.type="Literal"]',
+				selector: 'JSXAttribute[name.name="id"][value.type="Literal"]',
 				message: 'Do not use string literals for IDs; use withInstanceId instead.',
 			},
 			{

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -5,6 +5,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - `wp.date.getSettings` has been removed. Please use `wp.date.__experimentalGetSettings` instead.
 - `wp.compose.remountOnPropChange` has been removed.
 - The following editor store actions have been removed: `createNotice`, `removeNotice`, `createSuccessNotice`, `createInfoNotice`, `createErrorNotice`, `createWarningNotice`. Use the equivalent actions by the same name from the `@wordpress/notices` module.
+- The id prop of wp.nux.DotTip has been removed. Please use the tipId prop instead.
 
 ## 4.3.0
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -550,6 +550,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-components',
 			'wp-compose',
 			'wp-data',
+			'wp-deprecated',
 			'wp-i18n',
 			'wp-polyfill',
 			'lodash',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2405,6 +2405,7 @@
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"lodash": "^4.17.10",

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -30,7 +30,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, mode } ) {
 			<FullscreenModeClose />
 			<div>
 				<Inserter disabled={ mode !== 'visual' } position="bottom right" />
-				<DotTip id="core/editor.inserter">
+				<DotTip tipId="core/editor.inserter">
 					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kinds of content: you can insert text, headings, images, lists, and lots more!' ) }
 				</DotTip>
 			</div>

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -59,7 +59,7 @@ function Header( {
 							aria-expanded={ isEditorSidebarOpened }
 							shortcut={ shortcuts.toggleSidebar }
 						/>
-						<DotTip id="core/editor.settings">
+						<DotTip tipId="core/editor.settings">
 							{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” to open it.' ) }
 						</DotTip>
 					</div>

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -167,7 +167,7 @@ export class PostPreviewButton extends Component {
 				disabled={ ! isSaveable }
 			>
 				{ _x( 'Preview', 'imperative verb' ) }
-				<DotTip id="core/editor.preview">
+				<DotTip tipId="core/editor.preview">
 					{ __( 'Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.' ) }
 				</DotTip>
 			</Button>

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -9,7 +9,7 @@ exports[`PostPreviewButton render() should match the snapshot 1`] = `
 >
   Preview
   <WithSelect(WithDispatch(DotTip))
-    id="core/editor.preview"
+    tipId="core/editor.preview"
   >
     Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.
   </WithSelect(WithDispatch(DotTip))>

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -31,7 +31,7 @@ export function PostPublishPanelToggle( {
 			isBusy={ isSaving && isPublished }
 		>
 			{ isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' ) }
-			<DotTip id="core/editor.publish">
+			<DotTip tipId="core/editor.publish">
 				{ __( 'Finished writing? That’s great, let’s get this published right now. Just click “Publish” and you’re good to go.' ) }
 			</DotTip>
 		</Button>

--- a/packages/nux/CHANGELOG.md
+++ b/packages/nux/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.7 (Unreleased)
+
+### Deprecations
+
+- The id prop of DotTip has been deprecated. Please use the tipId prop instead.
+
 ## 2.0.6 (2018-10-22)
 
 ## 2.0.5 (2018-10-19)

--- a/packages/nux/README.md
+++ b/packages/nux/README.md
@@ -18,7 +18,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## DotTip
 
-`DotTip` is a React component that renders a single _tip_ on the screen. The tip will point to the React element that `DotTip` is nested within. Each tip is uniquely identified by a string passed to `id`.
+`DotTip` is a React component that renders a single _tip_ on the screen. The tip will point to the React element that `DotTip` is nested within. Each tip is uniquely identified by a string passed to `tipId`.
 
 See [the component's README][dot-tip-readme] for more information.
 
@@ -27,7 +27,7 @@ See [the component's README][dot-tip-readme] for more information.
 ```jsx
 <button onClick={ ... }>
 	Add to Cart
-	<DotTip id="acme/add-to-cart">
+	<DotTip tipId="acme/add-to-cart">
 		Click here to add the product to your shopping cart.
 	</DotTip>
 </button>

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -24,6 +24,7 @@
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"lodash": "^4.17.10",

--- a/packages/nux/src/components/dot-tip/README.md
+++ b/packages/nux/src/components/dot-tip/README.md
@@ -1,14 +1,14 @@
 DotTip
 ========
 
-`DotTip` is a React component that renders a single _tip_ on the screen. The tip will point to the React element that `DotTip` is nested within. Each tip is uniquely identified by a string passed to `id`.
+`DotTip` is a React component that renders a single _tip_ on the screen. The tip will point to the React element that `DotTip` is nested within. Each tip is uniquely identified by a string passed to `tipId`.
 
 ## Usage
 
 ```jsx
 <button onClick={ ... }>
 	Add to Cart
-	<DotTip id="acme/add-to-cart">
+	<DotTip tipId="acme/add-to-cart">
 		Click here to add the product to your shopping cart.
 	</DotTip>
 </button>
@@ -19,7 +19,7 @@ DotTip
 
 The component accepts the following props:
 
-### id
+### tipId
 
 A string that uniquely identifies the tip. Identifiers should be prefixed with the name of the plugin, followed by a `/`. For example, `acme/add-to-cart`.
 

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -5,6 +5,7 @@ import { compose } from '@wordpress/compose';
 import { Popover, Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { deprecated } from '@wordpress/deprecated';
 
 function getAnchorRect( anchor ) {
 	// The default getAnchorRect() excludes an element's top and bottom padding
@@ -58,7 +59,15 @@ export function DotTip( {
 }
 
 export default compose(
-	withSelect( ( select, { tipId } ) => {
+	withSelect( ( select, { tipId, id } ) => {
+		if ( id ) {
+			tipId = id;
+			deprecated( 'The id prop of wp.nux.DotTip', {
+				plugin: 'Gutenberg',
+				version: '4.4',
+				alternative: 'the tipId prop',
+			} );
+		}
 		const { isTipVisible, getAssociatedGuide } = select( 'core/nux' );
 		const associatedGuide = getAssociatedGuide( tipId );
 		return {
@@ -66,11 +75,11 @@ export default compose(
 			hasNextTip: !! ( associatedGuide && associatedGuide.nextTipId ),
 		};
 	} ),
-	withDispatch( ( dispatch, { tipId } ) => {
+	withDispatch( ( dispatch, { tipId, id } ) => {
 		const { dismissTip, disableTips } = dispatch( 'core/nux' );
 		return {
 			onDismiss() {
-				dismissTip( tipId );
+				dismissTip( tipId || id );
 			},
 			onDisable() {
 				disableTips();

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -58,19 +58,19 @@ export function DotTip( {
 }
 
 export default compose(
-	withSelect( ( select, { id } ) => {
+	withSelect( ( select, { tipId } ) => {
 		const { isTipVisible, getAssociatedGuide } = select( 'core/nux' );
-		const associatedGuide = getAssociatedGuide( id );
+		const associatedGuide = getAssociatedGuide( tipId );
 		return {
-			isVisible: isTipVisible( id ),
+			isVisible: isTipVisible( tipId ),
 			hasNextTip: !! ( associatedGuide && associatedGuide.nextTipId ),
 		};
 	} ),
-	withDispatch( ( dispatch, { id } ) => {
+	withDispatch( ( dispatch, { tipId } ) => {
 		const { dismissTip, disableTips } = dispatch( 'core/nux' );
 		return {
 			onDismiss() {
-				dismissTip( id );
+				dismissTip( tipId );
 			},
 			onDisable() {
 				disableTips();


### PR DESCRIPTION
Resolves #10305

## Description
This PR renames `id` prop on `<DotTip />` to `tipId` to avoid using common DOM attributes as prop names.

It also removes the eslint exception in the [selector](https://github.com/WordPress/gutenberg/blob/a72dc8461cdaba310d1afe1969df51a10af0e3b8/.eslintrc.js#L161), thus reverting it back to its [original rule](https://github.com/WordPress/gutenberg/commit/346788c5ece426ec4c59a248b1de68219ab4c2e9#diff-e4403a877d80de653400d88d85e4801aR158).

## How has this been tested?
Manually tested by viewing NUX tips in a new post. Execute `localStorage.setItem('WP_DATA_USER_1', '')` in the console to remove user data from locale storage if you've already dismissed tips before 

I also ran both unit and e2e tests.

`npm run lint` against changes. Also ran against original props, e.g., `<DotTip id="core/editor.publish">` and received the following error: `error  Do not use string literals for IDs; use withInstanceId instead  no-restricted-syntax`

## Screenshots <!-- if applicable -->
<img width="510" alt="screen shot 2018-10-03 at 4 50 01 pm" src="https://user-images.githubusercontent.com/6458278/46438648-6c0bc800-c72c-11e8-8369-a44b565bf6a1.png">

## Types of changes
This PR renames the `id` prop to `tipId`, and correcting related side effects in the tests/snapshots.
We're also updating the documentation to reflect this change, and removing the exception in the eslint selector.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
