### PR TITLE
Try: Larger drag handles

### DIFF
--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -335,15 +335,10 @@
 @mixin resize-handler__container() {
 	display: none;
 
-	// The unfortunate use of `!important` in the CSS below is because the
-	// re-resizable package, which we use for our resize functionality,
-	// applies an inline `style` attribute that cannot be disabled.
-	// See https://github.com/WordPress/gutenberg/pull/10331
-
 	// The handle itself is a pseudo element, and will sit inside this larger
-	// container size
-	width: $resize-handler-container-size !important;
-	height: $resize-handler-container-size !important;
+	// container size.
+	width: $resize-handler-container-size;
+	height: $resize-handler-container-size;
 	padding: $grid-size-small;
 }
 

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -326,3 +326,34 @@
 	// icon standards.
 	margin-right: 2px;
 }
+
+
+/**
+ * Styles for resize handles
+ */
+
+@mixin resize-handler-container() {
+	display: none;
+
+	// The unfortunate use of `!important` in the CSS below is because the
+	// re-resizable package, which we use for our resize functionality,
+	// applies an inline `style` attribute that cannot be disabled.
+	// See https://github.com/WordPress/gutenberg/pull/10331
+
+	// The handle itself is a pseudo element, and will sit inside this larger
+	// container size
+	width: $resize-handler-container-size !important;
+	height: $resize-handler-container-size !important;
+	padding: $grid-size-small;
+}
+
+@mixin resize-handler() {
+	display: block;
+	content: "";
+	width: $resize-handler-size;
+	height: $resize-handler-size;
+	border: 2px solid $white;
+	border-radius: 50%;
+	background: theme(primary);
+	cursor: inherit;
+}

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -332,7 +332,7 @@
  * Styles for resize handles
  */
 
