### PR TITLE
Fix scroll issue on small viewports.

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -89,7 +89,10 @@
 	// then pause, then keep scrolling downwards, the browser doesn't try to scroll
 	// the parent element, usually invoking a "bounce" effect and then preventing you
 	// from scrolling upwards until you pause again.
-	overscroll-behavior-y: none;
+	// This is only necessary beyond the small breakpoint because that's when the scroll container changes.
+	@include break-small() {
+		overscroll-behavior-y: none;
+	}
 
 	.edit-post-visual-editor {
 		flex-grow: 1;


### PR DESCRIPTION
This is sort of a hotfix PR.

Not long ago I introduced overscroll-behavior-y: none; as a fix for the issues overscroll bounce issues that can happen when scrolling multiple individual divs instead of the body container.

That fix is still solid, but the fix failed to take in account small viewports where the body does indeed scroll, causing a regression.

Test in master: make the viewport smaller than 600px then scroll. It doesn't work in Firefox or Chrome. This is because below 600px, body scrolls, and beyond that, edit-post-layout__content scrolls.

This PR simply scopes this better so the rule is only applied beyond the 600px breakpoint.

Filing this in 4.0 milestone in case we can include it in the final 4.0 release. Feel free to move milestone if need be.