### PR TITLE
Blocks: Normalize RichText value from string (as HTML), children

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -3,10 +3,6 @@
  */
 import uuid from 'uuid/v4';
 import {
-	cond,
-	isString,
-	stubTrue,
-	identity,
 	every,
 	reduce,
 	castArray,
@@ -24,31 +20,12 @@ import {
  * WordPress dependencies
  */
 import { createHooks, applyFilters } from '@wordpress/hooks';
-import { create } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
 import { getBlockType, getBlockTypes } from './registration';
-import children from './children';
-
-function isInvalidRichTextValue( value ) {
-	return ! value || ! value.text;
-}
-
-function isChildrenValue( value ) {
-	return Array.isArray( value );
-}
-
-const SCHEMA_SOURCE_NORMALIZE_VALUE = {
-	'rich-text': cond( [
-		[ isString, ( html ) => create( { html } ) ],
-		[ isChildrenValue, ( value ) => create( { html: children.toHTML( value ) } ) ],
-		[ isInvalidRichTextValue, () => create() ],
-		[ stubTrue, identity ],
-	] ),
-};
 
 /**
  * Returns a block object given its type and attributes.
@@ -70,11 +47,6 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
 
 		if ( value === undefined && schema.hasOwnProperty( 'default' ) ) {
 			value = schema.default;
-		}
-
-		if ( SCHEMA_SOURCE_NORMALIZE_VALUE.hasOwnProperty( schema.source ) ) {
-			const toNormalValue = SCHEMA_SOURCE_NORMALIZE_VALUE[ schema.source ];
-			value = toNormalValue( value );
 		}
 
 		if ( [ 'node', 'children' ].indexOf( schema.source ) !== -1 ) {

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -20,6 +20,7 @@ import {
  * WordPress dependencies
  */
 import { createHooks, applyFilters } from '@wordpress/hooks';
+import { create } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -49,6 +50,15 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
 			value = schema.default;
 		}
 
+		if ( schema.source === 'rich-text' ) {
+			// Ensure value passed is always a rich text value.
+			if ( typeof value === 'string' ) {
+				value = create( { text: value } );
+			} else if ( ! value || ! value.text ) {
+				value = create();
+			}
+		}
+
 		if ( [ 'node', 'children' ].indexOf( schema.source ) !== -1 ) {
 			deprecated( `${ schema.source } source`, {
 				alternative: 'rich-text source',
@@ -57,15 +67,18 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
 			} );
 
 			// Ensure value passed is always an array, which we're expecting in
-			// the RichText component to handle the deprecated value.
-			if ( typeof result[ key ] === 'string' ) {
+			// the RichText getColorObjectByAttributeValuescomponent to handle the deprecated value.
+			if ( typeof value === 'string' ) {
 				value = [ value ];
 			} else if ( ! Array.isArray( value ) ) {
 				value = [];
 			}
 		}
 
-		result[ key ] = value;
+		if ( value !== undefined ) {
+			result[ key ] = value;
+		}
+
 		return result;
 	}, {} );
 

--- a/test/e2e/test-plugins/block-icons/index.js
+++ b/test/e2e/test-plugins/block-icons/index.js
@@ -1,6 +1,5 @@
 ( function() {
 	var registerBlockType = wp.blocks.registerBlockType;
-	var create = wp.richText.create;
 	var el = wp.element.createElement;
 	var InnerBlocks = wp.editor.InnerBlocks;
     var circle = el( 'circle', { cx: 10, cy: 10, r: 10, fill: 'red', stroke: 'blue', strokeWidth: '10' } );
@@ -19,7 +18,7 @@
 						allowedBlocks: [ 'core/paragraph', 'core/image' ],
 						template: [
 							[ 'core/paragraph', {
-								content: create( { text: 'TestSimpleSvgIcon' } ),
+								content: 'TestSimpleSvgIcon',
 							} ],
 						],
 					}
@@ -47,7 +46,7 @@
 						allowedBlocks: [ 'core/paragraph', 'core/image' ],
 						template: [
 							[ 'core/paragraph', {
-								content: create( { text: 'TestDashIcon' } ),
+								content: 'TestDashIcon'
 							} ],
 						],
 					}
@@ -77,7 +76,7 @@
 						allowedBlocks: [ 'core/paragraph', 'core/image' ],
 						template: [
 							[ 'core/paragraph', {
-								content: create( { text: 'TestFunctionIcon' } ),
+								content: 'TestFunctionIcon',
 							} ],
 						],
 					}
@@ -109,7 +108,7 @@
 						allowedBlocks: [ 'core/paragraph', 'core/image' ],
 						template: [
 							[ 'core/paragraph', {
-								content: create( { text: 'TestIconColors' } ),
+								content: 'TestIconColors',
 							} ],
 						],
 					}
@@ -140,7 +139,7 @@
 						allowedBlocks: [ 'core/paragraph', 'core/image' ],
 						template: [
 							[ 'core/paragraph', {
-								content: create( { text: 'TestIconColors' } ),
+								content: 'TestIconColors',
 							} ],
 						],
 					}

--- a/test/e2e/test-plugins/inner-blocks-templates/index.js
+++ b/test/e2e/test-plugins/inner-blocks-templates/index.js
@@ -7,7 +7,7 @@
 	var TEMPLATE = [
 		[ 'core/paragraph', {
 			fontSize: 'large',
-			content: create( { text: 'Content…' } ),
+			content: 'Content…',
 		} ],
 	];
 


### PR DESCRIPTION
The idea of this PR is to ensure previous templates still work while avoiding leaking the new RichText structure format into the format of the templates.

```php
<?php

/**
 * Plugin Name: Demo CPT
 */

add_action( 'init', function() {
	register_post_type( 'book', [
		'label' => 'Book',
		'show_in_rest' => true,
		'public' => true,
		'show_ui' => true,
		'supports' => [ 'title', 'editor' ],
		'template' => [
			[ 'core/paragraph', [
				'content' => 'Hello <strong>world</strong>!',
			] ],
			[ 'core/paragraph', [
				'content' => [
					'Hello ',
					[
						'type' => 'strong', 
						'props' => [ 'children' => 'world' ]
					],
					'!'
				],
			] ],
			[ 'core/paragraph', [
				'content' => [
					'text' => 'Hello world!',
					'formats' => [
						null,
						null,
						null,
						null,
						null,
						null,
						[ [ 'type' => 'strong' ] ],
						[ [ 'type' => 'strong' ] ],
						[ [ 'type' => 'strong' ] ],
						[ [ 'type' => 'strong' ] ],
						[ [ 'type' => 'strong' ] ],
						null
					],
				],
			] ],
		],
		'template_lock' => 'all',
	] );
} );
```