### PR TITLE
Update shortcut opacity

### DIFF
--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -52,7 +52,7 @@
 
 .components-menu-item__shortcut {
 	align-self: center;
-	opacity: 0.5;
+	opacity: 0.84;
 	margin-right: 0;
 	margin-left: auto;
 	padding-left: 8px;


### PR DESCRIPTION
## Description
Increased opacity at .84, the [lowest it can be while still passing WCAG AA standards](https://www.joedolson.com/tools/color-contrast.php?type=hex&color=%23555d66&color2=%23ffffff&alpha=0.84). Fixes #10576.

## How has this been tested?
Doesn't affect anything except this small section because it's very specific CSS.

## Screenshots 
Original: 
<img width="185" alt="2018-10-13 14_01_51-edit post five college blended learning and digital humanities wordpress" src="https://user-images.githubusercontent.com/8887194/46908435-9f9adf00-cef0-11e8-974b-01cbfcfa51e2.png">

Updated:
<img width="185" alt="2018-10-13 14_01_28-edit post five college blended learning and digital humanities wordpress" src="https://user-images.githubusercontent.com/8887194/46908434-9f024880-cef0-11e8-86b9-e98688f1f131.png">


## Types of changes
Very small CSS change

## Checklist:
- [X] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
