### PR TITLE
Fix formatting in getEditorSettings docs and update getTokenSettings docs.

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1259,19 +1259,20 @@ Returns the editor settings.
 
 *Returns*
 
-The editor settings object
+The editor settings object.
 
 ### getTokenSettings
 
-Returns the editor settings.
+Returns the token settings.
 
 *Parameters*
 
  * state: Editor state.
+ * name: Token name.
 
 *Returns*
 
-The editor settings object
+Token settings object, or the named token settings object if set.
 
 ### isPostLocked
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1928,23 +1928,24 @@ export function getBlockListSettings( state, clientId ) {
 	return state.blockListSettings[ clientId ];
 }
 
-/*
+/**
  * Returns the editor settings.
  *
  * @param {Object} state Editor state.
  *
- * @return {Object} The editor settings object
+ * @return {Object} The editor settings object.
  */
 export function getEditorSettings( state ) {
 	return state.settings;
 }
 
-/*
- * Returns the editor settings.
+/**
+ * Returns the token settings.
  *
  * @param {Object} state Editor state.
+ * @param {?string} name Token name.
  *
- * @return {Object} The editor settings object
+ * @return {Object} Token settings object, of the named token if set.
  */
 export function getTokenSettings( state, name ) {
 	if ( ! name ) {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1928,23 +1928,24 @@ export function getBlockListSettings( state, clientId ) {
 	return state.blockListSettings[ clientId ];
 }
 
-/*
+/**
  * Returns the editor settings.
  *
  * @param {Object} state Editor state.
  *
- * @return {Object} The editor settings object
+ * @return {Object} The editor settings object.
  */
 export function getEditorSettings( state ) {
 	return state.settings;
 }
 
-/*
- * Returns the editor settings.
+/**
+ * Returns the token settings.
  *
  * @param {Object} state Editor state.
+ * @param {?string} name Token name.
  *
- * @return {Object} The editor settings object
+ * @return {Object} Token settings object, or the named token settings object if set.
  */
 export function getTokenSettings( state, name ) {
 	if ( ! name ) {


### PR DESCRIPTION
## Description
Added formatting change to include getEditorSettings and getTokenSettings in lint-js, update getTokenSettings docs to not be a copy of getEditorSettings and add name param. Fixes #10593. I gave my best shot at the getTokenSettings docs, but I am still exploring the gutenberg code so if @aduth or anyone else sees something I missed or got wrong, feel free to update.  

## How has this been tested?
Fixiing the missing second asterisk added getEditorSettings and getTokenSettings to the lint-js task, adding the name param fixed the error it reported.

## Screenshots
N/A

## Types of changes
Documentation fix and update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
