### PR TITLE
i18n: Minor fixes after deprecations were removed

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -163,7 +163,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-i18n',
 		gutenberg_url( 'build/i18n/index.js' ),
-		array( 'wp-deprecated', 'wp-polyfill' ),
+		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/i18n/index.js' ),
 		true
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,6 +2249,7 @@
 				"classnames": "^2.2.5",
 				"dom-scroll-into-view": "^1.2.1",
 				"inherits": "^2.0.3",
+				"jquery": "^3.3.1",
 				"lodash": "^4.17.10",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
@@ -2294,7 +2295,6 @@
 			"version": "file:packages/i18n",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
-				"@wordpress/deprecated": "file:packages/deprecated",
 				"gettext-parser": "^1.3.1",
 				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
@@ -20606,7 +20606,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 3.0.0 (2018-09-30)
 
-### Braking Change
+### Breaking Change
 
-- `wp.i18n.getI18n` has been removed. Use `__`, `_x`, `_n`, or `_nx` instead.
-- `wp.i18n.dcnpgettext` has been removed. Use `__`, `_x`, `_n`, or `_nx` instead.
+- `getI18n` has been removed. Use `__`, `_x`, `_n`, or `_nx` instead.
+- `dcnpgettext` has been removed. Use `__`, `_x`, `_n`, or `_nx` instead.
 
 ## 2.0.0 (2018-09-05)
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,7 +24,6 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
-		"@wordpress/deprecated": "file:../deprecated",
 		"gettext-parser": "^1.3.1",
 		"jed": "^1.1.1",
 		"lodash": "^4.17.10",


### PR DESCRIPTION
## Description
Follow-up for #10153.

This PR addresses a few minor issues missed when deprecation functions from i18n package.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
