### PR TITLE
Allow link to be edited while selection is collapsed

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -126,7 +126,7 @@ class LinkContainer extends Component {
 		const href = prependHTTP( inputValue );
 		const format = createLinkFormat( { href, opensInNewWindow } );
 
-		if ( isCollapsed( record ) ) {
+		if ( isCollapsed( record ) && link === undefined ) {
 			const toInsert = applyFormat( create( { text: href } ), format, 0, href.length );
 			this.props.onChange( insert( record, toInsert ) );
 		} else {

--- a/packages/rich-text/src/apply-format.js
+++ b/packages/rich-text/src/apply-format.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+
+import { find } from 'lodash';
+
+/**
  * Internal dependencies
  */
 
@@ -24,15 +30,37 @@ export function applyFormat(
 ) {
 	const newFormats = formats.slice( 0 );
 
-	for ( let index = startIndex; index < endIndex; index++ ) {
-		if ( formats[ index ] ) {
-			const newFormatsAtIndex = formats[ index ].filter( ( { type } ) => type !== format.type );
-			newFormatsAtIndex.push( format );
-			newFormats[ index ] = newFormatsAtIndex;
-		} else {
-			newFormats[ index ] = [ format ];
+	// If the selection is collapsed, expand start and end to the edges of the
+	// format.
+	if ( startIndex === endIndex ) {
+		const startFormat = find( newFormats[ startIndex ], { type: format.type } );
+
+		while ( find( newFormats[ startIndex ], startFormat ) ) {
+			applyFormats( newFormats, startIndex, format );
+			startIndex--;
+		}
+
+		endIndex++;
+
+		while ( find( newFormats[ endIndex ], startFormat ) ) {
+			applyFormats( newFormats, endIndex, format );
+			endIndex++;
+		}
+	} else {
+		for ( let index = startIndex; index < endIndex; index++ ) {
+			applyFormats( newFormats, index, format );
 		}
 	}
 
 	return normaliseFormats( { formats: newFormats, text, start, end } );
+}
+
+function applyFormats( formats, index, format ) {
+	if ( formats[ index ] ) {
+		const newFormatsAtIndex = formats[ index ].filter( ( { type } ) => type !== format.type );
+		newFormatsAtIndex.push( format );
+		formats[ index ] = newFormatsAtIndex;
+	} else {
+		formats[ index ] = [ format ];
+	}
 }

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -13,6 +13,8 @@ import { getSparseArrayLength } from './helpers';
 describe( 'applyFormat', () => {
 	const strong = { type: 'strong' };
 	const em = { type: 'em' };
+	const a = { type: 'a', attributes: { href: '#' } };
+	const a2 = { type: 'a', attributes: { href: '#test' } };
 
 	it( 'should apply format', () => {
 		const record = {
@@ -48,5 +50,25 @@ describe( 'applyFormat', () => {
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
 		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+	} );
+
+	it( 'should apply format on existing format if selection is collapsed', () => {
+		const record = {
+			formats: [ , , , , [ a ], [ a ], [ a ], , , , , , , ],
+			text: 'one two three',
+			start: 4,
+			end: 4,
+		};
+		const expected = {
+			formats: [ , , , , [ a2 ], [ a2 ], [ a2 ], , , , , , , ],
+			text: 'one two three',
+			start: 4,
+			end: 4,
+		};
+		const result = applyFormat( deepFreeze( record ), a2 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
 	} );
 } );

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -52,6 +52,26 @@ describe( 'applyFormat', () => {
 		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
 	} );
 
+	it( 'should not apply format on non existing format if selection is collapsed', () => {
+		const record = {
+			formats: [ , , , , [ a ], [ a ], [ a ], , , , , , , ],
+			text: 'one two three',
+			start: 0,
+			end: 0,
+		};
+		const expected = {
+			formats: [ , , , , [ a ], [ a ], [ a ], , , , , , , ],
+			text: 'one two three',
+			start: 0,
+			end: 0,
+		};
+		const result = applyFormat( deepFreeze( record ), a2 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+	} );
+
 	it( 'should apply format on existing format if selection is collapsed', () => {
 		const record = {
 			formats: [ , , , , [ a ], [ a ], [ a ], , , , , , , ],

--- a/test/e2e/specs/__snapshots__/links.test.js.snap
+++ b/test/e2e/specs/__snapshots__/links.test.js.snap
@@ -30,6 +30,12 @@ exports[`Links can be edited 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Links can be edited with collapsed selection 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <a href=\\"https://wordpress.org/gutenberg/handbook\\">Gutenberg</a></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Links can be removed 1`] = `
 "<!-- wp:paragraph -->
 <p>This is Gutenberg</p>

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -7,6 +7,7 @@ import {
 	getEditedPostContent,
 	newPost,
 	pressWithModifier,
+	pressTimes,
 } from '../support/utils';
 
 /**
@@ -23,6 +24,11 @@ describe( 'Links', () => {
 
 	const waitForAutoFocus = async () => {
 		await page.waitForFunction( () => !! document.activeElement.closest( '.editor-url-input' ) );
+	};
+
+	const moveMouse = async () => {
+		await page.mouse.move( 200, 300, { steps: 10 } );
+		await page.mouse.move( 250, 350, { steps: 10 } );
 	};
 
 	it( 'can be created by selecting text and clicking Link', async () => {
@@ -79,8 +85,7 @@ describe( 'Links', () => {
 		await page.keyboard.type( 'This is Gutenberg: ' );
 
 		// Trigger isTyping = false
-		await page.mouse.move( 200, 300, { steps: 10 } );
-		await page.mouse.move( 250, 350, { steps: 10 } );
+		await moveMouse();
 
 		// Press Cmd+K to insert a link
 		await pressWithModifier( META_KEY, 'K' );
@@ -225,8 +230,7 @@ describe( 'Links', () => {
 		await page.keyboard.type( 'Text' );
 
 		// we need to trigger isTyping = false
-		await page.mouse.move( 200, 300, { steps: 10 } );
-		await page.mouse.move( 250, 350, { steps: 10 } );
+		await moveMouse();
 		await page.waitForSelector( 'button[aria-label="Link"]' );
 		await page.click( 'button[aria-label="Link"]' );
 
@@ -239,5 +243,17 @@ describe( 'Links', () => {
 		await page.keyboard.press( 'Escape' );
 		modal = await page.$( '.editor-format-toolbar__link-modal' );
 		expect( modal ).toBeNull();
+	} );
+
+	it( 'can be edited with collapsed selection', async () => {
+		await createAndReselectLink();
+		// Make a collapsed selection inside the link
+		await pressTimes( 'ArrowRight', 3 );
+		await moveMouse();
+		await page.click( 'button[aria-label="Edit"]' );
+		await waitForAutoFocus();
+		await page.keyboard.type( '/handbook' );
+		await page.click( 'button[aria-label="Apply"]' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description

Fixes #10368. Adds logic to applyFormat to edit the format around the caret if it is of the same type. This logic is already present in `removeFormat`. Adds e2e test.

## How has this been tested?
See #10368.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->