### PR TITLE
Move embed scripts into the body in preview documents

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -157,7 +157,9 @@ class Sandbox extends Component {
 		`;
 
 		// put the html snippet into a html document, and then write it to the iframe's document
-		// we can use this in the future to inject custom styles or scripts
+		// we can use this in the future to inject custom styles or scripts.
+		// Scripts go into the body rather than the head, to support embedded content such as Instagram
+		// that expect the scripts to be part of the body.
 		const htmlDoc = (
 			<html lang={ document.documentElement.lang } className={ this.props.type }>
 				<head>

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -163,13 +163,13 @@ class Sandbox extends Component {
 				<head>
 					<title>{ this.props.title }</title>
 					<style dangerouslySetInnerHTML={ { __html: style } } />
-					{ ( this.props.scripts && this.props.scripts.map(
-						( src ) => <script key={ src } src={ src } />
-					) ) }
 				</head>
 				<body data-resizable-iframe-connected="data-resizable-iframe-connected" className={ this.props.type }>
 					<div dangerouslySetInnerHTML={ { __html: this.props.html } } />
 					<script type="text/javascript" dangerouslySetInnerHTML={ { __html: observeAndResizeJS } } />
+					{ ( this.props.scripts && this.props.scripts.map(
+						( src ) => <script key={ src } src={ src } />
+					) ) }
 				</body>
 			</html>
 		);


### PR DESCRIPTION
## Description

Jetpack supplies embeds that use shortcodes, and enqueue scripts needed for the embeds to work. We were including these scripts in `<head>` but that doesn't work for all embeds. This change moves them into the body of the preview document, which fixes issues with Instagram embeds.

## How has this been tested?

Install Jetpack and make sure the shortcode module is enabled.

In a new post, embed https://www.pinterest.co.uk/pin/373869206564305678/ and https://www.instagram.com/p/BoEH8K_lCJ4/?taken-by=juicedpixels

Both should show a preview of the embed.

## Types of changes
Bug fix
