### PR TITLE
Prefix rich text value keys with underscore

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -56,7 +56,7 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
 			// Ensure value passed is always a rich text value.
 			if ( typeof result[ key ] === 'string' ) {
 				result[ key ] = create( { text: result[ key ] } );
-			} else if ( ! result[ key ] || ! result[ key ].text ) {
+			} else if ( typeof result[ key ] !== 'object' ) {
 				result[ key ] = create();
 			}
 		}

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -152,8 +152,8 @@ describe( 'block factory', () => {
 
 			expect( block.attributes ).toEqual( {
 				content: {
-					formats: [ , , , , ],
-					text: 'test',
+					_formats: [ , , , , ],
+					_text: 'test',
 				},
 			} );
 		} );

--- a/packages/editor/src/components/document-outline/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/document-outline/test/__snapshots__/index.js.snap
@@ -17,7 +17,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
         tagName="span"
         value={
           Object {
-            "formats": Array [
+            "_formats": Array [
               undefined,
               undefined,
               undefined,
@@ -33,7 +33,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
               undefined,
               undefined,
             ],
-            "text": "Heading parent",
+            "_text": "Heading parent",
           }
         }
       />
@@ -50,7 +50,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
         tagName="span"
         value={
           Object {
-            "formats": Array [
+            "_formats": Array [
               undefined,
               undefined,
               undefined,
@@ -65,7 +65,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
               undefined,
               undefined,
             ],
-            "text": "Heading child",
+            "_text": "Heading child",
           }
         }
       />
@@ -91,7 +91,7 @@ exports[`DocumentOutline header blocks present should render warnings for multip
         tagName="span"
         value={
           Object {
-            "formats": Array [
+            "_formats": Array [
               undefined,
               undefined,
               undefined,
@@ -102,7 +102,7 @@ exports[`DocumentOutline header blocks present should render warnings for multip
               undefined,
               undefined,
             ],
-            "text": "Heading 1",
+            "_text": "Heading 1",
           }
         }
       />
@@ -127,7 +127,7 @@ exports[`DocumentOutline header blocks present should render warnings for multip
         tagName="span"
         value={
           Object {
-            "formats": Array [
+            "_formats": Array [
               undefined,
               undefined,
               undefined,
@@ -138,7 +138,7 @@ exports[`DocumentOutline header blocks present should render warnings for multip
               undefined,
               undefined,
             ],
