### PR TITLE
Add translator comment for 'View' menu label

### DIFF
--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -13,6 +13,7 @@ import FeatureToggle from '../feature-toggle';
 function WritingMenu( { onClose } ) {
 	return (
 		<MenuGroup
+			/* translators: Translate as a noun (label for writing menu) */
 			label={ __( 'View' ) }
 		>
 			<FeatureToggle feature="fixedToolbar" label={ __( 'Unified Toolbar' ) } onToggle={ onClose } />

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -2,7 +2,7 @@
  * WordPress Dependencies
  */
 import { MenuGroup } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { ifViewportMatches } from '@wordpress/viewport';
 
 /**

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -13,8 +13,7 @@ import FeatureToggle from '../feature-toggle';
 function WritingMenu( { onClose } ) {
 	return (
 		<MenuGroup
-			/* translators: Translate as a noun (label for writing menu) */
-			label={ __( 'View' ) }
+			label={ _x( 'View', 'noun' ) }
 		>
 			<FeatureToggle feature="fixedToolbar" label={ __( 'Unified Toolbar' ) } onToggle={ onClose } />
 			<FeatureToggle feature="focusMode" label={ __( 'Spotlight Mode' ) } onToggle={ onClose } />


### PR DESCRIPTION
Fixes #10499

## Description

This PR adds a translator comment for the "View" label in the writing menu, to provide additional detail about how to translate it.

![image](https://user-images.githubusercontent.com/8658164/46864292-d5b56180-ce11-11e8-86b6-b5a797482ecf.png)
