### PR TITLE
Testing: Add missing e2e tests for Plugins API

### DIFF
--- a/test/e2e/specs/plugins-api.test.js
+++ b/test/e2e/specs/plugins-api.test.js
@@ -2,9 +2,12 @@
  * Internal dependencies
  */
 import {
+	clickBlockAppender,
 	clickOnMoreMenuItem,
 	openDocumentSettingsSidebar,
 	newPost,
+	openPublishPanel,
+	publishPost,
 } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
@@ -24,6 +27,31 @@ describe( 'Using Plugins API', () => {
 
 			const pluginPostStatusInfoText = await page.$eval( '.edit-post-post-status .my-post-status-info-plugin', ( el ) => el.innerText );
 			expect( pluginPostStatusInfoText ).toBe( 'My post status info' );
+		} );
+	} );
+
+	describe( 'Publish Panel', () => {
+		afterEach( async () => {
+			// Close Publish panel.
+			await page.click( '.editor-post-publish-panel__header button[aria-label="Close panel"]' );
+		} );
+
+		it( 'Should render publish panel inside Pre-publish sidebar', async () => {
+			// Type something first to activate Publish button.
+			await clickBlockAppender();
+			await page.keyboard.type( 'First paragraph' );
+
+			await openPublishPanel();
+
+			const pluginPublishPanelText = await page.$eval( '.editor-post-publish-panel .my-publish-panel-plugin__pre', ( el ) => el.innerText );
+			expect( pluginPublishPanelText ).toMatch( 'My pre publish panel' );
+		} );
+
+		it( 'Should render publish panel inside Post-publish sidebar', async () => {
+			await publishPost();
+
+			const pluginPublishPanelText = await page.$eval( '.editor-post-publish-panel .my-publish-panel-plugin__post', ( el ) => el.innerText );
+			expect( pluginPublishPanelText ).toMatch( 'My post publish panel' );
 		} );
 	} );
 