-            "text": "Heading 1",
+            "_text": "Heading 1",
           }
         }
       />

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -221,10 +221,10 @@ export class RichText extends Component {
 	 * @return {Object} The current record (value and selection).
 	 */
 	getRecord() {
-		const { formats, text } = this.formatToValue( this.props.value );
-		const { start, end } = this.state;
+		const { _formats, _text } = this.formatToValue( this.props.value );
+		const { _start, _end } = this.state;
 
-		return { formats, text, start, end };
+		return { _formats, _text, _start, _end };
 	}
 
 	createRecord() {
@@ -421,10 +421,10 @@ export class RichText extends Component {
 			return;
 		}
 
-		const { start, end } = this.createRecord();
+		const { _start, _end } = this.createRecord();
 
-		if ( start !== this.state.start || end !== this.state.end ) {
-			this.setState( { start, end } );
+		if ( _start !== this.state._start || _end !== this.state._end ) {
+			this.setState( { _start, _end } );
 		}
 	}
 
@@ -441,11 +441,11 @@ export class RichText extends Component {
 			this.applyRecord( record );
 		}
 
-		const { start, end } = record;
+		const { _start, _end } = record;
 
 		this.savedContent = this.valueToFormat( record );
 		this.props.onChange( this.savedContent );
-		this.setState( { start, end } );
+		this.setState( { _start, _end } );
 	}
 
 	onCreateUndoLevel( event ) {
@@ -778,8 +778,8 @@ export class RichText extends Component {
 
 			if ( this.isActive() ) {
 				const length = getTextContent( prevProps.value ).length;
-				record.start = length;
-				record.end = length;
+				record._start = length;
+				record._end = length;
 			}
 
 			this.applyRecord( record );
@@ -813,19 +813,19 @@ export class RichText extends Component {
 		return value;
 	}
 
-	valueToFormat( { formats, text } ) {
+	valueToFormat( { _formats, _text } ) {
 		const { format, multiline } = this.props;
 
 		// Handle deprecated `children` and `node` sources.
 		if ( this.usedDeprecatedChildrenSource ) {
-			return children.fromDOM( unstableToDom( { formats, text }, multiline ).body.childNodes );
+			return children.fromDOM( unstableToDom( { _formats, _text }, multiline ).body.childNodes );
 		}
 
 		if ( format === 'string' ) {
-			return toHTMLString( { formats, text }, multiline );
+			return toHTMLString( { _formats, _text }, multiline );
 		}
 
-		return { formats, text };
+		return { _formats, _text };
 	}
 
 	render() {

--- a/packages/rich-text/src/apply-format.js
+++ b/packages/rich-text/src/apply-format.js
@@ -17,16 +17,16 @@ import { normaliseFormats } from './normalise-formats';
  * @return {Object} A new value with the format applied.
  */
 export function applyFormat(
-	{ formats, text, start, end },
+	{ _formats, _text, _start, _end },
 	format,
-	startIndex = start,
-	endIndex = end
+	startIndex = _start,
+	endIndex = _end
 ) {
-	const newFormats = formats.slice( 0 );
+	const newFormats = _formats.slice( 0 );
 
 	for ( let index = startIndex; index < endIndex; index++ ) {
-		if ( formats[ index ] ) {
-			const newFormatsAtIndex = formats[ index ].filter( ( { type } ) => type !== format.type );
+		if ( newFormats[ index ] ) {
+			const newFormatsAtIndex = newFormats[ index ].filter( ( { type } ) => type !== format.type );
 			newFormatsAtIndex.push( format );
 			newFormats[ index ] = newFormatsAtIndex;
 		} else {
@@ -34,5 +34,5 @@ export function applyFormat(
 		}
 	}
 
-	return normaliseFormats( { formats: newFormats, text, start, end } );
+	return normaliseFormats( { _formats: newFormats, _text, _start, _end } );
 }

--- a/packages/rich-text/src/concat.js
+++ b/packages/rich-text/src/concat.js
@@ -13,8 +13,8 @@ import { normaliseFormats } from './normalise-formats';
  * @return {Object} A new value combining all given records.
  */
 export function concat( ...values ) {
-	return normaliseFormats( values.reduce( ( accumlator, { formats, text } ) => ( {
-		text: accumlator.text + text,
-		formats: accumlator.formats.concat( formats ),
+	return normaliseFormats( values.reduce( ( accumlator, { _formats, _text } ) => ( {
+		_text: accumlator._text + _text,
+		_formats: accumlator._formats.concat( _formats ),
 	} ) ) );
 }

--- a/packages/rich-text/src/get-active-format.js
+++ b/packages/rich-text/src/get-active-format.js
@@ -15,10 +15,10 @@ import { find } from 'lodash';
  *
  * @return {?Object} Active format object of the specified type, or undefined.
  */
-export function getActiveFormat( { formats, start }, formatType ) {
-	if ( start === undefined ) {
+export function getActiveFormat( { _formats, _start }, formatType ) {
+	if ( _start === undefined ) {
 		return;
 	}
 
-	return find( formats[ start ], { type: formatType } );
+	return find( _formats[ _start ], { type: formatType } );
 }

--- a/packages/rich-text/src/get-text-content.js
+++ b/packages/rich-text/src/get-text-content.js
@@ -6,6 +6,6 @@
  *
  * @return {string} The text content.
  */
-export function getTextContent( { text } ) {
-	return text;
+export function getTextContent( { _text } ) {
+	return _text;
 }

--- a/packages/rich-text/src/insert.js
+++ b/packages/rich-text/src/insert.js
@@ -19,21 +19,21 @@ import { normaliseFormats } from './normalise-formats';
  * @return {Object} A new value with the value inserted.
  */
 export function insert(
-	{ formats, text, start, end },
+	{ _formats, _text, _start, _end },
 	valueToInsert,
-	startIndex = start,
-	endIndex = end
+	startIndex = _start,
+	endIndex = _end
 ) {
 	if ( typeof valueToInsert === 'string' ) {
 		valueToInsert = create( { text: valueToInsert } );
 	}
 
-	const index = startIndex + valueToInsert.text.length;
+	const index = startIndex + valueToInsert._text.length;
 
 	return normaliseFormats( {
-		formats: formats.slice( 0, startIndex ).concat( valueToInsert.formats, formats.slice( endIndex ) ),
-		text: text.slice( 0, startIndex ) + valueToInsert.text + text.slice( endIndex ),
-		start: index,
-		end: index,
+		_formats: _formats.slice( 0, startIndex ).concat( valueToInsert._formats, _formats.slice( endIndex ) ),
+		_text: _text.slice( 0, startIndex ) + valueToInsert._text + _text.slice( endIndex ),
+		_start: index,
+		_end: index,
 	} );
 }

--- a/packages/rich-text/src/is-collapsed.js
+++ b/packages/rich-text/src/is-collapsed.js
@@ -9,10 +9,10 @@
  * @return {?boolean} True if the selection is collapsed, false if not,
  *                    undefined if there is no selection.
  */
-export function isCollapsed( { start, end } ) {
-	if ( start === undefined || end === undefined ) {
+export function isCollapsed( { _start, _end } ) {
+	if ( _start === undefined || _end === undefined ) {
 		return;
 	}
 
-	return start === end;
+	return _start === _end;
 }

--- a/packages/rich-text/src/is-empty.js
+++ b/packages/rich-text/src/is-empty.js
@@ -6,8 +6,8 @@
  *
  * @return {boolean} True if the value is empty, false if not.
  */
-export function isEmpty( { text } ) {
-	return text.length === 0;
+export function isEmpty( { _text } ) {
+	return _text.length === 0;
 }
 
 /**
@@ -18,22 +18,22 @@ export function isEmpty( { text } ) {
  *
  * @return {boolean} True if the line is empty, false if not.
  */
-export function isEmptyLine( { text, start, end } ) {
-	if ( start !== end ) {
+export function isEmptyLine( { _text, _start, _end } ) {
+	if ( _start !== _end ) {
 		return false;
 	}
 
-	if ( text.length === 0 ) {
+	if ( _text.length === 0 ) {
 		return true;
 	}
 
-	if ( start === 0 && text.slice( 0, 1 ) === '\u2028' ) {
+	if ( _start === 0 && _text.slice( 0, 1 ) === '\u2028' ) {
 		return true;
 	}
 
-	if ( start === text.length && text.slice( -1 ) === '\u2028' ) {
+	if ( _start === _text.length && _text.slice( -1 ) === '\u2028' ) {
 		return true;
 	}
 
-	return text.slice( start - 1, end + 1 ) === '\u2028\u2028';
+	return _text.slice( _start - 1, _end + 1 ) === '\u2028\u2028';
 }

--- a/packages/rich-text/src/join.js
+++ b/packages/rich-text/src/join.js
@@ -20,8 +20,8 @@ export function join( values, separator = '' ) {
 		separator = create( { text: separator } );
 	}
 
-	return normaliseFormats( values.reduce( ( accumlator, { formats, text } ) => ( {
-		text: accumlator.text + separator.text + text,
-		formats: accumlator.formats.concat( separator.formats, formats ),
+	return normaliseFormats( values.reduce( ( accumlator, { _formats, _text } ) => ( {
+		_text: accumlator._text + separator._text + _text,
+		_formats: accumlator._formats.concat( separator._formats, _formats ),
 	} ) ) );
 }

--- a/packages/rich-text/src/normalise-formats.js
+++ b/packages/rich-text/src/normalise-formats.js
@@ -11,8 +11,8 @@ import { isFormatEqual } from './is-format-equal';
  *
  * @return {Object} New value with normalised formats.
  */
-export function normaliseFormats( { formats, text, start, end } ) {
-	const newFormats = formats.slice( 0 );
+export function normaliseFormats( { _formats, _text, _start, _end } ) {
+	const newFormats = _formats.slice( 0 );
 
 	newFormats.forEach( ( formatsAtIndex, index ) => {
 		const lastFormatsAtIndex = newFormats[ index - 1 ];
@@ -32,5 +32,5 @@ export function normaliseFormats( { formats, text, start, end } ) {
 		}
 	} );
 
-	return { formats: newFormats, text, start, end };
+	return { _formats: newFormats, _text, _start, _end };
 }

--- a/packages/rich-text/src/remove-format.js
+++ b/packages/rich-text/src/remove-format.js
@@ -23,12 +23,12 @@ import { normaliseFormats } from './normalise-formats';
  * @return {Object} A new value with the format applied.
  */
 export function removeFormat(
-	{ formats, text, start, end },
+	{ _formats, _text, _start, _end },
 	formatType,
-	startIndex = start,
-	endIndex = end
+	startIndex = _start,
+	endIndex = _end
 ) {
-	const newFormats = formats.slice( 0 );
+	const newFormats = _formats.slice( 0 );
 
 	// If the selection is collapsed, expand start and end to the edges of the
 	// format.
@@ -54,7 +54,7 @@ export function removeFormat(
 		}
 	}
 
-	return normaliseFormats( { formats: newFormats, text, start, end } );
+	return normaliseFormats( { _formats: newFormats, _text, _start, _end } );
 }
 
 function filterFormats( formats, index, formatType ) {

--- a/packages/rich-text/src/replace.js
+++ b/packages/rich-text/src/replace.js
@@ -20,8 +20,8 @@ import { normaliseFormats } from './normalise-formats';
  *
  * @return {Object} A new value with replacements applied.
  */
-export function replace( { formats, text, start, end }, pattern, replacement ) {
-	text = text.replace( pattern, ( match, ...rest ) => {
+export function replace( { _formats, _text, _start, _end }, pattern, replacement ) {
+	_text = _text.replace( pattern, ( match, ...rest ) => {
 		const offset = rest[ rest.length - 2 ];
 		let newText = replacement;
 		let newFormats;
@@ -31,24 +31,24 @@ export function replace( { formats, text, start, end }, pattern, replacement ) {
 		}
 
 		if ( typeof newText === 'object' ) {
-			newFormats = newText.formats;
-			newText = newText.text;
+			newFormats = newText._formats;
+			newText = newText._text;
 		} else {
 			newFormats = Array( newText.length );
 
-			if ( formats[ offset ] ) {
-				newFormats = newFormats.fill( formats[ offset ] );
+			if ( _formats[ offset ] ) {
+				newFormats = newFormats.fill( _formats[ offset ] );
 			}
 		}
 
-		formats = formats.slice( 0, offset ).concat( newFormats, formats.slice( offset + match.length ) );
+		_formats = _formats.slice( 0, offset ).concat( newFormats, _formats.slice( offset + match.length ) );
 
-		if ( start ) {
-			start = end = offset + newText.length;
+		if ( _start ) {
+			_start = _end = offset + newText.length;
 		}
 
 		return newText;
 	} );
 
-	return normaliseFormats( { formats, text, start, end } );
+	return normaliseFormats( { _formats, _text, _start, _end } );
 }

--- a/packages/rich-text/src/slice.js
+++ b/packages/rich-text/src/slice.js
@@ -10,16 +10,16 @@
  * @return {Object} A new extracted value.
  */
 export function slice(
-	{ formats, text, start, end },
-	startIndex = start,
-	endIndex = end
+	{ _formats, _text, _start, _end },
+	startIndex = _start,
+	endIndex = _end
 ) {
 	if ( startIndex === undefined || endIndex === undefined ) {
-		return { formats, text };
+		return { _formats, _text };
 	}
 
 	return {
-		formats: formats.slice( startIndex, endIndex ),
-		text: text.slice( startIndex, endIndex ),
+		_formats: _formats.slice( startIndex, endIndex ),
+		_text: _text.slice( startIndex, endIndex ),
 	};
 }

--- a/packages/rich-text/src/split.js
+++ b/packages/rich-text/src/split.js
@@ -15,33 +15,33 @@ import { replace } from './replace';
  *
  * @return {Array} An array of new values.
  */
-export function split( { formats, text, start, end }, string ) {
+export function split( { _formats, _text, _start, _end }, string ) {
 	if ( typeof string !== 'string' ) {
 		return splitAtSelection( ...arguments );
 	}
 
 	let nextStart = 0;
 
-	return text.split( string ).map( ( substring ) => {
+	return _text.split( string ).map( ( substring ) => {
 		const startIndex = nextStart;
 		const value = {
-			formats: formats.slice( startIndex, startIndex + substring.length ),
-			text: substring,
+			_formats: _formats.slice( startIndex, startIndex + substring.length ),
+			_text: substring,
 		};
 
 		nextStart += string.length + substring.length;
 
-		if ( start !== undefined && end !== undefined ) {
-			if ( start > startIndex && start < nextStart ) {
-				value.start = start - startIndex;
-			} else if ( start < startIndex && end > startIndex ) {
-				value.start = 0;
+		if ( _start !== undefined && _end !== undefined ) {
+			if ( _start > startIndex && _start < nextStart ) {
+				value._start = _start - startIndex;
+			} else if ( _start < startIndex && _end > startIndex ) {
+				value._start = 0;
 			}
 
-			if ( end > startIndex && end < nextStart ) {
-				value.end = end - startIndex;
-			} else if ( start < nextStart && end > nextStart ) {
-				value.end = substring.length;
+			if ( _end > startIndex && _end < nextStart ) {
+				value._end = _end - startIndex;
+			} else if ( _start < nextStart && _end > nextStart ) {
+				value._end = substring.length;
 			}
 		}
 
@@ -50,19 +50,19 @@ export function split( { formats, text, start, end }, string ) {
 }
 
 function splitAtSelection(
-	{ formats, text, start, end },
-	startIndex = start,
-	endIndex = end
+	{ _formats, _text, _start, _end },
+	startIndex = _start,
+	endIndex = _end
 ) {
 	const before = {
-		formats: formats.slice( 0, startIndex ),
-		text: text.slice( 0, startIndex ),
+		_formats: _formats.slice( 0, startIndex ),
+		_text: _text.slice( 0, startIndex ),
 	};
 	const after = {
-		formats: formats.slice( endIndex ),
-		text: text.slice( endIndex ),
-		start: 0,
-		end: 0,
+		_formats: _formats.slice( endIndex ),
+		_text: _text.slice( endIndex ),
+		_start: 0,
+		_end: 0,
 	};
 
 	return [

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -16,37 +16,37 @@ describe( 'applyFormat', () => {
 
 	it( 'should apply format', () => {
 		const record = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const expected = {
-			formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const result = applyFormat( deepFreeze( record ), strong, 3, 6 );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 4 );
 	} );
 
 	it( 'should apply format by selection', () => {
 		const record = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
-			start: 3,
-			end: 6,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
+			_start: 3,
+			_end: 6,
 		};
 		const expected = {
-			formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
-			text: 'one two three',
-			start: 3,
-			end: 6,
+			_formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
+			_text: 'one two three',
+			_start: 3,
+			_end: 6,
 		};
 		const result = applyFormat( deepFreeze( record ), strong );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 4 );
 	} );
 } );

--- a/packages/rich-text/src/test/concat.js
+++ b/packages/rich-text/src/test/concat.js
@@ -15,22 +15,22 @@ describe( 'concat', () => {
 
 	it( 'should merge records', () => {
 		const one = {
-			formats: [ , , [ em ] ],
-			text: 'one',
+			_formats: [ , , [ em ] ],
+			_text: 'one',
 		};
 		const two = {
-			formats: [ [ em ], , , ],
-			text: 'two',
+			_formats: [ [ em ], , , ],
+			_text: 'two',
 		};
 		const three = {
-			formats: [ , , [ em ], [ em ], , , ],
-			text: 'onetwo',
+			_formats: [ , , [ em ], [ em ], , , ],
+			_text: 'onetwo',
 		};
 
 		const merged = concat( deepFreeze( one ), deepFreeze( two ) );
 
 		expect( merged ).not.toBe( one );
 		expect( merged ).toEqual( three );
-		expect( getSparseArrayLength( merged.formats ) ).toBe( 2 );
+		expect( getSparseArrayLength( merged._formats ) ).toBe( 2 );
 	} );
 } );

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -40,10 +40,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 0,
-				formats: [],
-				text: '',
+				_start: 0,
+				_end: 0,
+				_formats: [],
+				_text: '',
 			},
 		},
 		{
@@ -56,10 +56,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 0,
-				formats: [],
-				text: '',
+				_start: 0,
+				_end: 0,
+				_formats: [],
+				_text: '',
 			},
 		},
 		{
@@ -72,10 +72,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 0,
-				formats: [],
-				text: '',
+				_start: 0,
+				_end: 0,
+				_formats: [],
+				_text: '',
 			},
 		},
 		{
@@ -88,10 +88,10 @@ describe( 'create', () => {
 				endContainer: element.firstChild,
 			} ),
 			record: {
-				start: 0,
-				end: 4,
-				formats: [ , , , , ],
-				text: 'test',
+				_start: 0,
+				_end: 4,
+				_formats: [ , , , , ],
+				_text: 'test',
 			},
 		},
 		{
@@ -104,10 +104,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 2,
-				formats: [ , , ],
-				text: '🍒',
+				_start: 0,
+				_end: 2,
+				_formats: [ , , ],
+				_text: '🍒',
 			},
 		},
 		{
@@ -120,10 +120,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 2,
-				formats: [ [ em ], [ em ] ],
-				text: '🍒',
+				_start: 0,
+				_end: 2,
+				_formats: [ [ em ], [ em ] ],
+				_text: '🍒',
 			},
 		},
 		{
@@ -136,10 +136,10 @@ describe( 'create', () => {
 				endContainer: element.firstChild,
 			} ),
 			record: {
-				start: 0,
-				end: 4,
-				formats: [ [ em ], [ em ], [ em ], [ em ] ],
-				text: 'test',
+				_start: 0,
+				_end: 4,
+				_formats: [ [ em ], [ em ], [ em ], [ em ] ],
+				_text: 'test',
 			},
 		},
 		{
@@ -152,10 +152,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 4,
-				formats: [ [ em, strong ], [ em, strong ], [ em, strong ], [ em, strong ] ],
-				text: 'test',
+				_start: 0,
+				_end: 4,
+				_formats: [ [ em, strong ], [ em, strong ], [ em, strong ], [ em, strong ] ],
+				_text: 'test',
 			},
 		},
 		{
@@ -168,10 +168,10 @@ describe( 'create', () => {
 				endContainer: element.querySelector( 'em' ),
 			} ),
 			record: {
-				start: 0,
-				end: 2,
-				formats: [ [ em ], [ em ], [ em ], [ em ] ],
-				text: 'test',
+				_start: 0,
+				_end: 2,
+				_formats: [ [ em ], [ em ], [ em ], [ em ] ],
+				_text: 'test',
 			},
 		},
 		{
@@ -184,10 +184,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 4,
-				formats: [ [ a ], [ a ], [ a ], [ a ] ],
-				text: 'test',
+				_start: 0,
+				_end: 4,
+				_formats: [ [ a ], [ a ], [ a ], [ a ] ],
+				_text: 'test',
 			},
 		},
 		{
@@ -200,10 +200,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 0,
-				formats: [ [ img ] ],
-				text: '\ufffc',
+				_start: 0,
+				_end: 0,
+				_formats: [ [ img ] ],
+				_text: '\ufffc',
 			},
 		},
 		{
@@ -216,10 +216,10 @@ describe( 'create', () => {
 				endContainer: element.querySelector( 'img' ),
 			} ),
 			record: {
-				start: 0,
-				end: 1,
-				formats: [ [ em, img ] ],
-				text: '\ufffc',
+				_start: 0,
+				_end: 1,
+				_formats: [ [ em, img ] ],
+				_text: '\ufffc',
 			},
 		},
 		{
@@ -232,10 +232,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 5,
-				formats: [ , , [ em ], [ em ], [ em, img ] ],
-				text: 'test\ufffc',
+				_start: 0,
+				_end: 5,
+				_formats: [ , , [ em ], [ em ], [ em, img ] ],
+				_text: 'test\ufffc',
 			},
 		},
 		{
@@ -248,10 +248,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 5,
-				formats: [ [ em, img ], [ em ], [ em ], , , ],
-				text: '\ufffctest',
+				_start: 0,
+				_end: 5,
+				_formats: [ [ em, img ], [ em ], [ em ], , , ],
+				_text: '\ufffctest',
 			},
 		},
 		{
@@ -264,10 +264,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 0,
-				formats: [ , ],
-				text: '\n',
+				_start: 0,
+				_end: 0,
+				_formats: [ , ],
+				_text: '\n',
 			},
 		},
 		{
@@ -280,10 +280,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 2,
-				end: 2,
-				formats: [ , , , , , ],
-				text: 'te\nst',
+				_start: 2,
+				_end: 2,
+				_formats: [ , , , , , ],
+				_text: 'te\nst',
 			},
 		},
 		{
@@ -296,10 +296,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 1,
-				formats: [ [ em ] ],
-				text: '\n',
+				_start: 0,
+				_end: 1,
+				_formats: [ [ em ] ],
+				_text: '\n',
 			},
 		},
 		{
@@ -313,10 +313,10 @@ describe( 'create', () => {
 				endContainer: element.lastChild,
 			} ),
 			record: {
-				start: 1,
-				end: 4,
-				formats: [ , , , , , , , ],
-				text: 'one\u2028two',
+				_start: 1,
+				_end: 4,
+				_formats: [ , , , , , , , ],
+				_text: 'one\u2028two',
 			},
 		},
 		{
@@ -330,10 +330,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 6,
-				formats: [ , , , list, list, list, , , , , , , ],
-				text: 'onetwo\u2028three',
+				_start: 0,
+				_end: 6,
+				_formats: [ , , , list, list, list, , , , , , , ],
+				_text: 'onetwo\u2028three',
 			},
 		},
 		{
@@ -347,10 +347,10 @@ describe( 'create', () => {
 				endContainer: element.lastChild,
 			} ),
 			record: {
-				start: 4,
-				end: 4,
-				formats: [ , , , , ],
-				text: 'one\u2028',
+				_start: 4,
+				_end: 4,
+				_formats: [ , , , , ],
+				_text: 'one\u2028',
 			},
 		},
 		{
@@ -366,10 +366,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 0,
-				formats: [],
-				text: '',
+				_start: 0,
+				_end: 0,
+				_formats: [],
+				_text: '',
 			},
 		},
 		{
@@ -385,10 +385,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 0,
-				formats: [],
-				text: '',
+				_start: 0,
+				_end: 0,
+				_formats: [],
+				_text: '',
 			},
 		},
 		{
@@ -404,10 +404,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 4,
-				formats: [ , , [ em ], [ em ] ],
-				text: 'test',
+				_start: 0,
+				_end: 4,
+				_formats: [ , , [ em ], [ em ] ],
+				_text: 'test',
 			},
 		},
 		{
@@ -423,10 +423,10 @@ describe( 'create', () => {
 				endContainer: element.lastChild,
 			} ),
 			record: {
-				start: 0,
-				end: 1,
-				formats: [ , , , ],
-				text: 'two',
+				_start: 0,
+				_end: 1,
+				_formats: [ , , , ],
+				_text: 'two',
 			},
 		},
 		{
@@ -442,10 +442,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 4,
-				formats: [ [ strong ], [ strong ], [ strong ], [ strong ] ],
-				text: 'test',
+				_start: 0,
+				_end: 4,
+				_formats: [ [ strong ], [ strong ], [ strong ], [ strong ] ],
+				_text: 'test',
 			},
 		},
 		{
@@ -461,10 +461,10 @@ describe( 'create', () => {
 				endContainer: element,
 			} ),
 			record: {
-				start: 0,
-				end: 0,
-				formats: [],
-				text: '',
+				_start: 0,
+				_end: 0,
+				_formats: [],
+				_text: '',
 			},
 		},
 		{
@@ -480,10 +480,10 @@ describe( 'create', () => {
 				endContainer: element.firstChild,
 			} ),
 			record: {
-				start: 4,
-				end: 4,
-				formats: [ , , , , ],
-				text: 'test',
+				_start: 4,
+				_end: 4,
+				_formats: [ , , , , ],
+				_text: 'test',
 			},
 		},
 		{
@@ -499,10 +499,10 @@ describe( 'create', () => {
 				endContainer: element.querySelector( 'em' ).firstChild,
 			} ),
 			record: {
-				start: 4,
-				end: 4,
-				formats: [ [ em ], [ em ], [ em ], [ em ] ],
-				text: 'test',
+				_start: 4,
+				_end: 4,
+				_formats: [ [ em ], [ em ], [ em ], [ em ] ],
+				_text: 'test',
 			},
 		},
 		{
@@ -518,10 +518,10 @@ describe( 'create', () => {
 				endContainer: element.lastChild,
 			} ),
 			record: {
-				start: 4,
-				end: 4,
-				formats: [ [ em ], [ em ], [ em ], [ em ] ],
-				text: 'test',
+				_start: 4,
+				_end: 4,
+				_formats: [ [ em ], [ em ], [ em ], [ em ] ],
+				_text: 'test',
 			},
 		},
 	];
@@ -531,8 +531,8 @@ describe( 'create', () => {
 			const element = createElement( html );
 			const range = createRange( element );
 			const createdRecord = create( { element, range, multilineTag, ...settings } );
-			const formatsLength = getSparseArrayLength( record.formats );
-			const createdFormatsLength = getSparseArrayLength( createdRecord.formats );
+			const formatsLength = getSparseArrayLength( record._formats );
+			const createdFormatsLength = getSparseArrayLength( createdRecord._formats );
 
 			expect( createdRecord ).toEqual( record );
 			expect( createdFormatsLength ).toEqual( formatsLength );
@@ -543,22 +543,22 @@ describe( 'create', () => {
 		const value = create( { html: '<em>te<strong>st</strong></em>' } );
 
 		expect( value ).toEqual( {
-			formats: [ [ em ], [ em ], [ em, strong ], [ em, strong ] ],
-			text: 'test',
+			_formats: [ [ em ], [ em ], [ em, strong ], [ em, strong ] ],
+			_text: 'test',
 		} );
 
-		expect( value.formats[ 0 ][ 0 ] ).toBe( value.formats[ 1 ][ 0 ] );
-		expect( value.formats[ 0 ][ 0 ] ).toBe( value.formats[ 2 ][ 0 ] );
-		expect( value.formats[ 2 ][ 1 ] ).toBe( value.formats[ 3 ][ 1 ] );
+		expect( value._formats[ 0 ][ 0 ] ).toBe( value._formats[ 1 ][ 0 ] );
+		expect( value._formats[ 0 ][ 0 ] ).toBe( value._formats[ 2 ][ 0 ] );
+		expect( value._formats[ 2 ][ 1 ] ).toBe( value._formats[ 3 ][ 1 ] );
 	} );
 
 	it( 'should use same reference for equal format', () => {
 		const value = create( { html: '<a href="#">a</a><a href="#">a</a>' } );
-		expect( value.formats[ 0 ][ 0 ] ).toBe( value.formats[ 1 ][ 0 ] );
+		expect( value._formats[ 0 ][ 0 ] ).toBe( value._formats[ 1 ][ 0 ] );
 	} );
 
 	it( 'should use different reference for different format', () => {
 		const value = create( { html: '<a href="#">a</a><a href="#a">a</a>' } );
-		expect( value.formats[ 0 ][ 0 ] ).not.toBe( value.formats[ 1 ][ 0 ] );
+		expect( value._formats[ 0 ][ 0 ] ).not.toBe( value._formats[ 1 ][ 0 ] );
 	} );
 } );

--- a/packages/rich-text/src/test/get-active-format.js
+++ b/packages/rich-text/src/test/get-active-format.js
@@ -9,10 +9,10 @@ describe( 'getActiveFormat', () => {
 
 	it( 'should get format by selection', () => {
 		const record = {
-			formats: [ [ em ], , , ],
-			text: 'one',
-			start: 0,
-			end: 0,
+			_formats: [ [ em ], , , ],
+			_text: 'one',
+			_start: 0,
+			_end: 0,
 		};
 
 		expect( getActiveFormat( record, 'em' ) ).toEqual( em );
@@ -20,10 +20,10 @@ describe( 'getActiveFormat', () => {
 
 	it( 'should get format by selection using the start', () => {
 		const record = {
-			formats: [ [ em ], , [ em ] ],
-			text: 'one',
-			start: 1,
-			end: 1,
+			_formats: [ [ em ], , [ em ] ],
+			_text: 'one',
+			_start: 1,
+			_end: 1,
 		};
 
 		expect( getActiveFormat( record, 'em' ) ).toBe( undefined );

--- a/packages/rich-text/src/test/insert.js
+++ b/packages/rich-text/src/test/insert.js
@@ -16,49 +16,49 @@ describe( 'insert', () => {
 
 	it( 'should delete and insert', () => {
 		const record = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
-			start: 6,
-			end: 6,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
+			_start: 6,
+			_end: 6,
 		};
 		const toInsert = {
-			formats: [ [ strong ] ],
-			text: 'a',
+			_formats: [ [ strong ] ],
+			_text: 'a',
 		};
 		const expected = {
-			formats: [ , , [ strong ], [ em ], , , , , , , ],
-			text: 'onao three',
-			start: 3,
-			end: 3,
+			_formats: [ , , [ strong ], [ em ], , , , , , , ],
+			_text: 'onao three',
+			_start: 3,
+			_end: 3,
 		};
 		const result = insert( deepFreeze( record ), toInsert, 2, 6 );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 2 );
 	} );
 
 	it( 'should insert line break with selection', () => {
 		const record = {
-			formats: [ , , ],
-			text: 'tt',
-			start: 1,
-			end: 1,
+			_formats: [ , , ],
+			_text: 'tt',
+			_start: 1,
+			_end: 1,
 		};
 		const toInsert = {
-			formats: [ , ],
-			text: '\n',
+			_formats: [ , ],
+			_text: '\n',
 		};
 		const expected = {
-			formats: [ , , , ],
-			text: 't\nt',
-			start: 2,
-			end: 2,
+			_formats: [ , , , ],
+			_text: 't\nt',
+			_start: 2,
+			_end: 2,
 		};
 		const result = insert( deepFreeze( record ), toInsert );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 0 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 0 );
 	} );
 } );

--- a/packages/rich-text/src/test/is-collapsed.js
+++ b/packages/rich-text/src/test/is-collapsed.js
@@ -7,8 +7,8 @@ import { isCollapsed } from '../is-collapsed';
 describe( 'isCollapsed', () => {
 	it( 'should return true for a collapsed selection', () => {
 		const record = {
-			start: 4,
-			end: 4,
+			_start: 4,
+			_end: 4,
 		};
 
 		expect( isCollapsed( record ) ).toBe( true );

--- a/packages/rich-text/src/test/is-empty.js
+++ b/packages/rich-text/src/test/is-empty.js
@@ -7,8 +7,8 @@ import { isEmpty, isEmptyLine } from '../is-empty';
 describe( 'isEmpty', () => {
 	it( 'should return true', () => {
 		const one = {
-			formats: [],
-			text: '',
+			_formats: [],
+			_text: '',
 		};
 
 		expect( isEmpty( one ) ).toBe( true );
@@ -16,8 +16,8 @@ describe( 'isEmpty', () => {
 
 	it( 'should return false', () => {
 		const one = {
-			formats: [],
-			text: 'test',
+			_formats: [],
+			_text: 'test',
 		};
 
 		expect( isEmpty( one ) ).toBe( false );
@@ -27,34 +27,34 @@ describe( 'isEmpty', () => {
 describe( 'isEmptyLine', () => {
 	it( 'should return true', () => {
 		const one = {
-			formats: [],
-			text: '',
-			start: 0,
-			end: 0,
+			_formats: [],
+			_text: '',
+			_start: 0,
+			_end: 0,
 		};
 		const two = {
-			formats: [ , , ],
-			text: '\u2028',
-			start: 0,
-			end: 0,
+			_formats: [ , , ],
+			_text: '\u2028',
+			_start: 0,
+			_end: 0,
 		};
 		const three = {
-			formats: [ , , ],
-			text: '\u2028',
-			start: 1,
-			end: 1,
+			_formats: [ , , ],
+			_text: '\u2028',
+			_start: 1,
+			_end: 1,
 		};
 		const four = {
-			formats: [ , , , , ],
-			text: '\u2028\u2028',
-			start: 1,
-			end: 1,
+			_formats: [ , , , , ],
+			_text: '\u2028\u2028',
+			_start: 1,
+			_end: 1,
 		};
 		const five = {
-			formats: [ , , , , ],
-			text: 'a\u2028\u2028b',
-			start: 2,
-			end: 2,
+			_formats: [ , , , , ],
+			_text: 'a\u2028\u2028b',
+			_start: 2,
+			_end: 2,
 		};
 
 		expect( isEmptyLine( one ) ).toBe( true );
@@ -66,16 +66,16 @@ describe( 'isEmptyLine', () => {
 
 	it( 'should return false', () => {
 		const one = {
-			formats: [ , , , , ],
-			text: '\u2028a\u2028',
-			start: 1,
-			end: 1,
+			_formats: [ , , , , ],
+			_text: '\u2028a\u2028',
+			_start: 1,
+			_end: 1,
 		};
 		const two = {
-			formats: [ , , , , ],
-			text: '\u2028\n',
-			start: 1,
-			end: 1,
+			_formats: [ , , , , ],
+			_text: '\u2028\n',
+			_start: 1,
+			_end: 1,
 		};
 
 		expect( isEmptyLine( one ) ).toBe( false );

--- a/packages/rich-text/src/test/join.js
+++ b/packages/rich-text/src/test/join.js
@@ -15,31 +15,31 @@ describe( 'join', () => {
 	const separators = [
 		' ',
 		{
-			text: ' ',
-			formats: [ , ],
+			_text: ' ',
+			_formats: [ , ],
 		},
 	];
 
 	separators.forEach( ( separator ) => {
 		it( 'should join records with string separator', () => {
 			const one = {
-				formats: [ , , [ em ] ],
-				text: 'one',
+				_formats: [ , , [ em ] ],
+				_text: 'one',
 			};
 			const two = {
-				formats: [ [ em ], , , ],
-				text: 'two',
+				_formats: [ [ em ], , , ],
+				_text: 'two',
 			};
 			const three = {
-				formats: [ , , [ em ], , [ em ], , , ],
-				text: 'one two',
+				_formats: [ , , [ em ], , [ em ], , , ],
+				_text: 'one two',
 			};
 			const result = join( [ deepFreeze( one ), deepFreeze( two ) ], separator );
 
 			expect( result ).not.toBe( one );
 			expect( result ).not.toBe( two );
 			expect( result ).toEqual( three );
-			expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
+			expect( getSparseArrayLength( result._formats ) ).toBe( 2 );
 		} );
 	} );
 } );

--- a/packages/rich-text/src/test/normalise-formats.js
+++ b/packages/rich-text/src/test/normalise-formats.js
@@ -16,16 +16,16 @@ describe( 'normaliseFormats', () => {
 
 	it( 'should normalise formats', () => {
 		const record = {
-			formats: [ , [ em ], [ { ...em }, { ...strong } ], [ em, strong ] ],
-			text: 'one two three',
+			_formats: [ , [ em ], [ { ...em }, { ...strong } ], [ em, strong ] ],
+			_text: 'one two three',
 		};
 		const result = normaliseFormats( deepFreeze( record ) );
 
 		expect( result ).toEqual( record );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
-		expect( result.formats[ 1 ][ 0 ] ).toBe( result.formats[ 2 ][ 0 ] );
-		expect( result.formats[ 1 ][ 0 ] ).toBe( result.formats[ 3 ][ 0 ] );
-		expect( result.formats[ 2 ][ 1 ] ).toBe( result.formats[ 3 ][ 1 ] );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 3 );
+		expect( result._formats[ 1 ][ 0 ] ).toBe( result._formats[ 2 ][ 0 ] );
+		expect( result._formats[ 1 ][ 0 ] ).toBe( result._formats[ 3 ][ 0 ] );
+		expect( result._formats[ 2 ][ 1 ] ).toBe( result._formats[ 3 ][ 1 ] );
 	} );
 } );

--- a/packages/rich-text/src/test/remove-format.js
+++ b/packages/rich-text/src/test/remove-format.js
@@ -16,33 +16,33 @@ describe( 'removeFormat', () => {
 
 	it( 'should remove format', () => {
 		const record = {
-			formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const expected = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const result = removeFormat( deepFreeze( record ), 'strong', 3, 6 );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 3 );
 	} );
 
 	it( 'should remove format for collased selection', () => {
 		const record = {
-			formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const expected = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const result = removeFormat( deepFreeze( record ), 'strong', 4, 4 );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 3 );
 	} );
 } );

--- a/packages/rich-text/src/test/replace.js
+++ b/packages/rich-text/src/test/replace.js
@@ -15,60 +15,60 @@ describe( 'replace', () => {
 
 	it( 'should replace string to string', () => {
 		const record = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
-			start: 6,
-			end: 6,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
+			_start: 6,
+			_end: 6,
 		};
 		const expected = {
-			formats: [ , , , , [ em ], , , , , , , ],
-			text: 'one 2 three',
-			start: 5,
-			end: 5,
+			_formats: [ , , , , [ em ], , , , , , , ],
+			_text: 'one 2 three',
+			_start: 5,
+			_end: 5,
 		};
 		const result = replace( deepFreeze( record ), 'two', '2' );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 1 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 1 );
 	} );
 
 	it( 'should replace string to record', () => {
 		const record = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
-			start: 6,
-			end: 6,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
+			_start: 6,
+			_end: 6,
 		};
 		const replacement = {
-			formats: [ , ],
-			text: '2',
+			_formats: [ , ],
+			_text: '2',
 		};
 		const expected = {
-			formats: [ , , , , , , , , , , , ],
-			text: 'one 2 three',
-			start: 5,
-			end: 5,
+			_formats: [ , , , , , , , , , , , ],
+			_text: 'one 2 three',
+			_start: 5,
+			_end: 5,
 		};
 		const result = replace( deepFreeze( record ), 'two', replacement );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 0 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 0 );
 	} );
 
 	it( 'should replace string to function', () => {
 		const record = {
-			formats: [ , , , , , , , , , , , , ],
-			text: 'abc12345#$*%',
-			start: 6,
-			end: 6,
+			_formats: [ , , , , , , , , , , , , ],
+			_text: 'abc12345#$*%',
+			_start: 6,
+			_end: 6,
 		};
 		const expected = {
-			formats: [ , , , , , , , , , , , , , , , , , , ],
-			text: 'abc - 12345 - #$*%',
-			start: 18,
-			end: 18,
+			_formats: [ , , , , , , , , , , , , , , , , , , ],
+			_text: 'abc - 12345 - #$*%',
+			_start: 18,
+			_end: 18,
 		};
 		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
 		const result = replace( deepFreeze( record ), /([^\d]*)(\d*)([^\w]*)/, ( match, p1, p2, p3 ) => {
@@ -77,6 +77,6 @@ describe( 'replace', () => {
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 0 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 0 );
 	} );
 } );

--- a/packages/rich-text/src/test/slice.js
+++ b/packages/rich-text/src/test/slice.js
@@ -1,3 +1,4 @@
+
 /**
  * External dependencies
  */
@@ -15,35 +16,35 @@ describe( 'slice', () => {
 
 	it( 'should slice', () => {
 		const record = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const expected = {
-			formats: [ , [ em ], [ em ] ],
-			text: ' tw',
+			_formats: [ , [ em ], [ em ] ],
+			_text: ' tw',
 		};
 		const result = slice( deepFreeze( record ), 3, 6 );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 2 );
 	} );
 
 	it( 'should slice record', () => {
 		const record = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
-			start: 3,
-			end: 6,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
+			_start: 3,
+			_end: 6,
 		};
 		const expected = {
-			formats: [ , [ em ], [ em ] ],
-			text: ' tw',
+			_formats: [ , [ em ], [ em ] ],
+			_text: ' tw',
 		};
 		const result = slice( deepFreeze( record ) );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
+		expect( getSparseArrayLength( result._formats ) ).toBe( 2 );
 	} );
 } );

--- a/packages/rich-text/src/test/split.js
+++ b/packages/rich-text/src/test/split.js
@@ -15,21 +15,21 @@ describe( 'split', () => {
 
 	it( 'should split', () => {
 		const record = {
-			start: 5,
-			end: 10,
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_start: 5,
+			_end: 10,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const expected = [
 			{
-				formats: [ , , , , [ em ], [ em ] ],
-				text: 'one tw',
+				_formats: [ , , , , [ em ], [ em ] ],
+				_text: 'one tw',
 			},
 			{
-				start: 0,
-				end: 0,
-				formats: [ [ em ], , , , , , , ],
-				text: 'o three',
+				_start: 0,
+				_end: 0,
+				_formats: [ [ em ], , , , , , , ],
+				_text: 'o three',
 			},
 		];
 		const result = split( deepFreeze( record ), 6, 6 );
@@ -37,28 +37,28 @@ describe( 'split', () => {
 		expect( result ).toEqual( expected );
 		result.forEach( ( item, index ) => {
 			expect( item ).not.toBe( record );
-			expect( getSparseArrayLength( item.formats ) )
-				.toBe( getSparseArrayLength( expected[ index ].formats ) );
+			expect( getSparseArrayLength( item._formats ) )
+				.toBe( getSparseArrayLength( expected[ index ]._formats ) );
 		} );
 	} );
 
 	it( 'should split with selection', () => {
 		const record = {
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
-			start: 6,
-			end: 6,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
+			_start: 6,
+			_end: 6,
 		};
 		const expected = [
 			{
-				formats: [ , , , , [ em ], [ em ] ],
-				text: 'one tw',
+				_formats: [ , , , , [ em ], [ em ] ],
+				_text: 'one tw',
 			},
 			{
-				formats: [ [ em ], , , , , , , ],
-				text: 'o three',
-				start: 0,
-				end: 0,
+				_formats: [ [ em ], , , , , , , ],
+				_text: 'o three',
+				_start: 0,
+				_end: 0,
 			},
 		];
 		const result = split( deepFreeze( record ) );
@@ -66,28 +66,28 @@ describe( 'split', () => {
 		expect( result ).toEqual( expected );
 		result.forEach( ( item, index ) => {
 			expect( item ).not.toBe( record );
-			expect( getSparseArrayLength( item.formats ) )
-				.toBe( getSparseArrayLength( expected[ index ].formats ) );
+			expect( getSparseArrayLength( item._formats ) )
+				.toBe( getSparseArrayLength( expected[ index ]._formats ) );
 		} );
 	} );
 
 	it( 'should split empty', () => {
 		const record = {
-			formats: [],
-			text: '',
-			start: 0,
-			end: 0,
+			_formats: [],
+			_text: '',
+			_start: 0,
+			_end: 0,
 		};
 		const expected = [
 			{
-				formats: [],
-				text: '',
+				_formats: [],
+				_text: '',
 			},
 			{
-				formats: [],
-				text: '',
-				start: 0,
-				end: 0,
+				_formats: [],
+				_text: '',
+				_start: 0,
+				_end: 0,
 			},
 		];
 		const result = split( deepFreeze( record ) );
@@ -95,28 +95,28 @@ describe( 'split', () => {
 		expect( result ).toEqual( expected );
 		result.forEach( ( item, index ) => {
 			expect( item ).not.toBe( record );
-			expect( getSparseArrayLength( item.formats ) )
-				.toBe( getSparseArrayLength( expected[ index ].formats ) );
+			expect( getSparseArrayLength( item._formats ) )
+				.toBe( getSparseArrayLength( expected[ index ]._formats ) );
 		} );
 	} );
 
 	it( 'should split multiline', () => {
 		const record = {
-			formats: [ , , , , , , , , , , ],
-			text: 'test\u2028\u2028test',
-			start: 5,
-			end: 5,
+			_formats: [ , , , , , , , , , , ],
+			_text: 'test\u2028\u2028test',
+			_start: 5,
+			_end: 5,
 		};
 		const expected = [
 			{
-				formats: [ , , , , ],
-				text: 'test',
+				_formats: [ , , , , ],
+				_text: 'test',
 			},
 			{
-				formats: [ , , , , ],
-				text: 'test',
-				start: 0,
-				end: 0,
+				_formats: [ , , , , ],
+				_text: 'test',
+				_start: 0,
+				_end: 0,
 			},
 		];
 		const result = split( deepFreeze( record ) );
@@ -124,44 +124,44 @@ describe( 'split', () => {
 		expect( result ).toEqual( expected );
 		result.forEach( ( item, index ) => {
 			expect( item ).not.toBe( record );
-			expect( getSparseArrayLength( item.formats ) )
-				.toBe( getSparseArrayLength( expected[ index ].formats ) );
+			expect( getSparseArrayLength( item._formats ) )
+				.toBe( getSparseArrayLength( expected[ index ]._formats ) );
 		} );
 	} );
 
 	it( 'should split search', () => {
 		const record = {
-			start: 6,
-			end: 16,
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , , , , , , , , , , , ],
-			text: 'one two three four five',
+			_start: 6,
+			_end: 16,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , , , , , , , , , , , ],
+			_text: 'one two three four five',
 		};
 		const expected = [
 			{
-				formats: [ , , , ],
-				text: 'one',
+				_formats: [ , , , ],
+				_text: 'one',
 			},
 			{
-				start: 2,
-				end: 3,
-				formats: [ [ em ], [ em ], [ em ] ],
-				text: 'two',
+				_start: 2,
+				_end: 3,
+				_formats: [ [ em ], [ em ], [ em ] ],
+				_text: 'two',
 			},
 			{
-				start: 0,
-				end: 5,
-				formats: [ , , , , , ],
-				text: 'three',
+				_start: 0,
+				_end: 5,
+				_formats: [ , , , , , ],
+				_text: 'three',
 			},
 			{
-				start: 0,
-				end: 2,
-				formats: [ , , , , ],
-				text: 'four',
+				_start: 0,
+				_end: 2,
+				_formats: [ , , , , ],
+				_text: 'four',
 			},
 			{
-				formats: [ , , , , ],
-				text: 'five',
+				_formats: [ , , , , ],
+				_text: 'five',
 			},
 		];
 		const result = split( deepFreeze( record ), ' ' );
@@ -169,32 +169,32 @@ describe( 'split', () => {
 		expect( result ).toEqual( expected );
 		result.forEach( ( item, index ) => {
 			expect( item ).not.toBe( record );
-			expect( getSparseArrayLength( item.formats ) )
-				.toBe( getSparseArrayLength( expected[ index ].formats ) );
+			expect( getSparseArrayLength( item._formats ) )
+				.toBe( getSparseArrayLength( expected[ index ]._formats ) );
 		} );
 	} );
 
 	it( 'should split search 2', () => {
 		const record = {
-			start: 5,
-			end: 6,
-			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
-			text: 'one two three',
+			_start: 5,
+			_end: 6,
+			_formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			_text: 'one two three',
 		};
 		const expected = [
 			{
-				formats: [ , , , ],
-				text: 'one',
+				_formats: [ , , , ],
+				_text: 'one',
 			},
 			{
-				start: 1,
-				end: 2,
-				formats: [ [ em ], [ em ], [ em ] ],
-				text: 'two',
+				_start: 1,
+				_end: 2,
+				_formats: [ [ em ], [ em ], [ em ] ],
+				_text: 'two',
 			},
 			{
-				formats: [ , , , , , ],
-				text: 'three',
+				_formats: [ , , , , , ],
+				_text: 'three',
 			},
 		];
 		const result = split( deepFreeze( record ), ' ' );
@@ -202,8 +202,8 @@ describe( 'split', () => {
 		expect( result ).toEqual( expected );
 		result.forEach( ( item, index ) => {
 			expect( item ).not.toBe( record );
-			expect( getSparseArrayLength( item.formats ) )
-				.toBe( getSparseArrayLength( expected[ index ].formats ) );
+			expect( getSparseArrayLength( item._formats ) )
+				.toBe( getSparseArrayLength( expected[ index ]._formats ) );
 		} );
 	} );
 } );

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -161,7 +161,7 @@ export function apply( value, current, multilineTag ) {
 
 	applyValue( body, current );
 
-	if ( value.start !== undefined ) {
+	if ( value._start !== undefined ) {
 		applySelection( selection, current );
 	}
 }

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -34,16 +34,16 @@ export function toTree( value, multilineTag, settings ) {
 		onStartIndex,
 		onEndIndex,
 	} = settings;
-	const { formats, text, start, end } = value;
-	const formatsLength = formats.length + 1;
+	const { _formats, _text, _start, _end } = value;
+	const formatsLength = _formats.length + 1;
 	const tree = createEmpty( tag );
 
 	append( tree, '' );
 
 	for ( let i = 0; i < formatsLength; i++ ) {
-		const character = text.charAt( i );
-		const characterFormats = formats[ i ];
-		const lastCharacterFormats = formats[ i - 1 ];
+		const character = _text.charAt( i );
+		const characterFormats = _formats[ i ];
+		const lastCharacterFormats = _formats[ i - 1 ];
 
 		let pointer = getLastChild( tree );
 
@@ -80,11 +80,11 @@ export function toTree( value, multilineTag, settings ) {
 			}
 		}
 
-		if ( onStartIndex && start === i + 1 ) {
+		if ( onStartIndex && _start === i + 1 ) {
 			onStartIndex( tree, pointer, multilineIndex );
 		}
 
-		if ( onEndIndex && end === i + 1 ) {
+		if ( onEndIndex && _end === i + 1 ) {
 			onEndIndex( tree, pointer, multilineIndex );
 		}
 	}

--- a/test/integration/full-content/fixtures/core__audio.json
+++ b/test/integration/full-content/fixtures/core__audio.json
@@ -6,8 +6,8 @@
         "attributes": {
             "src": "https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3",
             "caption": {
-                "formats": [],
-                "text": ""
+                "_formats": [],
+                "_text": ""
             },
             "autoplay": false,
             "loop": false,

--- a/test/integration/full-content/fixtures/core__button__center.json
+++ b/test/integration/full-content/fixtures/core__button__center.json
@@ -6,7 +6,7 @@
         "attributes": {
             "url": "https://github.com/WordPress/gutenberg",
             "text": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -28,7 +28,7 @@
                     null,
                     null
                 ],
-                "text": "Help build Gutenberg"
+                "_text": "Help build Gutenberg"
             },
             "align": "center"
         },

--- a/test/integration/full-content/fixtures/core__column.json
+++ b/test/integration/full-content/fixtures/core__column.json
@@ -11,7 +11,7 @@
                 "isValid": true,
                 "attributes": {
                     "content": {
-                        "formats": [
+                        "_formats": [
                             null,
                             null,
                             null,
@@ -38,7 +38,7 @@
                             null,
                             null
                         ],
-                        "text": "Column One, Paragraph One"
+                        "_text": "Column One, Paragraph One"
                     },
                     "dropCap": false
                 },
@@ -51,7 +51,7 @@
                 "isValid": true,
                 "attributes": {
                     "content": {
-                        "formats": [
+                        "_formats": [
                             null,
                             null,
                             null,
@@ -78,7 +78,7 @@
                             null,
                             null
                         ],
-                        "text": "Column One, Paragraph Two"
+                        "_text": "Column One, Paragraph Two"
                     },
                     "dropCap": false
                 },

--- a/test/integration/full-content/fixtures/core__columns.json
+++ b/test/integration/full-content/fixtures/core__columns.json
@@ -19,7 +19,7 @@
                         "isValid": true,
                         "attributes": {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -46,7 +46,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "Column One, Paragraph One"
+                                "_text": "Column One, Paragraph One"
                             },
                             "dropCap": false
                         },
@@ -59,7 +59,7 @@
                         "isValid": true,
                         "attributes": {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -86,7 +86,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "Column One, Paragraph Two"
+                                "_text": "Column One, Paragraph Two"
                             },
                             "dropCap": false
                         },
@@ -108,7 +108,7 @@
                         "isValid": true,
                         "attributes": {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -135,7 +135,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "Column Two, Paragraph One"
+                                "_text": "Column Two, Paragraph One"
                             },
                             "dropCap": false
                         },
@@ -148,7 +148,7 @@
                         "isValid": true,
                         "attributes": {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -177,7 +177,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "Column Three, Paragraph One"
+                                "_text": "Column Three, Paragraph One"
                             },
                             "dropCap": false
                         },

--- a/test/integration/full-content/fixtures/core__cover-image.json
+++ b/test/integration/full-content/fixtures/core__cover-image.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "title": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -18,7 +18,7 @@
                     null,
                     null
                 ],
-                "text": "Guten Berg!"
+                "_text": "Guten Berg!"
             },
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "contentAlign": "center",

--- a/test/integration/full-content/fixtures/core__embed.json
+++ b/test/integration/full-content/fixtures/core__embed.json
@@ -6,7 +6,7 @@
         "attributes": {
             "url": "https://example.com/",
             "caption": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -44,7 +44,7 @@
                     null,
                     null
                 ],
-                "text": "Embedded content from an example URL"
+                "_text": "Embedded content from an example URL"
             },
             "allowResponsive": true
         },

--- a/test/integration/full-content/fixtures/core__file__new-window.json
+++ b/test/integration/full-content/fixtures/core__file__new-window.json
@@ -7,19 +7,19 @@
             "id": 176,
             "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
             "fileName": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
                     null
                 ],
-                "text": "6546"
+                "_text": "6546"
             },
             "textLinkHref": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
             "textLinkTarget": "_blank",
             "showDownloadButton": true,
             "downloadButtonText": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -29,7 +29,7 @@
                     null,
                     null
                 ],
-                "text": "Download"
+                "_text": "Download"
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__file__no-download-button.json
+++ b/test/integration/full-content/fixtures/core__file__no-download-button.json
@@ -7,7 +7,7 @@
             "id": 176,
             "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
             "fileName": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -18,13 +18,13 @@
                     null,
                     null
                 ],
-                "text": "lkjfijwef"
+                "_text": "lkjfijwef"
             },
             "textLinkHref": "http://localhost:8888/?attachment_id=176",
             "showDownloadButton": false,
             "downloadButtonText": {
-                "formats": [],
-                "text": ""
+                "_formats": [],
+                "_text": ""
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__file__no-text-link.json
+++ b/test/integration/full-content/fixtures/core__file__no-text-link.json
@@ -7,12 +7,12 @@
             "id": 176,
             "href": "http://localhost:8888/wp-content/uploads/2018/05/keycodes.js",
             "fileName": {
-                "formats": [],
-                "text": ""
+                "_formats": [],
+                "_text": ""
             },
             "showDownloadButton": true,
             "downloadButtonText": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -22,7 +22,7 @@
                     null,
                     null
                 ],
-                "text": "Download"
+                "_text": "Download"
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__gallery.json
+++ b/test/integration/full-content/fixtures/core__gallery.json
@@ -9,16 +9,16 @@
                     "url": "https://cldup.com/uuUqE_dXzy.jpg",
                     "alt": "title",
                     "caption": {
-                        "formats": [],
-                        "text": ""
+                        "_formats": [],
+                        "_text": ""
                     }
                 },
                 {
                     "url": "http://google.com/hi.png",
                     "alt": "title",
                     "caption": {
-                        "formats": [],
-                        "text": ""
+                        "_formats": [],
+                        "_text": ""
                     }
                 }
             ],

--- a/test/integration/full-content/fixtures/core__gallery__columns.json
+++ b/test/integration/full-content/fixtures/core__gallery__columns.json
@@ -9,16 +9,16 @@
                     "url": "https://cldup.com/uuUqE_dXzy.jpg",
                     "alt": "title",
                     "caption": {
-                        "formats": [],
-                        "text": ""
+                        "_formats": [],
+                        "_text": ""
                     }
                 },
                 {
                     "url": "http://google.com/hi.png",
                     "alt": "title",
                     "caption": {
-                        "formats": [],
-                        "text": ""
+                        "_formats": [],
+                        "_text": ""
                     }
                 }
             ],

--- a/test/integration/full-content/fixtures/core__heading__h2-em.json
+++ b/test/integration/full-content/fixtures/core__heading__h2-em.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -56,7 +56,7 @@
                     null,
                     null
                 ],
-                "text": "The Inserter Tool"
+                "_text": "The Inserter Tool"
             },
             "level": 2
         },

--- a/test/integration/full-content/fixtures/core__heading__h2.json
+++ b/test/integration/full-content/fixtures/core__heading__h2.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -65,7 +65,7 @@
                     null,
                     null
                 ],
-                "text": "A picture is worth a thousand words, or so the saying goes"
+                "_text": "A picture is worth a thousand words, or so the saying goes"
             },
             "level": 2
         },

--- a/test/integration/full-content/fixtures/core__image.json
+++ b/test/integration/full-content/fixtures/core__image.json
@@ -7,8 +7,8 @@
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "alt": "",
             "caption": {
-                "formats": [],
-                "text": ""
+                "_formats": [],
+                "_text": ""
             },
             "linkDestination": "none"
         },

--- a/test/integration/full-content/fixtures/core__image__attachment-link.json
+++ b/test/integration/full-content/fixtures/core__image__attachment-link.json
@@ -7,8 +7,8 @@
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "alt": "",
             "caption": {
-                "formats": [],
-                "text": ""
+                "_formats": [],
+                "_text": ""
             },
             "href": "http://localhost:8888/?attachment_id=7",
             "linkDestination": "attachment"

--- a/test/integration/full-content/fixtures/core__image__center-caption.json
+++ b/test/integration/full-content/fixtures/core__image__center-caption.json
@@ -7,7 +7,7 @@
             "url": "https://cldup.com/YLYhpou2oq.jpg",
             "alt": "",
             "caption": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -76,7 +76,7 @@
                     null,
                     null
                 ],
-                "text": "Give it a try. Press the \"really wide\" button on the image toolbar."
+                "_text": "Give it a try. Press the \"really wide\" button on the image toolbar."
             },
             "align": "center",
             "linkDestination": "none"

--- a/test/integration/full-content/fixtures/core__image__custom-link.json
+++ b/test/integration/full-content/fixtures/core__image__custom-link.json
@@ -7,8 +7,8 @@
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "alt": "",
             "caption": {
-                "formats": [],
-                "text": ""
+                "_formats": [],
+                "_text": ""
             },
             "href": "https://wordpress.org/",
             "linkDestination": "custom"

--- a/test/integration/full-content/fixtures/core__image__media-link.json
+++ b/test/integration/full-content/fixtures/core__image__media-link.json
@@ -7,8 +7,8 @@
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "alt": "",
             "caption": {
-                "formats": [],
-                "text": ""
+                "_formats": [],
+                "_text": ""
             },
             "href": "https://cldup.com/uuUqE_dXzy.jpg",
             "linkDestination": "media"

--- a/test/integration/full-content/fixtures/core__list__ul.json
+++ b/test/integration/full-content/fixtures/core__list__ul.json
@@ -6,7 +6,7 @@
         "attributes": {
             "ordered": false,
             "values": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -221,7 +221,7 @@
                     null,
                     null
                 ],
-                "text": "Text & Headings Images & Videos Galleries Embeds, like YouTube, Tweets, or other WordPress posts. Layout blocks, like Buttons, Hero Images, Separators, etc. And Lists like this one of course :)"
+                "_text": "Text & Headings Images & Videos Galleries Embeds, like YouTube, Tweets, or other WordPress posts. Layout blocks, like Buttons, Hero Images, Separators, etc. And Lists like this one of course :)"
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__paragraph__align-right.json
+++ b/test/integration/full-content/fixtures/core__paragraph__align-right.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -77,7 +77,7 @@
                     null,
                     null
                 ],
-                "text": "... like this one, which is separate from the above and right aligned."
+                "_text": "... like this one, which is separate from the above and right aligned."
             },
             "align": "right",
             "dropCap": false

--- a/test/integration/full-content/fixtures/core__paragraph__deprecated.json
+++ b/test/integration/full-content/fixtures/core__paragraph__deprecated.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -52,7 +52,7 @@
                     null,
                     null
                 ],
-                "text": "Unwrapped is still valid."
+                "_text": "Unwrapped is still valid."
             },
             "dropCap": false
         },

--- a/test/integration/full-content/fixtures/core__preformatted.json
+++ b/test/integration/full-content/fixtures/core__preformatted.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -90,7 +90,7 @@
                     null,
                     null
                 ],
-                "text": "Some preformatted text...\nAnd more!"
+                "_text": "Some preformatted text...\nAnd more!"
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__pullquote.json
+++ b/test/integration/full-content/fixtures/core__pullquote.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "value": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -33,10 +33,10 @@
                     null,
                     null
                 ],
-                "text": "Testing pullquote block..."
+                "_text": "Testing pullquote block..."
             },
             "citation": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -55,7 +55,7 @@
                     null,
                     null
                 ],
-                "text": "...with a caption"
+                "_text": "...with a caption"
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.json
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "value": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -46,10 +46,10 @@
                     null,
                     null
                 ],
-                "text": "Paragraph one Paragraph two"
+                "_text": "Paragraph one Paragraph two"
             },
             "citation": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -62,7 +62,7 @@
                     null,
                     null
                 ],
-                "text": "by whomever"
+                "_text": "by whomever"
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__quote__style-1.json
+++ b/test/integration/full-content/fixtures/core__quote__style-1.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "value": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -239,10 +239,10 @@
                     null,
                     null
                 ],
-                "text": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
+                "_text": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
             },
             "citation": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -264,7 +264,7 @@
                     null,
                     null
                 ],
-                "text": "Matt Mullenweg, 2017"
+                "_text": "Matt Mullenweg, 2017"
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__quote__style-2.json
+++ b/test/integration/full-content/fixtures/core__quote__style-2.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "value": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -73,10 +73,10 @@
                     null,
                     null
                 ],
-                "text": "There is no greater agony than bearing an untold story inside you."
+                "_text": "There is no greater agony than bearing an untold story inside you."
             },
             "citation": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -90,7 +90,7 @@
                     null,
                     null
                 ],
-                "text": "Maya Angelou"
+                "_text": "Maya Angelou"
             },
             "className": "is-style-large"
         },

--- a/test/integration/full-content/fixtures/core__subhead.json
+++ b/test/integration/full-content/fixtures/core__subhead.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -53,7 +53,7 @@
                     ],
                     null
                 ],
-                "text": "This is a subhead."
+                "_text": "This is a subhead."
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__table.json
+++ b/test/integration/full-content/fixtures/core__table.json
@@ -10,7 +10,7 @@
                     "cells": [
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -19,13 +19,13 @@
                                     null,
                                     null
                                 ],
-                                "text": "Version"
+                                "_text": "Version"
                             },
                             "tag": "th"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -35,19 +35,19 @@
                                     null,
                                     null
                                 ],
-                                "text": "Musician"
+                                "_text": "Musician"
                             },
                             "tag": "th"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
                                     null
                                 ],
-                                "text": "Date"
+                                "_text": "Date"
                             },
                             "tag": "th"
                         }
@@ -59,7 +59,7 @@
                     "cells": [
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     [
                                         {
                                             "type": "a",
@@ -85,13 +85,13 @@
                                         }
                                     ]
                                 ],
-                                "text": ".70"
+                                "_text": ".70"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -112,13 +112,13 @@
                                     null,
                                     null
                                 ],
-                                "text": "No musician chosen."
+                                "_text": "No musician chosen."
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -132,7 +132,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "May 27, 2003"
+                                "_text": "May 27, 2003"
                             },
                             "tag": "td"
                         }
