### PR TITLE
Add self-closing tag support when comparing HTML

### DIFF
--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -473,6 +473,24 @@ describe( 'validation', () => {
 			expect( console ).toHaveWarned();
 			expect( isEquivalent ).toBe( false );
 		} );
+
+		it( 'should return true when comparing self-closing and normal tags', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />',
+				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+		} );
+
+		it( 'should return true when comparing self-closing and normal tags, ignoring trailing space', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"/>',
+				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+		} );
 	} );
 
 	describe( 'isValidBlock()', () => {

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -475,18 +475,32 @@ describe( 'validation', () => {
 		} );
 
 		it( 'should return true when comparing self-closing and normal tags', () => {
-			const isEquivalent = isEquivalentHTML(
+			let isEquivalent = isEquivalentHTML(
 				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />',
 				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+
+			isEquivalent = isEquivalentHTML(
+				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>',
+				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />'
 			);
 
 			expect( isEquivalent ).toBe( true );
 		} );
 
 		it( 'should return true when comparing self-closing and normal tags, ignoring trailing space', () => {
-			const isEquivalent = isEquivalentHTML(
+			let isEquivalent = isEquivalentHTML(
 				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"/>',
 				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+
+			isEquivalent = isEquivalentHTML(
+				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>',
+				'<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"/>'
 			);
 
 			expect( isEquivalent ).toBe( true );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -14,6 +14,7 @@ import {
 	getNextNonWhitespaceToken,
 	isEquivalentHTML,
 	isValidBlock,
+	isClosedByToken,
 } from '../validation';
 import {
 	registerBlockType,
@@ -317,6 +318,53 @@ describe( 'validation', () => {
 
 			expect( token ).toBeUndefined();
 			expect( tokens ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'isClosedByToken()', () => {
+		it( 'should return true if self-closed token is closed by an end token', () => {
+			const isClosed = isClosedByToken(
+				{ type: 'StartTag', tagName: 'div', selfClosing: true },
+				{ type: 'EndTag', tagName: 'div' },
+			);
+
+			expect( isClosed ).toBe( true );
+		} );
+
+		it( 'should return false if open token is not closed by an end token', () => {
+			const isClosed = isClosedByToken(
+				{ type: 'StartTag', tagName: 'div', selfClosing: false },
+				{ type: 'EndTag', tagName: 'div' },
+			);
+
+			expect( isClosed ).toBe( false );
+		} );
+
+		it( 'should return false if self-closed token has a different name to the end token', () => {
+			const isClosed = isClosedByToken(
+				{ type: 'StartTag', tagName: 'div', selfClosing: true },
+				{ type: 'EndTag', tagName: 'span' },
+			);
+
+			expect( isClosed ).toBe( false );
+		} );
+
+		it( 'should return false if self-closed token is not closed by a start token', () => {
+			const isClosed = isClosedByToken(
+				{ type: 'StartTag', tagName: 'div', selfClosing: true },
+				{ type: 'StartTag', tagName: 'div' },
+			);
+
+			expect( isClosed ).toBe( false );
+		} );
+
+		it( 'should return false if self-closed token is not closed by an undefined token', () => {
+			const isClosed = isClosedByToken(
+				{ type: 'StartTag', tagName: 'div', selfClosing: true },
+				undefined,
+			);
+
+			expect( isClosed ).toBe( false );
 		} );
 	} );
 

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -398,25 +398,21 @@ function getHTMLTokens( html ) {
 }
 
 /**
- * Returns true if the next HTML tag closes the current tag, false otherwise. Note this check does not
- * affect the array of tokens
+ * Returns true if the next HTML token closes the current token.
  *
- * @param {Object} currentToken Current token to compare against.
- * @param {Array} tokens Array of remaining HTML tokens.
+ * @param {Object} currentToken Current token to compare with.
+ * @param {Object|undefined} nextToken Next token to compare against.
  *
- * @return {boolean} Whether the next token in `tokens` closes `currentToken`, false otherwise
+ * @return {boolean} true if `nextToken` closes `currentToken`, false otherwise
  */
-function isClosedByNextToken( currentToken, tokens ) {
-	// Check if this is a self closing tag
+export function isClosedByToken( currentToken, nextToken ) {
+	// Ensure this is a self closed token
 	if ( ! currentToken.selfClosing ) {
 		return false;
 	}
 
-	// Peek at the next token without consuming
-	const [ next ] = tokens;
-
-	// Check token names and determine if the next token is the closing tag for the current token
-	if ( next && next.tagName === currentToken.tagName && next.type === 'EndTag' ) {
+	// Check token names and determine if nextToken is the closing tag for currentToken
+	if ( nextToken && nextToken.tagName === currentToken.tagName && nextToken.type === 'EndTag' ) {
 		return true;
 	}
 
@@ -465,10 +461,16 @@ export function isEquivalentHTML( actual, expected ) {
 			return false;
 		}
 
-		// Peek at the next token to see if it closes a self-closing tag.
-		if ( isClosedByNextToken( actualToken, expectedTokens ) ) {
-			// Consume the next closing token that matches the current self-closing token
+		// Peek at the next tokens (actual and expected) to see if they close
+		// a self-closing tag
+		if ( isClosedByToken( actualToken, expectedTokens[ 0 ] ) ) {
+			// Consume the next expected token that closes the current actual
+			// self-closing token
 			getNextNonWhitespaceToken( expectedTokens );
+		} else if ( isClosedByToken( expectedToken, actualTokens[ 0 ] ) ) {
+			// Consume the next actual token that closes the current expected
+			// self-closing token
+			getNextNonWhitespaceToken( actualTokens );
 		}
 	}
 


### PR DESCRIPTION
Self-closed tags in a custom HTML block result in a validation warning. For example, paste this in a custom HTML block:

`<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />`

When the post is reloaded this warning will be shown:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/46737012-5e0cf880-cc92-11e8-8ea4-befc2a4b990e.jpg)

This is a combination of two factors:
- The original HTML isn't used when generating a block's output HTML, so it has no knowledge of self-closed tags and compares self-closed against expanded tags
- Although `isEquivalentHTML` detects self-closed tags they aren't used

This PR modifies `isEquivalentHTML` so that a self-closed tag is considered effectively equivalent to an expanded tag (providing it has no other content):

`<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />`
`<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>`

Note that Gutenberg will still transform `<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />` to `<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>`, but this is a different issue that will be looked at separately.

This is a follow on from #10066

## How has this been tested?
Additional unit tests added. Manually verify that `<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />` can be pasted into a custom HTML block and the post reloaded without warning.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
