### PR TITLE
Fix publish buttons with long text

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -97,7 +97,7 @@
 		height: auto;
 		justify-content: center;
 		padding: 3px 10px 4px;
-		line-height: 20px;
+		line-height: 1.6;
 		text-align: center;
 		white-space: normal;
 	}

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -86,14 +86,11 @@
 	display: flex;
 	align-content: space-between;
 	flex-wrap: wrap;
+	margin: -5px;
 
 	> * {
-		//flex-grow: 1;
-		margin-right: 10px;
-
-		&:last-child {
-			margin-right: 0;
-		}
+		flex-grow: 1;
+		margin: 5px;
 	}
 
 	.components-button {
@@ -103,10 +100,6 @@
 		line-height: 20px;
 		text-align: center;
 		white-space: normal;
-	}
-
-	.components-button + .components-button {
-		margin-bottom: 0.5em;
 	}
 
 	.components-clipboard-button {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -85,9 +85,10 @@
 .post-publish-panel__postpublish-buttons {
 	display: flex;
 	align-content: space-between;
+	flex-wrap: wrap;
 
 	> * {
-		flex-grow: 1;
+		//flex-grow: 1;
 		margin-right: 10px;
 
 		&:last-child {
@@ -96,7 +97,16 @@
 	}
 
 	.components-button {
+		height: auto;
 		justify-content: center;
+		padding: 3px 10px 4px;
+		line-height: 20px;
+		text-align: center;
+		white-space: normal;
+	}
+
+	.components-button + .components-button {
+		margin-bottom: 0.5em;
 	}
 
 	.components-clipboard-button {


### PR DESCRIPTION
Currently, when the post-publish buttons use longer text strings, they run off the screen. This should be solved by the changes planned in #9398, but since that's been a bit stalled this is a quick patch in the meantime.

Before:
<img width="983" alt="screenshot 2018-10-11 14 46 42" src="https://user-images.githubusercontent.com/376315/46808575-9a108e00-cd64-11e8-8e1c-068a48d19479.png">

After:
<img width="977" alt="screenshot 2018-10-11 14 44 54" src="https://user-images.githubusercontent.com/376315/46808574-9a108e00-cd64-11e8-86b7-190f3cae2217.png">

It's not 100% ideal but it should accommodate any range of text strings for these buttons.

The CSS changes introduced here are specific only to these two buttons, rather than being scoped more widely across other button components. This seems a sensible approach here since there's already quite a bit of CSS that's scoped specifically to these instances of the buttons, and since this panel is subject to change at some point in the potentially maybe near-ish future-ish.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
