### PR TITLE
Use post type's REST controller class as autosave parent controller

### DIFF
--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -56,10 +56,12 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 * @param string $parent_post_type Post type of the parent.
 	 */
 	public function __construct( $parent_post_type ) {
-		$this->parent_post_type     = $parent_post_type;
-		$post_type_object           = get_post_type_object( $parent_post_type );
+		$this->parent_post_type = $parent_post_type;
+		$post_type_object       = get_post_type_object( $parent_post_type );
+
 		// Ensure that post type-specific controller logic is available.
-		$parent_controller_class    = ! empty( $post_type_object->rest_controller_class ) ? $post_type_object->rest_controller_class : 'WP_REST_Posts_Controller';
+		$parent_controller_class = ! empty( $post_type_object->rest_controller_class ) ? $post_type_object->rest_controller_class : 'WP_REST_Posts_Controller';
+
 		$this->parent_controller    = new $parent_controller_class( $post_type_object->name );
 		$this->revisions_controller = new WP_REST_Revisions_Controller( $parent_post_type );
 		$this->rest_namespace       = 'wp/v2';

--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -58,6 +58,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	public function __construct( $parent_post_type ) {
 		$this->parent_post_type     = $parent_post_type;
 		$post_type_object           = get_post_type_object( $parent_post_type );
+		// Ensure that post type-specific controller logic is available.
 		$parent_controller_class    = ! empty( $post_type_object->rest_controller_class ) ? $post_type_object->rest_controller_class : 'WP_REST_Posts_Controller';
 		$this->parent_controller    = new $parent_controller_class( $post_type_object->name );
 		$this->revisions_controller = new WP_REST_Revisions_Controller( $parent_post_type );

--- a/lib/class-wp-rest-autosaves-controller.php
+++ b/lib/class-wp-rest-autosaves-controller.php
@@ -57,11 +57,12 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 */
 	public function __construct( $parent_post_type ) {
 		$this->parent_post_type     = $parent_post_type;
-		$this->parent_controller    = new WP_REST_Posts_Controller( $parent_post_type );
+		$post_type_object           = get_post_type_object( $parent_post_type );
+		$parent_controller_class    = ! empty( $post_type_object->rest_controller_class ) ? $post_type_object->rest_controller_class : 'WP_REST_Posts_Controller';
+		$this->parent_controller    = new $parent_controller_class( $post_type_object->name );
 		$this->revisions_controller = new WP_REST_Revisions_Controller( $parent_post_type );
 		$this->rest_namespace       = 'wp/v2';
 		$this->rest_base            = 'autosaves';
-		$post_type_object           = get_post_type_object( $parent_post_type );
 		$this->parent_base          = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
 	}
 


### PR DESCRIPTION
## Description

I have a post type with a custom `rest_controller_class` that extends `WP_REST_Posts_Controller`. The custom controller overrides `prepare_item_for_database()` to modify the post data before calling the parent method to complete saving. 

Currently, `WP_REST_Autosaves_Controller::$parent_controller` is always instantiated as a `WP_REST_Posts_Controller`, which means the custom controller with its additional logic is bypassed. This PR would modify the autosave controller to set the `$parent_controller` to the post type-specific controller, if it exists.

In normal Gutenberg usage, `gutenberg_register_rest_routes()` won't instantiate an autosave controller for a post type unless the post type's controller class is a subclass of `WP_REST_Controller`, so I've omitted that check from the constructor.

## How has this been tested?

I've tested this change by verifying that my custom preparation logic is applied before the autosave revision is created. I've also verified that `WP_REST_Posts_Controller::prepare_item_for_database()` is applied as usual when no custom controller is set for the post type.

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
