### PR TITLE
Fix: Remove unused code after 7905

### DIFF
--- a/packages/block-library/src/block/edit-panel/index.js
+++ b/packages/block-library/src/block/edit-panel/index.js
@@ -30,7 +30,7 @@ class ReusableBlockEditPanel extends Component {
 		if ( ! prevProps.isEditing && this.props.isEditing ) {
 			this.titleField.current.select();
 		}
-		// Move focus back to the Edit button after pressing the Escape key or after saving.
+		// Move focus back to the Edit button after pressing the Escape key or Save.
 		if ( ( prevProps.isEditing || prevProps.isSaving ) && ! this.props.isEditing && ! this.props.isSaving ) {
 			this.editButton.current.focus();
 		}

--- a/packages/block-library/src/block/edit-panel/index.js
+++ b/packages/block-library/src/block/edit-panel/index.js
@@ -30,7 +30,7 @@ class ReusableBlockEditPanel extends Component {
 		if ( ! prevProps.isEditing && this.props.isEditing ) {
 			this.titleField.current.select();
 		}
-		// Move focus back to the Edit button after pressing the Escape key, Cancel, or Save.
+		// Move focus back to the Edit button after pressing the Escape key or after saving.
 		if ( ( prevProps.isEditing || prevProps.isSaving ) && ! this.props.isEditing && ! this.props.isSaving ) {
 			this.editButton.current.focus();
 		}

--- a/packages/block-library/src/block/edit-panel/style.scss
+++ b/packages/block-library/src/block/edit-panel/style.scss
@@ -39,8 +39,6 @@
 	}
 
 	.components-button.reusable-block-edit-panel__button {
-		margin: 0 $grid-size-small 0 0;
-
 		// Prevent button shrinking in IE11 when other items have a 100% flex basis.
 		// This should be safe to apply in all browsers because we don't want these
 		// buttons to shrink anyway.


### PR DESCRIPTION
## Description
In #7905 we removed the cancel button from the reusable block. 
This PR removes CSS code that is not longer needed because there is no second button and changes a comment about changing focus.
