### PR TITLE
Fix modal header overlapping the border

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -104,6 +104,7 @@
 	overflow: auto;
 	height: 100%;
 	padding: ($header-height+$panel-padding) $panel-padding $panel-padding $panel-padding;
+	border: 2px solid $white;
 
 	&:focus {
 		outline: $border-width solid $dark-gray-500;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -104,6 +104,9 @@
 	overflow: auto;
 	height: 100%;
 	padding: ($header-height+$panel-padding) $panel-padding $panel-padding $panel-padding;
+
+	// This border covers up a rounding error that makes text visible under the fixed header.
+	// This is caused by the vertical centering using translate, which places on subpixels.
 	border: 2px solid $white;
 
 	&:focus {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -63,7 +63,7 @@
 	align-items: stretch;
 	justify-content: space-between;
 	position: fixed;
-	top: 0;
+	top: $border-width;
 	background: $white;
 	width: calc(100% - #{$panel-padding + $panel-padding});
 	height: $header-height;


### PR DESCRIPTION
A change in #9900 has made the heading in a modal overlap with the top border:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/46678257-23e11f80-cbdc-11e8-9b0f-14983ce2bc59.jpg)

This is only visible on a small screen.

This PR tweaks the top offset, pushing it down by the border width:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/46678398-73bfe680-cbdc-11e8-9800-ee3eff84267a.jpg)

It fixes the small screen problem and doesn't appear to negatively affect a desktop screen (although this could be tweaked further)

## How has this been tested?
Set display to a small screen and open the keyboard shortcuts modal. Verify the heading overlaps and that the PR fixes the overlap.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
