### PR TITLE
Style nested `<ul>`s with circles instead of normal bullets

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -1,3 +1,10 @@
+// Override the default list style type _only in the editor_
+// to avoid :not() selector specificity issues.
+// See https://github.com/WordPress/gutenberg/pull/10358
+ul.wp-block-gallery li {
+	list-style-type: none;
+}
+
 .blocks-gallery-item {
 
 	// Hide the focus outline that otherwise briefly appears when selecting a block.

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -24,6 +24,10 @@ ul:not(.wp-block-gallery) {
 	list-style-type: disc;
 }
 
+ul:not(.wp-block-gallery) ul {
+	list-style-type: circle;
+}
+
 ol {
 	list-style-type: decimal;
 }

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -20,14 +20,15 @@ ol {
 	padding: 0;
 }
 
-ul:not(.wp-block-gallery) {
+ul {
 	list-style-type: disc;
-}
-
-ul:not(.wp-block-gallery) ul {
-	list-style-type: circle;
 }
 
 ol {
 	list-style-type: decimal;
+}
+
+ul ul,
+ol ul {
+	list-style-type: circle;
 }


### PR DESCRIPTION
Discovered while working on #10303 that we style nested unordered lists with a normal bullet, instead of `circle` which is more typical of user agent stylesheets (aka default browser styles).

In the Chrome user agent styles, for instance, you can see the default is overridden:

![devtools_-_dev_tomodomo_co_wp-admin_post_php_post_78_action_edit_and_edit_page_ _tomodomo_ _wordpress](https://user-images.githubusercontent.com/1231306/46536471-9f5d6c80-c87c-11e8-920d-88aa18ed8e0e.png)

This adds a rule to the editor stylesheets to handle nested styles.

Here's the before:

![edit_page_ _tomodomo_ _wordpress](https://user-images.githubusercontent.com/1231306/46536780-86a18680-c87d-11e8-9c75-4192dee005ce.png)

And here's the after:

![edit_page_ _tomodomo_ _wordpress](https://user-images.githubusercontent.com/1231306/46536751-6ffb2f80-c87d-11e8-91b9-9b58ee56f455.png)


One small implementation note: I've removed a `:not()` selector that was previously ensuring the `<ul>` CSS rule did not apply to `.wp-block-gallery` and instead placed an override in the gallery block's editor stylesheet.

I expect this to be slightly controversial, but this is intentional to avoid a selector specificity issue. Basically, `ul:not(.wp-block-gallery)` is _more_ specific than `ol ul`. We would have had to do something like `ol:not(.wp-block-gallery) ul` or whatever to increase the specificity which is kind of annoying and unnecessary. To me, this feels like a case where the gallery should manage its own overrides.