### PR TITLE
fixes #1520 by adding validation that the Alt value is not empty

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -110,6 +110,14 @@ class ImageEdit extends Component {
 		}
 	}
 
+	checkAltValue( altText, filename ) {
+		if ( ! altText ) {
+			this.props.setAttributes( { alt: 'This image has an empty alt attribute, the file name is ' + filename } );
+			return;
+		}
+		this.props.setAttributes( { alt: altText } );
+	}
+
 	onSelectImage( media ) {
 		if ( ! media || ! media.url ) {
 			this.props.setAttributes( {
@@ -120,8 +128,9 @@ class ImageEdit extends Component {
 			} );
 			return;
 		}
+		this.checkAltValue( media.alt, media.filename );
 		this.props.setAttributes( {
-			...pick( media, [ 'alt', 'id', 'caption', 'url' ] ),
+			...pick( media, [ 'id', 'caption', 'url' ] ),
 			width: undefined,
 			height: undefined,
 		} );


### PR DESCRIPTION
## Description
This PR will allow default values to be set for Alt text in the editing context (and also the front end). This is a first pass and open to discussion around the approach, naming of the functions, and the default string we move forward on. 


## How to test the PR:
1) Go to new post
2) Create image block
3) select image with no alt text defined
4) inspect the image in the editor after creating. You will find that the alt value is set to  'This image has an empty alt attribute, the file name is FILENAME'

## Types of changes
Introduces new function of `checkAltValue`. I'm happy to change that.

