### PR TITLE
Fix buggy behaviour on fast enter to split blocks

### DIFF
--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -70,9 +70,21 @@ export function toTree( value, multilineTag, settings ) {
 			} );
 		}
 
+		// If there is selection at 0, handle it before characters are inserted.
+
+		if ( onStartIndex && start === 0 && i === 0 ) {
+			onStartIndex( tree, pointer, multilineIndex );
+		}
+
+		if ( onEndIndex && end === 0 && i === 0 ) {
+			onEndIndex( tree, pointer, multilineIndex );
+		}
+
 		if ( character !== '\ufffc' ) {
 			if ( character === '\n' ) {
 				pointer = append( getParent( pointer ), { type: 'br', object: true } );
+				// Ensure pointer is text node.
+				pointer = append( getParent( pointer ), '' );
 			} else if ( ! isText( pointer ) ) {
 				pointer = append( getParent( pointer ), character );
 			} else {


### PR DESCRIPTION
## Description

WIP: this relies on #10297!
Also note that this fixes a bug that existed long before the new rich text value!

Fixes #6021. In master, keep enter pressed in a paragraph, and observe blocks with too many BR elements, or nested paragraph elements, or BR elements around existing text. This is caused by attaching the keydown handler too late (during TinyMCE setup), resulting in default browser behaviour executing. The solution is to attach handler on the content editable element with React as soon as the element is created.

## How has this been tested?
When keeping enter pressed in a paragraph, it should create a bunch a clean, empty paragraphs.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
