### PR TITLE
Add explicit button bottom margin for centered.

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -26,6 +26,9 @@ $blocks-button__line-height: $big-font-size + 6px;
 
 	&.aligncenter {
 		text-align: center;
+
+		// This explicitly duplicates the bottom margin, because many themes center using margin: 0 auto; so we need to be explicity.
+		margin-bottom: 1.5em;
 	}
 
 	&.alignright {

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -28,6 +28,7 @@
 
 .editor-block-list__block[data-type="core/image"][data-align="center"] {
 	.wp-block-image {
+		clear: both;
 		margin-left: auto;
 		margin-right: auto;
 	}


### PR DESCRIPTION
This fixes #7812, though in a somewhat heavy handed way.

The issue is that many WordPress themes have this in their CSS files:

```
.aligncenter {
margin: 0 auto;
}
```

That zeroes out the bottom margin on a centered button block.

If that style instead was:

```
.aligncenter {
margin-left: auto;
margin-right: auto;
}
```

... this would be a non issue.

So the question becomes — do we increase the specificity of the centered button block margin rules to cover up years of bad practice? Or are we okay with centered buttons having no bottom margin in many older WordPress themes?

Decide, then merge or don't ;)