### PR TITLE
Clean up variables, comments, reduce complexity

### DIFF
--- a/assets/stylesheets/_colors.scss
+++ b/assets/stylesheets/_colors.scss
@@ -2,8 +2,7 @@
  * Colors
  */
 
-// Hugo's new WordPress shades of gray,
-// from http://codepen.io/hugobaeta/pen/grJjVp
+// Hugo's new WordPress shades of gray, from http://codepen.io/hugobaeta/pen/grJjVp.
 $black: #000;
 $dark-gray-900: #191e23;
 $dark-gray-800: #23282d;
@@ -19,7 +18,7 @@ $light-gray-900: #a2aab2;
 $light-gray-800: #b5bcc2;
 $light-gray-700: #ccd0d4;
 $light-gray-600: #d7dade;
-$light-gray-500: #e2e4e7; // Good for "grayed" items and borders
+$light-gray-500: #e2e4e7; // Good for "grayed" items and borders.
 $light-gray-400: #e8eaeb;
 $light-gray-300: #edeff0;
 $light-gray-200: #f3f4f5;
@@ -66,8 +65,8 @@ $light-opacity-light-300: rgba($white, 0.2);
 $light-opacity-light-200: rgba($white, 0.15);
 $light-opacity-light-100: rgba($white, 0.1);
 
-// Additional colors
-// some from https://make.wordpress.org/design/handbook/foundations/colors/
+// Additional colors.
+// Some are from https://make.wordpress.org/design/handbook/foundations/colors/.
 $blue-wordpress-700: #00669b;
 $blue-dark-900: #0071a1;
 
@@ -83,7 +82,7 @@ $blue-medium-100: #e5f5fa;
 $blue-medium-highlight: #b3e7fe;
 $blue-medium-focus: #007cba;
 
-// Alert colors
+// Alert colors.
 $alert-yellow: #f0b849;
 $alert-red: #d94f4f;
 $alert-green: #4ab866;

--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -12,10 +12,9 @@ $editor-font-size: 16px;
 $text-editor-font-size: 14px;
 $editor-line-height: 1.8;
 $big-font-size: 18px;
-$mobile-text-min-font-size: 16px;	// Any font size below 16px will cause Mobile Safari to "zoom in"
+$mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in"
 
 // Grid size
-$item-spacing: 10px; // Should deprecate this in favor of $grid-size.
 $grid-size-small: 4px;
 $grid-size: 8px;
 $grid-size-large: 16px;
@@ -52,14 +51,11 @@ $resize-handler-size: 16px;
 $resize-handler-container-size: $resize-handler-size + ($grid-size-small * 2); // Make the resize handle container larger so there's a larger grabbable area.
 
 // Blocks
-$block-padding: 14px; // padding of nested blocks
-$block-spacing: 4px; // vertical space between blocks
-
-$block-side-ui-width: 28px; // width of the side UI, matches half matches half of a single line of text, so two buttons stacke matches 1
-$block-side-ui-clearance: 2px; // space between side UI and block
-$block-side-ui-padding: $block-side-ui-width + $block-side-ui-clearance; // total space used to accommodate side UI
-
-$block-container-side-padding: $block-side-ui-width + $block-padding + 2 * $block-side-ui-clearance;
+$block-padding: 14px; // Space between block footprint and focus boundaries. These are drawn outside the block footprint, and do not affect the size.
+$block-spacing: 4px; // Vertical space between blocks.
+$block-side-ui-width: 28px; // Width of the movers/drag handle UI.
+$block-side-ui-clearance: 2px; // Space between movers/drag handle UI, and block.
+$block-container-side-padding: $block-side-ui-width + $block-padding + 2 * $block-side-ui-clearance; // Total space left and right of the block footprint.
 
 // Buttons & UI Widgets
 $radius-round-rectangle: 4px;

--- a/packages/block-library/src/block/edit-panel/style.scss
+++ b/packages/block-library/src/block/edit-panel/style.scss
@@ -26,7 +26,7 @@
 	}
 
 	.reusable-block-edit-panel__label {
-		margin-right: $item-spacing;
+		margin-right: $grid-size;
 		white-space: nowrap;
 		font-weight: 600;
 	}
@@ -35,11 +35,11 @@
 		flex: 1 1 100%;
 		font-size: 14px;
 		height: 30px;
