### PR TITLE
Wrap cite tag with footer in Quote and Pullquote blocks

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -90,6 +90,7 @@ class PullQuoteEdit extends Component {
 						/>
 						{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 							<RichText
+								tagName="footer"
 								value={ citation }
 								/* translators: the individual or entity quoted */
 								placeholder={ __( 'Write citation…' ) }
@@ -98,7 +99,6 @@ class PullQuoteEdit extends Component {
 										citation: nextCitation,
 									} )
 								}
-								className="wp-block-pullquote__citation"
 							/>
 						) }
 					</blockquote>

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -9,7 +9,7 @@
 }
 
 .wp-block-pullquote {
-	cite .editor-rich-text__tinymce[data-is-empty="true"]::before {
+	footer .editor-rich-text__tinymce[data-is-empty="true"]::before {
 		font-size: 14px;
 		font-family: $default-font;
 	}
@@ -35,12 +35,12 @@
 		font-size: 32px;
 	}
 
-	.wp-block-pullquote__citation {
+	footer {
 		text-transform: none;
 		font-style: normal;
 	}
 }
 
-.wp-block-pullquote .wp-block-pullquote__citation {
+.wp-block-pullquote footer {
 	color: inherit;
 }

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -31,7 +31,7 @@ const blockAttributes = {
 	},
 	citation: {
 		source: 'html',
-		selector: 'cite',
+		selector: 'footer cite',
 	},
 	mainColor: {
 		type: 'string',
@@ -109,47 +109,109 @@ export const settings = {
 			<figure className={ figureClass } style={ figureStyles }>
 				<blockquote className={ blockquoteClasses } style={ blockquoteStyle } >
 					<RichText.Content value={ value } multiline="p" />
-					{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					{ ! RichText.isEmpty( citation ) && (
+						<footer>
+							<RichText.Content tagName="cite" value={ citation } />
+						</footer>
+					) }
 				</blockquote>
 			</figure>
 		);
 	},
 
-	deprecated: [ {
-		attributes: {
-			...blockAttributes,
-		},
-		save( { attributes } ) {
-			const { value, citation } = attributes;
-			return (
-				<blockquote>
-					<RichText.Content value={ value } multiline="p" />
-					{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
-				</blockquote>
-			);
-		},
-	}, {
-		attributes: {
-			...blockAttributes,
-			citation: {
-				source: 'html',
-				selector: 'footer',
+	deprecated: [
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					source: 'html',
+					selector: 'cite',
+				},
 			},
-			align: {
-				type: 'string',
-				default: 'none',
+			save( { attributes } ) {
+				const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;
+				const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+
+				let figureClass, figureStyles;
+				// Is solid color style
+				if ( isSolidColorStyle ) {
+					figureClass = getColorClassName( 'background-color', mainColor );
+					if ( ! figureClass ) {
+						figureStyles = {
+							backgroundColor: customMainColor,
+						};
+					}
+				// Is normal style and a custom color is being used ( we can set a style directly with its value)
+				} else if ( customMainColor ) {
+					figureStyles = {
+						borderColor: customMainColor,
+					};
+				// Is normal style and a named color is being used, we need to retrieve the color value to set the style,
+				// as there is no expectation that themes create classes that set border colors.
+				} else if ( mainColor ) {
+					const colors = get( select( 'core/editor' ).getEditorSettings(), [ 'colors' ], [] );
+					const colorObject = getColorObjectByAttributeValues( colors, mainColor );
+					figureStyles = {
+						borderColor: colorObject.color,
+					};
+				}
+
+				const blockquoteTextColorClass = getColorClassName( 'color', textColor );
+				const blockquoteClasses = textColor || customTextColor ? classnames( 'has-text-color', {
+					[ blockquoteTextColorClass ]: blockquoteTextColorClass,
+				} ) : undefined;
+				const blockquoteStyle = blockquoteTextColorClass ? undefined : { color: customTextColor };
+				return (
+					<figure className={ figureClass } style={ figureStyles }>
+						<blockquote className={ blockquoteClasses } style={ blockquoteStyle } >
+							<RichText.Content value={ value } multiline="p" />
+							{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+						</blockquote>
+					</figure>
+				);
 			},
 		},
-
-		save( { attributes } ) {
-			const { value, citation, align } = attributes;
-
-			return (
-				<blockquote className={ `align${ align }` }>
-					<RichText.Content value={ value } />
-					{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="footer" value={ citation } /> }
-				</blockquote>
-			);
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					source: 'html',
+					selector: 'cite',
+				},
+			},
+			save( { attributes } ) {
+				const { value, citation } = attributes;
+				return (
+					<blockquote>
+						<RichText.Content value={ value } multiline="p" />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				);
+			},
 		},
-	} ],
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					source: 'html',
+					selector: 'footer',
+				},
+				align: {
+					type: 'string',
+					default: 'none',
+				},
+			},
+
+			save( { attributes } ) {
+				const { value, citation, align } = attributes;
+
+				return (
+					<blockquote className={ `align${ align }` }>
+						<RichText.Content value={ value } />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="footer" value={ citation } /> }
+					</blockquote>
+				);
+			},
+		},
+	],
 };

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -18,7 +18,6 @@
 		line-height: 1.6;
 	}
 
