### PR TITLE
Hide 'Add to Reusable Blocks' button when 'core/block' is disabled

### DIFF
--- a/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
@@ -49,7 +49,7 @@ export function ReusableBlockConvertButton( {
 
 export default compose( [
 	withSelect( ( select, { clientIds } ) => {
-		const { getBlock, getReusableBlock } = select( 'core/editor' );
+		const { getBlock, canInsertBlockType, getReusableBlock } = select( 'core/editor' );
 		const {
 			getFreeformFallbackBlockName,
 			getUnregisteredFallbackBlockName,
@@ -57,10 +57,15 @@ export default compose( [
 
 		const blocks = map( clientIds, ( clientId ) => getBlock( clientId ) );
 
-		// Hide 'Add to Reusable Blocks' on Classic blocks. Showing it causes a
-		// confusing UX, because of its similarity to the 'Convert to Blocks' button.
 		const isVisible = (
 			every( blocks, ( block ) => !! block ) &&
+
+			// Hide 'Add to Reusable Blocks' when Reusable Blocks are disabled, i.e. when
+			// core/block is not in the allowed_block_types filter.
+			canInsertBlockType( 'core/block' ) &&
+
+			// Hide 'Add to Reusable Blocks' on Classic blocks. Showing it causes a
+			// confusing UX, because of its similarity to the 'Convert to Blocks' button.
 			( blocks.length !== 1 || (
 				blocks[ 0 ].name !== getFreeformFallbackBlockName() &&
 				blocks[ 0 ].name !== getUnregisteredFallbackBlockName()
@@ -68,12 +73,12 @@ export default compose( [
 		);
 
 		return {
+			isVisible,
 			isStaticBlock: isVisible && (
 				blocks.length !== 1 ||
 				! isReusableBlock( blocks[ 0 ] ) ||
 				! getReusableBlock( blocks[ 0 ].attributes.ref )
 			),
-			isVisible,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientIds, onToggle = noop } ) => {

--- a/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
@@ -58,6 +58,8 @@ export default compose( [
 		const blocks = map( clientIds, ( clientId ) => getBlock( clientId ) );
 
 		const isVisible = (
+			// Guard against the case where a regular block has *just* been converted to a
+			// reusable block and doesn't yet exist in the editor store.
 			every( blocks, ( block ) => !! block ) &&
 
 			// Hide 'Add to Reusable Blocks' when Reusable Blocks are disabled, i.e. when


### PR DESCRIPTION
Fixes #5893.

Hides the _Add to Reusable Block_ button when `'core/block'` is not in the array returned by the `allowed_block_types` filter.

**To test:**

1. Add this to the bottom of `gutenberg.php`:

```php
add_filter( 'allowed_block_types', function() {
	return [ 'core/paragraph', 'core/image', 'core/quote' ];
} );
```

2. Check that you are not able to create or insert Reusable Blocks.

3. Now, change the above PHP code to look like this:

```php
add_filter( 'allowed_block_types', function() {
	return [ 'core/paragraph', 'core/image', 'core/quote', 'core/block' ];
} );
```

4. You should be able to once again create and insert Reusable Blocks.

5. Check that the _Add to Reusable Block_ does not appear when you select _More options_ on a _Classic_ block.