### PR TITLE
Parser: Replace dynamic-block regex in `do_blocks`

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -246,7 +246,7 @@ function _recurse_blocks( $blocks, $all_blocks ) {
  * @return string
  */
 function strip_dynamic_blocks( $content ) {
-	return _recurse_strip_dynamic_blocks( parse_blocks( $content ) );
+	return _recurse_strip_dynamic_blocks( gutenberg_parse_blocks( $content ) );
 }
 
 /**

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -171,7 +171,7 @@ function gutenberg_render_block( $block ) {
  * @return string          Updated post content.
  */
 function do_blocks( $content ) {
-	$blocks = parse_blocks( $content );
+	$blocks = gutenberg_parse_blocks( $content );
 	return _recurse_blocks( $blocks, $blocks );
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode().

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -110,6 +110,7 @@ function get_dynamic_block_names() {
  * @return string
  */
 function get_dynamic_blocks_regex() {
+	_deprecated_function( __FUNCTION__, '4.1.0', __( "Dynamic blocks shouldn't be extracted by regex. Use parse_blocks() instead.", 'gutenberg' ) );
 	$dynamic_block_names   = get_dynamic_block_names();
 	$dynamic_block_pattern = (
 		'/<!--\s+wp:(' .
@@ -230,13 +231,30 @@ function _recurse_blocks( $blocks, $all_blocks ) {
 /**
  * Remove all dynamic blocks from the given content.
  *
- * @since 3.6.0
+ * @since 5.0.0
  *
  * @param string $content Content of the current post.
  * @return string
  */
 function strip_dynamic_blocks( $content ) {
-	return preg_replace( get_dynamic_blocks_regex(), '', $content );
+	return _recurse_strip_dynamic_blocks( parse_blocks( $content ) );
+}
+
+function _recurse_strip_dynamic_blocks( $blocks ) {
+	$clean_content  = '';
+	$dynamic_blocks = get_dynamic_block_names();
+
+	foreach ( $blocks as $block ) {
+		if ( ! in_array( $block['blockName'], $dynamic_blocks ) ) {
+			if ( $block['innerBlocks'] ) {
+				$clean_content .= _recurse_strip_dynamic_blocks( $block['innerBlocks'] );
+			} else {
+				$clean_content .= $block['innerHTML'];
+			}
+		}
+	}
+
+	return $clean_content;
 }
 
 /**

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -177,6 +177,15 @@ function do_blocks( $content ) {
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode().
 
+/**
+ * Helper function for do_blocks(), to recurse through the block tree.
+ *
+ * @since 4.1.0
+ * @access private
+ *
+ * @param array $blocks Array of blocks from parse_blocks()
+ * @return string
+ */
 function _recurse_blocks( $blocks, $all_blocks ) {
 	global $post;
 
@@ -198,7 +207,7 @@ function _recurse_blocks( $blocks, $all_blocks ) {
 
 			// Replace dynamic block with server-rendered output.
 			$block_content = $block_type->render( (array) $block['attrs'], $block['innerHTML'] );
-		} else if ( $block['innerBlocks'] ) {
+		} elseif ( $block['innerBlocks'] ) {
 			$block_content = _recurse_blocks( $block['innerBlocks'], $all_blocks );
 		} else {
 			$block_content = $block['innerHTML'];
@@ -231,7 +240,7 @@ function _recurse_blocks( $blocks, $all_blocks ) {
 /**
  * Remove all dynamic blocks from the given content.
  *
- * @since 5.0.0
+ * @since 4.1.0
  *
  * @param string $content Content of the current post.
  * @return string
@@ -240,6 +249,15 @@ function strip_dynamic_blocks( $content ) {
 	return _recurse_strip_dynamic_blocks( parse_blocks( $content ) );
 }
 
+/**
+ * Helper function for strip_dynamic_blocks(), to recurse through the block tree.
+ *
+ * @since 4.1.0
+ * @access private
+ *
+ * @param array $blocks Array of blocks from parse_blocks()
+ * @return string
+ */
 function _recurse_strip_dynamic_blocks( $blocks ) {
 	$clean_content  = '';
 	$dynamic_blocks = get_dynamic_block_names();

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -306,7 +306,7 @@ class WP_Block_Parser {
 				 * block and add it as a new innerBlock to the parent
 				 */
 				$stack_top = array_pop( $this->stack );
-				$stack_top->block->innerHTML .= substr( $this->document, $stack_top->prev_offset, $start_offset - $stack_top->prev_offset );
+				$stack_top->block->innerBlocks[] = (array) $this->freeform( substr( $this->document, $stack_top->prev_offset, $start_offset - $stack_top->prev_offset ) );
 				$stack_top->prev_offset = $start_offset + $token_length;
 
 				$this->add_inner_block(
@@ -440,8 +440,8 @@ class WP_Block_Parser {
 	 */
 	function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
 		$parent = $this->stack[ count( $this->stack ) - 1 ];
-		$parent->block->innerBlocks[] = $block;
-		$parent->block->innerHTML .= substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
+		$parent->block->innerBlocks[] = (array) $this->freeform( substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset ) );
+		$parent->block->innerBlocks[] = (array) $block;
 		$parent->prev_offset = $last_offset ? $last_offset : $token_start + $token_length;
 	}
 
@@ -456,9 +456,15 @@ class WP_Block_Parser {
 		$stack_top   = array_pop( $this->stack );
 		$prev_offset = $stack_top->prev_offset;
 
-		$stack_top->block->innerHTML .= isset( $end_offset )
+		$html = isset( $end_offset )
 			? substr( $this->document, $prev_offset, $end_offset - $prev_offset )
 			: substr( $this->document, $prev_offset );
+
+		if ( $stack_top->block->innerBlocks ) {
+			$stack_top->block->innerBlocks[] = (array) $this->freeform( $html );
+		} else {
+			$stack_top->block->innerHTML = $html;
+		}
 
 		if ( isset( $stack_top->leading_html_start ) ) {
 			$this->output[] = (array) self::freeform( substr(

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -306,7 +306,14 @@ class WP_Block_Parser {
 				 * block and add it as a new innerBlock to the parent
 				 */
 				$stack_top = array_pop( $this->stack );
-				$stack_top->block->innerBlocks[] = (array) $this->freeform( substr( $this->document, $stack_top->prev_offset, $start_offset - $stack_top->prev_offset ) );
+
+				$html = substr( $this->document, $stack_top->prev_offset, $start_offset - $stack_top->prev_offset );
+				if ( $stack_top->block->innerBlocks ) {
+					$stack_top->block->innerBlocks[] = (array) $this->freeform( $html );
+				} else {
+					$stack_top->block->innerHTML = $html;
+				}
+
 				$stack_top->prev_offset = $start_offset + $token_length;
 
 				$this->add_inner_block(


### PR DESCRIPTION
## Description

Previously we have been using a simplified parse to grab dynamic
blocks and replace them with their rendered content.

Since #8083 we've had a fast default parser which removes the need
for a simplified parse here.

In this patch we're replacing the existing simplified parser in
`do_blocks` with the new default parser. This will open up new
opportunities for working with nested blocks on the server.

## Resolves or addresses:
 - #6751
 - #7247
 - #8760

## Status
 - [ ] it appears like the old parser relies on the raw content in the blocks but the parser spec doesn't provide this. this means that after this patch we might be wiping out all nested block content on render. this needs to be fixed 😉
 - [x] I'm not sure what the `mobile` files are but they mirror this one. can someone explain what those are? are they auto-generated? do we have to update them?
 - [ ] this doesn't replace usage of the simplified parser in `strip_dynamic_blocks()`. we should probably revisit #6170 to prevent introducing another tear-down-built-up double iteration in those simpler functions. for now, I've left in the regex solution built by @aduth 

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.