### PR TITLE
Fix mentions after rich text value merge

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -180,7 +180,7 @@ export class Autocomplete extends Component {
 		const { record, onChange } = this.props;
 		const end = record.start;
 		const start = end - open.triggerPrefix.length - query.length;
-		const toInsert = create( renderToString( replacement ) );
+		const toInsert = create( { html: renderToString( replacement ) } );
 
 		onChange( insert( record, toInsert, start, end ) );
 	}

--- a/test/e2e/specs/__snapshots__/mentions.test.js.snap
+++ b/test/e2e/specs/__snapshots__/mentions.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`autocomplete mentions should insert mention 1`] = `
+"<!-- wp:paragraph -->
+<p>I am @admin.</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/mentions.test.js
+++ b/test/e2e/specs/mentions.test.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import {
+	newPost,
+	getEditedPostContent,
+	clickBlockAppender,
+} from '../support/utils';
+
+describe( 'autocomplete mentions', () => {
+	beforeAll( async () => {
+		await newPost();
+	} );
+
+	it( 'should insert mention', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'I am @a' );
+		await page.waitForSelector( '.components-autocomplete__result' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '.' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description

Mentions are broken because I forgot to update the `create` call after I changed that function in the PR and we didn't catch it before merge. I added an e2e test to ensure it doesn't happen again.

## How has this been tested?

Trigger autocomplete with `@...` and press enter to insert.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->