### PR TITLE
Silence PHP errors on REST API responses

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -162,6 +162,8 @@ function gutenberg_pre_init() {
 
 	require_once dirname( __FILE__ ) . '/lib/load.php';
 
+	gutenberg_silence_rest_errors();
+
 	add_filter( 'replace_editor', 'gutenberg_init', 10, 2 );
 }
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -473,3 +473,18 @@ function gutenberg_filter_user_collection_parameters( $query_params ) {
 	return $query_params;
 }
 add_filter( 'rest_user_collection_params', 'gutenberg_filter_user_collection_parameters' );
+
+/**
+ * Silence PHP Warnings and Errors in JSON requests
+ *
+ * @todo This is a temporary measure until errors are properly silenced in REST API responses in core
+ *
+ * @see https://core.trac.wordpress.org/ticket/44534
+ */
+function gutenberg_silence_rest_errors() {
+
+	if ( ! empty( $_SERVER['CONTENT_TYPE'] ) && 'application/json' === $_SERVER['CONTENT_TYPE'] ) {
+		@ini_set( 'display_errors', 0 );
+	}
+
+}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -483,7 +483,8 @@ add_filter( 'rest_user_collection_params', 'gutenberg_filter_user_collection_par
  */
 function gutenberg_silence_rest_errors() {
 
-	if ( ! empty( $_SERVER['CONTENT_TYPE'] ) && 'application/json' === $_SERVER['CONTENT_TYPE'] ) {
+	if ( ( isset( $_SERVER['CONTENT_TYPE'] ) && 'application/json' === $_SERVER['CONTENT_TYPE'] ) ||
+		( isset( $_SERVER['HTTP_ACCEPT'] ) && strpos( $_SERVER['HTTP_ACCEPT'], 'application/json' ) !== false ) ) {
 		// @codingStandardsIgnoreStart
 		@ini_set( 'display_errors', 0 );
 		// @codingStandardsIgnoreEnd

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -484,7 +484,9 @@ add_filter( 'rest_user_collection_params', 'gutenberg_filter_user_collection_par
 function gutenberg_silence_rest_errors() {
 
 	if ( ! empty( $_SERVER['CONTENT_TYPE'] ) && 'application/json' === $_SERVER['CONTENT_TYPE'] ) {
+		// @codingStandardsIgnoreStart
 		@ini_set( 'display_errors', 0 );
+		// @codingStandardsIgnoreEnd
 	}
 
 }


### PR DESCRIPTION
This is a test of the method discussed on #10476 and https://core.trac.wordpress.org/ticket/44534 to prevent PHP errors and warnings from mangling JSON in REST API responses.

The method here is the earliest we can possibly check for and silence errors. Ideally we would add this header check to core inside of `wp_debug_mode()`. 

We could call `wp_debug_mode()` on `rest_api_init`, but that is further along in the request and there are a bunch of opportunities for plugins/themes to emit errors while loading. 

This method in Gutenberg would essentially leave the window for errors to the loading of mu-plugins, network activated plugins in multisite, and any plugins that come before `Gutenberg` alphabetically. Any errors emitted by later alphabetically ordered plugins loading, hooks/filters and the theme would be silenced.

Fixes #10476 
Related #10492