### PR TITLE
Bold permalink label

### DIFF
--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -39,6 +39,7 @@
 
 .editor-post-permalink__label {
 	margin: 0 10px 0 5px;
+	font-weight: 600;
 }
 
 .editor-post-permalink__link {


### PR DESCRIPTION
## Description
The PR makes the permalink label bold to become more consistent with other labels.
This was suggested and approved in https://github.com/WordPress/gutenberg/pull/6480#issuecomment-385196153

**Before**
<img width="641" alt="bildschirmfoto 2018-10-12 um 21 15 44" src="https://user-images.githubusercontent.com/695201/46890636-b8ab7d80-ce67-11e8-8a37-9bc4a35b498d.png">

**After**
<img width="1002" alt="bildschirmfoto 2018-10-12 um 21 49 25" src="https://user-images.githubusercontent.com/695201/46890958-b7c71b80-ce68-11e8-9218-45b397802698.png">

