### PR TITLE
Fix button block regressions

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -32,7 +32,7 @@ $blocks-button__line-height: $big-font-size + 6px;
 	}
 
 	// Don't let the placeholder text wrap in the variation preview.
-	.editor-block-styles__item-preview & {
+	.editor-block-preview__content & {
 		max-width: 100%;
 
 		.wp-block-button__link {

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -31,9 +31,16 @@ $blocks-button__line-height: $big-font-size + 6px;
 		opacity: 0.8;
 	}
 
-	.editor-block-styles__item & .wp-block-button__link {
-		white-space: nowrap;
-		text-overflow: ellipsis;
+	// Don't let the placeholder text wrap in the variation preview.
+	.editor-block-styles__item-preview & {
+		max-width: 100%;
+
+		.wp-block-button__link {
+			max-width: 100%;
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+		}
 	}
 }
 

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -1,3 +1,5 @@
+$blocks-button__line-height: $big-font-size + 6px;
+
 .editor-block-list__block[data-type="core/button"] {
 	&[data-align="center"] {
 		text-align: center;
@@ -14,14 +16,24 @@
 	margin-bottom: 0;
 	position: relative;
 
-	.editor-rich-text__tinymce {
+	.editor-rich-text__tinymce.mce-content-body {
 		cursor: text;
-		line-height: 1;
+		line-height: $blocks-button__line-height;
 	}
 
-	&:not(.has-text-color) .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
+	// Make placeholder text white unless custom colors or outline versions are chosen.
+	&:not(.has-text-color):not(.is-style-outline) .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
 		color: $white;
+	}
+
+	// Increase placeholder opacity to meet contrast ratios.
+	.editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce {
 		opacity: 0.8;
+	}
+
+	.editor-block-styles__item & .wp-block-button__link {
+		white-space: nowrap;
+		text-overflow: ellipsis;
 	}
 }
 


### PR DESCRIPTION
The button block regressed as part of a few changes recently, including one to increase placeholder text contrast.

This PR fixes that.

It also fixes an issue where the text on the outline button version was white.

Before:

![screenshot 2018-10-12 at 21 17 05](https://user-images.githubusercontent.com/1204802/46889736-f65ad700-ce64-11e8-9c0b-f26237c2bd1d.png)

After:

![screenshot 2018-10-12 at 21 19 14](https://user-images.githubusercontent.com/1204802/46889986-acbebc00-ce65-11e8-88a8-8f89ee48ca78.png)

![screenshot 2018-10-12 at 21 19 24](https://user-images.githubusercontent.com/1204802/46889992-b0ead980-ce65-11e8-8bbc-79d2e159ffd6.png)

![screenshot 2018-10-12 at 21 20 26](https://user-images.githubusercontent.com/1204802/46889998-b516f700-ce65-11e8-9ed5-21991f8d3da5.png)
