### PR TITLE
Fix: `z-index: -1` needed for publish footer due to accordions

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -37,6 +37,7 @@
 	padding: 16px;
 	position: absolute;
 	bottom: 0;
+	z-index: -1;
 }
 
 .components-button.editor-post-publish-panel__toggle.is-primary {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
In testing the new calendar feature (#7621) I spotted a bug. When using the new pre-publish toggle (#9760), opening longer panels cause a z-index issue as such:
<img width="284" alt="screen shot 2018-10-13 at 6 36 52 pm" src="https://user-images.githubusercontent.com/963672/46912087-084e7f80-cf22-11e8-9c72-cd5a8539ccf4.png">

The problem has to do with the way the accordions above behave, and a quick `z-index: -1` gets it to cooperate again.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested the fix replicated the bug in Safari, Firefox and Chrome. I was not able to test in Edge or Opera, so this would be nice if it's required for merge.

## Screenshots <!-- if applicable -->
In addition to the bug was screenshot above, The bug and fix is seen here as a screen recording:
https://www.youtube.com/embed/M6CJtV1yFq4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fixes a small regression oversight probably missed in #9670.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
