### PR TITLE
Deactivate plugin if WordPress 5.0 Beta detected

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -128,6 +128,19 @@ function gutenberg_wordpress_version_notice() {
 }
 
 /**
+ * Display a conflict notice and deactivate the Gutenberg plugin.
+ *
+ * @since 4.1.0
+ */
+function gutenberg_wordpress_conflict_notice() {
+	echo '<div class="notice notice-warning"><p>';
+	echo __( 'You are running WordPress 5.0 Beta or higher, which supplants the current version of the Gutenberg plugin. In order to avoid conflicts, the plugin has been disabled.', 'gutenberg' );
+	echo '</p></div>';
+
+	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );
+}
+
+/**
  * Display a build notice.
  *
  * @since 0.1.0
@@ -157,6 +170,11 @@ function gutenberg_pre_init() {
 
 	if ( version_compare( $version, '4.9.8', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
+		return;
+	}
+
+	if ( defined( 'GUTENBERG_STABLE_LOADED' ) && GUTENBERG_STABLE_LOADED ) {
+		add_action( 'admin_notices', 'gutenberg_wordpress_conflict_notice' );
 		return;
 	}
 


### PR DESCRIPTION
## Description

This PR is currently the most basic working implementation possible to illustrate the concept.

- Looks for tentative constant `GUTENBERG_STABLE_LOADED`, assumed to be defined in 5.0 branch.
- If constant found, deactivates plugin and shows admin notice explaining deactivation.

### Rationale

WordPress 5.0 Beta 1 is fast approaching. Gutenberg 4.1 RC is expected shortly before that, and the plugin should prepare for the beta by — for now — simply deactivating itself in order to avoid fatal conflicts between core and plugin.

Note that the plan, once 5.0 is released, is for the plugin to fully support 5.0+. When that time comes, the Gutenberg plugin will be a channel for incremental development of Gutenberg, in particular for so-called [Phase 2](https://make.wordpress.org/core/2018/10/05/gutenberg-phase-2-leads/) of the project.

### Questions

- [ ] I haven't fully weighed the merits of a constant vs. checking for `function_exists( 'register_block_type' )`. My concern w.r.t the latter is the timing of function definition in core vs. plugins, and the likelihood of certain setups out there breaking our assumptions. In contrast, the primacy of `wp-config.php` is much more likely to be honored.

## How has this been tested?

In your `wp-config.php`, add

```php
define( 'GUTENBERG_STABLE_LOADED', true );
```

make sure to define this constant _before_ `wp-config.php` requires any other file.

## Screenshots

![gutenberg-wordpress-conflict-notice](https://user-images.githubusercontent.com/150562/46980878-e72a9200-d0cd-11e8-93a6-9fc1b4489258.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->