### PR TITLE
Fix/block separator style class

### DIFF
--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -18,7 +18,7 @@ export const settings = {
 	keywords: [ __( 'horizontal-line' ), 'hr', __( 'divider' ) ],
 
 	styles: [
-		{ name: 'default', label: __( 'Short Line' ), isDefault: true },
+		{ name: 'short', label: __( 'Short Line' ), isDefault: true },
 		{ name: 'wide', label: __( 'Wide Line' ) },
 		{ name: 'dots', label: __( 'Dots' ) },
 	],

--- a/packages/block-library/src/separator/theme.scss
+++ b/packages/block-library/src/separator/theme.scss
@@ -3,8 +3,8 @@
 	border-bottom: 2px solid $dark-gray-100;
 	margin: 1.65em auto;
 
-	// Default, thin style
-	&:not(.is-style-wide):not(.is-style-dots) {
+	// Default, short style
+	&.is-style-short {
 		max-width: 100px;
 	}
 }


### PR DESCRIPTION
## Description

Fixes #10569 

## Types of changes

Renaming `default` style to `short` for "Short Line" style.
Applying CSS styles for "Short Line" directly onto `.is-style-short` CSS class.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
