### PR TITLE
Fix typo: WordPRess -> WordPress

### DIFF
--- a/components/code-editor/index.js
+++ b/components/code-editor/index.js
@@ -13,7 +13,7 @@ import Placeholder from '../../packages/components/src/placeholder';
 import Spinner from '../../packages/components/src/spinner';
 
 /**
- * @var {string?} siteURL WordPRess Site URL
+ * @var {string?} siteURL WordPress Site URL
  */
 let siteURL;
 


### PR DESCRIPTION
Fixes a typo in `components/code-editor/index.js`:

WordPRess -> WordPress