### PR TITLE
Use TextControl with label for post-publish permalink

### DIFF
--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -6,7 +6,12 @@ import { get } from 'lodash';
 /**
  * WordPress Dependencies
  */
-import { PanelBody, Button, ClipboardButton } from '@wordpress/components';
+import {
+	Button,
+	ClipboardButton,
+	PanelBody,
+	TextControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
@@ -65,12 +70,12 @@ class PostPublishPanelPostpublish extends Component {
 				</PanelBody>
 				<PanelBody>
 					<div><strong>{ postPublishBodyText }</strong></div>
-					<input
+					<TextControl
+						label={ __( 'Permalink' ) }
 						className="post-publish-panel__postpublish-link-input"
 						readOnly
 						value={ post.link }
 						onFocus={ this.onSelectInput }
-						type="text"
 					/>
 					<div className="post-publish-panel__postpublish-buttons">
 						{ ! isScheduled && (

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -75,7 +75,7 @@ class PostPublishPanelPostpublish extends Component {
 						className="post-publish-panel__postpublish-link-input"
 						readOnly
 						value={ post.link }
-						onFocus={ this.onSelectInput }
+						onClick={ this.onSelectInput }
 					/>
 					<div className="post-publish-panel__postpublish-buttons">
 						{ ! isScheduled && (

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -104,10 +104,12 @@
 	}
 }
 
-.post-publish-panel__postpublish-link-input[readonly] {
+.post-publish-panel__postpublish-link-input {
+	margin: $grid-size-large 0;
+}
+
+.post-publish-panel__postpublish-link-input .components-text-control__input[readonly] {
 	width: 100%;
-	padding: 10px;
-	margin: 15px 0;
 	background: $white;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
Fixes #9535.

Small change to the post-publish panel to use a `TextControl` with a "Permalink" label…

![edit_page_ _tomodomo_ _wordpress_and_web_inspector_ _dev_tomodomo_co_ _post_php](https://user-images.githubusercontent.com/1231306/46705849-610ad900-cbff-11e8-8235-2c6103a36784.png)

Also adjusted to use one of the grid-size variables.

It's a WIP because the click-to-select-text isn't working now that it's a TextControl instead of an input. Would love some help on that!