### PR TITLE
Fix table block alignment

### DIFF
--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -1,3 +1,21 @@
+.editor-block-list__block[data-type="core/table"] {
+	&[data-align="left"],
+	&[data-align="right"],
+	&[data-align="center"] {
+		table {
+			// Ensure the table element is not full-width when aligned.
+			width: auto;
+		}
+	}
+
+	&[data-align="center"] {
+		table {
+			margin: 0 auto;
+		}
+	}
+}
+
+
 .wp-block-table {
 	table {
 		border-collapse: collapse;

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -9,6 +9,8 @@
 	}
 
 	&[data-align="center"] {
+		text-align: initial;
+
 		table {
 			margin: 0 auto;
 		}

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -4,4 +4,17 @@
 		table-layout: fixed;
 		width: 100%;
 	}
+
+	&.alignleft,
+	&.aligncenter,
+	&.alignright {
+		// Override default display property for align styles.
+		// The table element needs to be kept as display table
+		// for table features to work reliably.
+		display: table;
+
+		// Table cannot be 100% width if it is aligned, so set
+		// width as auto.
+		width: auto;
+	}
 }


### PR DESCRIPTION
## Description
Fixes #9778 - alignment styles not working as expected for the table block.

There were a few issues:
1. Table blocks generally default to 100%, so floating/centering might not have an effect
2. `.alignleft` and `.alignright` classes were setting the table element to `display: inline` - we've established on other PRs that its a bad idea to override the display property of the table block, as it tends to cause other table specific css properties to stop working (like `table-layout: fixed`).
3. Similarly, `.aligncenter` was setting the table element to `display: block`.
4. A block level rule sets `text-align: center` when content is centered, but causes text in cells to be centered instead of the entire table.

Fixes:
1. When the table block is floated or centered, use `width: auto;` so that the table's width collapses to that of its content.
2. Override the display property for the table block when aligned so that it's always `table`.
3. In the editor, add some specific styles for centering the table using `margin: 0 auto` so that it replicates what the user sees when viewing the post.
4. Set `text-align: initial` for a centered table block.

## How has this been tested?
- Manual testing

## Screenshots <!-- if applicable -->
**Left alignment**
![screen shot 2018-10-10 at 4 52 33 pm](https://user-images.githubusercontent.com/677833/46726281-9b807e80-ccb0-11e8-80f3-216f438df222.png)
![screen shot 2018-10-10 at 4 53 39 pm](https://user-images.githubusercontent.com/677833/46726274-9a4f5180-ccb0-11e8-86f1-92d97ef8bed1.png)
**Center alignment**
![screen shot 2018-10-10 at 4 52 45 pm](https://user-images.githubusercontent.com/677833/46726280-9b807e80-ccb0-11e8-8bee-d117464019dd.png)
![screen shot 2018-10-10 at 4 53 27 pm](https://user-images.githubusercontent.com/677833/46726275-9ae7e800-ccb0-11e8-8d3b-73ae6e1547cf.png)
**Right alignment**
![screen shot 2018-10-10 at 4 52 54 pm](https://user-images.githubusercontent.com/677833/46726279-9ae7e800-ccb0-11e8-9a53-f9b013e5f4dd.png)
![screen shot 2018-10-10 at 4 53 13 pm](https://user-images.githubusercontent.com/677833/46726277-9ae7e800-ccb0-11e8-9cb5-650b5299b0e9.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