-@mixin resize-handler-container() {
+@mixin resize-handler__container() {
 	display: none;
 
 	// The unfortunate use of `!important` in the CSS below is because the
@@ -347,7 +347,7 @@
 	padding: $grid-size-small;
 }
 
-@mixin resize-handler() {
+@mixin resize-handler__visible-handle() {
 	display: block;
 	content: "";
 	width: $resize-handler-size;

--- a/edit-post/assets/stylesheets/_variables.scss
+++ b/edit-post/assets/stylesheets/_variables.scss
@@ -48,6 +48,7 @@ $icon-button-size: 36px;
 $icon-button-size-small: 24px;
 $inserter-tabs-height: 36px;
 $block-toolbar-height: $block-controls-height + $border-width;
+$resize-handler-size: 16px;
 
 // Blocks
 $block-padding: 14px; // padding of nested blocks

--- a/edit-post/assets/stylesheets/_variables.scss
+++ b/edit-post/assets/stylesheets/_variables.scss
@@ -49,6 +49,7 @@ $icon-button-size-small: 24px;
 $inserter-tabs-height: 36px;
 $block-toolbar-height: $block-controls-height + $border-width;
 $resize-handler-size: 16px;
+$resize-handler-container-size: $resize-handler-size + ($grid-size-small * 2); // Make the resize handle container larger so there's a larger grabbable area.
 
 // Blocks
 $block-padding: 14px; // padding of nested blocks

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -431,6 +431,16 @@ class ImageEdit extends Component {
 							}
 							/* eslint-enable no-lonely-if */
 
+							// Removes the inline styles in the drag handles
+							const handleStylesOverrides = {
+								width: null,
+								height: null,
+								top: null,
+								right: null,
+								bottom: null,
+								left: null,
+							};
+
 							return (
 								<Fragment>
 									{ getInspectorControls( imageWidth, imageHeight ) }
@@ -451,6 +461,11 @@ class ImageEdit extends Component {
 											right: 'block-library-image__resize-handler-right',
 											bottom: 'block-library-image__resize-handler-bottom',
 											left: 'block-library-image__resize-handler-left',
+										} }
+										handleStyles={ {
+											right: handleStylesOverrides,
+											bottom: handleStylesOverrides,
+											left: handleStylesOverrides,
 										} }
 										enable={ {
 											top: false,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -431,7 +431,7 @@ class ImageEdit extends Component {
 							}
 							/* eslint-enable no-lonely-if */
 
-							// Removes the inline styles in the drag handles
+							// Removes the inline styles in the drag handles.
 							const handleStylesOverrides = {
 								width: null,
 								height: null,

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -41,24 +41,19 @@
 }
 
 /*!rtl:begin:ignore*/
-// The unfortunate use of `!important` in the CSS below is because the
-// re-resizable package, which we use for our resize functionality,
-// applies an inline `style` attribute that cannot be disabled.
-// See https://github.com/WordPress/gutenberg/pull/10331
-
 .block-library-image__resize-handler-right {
-	top: calc(50% - #{$resize-handler-container-size / 2}) !important;
-	right: calc(#{$resize-handler-container-size / 2} * -1) !important;
+	top: calc(50% - #{$resize-handler-container-size / 2});
+	right: calc(#{$resize-handler-container-size / 2} * -1);
 }
 
 .block-library-image__resize-handler-left {
-	top: calc(50% - #{$resize-handler-container-size / 2}) !important;
-	left: calc(#{$resize-handler-container-size / 2} * -1) !important;
+	top: calc(50% - #{$resize-handler-container-size / 2});
+	left: calc(#{$resize-handler-container-size / 2} * -1);
 }
 
 .block-library-image__resize-handler-bottom {
-	bottom: calc(#{$resize-handler-container-size / 2} * -1) !important;
-	left: calc(50% - #{$resize-handler-container-size / 2}) !important;
+	bottom: calc(#{$resize-handler-container-size / 2} * -1);
+	left: calc(50% - #{$resize-handler-container-size / 2});
 }
 /*!rtl:end:ignore*/
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -25,13 +25,7 @@
 .block-library-image__resize-handler-right,
 .block-library-image__resize-handler-bottom,
 .block-library-image__resize-handler-left {
-	display: none;
-	border-radius: 50%;
-	border: 2px solid $white;
-	width: 16px !important;
-	height: 16px !important;
-	position: absolute;
-	background: theme(primary);
+	@include resize-handler-container();
 
 	.wp-block-image.is-focused & {
 		display: block;
@@ -39,20 +33,32 @@
 	}
 }
 
+// Draw the visible handle
+.block-library-image__resize-handler-right::before,
+.block-library-image__resize-handler-bottom::before,
+.block-library-image__resize-handler-left::before {
+	@include resize-handler();
+}
+
 /*!rtl:begin:ignore*/
+// The unfortunate use of `!important` in the CSS below is because the
+// re-resizable package, which we use for our resize functionality,
+// applies an inline `style` attribute that cannot be disabled.
+// See https://github.com/WordPress/gutenberg/pull/10331
+
 .block-library-image__resize-handler-right {
-	top: calc(50% - 9px) !important;
-	right: -8px !important;
+	top: calc(50% - #{$resize-handler-container-size / 2}) !important;
+	right: calc(#{$resize-handler-container-size / 2} * -1) !important;
 }
 
 .block-library-image__resize-handler-left {
-	top: calc(50% - 9px) !important;
-	left: -8px !important;
+	top: calc(50% - #{$resize-handler-container-size / 2}) !important;
+	left: calc(#{$resize-handler-container-size / 2} * -1) !important;
 }
 
 .block-library-image__resize-handler-bottom {
-	bottom: -8px !important;
-	left: calc(50% - 9px) !important;
+	bottom: calc(#{$resize-handler-container-size / 2} * -1) !important;
+	left: calc(50% - #{$resize-handler-container-size / 2}) !important;
 }
 /*!rtl:end:ignore*/
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -25,7 +25,7 @@
 .block-library-image__resize-handler-right,
 .block-library-image__resize-handler-bottom,
 .block-library-image__resize-handler-left {
-	@include resize-handler-container();
+	@include resize-handler__container();
 
 	.wp-block-image.is-focused & {
 		display: block;
@@ -37,7 +37,7 @@
 .block-library-image__resize-handler-right::before,
 .block-library-image__resize-handler-bottom::before,
 .block-library-image__resize-handler-left::before {
-	@include resize-handler();
+	@include resize-handler__visible-handle();
 }
 
 /*!rtl:begin:ignore*/

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -9,7 +9,7 @@
 }
 
 .block-library-spacer__resize-handler-bottom {
-	@include resize-handler-container();
+	@include resize-handler__container();
 
 	// Offset the handle container's position.
 	position: absolute;
@@ -18,5 +18,5 @@
 }
 
 .block-library-spacer__resize-handler-bottom::before {
-	@include resize-handler();
+	@include resize-handler__visible-handle();
 }

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,5 +1,4 @@
 .block-library-spacer__resize-container.is-selected {
-	.block-library-spacer__resize-handler-top,
 	.block-library-spacer__resize-handler-bottom {
 		display: block;
 	}
@@ -9,17 +8,32 @@
 	background: $light-gray-200;
 }
 
-.block-library-spacer__resize-handler-top,
 .block-library-spacer__resize-handler-bottom {
 	display: none;
-	border-radius: 50%;
-	border: 2px solid $white;
-	width: 15px !important;
-	height: 15px !important;
+
+	// Make the container larger so there's a larger grabbable area
+	$resize-handler-container-size: $resize-handler-size + ($grid-size-small * 2);
+
+	// Offset the handle's position
 	position: absolute;
-	background: theme(primary);
+	left: calc(50% - #{$resize-handler-container-size / 2}) !important;
+	bottom: calc(#{$resize-handler-container-size / 2} * -1) !important;
+
+	// Apply the width/height of the container size plus padding so the handle
+	// sits in the middle of the grabbable area
+	width: $resize-handler-container-size !important;
+	height: $resize-handler-container-size !important;
+	padding: $grid-size-small;
+}
+
+.block-library-spacer__resize-handler-bottom::before {
+	display: block;
+	content: "";
+	border: 2px solid $white;
+	border-radius: 50%;
+	width: $resize-handler-size !important;
+	height: $resize-handler-size !important;
 	padding: 0 3px 3px 0;
+	background: theme(primary);
 	cursor: se-resize;
-	left: 50% !important;
-	margin-left: -7.5px;
 }

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -9,31 +9,14 @@
 }
 
 .block-library-spacer__resize-handler-bottom {
-	display: none;
+	@include resize-handler-container();
 
-	// Make the container larger so there's a larger grabbable area
-	$resize-handler-container-size: $resize-handler-size + ($grid-size-small * 2);
-
-	// Offset the handle's position
+	// Offset the handle container's position.
 	position: absolute;
-	left: calc(50% - #{$resize-handler-container-size / 2}) !important;
 	bottom: calc(#{$resize-handler-container-size / 2} * -1) !important;
-
-	// Apply the width/height of the container size plus padding so the handle
-	// sits in the middle of the grabbable area
-	width: $resize-handler-container-size !important;
-	height: $resize-handler-container-size !important;
-	padding: $grid-size-small;
+	left: calc(50% - #{$resize-handler-container-size / 2}) !important;
 }
 
 .block-library-spacer__resize-handler-bottom::before {
-	display: block;
-	content: "";
-	border: 2px solid $white;
-	border-radius: 50%;
-	width: $resize-handler-size !important;
-	height: $resize-handler-size !important;
-	padding: 0 3px 3px 0;
-	background: theme(primary);
-	cursor: se-resize;
+	@include resize-handler();
 }

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -13,8 +13,8 @@
 
 	// Offset the handle container's position.
 	position: absolute;
-	bottom: calc(#{$resize-handler-container-size / 2} * -1) !important;
-	left: calc(50% - #{$resize-handler-container-size / 2}) !important;
+	bottom: calc(#{$resize-handler-container-size / 2} * -1);
+	left: calc(50% - #{$resize-handler-container-size / 2});
 }
 
 .block-library-spacer__resize-handler-bottom::before {

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -36,6 +36,16 @@ export const settings = {
 			const { height } = attributes;
 			const id = `block-spacer-height-input-${ instanceId }`;
 
+			// Removes the inline styles in the drag handle
+			const handleStylesOverrides = {
+				width: null,
+				height: null,
+				top: null,
+				right: null,
+				bottom: null,
+				left: null,
+			};
+
 			return (
 				<Fragment>
 					<ResizableBox
@@ -48,8 +58,10 @@ export const settings = {
 						} }
 						minHeight="20"
 						handleClasses={ {
-							top: 'block-library-spacer__resize-handler-top',
 							bottom: 'block-library-spacer__resize-handler-bottom',
+						} }
+						handleStyles={ {
+							bottom: handleStylesOverrides,
 						} }
 						enable={ {
 							top: false,

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -36,7 +36,7 @@ export const settings = {
 			const { height } = attributes;
 			const id = `block-spacer-height-input-${ instanceId }`;
 
-			// Removes the inline styles in the drag handle
+			// Removes the inline styles in the drag handles.
 			const handleStylesOverrides = {
 				width: null,
 				height: null,


### PR DESCRIPTION
This is an attempt to make a larger target area for drag handles. The handle itself doesn't change its appearance, but you now have a larger target area for your cursor, as depicted here:

![fullscreen_4_10_18__10_49](https://user-images.githubusercontent.com/1231306/46482346-6c0ad700-c7c3-11e8-94a2-7431b0d52d90.png)

Basically the visible handle is now a pseudo element positioned inside the larger handle container.

Fixes #8206 — the larger target area makes it a bit easier to grab the handle when there's a block below the spacer block.

I'd like to also extend this to the image block but just want the OK before going forward with that.

### Some other notes:

I introduced a new variable, `$resize-handler-size: 16px`, because until now the spacer and image drag handles were different sizes (15px and 16px respectively). If this approach is worth moving forward with, I'll use this variable on the image drag handles as well.

I am also using another new variable `$resize-handler-container-size` to calculate the size of the container (the drag handle plus padding). I'm doing it inline in the spacer block drag handle CSS block but if this moves forward I would move it in with the other variables. This is just temporary :)