### PR TITLE
Account for null value in redux-routine createRuntime

### DIFF
--- a/packages/redux-routine/src/is-action.js
+++ b/packages/redux-routine/src/is-action.js
@@ -23,6 +23,6 @@ export function isAction( object ) {
  *
  * @return {boolean} Whether object is an action and is of specific type.
  */
-export function isSpecificAction( object, expectedType ) {
+export function isActionOfType( object, expectedType ) {
 	return isAction( object ) && object.type === expectedType;
 }

--- a/packages/redux-routine/src/is-action.js
+++ b/packages/redux-routine/src/is-action.js
@@ -18,7 +18,7 @@ export function isAction( object ) {
  * Returns true if the given object quacks like an action and has a specific
  * action type
  *
- * @param {*} object Object to test
+ * @param {*}      object       Object to test
  * @param {string} expectedType The expected type for the action.
  *
  * @return {boolean} Whether object is an action and is of specific type.

--- a/packages/redux-routine/src/is-action.js
+++ b/packages/redux-routine/src/is-action.js
@@ -1,0 +1,28 @@
+/**
+ * External imports
+ */
+import { isPlainObject, isString } from 'lodash';
+
+/**
+ * Returns true if the given object quacks like an action.
+ *
+ * @param {*} object Object to test
+ *
+ * @return {boolean}  Whether object is an action.
+ */
+export function isAction( object ) {
+	return isPlainObject( object ) && isString( object.type );
+}
+
+/**
+ * Returns true if the given object quacks like an action and has a specific
+ * action type
+ *
+ * @param {*} object Object to test
+ * @param {string} expectedType The expected type for the action.
+ *
+ * @return {boolean} Whether object is an action and is of specific type.
+ */
+export function isSpecificAction( object, expectedType ) {
+	return isAction( object ) && object.type === expectedType;
+}

--- a/packages/redux-routine/src/runtime.js
+++ b/packages/redux-routine/src/runtime.js
@@ -9,7 +9,7 @@ import isPromise from 'is-promise';
  * Internal dependencies
  */
 import castError from './cast-error';
-import { isSpecificAction, isAction } from './is-action';
+import { isActionOfType, isAction } from './is-action';
 
 /**
  * Create a co-routine runtime.
@@ -21,7 +21,7 @@ import { isSpecificAction, isAction } from './is-action';
  */
 export default function createRuntime( controls = {}, dispatch ) {
 	const rungenControls = map( controls, ( control, actionType ) => ( value, next, iterate, yieldNext, yieldError ) => {
-		if ( ! isSpecificAction( value, actionType ) ) {
+		if ( ! isActionOfType( value, actionType ) ) {
 			return false;
 		}
 		const routine = control( value );

--- a/packages/redux-routine/src/runtime.js
+++ b/packages/redux-routine/src/runtime.js
@@ -9,6 +9,7 @@ import isPromise from 'is-promise';
  * Internal dependencies
  */
 import castError from './cast-error';
+import { isSpecificAction, isAction } from './is-action';
 
 /**
  * Create a co-routine runtime.
@@ -20,7 +21,7 @@ import castError from './cast-error';
  */
 export default function createRuntime( controls = {}, dispatch ) {
 	const rungenControls = map( controls, ( control, actionType ) => ( value, next, iterate, yieldNext, yieldError ) => {
-		if ( typeof value !== 'object' || value.type !== actionType ) {
+		if ( ! isSpecificAction( value, actionType ) ) {
 			return false;
 		}
 		const routine = control( value );
@@ -37,7 +38,7 @@ export default function createRuntime( controls = {}, dispatch ) {
 	} );
 
 	const unhandledActionControl = ( value, next ) => {
-		if ( typeof value !== 'object' || ! isString( value.type ) ) {
+		if ( ! isAction( value ) || ! isString( value.type ) ) {
 			return false;
 		}
 		dispatch( value );

--- a/packages/redux-routine/src/runtime.js
+++ b/packages/redux-routine/src/runtime.js
@@ -38,7 +38,7 @@ export default function createRuntime( controls = {}, dispatch ) {
 	} );
 
 	const unhandledActionControl = ( value, next ) => {
-		if ( ! isAction( value ) || ! isString( value.type ) ) {
+		if ( ! isAction( value ) ) {
 			return false;
 		}
 		dispatch( value );

--- a/packages/redux-routine/src/test/is-action.js
+++ b/packages/redux-routine/src/test/is-action.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isAction, isSpecificAction } from '../is-action';
+import { isAction, isActionOfType } from '../is-action';
 
 const nonActions = [
 	null,
@@ -24,16 +24,16 @@ describe( 'isAction()', () => {
 	} );
 } );
 
-describe( 'isSpecificAction', () => {
+describe( 'isActionOfType', () => {
 	it( 'should return false if not an action', () => {
 		nonActions.forEach( ( value ) => {
-			expect( isSpecificAction( value, 'foo' ) ).toBe( false );
+			expect( isActionOfType( value, 'foo' ) ).toBe( false );
 		} );
 	} );
 	it( 'should return false if is an action but not of correct type', () => {
-		expect( isSpecificAction( validAction, 'loser' ) ).toBe( false );
+		expect( isActionOfType( validAction, 'loser' ) ).toBe( false );
 	} );
 	it( 'should return true if is an action and of correct type', () => {
-		expect( isSpecificAction( validAction, 'winner' ) ).toBe( true );
+		expect( isActionOfType( validAction, 'winner' ) ).toBe( true );
 	} );
 } );

--- a/packages/redux-routine/src/test/is-action.js
+++ b/packages/redux-routine/src/test/is-action.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { isAction, isSpecificAction } from '../is-action';
+
+const nonActions = [
+	null,
+	[],
+	42,
+	'foo',
+	function() {},
+	{ foo: 'bar' },
+];
+const validAction = { type: 'winner' };
+
+describe( 'isAction()', () => {
+	it( 'should return false if not an action', () => {
+		nonActions.forEach( ( value ) => {
+			expect( isAction( value ) ).toBe( false );
+		} );
+	} );
+	it( 'should return true if an action', () => {
+		expect( isAction( validAction ) ).toBe( true );
+	} );
+} );
+
+describe( 'isSpecificAction', () => {
+	it( 'should return false if not an action', () => {
+		nonActions.forEach( ( value ) => {
+			expect( isSpecificAction( value, 'foo' ) ).toBe( false );
+		} );
+	} );
+	it( 'should return false if is an action but not of correct type', () => {
+		expect( isSpecificAction( validAction, 'loser' ) ).toBe( false );
+	} );
+	it( 'should return true if is an action and of correct type', () => {
+		expect( isSpecificAction( validAction, 'winner' ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
In the `createRuntime` method found in `packages/redux-routine/src/runtime`, the following conditional would produce an error if `value` is null:

```
( typeof value !== 'object' || value.type !== actionType )
```

It appears that `null` could be an incoming value and since `typeof null === 'object'` evaluates to `true` there would be an error with the following `value.type` test.

In this pull:

- created `isAction` and `isSpecificAction` for detection objects that serve as action objects.
- implemented the above two functions in `createRuntime` to explicitly check that value "quacks like an action" and "quacks like the expected action".

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- I've added unit tests for the new utility functions and verified they passed.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
