### PR TITLE
Columns Block: Make responsive, make editor and theme match

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -6,13 +6,6 @@
 	margin-left: 0;
 	margin-right: 0;
 
-	&:first-child {
-		margin-left: -$block-padding;
-	}
-	&:last-child {
-		margin-right: -$block-padding;
-	}
-
 	// This max-width is used to constrain the main editor column, it should not cascade into columns
 	.editor-block-list__block {
 		max-width: none;
@@ -58,6 +51,31 @@
 			display: flex;
 			flex-direction: column;
 			flex: 1;
+
+			// The Column block is a child of the Columns block and is mostly a passthrough container.
+			// Therefore it shouldn't add additional paddings and margins, so we reset these, and compensate for margins.
+			// @todo In the future, if a passthrough feature lands, it would be good to apply these rules to such an element in a more generic way.
+			padding-left: $block-padding;
+			padding-right: $block-padding;
+			margin-top: -$block-padding;
+			margin-bottom: -$block-padding;
+
+			> .editor-block-contextual-toolbar {
+				top: $block-toolbar-height - $border-width;
+				transform: translateY(-$block-toolbar-height - $border-width);
+				margin-left: -$block-padding - $block-padding - $border-width;
+			}
+
+			> .editor-block-list__block-edit::before {
+				top: 0;
+				right: 0;
+				bottom: 0;
+				left: 0;
+			}
+
+			> .editor-block-list__breadcrumb {
+				margin-right: -$block-padding - $border-width;
+			}
 
 			// Every .editor-block-list__block has auto-left/right margins, which centers columns.
 			// Since they aren't centered on the front-end, we explicitly set a zero left margin here.

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -55,31 +55,41 @@
 			// The Column block is a child of the Columns block and is mostly a passthrough container.
 			// Therefore it shouldn't add additional paddings and margins, so we reset these, and compensate for margins.
 			// @todo In the future, if a passthrough feature lands, it would be good to apply these rules to such an element in a more generic way.
-			padding-left: $block-padding;
-			padding-right: $block-padding;
 			margin-top: -$block-padding;
 			margin-bottom: -$block-padding;
 
-			> .editor-block-contextual-toolbar {
-				top: $block-toolbar-height - $border-width;
-				transform: translateY(-$block-toolbar-height - $border-width);
-				margin-left: -$block-padding - $block-padding - $border-width;
+			// On mobile, only a single column is shown, so match adjacent block paddings.
+			padding-left: 0;
+			padding-right: 0;
+			margin-left: -$block-padding;
+			margin-right: -$block-padding;
+			@include break-small () {
+				padding-left: $block-padding;
+				padding-right: $block-padding;
+				margin-right: inherit;
+				// Every .editor-block-list__block has auto-left/right margins, which centers columns.
+				// Since they aren't centered on the front-end, we explicitly set a zero left margin here.
+				margin-left: 0;
 			}
 
-			> .editor-block-list__block-edit::before {
-				top: 0;
-				right: 0;
-				bottom: 0;
-				left: 0;
-			}
+			@include break-small() {
+				> .editor-block-contextual-toolbar {
+					top: $block-toolbar-height - $border-width;
+					transform: translateY(-$block-toolbar-height - $border-width);
+					margin-left: -$block-padding - $block-padding - $border-width;
+				}
 
-			> .editor-block-list__breadcrumb {
-				margin-right: -$block-padding - $border-width;
-			}
+				> .editor-block-list__block-edit::before {
+					top: 0;
+					right: 0;
+					bottom: 0;
+					left: 0;
+				}
 
-			// Every .editor-block-list__block has auto-left/right margins, which centers columns.
-			// Since they aren't centered on the front-end, we explicitly set a zero left margin here.
-			margin-left: 0;
+				> .editor-block-list__breadcrumb {
+					margin-right: -$block-padding - $border-width;
+				}
+			}
 
 			// Responsiveness: Show at most one columns on mobile.
 			flex-basis: 100%;
@@ -93,6 +103,24 @@
 			// On medium-sized viewports, allow any amount of columns.
 			@include break-medium() {
 				flex-basis: inherit;
+			}
+
+			// Add space between columns. Themes can customize this if they wish to work differently.
+			// This has to match the same padding applied in style.scss.
+			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+			@include break-small() {
+				> .editor-block-list__block-edit {
+					padding-left: $grid-size-large;
+					padding-right: $grid-size-large;
+				}
+
+				&:first-child > .editor-block-list__block-edit {
+					padding-left: 0;
+				}
+
+				&:last-child > .editor-block-list__block-edit {
+					padding-right: 0;
+				}
 			}
 		}
 	}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -109,12 +109,22 @@
 					padding-right: $grid-size-large;
 				}
 