-	cite,
 	footer {
 		position: relative;
 	}
@@ -46,13 +45,13 @@
 			font-size: 32px;
 		}
 
-		cite {
+		footer {
 			text-transform: none;
 			font-style: normal;
 		}
 	}
 }
 
-.wp-block-pullquote cite {
+.wp-block-pullquote footer {
 	color: inherit;
 }

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -3,9 +3,7 @@
 	border-bottom: 4px solid $dark-gray-500;
 	color: $dark-gray-600;
 
-	cite,
-	footer,
-	&__citation {
+	footer {
 		color: $dark-gray-600;
 		text-transform: uppercase;
 		font-size: $default-font-size;

--- a/packages/block-library/src/quote/editor.scss
+++ b/packages/block-library/src/quote/editor.scss
@@ -1,7 +1,7 @@
 .wp-block-quote {
 	margin: 0;
 
-	&__citation {
+	footer {
 		font-size: $default-font-size;
 	}
 }

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -24,7 +24,7 @@ const blockAttributes = {
 	},
 	citation: {
 		source: 'html',
-		selector: 'cite',
+		selector: 'footer cite',
 	},
 	align: {
 		type: 'string',
@@ -170,6 +170,7 @@ export const settings = {
 					/>
 					{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 						<RichText
+							tagName="footer"
 							value={ citation }
 							onChange={
 								( nextCitation ) => setAttributes( {
@@ -178,7 +179,6 @@ export const settings = {
 							}
 							/* translators: the individual or entity quoted */
 							placeholder={ __( 'Write citation…' ) }
-							className="wp-block-quote__citation"
 						/>
 					) }
 				</blockquote>
@@ -192,7 +192,11 @@ export const settings = {
 		return (
 			<blockquote style={ { textAlign: align ? align : null } }>
 				<RichText.Content multiline="p" value={ value } />
-				{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+				{ ! RichText.isEmpty( citation ) && (
+					<footer>
+						<RichText.Content tagName="cite" value={ citation } />
+					</footer>
+				) }
 			</blockquote>
 		);
 	},
@@ -209,6 +213,29 @@ export const settings = {
 		{
 			attributes: {
 				...blockAttributes,
+				citation: {
+					source: 'html',
+					selector: 'cite',
+				},
+			},
+			save( { attributes } ) {
+				const { align, value, citation } = attributes;
+
+				return (
+					<blockquote style={ { textAlign: align ? align : null } }>
+						<RichText.Content multiline="p" value={ value } />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				);
+			},
+		},
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					source: 'html',
+					selector: 'cite',
+				},
 				style: {
 					type: 'number',
 					default: 1,

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -10,7 +10,6 @@
 			line-height: 1.6;
 		}
 
-		cite,
 		footer {
 			font-size: 18px;
 			text-align: right;

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -1,9 +1,7 @@
 .wp-block-quote {
 	margin: 20px 0;
 
-	cite,
-	footer,
-	&__citation {
+	footer {
 		color: $dark-gray-300;
 		font-size: $default-font-size;
 		margin-top: 1em;

--- a/post-content.php
+++ b/post-content.php
@@ -76,7 +76,7 @@
 <!-- wp:quote {"style":1} -->
 <blockquote class="wp-block-quote">
 	<p><?php _e( 'The editor will endeavor to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.', 'gutenberg' ); ?></p>
-	<cite><?php _e( 'Matt Mullenweg, 2017', 'gutenberg' ); ?></cite>
+	<footer><cite><?php _e( 'Matt Mullenweg, 2017', 'gutenberg' ); ?></cite></footer>
 </blockquote>
 <!-- /wp:quote -->
 
@@ -142,7 +142,7 @@ https://vimeo.com/22439234
 <!-- /wp:paragraph -->
 
 <!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p><?php _e( 'Code is Poetry', 'gutenberg' ); ?></p><cite><?php _e( 'The WordPress community', 'gutenberg' ); ?></cite></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p><?php _e( 'Code is Poetry', 'gutenberg' ); ?></p><footer><cite><?php _e( 'The WordPress community', 'gutenberg' ); ?></cite></footer></blockquote></figure>
 <!-- /wp:pullquote -->
 
 <!-- wp:paragraph {"align":"center"} -->

--- a/test/integration/full-content/fixtures/core__pullquote.html
+++ b/test/integration/full-content/fixtures/core__pullquote.html
@@ -1,7 +1,8 @@
 <!-- wp:core/pullquote -->
 <figure class="wp-block-pullquote">
     <blockquote>
-    <p>Testing pullquote block...</p><cite>...with a caption</cite>
+    <p>Testing pullquote block...</p>
+    <footer><cite>...with a caption</cite></footer>
     </blockquote>
 </figure>
 <!-- /wp:core/pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote.json
+++ b/test/integration/full-content/fixtures/core__pullquote.json
@@ -8,6 +8,6 @@
             "citation": "...with a caption"
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p>\n    <footer><cite>...with a caption</cite></footer>\n    </blockquote>\n</figure>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__pullquote.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/pullquote",
         "attrs": {},
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p>\n    <footer><cite>...with a caption</cite></footer>\n    </blockquote>\n</figure>\n"
     },
     {
         "blockName": null,

--- a/test/integration/full-content/fixtures/core__pullquote.serialized.html
+++ b/test/integration/full-content/fixtures/core__pullquote.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>Testing pullquote block...</p><footer><cite>...with a caption</cite></footer></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.html
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.html
@@ -3,7 +3,7 @@
     <blockquote>
         <p>Paragraph <strong>one</strong></p>
         <p>Paragraph two</p>
-        <cite>by whomever</cite>
-	</blockquote>
+        <footer><cite>by whomever</cite></footer>
+    </blockquote>
 </figure>
 <!-- /wp:core/pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.json
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.json
@@ -8,6 +8,6 @@
             "citation": "by whomever"
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-pullquote\">\n    <blockquote>\n        <p>Paragraph <strong>one</strong></p>\n        <p>Paragraph two</p>\n        <cite>by whomever</cite>\n\t</blockquote>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-pullquote\">\n    <blockquote>\n        <p>Paragraph <strong>one</strong></p>\n        <p>Paragraph two</p>\n        <footer><cite>by whomever</cite></footer>\n    </blockquote>\n</figure>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/pullquote",
         "attrs": {},
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n        <p>Paragraph <strong>one</strong></p>\n        <p>Paragraph two</p>\n        <cite>by whomever</cite>\n\t</blockquote>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n        <p>Paragraph <strong>one</strong></p>\n        <p>Paragraph two</p>\n        <footer><cite>by whomever</cite></footer>\n    </blockquote>\n</figure>\n"
     },
     {
         "blockName": null,

--- a/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/test/integration/full-content/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>Paragraph <strong>one</strong></p><p>Paragraph two</p><cite>by whomever</cite></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>Paragraph <strong>one</strong></p><p>Paragraph two</p><footer><cite>by whomever</cite></footer></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/test/integration/full-content/fixtures/core__quote__style-1.html
+++ b/test/integration/full-content/fixtures/core__quote__style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote -->
-<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>
 <!-- /wp:core/quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-1.json
+++ b/test/integration/full-content/fixtures/core__quote__style-1.json
@@ -8,6 +8,6 @@
             "citation": "Matt Mullenweg, 2017"
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__quote__style-1.parsed.json
+++ b/test/integration/full-content/fixtures/core__quote__style-1.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/quote",
         "attrs": {},
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>\n"
     },
     {
         "blockName": null,

--- a/test/integration/full-content/fixtures/core__quote__style-1.serialized.html
+++ b/test/integration/full-content/fixtures/core__quote__style-1.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:quote -->
-<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>
 <!-- /wp:quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-2.html
+++ b/test/integration/full-content/fixtures/core__quote__style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"className":"is-style-large"} -->
-<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>
 <!-- /wp:core/quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-2.json
+++ b/test/integration/full-content/fixtures/core__quote__style-2.json
@@ -9,6 +9,6 @@
             "className": "is-style-large"
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__quote__style-2.parsed.json
+++ b/test/integration/full-content/fixtures/core__quote__style-2.parsed.json
@@ -5,7 +5,7 @@
             "className": "is-style-large"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>\n"
     },
     {
         "blockName": null,

--- a/test/integration/full-content/fixtures/core__quote__style-2.serialized.html
+++ b/test/integration/full-content/fixtures/core__quote__style-2.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:quote {"className":"is-style-large"} -->
-<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>
 <!-- /wp:quote -->


### PR DESCRIPTION
## Description
Previously #9804.

This PR changes the Quote and Pullquote blocks to wrap their `<cite>`s with `<footer>`s. The reason for this is that `<cite>` tags can be used within a quote but not be the citation of a quote, e.g. using a `<cite>` element to refer to a book or ship. The use of a `<footer>` improves the semantics to show that the contained `<cite>` is the citation of the entire `<blockquote>`, and makes it easier for themes to style inline `<cite>`s differently from the one in the `<footer>`.

In the editor, the RichText field for the citation is a `<footer>` element, where previously it was a `<div>` due to #8785 and before that it was a `<cite>`.

## How has this been tested?
I have tested to make sure that old Quote and Pullquote blocks are automatically converted properly. Some errors appear in the JavaScript console the first time a post is opened containing the deprecated forms of the blocks, but I am guessing that is due to the deprecated forms not matching the other even older deprecated forms before matching the last one in the list. **The content is preserved and automatically converted as expected and no blocks are made invalid. After saving, no errors appear in the JavaScript console.**

(I would say that the failed matches of deprecated forms should not be called out in the JavaScript console as errors, but I am not sure of the history of this functionality or how it works, and that is out-of-scope for this PR anyway.)

## Additional info
- https://www.w3.org/TR/html52/grouping-content.html#the-blockquote-element (Specifically example 15.)
- https://www.w3.org/TR/html52/textlevel-semantics.html#the-cite-element