### PR TITLE
[RN mobile] fix className style in SVG primitive

### DIFF
--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -32,12 +32,6 @@ export const SVG = ( props ) => {
 	}
 
 	const safeProps = styleValues.length == 0 ? { ...omit( props, [ 'style' ] ) } : { ...props, style: styleValues };
-	if ( safeProps.width !== undefined && safeProps.height !== undefined ) {
-		return (
-			<Svg { ...safeProps } />
-		);
-	}
-
 	return (
 		<Svg
 			height="100%"

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -4,6 +4,11 @@
 import { omit } from 'lodash';
 import { Svg } from 'react-native-svg';
 
+/**
+ * Internal dependencies
+ */
+import styles from '../../dashicon/style.scss';
+
 export {
 	G,
 	Path,
@@ -11,7 +16,31 @@ export {
 } from 'react-native-svg';
 
 export const SVG = ( props ) => {
+<<<<<<< HEAD
 	const appliedProps = omit( props, 'className' );
+=======
+	// We're using the react-native-classname-to-style plugin, so when a `className` prop is passed it gets converted to `style` here.
+	// Given it carries a string (as it was originally className) but an object is expected for `style`,
+	// we need to check whether `style` exists and is a string, and convert it to an object
+	let styleKeys = new Array();
+	let styleValues = new Array();
+	if ( typeof props.style === 'string' || props.style instanceof String ) {
+		styleKeys = props.style.split( ' ' );
+		styleKeys.forEach(element => {
+			let oneStyle = styles[ styleKeys[ element ] ];
+			if ( oneStyle != undefined ) {
+				styleValues.push( styles[ styleKeys[ element ] ] );
+			}
+		});
+	}
+
+	const safeProps = styleValues.length == 0 ? { ...omit( props, [ 'style' ] ) } : { ...props, style: styleValues };
+	if ( safeProps.width !== undefined && safeProps.height !== undefined ) {
+		return (
+			<Svg { ...safeProps } />
+		);
+	}
+>>>>>>> 2d474511d... building an object out of the passed style/className concatenated string on svgnative implementation
 
 	return (
 		<Svg

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -20,18 +20,18 @@ export const SVG = ( props ) => {
 	// Given it carries a string (as it was originally className) but an object is expected for `style`,
 	// we need to check whether `style` exists and is a string, and convert it to an object
 	let styleKeys = new Array();
-	let styleValues = new Array();
+	const styleValues = new Array();
 	if ( typeof props.style === 'string' || props.style instanceof String ) {
 		styleKeys = props.style.split( ' ' );
-		styleKeys.forEach(element => {
-			let oneStyle = styles[ element ];
-			if ( oneStyle != undefined ) {
+		styleKeys.forEach( (element) => {
+			const oneStyle = styles[ element ];
+			if ( oneStyle !== undefined ) {
 				styleValues.push( oneStyle );
 			}
-		});
+		} );
 	}
 
-	const safeProps = styleValues.length == 0 ? { ...omit( props, [ 'style' ] ) } : { ...props, style: styleValues };
+	const safeProps = styleValues.length === 0 ? { ...omit( props, [ 'style' ] ) } : { ...props, style: styleValues };
 	return (
 		<Svg
 			height="100%"

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -27,9 +27,9 @@ export const SVG = ( props ) => {
 	if ( typeof props.style === 'string' || props.style instanceof String ) {
 		styleKeys = props.style.split( ' ' );
 		styleKeys.forEach(element => {
-			let oneStyle = styles[ styleKeys[ element ] ];
+			let oneStyle = styles[ element ];
 			if ( oneStyle != undefined ) {
-				styleValues.push( styles[ styleKeys[ element ] ] );
+				styleValues.push( oneStyle );
 			}
 		});
 	}

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -16,9 +16,6 @@ export {
 } from 'react-native-svg';
 
 export const SVG = ( props ) => {
-<<<<<<< HEAD
-	const appliedProps = omit( props, 'className' );
-=======
 	// We're using the react-native-classname-to-style plugin, so when a `className` prop is passed it gets converted to `style` here.
 	// Given it carries a string (as it was originally className) but an object is expected for `style`,
 	// we need to check whether `style` exists and is a string, and convert it to an object
@@ -40,13 +37,12 @@ export const SVG = ( props ) => {
 			<Svg { ...safeProps } />
 		);
 	}
->>>>>>> 2d474511d... building an object out of the passed style/className concatenated string on svgnative implementation
 
 	return (
 		<Svg
 			height="100%"
 			width="100%"
-			{ ...appliedProps }
+			{ ...safeProps }
 		/>
 	);
 };

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -23,7 +23,7 @@ export const SVG = ( props ) => {
 	const styleValues = new Array();
 	if ( typeof props.style === 'string' || props.style instanceof String ) {
 		styleKeys = props.style.split( ' ' );
-		styleKeys.forEach( (element) => {
+		styleKeys.forEach( ( element ) => {
 			const oneStyle = styles[ element ];
 			if ( oneStyle !== undefined ) {
 				styleValues.push( oneStyle );


### PR DESCRIPTION
## Description
As explained in https://github.com/WordPress/gutenberg/pull/9294#discussion_r215695160, commits  2d47451 and b678c6d introduced a change that makes sure to convert a string `className` value to a `style` _object_ for ReactNative to work properly without needing to strip the `className` altogether (and thus losing any intended modifiers, as is [currently being done in `master`](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/primitives/svg/index.native.js#L14)).
These commits were removed somehow after introducing #9685 and applying the "older" #9294 after it, so this PR only brings this change back as originally intended.

## How has this been tested?

To test how this works:

1. make sure to add the following sample/test code 

```
.dashicons-editor-bold {
	transform: rotate(20deg);
}

```
to `packages/components/src/dashicon/style.scss` 


2. Run the [mobile Gutenberg app](https://github.com/wordpress-mobile/gutenberg-mobile/) 

This way the styles get passed to the svg component, this is how the bold icon gets rendered:

<img width="307" alt="screen shot 2018-09-06 at 13 21 46" src="https://user-images.githubusercontent.com/6597771/45171725-860fc480-b1d9-11e8-9fac-1c0bba64c3f3.png">

Verify the  **B** icon is slightly (20 degrees) leaning to the right as seen in the screenshot



## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
