### PR TITLE
Hide toolbar buttons if no image is selected

### DIFF
--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -167,27 +167,31 @@ export const settings = {
 							value={ align }
 							onChange={ updateAlignment }
 						/>
-						<AlignmentToolbar
-							value={ contentAlign }
-							onChange={ ( nextAlign ) => {
-								setAttributes( { contentAlign: nextAlign } );
-							} }
-						/>
-						<Toolbar>
-							<MediaUpload
-								onSelect={ onSelectImage }
-								allowedTypes={ ALLOWED_MEDIA_TYPES }
-								value={ id }
-								render={ ( { open } ) => (
-									<IconButton
-										className="components-toolbar__control"
-										label={ __( 'Edit image' ) }
-										icon="edit"
-										onClick={ open }
+						{ !! url && (
+							<Fragment>
+								<AlignmentToolbar
+									value={ contentAlign }
+									onChange={ ( nextAlign ) => {
+										setAttributes( { contentAlign: nextAlign } );
+									} }
+								/>
+								<Toolbar>
+									<MediaUpload
+										onSelect={ onSelectImage }
+										allowedTypes={ ALLOWED_MEDIA_TYPES }
+										value={ id }
+										render={ ( { open } ) => (
+											<IconButton
+												className="components-toolbar__control"
+												label={ __( 'Edit image' ) }
+												icon="edit"
+												onClick={ open }
+											/>
+										) }
 									/>
-								) }
-							/>
-						</Toolbar>
+								</Toolbar>
+							</Fragment>
+						) }
 					</BlockControls>
 					{ !! url && (
 						<InspectorControls>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -233,22 +233,23 @@ class ImageEdit extends Component {
 					value={ align }
 					onChange={ this.updateAlignment }
 				/>
-
-				<Toolbar>
-					<MediaUpload
-						onSelect={ this.onSelectImage }
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						value={ id }
-						render={ ( { open } ) => (
-							<IconButton
-								className="components-toolbar__control"
-								label={ __( 'Edit image' ) }
-								icon="edit"
-								onClick={ open }
-							/>
-						) }
-					/>
-				</Toolbar>
+				{ !! url && (
+					<Toolbar>
+						<MediaUpload
+							onSelect={ this.onSelectImage }
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							value={ id }
+							render={ ( { open } ) => (
+								<IconButton
+									className="components-toolbar__control"
+									label={ __( 'Edit image' ) }
+									icon="edit"
+									onClick={ open }
+								/>
+							) }
+						/>
+					</Toolbar>
+				) }
 			</BlockControls>
 		);
 


### PR DESCRIPTION
## Description
This PR hides some Toolbar buttons if no image is selected.
Fixes #5246

**Image Block:**

No image selected
<img width="215" alt="bildschirmfoto 2018-10-14 um 22 19 21" src="https://user-images.githubusercontent.com/695201/46921729-51c0cc80-cfff-11e8-8db3-4f39cb161071.png">


Image selected
<img width="247" alt="bildschirmfoto 2018-10-14 um 22 19 33" src="https://user-images.githubusercontent.com/695201/46921731-56858080-cfff-11e8-9d24-15bade421143.png">


**Cover Image Block:**

No image selected
<img width="209" alt="bildschirmfoto 2018-10-14 um 22 19 27" src="https://user-images.githubusercontent.com/695201/46921732-5b4a3480-cfff-11e8-8f8c-af40cd55dd68.png">


Image selected
<img width="345" alt="bildschirmfoto 2018-10-14 um 22 19 41" src="https://user-images.githubusercontent.com/695201/46921735-5f765200-cfff-11e8-8bfc-840fa46330ef.png">

