### PR TITLE
Remove unused isButton prop

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -87,7 +87,6 @@ function FontSizePicker( {
 					type="button"
 					disabled={ value === undefined }
 					onClick={ () => onChange( undefined ) }
-					isButton
 					isSmall
 					isDefault
 					aria-label={ __( 'Reset font size' ) }


### PR DESCRIPTION
## Description
FontSizePicker component was passing isButton prop to Button component but this component doesn't use isButton in any place.

The warning below show up in console:
Warning: React does not recognize the `isButton` prop on a DOM element.

## How has this been tested?
This has been tested with "npm test" and manually on Chrome

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
