### PR TITLE
Blocks: Try to move filtering blocks until editor mounts

### DIFF
--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -36,6 +36,7 @@ export {
 	getBlockTypes,
 	getBlockSupport,
 	hasBlockSupport,
+	isBlockDefinitionValid,
 	isReusableBlock,
 	getChildBlockNames,
 	hasChildBlocks,

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -79,9 +79,18 @@ export function initializeEditor( id, postType, postId, settings, overridePost )
 
 		return blockType;
 	} );
+	addFilter( 'blocks.registerBlockType', 'wp-js-plugin-starter/hello-world2/filter-name', ( blockType, name ) => {
+		if ( name === 'wp-js-plugin-starter/hello-world2' ) {
+			return {
+				...blockType,
+				category: 'common',
+			};
+		}
+
+		return blockType;
+	} );
 	// TODO: <END>Remove this later</END>.
 
-	// TODO: We no longer need to register core blocks in here. We can do it at any time.
 	registerCoreBlocks();
 
 	// TODO: <START>Remove this later</START>.
@@ -103,6 +112,26 @@ export function initializeEditor( id, postType, postId, settings, overridePost )
 			);
 		},
 	} );
+	/*
+	wp.blocks.registerBlockType( 'wp-js-plugin-starter/hello-world2', {
+		title: 'Hello World 2',
+		description: 'Just another Hello World block',
+		icon: 'admin-site',
+		category: 'widgets',
+
+		edit: function() {
+			return (
+				'Hello Editor'
+			);
+		},
+
+		save: function() {
+			return (
+				'Hello Frontend'
+			);
+		}
+	} );
+	*/
 	// TODO: <END>Remove this later</END>.
 
 	dispatch( 'core/nux' ).triggerGuide( [

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -9,6 +9,8 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
+import { registerBlockType, registerBlockStyle } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -58,7 +60,50 @@ export function initializeEditor( id, postType, postId, settings, overridePost )
 	const target = document.getElementById( id );
 	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, overridePost );
 
+	// TODO: <START>Remove this later</START>.
+	registerBlockStyle( 'core/list', {
+		label: 'Large',
+		name: 'large',
+	} );
+	registerBlockStyle( 'wp-js-plugin-starter/hello-world', {
+		label: 'Hello',
+		name: 'hello',
+	} );
+	addFilter( 'blocks.registerBlockType', 'wp-js-plugin-starter/hello-world/filter-name', ( blockType, name ) => {
+		if ( name === 'wp-js-plugin-starter/hello-world' ) {
+			return {
+				...blockType,
+				category: 'nope',
+			};
+		}
+
+		return blockType;
+	} );
+	// TODO: <END>Remove this later</END>.
+
+	// TODO: We no longer need to register core blocks in here. We can do it at any time.
 	registerCoreBlocks();
+
+	// TODO: <START>Remove this later</START>.
+	registerBlockType( 'wp-js-plugin-starter/hello-world', {
+		title: 'Hello World',
+		description: 'Just another Hello World block',
+		icon: 'admin-site',
+		category: 'widgets',
+
+		edit: function() {
+			return (
+				<p>Hello Editor</p>
+			);
+		},
+
+		save: function() {
+			return (
+				<p>Hello Frontend</p>
+			);
+		},
+	} );
+	// TODO: <END>Remove this later</END>.
 
 	dispatch( 'core/nux' ).triggerGuide( [
 		'core/editor.inserter',

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, map } from 'lodash';
+import { differenceBy, flow, map } from 'lodash';
 
 /**
  * WordPress Dependencies
@@ -25,18 +25,15 @@ class EditorProvider extends Component {
 
 		// Assume that we don't need to initialize in the case of an error recovery.
 		if ( ! props.recovery ) {
-			this.applyFiltersToBlockTypes();
+			this.applyFiltersToBlockTypes( props.blockTypes );
 			this.props.updateEditorSettings( props.settings );
 			this.props.updatePostLock( props.settings.postLock );
 			this.props.setupEditor( props.post, props.settings.autosave );
 		}
 	}
 
-	applyFiltersToBlockTypes() {
-		const {
-			addBlockTypes,
-			blockTypes,
-		} = this.props;
+	applyFiltersToBlockTypes( blockTypes ) {
+		const { addBlockTypes } = this.props;
 
 		const modifiedBlockTypes = blockTypes.map( ( blockType ) => {
 			const modifiedBlockType = applyFilters( 'blocks.registerBlockType', blockType, blockType.name );
@@ -80,6 +77,12 @@ class EditorProvider extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.settings !== prevProps.settings ) {
 			this.props.updateEditorSettings( this.props.settings );
+		}
+		if ( this.props.blockTypes !== prevProps.blockTypes ) {
+			const newBlockTypes = differenceBy( this.props.blockTypes, prevProps.blockTypes, 'name' );
+			if ( newBlockTypes.length > 0 ) {
+				this.applyFiltersToBlockTypes( newBlockTypes );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Resolves: #4848.

WIP

In the ideal case we should be able to support the following:

- register block override
- register block
- register block override
- **initialize editor and let users write their post**
- register block (and apply all previously registered overrides)
- unregister block
- register block override and apply to all matching blocks
- remove override and update matching blocks

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
