### PR TITLE
Fix demo content crash on malformed URL

### DIFF
--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -11,6 +11,7 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { ClipboardButton, Button, ExternalLink } from '@wordpress/components';
+import { safeDecodeURI } from '@wordpress/url';
 
 /**
  * Internal Dependencies
@@ -84,7 +85,7 @@ class PostPermalink extends Component {
 						target="_blank"
 						ref={ ( linkElement ) => this.linkElement = linkElement }
 					>
-						{ decodeURI( samplePermalink ) }
+						{ safeDecodeURI( samplePermalink ) }
 						&lrm;
 					</ExternalLink>
 				}

--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -11,7 +11,7 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import { ESCAPE, LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
-import { prependHTTP } from '@wordpress/url';
+import { prependHTTP, safeDecodeURI } from '@wordpress/url';
 import {
 	create,
 	insert,
@@ -79,7 +79,7 @@ const LinkViewer = ( { href, editLink } ) => (
 			className="editor-format-toolbar__link-container-value"
 			href={ href }
 		>
-			{ filterURLForDisplay( decodeURI( href ) ) }
+			{ filterURLForDisplay( safeDecodeURI( href ) ) }
 		</ExternalLink>
 		<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ editLink } />
 	</div>
@@ -216,7 +216,6 @@ class LinkContainer extends Component {
 							/>
 						) }
 					</URLPopover>
-
 				</PositionedAtSelection>
 			</Fill>
 		);

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (Unreleased)
+
+### Features
+
+- Added `safeDecodeURI`.
+
 ## 2.0.1 (2018-09-30)
 
 ### Bug Fixes

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -48,3 +48,19 @@ export function prependHTTP( url ) {
 
 	return url;
 }
+
+/**
+ * Safely decodes a URI with `decodeURI`. Returns the URI unmodified if
+ * `decodeURI` throws an error.
+ *
+ * @param {string} uri URI to decode.
+ *
+ * @return {string} Decoded URI if possible.
+ */
+export function safeDecodeURI( uri ) {
+	try {
+		return decodeURI( uri );
+	} catch ( uriError ) {
+		return uri;
+	}
+}

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -6,7 +6,12 @@ import { every } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isURL, addQueryArgs, prependHTTP } from '../';
+import {
+	isURL,
+	addQueryArgs,
+	prependHTTP,
+	safeDecodeURI,
+} from '../';
 
 describe( 'isURL', () => {
 	it( 'returns true when given things that look like a URL', () => {
@@ -60,7 +65,7 @@ describe( 'addQueryArgs', () => {
 		const url = 'https://andalouses.example/beach?time[]=10&time[]=11';
 		const args = { beach: [ 'sand', 'rock' ] };
 
-		expect( decodeURI( addQueryArgs( url, args ) ) ).toBe( 'https://andalouses.example/beach?time[0]=10&time[1]=11&beach[0]=sand&beach[1]=rock' );
+		expect( safeDecodeURI( addQueryArgs( url, args ) ) ).toBe( 'https://andalouses.example/beach?time[0]=10&time[1]=11&beach[0]=sand&beach[1]=rock' );
 	} );
 } );
 
@@ -117,5 +122,20 @@ describe( 'prependHTTP', () => {
 		const url = 'mailto:foo@wordpress.org';
 
 		expect( prependHTTP( url ) ).toBe( url );
+	} );
+} );
+
+describe( 'safeDecodeURI', () => {
+	it( 'should decode URI if formed well', () => {
+		const encoded = 'https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B';
+		const decoded = 'https://mozilla.org/?x=шеллы';
+
+		expect( safeDecodeURI( encoded ) ).toBe( decoded );
+	} );
+
+	it( 'should return URI if malformed', () => {
+		const malformed = '%1';
+
+		expect( safeDecodeURI( malformed ) ).toBe( malformed );
 	} );
 } );

--- a/post-content.php
+++ b/post-content.php
@@ -149,9 +149,9 @@ https://vimeo.com/22439234
 <p style="text-align:center">
 	<em>
 		<?php
-		sprintf(
+		echo sprintf(
 			/* translators: %s: Gutenberg GitHub repository URL */
-			_e( 'If you want to learn more about how to build additional blocks, or if you are interested in helping with the project, head over to the <a href="%s">GitHub repository</a>.', 'gutenberg' ),
+			__( 'If you want to learn more about how to build additional blocks, or if you are interested in helping with the project, head over to the <a href="%s">GitHub repository</a>.', 'gutenberg' ),
 			'https://github.com/WordPress/gutenberg'
 		);
 		?>


### PR DESCRIPTION
## Description

Demo content outputs `%s` as a href attribute, which crashes the whole app if it is clicked. It is caused by [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) which throws if the URI is malformed.

Solution:

1. Fix the demo content URL.
2. Wrap it in `safeEncodeURI` so it wouldn't crash the app.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->