### PR TITLE
Add striped table variation

### DIFF
--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -89,6 +89,11 @@ export const settings = {
 		foot: getTableSectionAttributeSchema( 'foot' ),
 	},
 
+	styles: [
+		{ name: 'default', label: __( 'Regular' ), isDefault: true },
+		{ name: 'striped', label: __( 'Striped' ) },
+	],
+
 	supports: {
 		align: true,
 	},

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -90,8 +90,8 @@ export const settings = {
 	},
 
 	styles: [
-		{ name: 'default', label: __( 'Regular' ), isDefault: true },
-		{ name: 'striped', label: __( 'Striped' ) },
+		{ name: 'regular', label: __( 'Regular' ), isDefault: true },
+		{ name: 'stripes', label: __( 'Stripes' ) },
 	],
 
 	supports: {

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -18,7 +18,7 @@
 		width: auto;
 	}
 
-	&.is-style-striped {
+	&.is-style-stripes {
 		border-spacing: 0;
 		border-collapse: inherit;
 

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -17,4 +17,19 @@
 		// width as auto.
 		width: auto;
 	}
+
+	&.is-style-striped {
+		border-spacing: 0;
+		border-collapse: inherit;
+
+		tr:nth-child(odd) {
+			background-color: $light-gray-200;
+		}
+
+		td {
+			border-color: transparent;
+		}
+
+		border-bottom: 1px solid $light-gray-200;
+	}
 }

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -18,6 +18,7 @@
 		width: auto;
 	}
 
+	// "Stripes" style variation.
 	&.is-style-stripes {
 		border-spacing: 0;
 		border-collapse: inherit;


### PR DESCRIPTION
This PR adds a simple striped variation of the table.

It features a light gray background on odd rows, and a thin bottom border in case the last row is even (and therefore without a boundary because of hidden cell borders).

Default table:

![screenshot 2018-10-09 at 10 33 32](https://user-images.githubusercontent.com/1204802/46657115-d51d9080-cbaf-11e8-875c-fbbe872021d9.png)

Variation:

![screenshot 2018-10-09 at 10 39 22](https://user-images.githubusercontent.com/1204802/46657122-da7adb00-cbaf-11e8-8959-dd32e33d3b16.png)

Theme:

![screenshot 2018-10-09 at 10 40 50](https://user-images.githubusercontent.com/1204802/46657135-e36bac80-cbaf-11e8-8fa3-e92836663d51.png)
