### PR TITLE
Add utils to the wp-data script dependencies.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -246,6 +246,7 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-data',
 		gutenberg_url( 'build/data/index.js' ),
 		array(
+			'utils',
 			'lodash',
 			'wp-compose',
 			'wp-deprecated',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -246,7 +246,6 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-data',
 		gutenberg_url( 'build/data/index.js' ),
 		array(
-			'utils',
 			'lodash',
 			'wp-compose',
 			'wp-deprecated',
@@ -264,7 +263,7 @@ function gutenberg_register_scripts_and_styles() {
 			"\n",
 			array(
 				'( function() {',
-				'	var userId = window.userSettings.uid;',
+				'	var userId = ' . get_current_user_ID() . ';',
 				'	var storageKey = "WP_DATA_USER_" + userId;',
 				'	wp.data',
 				'		.use( wp.data.plugins.persistence, { storageKey: storageKey } )',


### PR DESCRIPTION
The `wp-data` inline script relies on `window.userSettings.uid`, a property set in the `utils` script.

Fixes #10102

## Description
Added `utils` as a script dependencies for `wp-data`.

## How has this been tested?
Tested locally using WordPress `5.0-alpha-43661` and Gutenberg `master` with HEAD at `7ec834b77686c6b291ae1ee18fe5860714b58236`.

## Types of changes
This is a bug fix for #10102.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
