### PR TITLE
fix: make "Manage Reusable Blocks" a link

### DIFF
--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -22,7 +22,7 @@ import scrollIntoView from 'dom-scroll-into-view';
  */
 import { __ } from '@wordpress/i18n';
 import { Component, findDOMNode, createRef } from '@wordpress/element';
-import { withSpokenMessages, PanelBody, IconButton } from '@wordpress/components';
+import { withSpokenMessages, PanelBody } from '@wordpress/components';
 import { getCategories, isReusableBlock } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withInstanceId, compose, withSafeTimeout } from '@wordpress/compose';
@@ -286,12 +286,12 @@ export class InserterMenu extends Component {
 							ref={ this.bindPanel( 'reusable' ) }
 						>
 							<BlockTypesList items={ reusableItems } onSelect={ onSelect } onHover={ this.onHover } />
-							<IconButton
+							<a
 								className="editor-inserter__manage-reusable-blocks"
-								icon="admin-generic"
-								label={ __( 'Manage All Reusable Blocks' ) }
 								href="edit.php?post_type=wp_block"
-							/>
+							>
+								{ __( 'Manage All Reusable Blocks' ) }
+							</a>
 						</PanelBody>
 					) }
 					{ isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory ) && (

--- a/packages/editor/src/components/inserter/style.scss
+++ b/packages/editor/src/components/inserter/style.scss
@@ -110,12 +110,11 @@ $block-inserter-search-height: 38px;
 
 .editor-inserter__reusable-blocks-panel {
 	position: relative;
+	text-align: center;
+}
 
-	.editor-inserter__manage-reusable-blocks {
-		bottom: 5px;
-		position: absolute;
-		right: 0;
-	}
+.editor-inserter__manage-reusable-blocks {
+	margin: $grid-size-large 0 0 $grid-size-large;
 }
 
 .editor-inserter__no-results {

--- a/packages/editor/src/components/inserter/style.scss
+++ b/packages/editor/src/components/inserter/style.scss
@@ -110,7 +110,7 @@ $block-inserter-search-height: 38px;
 
 .editor-inserter__reusable-blocks-panel {
 	position: relative;
-	text-align: center;
+	text-align: right;
 }
 
 .editor-inserter__manage-reusable-blocks {


### PR DESCRIPTION
Fix #10009.

## Description
Convert the "Manage all Reusable Blocks" button to a link. Previously, it was an icon-only button, which isn't good for accessibility or UX, and caused confusion regarding the result of interacting with the button (see: #10435).

This makes it clear the item is a link which will navigate to another part of the site.

## How has this been tested?
Tested locally in Firefox and Chrome, link works as expected. No longer looks like a button that doesn't act like one.

## Screenshots

### Before
<img width="472" alt="screenshot 2018-10-09 21 23 01" src="https://user-images.githubusercontent.com/90871/46696197-8270c280-cc09-11e8-8199-b81bc3876858.png">
<img width="491" alt="screenshot 2018-10-09 21 22 52" src="https://user-images.githubusercontent.com/90871/46696199-8270c280-cc09-11e8-9adb-0b9c9057d9e8.png">

### After
<img width="468" alt="screenshot 2018-10-10 00 21 59" src="https://user-images.githubusercontent.com/90871/46704383-a55ba080-cc22-11e8-8dd1-513cc775eeeb.png">
