### PR TITLE
Permit default_title, default_content, and default_excerpt filters to work as expected

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1356,13 +1356,13 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		// or filtered value.
 		$initial_edits = array(
 			'title' => array(
-				'raw' => apply_filters( 'the_title', $post->post_title, $post->ID ),
+				'raw' => $post->post_title,
 			),
 			'content' => array(
-				'raw' => apply_filters( 'the_content', $post->post_content, $post->ID ),
+				'raw' => $post->post_content,
 			),
 			'excerpt' => array(
-				'raw' => apply_filters( 'the_excerpt', $post->post_excerpt, $post->ID ),
+				'raw' => $post->post_excerpt,
 			)
 		);
 	} else {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1356,8 +1356,14 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		// or filtered value.
 		$initial_edits = array(
 			'title' => array(
-				'raw' => apply_filters( 'the_title', '', $post->ID ),
+				'raw' => apply_filters( 'the_title', $post->post_title, $post->ID ),
 			),
+			'content' => array(
+				'raw' => apply_filters( 'the_content', $post->post_content, $post->ID ),
+			),
+			'excerpt' => array(
+				'raw' => apply_filters( 'the_excerpt', $post->post_excerpt, $post->ID ),
+			)
 		);
 	} else {
 		$initial_edits = null;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1355,7 +1355,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		// Override "(Auto Draft)" new post default title with empty string,
 		// or filtered value.
 		$initial_edits = array(
-			'title' => array(
+			'title'   => array(
 				'raw' => $post->post_title,
 			),
 			'content' => array(
@@ -1363,7 +1363,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 			),
 			'excerpt' => array(
 				'raw' => $post->post_excerpt,
-			)
+			),
 		);
 	} else {
 		$initial_edits = null;

--- a/test/e2e/specs/new-post-default-content.test.js
+++ b/test/e2e/specs/new-post-default-content.test.js
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import {newPost, getEditedPostContent, openDocumentSettingsSidebar} from '../support/utils';
+import { activatePlugin, deactivatePlugin } from '../support/plugins';
+
+describe( 'new editor filtered state', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-plugin-default-post-content' );
+	} );
+
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-plugin-default-post-content' );
+	} );
+
+	it( 'should respect default content', async () => {
+		// @todo: verify the excerpt too
+		// open the sidebar, we want to see the excerpt.
+		// await openDocumentSettingsSidebar();
+		// const excerpt_button = await page.$x( '//button[@class="components-button components-panel__body-toggle"][contains(text(),"Excerpt")]' );
+		// if ( excerpt_button ) {
+		// 	await page.click( excerpt_button );
+		// }
+
+		// get the values that should have their defaults changed.
+		const title = await page.$eval(
+			'.editor-post-title__input',
+			( element ) => element.innerText
+		);
+		const content = getEditedPostContent();
+		// const excerpt = await page.$eval(
+		// 	'.editor-post-excerpt textarea',
+		// 	( element ) => element.innerText
+		// );
+
+		// assert they match what the plugin set.
+		expect( title ).toBe( 'My default title' );
+		expect( content ).toBe( 'My default content' );
+		// expect( excerpt ).toBe( 'My default excerpt' );
+	} );
+} );

--- a/test/e2e/specs/new-post-default-content.test.js
+++ b/test/e2e/specs/new-post-default-content.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { newPost, getEditedPostContent } from '../support/utils';
+import { newPost, getEditedPostContent, openDocumentSettingsSidebar } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
 describe( 'new editor filtered state', () => {
@@ -18,28 +18,27 @@ describe( 'new editor filtered state', () => {
 	} );
 
 	it( 'should respect default content', async () => {
-		// @todo: verify the excerpt too
-		// open the sidebar, we want to see the excerpt.
-		// await openDocumentSettingsSidebar();
-		// const excerpt_button = await page.$x( '//button[@class="components-button components-panel__body-toggle"][contains(text(),"Excerpt")]' );
-		// if ( excerpt_button ) {
-		// 	await page.click( excerpt_button );
-		// }
-
 		// get the values that should have their defaults changed.
 		const title = await page.$eval(
 			'.editor-post-title__input',
-			( element ) => element.innerText
+			( element ) => element.innerHTML
 		);
-		const content = getEditedPostContent();
-		// const excerpt = await page.$eval(
-		// 	'.editor-post-excerpt textarea',
-		// 	( element ) => element.innerText
-		// );
+		const content = await getEditedPostContent();
+
+		// open the sidebar, we want to see the excerpt.
+		await openDocumentSettingsSidebar();
+		const [excerpt_button] = await page.$x( '//div[@class="edit-post-sidebar"]//button[@class="components-button components-panel__body-toggle"][contains(text(),"Excerpt")]' );
+		if ( excerpt_button ) {
+			await excerpt_button.click( 'button' );
+		}
+		const excerpt = await page.$eval(
+			'.editor-post-excerpt textarea',
+			( element ) => element.innerHTML
+		);
 
 		// assert they match what the plugin set.
 		expect( title ).toBe( 'My default title' );
 		expect( content ).toBe( 'My default content' );
-		// expect( excerpt ).toBe( 'My default excerpt' );
+		expect( excerpt ).toBe( 'My default excerpt' );
 	} );
 } );

