### PR TITLE
Adjust media upload source for rich text

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -130,8 +130,7 @@ attributes: {
 		attribute: 'src',
 	},
 	author: {
-		type: 'string',
-		source: 'children',
+		source: 'rich-text',
 		selector: '.book-author',
 	},
 	pages: {

--- a/docs/block-api/deprecated-blocks.md
+++ b/docs/block-api/deprecated-blocks.md
@@ -204,8 +204,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 		{
 			attributes: {
 				title: {
-					type: 'array',
-					source: 'children',
+					source: 'rich-text',
 					selector: 'p',
 				},
 			},
@@ -245,8 +244,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 		{
 			attributes: {
 				title: {
-					type: 'array',
-					source: 'children',
+					source: 'rich-text',
 					selector: 'p',
 				},
 			},

--- a/docs/blocks/block-controls-toolbars-and-inspector.md
+++ b/docs/blocks/block-controls-toolbars-and-inspector.md
@@ -29,8 +29,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 
 	attributes: {
 		content: {
-			type: 'array',
-			source: 'children',
+			source: 'rich-text',
 			selector: 'p',
 		},
 		alignment: {
@@ -111,8 +110,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 
 	attributes: {
 		content: {
-			type: 'array',
-			source: 'children',
+			source: 'rich-text',
 			selector: 'p',
 		},
 		alignment: {

--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -24,8 +24,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 
 	attributes: {
 		content: {
-			type: 'array',
-			source: 'children',
+			source: 'rich-text',
 			selector: 'p',
 		}
 	},
@@ -73,8 +72,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 
 	attributes: {
 		content: {
-			type: 'array',
-			source: 'children',
+			source: 'rich-text',
 			selector: 'p',
 		},
 	},
@@ -100,10 +98,10 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 		const { content } = attributes;
 
 		return (
-			<RichText.Content 
-				tagName="p" 
-				className={ className } 
-				value={ content } 
+			<RichText.Content
+				tagName="p"
+				className={ className }
+				value={ content }
 			/>
 		);
 	},
@@ -123,4 +121,4 @@ The `RichText` component can be considered as a super-powered `textarea` element
 
 Implementing this behavior as a component enables you as the block implementer to be much more granular about editable fields. Your block may not need `RichText` at all, or it may need many independent `RichText` elements, each operating on a subset of the overall block state.
 
-Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `children` attribute source when extracting the value from saved content. You'll also use `RichText.Content` in the `save` function to output RichText values.
+Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `rich-text` attribute source when extracting the value from saved content. You'll also use `RichText.Content` in the `save` function to output RichText values.

--- a/edit-post/hooks/components/media-upload/index.js
+++ b/edit-post/hooks/components/media-upload/index.js
@@ -209,7 +209,7 @@ class MediaUpload extends Component {
 		return ! mediaObject.caption ?
 			mediaObject :
 			{ ...mediaObject, caption: parseWithAttributeSchema( mediaObject.caption, {
-				source: 'children',
+				source: 'rich-text',
 			} ) };
 	}
 

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -97,7 +97,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/file', {
 						href: attributes.src,
-						fileName: attributes.caption && attributes.caption.join(),
+						fileName: attributes.caption,
 						textLinkHref: attributes.src,
 						id: attributes.id,
 					} );
@@ -109,7 +109,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/file', {
 						href: attributes.src,
-						fileName: attributes.caption && attributes.caption.join(),
+						fileName: attributes.caption,
 						textLinkHref: attributes.src,
 						id: attributes.id,
 					} );
@@ -121,7 +121,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/file', {
 						href: attributes.url,
-						fileName: attributes.caption && attributes.caption.join(),
+						fileName: attributes.caption,
 						textLinkHref: attributes.url,
 						id: attributes.id,
 					} );
@@ -143,7 +143,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/audio', {
 						src: attributes.href,
-						caption: [ attributes.fileName ],
+						caption: attributes.fileName,
 						id: attributes.id,
 					} );
 				},
@@ -162,7 +162,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/video', {
 						src: attributes.href,
-						caption: [ attributes.fileName ],
+						caption: attributes.fileName,
 						id: attributes.id,
 					} );
 				},
