### PR TITLE
Paste: detect single line and treat as inline text

### DIFF
--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -58,20 +58,20 @@ describe( 'Blocks raw handling', () => {
 			HTML: '&lt;p&gt;Some &lt;strong&gt;bold&lt;/strong&gt; text.&lt;/p&gt;',
 			plainText: '<p>Some <strong>bold</strong> text.</p>',
 			mode: 'AUTO',
-		} ).map( getBlockContent ).join( '' );
+		} );
 
-		expect( filtered ).toBe( '<p>Some <strong>bold</strong> text.</p>' );
+		expect( filtered ).toBe( 'Some <strong>bold</strong> text.' );
 		expect( console ).toHaveLogged();
 	} );
 
 	it( 'should parse Markdown with HTML', () => {
 		const filtered = rawHandler( {
 			HTML: '',
-			plainText: '# Some <em>heading</em>',
+			plainText: '# Some <em>heading</em>\n\nA paragraph.',
 			mode: 'AUTO',
 		} ).map( getBlockContent ).join( '' );
 
-		expect( filtered ).toBe( '<h1>Some <em>heading</em></h1>' );
+		expect( filtered ).toBe( '<h1>Some <em>heading</em></h1><p>A paragraph.</p>' );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -92,6 +92,28 @@ describe( 'Blocks raw handling', () => {
 		} );
 
 		expect( filtered ).toBe( 'schön' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should treat single list item as inline text', () => {
+		const filtered = rawHandler( {
+			HTML: '<ul><li>Some <strong>bold</strong> text.</li></ul>',
+			plainText: 'Some <strong>bold</strong> text.\n',
+			mode: 'AUTO',
+		} );
+
+		expect( filtered ).toBe( 'Some <strong>bold</strong> text.' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should treat multiple list items as a block', () => {
+		const filtered = rawHandler( {
+			HTML: '<ul><li>One</li><li>Two</li><li>Three</li></ul>',
+			plainText: 'One\nTwo\nThree\n',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
 		expect( console ).toHaveLogged();
 	} );
 


### PR DESCRIPTION
## Description

Fixes #6555.

If the pasted content results in one block, and the plain text version has no line breaks, then paste as inline text if `mode` is set to `AUTO`.

This PR is block agnostic compared to #5354, because it checks the original plain text.

## How has this been tested?
See #6555 and #5354.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->