### PR TITLE
Remove autosaveable check from autosave monitor

### DIFF
--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -7,13 +7,10 @@ import { withSelect, withDispatch } from '@wordpress/data';
 
 export class AutosaveMonitor extends Component {
 	componentDidUpdate( prevProps ) {
-		const { isDirty, isAutosaveable } = this.props;
+		const { isDirty } = this.props;
 
-		if (
-			prevProps.isDirty !== isDirty ||
-			prevProps.isAutosaveable !== isAutosaveable
-		) {
-			this.toggleTimer( isDirty && isAutosaveable );
+		if ( prevProps.isDirty !== isDirty ) {
+			this.toggleTimer( isDirty );
 		}
 	}
 
@@ -41,13 +38,11 @@ export default compose( [
 	withSelect( ( select ) => {
 		const {
 			isEditedPostDirty,
-			isEditedPostAutosaveable,
 			getEditorSettings,
 		} = select( 'core/editor' );
 		const { autosaveInterval } = getEditorSettings();
 		return {
 			isDirty: isEditedPostDirty(),
-			isAutosaveable: isEditedPostAutosaveable(),
 			autosaveInterval,
 		};
 	} ),

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -22,36 +22,16 @@ describe( 'AutosaveMonitor', () => {
 	} );
 
 	describe( '#componentDidUpdate()', () => {
-		it( 'should start autosave timer when having become dirty and saveable', () => {
-			wrapper.setProps( { isDirty: true, isAutosaveable: true } );
+		it( 'should start autosave timer when having become dirty', () => {
+			wrapper.setProps( { isDirty: true } );
 
 			expect( toggleTimer ).toHaveBeenCalledWith( true );
-		} );
-
-		it( 'should stop autosave timer when the autosave is up to date', () => {
-			wrapper.setProps( { isDirty: true, isAutosaveable: false } );
-
-			expect( toggleTimer ).toHaveBeenCalledWith( false );
-		} );
-
-		it( 'should stop autosave timer when having become dirty but not autosaveable', () => {
-			wrapper.setProps( { isDirty: true, isAutosaveable: false } );
-
-			expect( toggleTimer ).toHaveBeenCalledWith( false );
 		} );
 
 		it( 'should stop autosave timer when having become not dirty', () => {
 			wrapper.setProps( { isDirty: true } );
 			toggleTimer.mockClear();
 			wrapper.setProps( { isDirty: false } );
-
-			expect( toggleTimer ).toHaveBeenCalledWith( false );
-		} );
-
-		it( 'should stop autosave timer when having become not autosaveable', () => {
-			wrapper.setProps( { isDirty: true } );
-			toggleTimer.mockClear();
-			wrapper.setProps( { isAutosaveable: false } );
 
 			expect( toggleTimer ).toHaveBeenCalledWith( false );
 		} );

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -59,7 +59,8 @@ export class PostPreviewButton extends Component {
 	 * Triggers autosave if post is autosaveable.
 	 */
 	openPreviewWindow() {
-		const { isAutosaveable, previewLink, currentPostLink } = this.props;
+		const { isEditedPostAutosaveable, previewLink, currentPostLink } = this.props;
+		const isAutosaveable = isEditedPostAutosaveable();
 
 		// Open a popup, BUT: Set it to a blank page until save completes. This
 		// is necessary because popups can only be opened in response to user
@@ -157,7 +158,7 @@ export default compose( [
 			isDirty: isEditedPostDirty(),
 			isNew: isEditedPostNew(),
 			isSaveable: isEditedPostSaveable(),
-			isAutosaveable: isEditedPostAutosaveable(),
+			isEditedPostAutosaveable: isEditedPostAutosaveable,
 			isViewable: get( postType, [ 'viewable' ], false ),
 		};
 	} ),

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -122,7 +122,7 @@ describe( 'PostPreviewButton', () => {
 		it( 'should open the currentPostLink if not autosaveable nor preview link available', () => {
 			const currentPostLink = 'https://wordpress.org/?p=1';
 			assertForPreview( {
-				isAutosaveable: false,
+				isEditedPostAutosaveable: () => false,
 				previewLink: undefined,
 				currentPostLink,
 			}, currentPostLink, false );
@@ -130,21 +130,21 @@ describe( 'PostPreviewButton', () => {
 
 		it( 'should save for autosaveable post with preview link', () => {
 			assertForPreview( {
-				isAutosaveable: true,
+				isEditedPostAutosaveable: () => true,
 				previewLink: 'https://wordpress.org/?p=1&preview=true',
 			}, null, true );
 		} );
 
 		it( 'should save for autosaveable post without preview link', () => {
 			assertForPreview( {
-				isAutosaveable: true,
+				isEditedPostAutosaveable: () => true,
 				previewLink: undefined,
 			}, null, true );
 		} );
 
 		it( 'should not save but open a popup window if not autosaveable but preview link available', () => {
 			assertForPreview( {
-				isAutosaveable: false,
+				isEditedPostAutosaveable: () => false,
 				previewLink: 'https://wordpress.org/?p=1&preview=true',
 			}, 'https://wordpress.org/?p=1&preview=true', false );
 		} );


### PR DESCRIPTION
## Description

This would be a quick fix for #10427. I'm not sure on the implications of removing the check in the autosave monitor. I'm also not sure if it would be a good idea to pass the selector function as a prop instead of the value, but like that we can call it only when needed. Again, unsure here if could get rid of this check and selector altogether... Would like some feedback around these issues from people who have worked on autosave before like @adamsilverstein and @aduth.

## How has this been tested?
Ensure serialisation does not run on every keystroke after the initial autosave. This could be done by logging it.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->