-		margin: #{ $item-spacing / 2 } 0 $item-spacing;
+		margin: $grid-size-small 0 $grid-size;
 	}
 
 	.components-button.reusable-block-edit-panel__button {
-		margin: 0 5px 0 0;
+		margin: 0 $grid-size-small 0 0;
 
 		// Prevent button shrinking in IE11 when other items have a 100% flex basis.
 		// This should be safe to apply in all browsers because we don't want these

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -25,10 +25,10 @@
 // Then at least an unselected columns block would be an accurate preview
 .editor-block-list__block[data-align="full"] .wp-block-columns .editor-block-list__layout {
 	&:first-child {
-		margin-left: $block-side-ui-padding;
+		margin-left: $block-side-ui-width + $block-side-ui-clearance;
 	}
 	&:last-child {
-		margin-right: $block-side-ui-padding;
+		margin-right: $block-side-ui-width + $block-side-ui-clearance;
 	}
 }
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -18,7 +18,7 @@
 	margin-left: 0;
 	margin-right: 0;
 
-	// Floats get an extra wrapping <aside> element, so the <figure> becomes a child.
+	// Floats get an extra wrapping <div> element, so the <figure> becomes a child.
 	.alignleft,
 	.alignright,
 	.aligncenter,

--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -9,7 +9,7 @@
 	label {
 		display: flex;
 		align-items: center;
-		margin-right: $item-spacing;
+		margin-right: $grid-size;
 		white-space: nowrap;
 		font-weight: 600;
 		flex-shrink: 0;
@@ -20,6 +20,6 @@
 	}
 
 	.dashicon {
-		margin-right: $item-spacing;
+		margin-right: $grid-size;
 	}
 }

