### PR TITLE
Add list and quote block transformation e2e tests

### DIFF
--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -85,7 +85,7 @@ export const settings = {
 				blocks: [ 'core/quote' ],
 				transform: ( { value } ) => {
 					return createBlock( 'core/list', {
-						values: value,
+						values: toHTMLString( create( { html: value, multilineTag: 'p' } ), 'li' ),
 					} );
 				},
 			},
@@ -143,7 +143,7 @@ export const settings = {
 				blocks: [ 'core/quote' ],
 				transform: ( { values } ) => {
 					return createBlock( 'core/quote', {
-						value: values,
+						value: toHTMLString( create( { html: values, multilineTag: 'li' } ), 'p' ),
 					} );
 				},
 			},

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -111,7 +111,7 @@ export const settings = {
 				regExp: /^[*-]\s/,
 				transform: ( { content } ) => {
 					return createBlock( 'core/list', {
-						values: content,
+						values: `<li>${ content }</li>`,
 					} );
 				},
 			},
@@ -121,7 +121,7 @@ export const settings = {
 				transform: ( { content } ) => {
 					return createBlock( 'core/list', {
 						ordered: true,
-						values: content,
+						values: `<li>${ content }</li>`,
 					} );
 				},
 			},

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -66,7 +66,7 @@ export const settings = {
 				blocks: [ 'core/heading' ],
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
-						value: content,
+						value: `<p>${ content }</p>`,
 					} );
 				},
 			},
@@ -75,7 +75,7 @@ export const settings = {
 				regExp: /^>\s/,
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
-						value: content,
+						value: `<p>${ content }</p>`,
 					} );
 				},
 			},

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -104,7 +104,7 @@ export class RichText extends Component {
 
 		this.savedContent = value;
 		this.containerRef = createRef();
-		this.patterns = getPatterns( { onReplace, multiline } );
+		this.patterns = getPatterns( { onReplace, multiline, valueToFormat: this.valueToFormat } );
 		this.enterPatterns = getBlockTransforms( 'from' ).filter( ( { type, trigger } ) =>
 			type === 'pattern' && trigger === 'enter'
 		);

--- a/packages/editor/src/components/rich-text/patterns.js
+++ b/packages/editor/src/components/rich-text/patterns.js
@@ -9,7 +9,7 @@ import { filter } from 'lodash';
 import { getBlockTransforms, findTransform } from '@wordpress/blocks';
 import { remove, applyFormat, getTextContent } from '@wordpress/rich-text';
 
-export function getPatterns( { onReplace, multiline } ) {
+export function getPatterns( { onReplace, multiline, valueToFormat } ) {
 	const patterns = filter( getBlockTransforms( 'from' ), ( { type, trigger } ) => {
 		return type === 'pattern' && trigger === undefined;
 	} );
@@ -32,7 +32,7 @@ export function getPatterns( { onReplace, multiline } ) {
 			const result = text.match( transformation.regExp );
 
 			const block = transformation.transform( {
-				content: remove( record, 0, result[ 0 ].length ),
+				content: valueToFormat( remove( record, 0, result[ 0 ].length ) ),
 				match: result,
 			} );
 

--- a/test/e2e/specs/__snapshots__/lists.test.js.snap
+++ b/test/e2e/specs/__snapshots__/lists.test.js.snap
@@ -1,18 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Lists can be converted to a paragraphs 1`] = `
+"<!-- wp:paragraph -->
+<p>one</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>two</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Lists can be created by converting a paragraph 1`] = `
+"<!-- wp:list -->
+<ul><li>test</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`Lists can be created by converting a paragraph with line breaks 1`] = `
+"<!-- wp:list -->
+<ul><li>one</li><li>two</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`Lists can be created by converting multiple paragraphs 1`] = `
+"<!-- wp:list -->
+<ul><li>one</li><li>two</li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`Lists can be created by typing "/list" 1`] = `
 "<!-- wp:list -->
 <ul><li>I’m a list</li></ul>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by using a hyphen at the start of a RichText block 1`] = `
+exports[`Lists can be created by typing an asterisk in front of text of a paragraph block 1`] = `
 "<!-- wp:list -->
-<ul><li>A list item</li></ul>
+<ul><li>test</li></ul>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by using an asterisk at the start of a RichText block 1`] = `
+exports[`Lists can be created by using a number at the start of a paragraph block 1`] = `
+"<!-- wp:list {\\"ordered\\":true} -->
+<ol><li>A list item</li></ol>
+<!-- /wp:list -->"
+`;
+
+exports[`Lists can be created by using an asterisk at the start of a paragraph block 1`] = `
 "<!-- wp:list -->
 <ul><li>A list item</li><li>Another list item</li></ul>
 <!-- /wp:list -->"

--- a/test/e2e/specs/__snapshots__/lists.test.js.snap
+++ b/test/e2e/specs/__snapshots__/lists.test.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Lists can be converted to a paragraphs 1`] = `
+exports[`Lists can be converted to a quote 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>one</p><p>two</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Lists can be converted to paragraphs 1`] = `
 "<!-- wp:paragraph -->
 <p>one</p>
 <!-- /wp:paragraph -->
