### PR TITLE
Stop trying to autosave when title and classic block content both are empty.

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -17,6 +17,7 @@ import {
 	reduce,
 	size,
 	some,
+	isEmpty,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -1457,6 +1458,17 @@ export function getBlocksForSerialization( state ) {
 	);
 
 	if ( isSingleUnmodifiedDefaultBlock ) {
+		return [];
+	}
+
+	// A single empty core/freeform block equivalent to an empty post.
+	const isSingleEmptyFreeformBlock = (
+		blocks.length === 1 &&
+		blocks[ 0 ].name === getUnknownTypeHandlerName() &&
+		( isEmpty( blocks[ 0 ].attributes ) || blocks[ 0 ].attributes.content === '' )
+	);
+
+	if ( isSingleEmptyFreeformBlock ) {
 		return [];
 	}
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -17,7 +17,6 @@ import {
 	reduce,
 	size,
 	some,
-	isEmpty,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -31,6 +30,7 @@ import {
 	hasBlockSupport,
 	hasChildBlocksWithInserterSupport,
 	getFreeformContentHandlerName,
+	getUnregisteredTypeHandlerName,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
 import { moment } from '@wordpress/date';
@@ -364,6 +364,20 @@ export function isEditedPostSaveable( state ) {
 }
 
 /**
+ * Determines whether all the block available in post are known or registered block or not.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} whether all the block available in post are known block or not.
+ */
+export function hasKnownBlocks( state ) {
+	return getBlockOrder( state ).some( ( clientId ) => (
+		state.editor.present.blocksByClientId[ clientId ].name !== getFreeformContentHandlerName() &&
+		state.editor.present.blocksByClientId[ clientId ].name !== getUnregisteredTypeHandlerName()
+	) );
+}
+
+/**
  * Returns true if the edited post has content. A post has content if it has at
  * least one saveable block or otherwise has a non-empty content property
  * assigned.
@@ -378,7 +392,7 @@ export function isEditedPostEmpty( state ) {
 	// operation by comparison. Since this function can be called frequently,
 	// optimize for the fast case where saveable blocks are non-empty.
 	return (
-		! getBlocksForSerialization( state ).length &&
+		! hasKnownBlocks( state ) ||
 		! getEditedPostAttribute( state, 'content' )
 	);
 }
@@ -1458,17 +1472,6 @@ export function getBlocksForSerialization( state ) {
 	);
 
 	if ( isSingleUnmodifiedDefaultBlock ) {
-		return [];
-	}
-
-	// A single empty core/freeform block equivalent to an empty post.
-	const isSingleEmptyFreeformBlock = (
-		blocks.length === 1 &&
-		blocks[ 0 ].name === getUnknownTypeHandlerName() &&
-		( isEmpty( blocks[ 0 ].attributes ) || blocks[ 0 ].attributes.content === '' )
-	);
-
-	if ( isSingleEmptyFreeformBlock ) {
 		return [];
 	}
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1022,6 +1022,56 @@ describe( 'selectors', () => {
 
 			expect( isEditedPostSaveable( state ) ).toBe( true );
 		} );
+
+		it( 'should return false if the post has no title, excerpt and empty classic block', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByClientId: {
+							123: {
+								clientId: 123,
+								name: 'core/freeform',
+								attributes: { },
+							},
+						},
+						blockOrder: {
+							'': [ 123 ],
+						},
+						edits: {},
+					},
+				},
+				currentPost: {},
+				saving: {},
+			};
+
+			expect( isEditedPostSaveable( state ) ).toBe( false );
+		} );
+
+		it( 'should return true if the post has a title and empty classic block', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByClientId: {
+							123: {
+								clientId: 123,
+								name: 'core/freeform',
+								attributes: { },
+							},
+						},
+						blockOrder: {
+							'': [ 123 ],
+						},
+						edits: {},
+					},
+				},
+				currentPost: {
+					title: 'sassel',
+				},
+				saving: {},
+			};
+
+			expect( isEditedPostSaveable( state ) ).toBe( true );
+		} );
 	} );
 
 	describe( 'isEditedPostAutosaveable', () => {
@@ -1254,6 +1304,83 @@ describe( 'selectors', () => {
 					},
 				},
 				currentPost: {},
+			};
+
+			expect( isEditedPostEmpty( state ) ).toBe( false );
+		} );
+
+		it( 'should return true if empty attributes classic block', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByClientId: {
+							123: {
+								clientId: 123,
+								name: 'core/freeform',
+								attributes: { },
+							},
+						},
+						blockOrder: {
+							'': [ 123 ],
+						},
+						edits: {},
+					},
+				},
+				currentPost: {},
+			};
+
+			expect( isEditedPostEmpty( state ) ).toBe( true );
+		} );
+
+		it( 'should return true if empty content classic block', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByClientId: {
+							123: {
+								clientId: 123,
+								name: 'core/freeform',
+								attributes: {
+									content: '',
+								},
+							},
+						},
+						blockOrder: {
+							'': [ 123 ],
+						},
+						edits: {},
+					},
+				},
+				currentPost: {
+					content: '',
+				},
+			};
+
+			expect( isEditedPostEmpty( state ) ).toBe( true );
+		} );
+
+		it( 'should return false if non empty content classic block', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByClientId: {
+							123: {
+								clientId: 123,
+								name: 'core/freeform',
+								attributes: {
+									content: 'Test Data',
+								},
+							},
+						},
+						blockOrder: {
+							'': [ 123 ],
+						},
+						edits: {},
+					},
+				},
+				currentPost: {
+					content: 'Test Data',
+				},
 			};
 
 			expect( isEditedPostEmpty( state ) ).toBe( false );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes: #6556

Add check in getBlocksForSerialization when single classic block ( core/freeform ) is available with empty content. 

https://github.com/WordPress/gutenberg/blob/69ced17277dceca17b3253a6d53f5cfb35eecfad/packages/editor/src/store/selectors.js#L372-L381

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Post autosave is not triggerd when one classic block content is availble and it's empty.
Screencast: https://drive.google.com/file/d/1p6HfNi7I6_57y8mbLhe9J8HTU4lAq--6/view

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
