### PR TITLE
Show the block styles in the block inspector

### DIFF
--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -39,7 +39,6 @@ const BlockInspector = ( { selectedBlock, blockType, count } ) => {
 					<div className="editor-block-inspector__card-description">{ blockType.description }</div>
 				</div>
 			</div>
-			<div><InspectorControls.Slot /></div>
 			{ !! blockType.styles && (
 				<div>
 					<PanelBody
@@ -52,6 +51,7 @@ const BlockInspector = ( { selectedBlock, blockType, count } ) => {
 					</PanelBody>
 				</div>
 			) }
+			<div><InspectorControls.Slot /></div>
 			<div>
 				<InspectorAdvancedControls.Slot>
 					{ ( fills ) => ! isEmpty( fills ) && (

--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal Dependencies
@@ -18,6 +19,7 @@ import SkipToSelectedBlock from '../skip-to-selected-block';
 import BlockIcon from '../block-icon';
 import InspectorControls from '../inspector-controls';
 import InspectorAdvancedControls from '../inspector-advanced-controls';
+import BlockStyles from '../block-styles';
 
 const BlockInspector = ( { selectedBlock, blockType, count } ) => {
 	if ( count > 1 ) {
@@ -28,30 +30,44 @@ const BlockInspector = ( { selectedBlock, blockType, count } ) => {
 		return <span className="editor-block-inspector__no-blocks">{ __( 'No block selected.' ) }</span>;
 	}
 
-	return [
-		<div className="editor-block-inspector__card" key="card">
-			<BlockIcon icon={ blockType.icon } showColors />
-			<div className="editor-block-inspector__card-content">
-				<div className="editor-block-inspector__card-title">{ blockType.title }</div>
-				<div className="editor-block-inspector__card-description">{ blockType.description }</div>
+	return (
+		<Fragment>
+			<div className="editor-block-inspector__card">
+				<BlockIcon icon={ blockType.icon } showColors />
+				<div className="editor-block-inspector__card-content">
+					<div className="editor-block-inspector__card-title">{ blockType.title }</div>
+					<div className="editor-block-inspector__card-description">{ blockType.description }</div>
+				</div>
 			</div>
-		</div>,
-		<div key="inspector-controls"><InspectorControls.Slot /></div>,
-		<div key="inspector-advanced-controls">
-			<InspectorAdvancedControls.Slot>
-				{ ( fills ) => ! isEmpty( fills ) && (
+			<div><InspectorControls.Slot /></div>
+			{ !! blockType.styles && (
+				<div className="editor-block-inspector__styles">
 					<PanelBody
-						className="editor-block-inspector__advanced"
-						title={ __( 'Advanced' ) }
+						title={ __( 'Styles' ) }
 						initialOpen={ false }
 					>
-						{ fills }
+						<BlockStyles
+							clientId={ selectedBlock.clientId }
+						/>
 					</PanelBody>
-				) }
-			</InspectorAdvancedControls.Slot>
-		</div>,
-		<SkipToSelectedBlock key="back" />,
-	];
+				</div>
+			) }
+			<div>
+				<InspectorAdvancedControls.Slot>
+					{ ( fills ) => ! isEmpty( fills ) && (
+						<PanelBody
+							className="editor-block-inspector__advanced"
+							title={ __( 'Advanced' ) }
+							initialOpen={ false }
+						>
+							{ fills }
+						</PanelBody>
+					) }
+				</InspectorAdvancedControls.Slot>
+			</div>
+			<SkipToSelectedBlock key="back" />
+		</Fragment>
+	);
 };
 
 export default withSelect(

--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -41,7 +41,7 @@ const BlockInspector = ( { selectedBlock, blockType, count } ) => {
 			</div>
 			<div><InspectorControls.Slot /></div>
 			{ !! blockType.styles && (
-				<div className="editor-block-inspector__styles">
+				<div>
 					<PanelBody
 						title={ __( 'Styles' ) }
 						initialOpen={ false }

--- a/packages/editor/src/components/block-inspector/style.scss
+++ b/packages/editor/src/components/block-inspector/style.scss
@@ -47,6 +47,3 @@
 	height: $icon-button-size-small;
 }
 
-.editor-block-inspector__styles .editor-block-styles__item {
-	width: 100%;
-}

--- a/packages/editor/src/components/block-inspector/style.scss
+++ b/packages/editor/src/components/block-inspector/style.scss
@@ -46,3 +46,7 @@
 	width: $icon-button-size;
 	height: $icon-button-size-small;
 }
+
+.editor-block-inspector__styles .editor-block-styles__item {
+	width: 100%;
+}

--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get } from 'lodash';
+import { find, get, noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -69,8 +69,8 @@ function BlockStyles( {
 	onChangeClassName,
 	name,
 	attributes,
-	onSwitch,
-	onHoverClassName,
+	onSwitch = noop,
+	onHoverClassName = noop,
 } ) {
 	if ( ! styles ) {
 		return null;


### PR DESCRIPTION
closes #10520 

This PR adds the styles selector to the block inspector like shown in this screenshot.

<img width="895" alt="screen shot 2018-10-12 at 10 22 06" src="https://user-images.githubusercontent.com/272444/46860693-e1505a80-ce08-11e8-8bb6-3b89c942b11e.png">