--- a/test/e2e/specs/plugins-api.test.js
+++ b/test/e2e/specs/plugins-api.test.js
@@ -14,11 +14,14 @@ import { activatePlugin, deactivatePlugin } from '../support/plugins';
 describe( 'Using Plugins API', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-plugin-plugins-api' );
-		await newPost();
 	} );
 
 	afterAll( async () => {
 		await deactivatePlugin( 'gutenberg-test-plugin-plugins-api' );
+	} );
+
+	beforeEach( async () => {
+		await newPost();
 	} );
 
 	describe( 'Post Status Info', () => {
@@ -31,16 +34,13 @@ describe( 'Using Plugins API', () => {
 	} );
 
 	describe( 'Publish Panel', () => {
-		afterEach( async () => {
-			// Close Publish panel.
-			await page.click( '.editor-post-publish-panel__header button[aria-label="Close panel"]' );
-		} );
-
-		it( 'Should render publish panel inside Pre-publish sidebar', async () => {
+		beforeEach( async () => {
 			// Type something first to activate Publish button.
 			await clickBlockAppender();
 			await page.keyboard.type( 'First paragraph' );
+		} );
 
+		it( 'Should render publish panel inside Pre-publish sidebar', async () => {
 			await openPublishPanel();
 
 			const pluginPublishPanelText = await page.$eval( '.editor-post-publish-panel .my-publish-panel-plugin__pre', ( el ) => el.innerText );
@@ -66,8 +66,13 @@ describe( 'Using Plugins API', () => {
 		it( 'Should close plugins sidebar using More Menu item', async () => {
 			await clickOnMoreMenuItem( 'Sidebar title plugin' );
 
-			const pluginSidebar = await page.$( '.edit-post-sidebar' );
-			expect( pluginSidebar ).toBeNull();
+			const pluginSidebarOpened = await page.$( '.edit-post-sidebar' );
+			expect( pluginSidebarOpened ).not.toBeNull();
+
+			await clickOnMoreMenuItem( 'Sidebar title plugin' );
+
+			const pluginSidebarClosed = await page.$( '.edit-post-sidebar' );
+			expect( pluginSidebarClosed ).toBeNull();
 		} );
 	} );
 } );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -311,19 +311,25 @@ export async function clickOnMoreMenuItem( buttonLabel ) {
 }
 
 /**
- * Publishes the post, resolving once the request is complete (once a notice
- * is displayed).
- *
- * @return {Promise} Promise resolving when publish is complete.
+ * Opens the publish panel.
  */
-export async function publishPost() {
-	// Opens the publish panel
+export async function openPublishPanel() {
 	await page.click( '.editor-post-publish-panel__toggle' );
 
 	// Disable reason: Wait for the animation to complete, since otherwise the
 	// click attempt may occur at the wrong point.
 	// eslint-disable-next-line no-restricted-syntax
 	await page.waitFor( 100 );
+}
+
+/**
+ * Publishes the post, resolving once the request is complete (once a notice
+ * is displayed).
+ *
+ * @return {Promise} Promise resolving when publish is complete.
+ */
+export async function publishPost() {
+	await openPublishPanel();
 
 	// Publish the post
 	await page.click( '.editor-post-publish-button' );

--- a/test/e2e/test-plugins/plugins-api/post-status-info.js
+++ b/test/e2e/test-plugins/plugins-api/post-status-info.js
@@ -1,18 +1,20 @@
-var el = wp.element.createElement;
-var __ = wp.i18n.__;
-var registerPlugin = wp.plugins.registerPlugin;
-var PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;
+( function() {
+	var el = wp.element.createElement;
+	var __ = wp.i18n.__;
+	var registerPlugin = wp.plugins.registerPlugin;
+	var PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;
 
-function MyPostStatusInfoPlugin() {
-	return el(
-		PluginPostStatusInfo,
-		{
-			className: 'my-post-status-info-plugin',
-		},
-		__( 'My post status info' )
-	);
-}
+	function MyPostStatusInfoPlugin() {
+		return el(
+			PluginPostStatusInfo,
+			{
+				className: 'my-post-status-info-plugin',
+			},
+			__( 'My post status info' )
+		);
+	}
 
-registerPlugin( 'my-post-status-info-plugin', {
-	render: MyPostStatusInfoPlugin
-} );
+	registerPlugin( 'my-post-status-info-plugin', {
+		render: MyPostStatusInfoPlugin
+	} );
+} )();

--- a/test/e2e/test-plugins/plugins-api/publish-panel.js
+++ b/test/e2e/test-plugins/plugins-api/publish-panel.js
@@ -1,47 +1,49 @@
-var el = wp.element.createElement;
-var Fragment = wp.element.Fragment;
-var __ = wp.i18n.__;
-var registerPlugin = wp.plugins.registerPlugin;
-var PluginPostPublishPanel = wp.editPost.PluginPostPublishPanel;
-var PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;
+( function() {
+	var el = wp.element.createElement;
+	var Fragment = wp.element.Fragment;
+	var __ = wp.i18n.__;
+	var registerPlugin = wp.plugins.registerPlugin;
+	var PluginPostPublishPanel = wp.editPost.PluginPostPublishPanel;
+	var PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;
 
-function PanelContent() {
-	return el(
-		'p',
-		{},
-		__( 'Here is the panel content!' )
-	);
-}
+	function PanelContent() {
+		return el(
+			'p',
+			{},
+			__( 'Here is the panel content!' )
+		);
+	}
 
-function MyPublishPanelPlugin() {
-	return el(
-		Fragment,
-		{},
-		el(
-			PluginPrePublishPanel,
-			{
-				className: 'my-publish-panel-plugin__pre',
-				title: __( 'My pre publish panel' )
-			},
+	function MyPublishPanelPlugin() {
+		return el(
+			Fragment,
+			{},
 			el(
-				PanelContent,
-				{}
-			)
-		),
-		el(
-			PluginPostPublishPanel,
-			{
-				className: 'my-publish-panel-plugin__post',
-				title: __( 'My post publish panel' )
-			},
+				PluginPrePublishPanel,
+				{
+					className: 'my-publish-panel-plugin__pre',
+					title: __( 'My pre publish panel' )
+				},
+				el(
+					PanelContent,
+					{}
+				)
+			),
 			el(
-				PanelContent,
-				{}
+				PluginPostPublishPanel,
+				{
+					className: 'my-publish-panel-plugin__post',
+					title: __( 'My post publish panel' )
+				},
+				el(
+					PanelContent,
+					{}
+				)
 			)
-		)
-	);
-}
+		);
+	}
 
-registerPlugin( 'my-publish-panel-plugin', {
-	render: MyPublishPanelPlugin
-} );
+	registerPlugin( 'my-publish-panel-plugin', {
+		render: MyPublishPanelPlugin
+	} );
+} )();

--- a/test/e2e/test-plugins/plugins-api/sidebar.js
+++ b/test/e2e/test-plugins/plugins-api/sidebar.js
@@ -1,106 +1,108 @@
-var Button = wp.components.Button;
-var PanelBody = wp.components.PanelBody;
-var PanelRow = wp.components.PanelRow;
-var compose = wp.compose.compose;
-var withDispatch = wp.data.withDispatch;
-var withSelect = wp.data.withSelect;
-var PlainText = wp.editor.PlainText;
-var Fragment = wp.element.Fragment;
-var el = wp.element.createElement;
-var __ = wp.i18n.__;
-var registerPlugin = wp.plugins.registerPlugin;
-var PluginSidebar = wp.editPost.PluginSidebar;
-var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
+( function() {
+	var Button = wp.components.Button;
+	var PanelBody = wp.components.PanelBody;
+	var PanelRow = wp.components.PanelRow;
+	var compose = wp.compose.compose;
+	var withDispatch = wp.data.withDispatch;
+	var withSelect = wp.data.withSelect;
+	var PlainText = wp.editor.PlainText;
+	var Fragment = wp.element.Fragment;
+	var el = wp.element.createElement;
+	var __ = wp.i18n.__;
+	var registerPlugin = wp.plugins.registerPlugin;
+	var PluginSidebar = wp.editPost.PluginSidebar;
+	var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
 
-function SidebarContents( props ) {
-	return el(
-		PanelBody,
-		{},
-		el(
-			PanelRow,
+	function SidebarContents( props ) {
+		return el(
+			PanelBody,
 			{},
 			el(
-				'label',
-				{
-					'htmlFor': 'title-plain-text'
-				},
-				__( 'Title:' ),
+				PanelRow,
+				{},
+				el(
+					'label',
+					{
+						'htmlFor': 'title-plain-text'
+					},
+					__( 'Title:' ),
+				),
+				el(
+					PlainText,
+					{
+						id: 'title-plain-text',
+						onChange: props.updateTitle,
+						placeholder: __( '(no title)' ),
+						value: props.title
+					}
+				)
 			),
 			el(
-				PlainText,
-				{
-					id: 'title-plain-text',
-					onChange: props.updateTitle,
-					placeholder: __( '(no title)' ),
-					value: props.title
-				}
+				PanelRow,
+				{},
+				el(
+					Button,
+					{
+						isPrimary: true,
+						onClick: props.resetTitle
+					},
+					__( 'Reset' )
+				)
 			)
-		),
-		el(
-			PanelRow,
+		);
+	}
+
+	var SidebarContentsWithDataHandling = compose( [
+		withSelect( function( select ) {
+			return {
+				title: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
+			};
+		} ),
+		withDispatch( function( dispatch ) {
+			function editPost( title ) {
+				dispatch( 'core/editor' ).editPost( {
+					title: title
+				} );
+			}
+
+			return {
+				updateTitle: function( title ) {
+					editPost( title );
+				},
+				resetTitle: function() {
+					editPost( '' );
+				}
+			};
+		} )
+	] )( SidebarContents );
+
+	function MySidebarPlugin() {
+		return el(
+			Fragment,
 			{},
 			el(
-				Button,
+				PluginSidebar,
 				{
-					isPrimary: true,
-					onClick: props.resetTitle
+					name: 'title-sidebar',
+					title: __( 'Sidebar title plugin' )
 				},
-				__( 'Reset' )
-			)
-		)
-	);
-}
-
-var SidebarContentsWithDataHandling = compose( [
-	withSelect( function( select ) {
-		return {
-			title: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
-		};
-	} ),
-	withDispatch( function( dispatch ) {
-		function editPost( title ) {
-			dispatch( 'core/editor' ).editPost( {
-				title: title
-			} );
-		}
-
-		return {
-			updateTitle: function( title ) {
-				editPost( title );
-			},
-			resetTitle: function() {
-				editPost( '' );
-			}
-		};
-	} )
-] )( SidebarContents );
-
-function MySidebarPlugin() {
-	return el(
-		Fragment,
-		{},
-		el(
-			PluginSidebar,
-			{
-				name: 'title-sidebar',
-				title: __( 'Sidebar title plugin' )
-			},
+				el(
+					SidebarContentsWithDataHandling,
+					{}
+				)
+			),
 			el(
-				SidebarContentsWithDataHandling,
-				{}
+				PluginSidebarMoreMenuItem,
+				{
+					target: 'title-sidebar'
+				},
+				__( 'Sidebar title plugin' )
 			)
-		),
-		el(
-			PluginSidebarMoreMenuItem,
-			{
-				target: 'title-sidebar'
-			},
-			__( 'Sidebar title plugin' )
-		)
-	);
-}
+		);
+	}
 
-registerPlugin( 'my-sidebar-plugin', {
-	icon: 'text',
-	render: MySidebarPlugin
-} );
+	registerPlugin( 'my-sidebar-plugin', {
+		icon: 'text',
+		render: MySidebarPlugin
+	} );
+} )();


### PR DESCRIPTION
## Description
This PR adds two basic tests for Publish Panel components integrated with Plugins API. I noticed that I added plugins before WordCamp Europe. Apparently, I forgot to add tests, this PR fixes it.

This PR also wraps JavaScript code of test plugins with IIFE (Immediately-invoked function expression) to avoid polluting global namespace. 

## How has this been tested?
`npm run test-e2e` plus the same check on Travis.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
