### PR TITLE
Fix clipping issue with Instagram embed

### DIFF
--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -23,6 +23,7 @@
 	max-width: $content-width;
 
 	@include break-small() {
+		// Compensate for side UI width.
 		.editor-block-list__block-edit {
 			margin-left: -$block-side-ui-width;
 			margin-right: -$block-side-ui-width;

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -1,10 +1,13 @@
 .wp-block-embed {
 	margin: 0;
+
 	// Necessary because we use responsive trickery to set width/height,
 	// therefore the video doesn't intrinsically clear floats like an image does.
 	clear: both;
+
 	// Apply a min-width, or the embed can collapse when floated.
-	min-width: $break-mobile / 2;
+	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
+	min-width: 360px;
 
 	&.is-loading {
 		display: flex;

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -3,7 +3,8 @@
 .editor-block-list__block[data-type="core/embed"][data-align="right"] .editor-block-list__block-edit,
 .wp-block-embed.alignleft,
 .wp-block-embed.alignright {
-	max-width: $content-width / 2;
+	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
+	max-width: 360px;
 	width: 100%;
 }
 


### PR DESCRIPTION
This fixes #10410.

Instagram embeds have a minimum width of 326px. We set it to 290px, which caused clipping.

This PR bumps the minimum width to 360px to give some margins, but it would be good to test other floated embeds to see what kind of min-widths they apply.

Screenshots of the fix:

![screenshot 2018-10-09 at 14 08 21](https://user-images.githubusercontent.com/1204802/46668606-2d16c000-cbcd-11e8-8e4f-6fe61e9289f2.png)

![screenshot 2018-10-09 at 14 08 26](https://user-images.githubusercontent.com/1204802/46668607-2e47ed00-cbcd-11e8-99f7-103c586450c7.png)
