### PR TITLE
Add Cover block; Deprecate cover image;

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -29,6 +29,8 @@ $z-layers: (
 	".edit-post-header": 30,
 	".block-library-button__inline-link .editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
 	".block-library-image__resize-handlers": 1, // Resize handlers above sibling inserter
+	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover block.
+	".wp-block-cover__video-background": 0, // Video background inside cover block.
 
 	// Side UI active buttons
 	".editor-block-mover__control": 1,

--- a/packages/block-library/src/cover-image/index.js
+++ b/packages/block-library/src/cover-image/index.js
@@ -23,6 +23,7 @@ import {
 	withColors,
 	getColorClassName,
 } from '@wordpress/editor';
+import deprecated from '@wordpress/deprecated';
 
 const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
 
@@ -74,6 +75,10 @@ export const settings = {
 	category: 'common',
 
 	attributes: blockAttributes,
+
+	supports: {
+		inserter: false,
+	},
 
 	transforms: {
 		from: [
@@ -132,6 +137,10 @@ export const settings = {
 		withNotices,
 	] )(
 		( { attributes, setAttributes, isSelected, className, noticeOperations, noticeUI, overlayColor, setOverlayColor } ) => {
+			deprecated( 'The Cover Image block', {
+				alternative: 'the Cover block',
+				plugin: 'Gutenberg',
+			} );
 			const { url, title, align, contentAlign, id, hasParallax, dimRatio } = attributes;
 			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 			const onSelectImage = ( media ) => {

--- a/packages/block-library/src/cover-image/test/index.js
+++ b/packages/block-library/src/cover-image/test/index.js
@@ -9,5 +9,8 @@ describe( 'core/cover-image', () => {
 		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
+		expect( console ).toHaveWarnedWith(
+			'The Cover Image block is deprecated and will be removed. Please use the Cover block instead.'
+		);
 	} );
 } );

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -1,0 +1,247 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	IconButton,
+	PanelBody,
+	RangeControl,
+	ToggleControl,
+	Toolbar,
+	withNotices,
+} from '@wordpress/components';
+import { Fragment, Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import {
+	BlockControls,
+	InspectorControls,
+	InnerBlocks,
+	MediaPlaceholder,
+	MediaUpload,
+	PanelColorSettings,
+	withColors,
+} from '@wordpress/editor';
+
+const INNER_BLOCKS_TEMPLATE = [
+	[ 'core/paragraph', {
+		align: 'center',
+		fontSize: 'large',
+		placeholder: __( 'Write title…' ),
+	} ],
+];
+const INNER_BLOCKS_ALLOWED_BLOCKS = [
+	'core/button',
+	'core/heading',
+	'core/paragraph',
+];
+const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+export const IMAGE_BACKGROUND_TYPE = 'image';
+export const VIDEO_BACKGROUND_TYPE = 'video';
+
+class CoverEdit extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onSelectMedia = this.onSelectMedia.bind( this );
+	}
+
+	onSelectMedia( media ) {
+		const { setAttributes } = this.props;
+		if ( ! media || ! media.url ) {
+			setAttributes( { url: undefined, id: undefined } );
+			return;
+		}
+		let mediaType;
+		// for media selections originated from a file upload.
+		if ( media.media_type ) {
+			if ( media.media_type === IMAGE_BACKGROUND_TYPE ) {
+				mediaType = IMAGE_BACKGROUND_TYPE;
+			} else {
+				// only images and videos are accepted so if the media_type is not an image we can assume it is a video.
+				// video contain the media type of 'file' in the object returned from the rest api.
+				mediaType = VIDEO_BACKGROUND_TYPE;
+			}
+		} else { // for media selections originated from existing files in the media library.
+			mediaType = media.type;
+		}
+		if ( mediaType ) {
+			setAttributes( {
+				url: media.url,
+				id: media.id,
+				backgroundType: mediaType,
+			} );
+			return;
+		}
+		setAttributes( { url: media.url, id: media.id } );
+	}
+
+	render() {
+		const {
+			attributes,
+			className,
+			noticeOperations,
+			noticeUI,
+			overlayColor,
+			setAttributes,
+			setOverlayColor,
+		} = this.props;
+
+		const {
+			backgroundType,
+			dimRatio,
+			hasParallax,
+			id,
+			url,
+		} = attributes;
+
+		const toggleParallax = () => setAttributes( {
+			hasParallax: ! hasParallax,
+		} );
+		const setDimRatio = ( ratio ) => setAttributes( { dimRatio: ratio } );
+
+		const style = {
+			...(
+				backgroundType === IMAGE_BACKGROUND_TYPE ?
+					backgroundImageStyles( url ) :
+					{}
+			),
+			backgroundColor: overlayColor.color,
+		};
+
+		const classes = classnames(
+			className,
+			dimRatioToClass( dimRatio ),
+			{
+				'has-background-dim': dimRatio !== 0,
+				'has-parallax': hasParallax,
+			}
+		);
+
+		const controls = (
+			<Fragment>
+				{ !! url && (
+					<BlockControls>
+						<Toolbar>
+							<MediaUpload
+								onSelect={ this.onSelectMedia }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								value={ id }
+								render={ ( { open } ) => (
+									<IconButton
+										className="components-toolbar__control"
+										label={ __( 'Edit media' ) }
+										icon="edit"
+										onClick={ open }
+									/>
+								) }
+							/>
+						</Toolbar>
+					</BlockControls>
+				) }
+				{ !! url && (
+					<InspectorControls>
+						<PanelBody title={ __( 'Cover Settings' ) }>
+							{ IMAGE_BACKGROUND_TYPE === backgroundType && (
+								<ToggleControl
+									label={ __( 'Fixed Background' ) }
+									checked={ hasParallax }
+									onChange={ toggleParallax }
+								/>
+							) }
+							<PanelColorSettings
+								title={ __( 'Overlay' ) }
+								initialOpen={ true }
+								colorSettings={ [ {
+									value: overlayColor.color,
+									onChange: setOverlayColor,
+									label: __( 'Overlay Color' ),
+								} ] }
+							>
+								<RangeControl
+									label={ __( 'Background Opacity' ) }
+									value={ dimRatio }
+									onChange={ setDimRatio }
+									min={ 0 }
+									max={ 100 }
+									step={ 10 }
+								/>
+							</PanelColorSettings>
+						</PanelBody>
+					</InspectorControls>
+				) }
+			</Fragment>
+		);
+
+		if ( ! url ) {
+			const icon = 'format-image';
+			const label = ( 'Cover' );
+
+			return (
+				<Fragment>
+					{ controls }
+					<MediaPlaceholder
+						icon={ icon }
+						className={ className }
+						labels={ {
+							title: label,
+							name: __( 'an image or a video' ),
+						} }
+						onSelect={ this.onSelectMedia }
+						accept="image/*,video/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						notices={ noticeUI }
+						onError={ noticeOperations.createErrorNotice }
+					/>
+				</Fragment>
+			);
+		}
+
+		return (
+			<Fragment>
+				{ controls }
+				<div
+					data-url={ url }
+					style={ style }
+					className={ classes }
+				>
+					{ VIDEO_BACKGROUND_TYPE === backgroundType && url && (
+						<video
+							className="wp-block-cover__video-background"
+							autoPlay
+							muted
+							loop
+							src={ url }
+						/>
+					) }
+					<div className="wp-block-cover__inner-container">
+						<InnerBlocks
+							template={ INNER_BLOCKS_TEMPLATE }
+							allowedBlocks={ INNER_BLOCKS_ALLOWED_BLOCKS }
+						/>
+					</div>
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+export default compose( [
+	withColors( { overlayColor: 'background-color' } ),
+	withNotices,
+] )( CoverEdit );
+
+export function dimRatioToClass( ratio ) {
+	return ( ratio === 0 || ratio === 50 ) ?
+		null :
+		'has-background-dim-' + ( 10 * Math.round( ratio / 10 ) );
+}
+
+export function backgroundImageStyles( url ) {
+	return url ?
+		{ backgroundImage: `url(${ url })` } :
+		{};
+}

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -1,0 +1,3 @@
+.wp-block-cover__inner-container .editor-block-list__block {
+	color: inherit;
+}

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	InnerBlocks,
+	getColorClassName,
+} from '@wordpress/editor';
+
+const blockAttributes = {
+	title: {
+		source: 'html',
+		selector: 'p',
+	},
+	url: {
+		type: 'string',
+	},
+	id: {
+		type: 'number',
+	},
+	hasParallax: {
+		type: 'boolean',
+		default: false,
+	},
+	dimRatio: {
+		type: 'number',
+		default: 50,
+	},
+	overlayColor: {
+		type: 'string',
+	},
+	customOverlayColor: {
+		type: 'string',
+	},
+	backgroundType: {
+		type: 'string',
+		default: 'image',
+	},
+};
+
+export const name = 'core/cover';
+
+import {
+	default as CoverEdit,
+	IMAGE_BACKGROUND_TYPE,
+	VIDEO_BACKGROUND_TYPE,
+	dimRatioToClass,
+	backgroundImageStyles,
+} from './edit';
+
+export const settings = {
+	title: __( 'Cover' ),
+
+	description: __( 'Add a full-width image or video, and layer text over it — great for headers.' ),
+
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" /><path d="M0 0h24v24H0z" fill="none" /></svg>,
+
+	category: 'common',
+
+	attributes: blockAttributes,
+
+	supports: {
+		align: true,
+	},
+
+	edit: CoverEdit,
+
+	save( { attributes, className } ) {
+		const {
+			backgroundType,
+			customOverlayColor,
+			dimRatio,
+			hasParallax,
+			overlayColor,
+			url,
+		} = attributes;
+		const overlayColorClass = getColorClassName(
+			'background-color',
+			overlayColor
+		);
+		const style = backgroundType === IMAGE_BACKGROUND_TYPE ?
+			backgroundImageStyles( url ) :
+			{};
+		if ( ! overlayColorClass ) {
+			style.backgroundColor = customOverlayColor;
+		}
+
+		const classes = classnames(
+			className,
+			dimRatioToClass( dimRatio ),
+			overlayColorClass,
+			{
+				'has-background-dim': dimRatio !== 0,
+				'has-parallax': hasParallax,
+			},
+		);
+
+		return (
+			<div className={ classes } style={ style }>
+				{ VIDEO_BACKGROUND_TYPE === backgroundType && url && ( <video
+					className="wp-block-cover__video-background"
+					autoPlay
+					muted
+					loop
+					src={ url }
+				/> ) }
+				<div className="wp-block-cover__inner-container">
+					<InnerBlocks.Content />
+				</div>
+			</div>
+		);
+	},
+};

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -1,0 +1,71 @@
+.wp-block-cover,
+.wp-block-cover.alignleft,
+.wp-block-cover.aligncenter,
+.wp-block-cover.alignright,
+.wp-block-cover.alignwide,
+.wp-block-cover.alignfull {
+	display: flex;
+}
+
+.wp-block-cover {
+	position: relative;
+	background-color: $black;
+	background-size: cover;
+	background-position: center center;
+	min-height: 430px;
+	width: 100%;
+	margin: 0 0 1.5em 0;
+
+	justify-content: center;
+	align-items: center;
+
+	&.has-parallax {
+		background-attachment: fixed;
+	}
+
+	&.has-background-dim::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		background-color: inherit;
+		opacity: 0.5;
+		z-index: z-index(".wp-block-cover__inner-container");
+	}
+
+	@for $i from 1 through 10 {
+		&.has-background-dim.has-background-dim-#{ $i * 10 }::before {
+			opacity: $i * 0.1;
+		}
+	}
+
+	.wp-block-cover__inner-container {
+		width: calc(100% - 70px);
+		z-index: z-index(".wp-block-cover__inner-container");
+		color: $light-gray-100;
+	}
+
+	p,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	.wp-block-subhead {
+		color: inherit;
+	}
+}
+
+.wp-block-cover__video-background {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translateX(-50%) translateY(-50%);
+	width: 100%;
+	height: 100%;
+	z-index: z-index(".wp-block-cover__video-background");
+	object-fit: fill;
+}

--- a/packages/block-library/src/cover/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/index.js.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/cover-image block edit matches snapshot 1`] = `
+<div
+  class="components-placeholder editor-media-placeholder wp-block-cover-image"
+>
+  <div
+    class="components-placeholder__label"
+  >
+    <svg
+      aria-hidden="true"
+      class="dashicon dashicons-format-image"
+      focusable="false"
+      height="20"
+      role="img"
+      viewBox="0 0 20 20"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M2.25 1h15.5c.69 0 1.25.56 1.25 1.25v15.5c0 .69-.56 1.25-1.25 1.25H2.25C1.56 19 1 18.44 1 17.75V2.25C1 1.56 1.56 1 2.25 1zM17 17V3H3v14h14zM10 6c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2 2-.9 2-2zm3 5s0-6 3-6v10c0 .55-.45 1-1 1H5c-.55 0-1-.45-1-1V8c2 0 3 4 3 4s1-3 3-3 3 2 3 2z"
+      />
+    </svg>
+    Cover Image
+  </div>
+  <div
+    class="components-placeholder__instructions"
+  >
+    Drag an image, upload a new one or select a file from your library.
+  </div>
+  <div
+    class="components-placeholder__fieldset"
+  >
+    <div
+      class="components-drop-zone"
+    >
+      <div
+        class="components-drop-zone__content"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload components-drop-zone__content-icon"
+          focusable="false"
+          height="40"
+          role="img"
+          viewBox="0 0 20 20"
+          width="40"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        <span
+          class="components-drop-zone__content-text"
+        >
+          Drop files to upload
+        </span>
+      </div>
+    </div>
+    <div
+      class="components-form-file-upload"
+    >
+      <button
+        class="components-button components-icon-button editor-media-placeholder__upload-button is-button is-default is-large"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload"
+          focusable="false"
+          height="20"
+          role="img"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        Upload
+      </button>
+      <input
+        accept="image/*"
+        style="display:none"
+        type="file"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/block-library/src/cover/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/index.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`core/cover-image block edit matches snapshot 1`] = `
+exports[`core/cover block edit matches snapshot 1`] = `
 <div
-  class="components-placeholder editor-media-placeholder wp-block-cover-image"
+  class="components-placeholder editor-media-placeholder wp-block-cover"
 >
   <div
     class="components-placeholder__label"
@@ -21,12 +21,12 @@ exports[`core/cover-image block edit matches snapshot 1`] = `
         d="M2.25 1h15.5c.69 0 1.25.56 1.25 1.25v15.5c0 .69-.56 1.25-1.25 1.25H2.25C1.56 19 1 18.44 1 17.75V2.25C1 1.56 1.56 1 2.25 1zM17 17V3H3v14h14zM10 6c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2 2-.9 2-2zm3 5s0-6 3-6v10c0 .55-.45 1-1 1H5c-.55 0-1-.45-1-1V8c2 0 3 4 3 4s1-3 3-3 3 2 3 2z"
       />
     </svg>
-    Cover Image
+    Cover
   </div>
   <div
     class="components-placeholder__instructions"
   >
-    Drag an image, upload a new one or select a file from your library.
+    Drag an image or a video, upload a new one or select a file from your library.
   </div>
   <div
     class="components-placeholder__fieldset"
@@ -82,7 +82,7 @@ exports[`core/cover-image block edit matches snapshot 1`] = `
         Upload
       </button>
       <input
-        accept="image/*"
+        accept="image/*,video/*"
         style="display:none"
         type="file"
       />

--- a/packages/block-library/src/cover/test/index.js
+++ b/packages/block-library/src/cover/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { name, settings } from '../';
+import { blockEditRender } from '../../test/helpers';
+
+describe( 'core/cover', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( name, settings );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -4,6 +4,7 @@
 @import "./categories/editor.scss";
 @import "./code/editor.scss";
 @import "./columns/editor.scss";
+@import "./cover/editor.scss";
 @import "./cover-image/editor.scss";
 @import "./embed/editor.scss";
 @import "./file/editor.scss";

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -24,6 +24,7 @@ import * as categories from './categories';
 import * as code from './code';
 import * as columns from './columns';
 import * as column from './columns/column';
+import * as cover from './cover';
 import * as coverImage from './cover-image';
 import * as embed from './embed';
 import * as file from './file';
@@ -69,6 +70,7 @@ export const registerCoreBlocks = () => {
 		code,
 		columns,
 		column,
+		cover,
 		coverImage,
 		embed,
 		...embed.common,

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -4,6 +4,7 @@
 @import "./button/style.scss";
 @import "./categories/style.scss";
 @import "./columns/style.scss";
+@import "./cover/style.scss";
 @import "./cover-image/style.scss";
 @import "./embed/style.scss";
 @import "./file/style.scss";

--- a/test/integration/full-content/fixtures/core__cover.html
+++ b/test/integration/full-content/fixtures/core__cover.html
@@ -1,0 +1,9 @@
+<!-- wp:cover {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
+<div class="wp-block-cover has-background-dim has-background-dim-40" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)">
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p style="text-align:center" class="has-large-font-size">Cover!</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/test/integration/full-content/fixtures/core__cover.json
+++ b/test/integration/full-content/fixtures/core__cover.json
@@ -1,0 +1,31 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/cover",
+        "isValid": true,
+        "attributes": {
+            "title": "",
+            "url": "https://cldup.com/uuUqE_dXzy.jpg",
+            "hasParallax": false,
+            "dimRatio": 40,
+            "backgroundType": "image"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "Cover!",
+                    "align": "center",
+                    "dropCap": false,
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p style=\"text-align:center\" class=\"has-large-font-size\">Cover!</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-cover has-background-dim has-background-dim-40\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/test/integration/full-content/fixtures/core__cover.parsed.json
+++ b/test/integration/full-content/fixtures/core__cover.parsed.json
@@ -1,0 +1,28 @@
+[
+    {
+        "blockName": "core/cover",
+        "attrs": {
+            "url": "https://cldup.com/uuUqE_dXzy.jpg",
+            "dimRatio": 40
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "center",
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p style=\"text-align:center\" class=\"has-large-font-size\">Cover!</p>\n\t\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-cover has-background-dim has-background-dim-40\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__cover.serialized.html
+++ b/test/integration/full-content/fixtures/core__cover.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:cover {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
+<div class="wp-block-cover has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p style="text-align:center" class="has-large-font-size">Cover!</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->


### PR DESCRIPTION
## Description
This PR adds a Cover block that is based on the cover image block.
The differences between this PR and the cover image is that this new block uses nesting (simplifying a lot the styles) and this PR allows background videos.

The Cover Image block was deprecated, no automatic migration exists but it should not be possible to insert new Cover Images (the same approach followed on the text columns to columns migration).

To do: transforms.

## How has this been tested?
Verify it is not possible to insert the cover image block.
Add the cover block verify it contains the same functionality offered in the cover image.
Verify now we can use videos as the background.
Verify the video background functionality works correctly on the editor and on the front end.

## Screenshots <!-- if applicable -->
![oct-16-2018 00-42-10](https://user-images.githubusercontent.com/11271197/46984299-6c1ca800-d0dc-11e8-876e-a745ea80c7a8.gif)

