### PR TITLE
Tools: Improve Lerna setup

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,7 @@
 	},
 	"ignoreChanges": [
 		"**/benchmark/*.js",
+		"**/CHANGELOG.md",
 		"**/test/**"
 	],
 	"packages": [

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0 (Unreleased)
+## 2.1.0 (2018-10-10)
 
 ### New Features
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.0 (Unreleased)
+## 4.1.0 (2018-10-10)
 
 ### New Feature
 

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 (Unreleased)
+## 1.0.0 (2018-10-10)
 
 ### New Features
 

--- a/packages/list-reusable-blocks/CHANGELOG.md
+++ b/packages/list-reusable-blocks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0 (Unreleased)
+## 1.1.0 (2018-10-10)
 
 ### New Features
 


### PR DESCRIPTION
## Description

Initially, I wanted to add only release dates to `CHANGELOG.md` files but I figured out we need also to add some improvement to Lerna config.

This PR adds a very simple change which teaches Lerna to skip `CHANGELOG.md` files when checking if packages should be published.

## How has this been tested?

At the moment Lerna shows 15 packages as modified. It happens because of 2 of them are beta releases - this means they always trigger a new release and also influence all packages that depend on them.

1. Run `npm run publish:check`.
2. Find a package which is not listed.
3. Modify `CHANGELOG.md` and commit it locally.
4. Run `npm run publish:check`.
5. Make sure that this package isn't included.