-				&:first-child > .editor-block-list__block-edit {
+				&:nth-child(odd) > .editor-block-list__block-edit {
 					padding-left: 0;
 				}
 
-				&:last-child > .editor-block-list__block-edit {
+				&:nth-child(even) > .editor-block-list__block-edit {
 					padding-right: 0;
+				}
+			}
+
+			@include break-medium() {
+				&:not(:first-child) > .editor-block-list__block-edit {
+					padding-left: $grid-size-large;
+				}
+
+				&:not(:last-child) > .editor-block-list__block-edit {
+					padding-right: $grid-size-large;
 				}
 			}
 		}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -47,14 +47,34 @@
 	> .editor-inner-blocks > .editor-block-list__layout {
 		display: flex;
 
+		// Responsiveness: Allow wrapping on mobile.
+		flex-wrap: wrap;
+
+		@include break-medium() {
+			flex-wrap: nowrap;
+		}
+
 		> [data-type="core/column"] {
 			display: flex;
 			flex-direction: column;
 			flex: 1;
-			width: 0;
 
-			.editor-block-list__block-edit {
-				flex-basis: 100%;
+			// Every .editor-block-list__block has auto-left/right margins, which centers columns.
+			// Since they aren't centered on the front-end, we explicitly set a zero left margin here.
+			margin-left: 0;
+
+			// Responsiveness: Show at most one columns on mobile.
+			flex-basis: 100%;
+
+			// Beyond mobile, allow 2 columns.
+			@include break-small() {
+				flex-basis: 50%;
+				flex-grow: 0;
+			}
+
+			// On medium-sized viewports, allow any amount of columns.
+			@include break-medium() {
+				flex-basis: inherit;
 			}
 		}
 	}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -100,11 +100,6 @@
 				flex-grow: 0;
 			}
 
-			// On medium-sized viewports, allow any amount of columns.
-			@include break-medium() {
-				flex-basis: inherit;
-			}
-
 			// Add space between columns. Themes can customize this if they wish to work differently.
 			// This has to match the same padding applied in style.scss.
 			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -8,7 +8,7 @@ import memoize from 'memize';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