@@ -17,6 +23,12 @@ exports[`Lists can be created by converting a paragraph 1`] = `
 `;
 
 exports[`Lists can be created by converting a paragraph with line breaks 1`] = `
+"<!-- wp:list -->
+<ul><li>one</li><li>two</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`Lists can be created by converting a quote 1`] = `
 "<!-- wp:list -->
 <ul><li>one</li><li>two</li></ul>
 <!-- /wp:list -->"

--- a/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Lists can be converted to a quote 1`] = `
+exports[`List can be converted to a quote 1`] = `
 "<!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><p>one</p><p>two</p></blockquote>
 <!-- /wp:quote -->"
 `;
 
-exports[`Lists can be converted to paragraphs 1`] = `
+exports[`List can be converted to paragraphs 1`] = `
 "<!-- wp:paragraph -->
 <p>one</p>
 <!-- /wp:paragraph -->
@@ -16,49 +16,49 @@ exports[`Lists can be converted to paragraphs 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Lists can be created by converting a paragraph 1`] = `
+exports[`List can be created by converting a paragraph 1`] = `
 "<!-- wp:list -->
 <ul><li>test</li></ul>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by converting a paragraph with line breaks 1`] = `
+exports[`List can be created by converting a paragraph with line breaks 1`] = `
 "<!-- wp:list -->
 <ul><li>one</li><li>two</li></ul>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by converting a quote 1`] = `
+exports[`List can be created by converting a quote 1`] = `
 "<!-- wp:list -->
 <ul><li>one</li><li>two</li></ul>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by converting multiple paragraphs 1`] = `
+exports[`List can be created by converting multiple paragraphs 1`] = `
 "<!-- wp:list -->
 <ul><li>one</li><li>two</li></ul>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by typing "/list" 1`] = `
+exports[`List can be created by typing "/list" 1`] = `
 "<!-- wp:list -->
 <ul><li>I’m a list</li></ul>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by typing an asterisk in front of text of a paragraph block 1`] = `
+exports[`List can be created by typing an asterisk in front of text of a paragraph block 1`] = `
 "<!-- wp:list -->
 <ul><li>test</li></ul>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by using a number at the start of a paragraph block 1`] = `
+exports[`List can be created by using a number at the start of a paragraph block 1`] = `
 "<!-- wp:list {\\"ordered\\":true} -->
 <ol><li>A list item</li></ol>
 <!-- /wp:list -->"
 `;
 
-exports[`Lists can be created by using an asterisk at the start of a paragraph block 1`] = `
+exports[`List can be created by using an asterisk at the start of a paragraph block 1`] = `
 "<!-- wp:list -->
 <ul><li>A list item</li><li>Another list item</li></ul>
 <!-- /wp:list -->"

--- a/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
@@ -63,3 +63,49 @@ exports[`List can be created by using an asterisk at the start of a paragraph bl
 <ul><li>A list item</li><li>Another list item</li></ul>
 <!-- /wp:list -->"
 `;
+
+exports[`List should create paragraph on split at end and merge back with content 1`] = `
+"<!-- wp:list -->
+<ul><li>one</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`List should create paragraph on split at end and merge back with content 2`] = `
+"<!-- wp:list -->
+<ul><li>one</li><li>two</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should split into two with paragraph and merge lists 1`] = `
+"<!-- wp:list -->
+<ul><li>one</li><li></li><li>two</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should split into two with paragraph and merge lists 2`] = `
+"<!-- wp:list -->
+<ul><li>one</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><li>two</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should split into two with paragraph and merge lists 3`] = `
+"<!-- wp:list -->
+<ul><li>one</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:list -->
+<ul><li>two</li></ul>
+<!-- /wp:list -->"
+`;

