### PR TITLE
Scripts: Add bare handling for lint-js script (no zero config)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2428,6 +2428,7 @@
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 				"@wordpress/jest-preset-default": "file:packages/jest-preset-default",
 				"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
+				"babel-eslint": "8.0.3",
 				"chalk": "^2.4.1",
 				"cross-spawn": "^5.1.0",
 				"eslint": "^4.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,6 +2430,7 @@
 				"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
 				"chalk": "^2.4.1",
 				"cross-spawn": "^5.1.0",
+				"eslint": "^4.19.1",
 				"jest": "^23.4.2",
 				"npm-package-json-lint": "^3.3.1",
 				"read-pkg-up": "^1.0.1",
@@ -6880,9 +6881,9 @@
 			}
 		},
 		"eslint": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
-			"integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
+			"version": "4.19.1",
+			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^5.3.0",
@@ -6894,7 +6895,7 @@
 				"doctrine": "^2.1.0",
 				"eslint-scope": "^3.7.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.2",
+				"espree": "^3.5.4",
 				"esquery": "^1.0.0",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^2.0.0",
@@ -6916,12 +6917,41 @@
 				"path-is-inside": "^1.0.2",
 				"pluralize": "^7.0.0",
 				"progress": "^2.0.0",
+				"regexpp": "^1.0.1",
 				"require-uncached": "^1.0.3",
 				"semver": "^5.3.0",
 				"strip-ansi": "^4.0.0",
 				"strip-json-comments": "~2.0.1",
-				"table": "^4.0.1",
+				"table": "4.0.2",
 				"text-table": "~0.2.0"
+			},
+			"dependencies": {
+				"ajv-keywords": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+					"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+					"dev": true
+				},
+				"regexpp": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+					"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+					"dev": true
+				},
+				"table": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+					"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+					"dev": true,
+					"requires": {
+						"ajv": "^5.2.3",
+						"ajv-keywords": "^2.1.0",
+						"chalk": "^2.1.0",
+						"lodash": "^4.17.4",
+						"slice-ansi": "1.0.0",
+						"string-width": "^2.1.1"
+					}
+				}
 			}
 		},
 		"eslint-config-wordpress": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
 		"deasync": "0.1.13",
 		"deep-freeze": "0.0.1",
 		"doctrine": "2.1.0",
-		"eslint": "4.16.0",
 		"eslint-config-wordpress": "2.0.0",
 		"eslint-plugin-jest": "21.5.0",
 		"eslint-plugin-jsx-a11y": "6.0.2",
@@ -163,8 +162,8 @@
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
 		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
 		"lint": "concurrently \"npm run lint-js\" \"npm run lint-pkg-json\" \"npm run lint-css\"",
-		"lint-js": "eslint .",
-		"lint-js:fix": "eslint . --fix",
+		"lint-js": "wp-scripts lint-js .",
+		"lint-js:fix": "wp-scripts lint-js . --fix",
 		"lint-php": "docker-compose run --rm composer run-script lint",
 		"lint-pkg-json": "wp-scripts lint-pkg-json ./packages",
 		"lint-css": "stylelint '**/*.scss'",
