### PR TITLE
Display embeds error message only when the form is submitted

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -72,6 +72,7 @@ export function getEmbedEdit( title, icon ) {
 			this.state = {
 				editingURL: false,
 				url: this.props.attributes.url,
+				isSubmitted: false,
 			};
 
 			if ( this.props.preview ) {
@@ -117,7 +118,7 @@ export function getEmbedEdit( title, icon ) {
 			}
 			const { url } = this.state;
 			const { setAttributes } = this.props;
-			this.setState( { editingURL: false } );
+			this.setState( { editingURL: false, isSubmitted: true } );
 			setAttributes( { url } );
 		}
 
@@ -255,11 +256,11 @@ export function getEmbedEdit( title, icon ) {
 		}
 
 		render() {
-			const { url, editingURL } = this.state;
+			const { url, editingURL, isSubmitted } = this.state;
 			const { caption, type, allowResponsive } = this.props.attributes;
 			const { fetching, setAttributes, isSelected, className, preview, previewIsFallback } = this.props;
 			// We have a URL, but couldn't get a preview, or the preview was the oEmbed fallback.
-			const cannotEmbed = url && ( ! preview || previewIsFallback );
+			const cannotEmbed = url && isSubmitted && ( ! preview || previewIsFallback );
 			const controls = (
 				<Fragment>
 					<BlockControls>
@@ -309,7 +310,7 @@ export function getEmbedEdit( title, icon ) {
 								className="components-placeholder__input"
 								aria-label={ label }
 								placeholder={ __( 'Enter URL to embed here…' ) }
-								onChange={ ( event ) => this.setState( { url: event.target.value } ) } />
+								onChange={ ( event ) => this.setState( { url: event.target.value, isSubmitted: false } ) } />
 							<Button
 								isLarge
 								type="submit">


### PR DESCRIPTION
Testing Gutenberg 4.0.0-RC1 I noticed a confusing behavior about the Embeds blocks. As soon as you enter some content into the URL input there is an error message that is added under the URL input no matter if the URL is actually embeddable. I would suggest to wait untill the form has been submitted to eventually display this error. Otherwise some users like me might be confused to see this error although the URL is embeddable.

PS: this PR should fix #10355

## Description
I've added a new property to the Embed block's state to track whether the form has been submitted or not.

## How has this been tested?
I've tested using this URL https://vimeo.com/287192106 which is an embeddable one within the Gutenberg Editor on WordPress trunk (as Gutenberg is not working on branch 5.0 of WordPress ??).
I've also ran the tests suite.

## Screenshots
![embeds-error-message](https://user-images.githubusercontent.com/1834524/46912372-22b14900-cf74-11e8-90f8-abb671084d51.png)
The error message

![Gif about the confusing error message](https://cldup.com/MpqK6N8lv3.gif)
The error message shows even if the URL is embeddable as the above GIF proves it.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
