### PR TITLE
Disable alternate diff drivers in setup script

### DIFF
--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -73,7 +73,7 @@ npm install
 npm install npm -g
 
 # There was a bug in NPM that caused changes in package-lock.json. Handle that.
-if [ "$TRAVIS" != "true" ] && ! git diff --exit-code package-lock.json >/dev/null; then
+if [ "$TRAVIS" != "true" ] && ! git diff --no-ext-diff --exit-code package-lock.json >/dev/null; then
 	if ask "$(warning_message "Your package-lock.json changed, which may mean there's an issue with your NPM cache. Would you like to try and automatically clean it up?" )" N 10; then
 		rm -rf node_modules/
 		npm cache clean --force >/dev/null 2>&1
@@ -83,7 +83,7 @@ if [ "$TRAVIS" != "true" ] && ! git diff --exit-code package-lock.json >/dev/nul
 		npm install
 
 		# Check that it's cleaned up now.
-		if git diff --exit-code package-lock.json >/dev/null; then
+		if git diff --no-ext-diff --exit-code package-lock.json >/dev/null; then
 			echo -e $(warning_message "Confirmed that the NPM cache is cleaned up." )
 		else
 			echo -e $(error_message "We were unable to clean the NPM cache, please manually review the changes to package-lock.json. Continuing with the setup process..." )


### PR DESCRIPTION
If you have an alternate diff driver set up (in my case it's a small shell script wrapping `vimdiff`), the setup script can hang when running `git diff --exit-code package.json` to check if package.json has changed. (Basically, Vim can't load the UI so you can close it and return the exit code, and throws up an error.)

This change adds the [`--no-ext-diff` flag](https://git-scm.com/docs/git-diff#git-diff---no-ext-diff) to those checks, which disables any external/custom diff drivers and uses git's built-in driver instead.

It's a small corner case but enforcing the use of git's internal diff driver should help guarantee slightly more consistency in general.

## Testing

Run `git diff --exit-code package.json` and `git diff --no-ext-diff --exit-code package.json` and confirm they return the same exit code.

Or run the whole setup script (or just `./bin/install-node-nvm.sh`) if you want 🤷‍♂️ 