### PR TITLE
Adding a bit more verbosity to the install script

### DIFF
--- a/bin/setup-local-env.sh
+++ b/bin/setup-local-env.sh
@@ -30,4 +30,11 @@ CURRENT_URL=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm cli option
 
 echo -e "\nWelcome to...\n"
 echo -e "\033[95m$GUTENBERG\033[0m"
-echo -e "Run $(action_format "npm run dev"), then open $(action_format "$CURRENT_URL") to get started!"
+
+# Give the user more context to what they should do next: Build Gutenberg and start testing!
+echo -e "\nRun $(action_format "npm run dev") to build the latest Gutenberg packages,"
+echo -e "then open $(action_format "$CURRENT_URL") to get started!"
+
+echo -e "\n\nAt this address, a local WordPress instance"
+echo -e "has been spun up in Docker automatically."
+echo -e "Default username: $(action_format "admin"), password: $(action_format "password")"

--- a/bin/setup-local-env.sh
+++ b/bin/setup-local-env.sh
@@ -35,6 +35,5 @@ echo -e "\033[95m$GUTENBERG\033[0m"
 echo -e "\nRun $(action_format "npm run dev") to build the latest Gutenberg packages,"
 echo -e "then open $(action_format "$CURRENT_URL") to get started!"
 
-echo -e "\n\nAt this address, a local WordPress instance"
-echo -e "has been spun up in Docker automatically."
+echo -e "\n\nAccess the above install using the following credentials:"
 echo -e "Default username: $(action_format "admin"), password: $(action_format "password")"


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Based on further details from [the main CONTRIBUTING doc](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md#local-environment), I've changed the install script to have a tad more detail for users, from:
```
Welcome to...

,⁻⁻⁻·       .                 |
|  ،⁓’.   . |---  ,---. ,---. |---. ,---. ,---. ,---.
|   | |   | |     |---' |   | |   | |---' |     |   |
`---' `---' `---’ `---’ '   ` `---' `---’ `     `---|
                                                `---'
Run npm run dev, then open http://localhost:8888 to get started!
``` 
to:
```
Welcome to...

,⁻⁻⁻·       .                 |
|  ،⁓’.   . |---  ,---. ,---. |---. ,---. ,---. ,---.
|   | |   | |     |---' |   | |   | |---' |     |   |
`---' `---' `---’ `---’ '   ` `---' `---’ `     `---|
                                                `---'

Run npm run dev to build the latest Gutenberg packages,
then open http://localhost:8888 to get started!


At this address, a local WordPress instance 
has been spun up in Docker automatically.
Default username: admin, password: password
```
in way that reuses the existing logic. I've also added manual line breaks to support default widths for most terminals (80 characters).

_Rationale:_ Installing stuff should be easy. The docs are there, and the build scripts should reinforce what's been there. This minor change would add a bit of ease during the initial build process.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've tested this `bash` script in two environments: MacOS and Ubuntu. As long as you install Docker correctly via the instructions, it generally "just works."

## Screenshots <!-- if applicable -->
Before:
<img width="682" alt="before" src="https://user-images.githubusercontent.com/963672/46911821-a854da80-cf1b-11e8-8901-4df4a8b4763b.png">
After:
<img width="682" alt="screen shot 2018-10-13 at 7 24 47 pm" src="https://user-images.githubusercontent.com/963672/46911936-bb68aa00-cf1d-11e8-8859-470138ec6d0e.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
I'd call this somewhere between a feature enhancement and bug fix, as the `localhost` link is presented without context (bug) and the default credentials should probably be in context too (feature).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

(Note: There are no `bash` coding standards, and I've largely left this intact.)