@@ -142,7 +142,7 @@
                     "cells": [
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     [
                                         {
                                             "type": "a",
@@ -168,13 +168,13 @@
                                         }
                                     ]
                                 ],
-                                "text": "1.0"
+                                "_text": "1.0"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -187,13 +187,13 @@
                                     null,
                                     null
                                 ],
-                                "text": "Miles Davis"
+                                "_text": "Miles Davis"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -210,7 +210,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "January 3, 2004"
+                                "_text": "January 3, 2004"
                             },
                             "tag": "td"
                         }
@@ -220,7 +220,7 @@
                     "cells": [
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -356,25 +356,25 @@
                                         }
                                     ]
                                 ],
-                                "text": "Lots of versions skipped, see the full list"
+                                "_text": "Lots of versions skipped, see the full list"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null
                                 ],
-                                "text": "…"
+                                "_text": "…"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null
                                 ],
-                                "text": "…"
+                                "_text": "…"
                             },
                             "tag": "td"
                         }
@@ -384,7 +384,7 @@
                     "cells": [
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     [
                                         {
                                             "type": "a",
@@ -410,13 +410,13 @@
                                         }
                                     ]
                                 ],
-                                "text": "4.4"
+                                "_text": "4.4"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -432,13 +432,13 @@
                                     null,
                                     null
                                 ],
