### PR TITLE
Cover Image block: move edit function into separate file + code cleanup

### DIFF
--- a/packages/block-library/src/cover-image/edit.js
+++ b/packages/block-library/src/cover-image/edit.js
@@ -1,0 +1,198 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	IconButton,
+	PanelBody,
+	RangeControl,
+	ToggleControl,
+	Toolbar,
+	withNotices,
+} from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import {
+	AlignmentToolbar,
+	BlockAlignmentToolbar,
+	BlockControls,
+	InspectorControls,
+	MediaPlaceholder,
+	MediaUpload,
+	PanelColorSettings,
+	RichText,
+	withColors,
+} from '@wordpress/editor';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+const CoverImageEdit = ( { attributes, setAttributes, isSelected, className, noticeOperations, noticeUI, overlayColor, setOverlayColor } ) => {
+	const { url, title, align, contentAlign, id, hasParallax, dimRatio } = attributes;
+	const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
+	const onSelectImage = ( media ) => {
+		if ( ! media || ! media.url ) {
+			setAttributes( { url: undefined, id: undefined } );
+			return;
+		}
+		setAttributes( { url: media.url, id: media.id } );
+	};
+	const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
+	const setDimRatio = ( ratio ) => setAttributes( { dimRatio: ratio } );
+	const setTitle = ( newTitle ) => setAttributes( { title: newTitle } );
+
+	const style = {
+		...backgroundImageStyles( url ),
+		backgroundColor: overlayColor.color,
+	};
+
+	const classes = classnames(
+		className,
+		contentAlign !== 'center' && `has-${ contentAlign }-content`,
+		dimRatioToClass( dimRatio ),
+		{
+			'has-background-dim': dimRatio !== 0,
+			'has-parallax': hasParallax,
+		}
+	);
+
+	const controls = (
+		<Fragment>
+			<BlockControls>
+				<BlockAlignmentToolbar
+					value={ align }
+					onChange={ updateAlignment }
+				/>
+				{ !! url && (
+					<Fragment>
+						<AlignmentToolbar
+							value={ contentAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { contentAlign: nextAlign } );
+							} }
+						/>
+						<Toolbar>
+							<MediaUpload
+								onSelect={ onSelectImage }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								value={ id }
+								render={ ( { open } ) => (
+									<IconButton
+										className="components-toolbar__control"
+										label={ __( 'Edit image' ) }
+										icon="edit"
+										onClick={ open }
+									/>
+								) }
+							/>
+						</Toolbar>
+					</Fragment>
+				) }
+			</BlockControls>
+			{ !! url && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Cover Image Settings' ) }>
+						<ToggleControl
+							label={ __( 'Fixed Background' ) }
+							checked={ hasParallax }
+							onChange={ toggleParallax }
+						/>
+						<PanelColorSettings
+							title={ __( 'Overlay' ) }
+							initialOpen={ true }
+							colorSettings={ [ {
+								value: overlayColor.color,
+								onChange: setOverlayColor,
+								label: __( 'Overlay Color' ),
+							} ] }
+						>
+							<RangeControl
+								label={ __( 'Background Opacity' ) }
+								value={ dimRatio }
+								onChange={ setDimRatio }
+								min={ 0 }
+								max={ 100 }
+								step={ 10 }
+							/>
+						</PanelColorSettings>
+					</PanelBody>
+				</InspectorControls>
+			) }
+		</Fragment>
+	);
+
+	if ( ! url ) {
+		const hasTitle = ! RichText.isEmpty( title );
+		const icon = hasTitle ? undefined : 'format-image';
+		const label = hasTitle ? (
+			<RichText
+				tagName="h2"
+				value={ title }
+				onChange={ setTitle }
+				inlineToolbar
+			/>
+		) : __( 'Cover Image' );
+
+		return (
+			<Fragment>
+				{ controls }
+				<MediaPlaceholder
+					icon={ icon }
+					className={ className }
+					labels={ {
+						title: label,
+						name: __( 'an image' ),
+					} }
+					onSelect={ onSelectImage }
+					accept="image/*"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					notices={ noticeUI }
+					onError={ noticeOperations.createErrorNotice }
+				/>
+			</Fragment>
+		);
+	}
+
+	return (
+		<Fragment>
+			{ controls }
+			<div
+				data-url={ url }
+				style={ style }
+				className={ classes }
+			>
+				{ ( ! RichText.isEmpty( title ) || isSelected ) && (
+					<RichText
+						tagName="p"
+						className="wp-block-cover-image-text"
+						placeholder={ __( 'Write title…' ) }
+						value={ title }
+						onChange={ setTitle }
+						inlineToolbar
+					/>
+				) }
+			</div>
+		</Fragment>
+	);
+};
+
+export default compose( [
+	withColors( { overlayColor: 'background-color' } ),
+	withNotices,
+] )( CoverImageEdit );
+
+function backgroundImageStyles( url ) {
+	return url ?
+		{ backgroundImage: `url(${ url })` } :
+		{};
+}
+
+function dimRatioToClass( ratio ) {
+	return ( ratio === 0 || ratio === 50 ) ?
+		null :
+		'has-background-dim-' + ( 10 * Math.round( ratio / 10 ) );
+}