--- a/test/e2e/specs/new-post-default-content.test.js
+++ b/test/e2e/specs/new-post-default-content.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import {newPost, getEditedPostContent, openDocumentSettingsSidebar} from '../support/utils';
+import { newPost, getEditedPostContent } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
 describe( 'new editor filtered state', () => {

--- a/test/e2e/specs/new-post-default-content.test.js
+++ b/test/e2e/specs/new-post-default-content.test.js
@@ -27,9 +27,9 @@ describe( 'new editor filtered state', () => {
 
 		// open the sidebar, we want to see the excerpt.
 		await openDocumentSettingsSidebar();
-		const [excerpt_button] = await page.$x( '//div[@class="edit-post-sidebar"]//button[@class="components-button components-panel__body-toggle"][contains(text(),"Excerpt")]' );
-		if ( excerpt_button ) {
-			await excerpt_button.click( 'button' );
+		const [ excerptButton ] = await page.$x( '//div[@class="edit-post-sidebar"]//button[@class="components-button components-panel__body-toggle"][contains(text(),"Excerpt")]' );
+		if ( excerptButton ) {
+			await excerptButton.click( 'button' );
 		}
 		const excerpt = await page.$eval(
 			'.editor-post-excerpt textarea',

--- a/test/e2e/specs/new-post.test.js
+++ b/test/e2e/specs/new-post.test.js
@@ -10,9 +10,10 @@ describe( 'new editor state', () => {
 
 	it( 'should show the New Post page in Gutenberg', async () => {
 		expect( page.url() ).toEqual( expect.stringContaining( 'post-new.php' ) );
-		// Should display the title.
+		// Should display the blank title.
 		const title = await page.$( '[placeholder="Add title"]' );
 		expect( title ).not.toBeNull();
+		expect( title.innerHTML ).toBeFalsy();
 		// Should display the Preview button.
 		const postPreviewButton = await page.$( '.editor-post-preview.components-button' );
 		expect( postPreviewButton ).not.toBeNull();

--- a/test/e2e/test-plugins/default-post-content.php
+++ b/test/e2e/test-plugins/default-post-content.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Default Post Content
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-plugin-default-post-content
+ */
+
+/**
+ * Change the default title.
+ */
+add_filter( 'default_title', function() {
+	return 'My default title';
+} );
+
+/**
+ * Change teh default post content.
+ */
+add_filter( 'default_content', function() {
+	return 'My default content';
+} );
+
+/**
+ * Change the default excerpt.
+ */
+add_filter( 'default_excerpt', function() {
+	return 'My default excerpt';
+} );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Don't assume new posts have only blank content. They may have defaults set using the filters `default_content`, `default_title` and `default_excerpt`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Add this code snippet to functions.php:

```
add_filter( 'default_title', function() {
	return 'My default title';
} );

add_filter( 'default_content', function() {
	return 'My default content';
} );

add_filter( 'default_excerpt', function() {
	return 'My default excerpt';
} );
```
when you create a new post with the classic editor, those default values will appear immediately when you begin a new post.
However, when you create a new post in Gutenberg, those default values don't appear.


## Screenshots <!-- if applicable -->
Classic editor:
![classic](https://user-images.githubusercontent.com/1766382/46552938-0dac2a00-c891-11e8-8acc-cd2ee8f51e80.png)
Gutenberg Master:
![gutenberg ignoring defaults](https://user-images.githubusercontent.com/1766382/46552945-13097480-c891-11e8-9a36-edbf320379f5.png)
Gutenberg this branch:
![gutenberg fixed2](https://user-images.githubusercontent.com/1766382/46555338-d1c89300-c897-11e8-95a2-60bc23f48875.png)




## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix. Addresses https://github.com/WordPress/gutenberg/issues/8757#issuecomment-427381004
All we needed to do is not ignore the values already set on the global `$post`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
