### PR TITLE
Fix small lineheight issue in editor style

### DIFF
--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -7,6 +7,7 @@
 .editor-rich-text__tinymce {
 	margin: 0;
 	position: relative;
+	line-height: $editor-line-height;
 
 	> p:empty {
 		min-height: $editor-font-size * $editor-line-height;
@@ -105,10 +106,6 @@
 	// To ensure legibility, we increase the default placeholder opacity to ensure contrast.
 	&[data-is-placeholder-visible="true"] + figcaption.editor-rich-text__tinymce {
 		opacity: 0.8;
-	}
-
-	&.mce-content-body {
-		line-height: $editor-line-height;
 	}
 }
 

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -11,6 +11,7 @@ body {
 
 p {
 	font-size: $editor-font-size;
+	line-height: $editor-line-height;
 }
 
 

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -11,7 +11,6 @@ body {
 
 p {
 	font-size: $editor-font-size;
-	line-height: $editor-line-height;
 }
 
 


### PR DESCRIPTION
In the editor, the line-height for text is 1.8. This is assigned on the Rich Text component directly.

But when you apply a text style manipulation, then reset it, this lineheight disappears, for some reason I'm not fully understanding.

This PR fixes that by simply assigning the lineheight to the p in the editor style.

To your incoming question: why doesn't the P inherit the lineheight from the body? Well, because WordPress itself applies a 1.5 lineheight to the p tag directly, which our editor inherits

(ノ°Д°)ノ︵ ┻━┻

GIF of the bug:

![the bug](https://user-images.githubusercontent.com/1204802/46498407-5f9a7480-c7eb-11e8-8ea1-d7c5aa6bd33c.gif)

GIF of the fix:

![fix](https://user-images.githubusercontent.com/1204802/46498414-632dfb80-c7eb-11e8-8656-6e4c182d3ea7.gif)