--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -6,34 +6,21 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { IconButton, PanelBody, RangeControl, ToggleControl, Toolbar, withNotices } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
-import { compose } from '@wordpress/compose';
 import {
-	BlockControls,
-	InspectorControls,
-	BlockAlignmentToolbar,
-	MediaPlaceholder,
-	MediaUpload,
-	AlignmentToolbar,
-	PanelColorSettings,
-	RichText,
-	withColors,
 	getColorClassName,
+	RichText,
 } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
 
 const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
 
 const blockAttributes = {
-	title: {
-		source: 'html',
-		selector: 'p',
-	},
-	url: {
-		type: 'string',
-	},
 	align: {
 		type: 'string',
 	},
@@ -41,28 +28,33 @@ const blockAttributes = {
 		type: 'string',
 		default: 'center',
 	},
-	id: {
-		type: 'number',
-	},
-	hasParallax: {
-		type: 'boolean',
-		default: false,
+	customOverlayColor: {
+		type: 'string',
 	},
 	dimRatio: {
 		type: 'number',
 		default: 50,
 	},
+	hasParallax: {
+		type: 'boolean',
+		default: false,
+	},
+	id: {
+		type: 'number',
+	},
 	overlayColor: {
 		type: 'string',
 	},
-	customOverlayColor: {
+	title: {
+		source: 'html',
+		selector: 'p',
+	},
+	url: {
 		type: 'string',
 	},
 };
 
 export const name = 'core/cover-image';
-
-const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 export const settings = {
 	title: __( 'Cover Image' ),
@@ -122,164 +114,12 @@ export const settings = {
 
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
-		if ( -1 !== validAlignments.indexOf( align ) ) {
+		if ( validAlignments.includes( align ) ) {
 			return { 'data-align': align };
 		}
 	},
 
-	edit: compose( [
-		withColors( { overlayColor: 'background-color' } ),
-		withNotices,
-	] )(
-		( { attributes, setAttributes, isSelected, className, noticeOperations, noticeUI, overlayColor, setOverlayColor } ) => {
-			const { url, title, align, contentAlign, id, hasParallax, dimRatio } = attributes;
-			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
-			const onSelectImage = ( media ) => {
-				if ( ! media || ! media.url ) {
-					setAttributes( { url: undefined, id: undefined } );
-					return;
-				}
-				setAttributes( { url: media.url, id: media.id } );
-			};
-			const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
-			const setDimRatio = ( ratio ) => setAttributes( { dimRatio: ratio } );
-			const setTitle = ( newTitle ) => setAttributes( { title: newTitle } );
-
-			const style = {
-				...backgroundImageStyles( url ),
-				backgroundColor: overlayColor.color,
-			};
-
-			const classes = classnames(
-				className,
-				contentAlign !== 'center' && `has-${ contentAlign }-content`,
-				dimRatioToClass( dimRatio ),
-				{
-					'has-background-dim': dimRatio !== 0,
-					'has-parallax': hasParallax,
-				}
-			);
-
-			const controls = (
-				<Fragment>
-					<BlockControls>
-						<BlockAlignmentToolbar
-							value={ align }
-							onChange={ updateAlignment }
-						/>
-						{ !! url && (
-							<Fragment>
-								<AlignmentToolbar
-									value={ contentAlign }
-									onChange={ ( nextAlign ) => {
-										setAttributes( { contentAlign: nextAlign } );
-									} }
-								/>
-								<Toolbar>
-									<MediaUpload
-										onSelect={ onSelectImage }
-										allowedTypes={ ALLOWED_MEDIA_TYPES }
-										value={ id }
-										render={ ( { open } ) => (
-											<IconButton
-												className="components-toolbar__control"
-												label={ __( 'Edit image' ) }
-												icon="edit"
-												onClick={ open }
-											/>
-										) }
-									/>
-								</Toolbar>
-							</Fragment>
-						) }
-					</BlockControls>
-					{ !! url && (
-						<InspectorControls>
-							<PanelBody title={ __( 'Cover Image Settings' ) }>
-								<ToggleControl
-									label={ __( 'Fixed Background' ) }
-									checked={ hasParallax }
-									onChange={ toggleParallax }
-								/>
-								<PanelColorSettings
-									title={ __( 'Overlay' ) }
-									initialOpen={ true }
-									colorSettings={ [ {
-										value: overlayColor.color,
-										onChange: setOverlayColor,
-										label: __( 'Overlay Color' ),
-									} ] }
-								>
-									<RangeControl
-										label={ __( 'Background Opacity' ) }
-										value={ dimRatio }
-										onChange={ setDimRatio }
-										min={ 0 }
-										max={ 100 }
-										step={ 10 }
-									/>
-								</PanelColorSettings>
-							</PanelBody>
-						</InspectorControls>
-					) }
-				</Fragment>
-			);
-
-			if ( ! url ) {
-				const hasTitle = ! RichText.isEmpty( title );
-				const icon = hasTitle ? undefined : 'format-image';
-				const label = hasTitle ? (
-					<RichText
-						tagName="h2"
-						value={ title }
-						onChange={ setTitle }
-						inlineToolbar
-					/>
-				) : __( 'Cover Image' );
-
-				return (
-					<Fragment>
-						{ controls }
-						<MediaPlaceholder
-							icon={ icon }
-							className={ className }
-							labels={ {
-								title: label,
-								name: __( 'an image' ),
-							} }
-							onSelect={ onSelectImage }
-							accept="image/*"
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							notices={ noticeUI }
-							onError={ noticeOperations.createErrorNotice }
-						/>
-					</Fragment>
-				);
-			}
-
-			return (
-				<Fragment>
-					{ controls }
-					<div
-						data-url={ url }
-						style={ style }
-						className={ classes }
-					>
-						{ ( ! RichText.isEmpty( title ) || isSelected ) && (
-							<RichText
-								tagName="p"
-								className="wp-block-cover-image-text"
-								placeholder={ __( 'Write title…' ) }
-								value={ title }
-								onChange={ setTitle }
-								inlineToolbar
-							/>
-						) }
-					</div>
-				</Fragment>
-			);
-		}
-	),
+	edit,
 
 	save( { attributes, className } ) {
 		const { url, title, hasParallax, dimRatio, align, contentAlign, overlayColor, customOverlayColor } = attributes;
@@ -341,14 +181,14 @@ export const settings = {
 	} ],
 };
 
-function dimRatioToClass( ratio ) {
-	return ( ratio === 0 || ratio === 50 ) ?
-		null :
-		'has-background-dim-' + ( 10 * Math.round( ratio / 10 ) );
-}
-
 function backgroundImageStyles( url ) {
 	return url ?
 		{ backgroundImage: `url(${ url })` } :
 		{};
+}
+
+function dimRatioToClass( ratio ) {
+	return ( ratio === 0 || ratio === 50 ) ?
+		null :
+		'has-background-dim-' + ( 10 * Math.round( ratio / 10 ) );
 }

--- a/test/integration/full-content/fixtures/core__cover-image.serialized.html
+++ b/test/integration/full-content/fixtures/core__cover-image.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
+<!-- wp:cover-image {"dimRatio":40,"url":"https://cldup.com/uuUqE_dXzy.jpg"} -->
 <div class="wp-block-cover-image has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)"><p class="wp-block-cover-image-text">Guten Berg!</p></div>
 <!-- /wp:cover-image -->


### PR DESCRIPTION
## Description
This PR splits the `edit` function of the Cover Image block into a separate file. It also does some code cleanup to the Cover Image `index.js` and `edit.js`.

## Types of changes
- Cover Image `edit` function split off from `cover-image/index.js` to new `cover-image/edit.js`.
- Imports in `index.js` and `edit.js` reorganized alphabetically.
- Attributes in `index.js` reorganized alphabetically.
- `getEditWrapperProps` in `index.js` now uses `Array.prototype.includes` instead of the slightly-less-readable `Array.prototype.indexOf`.

## Testing instructions
There should be no difference in behavior compared to `master`.