### PR TITLE
HTML parser: don't alter raw HTML

### DIFF
--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -226,6 +226,10 @@ export function matcherFromSource( sourceConfig ) {
  * @return {*} Attribute value.
  */
 export function parseWithAttributeSchema( innerHTML, attributeSchema ) {
+	if ( attributeSchema.source === 'html' && ! attributeSchema.selector ) {
+		return innerHTML;
+	}
+
 	return hpqParse( innerHTML, matcherFromSource( attributeSchema ) );
 }
 

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -287,6 +287,20 @@ describe( 'block parser', () => {
 			);
 			expect( value ).toBeUndefined();
 		} );
+
+		it( 'should return original content for html source with no selector', () => {
+			const value = getBlockAttribute(
+				'content',
+				{
+					type: 'string',
+					source: 'html',
+				},
+				'<path />',
+				{}
+			);
+
+			expect( value ).toBe( '<path />' );
+		} );
 	} );
 
 	describe( 'getBlockAttributes()', () => {


### PR DESCRIPTION
Currently if you use an HTML block it will be parsed and reformatted when saved. This has the effect of transforming valid HTML such as:

`<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />`

Into:

`<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none"></path>`

Although technically correct it does mean the HTML changes on save, which is unexpected.

The reason for this is the HTML goes into `hpq`, which uses the browser and `createHTMLDocument`. This converts the user HTML into a valid DOM tree, modifying as appropriate, expanding self-closing tags, and removing unnecessary whitespace.

When the HTML is then returned it is the browser's version, and the original version is discarded. For most blocks this is fine as the HTML is generated by Gutenberg, but for the HTML block the HTML is generated by the user.

This is another follow-on from #10066, and in conjunction with #10474.

## How has this been tested?
Additional unit test added. Manually test by creating a custom HTML block and adding:

`<path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />`

Verify that on saving the post and reloading the page the block HTML remains the same.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
