### PR TITLE
Add explicit bottom margin to `figure` elements (image, embed)

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -16,7 +16,7 @@
 		@include caption-style();
 	}
 
-	// The image block is in a `figure` element, and many themes zero this out.
+	// The embed block is in a `figure` element, and many themes zero this out.
 	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
 	margin-bottom: 1em;
 

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -16,6 +16,10 @@
 		@include caption-style();
 	}
 
+	// The image block is in a `figure` element, and many themes zero this out.
+	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
+	margin-bottom: 1em;
+
 	// Add responsiveness to common aspect ratios.
 	&.wp-embed-aspect-21-9 .wp-block-embed__wrapper,
 	&.wp-embed-aspect-18-9 .wp-block-embed__wrapper,

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -1,6 +1,10 @@
 .wp-block-image {
 	max-width: 100%;
 
+	// The image block is in a `figure` element, and many themes zero this out.
+	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
+	margin-bottom: 1em;
+
 	img {
 		max-width: 100%;
 	}


### PR DESCRIPTION
Fixes #9530.

The `figure` element is often used in WordPress themes in a way that requires its margin to be reset, usually because they are nested inside other elements that have margins. That means many themes have this in their stylesheet:

```
figure {
margin: 0;
}
```

In Gutenberg, the embed block and the image block both use the `figure` element as their primary container, and as part of the flow next to paragraphs and other elements in the post. When the margin is zeroed out, that means no margin below an image.

This PR sets an explicit bottom margin on image and embed blocks (1em, which happens to be the same as the bottom margin the figure element is born with), so that we avoid situations where a caption on an image is snug up against the next block.