### PR TITLE
Adjust rich-text source mentions in docs

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -130,7 +130,7 @@ attributes: {
 		attribute: 'src',
 	},
 	author: {
-		source: 'rich-text',
+		source: 'html',
 		selector: '.book-author',
 	},
 	pages: {
@@ -413,7 +413,7 @@ align: true,
 align: [ 'left', 'right', 'full' ],
 ```
 When supports align is used the block attributes definition is extended to include an align attribute with a string type.
-By default, no alignment is assigned to the block. 
+By default, no alignment is assigned to the block.
 The block can apply a default alignment by specifying its own align attribute with a default e.g.:
 ```
 attributes: {

--- a/docs/block-api/attributes.md
+++ b/docs/block-api/attributes.md
@@ -55,26 +55,17 @@ Use `html` to extract the inner HTML from markup.
 // { "content": "The inner text of the <strong>figcaption</strong> element" }
 ```
 
-### `children`
-
-Use `children` to extract child nodes of the matched element, returned as an array of virtual elements. This is most commonly used in combination with the `RichText` component.
-
-_Example_: Extract child nodes from a paragraph of rich text.
+Use the `multiline` property to extract the inner HTML for the use in `RichText` with the `multiline` prop.
 
 ```js
 {
 	content: {
-		source: 'children',
-		selector: 'p'
+		source: 'html',
+		multiline: 'p',
+		selector: 'blockquote',
 	}
 }
-// {
-//   "content": [
-//     "Vestibulum eu ",
-//     { "type": "strong", "children": "tortor" },
-//     " vel urna."
-//   ]
-// }
+// { "content": "<p>Quoted text</p><p>And more</p>" }
 ```
 
 ### `query`

--- a/docs/block-api/attributes.md
+++ b/docs/block-api/attributes.md
@@ -55,7 +55,7 @@ Use `html` to extract the inner HTML from markup.
 // { "content": "The inner text of the <strong>figcaption</strong> element" }
 ```
 
-Use the `multiline` property to extract the inner HTML for the use in `RichText` with the `multiline` prop.
+Use the `multiline` property to extract the inner HTML of matching tag names for the use in `RichText` with the `multiline` prop.
 
 ```js
 {
@@ -65,7 +65,7 @@ Use the `multiline` property to extract the inner HTML for the use in `RichText`
 		selector: 'blockquote',
 	}
 }
-// { "content": "<p>Quoted text</p><p>And more</p>" }
+// { "content": "<p>First line</p><p>Second line</p>" }
 ```
 
 ### `query`

--- a/docs/block-api/deprecated-blocks.md
+++ b/docs/block-api/deprecated-blocks.md
@@ -204,7 +204,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 		{
 			attributes: {
 				title: {
-					source: 'rich-text',
+					source: 'html',
 					selector: 'p',
 				},
 			},
@@ -244,7 +244,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 		{
 			attributes: {
 				title: {
-					source: 'rich-text',
+					source: 'html',
 					selector: 'p',
 				},
 			},

--- a/docs/blocks/block-controls-toolbars-and-inspector.md
+++ b/docs/blocks/block-controls-toolbars-and-inspector.md
@@ -29,7 +29,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 
 	attributes: {
 		content: {
-			source: 'rich-text',
+			source: 'html',
 			selector: 'p',
 		},
 		alignment: {
@@ -110,7 +110,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 
 	attributes: {
 		content: {
-			source: 'rich-text',
+			source: 'html',
 			selector: 'p',
 		},
 		alignment: {

--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -24,7 +24,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 
 	attributes: {
 		content: {
-			source: 'rich-text',
+			source: 'html',
 			selector: 'p',
 		}
 	},
@@ -72,7 +72,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 
 	attributes: {
 		content: {
-			source: 'rich-text',
+			source: 'html',
 			selector: 'p',
 		},
 	},
@@ -111,7 +111,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 
 When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [source function](../../docs/block-api/attributes.md) to find the desired value from the markup of the block.
 
-In the code snippet above, when loading the editor, we will extract the `content` value as the children of the paragraph element in the saved post's markup.
+In the code snippet above, when loading the editor, we will extract the `content` value as the html of the paragraph element in the saved post's markup.
 
 ## Components and the `RichText` Component
 
@@ -121,4 +121,4 @@ The `RichText` component can be considered as a super-powered `textarea` element
 
 Implementing this behavior as a component enables you as the block implementer to be much more granular about editable fields. Your block may not need `RichText` at all, or it may need many independent `RichText` elements, each operating on a subset of the overall block state.
 
-Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `rich-text` attribute source when extracting the value from saved content. You'll also use `RichText.Content` in the `save` function to output RichText values.
+Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `html` attribute source when extracting the value from saved content. You'll also use `RichText.Content` in the `save` function to output RichText values.

--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -111,7 +111,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 
 When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [source function](../../docs/block-api/attributes.md) to find the desired value from the markup of the block.
 
-In the code snippet above, when loading the editor, we will extract the `content` value as the html of the paragraph element in the saved post's markup.
+In the code snippet above, when loading the editor, we will extract the `content` value as the HTML of the paragraph element in the saved post's markup.
 
 ## Components and the `RichText` Component
 


### PR DESCRIPTION
## Description

After #10439, adjusts the docs to suggest 'html' source instead of 'rich-text'.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->