### PR TITLE
Testing: Fix failing Writing Flow test

### DIFF
--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -149,13 +149,11 @@ describe( 'adding blocks', () => {
 		await pressWithModifier( META_KEY, 'b' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
-		// When returning to Visual mode, backspace in selected block should
-		// reset to an unmodified default block.
+		// Reset.
 		await page.keyboard.press( 'Backspace' );
 
 		// Ensure no data-mce-selected. Notably, this can occur when content
 		// is saved while typing within an inline boundary.
-		await clickBlockAppender();
 		await pressWithModifier( META_KEY, 'b' );
 		await page.keyboard.type( 'Inside' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -149,7 +149,7 @@ describe( 'adding blocks', () => {
 		await pressWithModifier( META_KEY, 'b' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
-		// Reset.
+		// Backspace to remove the content in this block, resetting it.
 		await page.keyboard.press( 'Backspace' );
 
 		// Ensure no data-mce-selected. Notably, this can occur when content


### PR DESCRIPTION
Regression of #9977

This pull request seeks to resolve a failing E2E test, failed to have been updated in #9977.

**Testing instructions**

Verify E2E tests pass:

```
npm run test-e2e
```