--- a/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Quote can be converted to headings 1`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>two</p><cite>cite</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be converted to headings 2`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading -->
+<h2>two</h2>
+<!-- /wp:heading -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p><cite>cite</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be converted to headings 3`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading -->
+<h2>two</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading -->
+<h2>cite</h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Quote can be converted to paragraphs 1`] = `
+"<!-- wp:paragraph -->
+<p>one</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>two</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Quote can be created by converting a heading 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>test</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be created by converting a paragraph 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>test</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be created by converting multiple paragraphs 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>one</p><p>two</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be created by typing "/quote" 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>I’m a quote</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be created by typing > in front of text of a paragraph block 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>test</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be created by using > at the start of a paragraph block 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>A quote</p><p>Another paragraph</p></blockquote>
+<!-- /wp:quote -->"
+`;

--- a/test/e2e/specs/blocks/list.test.js
+++ b/test/e2e/specs/blocks/list.test.js
@@ -9,9 +9,9 @@ import {
 	convertBlock,
 	pressWithModifier,
 	insertBlock,
-} from '../support/utils';
+} from '../../support/utils';
 
-describe( 'Lists', () => {
+describe( 'List', () => {
 	beforeEach( async () => {
 		await newPost();
 	} );

--- a/test/e2e/specs/blocks/list.test.js
+++ b/test/e2e/specs/blocks/list.test.js
@@ -116,4 +116,43 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should create paragraph on split at end and merge back with content', async () => {
+		await insertBlock( 'List' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.type( 'two' );
+		await pressTimes( 'ArrowLeft', 'two'.length );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should split into two with paragraph and merge lists', async () => {
+		await insertBlock( 'List' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// Should remove paragraph without creating empty list item.
+		await page.keyboard.press( 'Backspace' );
+
+		// Should merge lists into one.
+		await page.keyboard.press( 'ArrowDown' );
+		await pressTimes( 'ArrowLeft', 'two'.length );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/test/e2e/specs/blocks/quote.test.js
+++ b/test/e2e/specs/blocks/quote.test.js
@@ -1,0 +1,105 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	newPost,
+	pressTimes,
+	convertBlock,
+	insertBlock,
+} from '../../support/utils';
+
+describe( 'Quote', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'can be created by using > at the start of a paragraph block', async () => {
+		// Create a block with some text that will trigger a list creation.
+		await clickBlockAppender();
+		await page.keyboard.type( '> A quote' );
+
+		// Create a second list item.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Another paragraph' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by typing > in front of text of a paragraph block', async () => {
+		// Create a list with the slash block shortcut.
+		await clickBlockAppender();
+		await page.keyboard.type( 'test' );
+		await pressTimes( 'ArrowLeft', 4 );
+		await page.keyboard.type( '> ' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by typing "/quote"', async () => {
+		// Create a list with the slash block shortcut.
+		await clickBlockAppender();
+		await page.keyboard.type( '/quote' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'I’m a quote' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting a paragraph', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'test' );
+		await convertBlock( 'Quote' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting multiple paragraphs', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.down( 'Shift' );
+		await page.click( '[data-type="core/paragraph"]' );
+		await page.keyboard.up( 'Shift' );
+		await convertBlock( 'Quote' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be converted to paragraphs', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await convertBlock( 'Paragraph' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting a heading', async () => {
+		await insertBlock( 'Heading' );
+		await page.keyboard.type( 'test' );
+		await convertBlock( 'Quote' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be converted to headings', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'cite' );
+		await convertBlock( 'Heading' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+		await page.click( '[data-type="core/quote"]' );
+		await convertBlock( 'Heading' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+		await page.click( '[data-type="core/quote"]' );
+		await convertBlock( 'Heading' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );

--- a/test/e2e/specs/convert-block-type.test.js
+++ b/test/e2e/specs/convert-block-type.test.js
@@ -5,6 +5,7 @@ import {
 	getEditedPostContent,
 	newPost,
 	insertBlock,
+	convertBlock,
 } from '../support/utils';
 
 describe( 'Code block', () => {
@@ -23,15 +24,7 @@ describe( 'Code block', () => {
 		const originalPostContent = await getEditedPostContent();
 		expect( originalPostContent ).toMatchSnapshot();
 
-		// Hover over this block to show its toolbar so we can click on the block
-		// conversion button.
-		const insertionPoint = await page.$( '.editor-block-list__block-edit' );
-		const rect = await insertionPoint.boundingBox();
-		await page.mouse.move( rect.x + ( rect.width / 2 ), rect.y + ( rect.height / 2 ), { steps: 10 } );
-
-		// Convert this block to a Preformatted block.
-		await page.click( '.editor-block-switcher__toggle' );
-		await page.click( '.editor-block-types-list__item[aria-label="Preformatted"]' );
+		await convertBlock( 'Preformatted' );
 
 		// The content should now be a Preformatted block with no data loss.
 		const convertedPostContent = await getEditedPostContent();

--- a/test/e2e/specs/lists.test.js
+++ b/test/e2e/specs/lists.test.js
@@ -87,12 +87,32 @@ describe( 'Lists', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'can be converted to a paragraphs', async () => {
+	it( 'can be converted to paragraphs', async () => {
 		await insertBlock( 'List' );
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
 		await convertBlock( 'Paragraph' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting a quote', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await convertBlock( 'List' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be converted to a quote', async () => {
+		await insertBlock( 'List' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await convertBlock( 'Quote' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/test/e2e/specs/lists.test.js
+++ b/test/e2e/specs/lists.test.js
@@ -5,6 +5,10 @@ import {
 	clickBlockAppender,
 	getEditedPostContent,
 	newPost,
+	pressTimes,
+	convertBlock,
+	pressWithModifier,
+	insertBlock,
 } from '../support/utils';
 
 describe( 'Lists', () => {
@@ -12,7 +16,7 @@ describe( 'Lists', () => {
 		await newPost();
 	} );
 
-	it( 'can be created by using an asterisk at the start of a RichText block', async () => {
+	it( 'can be created by using an asterisk at the start of a paragraph block', async () => {
 		// Create a block with some text that will trigger a list creation.
 		await clickBlockAppender();
 		await page.keyboard.type( '* A list item' );
@@ -24,10 +28,20 @@ describe( 'Lists', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'can be created by using a hyphen at the start of a RichText block', async () => {
+	it( 'can be created by typing an asterisk in front of text of a paragraph block', async () => {
+		// Create a list with the slash block shortcut.
+		await clickBlockAppender();
+		await page.keyboard.type( 'test' );
+		await pressTimes( 'ArrowLeft', 4 );
+		await page.keyboard.type( '* ' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by using a number at the start of a paragraph block', async () => {
 		// Create a block with some text that will trigger a list creation.
 		await clickBlockAppender();
-		await page.keyboard.type( '- A list item' );
+		await page.keyboard.type( '1) A list item' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -38,6 +52,47 @@ describe( 'Lists', () => {
 		await page.keyboard.type( '/list' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'I’m a list' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting a paragraph', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'test' );
+		await convertBlock( 'List' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting multiple paragraphs', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.down( 'Shift' );
+		await page.click( '[data-type="core/paragraph"]' );
+		await page.keyboard.up( 'Shift' );
+		await convertBlock( 'List' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting a paragraph with line breaks', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'one' );
+		await pressWithModifier( 'Shift', 'Enter' );
+		await page.keyboard.type( 'two' );
+		await convertBlock( 'List' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be converted to a paragraphs', async () => {
+		await insertBlock( 'List' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await convertBlock( 'Paragraph' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -262,6 +262,14 @@ export async function insertBlock( searchTerm, panelName = null ) {
 	await waitForRichTextInitialization();
 }
 
+export async function convertBlock( name ) {
+	await page.mouse.move( 200, 300, { steps: 10 } );
+	await page.mouse.move( 250, 350, { steps: 10 } );
+	await page.click( '.editor-block-switcher__toggle' );
+	await page.click( `.editor-block-types-list__item[aria-label="${ name }"]` );
+	await waitForRichTextInitialization();
+}
+
 /**
  * Performs a key press with modifier (Shift, Control, Meta, Mod), where "Mod"
  * is normalized to platform-specific modifier (Meta in MacOS, else Control).


### PR DESCRIPTION
## Description

This adds e2e test for list transformations. Some transformations were broken.

## How has this been tested?
Inspect the tests.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
