### PR TITLE
Applying text alignment classes except when "undefined"

### DIFF
--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -152,7 +152,7 @@ export const settings = {
 
 			const classes = classnames(
 				className,
-				contentAlign !== 'center' && `has-${ contentAlign }-content`,
+				contentAlign !== 'undefined' && `has-${ contentAlign }-content`,
 				dimRatioToClass( dimRatio ),
 				{
 					'has-background-dim': dimRatio !== 0,
@@ -292,7 +292,7 @@ export const settings = {
 			{
 				'has-background-dim': dimRatio !== 0,
 				'has-parallax': hasParallax,
-				[ `has-${ contentAlign }-content` ]: contentAlign !== 'center',
+				[ `has-${ contentAlign }-content` ]: contentAlign !== 'undefined',
 			},
 			align ? `align${ align }` : null,
 		);

--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -39,7 +39,6 @@ const blockAttributes = {
 	},
 	contentAlign: {
 		type: 'string',
-		default: 'center',
 	},
 	id: {
 		type: 'number',

--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -152,7 +152,7 @@ export const settings = {
 
 			const classes = classnames(
 				className,
-				contentAlign !== 'undefined' && `has-${ contentAlign }-content`,
+				contentAlign !== undefined && `has-${ contentAlign }-content`,
 				dimRatioToClass( dimRatio ),
 				{
 					'has-background-dim': dimRatio !== 0,
@@ -292,7 +292,7 @@ export const settings = {
 			{
 				'has-background-dim': dimRatio !== 0,
 				'has-parallax': hasParallax,
-				[ `has-${ contentAlign }-content` ]: contentAlign !== 'undefined',
+				[ `has-${ contentAlign }-content` ]: contentAlign !== undefined,
 			},
 			align ? `align${ align }` : null,
 		);


### PR DESCRIPTION
## Description
Fixes #10558

## How has this been tested?
Please note that I don't have properly set up dev environment to create Gutenberg build so I couldn't really test this. Can someone please test the code? Thanks!

## Types of changes
Instead of checking for `center` align value for not applying the text alignment class, we check for `undefined`.

## Checklist:
- [ ] My code is tested.