@@ -201,7 +200,7 @@
 			"stylelint"
 		],
 		"*.js": [
-			"eslint"
+			"wp-scripts lint-js"
 		],
 		"{docs/{root-manifest.json,tool/*.js},packages/{*/README.md,*/src/{actions,selectors}.js,components/src/*/**/README.md}}": [
 			"npm run docs:build"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
 		"@wordpress/postcss-themes": "file:packages/postcss-themes",
 		"@wordpress/scripts": "file:packages/scripts",
 		"autoprefixer": "8.2.0",
-		"babel-eslint": "8.0.3",
 		"babel-loader": "8.0.0",
 		"chalk": "2.4.1",
 		"check-node-version": "3.1.1",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.0 (Unreleased)
+
+### New Feature
+
+- Added support for `lint-js` script ([#10504](https://github.com/WordPress/gutenberg/pull/10504))
+ 
 ## 2.3.0 (2018-09-30)
 
 ### Improvements

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -27,9 +27,26 @@ _Example:_
 
 ## Available Scripts
 
+### `wp-scripts lint-js`
+
+Helps enforce coding style guidelines for your JavaScript files. It uses [eslint](https://eslint.org/) with no rules provided (we plan to add zero config support in the near future). You can specify your own rules as described in [eslint docs](https://eslint.org/docs/rules/).
+
+_Example:_
+
+```json
+{
+	"scripts": {
+		"lint:js": "wp-scripts lint-js ."
+	}
+}
+```
+
+This is how you execute the script with presented setup:
+* `npm run lint:js` - lints JavaScripts files in the whole project's.
+
 ### `wp-scripts lint-pkg-json`
 
-Helps enforce standards for your package.json file. It uses [npm-package-json-lint](https://www.npmjs.com/package/npm-package-json-lint) with the set of default rules provided. You can override them with your own rules as described in [npm-package-json-lint wiki](https://github.com/tclindner/npm-package-json-lint/wiki).
+Helps enforce standards for your package.json files. It uses [npm-package-json-lint](https://www.npmjs.com/package/npm-package-json-lint) with the set of default rules provided. You can override them with your own rules as described in [npm-package-json-lint wiki](https://github.com/tclindner/npm-package-json-lint/wiki).
 
 _Example:_
 
@@ -42,7 +59,7 @@ _Example:_
 ```
 
 This is how you execute those scripts using the presented setup:
-* `npm run lint:pkg-jsont` - lints `package.json` file in the project's root folder.
+* `npm run lint:pkg-json` - lints `package.json` file in the project's root folder.
 
 ### `wp-scripts test-unit-js`
 

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	parser: 'babel-eslint',
+};

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
 		"@wordpress/jest-preset-default": "file:../jest-preset-default",
 		"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",
+		"babel-eslint": "8.0.3",
 		"chalk": "^2.4.1",
 		"cross-spawn": "^5.1.0",
 		"eslint": "^4.19.1",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",
 		"chalk": "^2.4.1",
 		"cross-spawn": "^5.1.0",
+		"eslint": "^4.19.1",
 		"jest": "^23.4.2",
 		"npm-package-json-lint": "^3.3.1",
 		"read-pkg-up": "^1.0.1",

--- a/packages/scripts/scripts/lint-js.js
+++ b/packages/scripts/scripts/lint-js.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+const { sync: spawn } = require( 'cross-spawn' );
+const { sync: resolveBin } = require( 'resolve-bin' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	fromConfigRoot,
+	getCliArgs,
+	hasCliArg,
+	hasProjectFile,
+} = require( '../utils' );
+
+const args = getCliArgs();
+
+const hasLintConfig = hasCliArg( '-c' ) ||
+	hasCliArg( '--configFile' ) ||
+	hasProjectFile( '.eslintrc.js' );
+
+const config = ! hasLintConfig ?
+	[ '--configFile', fromConfigRoot( '.eslintrc.js' ) ] :
+	[];
+
+const result = spawn(
+	resolveBin( 'eslint' ),
+	[ ...config, ...args ],
+	{ stdio: 'inherit' }
+);
+
+process.exit( result.status );

--- a/packages/scripts/scripts/lint-js.js
+++ b/packages/scripts/scripts/lint-js.js
@@ -11,17 +11,23 @@ const {
 	fromConfigRoot,
 	getCliArgs,
 	hasCliArg,
+	hasPackageProp,
 	hasProjectFile,
 } = require( '../utils' );
 
 const args = getCliArgs();
 
 const hasLintConfig = hasCliArg( '-c' ) ||
-	hasCliArg( '--configFile' ) ||
-	hasProjectFile( '.eslintrc.js' );
+	hasCliArg( '--config' ) ||
+	hasProjectFile( '.eslintrc.js' ) ||
+	hasProjectFile( '.eslintrc.yaml' ) ||
+	hasProjectFile( '.eslintrc.yml' ) ||
+	hasProjectFile( '.eslintrc.json' ) ||
+	hasProjectFile( '.eslintrc' ) ||
+	hasPackageProp( 'eslintConfig' );
 
 const config = ! hasLintConfig ?
-	[ '--configFile', fromConfigRoot( '.eslintrc.js' ) ] :
+	[ '--config', fromConfigRoot( '.eslintrc.js' ) ] :
 	[];
 
 const result = spawn(

--- a/test/e2e/specs/preview.test.js
+++ b/test/e2e/specs/preview.test.js
@@ -67,7 +67,7 @@ describe( 'Preview', () => {
 
 		// When autosave completes for a new post, the URL of the editor should
 		// update to include the ID. Use this to assert on preview URL.
-		const [ , postId ] = await ( await editorPage.waitForFunction( () => {
+		const [ , postId ] = await( await editorPage.waitForFunction( () => {
 			return window.location.search.match( /[\?&]post=(\d+)/ );
 		} ) ).jsonValue();
 


### PR DESCRIPTION
## Description
This PR adds `wp-scripts lint-js` script to the `@wordpress/scripts` package. The idea is to have it working with #7965 which will offer zero config support when it's ready. At the moment this is just proxy over `eslint` so it only makes it easier to maintain your dependencies for tools.

## How has this been tested?
`npm run lint-js` inside Gutenberg should work as before.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
