### PR TITLE
Fix padding in validation modal

### DIFF
--- a/packages/editor/src/components/block-compare/style.scss
+++ b/packages/editor/src/components/block-compare/style.scss
@@ -7,10 +7,6 @@
 	overflow: auto;
 	height: auto;
 
-	.components-modal__content {
-		padding: 0;
-	}
-
 	@include break-small() {
 		max-height: 70%;
 	}
@@ -25,7 +21,7 @@
 		justify-content: space-between;
 		flex-direction: column;
 		width: 50%;
-		padding: 0 $panel-padding 0 $panel-padding;
+		padding: 0 $panel-padding 0 0;
 		min-width: 200px;
 
 		button {


### PR DESCRIPTION
A regression in #9900 made the padding in the block validation model a bit wonky:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/46676507-97812d80-cbd8-11e8-82dd-55eb7e73b97c.jpg)

This removes the custom validation padding CSS so it looks like:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/46676474-846e5d80-cbd8-11e8-96e2-457df96a0d1d.jpg)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