@@ -42,12 +42,7 @@ const getColumnsTemplate = memoize( ( columns ) => {
 export const name = 'core/columns';
 
 export const settings = {
-	title: sprintf(
-		/* translators: Block title modifier */
-		__( '%1$s (%2$s)' ),
-		__( 'Columns' ),
-		__( 'beta' )
-	),
+	title: __( 'Columns' ),
 
 	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><g><path d="M21 4H3L2 5v14l1 1h18l1-1V5l-1-1zM8 18H4V6h4v12zm6 0h-4V6h4v12zm6 0h-4V6h4v12z" /></g></svg>,
 

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -22,11 +22,6 @@
 		flex-grow: 0;
 	}
 
-	// On medium-sized viewports, allow any amount of columns.
-	@include break-medium() {
-		flex-basis: inherit;
-	}
-
 	// Add space between columns. Themes can customize this if they wish to work differently.
 	// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
 	@include break-small() {

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -26,4 +26,19 @@
 	@include break-medium() {
 		flex-basis: inherit;
 	}
+
+	// Add space between columns. Themes can customize this if they wish to work differently.
+	// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+	@include break-small() {
+		padding-left: $grid-size-large;
+		padding-right: $grid-size-large;
+
+		&:first-child {
+			padding-left: 0;
+		}
+
+		&:last-child {
+			padding-right: 0;
+		}
+	}
 }

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -1,7 +1,29 @@
 .wp-block-columns {
 	display: flex;
+
+	// Responsiveness: Allow wrapping on mobile.
+	flex-wrap: wrap;
+
+	@include break-medium() {
+		flex-wrap: nowrap;
+	}
 }
 
 .wp-block-column {
 	flex: 1;
+	margin-bottom: 1em;
+
+	// Responsiveness: Show at most one columns on mobile.
+	flex-basis: 100%;
+
+	// Beyond mobile, allow 2 columns.
+	@include break-small() {
+		flex-basis: 50%;
+		flex-grow: 0;
+	}
+
+	// On medium-sized viewports, allow any amount of columns.
+	@include break-medium() {
+		flex-basis: inherit;
+	}
 }

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -28,12 +28,22 @@
 		padding-left: $grid-size-large;
 		padding-right: $grid-size-large;
 
-		&:first-child {
+		&:nth-child(odd) {
 			padding-left: 0;
 		}
 
-		&:last-child {
+		&:nth-child(even) {
 			padding-right: 0;
+		}
+	}
+
+	@include break-medium() {
+		&:not(:first-child) {
+			padding-left: $grid-size-large;
+		}
+
+		&:not(:last-child) {
+			padding-right: $grid-size-large;
 		}
 	}
 }

--- a/test/e2e/specs/block-hierarchy-navigation.test.js
+++ b/test/e2e/specs/block-hierarchy-navigation.test.js
@@ -21,14 +21,14 @@ describe( 'Navigating the block hierarchy', () => {
 	} );
 
 	it( 'should navigate using the block hierarchy dropdown menu', async () => {
-		await insertBlock( 'Columns (beta)' );
+		await insertBlock( 'Columns' );
 
 		// Add a paragraph in the first column.
 		await page.keyboard.type( 'First column' );
 
 		// Navigate to the columns blocks.
 		await page.click( '[aria-label="Block Navigation"]' );
-		const columnsBlockMenuItem = ( await page.$x( "//button[contains(@class,'editor-block-navigation__item') and contains(text(), 'Columns (beta)')]" ) )[ 0 ];
+		const columnsBlockMenuItem = ( await page.$x( "//button[contains(@class,'editor-block-navigation__item') and contains(text(), 'Columns')]" ) )[ 0 ];
 		await columnsBlockMenuItem.click();
 
 		// Tweak the columns count.
@@ -53,7 +53,7 @@ describe( 'Navigating the block hierarchy', () => {
 	} );
 
 	it( 'should navigate block hierarchy using only the keyboard', async () => {
-		await insertBlock( 'Columns (beta)' );
+		await insertBlock( 'Columns' );
 
 		// Add a paragraph in the first column.
 		await page.keyboard.type( 'First column' );


### PR DESCRIPTION
This PR does a number of things.

1. It fixes #7818 by making sure the editor view and theme view are the same, dimension wise. It also adds some margin betweeen columns. 
2. It fixes #6048 by adding basic responsiveness. Essentially mobile has 1 column, beyond mobile has 2, beyond "medium" (782 breakpoint) we show whatever the user has set it to, i.e. 3 or up to 6.
3. It refactors the margins and paddings of the columns block to "level the playing field" between editor and theme, basically making the dimensions the same. This involved making the column (singular) block essentially lose its visual block padding and footprint. 

Editor:

![screenshot 2018-10-12 at 10 52 25](https://user-images.githubusercontent.com/1204802/46859408-f976a880-ce0d-11e8-9994-0f7d01602f9f.png)

Theme:

![screenshot 2018-10-12 at 10 53 16](https://user-images.githubusercontent.com/1204802/46859414-fb406c00-ce0d-11e8-841f-9c586fc14f0d.png)

Dimensions:

![columns](https://user-images.githubusercontent.com/1204802/46859433-05fb0100-ce0e-11e8-801b-0d2e27ebdd11.gif)

Responsive:

![responsive](https://user-images.githubusercontent.com/1204802/46859457-14491d00-ce0e-11e8-9be5-7e202ddf6a88.gif)

There is some overlap with the column blocks due to the fact that this PR makes them more or less lose their footprint, which makes the hover outlines overlap at times. Perhaps the longer term fix here is to make those blocks actual pass-through blocks so they don't have hover outlines, or can be selected. But in the mean time, this PR intends to make the columns block ship-ready for 5.0. 

Please test it thoroughly and decide if you agree!