### PR TITLE
Fix adding links from the autocompleter

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { hasIn, includes } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -170,7 +175,13 @@ class LinkContainer extends Component {
 		event.preventDefault();
 	}
 
-	resetState() {
+	resetState( event ) {
+		// URLInput's autocomplete list can trigger onClickOutside on the link container's popover.
+		// Return early here if the click originated from one of the autocomplete suggestions.
+		if ( hasIn( event, [ 'target', 'classList' ] ) && includes( event.target.classList, 'editor-url-input__suggestion' ) ) {
+			return;
+		}
+
 		this.props.stopAddingLink();
 		this.setState( { editLink: false } );
 	}

--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { hasIn, includes } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -175,13 +170,7 @@ class LinkContainer extends Component {
 		event.preventDefault();
 	}
 
-	resetState( event ) {
-		// URLInput's autocomplete list can trigger onClickOutside on the link container's popover.
-		// Return early here if the click originated from one of the autocomplete suggestions.
-		if ( hasIn( event, [ 'target', 'classList' ] ) && includes( event.target.classList, 'editor-url-input__suggestion' ) ) {
-			return;
-		}
-
+	resetState() {
 		this.props.stopAddingLink();
 		this.setState( { editLink: false } );
 	}

--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { hasIn } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -58,7 +53,7 @@ function isShowingInput( props, state ) {
 	return props.addingLink || state.editLink;
 }
 
-const LinkEditor = ( { inputValue, onChangeInputValue, onKeyDown, submitLink, bindAutocompleteRef } ) => (
+const LinkEditor = ( { inputValue, onChangeInputValue, onKeyDown, submitLink, autocompleteRef } ) => (
 	// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
 	/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 	<form
@@ -70,7 +65,7 @@ const LinkEditor = ( { inputValue, onChangeInputValue, onKeyDown, submitLink, bi
 		<URLInput
 			value={ inputValue }
 			onChange={ onChangeInputValue }
-			bindAutocompleteRef={ bindAutocompleteRef }
+			autocompleteRef={ autocompleteRef }
 		/>
 		<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 	</form>
@@ -105,8 +100,6 @@ class LinkContainer extends Component {
 		this.onChangeInputValue = this.onChangeInputValue.bind( this );
 		this.setLinkTarget = this.setLinkTarget.bind( this );
 		this.resetState = this.resetState.bind( this );
-		this.bindAutocompleteRef = this.bindAutocompleteRef.bind( this );
-
 		this.autocompleteRef = createRef();
 
 		this.state = {};
@@ -182,16 +175,12 @@ class LinkContainer extends Component {
 		event.preventDefault();
 	}
 
-	bindAutocompleteRef( ref ) {
-		this.autocompleteRef = ref;
-	}
-
 	resetState( event ) {
 		// The autocomplete suggestions list renders in a separate popover (in a portal),
 		// so onClickOutside fails to detect that a click on a suggestion occured in the
 		// LinkContainer. Detect clicks on autocomplete suggestions using a ref here, and
 		// return early if so.
-		if ( hasIn( this, [ 'autocompleteRef', 'contains' ] ) && this.autocompleteRef.contains( event.target ) ) {
+		if ( this.autocompleteRef.current && this.autocompleteRef.current.contains( event.target ) ) {
 			return;
 		}
 
@@ -232,7 +221,7 @@ class LinkContainer extends Component {
 								onChangeInputValue={ this.onChangeInputValue }
 								onKeyDown={ this.onKeyDown }
 								submitLink={ this.submitLink }
-								bindAutocompleteRef={ this.bindAutocompleteRef }
+								autocompleteRef={ this.autocompleteRef }
 							/>
 						) : (
 							<LinkViewer

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -9,7 +9,7 @@ import scrollIntoView from 'dom-scroll-into-view';
  * WordPress dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, Fragment, createRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { UP, DOWN, ENTER } from '@wordpress/keycodes';
 import { Spinner, withSpokenMessages, Popover } from '@wordpress/components';
@@ -23,12 +23,12 @@ import { addQueryArgs } from '@wordpress/url';
 const stopEventPropagation = ( event ) => event.stopPropagation();
 
 class URLInput extends Component {
-	constructor() {
+	constructor( { autocompleteRef } ) {
 		super( ...arguments );
 
 		this.onChange = this.onChange.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
-		this.bindListNode = this.bindListNode.bind( this );
+		this.autocompleteRef = autocompleteRef || createRef();
 		this.updateSuggestions = throttle( this.updateSuggestions.bind( this ), 200 );
 
 		this.suggestionNodes = [];
@@ -46,7 +46,7 @@ class URLInput extends Component {
 		// when already expanded
 		if ( showSuggestions && selectedSuggestion !== null && ! this.scrollingIntoView ) {
 			this.scrollingIntoView = true;
-			scrollIntoView( this.suggestionNodes[ selectedSuggestion ], this.listNode, {
+			scrollIntoView( this.suggestionNodes[ selectedSuggestion ], this.autocompleteRef, {
 				onlyScrollIfNeeded: true,
 			} );
 
@@ -58,13 +58,6 @@ class URLInput extends Component {
 
 	componentWillUnmount() {
 		delete this.suggestionsRequest;
-	}
-
-	bindListNode( ref ) {
-		this.listNode = ref;
-		if ( this.props.bindAutocompleteRef ) {
-			this.props.bindAutocompleteRef( ref );
-		}
 	}
 
 	bindSuggestionNode( index ) {
@@ -216,7 +209,7 @@ class URLInput extends Component {
 						<div
 							className="editor-url-input__suggestions"
 							id={ `editor-url-input-suggestions-${ instanceId }` }
-							ref={ this.bindListNode }
+							ref={ this.autocompleteRef }
 							role="listbox"
 						>
 							{ posts.map( ( post, index ) => (

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -62,6 +62,9 @@ class URLInput extends Component {
 
 	bindListNode( ref ) {
 		this.listNode = ref;
+		if ( this.props.bindAutocompleteRef ) {
+			this.props.bindAutocompleteRef( ref );
+		}
 	}
 
 	bindSuggestionNode( index ) {

--- a/packages/editor/src/components/url-popover/index.js
+++ b/packages/editor/src/components/url-popover/index.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import {

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -256,4 +256,56 @@ describe( 'Links', () => {
 		await page.click( 'button[aria-label="Apply"]' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	// Test for regressions of https://github.com/WordPress/gutenberg/issues/10496.
+	it( 'allows autocomplete suggestions to be selected with the mouse', async () => {
+		const titleText = 'Unique post title';
+
+		// First create a post that we can search for using the link autocompletion.
+		await page.type( '.editor-post-title__input', titleText );
+		await page.click( '.editor-post-publish-panel__toggle' );
+
+		// Disable reason: Wait for the animation to complete, since otherwise the
+		// click attempt may occur at the wrong point.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 100 );
+
+		// Publish the post
+		await page.click( '.editor-post-publish-button' );
+
+		await page.waitForSelector( '.post-publish-panel__postpublish-link-input' );
+		const postURL = await page.evaluate( () => document.querySelector( '.post-publish-panel__postpublish-link-input' ).value );
+
+		// Now create a new post and try to select the post created previously
+		// from the autocomplete suggestions.
+		await newPost();
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg' );
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+		await page.click( 'button[aria-label="Link"]' );
+
+		await page.keyboard.type( titleText );
+		await page.waitForSelector( '.editor-url-input__suggestion' );
+		const autocompleteSuggestions = await page.$x( `//*[contains(@class, "editor-url-input__suggestion")]//button[contains(text(), '${ titleText }')]` );
+
+		// Expect there to be some autocomplete suggestions.
+		expect( autocompleteSuggestions.length ).toBeGreaterThan( 0 );
+
+		const firstSuggestion = autocompleteSuggestions[ 0 ];
+
+		// Expect that clicking on the autocomplete suggestion doesn't dismiss the link popover.
+		// and that the url input has a value.
+		await firstSuggestion.click();
+		expect( await page.$( '.editor-format-toolbar__link-modal' ) ).not.toBeNull();
+
+		// Expect the url input value to have been updated with the post url
+		const inputValue = await page.evaluate( () => document.querySelector( '.editor-url-input input[aria-label="URL"]' ).value );
+		expect( inputValue ).toEqual( postURL );
+
+		// Expect the link to apply correctly.
+		// Note - have avoided using snapshots here since the link url can't be determined ahead of time.
+		await page.click( 'button[aria-label="Apply"]' );
+		const linkHref = await page.evaluate( () => document.querySelector( '.editor-format-toolbar__link-value' ).href );
+		expect( linkHref ).toEqual( postURL );
+	} );
 } );

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -273,8 +273,8 @@ describe( 'Links', () => {
 		// Publish the post
 		await page.click( '.editor-post-publish-button' );
 
-		await page.waitForSelector( '.post-publish-panel__postpublish-link-input' );
-		const postURL = await page.evaluate( () => document.querySelector( '.post-publish-panel__postpublish-link-input' ).value );
+		await page.waitForSelector( '.post-publish-panel__postpublish-post-address input' );
+		const postURL = await page.evaluate( () => document.querySelector( '.post-publish-panel__postpublish-post-address input' ).value );
 
 		// Now create a new post and try to select the post created previously
 		// from the autocomplete suggestions.
@@ -283,6 +283,9 @@ describe( 'Links', () => {
 		await page.keyboard.type( 'This is Gutenberg' );
 		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
 		await page.click( 'button[aria-label="Link"]' );
+
+		// Wait for the URL field to auto-focus
+		await waitForAutoFocus();
 
 		await page.keyboard.type( titleText );
 		await page.waitForSelector( '.editor-url-input__suggestion' );
@@ -296,7 +299,7 @@ describe( 'Links', () => {
 		// Expect that clicking on the autocomplete suggestion doesn't dismiss the link popover.
 		// and that the url input has a value.
 		await firstSuggestion.click();
-		expect( await page.$( '.editor-format-toolbar__link-modal' ) ).not.toBeNull();
+		expect( await page.$( '.editor-url-popover' ) ).not.toBeNull();
 
 		// Expect the url input value to have been updated with the post url
 		const inputValue = await page.evaluate( () => document.querySelector( '.editor-url-input input[aria-label="URL"]' ).value );
@@ -305,7 +308,7 @@ describe( 'Links', () => {
 		// Expect the link to apply correctly.
 		// Note - have avoided using snapshots here since the link url can't be determined ahead of time.
 		await page.click( 'button[aria-label="Apply"]' );
-		const linkHref = await page.evaluate( () => document.querySelector( '.editor-format-toolbar__link-value' ).href );
+		const linkHref = await page.evaluate( () => document.querySelector( '.editor-format-toolbar__link-container-value' ).href );
 		expect( linkHref ).toEqual( postURL );
 	} );
 } );


### PR DESCRIPTION
Fixes #10496

## Description
When adding links from the autocompletion list, the `onClickOutside` handler on the LinkContainer popover was being triggered, causing the link not to be set and triggering closure of the popover.

This fix adds a clause at the start of the `onClickOutside` handler, detecting if the click originated from a autocomplete entry and returning early if so.

## How has this been tested?
- Manually tested adding links
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
