### PR TITLE
Deprecate PanelColor components

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -4,6 +4,8 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 
 - `isEditorSidebarPanelOpened` selector (`core/edit-post`) has been removed. Please use `isEditorPanelEnabled` instead.
 - `toggleGeneralSidebarEditorPanel` action (`core/edit-post`) has been removed. Please use `toggleEditorPanelOpened` instead.
+- `wp.components.PanelColor` component has been removed. Please use `wp.editor.PanelColorSettings` instead.
+- `wp.editor.PanelColor` component has been removed. Please use `wp.editor.PanelColorSettings` instead.
 
 ## 4.2.0
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,12 +1,14 @@
+## 4.2.0 (Unreleased)
+
+### Deprecation
+
+- `wp.components.PanelColor` has been deprecated in favor of `wp.editor.PanelColorSettings`.
+
 ## 4.1.0 (2018-10-10)
 
 ### New Feature
 
 - Added a new `ResizableBox` component.
-
-### Deprecation
-
-- `wp.components.PanelColor` has been deprecated in favor of `wp.editor.PanelColorSettings`.
 
 ## 4.0.0 (2018-09-30)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added a new `ResizableBox` component.
 
+### Deprecation
+
+- `wp.components.PanelColor` has been deprecated in favor of `wp.editor.PanelColorSettings`.
+
 ## 4.0.0 (2018-09-30)
 
 ### Breaking Change

--- a/packages/components/src/panel/color.js
+++ b/packages/components/src/panel/color.js
@@ -12,7 +12,7 @@ import ColorIndicator from '../color-indicator';
 
 function PanelColor( { colorValue, colorName, title, ...props } ) {
 	deprecated( 'wp.editor.PanelColor', {
-		version: '4.2',
+		version: '4.3',
 		alternative: 'wp.editor.PanelColorSettings',
 		plugin: 'Gutenberg',
 	} );

--- a/packages/components/src/panel/color.js
+++ b/packages/components/src/panel/color.js
@@ -11,7 +11,7 @@ import PanelBody from './body';
 import ColorIndicator from '../color-indicator';
 
 function PanelColor( { colorValue, colorName, title, ...props } ) {
-	deprecated( 'wp.editor.PanelColor', {
+	deprecated( 'wp.components.PanelColor', {
 		version: '4.3',
 		alternative: 'wp.editor.PanelColorSettings',
 		plugin: 'Gutenberg',

--- a/packages/components/src/panel/color.js
+++ b/packages/components/src/panel/color.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -10,6 +11,12 @@ import PanelBody from './body';
 import ColorIndicator from '../color-indicator';
 
 function PanelColor( { colorValue, colorName, title, ...props } ) {
+	deprecated( 'wp.editor.PanelColor', {
+		version: '4.2',
+		alternative: 'wp.editor.PanelColorSettings',
+		plugin: 'Gutenberg',
+	} );
+
 	// translators: %s: The name of the color e.g: "vivid red" or color hex code if name is not available e.g: "#f00".
 	const currentColorLabel = sprintf( __( '(current color: %s)' ), colorName || colorValue );
 	return (

--- a/packages/components/src/panel/test/color.js
+++ b/packages/components/src/panel/test/color.js
@@ -13,5 +13,9 @@ describe( 'PanelColor', () => {
 		const wrapper = shallow( <PanelColor title="sample title" /> );
 
 		expect( wrapper ).toMatchSnapshot();
+
+		expect( console ).toHaveWarnedWith(
+			'wp.components.PanelColor is deprecated and will be removed from Gutenberg in 4.3. Please use wp.editor.PanelColorSettings instead.'
+		);
 	} );
 } );

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.1.0 (Unreleased)
+
+### Deprecations
+
+- `wp.editor.PanelColor` has been deprecated in favor of `wp.editor.PanelColorSettings`.
+
 ## 4.0.0 (2018-09-30)
 
 ### Breaking Changes

--- a/packages/editor/src/components/panel-color/index.js
+++ b/packages/editor/src/components/panel-color/index.js
@@ -8,6 +8,7 @@ import { omit } from 'lodash';
  */
 import { PanelColor as PanelColorComponent } from '@wordpress/components';
 import { ifCondition, compose } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -17,6 +18,12 @@ import withColorContext from '../color-palette/with-color-context';
 import { getColorObjectByColorValue } from '../colors';
 
 function PanelColor( { colors, title, colorValue, initialOpen, ...props } ) {
+	deprecated( 'wp.editor.PanelColor', {
+		version: '4.2',
+		alternative: 'wp.editor.PanelColorSettings',
+		plugin: 'Gutenberg',
+	} );
+
 	const colorObject = getColorObjectByColorValue( colors, colorValue );
 	const colorName = colorObject && colorObject.name;
 	return (

--- a/packages/editor/src/components/panel-color/index.js
+++ b/packages/editor/src/components/panel-color/index.js
@@ -19,7 +19,7 @@ import { getColorObjectByColorValue } from '../colors';
 
 function PanelColor( { colors, title, colorValue, initialOpen, ...props } ) {
 	deprecated( 'wp.editor.PanelColor', {
-		version: '4.2',
+		version: '4.3',
 		alternative: 'wp.editor.PanelColorSettings',
 		plugin: 'Gutenberg',
 	} );


### PR DESCRIPTION
Fixes #10367.

This PR deprecates `wp.components.PanelColor` and `wp.editor.PanelColor` in favour of `wp.editor.PanelColorSettings`, which is a more robust component for the reasons documented in #10367:

> Overall `PanelColorSettings` seems superior because of its support for multiple color values and for not having the clear button float issue.

It also updates the `@wordpress/editor` and `@wordpress/components` changelogs to mention the deprecation.

One note is that deprecating `wp.components.PanelColor` will mean there's no component to provide a color panel that isn't wrapped inside `withColorContext`. Users who wish to have a panel with a color palette that uses a separate set of colors than what's defined with `add_theme_support('editor-color-palette');` will need to build their own panel component.

As such, it may be desired to deprecate `wp.editor.PanelColor`, while _keeping_ `wp.components.PanelColor` and simply fixing the visual bug noted in #10367. However, this would be a use-case that Gutenberg itself does not need/use, so it might not be worth continuing to support.

I've never done a deprecation like this… I think I got everything but would very much appreciate a close look/review 😄 