### PR TITLE
Use permalink template filter only for wp version < 5.0.0.

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -284,7 +284,18 @@ function gutenberg_add_target_schema_to_links( $response, $post, $request ) {
  * @return string That same post type.
  */
 function gutenberg_register_post_prepare_functions( $post_type ) {
-	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_permalink_template_to_posts', 10, 3 );
+
+	// Get unmodified $wp_version.
+	include ABSPATH . WPINC . '/version.php';
+
+	// Strip '-src' from the version string. Messes up version_compare().
+	$version = str_replace( '-src', '', $wp_version );
+
+	// Apply filter to older versions of WordPress.
+	if ( version_compare( $version, '5.0.0', '<' ) ) {
+		add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_permalink_template_to_posts', 10, 3 );
+	}
+
 	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_block_format_to_post_content', 10, 3 );
 	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_target_schema_to_links', 10, 3 );
 	add_filter( "rest_{$post_type}_collection_params", 'gutenberg_filter_post_collection_parameters', 10, 2 );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes: #10400
This is to use Gutenberg for WordPress nightly builds and trunk once core trac #45017 patch merge in it.

eventually, `lib/rest-api.php` will be removed entirely before WordPress 5.0.
ref: https://github.com/WordPress/gutenberg/issues/10400#issuecomment-427817922

 <!--  ## How has this been tested? -->
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

 <!--  ## Screenshots   --> <!-- if applicable -->

<!--  ## Types of changes  -->
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
