### PR TITLE
Try: Alternate floats markup

### DIFF
--- a/docs/extensibility/theme-support.md
+++ b/docs/extensibility/theme-support.md
@@ -65,8 +65,8 @@ Here's the markup for an `Image` with a caption:
 Here's the markup for a left-floated image:
 
 ```html
-<div class="wp-block-image">
-	<figure class="alignleft">
+<div class="wp-block-image alignleft">
+	<figure>
 		<img src="..." alt="" width="200px">
 		<figcaption>Short image caption.</figcaption>
 	</figure>

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -228,8 +228,8 @@ export const settings = {
 
 		if ( 'left' === align || 'right' === align || 'center' === align ) {
 			return (
-				<div>
-					<figure className={ classes }>
+				<div className={ classes }>
+					<figure>
 						{ figure }
 					</figure>
 				</div>

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -18,11 +18,11 @@
 	margin-left: 0;
 	margin-right: 0;
 
-	// Floats get an extra wrapping <aside> element, so the <figure> becomes a child.
-	.alignleft,
-	.alignright,
-	.aligncenter,
-	&.is-resized {
+	// Floats get an extra wrapping <div> element, so the <figure> becomes a child.
+	&.alignleft figure,
+	&.alignright figure,
+	&.aligncenter figure,
+	&.is-resized figure {
 		display: table;
 
 		// The figure is born with left and right margin.
@@ -36,17 +36,17 @@
 		}
 	}
 
-	.alignleft {
+	&.alignleft figure {
 		float: left;
 		margin-right: 1em;
 	}
 
-	.alignright {
+	&.alignright figure {
 		float: right;
 		margin-left: 1em;
 	}
 
-	.aligncenter {
+	&.aligncenter figure {
 		margin-left: auto;
 		margin-right: auto;
 	}


### PR DESCRIPTION
Depending on feedback in https://github.com/WordPress/gutenberg/issues/10099#issuecomment-427735660, this may fix #10099.

May, because it might not be necessary, or a different fix such as letting the additional divs be opt-in via a theme-support call, something in that vein. Please see #10099 for further context, and https://github.com/WordPress/gutenberg/blob/master/docs/extensibility/theme-support.md#wide-alignments-and-floats for context as to why the markup is as it is today.

Ironically in my testing, adding the alignment class to the figure itself seems to be the more compatible approach, but this PR should work in old themes as well.

If this turns out to be the approach we need to take, we'll likely need a deprecation handler.

To test this, add a bunch of floats, centered images, fullwide images, anything you can throw at it, and verify that it looks good in a Twenty theme. 