### PR TITLE
[Fix] Establish consistency between front-end and back-end classes for Youtube (Embed) block

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -343,7 +343,7 @@ export function getEmbedEdit( title, icon ) {
 			);
 
 			return (
-				<figure className={ classnames( className, 'wp-block-embed', { 'is-video': 'video' === type } ) }>
+				<figure className={ classnames( className, 'wp-block-embed', { 'is-type-video': 'video' === type } ) }>
 					{ controls }
 					{ ( cannotPreview ) ? (
 						<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label }>


### PR DESCRIPTION
## Description
This PR closes #10121 which reports the usage of `is-video` class in the editor for the Youtube (Embed) block, whereas `is-type-video` class is used for the same in the front-end. This changes the editor class from `is-video` to `is-type-video`.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the "Youtube" (Embed) block.
3. Using the browser developer tools, make sure the `is-type-video` class is used for the block in both front-end and backend instead of the `is-video` class.

This was tested in WP 4.9.8, Gutenberg 3.9.0, Apache server with PHP 7.2.0 and MySQL 5.6.34. According to initial tests, the code doesn’t seem to affect any other areas.

## Screenshots <!-- if applicable -->
![pull-10121](https://user-images.githubusercontent.com/20284937/46623567-d1f2b800-cb4f-11e8-9003-89885ea2a513.png)

## Types of changes
This PR just replaces the `is-video` with `is-type-video` class in the embed block file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
