### PR TITLE
Fix/media caption processing

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -26,7 +26,6 @@ import {
 	InspectorControls,
 	mediaUpload,
 } from '@wordpress/editor';
-import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -46,16 +45,7 @@ export function defaultColumnsNumber( attributes ) {
 }
 
 export const pickRelevantMediaFiles = ( image ) => {
-	let { caption } = image;
-
-	if ( typeof caption !== 'object' ) {
-		caption = create( { html: caption } );
-	}
-
-	return {
-		...pick( image, [ 'alt', 'id', 'link', 'url' ] ),
-		caption,
-	};
+	return pick( image, [ 'alt', 'id', 'link', 'url', 'caption' ] );
 };
 
 class GalleryEdit extends Component {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -40,7 +40,6 @@ import {
 } from '@wordpress/editor';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose } from '@wordpress/compose';
-import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -58,16 +57,7 @@ const LINK_DESTINATION_CUSTOM = 'custom';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 export const pickRelevantMediaFiles = ( image ) => {
-	let { caption } = image;
-
-	if ( typeof caption !== 'object' ) {
-		caption = create( { html: caption } );
-	}
-
-	return {
-		...pick( image, [ 'alt', 'id', 'link', 'url' ] ),
-		caption,
-	};
+	return pick( image, [ 'alt', 'id', 'link', 'url', 'caption' ] );
 };
 
 class ImageEdit extends Component {
@@ -130,7 +120,7 @@ class ImageEdit extends Component {
 				url: undefined,
 				alt: undefined,
 				id: undefined,
-				caption: create(),
+				caption: undefined,
 			} );
 			return;
 		}

--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -6,7 +6,6 @@ import { castArray, pick } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { parseWithAttributeSchema } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import deprecated from '@wordpress/deprecated';
@@ -91,7 +90,6 @@ class MediaUpload extends Component {
 		this.onSelect = this.onSelect.bind( this );
 		this.onUpdate = this.onUpdate.bind( this );
 		this.onClose = this.onClose.bind( this );
-		this.processMediaCaption = this.processMediaCaption.bind( this );
 
 		let allowedTypesToUse = allowedTypes;
 		if ( ! allowedTypes && deprecatedType ) {
@@ -162,9 +160,9 @@ class MediaUpload extends Component {
 		}
 
 		if ( multiple ) {
-			onSelect( selectedImages.models.map( ( model ) => this.processMediaCaption( slimImageObject( model.toJSON() ) ) ) );
+			onSelect( selectedImages.models.map( ( model ) => slimImageObject( model.toJSON() ) ) );
 		} else {
-			onSelect( this.processMediaCaption( slimImageObject( ( selectedImages.models[ 0 ].toJSON() ) ) ) );
+			onSelect( slimImageObject( ( selectedImages.models[ 0 ].toJSON() ) ) );
 		}
 	}
 
@@ -174,8 +172,8 @@ class MediaUpload extends Component {
 		const attachment = this.frame.state().get( 'selection' ).toJSON();
 		onSelect(
 			multiple ?
-				attachment.map( this.processMediaCaption ) :
-				this.processMediaCaption( attachment[ 0 ] )
+				attachment :
+				attachment[ 0 ]
 		);
 	}
 
@@ -203,14 +201,6 @@ class MediaUpload extends Component {
 
 	openModal() {
 		this.frame.open();
-	}
-
-	processMediaCaption( mediaObject ) {
-		return ! mediaObject.caption ?
-			mediaObject :
-			{ ...mediaObject, caption: parseWithAttributeSchema( mediaObject.caption, {
-				source: 'rich-text',
-			} ) };
 	}
 
 	render() {


### PR DESCRIPTION
## Description

Media processing wasn't updated during #10439. The good thing now is that the format is just HTML, so we can pass the caption directly to `RichText` without any conversions.

## How has this been tested?
Test the image and gallery blocks by inserting images form the media library with captions.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->