### PR TITLE
Make possible to overwrite the globally defined colors in PanelColorSettings

### DIFF
--- a/packages/editor/src/components/color-palette/control.js
+++ b/packages/editor/src/components/color-palette/control.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { BaseControl, ColorIndicator } from '@wordpress/components';
+import { ifCondition, compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 
@@ -15,7 +16,13 @@ import { getColorObjectByColorValue } from '../colors';
 // translators: first %s: The type of color (e.g. background color), second %s: the color name or value (e.g. red or #ff0000)
 const colorIndicatorAriaLabel = __( '(current %s: %s)' );
 
-export function ColorPaletteControl( { label, value, onChange, colors } ) {
+export function ColorPaletteControl( {
+	colors,
+	disableCustomColors,
+	label,
+	onChange,
+	value,
+} ) {
 	const colorObject = getColorObjectByColorValue( colors, value );
 	const colorName = colorObject && colorObject.name;
 	const ariaLabel = sprintf( colorIndicatorAriaLabel, label.toLowerCase(), colorName || value );
@@ -40,9 +47,13 @@ export function ColorPaletteControl( { label, value, onChange, colors } ) {
 				className="editor-color-palette-control__color-palette"
 				value={ value }
 				onChange={ onChange }
+				{ ... { colors, disableCustomColors } }
 			/>
 		</BaseControl>
 	);
 }
 
-export default withColorContext( ColorPaletteControl );
+export default compose( [
+	withColorContext,
+	ifCondition( ( { hasColorsToChoose } ) => hasColorsToChoose ),
+] )( ColorPaletteControl );

--- a/packages/editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -15,6 +15,14 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
 >
   <WithColorContext(ColorPalette)
     className="editor-color-palette-control__color-palette"
+    colors={
+      Array [
+        Object {
+          "color": "#f00",
+          "name": "red",
+        },
+      ]
+    }
     onChange={[Function]}
     value="#f00"
   />

--- a/packages/editor/src/components/color-palette/with-color-context.js
+++ b/packages/editor/src/components/color-palette/with-color-context.js
@@ -12,10 +12,13 @@ import { withSelect } from '@wordpress/data';
 
 export default createHigherOrderComponent(
 	withSelect(
-		( select ) => {
+		( select, ownProps ) => {
 			const settings = select( 'core/editor' ).getEditorSettings();
-			const colors = settings.colors;
-			const disableCustomColors = settings.disableCustomColors;
+			const colors = ownProps.colors === undefined ?
+				settings.colors : ownProps.colors;
+
+			const disableCustomColors = ownProps.disableCustomColors === undefined ?
+				settings.disableCustomColors : ownProps.disableCustomColors;
 			return {
 				colors,
 				disableCustomColors,

--- a/packages/editor/src/components/panel-color-settings/index.js
+++ b/packages/editor/src/components/panel-color-settings/index.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { omit } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { PanelBody, ColorIndicator } from '@wordpress/components';
-import { ifCondition, compose } from '@wordpress/compose';
+import { ifCondition } from '@wordpress/compose';
 import { sprintf, __ } from '@wordpress/i18n';
 
 /**
@@ -17,58 +17,107 @@ import ColorPaletteControl from '../color-palette/control';
 import withColorContext from '../color-palette/with-color-context';
 import { getColorObjectByColorValue } from '../colors';
 
+const customColorsDisableForSetting = ( disableCustomColors, colorSetting ) => {
+	if ( colorSetting.disableCustomColors !== undefined ) {
+		return colorSetting.disableCustomColors;
+	}
+	return disableCustomColors;
+};
+
+const hasColorsToChooseInSetting = (
+	colors = [],
+	disableCustomColors,
+	colorSetting ) => {
+	if ( ! customColorsDisableForSetting( disableCustomColors, colorSetting ) ) {
+		return true;
+	}
+	return ( colorSetting.colors || colors ).length > 0;
+};
+
+const hasColorsToChoose = ( { colors, disableCustomColors, colorSettings } ) => {
+	return some( colorSettings, ( colorSetting ) => {
+		return hasColorsToChooseInSetting(
+			colors,
+			disableCustomColors,
+			colorSetting
+		);
+	} );
+};
+
 // translators: first %s: The type of color (e.g. background color), second %s: the color name or value (e.g. red or #ff0000)
 const colorIndicatorAriaLabel = __( '(%s: %s)' );
 
 const renderColorIndicators = ( colorSettings, colors ) => {
-	return colorSettings.map( ( { value, label }, index ) => {
-		if ( ! value ) {
-			return null;
+	return colorSettings.map(
+		( { value, label, colors: availableColors }, index ) => {
+			if ( ! value ) {
+				return null;
+			}
+
+			const colorObject = getColorObjectByColorValue(
+				availableColors || colors,
+				value
+			);
+			const colorName = colorObject && colorObject.name;
+			const ariaLabel = sprintf(
+				colorIndicatorAriaLabel,
+				label.toLowerCase(),
+				colorName || value
+			);
+
+			return (
+				<ColorIndicator
+					key={ index }
+					colorValue={ value }
+					aria-label={ ariaLabel }
+				/>
+			);
 		}
-
-		const colorObject = getColorObjectByColorValue( colors, value );
-		const colorName = colorObject && colorObject.name;
-		const ariaLabel = sprintf( colorIndicatorAriaLabel, label.toLowerCase(), colorName || value );
-
-		return (
-			<ColorIndicator
-				key={ index }
-				colorValue={ value }
-				aria-label={ ariaLabel }
-			/>
-		);
-	} );
+	);
 };
 
 // colorSettings is passed as an array of props so that it can be used for
 // mapping both ColorIndicator and ColorPaletteControl components. Passing
 // an array of components/nodes here wouldn't be feasible.
-export function PanelColorSettings( { title, colorSettings, colors, children, ...props } ) {
-	const className = 'editor-panel-color-settings';
+export const PanelColorSettings = ifCondition( hasColorsToChoose )(
+	( {
+		children,
+		colors,
+		colorSettings,
+		disableCustomColors,
+		title,
+		...props
+	} ) => {
+		const className = 'editor-panel-color-settings';
 
-	const titleElement = (
-		<span className={ `${ className }__panel-title` }>
-			{ title }
-			{ renderColorIndicators( colorSettings, colors ) }
-		</span>
-	);
+		const titleElement = (
+			<span className={ `${ className }__panel-title` }>
+				{ title }
+				{ renderColorIndicators( colorSettings, colors ) }
+			</span>
+		);
 
-	return (
-		<PanelBody
-			className={ className }
-			title={ titleElement }
-			{ ...omit( props, 'colors' ) }
-		>
-			{ colorSettings.map( ( settings, index ) => (
-				<ColorPaletteControl key={ index } { ...settings } />
-			) ) }
+		return (
+			<PanelBody
+				className={ className }
+				title={ titleElement }
+				{ ...props }
+			>
+				{ colorSettings.map( ( settings, index ) => (
+					<ColorPaletteControl
+						key={ index }
+						{ ...{
+							colors,
+							disableCustomColors,
+							...settings,
+						} }
+					/>
+				) ) }
 
-			{ children }
-		</PanelBody>
-	);
-}
+				{ children }
+			</PanelBody>
+		);
+	}
+);
 
-export default compose( [
-	withColorContext,
-	ifCondition( ( { hasColorsToChoose } ) => hasColorsToChoose ),
-] )( PanelColorSettings );
+export default withColorContext( PanelColorSettings );

--- a/packages/editor/src/components/panel-color-settings/index.js
+++ b/packages/editor/src/components/panel-color-settings/index.js
@@ -17,7 +17,7 @@ import ColorPaletteControl from '../color-palette/control';
 import withColorContext from '../color-palette/with-color-context';
 import { getColorObjectByColorValue } from '../colors';
 
-const customColorsDisableForSetting = ( disableCustomColors, colorSetting ) => {
+const hasCustomColorsDisabledForSetting = ( disableCustomColors, colorSetting ) => {
 	if ( colorSetting.disableCustomColors !== undefined ) {
 		return colorSetting.disableCustomColors;
 	}
@@ -28,7 +28,7 @@ const hasColorsToChooseInSetting = (
 	colors = [],
 	disableCustomColors,
 	colorSetting ) => {
-	if ( ! customColorsDisableForSetting( disableCustomColors, colorSetting ) ) {
+	if ( ! hasCustomColorsDisabledForSetting( disableCustomColors, colorSetting ) ) {
 		return true;
 	}
 	return ( colorSetting.colors || colors ).length > 0;

--- a/packages/editor/src/components/panel-color-settings/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/panel-color-settings/test/__snapshots__/index.js.snap
@@ -1,35 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PanelColorSettings matches the snapshot 1`] = `
-<PanelBody
-  className="editor-panel-color-settings"
-  title={
-    <span
-      className="editor-panel-color-settings__panel-title"
-    >
-      Test Title
-      <ColorIndicator
-        aria-label="(border color: #000)"
-        colorValue="#000"
-      />
-      <ColorIndicator
-        aria-label="(background color: #111)"
-        colorValue="#111"
-      />
-    </span>
+<Component
+  colorSettings={
+    Array [
+      Object {
+        "label": "border color",
+        "onChange": [Function],
+        "value": "#000",
+      },
+      Object {
+        "label": "background color",
+        "onChange": [Function],
+        "value": "#111",
+      },
+    ]
   }
->
-  <WithColorContext(ColorPaletteControl)
-    key="0"
-    label="border color"
-    onChange={[Function]}
-    value="#000"
-  />
-  <WithColorContext(ColorPaletteControl)
-    key="1"
-    label="background color"
-    onChange={[Function]}
-    value="#111"
-  />
-</PanelBody>
+  colors={Array []}
+  title="Test Title"
+/>
+`;
+
+exports[`PanelColorSettings should render a color panel if at least one setting specifies some colors to choose 1`] = `
+<Component
+  colorSettings={
+    Array [
+      Object {
+        "colors": Array [
+          Object {
+            "color": "#ff0000",
+            "name": "Red",
+            "slug": "red",
+          },
+        ],
+        "label": "border color",
+        "onChange": [Function],
+        "value": "#000",
+      },
+      Object {
+        "label": "background color",
+        "onChange": [Function],
+        "value": "#111",
+      },
+    ]
+  }
+  colors={Array []}
+  disableCustomColors={true}
+  title="Test Title"
+/>
+`;
+
+exports[`PanelColorSettings should render a color panel if at least one setting supports custom colors 1`] = `
+<Component
+  colorSettings={
+    Array [
+      Object {
+        "label": "border color",
+        "onChange": [Function],
+        "value": "#000",
+      },
+      Object {
+        "disableCustomColors": false,
+        "label": "background color",
+        "onChange": [Function],
+        "value": "#111",
+      },
+    ]
+  }
+  colors={Array []}
+  disableCustomColors={true}
+  title="Test Title"
+/>
 `;

--- a/packages/editor/src/components/panel-color-settings/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/panel-color-settings/test/__snapshots__/index.js.snap
@@ -21,6 +21,42 @@ exports[`PanelColorSettings matches the snapshot 1`] = `
 />
 `;
 
+exports[`PanelColorSettings matches the snapshot 2`] = `
+<PanelBody
+  className="editor-panel-color-settings"
+  title={
+    <span
+      className="editor-panel-color-settings__panel-title"
+    >
+      Test Title
+      <ColorIndicator
+        aria-label="(border color: #000)"
+        colorValue="#000"
+      />
+      <ColorIndicator
+        aria-label="(background color: #111)"
+        colorValue="#111"
+      />
+    </span>
+  }
+>
+  <WithColorContext(IfCondition(ColorPaletteControl))
+    colors={Array []}
+    key="0"
+    label="border color"
+    onChange={[Function]}
+    value="#000"
+  />
+  <WithColorContext(IfCondition(ColorPaletteControl))
+    colors={Array []}
+    key="1"
+    label="background color"
+    onChange={[Function]}
+    value="#111"
+  />
+</PanelBody>
+`;
+
 exports[`PanelColorSettings should render a color panel if at least one setting specifies some colors to choose 1`] = `
 <Component
   colorSettings={
@@ -50,6 +86,52 @@ exports[`PanelColorSettings should render a color panel if at least one setting 
 />
 `;
 
+exports[`PanelColorSettings should render a color panel if at least one setting specifies some colors to choose 2`] = `
+<PanelBody
+  className="editor-panel-color-settings"
+  title={
+    <span
+      className="editor-panel-color-settings__panel-title"
+    >
+      Test Title
+      <ColorIndicator
+        aria-label="(border color: #000)"
+        colorValue="#000"
+      />
+      <ColorIndicator
+        aria-label="(background color: #111)"
+        colorValue="#111"
+      />
+    </span>
+  }
+>
+  <WithColorContext(IfCondition(ColorPaletteControl))
+    colors={
+      Array [
+        Object {
+          "color": "#ff0000",
+          "name": "Red",
+          "slug": "red",
+        },
+      ]
+    }
+    disableCustomColors={true}
+    key="0"
+    label="border color"
+    onChange={[Function]}
+    value="#000"
+  />
+  <WithColorContext(IfCondition(ColorPaletteControl))
+    colors={Array []}
+    disableCustomColors={true}
+    key="1"
+    label="background color"
+    onChange={[Function]}
+    value="#111"
+  />
+</PanelBody>
+`;
+
 exports[`PanelColorSettings should render a color panel if at least one setting supports custom colors 1`] = `
 <Component
   colorSettings={
@@ -71,4 +153,42 @@ exports[`PanelColorSettings should render a color panel if at least one setting 
   disableCustomColors={true}
   title="Test Title"
 />
+`;
+
+exports[`PanelColorSettings should render a color panel if at least one setting supports custom colors 2`] = `
+<PanelBody
+  className="editor-panel-color-settings"
+  title={
+    <span
+      className="editor-panel-color-settings__panel-title"
+    >
+      Test Title
+      <ColorIndicator
+        aria-label="(border color: #000)"
+        colorValue="#000"
+      />
+      <ColorIndicator
+        aria-label="(background color: #111)"
+        colorValue="#111"
+      />
+    </span>
+  }
+>
+  <WithColorContext(IfCondition(ColorPaletteControl))
+    colors={Array []}
+    disableCustomColors={true}
+    key="0"
+    label="border color"
+    onChange={[Function]}
+    value="#000"
+  />
+  <WithColorContext(IfCondition(ColorPaletteControl))
+    colors={Array []}
+    disableCustomColors={false}
+    key="1"
+    label="background color"
+    onChange={[Function]}
+    value="#111"
+  />
+</PanelBody>
 `;

--- a/packages/editor/src/components/panel-color-settings/test/index.js
+++ b/packages/editor/src/components/panel-color-settings/test/index.js
@@ -32,4 +32,108 @@ describe( 'PanelColorSettings', () => {
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
+
+	it( 'should not render anything if there are no colors to choose', () => {
+		const wrapper = shallow(
+			<PanelColorSettings
+				title="Test Title"
+				colors={ [] }
+				disableCustomColors={ true }
+				colorSettings={ [
+					{
+						value: '#000',
+						onChange: noop,
+						label: 'border color',
+					},
+					{
+						value: '#111',
+						onChange: noop,
+						label: 'background color',
+					},
+				] }
+			/>
+		);
+
+		expect( wrapper.type() ).toBeNull();
+	} );
+
+	it( 'should render a color panel if at least one setting supports custom colors', () => {
+		const wrapper = shallow(
+			<PanelColorSettings
+				title="Test Title"
+				colors={ [] }
+				disableCustomColors={ true }
+				colorSettings={ [
+					{
+						value: '#000',
+						onChange: noop,
+						label: 'border color',
+					},
+					{
+						value: '#111',
+						onChange: noop,
+						label: 'background color',
+						disableCustomColors: false,
+					},
+				] }
+			/>
+		);
+		expect( wrapper.type() ).not.toBeNull();
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'should render a color panel if at least one setting specifies some colors to choose', () => {
+		const wrapper = shallow(
+			<PanelColorSettings
+				title="Test Title"
+				colors={ [] }
+				disableCustomColors={ true }
+				colorSettings={ [
+					{
+						value: '#000',
+						onChange: noop,
+						label: 'border color',
+						colors: [ {
+							slug: 'red',
+							name: 'Red',
+							color: '#ff0000',
+						} ],
+					},
+					{
+						value: '#111',
+						onChange: noop,
+						label: 'background color',
+					},
+				] }
+			/>
+		);
+		expect( wrapper.type() ).not.toBeNull();
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'should not render anything if none of the setting panels has colors to choose', () => {
+		const wrapper = shallow(
+			<PanelColorSettings
+				title="Test Title"
+				disableCustomColors={ false }
+				colorSettings={ [
+					{
+						value: '#000',
+						onChange: noop,
+						label: 'border color',
+						colors: [],
+						disableCustomColors: true,
+					},
+					{
+						value: '#111',
+						onChange: noop,
+						label: 'background color',
+						colors: [],
+						disableCustomColors: true,
+					},
+				] }
+			/>
+		);
+		expect( wrapper.type() ).toBeNull();
+	} );
 } );

--- a/packages/editor/src/components/panel-color-settings/test/index.js
+++ b/packages/editor/src/components/panel-color-settings/test/index.js
@@ -31,6 +31,7 @@ describe( 'PanelColorSettings', () => {
 		);
 
 		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.dive() ).toMatchSnapshot();
 	} );
 
 	it( 'should not render anything if there are no colors to choose', () => {
@@ -80,6 +81,7 @@ describe( 'PanelColorSettings', () => {
 		);
 		expect( wrapper.type() ).not.toBeNull();
 		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.dive() ).toMatchSnapshot();
 	} );
 
 	it( 'should render a color panel if at least one setting specifies some colors to choose', () => {
@@ -109,6 +111,7 @@ describe( 'PanelColorSettings', () => {
 		);
 		expect( wrapper.type() ).not.toBeNull();
 		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.dive() ).toMatchSnapshot();
 	} );
 
 	it( 'should not render anything if none of the setting panels has colors to choose', () => {


### PR DESCRIPTION
This PR makes it possible to overwrite the globally defined colors (colors arrays and disableCustomColors) in PanelColorSettings.

The overwrite can be global for all the color panels of the component or local per each settings panel.

This PR makes sure that we offer all the functionality that the combination of wp.editor.PanelColor and wp.components.PanelColor had. Making it possible to deprecate these components and unify the color UI components. Deprecation PR created by @chrisvanpatten is available in https://github.com/WordPress/gutenberg/pull/10391.


## How has this been tested?
I checked that the blocks using colors (button, paragraph, pull quote still work as before).
I tried a theme that sets the colors or disables custom colors, and everything worked as before.
I created the test block available in https://gist.github.com/jorgefilipecosta/ac1d68e492869465b054868baac60df2 and checked that the definition overwrites specified were correctly applied.
