### PR TITLE
Try "letterbox" phrasing for embed toggle

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -275,7 +275,7 @@ export function getEmbedEdit( title, icon ) {
 		}
 
 		getResponsiveHelp( checked ) {
-			return checked ? __( 'Videos and other content is sized to avoid letterboxing.' ) : __( 'Videos and other embeds are not resized and may be letterboxed.' );
+			return checked ? __( 'This embed will preserve its aspect ratio when the browser is resized.' ) : __( 'This embed may not preserve its aspect ratio when the browser is resized.' );
 		}
 
 		toggleResponsive() {
@@ -313,7 +313,7 @@ export function getEmbedEdit( title, icon ) {
 						<InspectorControls>
 							<PanelBody title={ __( 'Media Settings' ) } className="blocks-responsive">
 								<ToggleControl
-									label={ __( 'Automatically scale content' ) }
+									label={ __( 'Resize for smaller devices' ) }
 									checked={ allowResponsive }
 									help={ this.getResponsiveHelp }
 									onChange={ this.toggleResponsive }

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -275,7 +275,7 @@ export function getEmbedEdit( title, icon ) {
 		}
 
 		getResponsiveHelp( checked ) {
-			return checked ? __( 'Videos and other content automatically resizes.' ) : __( 'Content is fixed size.' );
+			return checked ? __( 'Videos and other content is sized to avoid letterboxing.' ) : __( 'Videos and other embeds are not resized and may be letterboxed.' );
 		}
 
 		toggleResponsive() {


### PR DESCRIPTION
This PR tries to rephrase the button that disables aspect-ratio based video responsiveness for the embed block.

Basically most themes _do_ apply some responsiveness to video embeds, and as such the previous "scale" phrasing could be slightly misleading. But what the feature really does, is leverage the aspect ratio of the video to ensure it's never letterboxed, i.e. has black bars on either side.

I'm not sure the phrasing here is exactly right as-is — in fact using the term letterbox seemed like a better idea in theory than in this branch — but pushing here for feedback regardless, to see if a better phrasing can emerge.

![letterboxing](https://user-images.githubusercontent.com/1204802/46654893-48bc9f00-cbaa-11e8-8da8-0fbc2d2d81b8.gif)
