### PR TITLE
Fix pullquote margin regressions.

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -1,5 +1,7 @@
 .wp-block-pullquote {
 	padding: 3em 0;
+	margin-left: 0;
+	margin-right: 0;
 	text-align: center;
 
 	&.alignleft,


### PR DESCRIPTION
Since the addition of the figure element to the pullquote, the margins were not reset it seems. This PR resets the intrinsic left and right margin on the figure to address that.

Before:

![screenshot 2018-10-09 at 10 11 50](https://user-images.githubusercontent.com/1204802/46655524-1ca21d80-cbac-11e8-8889-e8a29e38322b.png)

After:

![screenshot 2018-10-09 at 10 13 08](https://user-images.githubusercontent.com/1204802/46655528-1f047780-cbac-11e8-9b40-91b5cc935970.png)