@@ -181,7 +181,7 @@ export const settings = {
 				transform: ( attributes ) => {
 					return createBlock( 'core/image', {
 						url: attributes.href,
-						caption: [ attributes.fileName ],
+						caption: attributes.fileName,
 						id: attributes.id,
 					} );
 				},

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -26,6 +26,7 @@ import {
 	InspectorControls,
 	mediaUpload,
 } from '@wordpress/editor';
+import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -44,9 +45,17 @@ export function defaultColumnsNumber( attributes ) {
 	return Math.min( 3, attributes.images.length );
 }
 
-const RELEVANT_MEDIA_FIELDS = [ 'alt', 'caption', 'id', 'link', 'url' ];
 export const pickRelevantMediaFiles = ( image ) => {
-	return pick( image, RELEVANT_MEDIA_FIELDS );
+	let { caption } = image;
+
+	if ( typeof caption !== 'object' ) {
+		caption = create( { html: caption } );
+	}
+
+	return {
+		...pick( image, [ 'alt', 'id', 'link', 'url' ] ),
+		caption,
+	};
 };
 
 class GalleryEdit extends Component {

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -123,7 +123,7 @@ class GalleryImage extends Component {
 					</div>
 				}
 				{ href ? <a href={ href }>{ img }</a> : img }
-				{ ( caption && caption.length > 0 ) || isSelected ? (
+				{ ( ! RichText.isEmpty( caption ) || isSelected ) ? (
 					<RichText
 						tagName="figcaption"
 						placeholder={ __( 'Write caption…' ) }

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -130,13 +130,17 @@ export const settings = {
 				},
 				transform( files, onChange ) {
 					const block = createBlock( 'core/gallery', {
-						images: files.map( ( file ) => ( { url: createBlobURL( file ) } ) ),
+						images: files.map( ( file ) => pickRelevantMediaFiles( {
+							url: createBlobURL( file ),
+						} ) ),
 					} );
 					mediaUpload( {
 						filesList: files,
-						onFileChange: ( images ) => onChange( block.clientId, {
-							images: images.map( ( image ) => pickRelevantMediaFiles( image ) ),
-						} ),
+						onFileChange: ( images ) => {
+							onChange( block.clientId, {
+								images: images.map( ( image ) => pickRelevantMediaFiles( image ) ),
+							} );
+						},
 						allowedTypes: [ 'image' ],
 					} );
 					return block;

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -40,6 +40,7 @@ import {
 } from '@wordpress/editor';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose } from '@wordpress/compose';
+import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -55,7 +56,19 @@ const LINK_DESTINATION_MEDIA = 'media';
 const LINK_DESTINATION_ATTACHMENT = 'attachment';
 const LINK_DESTINATION_CUSTOM = 'custom';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
-export const RELEVANT_MEDIA_FIELDS = [ 'alt', 'caption', 'id', 'url' ];
+
+export const pickRelevantMediaFiles = ( image ) => {
+	let { caption } = image;
+
+	if ( typeof caption !== 'object' ) {
+		caption = create( { html: caption } );
+	}
+
+	return {
+		...pick( image, [ 'alt', 'id', 'link', 'url' ] ),
+		caption,
+	};
+};
 
 class ImageEdit extends Component {
 	constructor() {
@@ -88,7 +101,7 @@ class ImageEdit extends Component {
 				mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ image ] ) => {
-						setAttributes( { ...pick( image, RELEVANT_MEDIA_FIELDS ) } );
+						setAttributes( pickRelevantMediaFiles( image ) );
 					},
 					allowedTypes: ALLOWED_MEDIA_TYPES,
 				} );
@@ -117,12 +130,13 @@ class ImageEdit extends Component {
 				url: undefined,
 				alt: undefined,
 				id: undefined,
-				caption: undefined,
+				caption: create(),
 			} );
 			return;
 		}
+
 		this.props.setAttributes( {
-			...pick( media, RELEVANT_MEDIA_FIELDS ),
+			...pickRelevantMediaFiles( media ),
 			width: undefined,
 			height: undefined,
 		} );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -495,7 +495,7 @@ class ImageEdit extends Component {
 						<RichText
 							tagName="figcaption"
 							placeholder={ __( 'Write caption…' ) }
-							value={ caption || [] }
+							value={ caption }
 							unstableOnFocus={ this.onFocusCaption }
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
 							isSelected={ this.state.captionFocused }

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -158,7 +158,7 @@ export const settings = {
 						selector: 'img',
 					},
 					caption: {
-						type: 'array',
+						type: 'rich-text',
 						// To do: needs to support HTML.
 						source: 'text',
 					},

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
 import { createBlobURL } from '@wordpress/blob';
+import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -158,9 +159,11 @@ export const settings = {
 						selector: 'img',
 					},
 					caption: {
-						type: 'rich-text',
-						// To do: needs to support HTML.
-						source: 'text',
+						shortcode: ( attributes, { shortcode } ) => {
+							const { content } = shortcode;
+							const html = content.replace( /\s*<img[^>]*>\s/, '' );
+							return create( { html } );
+						},
 					},
 					href: {
 						type: 'string',

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -115,6 +115,7 @@ describe( 'Blocks raw handling', () => {
 			'markdown',
 			'wordpress',
 			'gutenberg',
+			'caption-shortcode',
 		].forEach( ( type ) => {
 			it( type, () => {
 				const HTML = readFile( path.join( __dirname, `fixtures/${ type }-in.html` ) );

--- a/test/integration/fixtures/caption-shortcode-in.html
+++ b/test/integration/fixtures/caption-shortcode-in.html
@@ -1,0 +1,1 @@
+<p>[caption id="attachment_122" align="alignnone" width="300"]<img class="size-medium wp-image-122" src="image.png" alt="" width="300" height="101" /> test[/caption]</p>

--- a/test/integration/fixtures/caption-shortcode-out.html
+++ b/test/integration/fixtures/caption-shortcode-out.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"id":122,"align":"none","className":"size-medium wp-image-122"} -->
+<figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption>test</figcaption></figure>
+<!-- /wp:image -->


### PR DESCRIPTION
## Description

1) Fixes media blocks to use `rich-text` source on upload.
2) Fixes file block transforms.
3) Updates some docs to use `rich-text` instead of `children`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