--- a/packages/components/src/menu-group/style.scss
+++ b/packages/components/src/menu-group/style.scss
@@ -1,9 +1,9 @@
 .components-menu-group {
 	width: 100%;
-	padding: $item-spacing - $border-width;
+	padding: $grid-size - $border-width;
 }
 
 .components-menu-group__label {
-	margin-bottom: $item-spacing;
+	margin-bottom: $grid-size;
 	color: $dark-gray-300;
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -67,7 +67,7 @@
 	background: $white;
 	width: calc(100% - #{$panel-padding + $panel-padding});
 	height: $header-height;
-	padding: $item-spacing 0;
+	padding: $grid-size 0;
 
 	.components-modal__header-heading {
 		font-size: 1em;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -93,7 +93,7 @@
 
 	.components-panel__arrow {
 		position: absolute;
-		right: $item-spacing;
+		right: $grid-size;
 		top: 50%;
 		transform: translateY(-50%);
 		color: $dark-gray-900;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -93,7 +93,7 @@
 
 	.components-panel__arrow {
 		position: absolute;
-		right: $grid-size;
+		right: $grid-size + 2;
 		top: 50%;
 		transform: translateY(-50%);
 		color: $dark-gray-900;

--- a/packages/components/src/range-control/style.scss
+++ b/packages/components/src/range-control/style.scss
@@ -43,7 +43,7 @@
 
 .components-range-control__slider {
 	width: 100%;
-	margin-left: $item-spacing;
+	margin-left: $grid-size;
 	padding: 0;
 	-webkit-appearance: none;
 	background: transparent;
@@ -119,7 +119,7 @@
 
 .components-range-control__number {
 	display: inline-block;
-	margin-left: $item-spacing;
+	margin-left: $grid-size;
 	font-weight: 500;
 	width: 50px;
 	padding: 3px 5px !important;

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -41,7 +41,7 @@
 
 	// Move toolbar into top Editor Bar.
 	@include break-large {
-		padding-left: $item-spacing;
+		padding-left: $grid-size;
 		position: static;
 		left: auto;
 		right: auto;

--- a/packages/edit-post/src/components/sidebar/sidebar-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/sidebar-header/style.scss
@@ -1,7 +1,7 @@
 /* Text Editor specific */
 .components-panel__header.edit-post-sidebar-header__small {
 	background: $white;
-	padding-right: $panel-padding / 2;
+	padding-right: $grid-size-small;
 
 	.edit-post-sidebar__title {
 		overflow: hidden;
@@ -16,7 +16,7 @@
 }
 
 .components-panel__header.edit-post-sidebar-header {
-	padding-right: $panel-padding / 2;
+	padding-right: $grid-size-small;
 
 	.components-icon-button {
 		display: none;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -81,9 +81,9 @@
 	overflow-wrap: break-word;
 
 	@include break-small() {
-		// The block mover needs to stay inside the block to allow clicks when hovering the block
-		padding-left: $block-padding + $block-side-ui-padding - $border-width;
-		padding-right: $block-padding + $block-side-ui-padding - $border-width;
+		// The block mover needs to stay inside the block to allow clicks when hovering the block-.
+		padding-left: $block-padding + $block-side-ui-width + $block-side-ui-clearance - $border-width;
+		padding-right: $block-padding + $block-side-ui-width + $block-side-ui-clearance - $border-width;
 	}
 
 	/**
@@ -423,8 +423,8 @@
 			margin-right: -$block-padding;
 
 			@include break-small() {
-				margin-left: -$block-side-ui-padding - $block-padding;
-				margin-right: -$block-side-ui-padding - $block-padding;
+				margin-left: -$block-side-ui-width - $block-side-ui-clearance - $block-padding;
+				margin-right: -$block-side-ui-width - $block-side-ui-clearance - $block-padding;
 			}
 
 			// This explicitly sets the width of the block, to override
@@ -470,7 +470,7 @@
 		.editor-block-list__empty-block-inserter,
 		.editor-default-block-appender .editor-inserter {
 			left: auto;
-			right: $item-spacing;
+			right: $grid-size;
 		}
 	}
 }
@@ -534,7 +534,7 @@
 		display: flex;
 		flex-direction: row;
 		// Make room for the height of the block toolbar above.
-		margin-top: $item-spacing + $block-toolbar-height - $block-padding;
+		margin-top: $grid-size + $block-toolbar-height - $block-padding;
 		margin-right: -$block-padding;
 		margin-left: -$block-padding;
 		border-top: $border-width solid $light-gray-500;
@@ -600,7 +600,7 @@
  */
 
 .editor-block-list .editor-inserter {
-	margin: $item-spacing;
+	margin: $grid-size;
 	cursor: move; // Fallback for IE/Edge < 14
 	cursor: grab;
 }

--- a/packages/editor/src/components/block-settings-menu/style.scss
+++ b/packages/editor/src/components/block-settings-menu/style.scss
@@ -10,14 +10,14 @@
 	}
 
 	.editor-block-settings-menu__content {
-		padding: $item-spacing - $border-width;
+		padding: $grid-size - $border-width;
 	}
 
 	.editor-block-settings-menu__separator {
-		margin-top: $item-spacing;
-		margin-bottom: $item-spacing;
-		margin-left: -$item-spacing + $border-width;
-		margin-right: -$item-spacing + $border-width;
+		margin-top: $grid-size;
+		margin-bottom: $grid-size;
+		margin-left: -$grid-size + $border-width;
+		margin-right: -$grid-size + $border-width;
 		border-top: $border-width solid $light-gray-500;
 
 		// Check if the separator is the last child in the node and if so, hide itself

--- a/packages/editor/src/components/block-styles/style.scss
+++ b/packages/editor/src/components/block-styles/style.scss
@@ -5,7 +5,7 @@
 }
 
 .editor-block-styles__item {
-	width: calc(50% - $grid-size-small);
+	width: calc(50% - #{ $grid-size-small });
 	margin: $grid-size-small 0;
 	flex-shrink: 0;
 	cursor: pointer;

--- a/packages/editor/src/components/block-styles/style.scss
+++ b/packages/editor/src/components/block-styles/style.scss
@@ -5,8 +5,8 @@
 }
 
 .editor-block-styles__item {
-	width: calc(50% - #{ $item-spacing / 2 });
-	margin: ($item-spacing / 2) 0;
+	width: calc(50% - $grid-size-small);
+	margin: $grid-size-small 0;
 	flex-shrink: 0;
 	cursor: pointer;
 	overflow: hidden;

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -91,7 +91,7 @@
 // Left side.
 .editor-block-list__empty-block-inserter,
 .editor-default-block-appender .editor-inserter {
-	right: $item-spacing; // Show to the right on mobile.
+	right: $grid-size; // Show to the right on mobile.
 
 	@include break-small {
 		left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -36,7 +36,7 @@
 	border: $border-width dashed $light-gray-900;
 	background-color: $light-gray-300;
 	line-height: 20px;
-	padding: $item-spacing 0;
+	padding: $grid-size 0;
 	text-align: center;
 
 	&:hover {

--- a/packages/editor/src/components/rich-text/format-toolbar/style.scss
+++ b/packages/editor/src/components/rich-text/format-toolbar/style.scss
@@ -30,7 +30,7 @@
 }
 
 .editor-format-toolbar__link-value {
-	margin: $item-spacing - $border-width;
+	margin: $grid-size - $border-width;
 	flex-grow: 1;
 	flex-shrink: 1;
 	overflow: hidden;


### PR DESCRIPTION
This PR does a few things:

1. It replaces the $item-spacing variable with $grid-size, which is one small step towards a base8 based grid.
2. It cleans up comments in the variables file, fixes a few typos, and clarifies comments.
3. It retires a rarely used variable and makes the SCSS math that used it slightly more clear.

Aside from a good code review and testing, this needs a visual regression sanity check. The $grid-size variable is 8px, whereas $item-spacing was 10px. In my own testing, this caused no issues, but it would still be good to check a bit more in-depth. If some margins are now too small, we can consider a 12px variant, or jump directly to 16px.

