### PR TITLE
Improve validation for attribute names in rich-text toHTMLString

### DIFF
--- a/packages/rich-text/src/to-html-string.js
+++ b/packages/rich-text/src/to-html-string.js
@@ -2,7 +2,11 @@
  * Internal dependencies
  */
 
-import { escapeHTML, escapeAttribute } from '@wordpress/escape-html';
+import {
+	escapeHTML,
+	escapeAttribute,
+	isValidAttributeName,
+} from '@wordpress/escape-html';
 
 /**
  * Internal dependencies
@@ -83,6 +87,10 @@ function createElementHTML( { type, attributes, object, children } ) {
 	let attributeString = '';
 
 	for ( const key in attributes ) {
+		if ( ! isValidAttributeName( key ) ) {
+			continue;
+		}
+
 		attributeString += ` ${ key }="${ escapeAttribute( attributes[ key ] ) }"`;
 	}
 


### PR DESCRIPTION
## Description
Adjusts toHTMLString to validate attribute name better.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