-                                "text": "Clifford Brown"
+                                "_text": "Clifford Brown"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -456,7 +456,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "December 8, 2015"
+                                "_text": "December 8, 2015"
                             },
                             "tag": "td"
                         }
@@ -466,7 +466,7 @@
                     "cells": [
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     [
                                         {
                                             "type": "a",
@@ -492,13 +492,13 @@
                                         }
                                     ]
                                 ],
-                                "text": "4.5"
+                                "_text": "4.5"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -515,13 +515,13 @@
                                     null,
                                     null
                                 ],
-                                "text": "Coleman Hawkins"
+                                "_text": "Coleman Hawkins"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -537,7 +537,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "April 12, 2016"
+                                "_text": "April 12, 2016"
                             },
                             "tag": "td"
                         }
@@ -547,7 +547,7 @@
                     "cells": [
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     [
                                         {
                                             "type": "a",
@@ -573,13 +573,13 @@
                                         }
                                     ]
                                 ],
-                                "text": "4.6"
+                                "_text": "4.6"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -593,13 +593,13 @@
                                     null,
                                     null
                                 ],
-                                "text": "Pepper Adams"
+                                "_text": "Pepper Adams"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -616,7 +616,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "August 16, 2016"
+                                "_text": "August 16, 2016"
                             },
                             "tag": "td"
                         }
