### PR TITLE
fix: Fix inserter misalignment regression

### DIFF
--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -171,11 +171,6 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-right & {
 		/*!rtl:ignore*/
-		margin-left: 0;
-	}
-
-	.components-popover.edit-post-more-menu__content:not(.is-mobile):not(.is-middle).is-right & {
-		/*!rtl:ignore*/
 		margin-left: -12px;
 	}
 
@@ -186,11 +181,6 @@ $arrow-size: 8px;
 	}
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-left & {
-		/*!rtl:ignore*/
-		margin-right: 0;
-	}
-
-	.components-popover.edit-post-more-menu__content:not(.is-mobile):not(.is-middle).is-left & {
 		/*!rtl:ignore*/
 		margin-right: -12px;
 	}

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -171,7 +171,7 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-right & {
 		/*!rtl:ignore*/
-		margin-left: -$grid-size-large;
+		margin-left: -24px;
 	}
 
 	.components-popover:not(.is-mobile).is-left & {
@@ -182,7 +182,7 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-left & {
 		/*!rtl:ignore*/
-		margin-right: -$grid-size-large;
+		margin-right: -24px;
 	}
 }
 

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -171,7 +171,7 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-right & {
 		/*!rtl:ignore*/
-		margin-left: -12px;
+		margin-left: -$grid-size-large;
 	}
 
 	.components-popover:not(.is-mobile).is-left & {
@@ -182,7 +182,7 @@ $arrow-size: 8px;
 
 	.components-popover:not(.is-mobile):not(.is-middle).is-left & {
 		/*!rtl:ignore*/
-		margin-right: -12px;
+		margin-right: -$grid-size-large;
 	}
 }
 

--- a/packages/nux/src/components/dot-tip/style.scss
+++ b/packages/nux/src/components/dot-tip/style.scss
@@ -82,7 +82,6 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 	&:not(.is-mobile).is-left,
 	&:not(.is-mobile).is-center,
 	&:not(.is-mobile).is-right {
-
 		// Position tips above popovers
 		z-index: z-index(".nux-dot-tip");
 
@@ -98,5 +97,25 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 				width: auto;
 			}
 		}
+	}
+
+	&.components-popover:not(.is-mobile):not(.is-middle).is-right .components-popover__content {
+		/*!rtl:ignore*/
+		margin-left: 0;
+	}
+
+	&.components-popover:not(.is-mobile):not(.is-middle).is-left .components-popover__content {
+		/*!rtl:ignore*/
+		margin-right: 0;
+	}
+
+	&.components-popover.edit-post-more-menu__content:not(.is-mobile):not(.is-middle).is-right .components-popover__content {
+		/*!rtl:ignore*/
+		margin-left: -12px;
+	}
+
+	&.components-popover.edit-post-more-menu__content:not(.is-mobile):not(.is-middle).is-left .components-popover__content {
+		/*!rtl:ignore*/
+		margin-right: -12px;
 	}
 }


### PR DESCRIPTION
Fix #10453

## Description
Fixed the visual regression caused in #10295 by moving the margin fix to target the NUX tooltips specifically.

## How has this been tested?
Tested in RTL and LTR, in Firefox, mobile and larger viewports.

## Screenshots

### Before
<img width="431" alt="screenshot 2018-10-09 20 52 41" src="https://user-images.githubusercontent.com/90871/46695809-6b7da080-cc08-11e8-9fbd-9dd25dc3a807.png">

### After
<img width="638" alt="screenshot 2018-10-10 01 30 52" src="https://user-images.githubusercontent.com/90871/46706426-4864e800-cc2c-11e8-8f80-f4a5faf8e53e.png">
