### PR TITLE
RichText: Ensure HTML can be created from serialized object

### DIFF
--- a/packages/rich-text/src/normalise-formats.js
+++ b/packages/rich-text/src/normalise-formats.js
@@ -17,7 +17,7 @@ export function normaliseFormats( { formats, text, start, end } ) {
 	newFormats.forEach( ( formatsAtIndex, index ) => {
 		const lastFormatsAtIndex = newFormats[ index - 1 ];
 
-		if ( lastFormatsAtIndex ) {
+		if ( lastFormatsAtIndex && formatsAtIndex ) {
 			const newFormatsAtIndex = formatsAtIndex.slice( 0 );
 
 			newFormatsAtIndex.forEach( ( format, formatIndex ) => {
@@ -29,6 +29,8 @@ export function normaliseFormats( { formats, text, start, end } ) {
 			} );
 
 			newFormats[ index ] = newFormatsAtIndex;
+		} else if ( ! formatsAtIndex ) {
+			delete newFormats[ index ];
 		}
 	} );
 

--- a/packages/rich-text/src/test/normalise-formats.js
+++ b/packages/rich-text/src/test/normalise-formats.js
@@ -27,5 +27,7 @@ describe( 'normaliseFormats', () => {
 		expect( result.formats[ 1 ][ 0 ] ).toBe( result.formats[ 2 ][ 0 ] );
 		expect( result.formats[ 1 ][ 0 ] ).toBe( result.formats[ 3 ][ 0 ] );
 		expect( result.formats[ 2 ][ 1 ] ).toBe( result.formats[ 3 ][ 1 ] );
+		// Should be serializable.
+		expect( JSON.stringify( record ) ).toBe( JSON.stringify( result ) );
 	} );
 } );

--- a/packages/rich-text/src/test/normalise-formats.js
+++ b/packages/rich-text/src/test/normalise-formats.js
@@ -13,21 +13,36 @@ import { getSparseArrayLength } from './helpers';
 describe( 'normaliseFormats', () => {
 	const strong = { type: 'strong' };
 	const em = { type: 'em' };
+	const record = deepFreeze( {
+		formats: [ , [ em ], [ { ...em }, { ...strong } ], [ em, strong ], , , ],
+		text: 'one two',
+	} );
 
-	it( 'should normalise formats', () => {
-		const record = {
-			formats: [ , [ em ], [ { ...em }, { ...strong } ], [ em, strong ] ],
-			text: 'one two three',
-		};
-		const result = normaliseFormats( deepFreeze( record ) );
-
-		expect( result ).toEqual( record );
-		expect( result ).not.toBe( record );
+	function isNormalised( result ) {
 		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
 		expect( result.formats[ 1 ][ 0 ] ).toBe( result.formats[ 2 ][ 0 ] );
 		expect( result.formats[ 1 ][ 0 ] ).toBe( result.formats[ 3 ][ 0 ] );
 		expect( result.formats[ 2 ][ 1 ] ).toBe( result.formats[ 3 ][ 1 ] );
-		// Should be serializable.
+	}
+
+	it( 'should normalise formats', () => {
+		const result = normaliseFormats( record );
+
+		expect( result ).toEqual( record );
+		expect( result ).not.toBe( record );
+		isNormalised( result );
+	} );
+
+	it( 'should be serializable', () => {
+		const result = normaliseFormats( record );
 		expect( JSON.stringify( record ) ).toBe( JSON.stringify( result ) );
+	} );
+
+	it( 'should normalise serialized formats', () => {
+		const deserialized = JSON.parse( JSON.stringify( record ) );
+		const result = normaliseFormats( deserialized );
+
+		expect( result ).toEqual( record );
+		isNormalised( result );
 	} );
 } );

--- a/packages/rich-text/src/test/to-html-string.js
+++ b/packages/rich-text/src/test/to-html-string.js
@@ -78,4 +78,16 @@ describe( 'toHTMLString', () => {
 
 		expect( toHTMLString( create( { element } ) ) ).toEqual( expectedHTML );
 	} );
+
+	it( 'should be able to work from serialized value (without references)', () => {
+		expect( toHTMLString( {
+			text: 'test',
+			formats: [
+				[ { type: 'strong' } ],
+				[ { type: 'strong' } ],
+				[ { type: 'strong' } ],
+				[ { type: 'strong' } ],
+			],
+		} ) ).toEqual( '<strong>test</strong>' );
+	} );
 } );

--- a/packages/rich-text/src/test/to-html-string.js
+++ b/packages/rich-text/src/test/to-html-string.js
@@ -81,13 +81,12 @@ describe( 'toHTMLString', () => {
 
 	it( 'should be able to work from serialized value (without references)', () => {
 		expect( toHTMLString( {
-			text: 'test',
+			text: 'abc',
 			formats: [
+				null,
 				[ { type: 'strong' } ],
-				[ { type: 'strong' } ],
-				[ { type: 'strong' } ],
-				[ { type: 'strong' } ],
+				null,
 			],
-		} ) ).toEqual( '<strong>test</strong>' );
+		} ) ).toEqual( 'a<strong>b</strong>c' );
 	} );
 } );

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -3,6 +3,7 @@
  */
 
 import { split } from './split';
+import { normaliseFormats } from './normalise-formats';
 
 export function toTree( value, multilineTag, settings ) {
 	if ( multilineTag ) {
@@ -35,7 +36,7 @@ export function toTree( value, multilineTag, settings ) {
 		onEndIndex,
 		onEmpty,
 	} = settings;
-	const { formats, text, start, end } = value;
+	const { formats, text, start, end } = normaliseFormats( value );
 	const formatsLength = formats.length + 1;
 	const tree = createEmpty( tag );
 


### PR DESCRIPTION
## Description
We should make sure the format references are created before converting to HTML so it works correctly. This makes it possible to use the value in the HTML comments.

## How has this been tested?

This blocks should work correctly:

```js
wp.blocks.registerBlockType( 'test/test', {
    title: 'test',
    description: 'test',
    category: 'common',

    attributes: {
        content: {
            default: wp.richText.create(),
        },
    },

    edit( props ) {
        return wp.element.createElement( wp.editor.RichText, {
            value: props.attributes.content,
            onChange: ( value ) => props.setAttributes( { content: value } ),
        } );
    },

    save() {
        return null;
    },
} );
```

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->