### PR TITLE
Fix: Show close button in long tags

### DIFF
--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -146,6 +146,7 @@
 	padding: 0 2px;
 	color: $dark-gray-500;
 	line-height: 10px;
+	overflow: initial;
 
 	&:hover {
 		color: $dark-gray-700;


### PR DESCRIPTION
## Description
The close button is hidden, if the tag is very long. This PR fixes the bug.
Fixes #10501 

## Screenshots <!-- if applicable -->
Before:
![bildschirmfoto 2018-10-11 um 16 45 02](https://user-images.githubusercontent.com/695201/46812489-1ca14980-cd75-11e8-9f32-ddad4bfcb0dd.png)

After
![bildschirmfoto 2018-10-11 um 16 45 11](https://user-images.githubusercontent.com/695201/46812487-1c08b300-cd75-11e8-8fba-3a3b0676233b.png)