@@ -626,7 +626,7 @@
                     "cells": [
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     [
                                         {
                                             "type": "a",
@@ -652,13 +652,13 @@
                                         }
                                     ]
                                 ],
-                                "text": "4.7"
+                                "_text": "4.7"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -673,13 +673,13 @@
                                     null,
                                     null
                                 ],
-                                "text": "Sarah Vaughan"
+                                "_text": "Sarah Vaughan"
                             },
                             "tag": "td"
                         },
                         {
                             "content": {
-                                "formats": [
+                                "_formats": [
                                     null,
                                     null,
                                     null,
@@ -697,7 +697,7 @@
                                     null,
                                     null
                                 ],
-                                "text": "December 6, 2016"
+                                "_text": "December 6, 2016"
                             },
                             "tag": "td"
                         }

--- a/test/integration/full-content/fixtures/core__text-columns.json
+++ b/test/integration/full-content/fixtures/core__text-columns.json
@@ -7,22 +7,22 @@
             "content": [
                 {
                     "children": {
-                        "formats": [
+                        "_formats": [
                             null,
                             null,
                             null
                         ],
-                        "text": "One"
+                        "_text": "One"
                     }
                 },
                 {
                     "children": {
-                        "formats": [
+                        "_formats": [
                             null,
                             null,
                             null
                         ],
-                        "text": "Two"
+                        "_text": "Two"
                     }
                 }
             ],

--- a/test/integration/full-content/fixtures/core__text__converts-to-paragraph.json
+++ b/test/integration/full-content/fixtures/core__text__converts-to-paragraph.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     null,
@@ -107,7 +107,7 @@
                     null,
                     null
                 ],
-                "text": "This is an old-style text block.  Changed to paragraph in #2135."
+                "_text": "This is an old-style text block.  Changed to paragraph in #2135."
             },
             "dropCap": false
         },

--- a/test/integration/full-content/fixtures/core__verse.json
+++ b/test/integration/full-content/fixtures/core__verse.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": {
-                "formats": [
+                "_formats": [
                     null,
                     null,
                     [
@@ -45,7 +45,7 @@
                     null,
                     null
                 ],
-                "text": "A verse…\nAnd more!"
+                "_text": "A verse…\nAnd more!"
             }
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__video.json
+++ b/test/integration/full-content/fixtures/core__video.json
@@ -6,8 +6,8 @@
         "attributes": {
             "autoplay": false,
             "caption": {
-                "formats": [],
-                "text": ""
+                "_formats": [],
+                "_text": ""
             },
             "controls": true,
             "loop": false,


### PR DESCRIPTION
## Description

Prefix rich text value keys with underscore to communicate that they are internal/private and not meant to be read or written.

## How has this been tested?
Trust the automated tests. :) Ensure Gutenberg loads and functions properly.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
