### PR TITLE
Update block-controls-toolbars-and-inspector.md

### DIFF
--- a/docs/blocks/block-controls-toolbars-and-inspector.md
+++ b/docs/blocks/block-controls-toolbars-and-inspector.md
@@ -84,6 +84,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 			alignment = props.attributes.alignment;
 
 		return el( RichText.Content, {
+			tagName: 'p',
 			className: props.className,
 			style: { textAlign: alignment },
 			value: content


### PR DESCRIPTION
The tagName 'p' is missing in ES5 save method.

If there is no tag no style can be applied to the element.

## Description
Added tagName property to ES5 save method

## How has this been tested?
This has been tested localy

## Types of changes
Missing line in documentation

## Checklist:
- [x ] My code is tested.
- [ x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
