### PR TITLE
Fix: Mobile: Custom color picker does not appear on mobile.

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -77,7 +77,10 @@ $z-layers: (
 
 	// Shows adminbar quicklink submenu above bottom popover:
 	// #wpadminbar ul li {z-index: 99999;}
-	".components-popover.is-bottom": 99990,
+	".components-popover:not(.is-mobile).is-bottom": 99990,
+
+	// Shows above edit post sidebar; Specificity needs to be higher than 3 classes.
+	".gutenberg__editor .components-popover.components-color-palette__picker.is-bottom": 100001,
 
 	".components-autocomplete__results": 1000000,
 

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -149,3 +149,7 @@ $color-palette-circle-spacing: 14px;
 	// ChromePicker has a hardcoded width, so we need to override the popover min-width.
 	min-width: unset;
 }
+
+.gutenberg__editor .components-popover.components-color-palette__picker.is-bottom {
+	z-index: z-index(".gutenberg__editor .components-popover.components-color-palette__picker.is-bottom");
+}

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -126,7 +126,7 @@ $arrow-size: 8px;
 
 		&.is-bottom {
 			top: 100%;
-			z-index: z-index(".components-popover.is-bottom");
+			z-index: z-index(".components-popover:not(.is-mobile).is-bottom");
 		}
 
 		&.is-middle {


### PR DESCRIPTION
## Description
On small sizes, the color picker was not appearing. This happened because its z-index was lower than the z-index of the sidebar on mobile.
This PR fixes this z-index problem.
Problem found in collaboration with @pento.

I added 'not(.is-mobile)' to an existing z-index because the rule where it was used was inside a not(.is-mobile) and that was not being referenced making debugging of z-index problems harder.

## How has this been tested?
Resize the window to a small size < 600px.
Add a button block.
Open the sidebar, go to color settings and open the custom color picker.
Verify the color picker appears (on master the color picker does not appear).