### PR TITLE
Make sure the plugin's header has always a gray background

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -3,7 +3,6 @@
 	padding-left: 0;
 	padding-right: $grid-size-small;
 	border-top: 0;
-	background: $light-gray-200;
 	position: sticky;
 	z-index: z-index(".components-panel__header.edit-post-sidebar__panel-tabs");
 	top: 0;

--- a/packages/edit-post/src/components/sidebar/sidebar-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/sidebar-header/style.scss
@@ -18,6 +18,8 @@
 .components-panel__header.edit-post-sidebar-header {
 	padding-right: $grid-size-small;
 
+	background: $light-gray-200;
+
 	.components-icon-button {
 		display: none;
 		margin-left: auto;


### PR DESCRIPTION
Fixes a small regression introduced by #10062 

This PR made the header's of all sidebar plugins white instead of gray.

**Testing instructions**

 - Install a plugin that uses the sidebar API https://wordpress.org/plugins/dropit/
 - Make sure the sidebar header is gray.
