### PR TITLE
Change default Pullquote style

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -21,7 +21,9 @@ import {
 } from '@wordpress/editor';
 
 export const SOLID_COLOR_STYLE_NAME = 'solid-color';
+export const BORDER_COLOR_STYLE_NAME = 'border-color';
 export const SOLID_COLOR_CLASS = `is-style-${ SOLID_COLOR_STYLE_NAME }`;
+export const BORDER_COLOR_CLASS = `is-style-${ BORDER_COLOR_STYLE_NAME }`;
 
 class PullQuoteEdit extends Component {
 	constructor( props ) {
@@ -59,10 +61,11 @@ class PullQuoteEdit extends Component {
 
 		const { value, citation } = attributes;
 
-		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
-		const figureStyle = isSolidColorStyle ?
-			{ backgroundColor: mainColor.color } :
-			{ borderColor: mainColor.color };
+		const isBorderColorStyle = includes( className, BORDER_COLOR_CLASS );
+		const figureStyle = isBorderColorStyle ?
+			{ borderColor: mainColor.color } :
+			{ backgroundColor: mainColor.color };
+
 		const blockquoteStyle = {
 			color: textColor.color,
 		};
@@ -73,7 +76,7 @@ class PullQuoteEdit extends Component {
 			<Fragment>
 				<figure style={ figureStyle } className={ classnames(
 					className, {
-						[ mainColor.class ]: isSolidColorStyle && mainColor.class,
+						[ mainColor.class ]: ! isBorderColorStyle && mainColor.class,
 					} ) }>
 					<blockquote style={ blockquoteStyle } className={ blockquoteClasses }>
 						<RichText
@@ -119,7 +122,7 @@ class PullQuoteEdit extends Component {
 							},
 						] }
 					>
-						{ isSolidColorStyle && (
+						{ ! isBorderColorStyle && (
 							<ContrastChecker
 								{ ...{
 									textColor: textColor.color,

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -1,46 +1,22 @@
-.editor-block-list__block[data-type="core/pullquote"] {
-	&[data-align="left"],
-	&[data-align="right"] {
-		& .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
-		& .editor-rich-text p {
-			font-size: 20px;
-		}
-	}
-}
-
 .wp-block-pullquote {
 	cite .editor-rich-text__tinymce[data-is-empty="true"]::before {
 		font-size: 14px;
 		font-family: $default-font;
 	}
-
-	.editor-rich-text__tinymce[data-is-empty="true"]::before {
-		width: 100%;
-		left: 50%;
-		transform: translateX(-50%);
-	}
-
-	& blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
-	& blockquote > .editor-rich-text p {
-		font-size: 28px;
-		line-height: 1.6;
-	}
-}
-
-.wp-block-pullquote.is-style-solid-color {
-	margin-left: 0;
-	margin-right: 0;
-
-	& blockquote > .editor-rich-text p {
-		font-size: 32px;
-	}
-
-	.wp-block-pullquote__citation {
-		text-transform: none;
-		font-style: normal;
-	}
 }
 
 .wp-block-pullquote .wp-block-pullquote__citation {
 	color: inherit;
+	text-transform: none;
+}
+
+.wp-block-pullquote.is-style-border-color .wp-block-pullquote__citation {
+	text-transform: uppercase;
+}
+
+.editor-block-list__block[data-type="core/pullquote"][data-align="full"] {
+	figure.wp-block-pullquote {
+		margin-right: 0;
+		margin-left: 0;
+	}
 }

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -64,7 +64,7 @@ export const settings = {
 	attributes: blockAttributes,
 
 	styles: [
-		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid Color' ), isDefault: true },
+		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid' ), isDefault: true },
 		{ name: BORDER_COLOR_STYLE_NAME, label: __( 'Border' ) },
 	],
 

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -20,7 +20,8 @@ import {
 import {
 	default as edit,
 	SOLID_COLOR_STYLE_NAME,
-	SOLID_COLOR_CLASS,
+	BORDER_COLOR_STYLE_NAME,
+	BORDER_COLOR_CLASS,
 } from './edit';
 
 const blockAttributes = {
@@ -62,8 +63,8 @@ export const settings = {
 	attributes: blockAttributes,
 
 	styles: [
-		{ name: 'default', label: __( 'Regular' ), isDefault: true },
-		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid Color' ) },
+		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid Color' ), isDefault: true },
+		{ name: BORDER_COLOR_STYLE_NAME, label: __( 'Border' ) },
 	],
 
 	supports: {
@@ -74,30 +75,33 @@ export const settings = {
 
 	save( { attributes } ) {
 		const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;
-		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+		const isBorderColorStyle = includes( className, BORDER_COLOR_CLASS );
 
 		let figureClass, figureStyles;
-		// Is solid color style
-		if ( isSolidColorStyle ) {
+		// Is border color style.
+		if ( isBorderColorStyle ) {
+			// Is border style and a custom color is being used ( we can set a style directly with its value).
+			if ( customMainColor ) {
+				figureStyles = {
+					borderColor: customMainColor,
+				};
+				// Is border style and a named color is being used, we need to retrieve the color value to set the style,
+				// as there is no expectation that themes create classes that set border colors.
+			} else if ( mainColor ) {
+				const colors = get( select( 'core/editor' ).getEditorSettings(), [ 'colors' ], [] );
+				const colorObject = getColorObjectByAttributeValues( colors, mainColor );
+				figureStyles = {
+					borderColor: colorObject.color,
+				};
+			}
+		// Is default style.
+		} else {
 			figureClass = getColorClassName( 'background-color', mainColor );
 			if ( ! figureClass ) {
 				figureStyles = {
 					backgroundColor: customMainColor,
 				};
 			}
-		// Is normal style and a custom color is being used ( we can set a style directly with its value)
-		} else if ( customMainColor ) {
-			figureStyles = {
-				borderColor: customMainColor,
-			};
-		// Is normal style and a named color is being used, we need to retrieve the color value to set the style,
-		// as there is no expectation that themes create classes that set border colors.
-		} else if ( mainColor ) {
-			const colors = get( select( 'core/editor' ).getEditorSettings(), [ 'colors' ], [] );
-			const colorObject = getColorObjectByAttributeValues( colors, mainColor );
-			figureStyles = {
-				borderColor: colorObject.color,
-			};
 		}
 
 		const blockquoteTextColorClass = getColorClassName( 'color', textColor );

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -20,6 +20,7 @@ import {
 import {
 	default as edit,
 	SOLID_COLOR_STYLE_NAME,
+	SOLID_COLOR_CLASS,
 	BORDER_COLOR_STYLE_NAME,
 	BORDER_COLOR_CLASS,
 } from './edit';
@@ -120,6 +121,73 @@ export const settings = {
 	},
 
 	deprecated: [ {
+		attributes: {
+			...blockAttributes,
+		},
+		// pull quote version where the default style was the version with border color.
+		save( { attributes } ) {
+			const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;
+			const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+
+			let figureClass, figureStyles;
+			// Is solid color style
+			if ( isSolidColorStyle ) {
+				figureClass = getColorClassName( 'background-color', mainColor );
+				if ( ! figureClass ) {
+					figureStyles = {
+						backgroundColor: customMainColor,
+					};
+				}
+			// Is normal style and a custom color is being used ( we can set a style directly with its value)
+			} else if ( customMainColor ) {
+				figureStyles = {
+					borderColor: customMainColor,
+				};
+			// Is normal style and a named color is being used, we need to retrieve the color value to set the style,
+			// as there is no expectation that themes create classes that set border colors.
+			} else if ( mainColor ) {
+				const colors = get( select( 'core/editor' ).getEditorSettings(), [ 'colors' ], [] );
+				const colorObject = getColorObjectByAttributeValues( colors, mainColor );
+				figureStyles = {
+					borderColor: colorObject.color,
+				};
+			}
+
+			const blockquoteTextColorClass = getColorClassName( 'color', textColor );
+			const blockquoteClasses = textColor || customTextColor ? classnames( 'has-text-color', {
+				[ blockquoteTextColorClass ]: blockquoteTextColorClass,
+			} ) : undefined;
+			const blockquoteStyle = blockquoteTextColorClass ? undefined : { color: customTextColor };
+			return (
+				<figure className={ figureClass } style={ figureStyles }>
+					<blockquote className={ blockquoteClasses } style={ blockquoteStyle } >
+						<RichText.Content value={ value } multiline="p" />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				</figure>
+			);
+		},
+		migrate: function( attributes ) {
+			if ( includes( attributes.className, SOLID_COLOR_CLASS ) ) {
+				// Block using the solid color style, markup is still tottaly valid and it should render as expected,
+				// we cam just use the same attributes as before.
+				return attributes;
+			}
+
+			// Block using the border color style (previous default),
+			// with some customization's that made the validation fail.
+			// Update its className to include a reference to the previous default color style,
+			// as classes for default class are not included.
+			let className = BORDER_COLOR_CLASS;
+			if ( attributes.className ) {
+				className = `${ BORDER_COLOR_CLASS } ${ attributes.className }`;
+			}
+			return {
+				...attributes,
+				className,
+			};
+		},
+	}, {
 		attributes: {
 			...blockAttributes,
 		},

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -1,39 +1,8 @@
-.wp-block-pullquote {
+figure.wp-block-pullquote {
 	padding: 3em 0;
-	margin-left: 0;
-	margin-right: 0;
-	text-align: center;
-
-	&.alignleft,
-	&.alignright {
-		max-width: $content-width / 2;
-
-		p {
-			font-size: 20px;
-		}
-	}
-
-	p {
-		font-size: 28px;
-		line-height: 1.6;
-	}
-
-	cite,
-	footer {
-		position: relative;
-	}
-	.has-text-color a {
-		color: inherit;
-	}
-}
-
-.wp-block-pullquote:not(.is-style-solid-color) {
-	background: none;
-}
-
-.wp-block-pullquote.is-style-solid-color {
 	border: none;
 	blockquote {
+		border: none;
 		margin-left: auto;
 		margin-right: auto;
 		text-align: left;
@@ -48,10 +17,48 @@
 
 		cite {
 			text-transform: none;
-			font-style: normal;
+		}
+	}
+
+	&.alignleft,
+	&.alignright {
+		max-width: $content-width / 2;
+		font-size: 20px;
+	}
+
+	cite,
+	footer {
+		position: relative;
+	}
+	.has-text-color a {
+		color: inherit;
+	}
+}
+
+.wp-block-pullquote.is-style-border-color {
+	border-top: 4px solid #555d66;
+	border-bottom: 4px solid #555d66;
+	padding: 0;
+	blockquote {
+		padding: 3em 0;
+		margin-left: 0;
+		margin-right: 0;
+		text-align: center;
+		max-width: 100%;
+
+		p {
+			margin-top: 1em;
+			margin-bottom: 1em;
+			font-size: 28px;
+			line-height: 1.6;
+		}
+
+		cite {
+			text-transform: uppercase;
 		}
 	}
 }
+
 
 .wp-block-pullquote cite {
 	color: inherit;

--- a/test/integration/full-content/fixtures/core__pullquote__border-style-colors.html
+++ b/test/integration/full-content/fixtures/core__pullquote__border-style-colors.html
@@ -1,0 +1,9 @@
+<!-- wp:pullquote {"customMainColor":"#bc5812","customTextColor":"#5b0b0b","className":"is-style-border-color"} -->
+<figure class="wp-block-pullquote is-style-border-color" style="border-color:#bc5812">
+	<blockquote class="has-text-color" style="color:#5b0b0b">
+		<p>sdfd</p>
+		<cite>sdfs</cite>
+	</blockquote>
+</figure>
+<!-- /wp:pullquote -->
+

--- a/test/integration/full-content/fixtures/core__pullquote__border-style-colors.json
+++ b/test/integration/full-content/fixtures/core__pullquote__border-style-colors.json
@@ -1,0 +1,16 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/pullquote",
+        "isValid": true,
+        "attributes": {
+            "value": "<p>sdfd</p>",
+            "citation": "sdfs",
+            "customMainColor": "#bc5812",
+            "customTextColor": "#5b0b0b",
+            "className": "is-style-border-color"
+        },
+        "innerBlocks": [],
+        "originalContent": "<figure class=\"wp-block-pullquote is-style-border-color\" style=\"border-color:#bc5812\">\n\t<blockquote class=\"has-text-color\" style=\"color:#5b0b0b\">\n\t\t<p>sdfd</p>\n\t\t<cite>sdfs</cite>\n\t</blockquote>\n</figure>"
+    }
+]

--- a/test/integration/full-content/fixtures/core__pullquote__border-style-colors.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote__border-style-colors.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "core/pullquote",
+        "attrs": {
+            "customMainColor": "#bc5812",
+            "customTextColor": "#5b0b0b",
+            "className": "is-style-border-color"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-pullquote is-style-border-color\" style=\"border-color:#bc5812\">\n\t<blockquote class=\"has-text-color\" style=\"color:#5b0b0b\">\n\t\t<p>sdfd</p>\n\t\t<cite>sdfs</cite>\n\t</blockquote>\n</figure>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__pullquote__border-style-colors.serialized.html
+++ b/test/integration/full-content/fixtures/core__pullquote__border-style-colors.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:pullquote {"customMainColor":"#bc5812","customTextColor":"#5b0b0b","className":"is-style-border-color"} -->
+<figure class="wp-block-pullquote is-style-border-color" style="border-color:#bc5812"><blockquote class="has-text-color" style="color:#5b0b0b"><p>sdfd</p><cite>sdfs</cite></blockquote></figure>
+<!-- /wp:pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote__border-style.html
+++ b/test/integration/full-content/fixtures/core__pullquote__border-style.html
@@ -1,0 +1,8 @@
+<!-- wp:pullquote {"className":"is-style-border-color"} -->
+<figure class="wp-block-pullquote is-style-border-color">
+	<blockquote>
+		<p>sdfd</p>
+		<cite>sdfs</cite>
+	</blockquote>
+</figure>
+<!-- /wp:pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote__border-style.json
+++ b/test/integration/full-content/fixtures/core__pullquote__border-style.json
@@ -1,0 +1,14 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/pullquote",
+        "isValid": true,
+        "attributes": {
+            "value": "<p>sdfd</p>",
+            "citation": "sdfs",
+            "className": "is-style-border-color"
+        },
+        "innerBlocks": [],
+        "originalContent": "<figure class=\"wp-block-pullquote is-style-border-color\">\n\t<blockquote>\n\t\t<p>sdfd</p>\n\t\t<cite>sdfs</cite>\n\t</blockquote>\n</figure>"
+    }
+]

--- a/test/integration/full-content/fixtures/core__pullquote__border-style.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote__border-style.parsed.json
@@ -1,0 +1,16 @@
+[
+    {
+        "blockName": "core/pullquote",
+        "attrs": {
+            "className": "is-style-border-color"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-pullquote is-style-border-color\">\n\t<blockquote>\n\t\t<p>sdfd</p>\n\t\t<cite>sdfs</cite>\n\t</blockquote>\n</figure>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__pullquote__border-style.serialized.html
+++ b/test/integration/full-content/fixtures/core__pullquote__border-style.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:pullquote {"className":"is-style-border-color"} -->
+<figure class="wp-block-pullquote is-style-border-color"><blockquote><p>sdfd</p><cite>sdfs</cite></blockquote></figure>
+<!-- /wp:pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote__solid-color-style-colors.html
+++ b/test/integration/full-content/fixtures/core__pullquote__solid-color-style-colors.html
@@ -1,0 +1,8 @@
+<!-- wp:pullquote {"customMainColor":"#bc5812","customTextColor":"#5b0b0b"} -->
+<figure class="wp-block-pullquote" style="background-color:#bc5812">
+	<blockquote class="has-text-color" style="color:#5b0b0b">
+		<p>sdfd</p>
+		<cite>sdfs</cite>
+	</blockquote>
+</figure>
+<!-- /wp:pullquote -->

--- a/test/integration/full-content/fixtures/core__pullquote__solid-color-style-colors.json
+++ b/test/integration/full-content/fixtures/core__pullquote__solid-color-style-colors.json
@@ -1,0 +1,15 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/pullquote",
+        "isValid": true,
+        "attributes": {
+            "value": "<p>sdfd</p>",
+            "citation": "sdfs",
+            "customMainColor": "#bc5812",
+            "customTextColor": "#5b0b0b"
+        },
+        "innerBlocks": [],
+        "originalContent": "<figure class=\"wp-block-pullquote\" style=\"background-color:#bc5812\">\n\t<blockquote class=\"has-text-color\" style=\"color:#5b0b0b\">\n\t\t<p>sdfd</p>\n\t\t<cite>sdfs</cite>\n\t</blockquote>\n</figure>"
+    }
+]

--- a/test/integration/full-content/fixtures/core__pullquote__solid-color-style-colors.parsed.json
+++ b/test/integration/full-content/fixtures/core__pullquote__solid-color-style-colors.parsed.json
@@ -1,0 +1,17 @@
+[
+    {
+        "blockName": "core/pullquote",
+        "attrs": {
+            "customMainColor": "#bc5812",
+            "customTextColor": "#5b0b0b"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-pullquote\" style=\"background-color:#bc5812\">\n\t<blockquote class=\"has-text-color\" style=\"color:#5b0b0b\">\n\t\t<p>sdfd</p>\n\t\t<cite>sdfs</cite>\n\t</blockquote>\n</figure>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__pullquote__solid-color-style-colors.serialized.html
+++ b/test/integration/full-content/fixtures/core__pullquote__solid-color-style-colors.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:pullquote {"customMainColor":"#bc5812","customTextColor":"#5b0b0b"} -->
+<figure class="wp-block-pullquote" style="background-color:#bc5812"><blockquote class="has-text-color" style="color:#5b0b0b"><p>sdfd</p><cite>sdfs</cite></blockquote></figure>
+<!-- /wp:pullquote -->


### PR DESCRIPTION
## Description
Closes: https://github.com/WordPress/gutenberg/issues/10386
This PR attempts to change the default style of the pull-quotes to be the solid color style.

It changes the name of the previous default style from 'default' to "Border".

Changing a default block style involves an almost complete refactor to the block styles,  this is the reason why we have significant style changes.

Changing a default block style also causes troubles regarding backward compatibility. Because classes are not set for the default style, given a block markup, it may be impossible to distinguish if it was created with the previous or the new default.
The state of this PR regarding back-compatibility is the following:
- For blocks created with the previous default style without any color change, we can not differentiate the markup between previous and new default styles, so the block is valid, and we apply the new default style.
- For blocks created in a version with the previous default style and with a main color change, the old markup is not valid now, we have a deprecation logic that detects this case and we migrate the block keeping the same style as before ( our migration function adds a class for the previous default style that was missing because classes for default styles are not added).
- For blocks created with the Solid Color style (the new default), everything should continue to work with the same style as before.


## How has this been tested?
I added some pullquote blocks changed the styles and colors and I verified things work as expected.
I pasted on the code editor the following markup containing blocks created on the previous version (4.0 RC):
```
<!-- wp:pullquote -->
<figure class="wp-block-pullquote"><blockquote><p>Previous default no change</p><cite>sdf</cite></blockquote></figure>
<!-- /wp:pullquote -->

<!-- wp:pullquote {"customMainColor":"#e32727","customTextColor":"#ca970c","className":"is-style-border-color"} -->
<figure class="wp-block-pullquote is-style-border-color" style="border-color:#e32727"><blockquote class="has-text-color" style="color:#ca970c"><p>Previous default Color chanes</p><cite>dsfdsfds</cite></blockquote></figure>
<!-- /wp:pullquote -->

<!-- wp:pullquote {"className":"is-style-solid-color"} -->
<figure class="wp-block-pullquote is-style-solid-color"><blockquote><p>Previous solid color</p><cite>aaaaa</cite></blockquote></figure>
<!-- /wp:pullquote -->

<!-- wp:pullquote {"customMainColor":"#c0560b","customTextColor":"#edb10f","className":"is-style-solid-color"} -->
<figure class="wp-block-pullquote is-style-solid-color" style="background-color:#c0560b"><blockquote class="has-text-color" style="color:#edb10f"><p>Previous solid color color change</p><cite>dsfdsf</cite></blockquote></figure>
<!-- /wp:pullquote -->
```
I checked no invalid blocks exist and the result is the one mentined before.

