### PR TITLE
i18n: Mark custom font sizes labels as translatable

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -6,7 +6,7 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { withInstanceId } from '@wordpress/compose';
 
 /**
@@ -52,7 +52,7 @@ function FontSizePicker( {
 							aria-expanded={ isOpen }
 							aria-label={ __( 'Custom font size' ) }
 						>
-							{ ( currentFont && currentFont.name ) || ( ! value && 'Normal' ) || 'Custom' }
+							{ ( currentFont && currentFont.name ) || ( ! value && __( 'Normal' ) ) || _x( 'Custom', 'font size name' ) }
 						</Button>
 					) }
 					renderContent={ () => (


### PR DESCRIPTION
## Description
In #9802 Font Size Picker was updated, but two labels that are shown for custom sizes were not i18n. 

For the first label, I used existing string from `EDITOR_SETTINGS_DEFAULTS.fontSizes` while for the second I added context since it wasn't used before. Context is proposed for both strings in #8710, which introduces context for much more strings. If #8710 is accepted and merged before this PR, this PR will become obsolete