### PR TITLE
Missing Block: Don't use dangerouslySetInnerHTML with i18n string

### DIFF
--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -17,7 +17,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 	let messageHTML;
 	if ( hasContent && hasHTMLBlock ) {
 		messageHTML = sprintf(
-			__( 'Your site doesn\'t include support for the <code>%s</code> block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
+			__( 'Your site doesn\'t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
 			originalName
 		);
 		actions.push(
@@ -27,7 +27,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 		);
 	} else {
 		messageHTML = sprintf(
-			__( 'Your site doesn\'t include support for the <code>%s</code> block. You can leave this block intact or remove it entirely.' ),
+			__( 'Your site doesn\'t include support for the "%s" block. You can leave this block intact or remove it entirely.' ),
 			originalName
 		);
 	}
@@ -35,7 +35,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 	return (
 		<Fragment>
 			<Warning actions={ actions }>
-				<span dangerouslySetInnerHTML={ { __html: messageHTML } } />
+				<span>{ messageHTML }</span>
 			</Warning>
 			<div>
 				<RawHTML>{ originalUndelimitedContent }</RawHTML>

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -35,7 +35,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 	return (
 		<Fragment>
 			<Warning actions={ actions }>
-				<span>{ messageHTML }</span>
+				{ messageHTML }
 			</Warning>
 			<div>
 				<RawHTML>{ originalUndelimitedContent }</RawHTML>


### PR DESCRIPTION
## Description

Fixes use of `dangerouslySetInnerHTML` with uncontrolled external input (i18n string). Identified in [this comment](https://github.com/WordPress/gutenberg/pull/8274/files/79222f46ab26c11f4f6b8e8289b4ad811a2faf76#r224857914).

## How has this been tested?


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->