### PR TITLE
Change variable name to prevent confusion.

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -28,7 +28,7 @@ import {
 
 const { getComputedStyle } = window;
 
-const fallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	const { textColor, backgroundColor } = ownProps;
 	const backgroundColorValue = backgroundColor && backgroundColor.color;
 	const textColorValue = textColor && textColor.color;
@@ -143,5 +143,5 @@ class ButtonEdit extends Component {
 
 export default compose( [
 	withColors( 'backgroundColor', { textColor: 'color' } ),
-	fallbackStyles,
+	applyFallbackStyles,
 ] )( ButtonEdit );

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -28,7 +28,7 @@ import {
 
 const { getComputedStyle } = window;
 
-const FallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+const fallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	const { textColor, backgroundColor } = ownProps;
 	const backgroundColorValue = backgroundColor && backgroundColor.color;
 	const textColorValue = textColor && textColor.color;
@@ -143,5 +143,5 @@ class ButtonEdit extends Component {
 
 export default compose( [
 	withColors( 'backgroundColor', { textColor: 'color' } ),
-	FallbackStyles,
+	fallbackStyles,
 ] )( ButtonEdit );


### PR DESCRIPTION
Change name of FallbackStyles variable to fallbackStyles in order to prevent confusion with React components in the Button block.

Closes #10618.

## Description
Changes the variable name from FallbackStyles to fallbackStyles.