### PR TITLE
Defer fetching non-hierarchical terms in FlatTermSelector

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -60,7 +60,6 @@ class FlatTermSelector extends Component {
 				}
 			);
 		}
-		this.searchTerms();
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
Fixes #10274

Remove call that fetches terms on `componentDidMount()`, delaying request for non-hierarchical terms until user input is provided. 

Tested using [the criteria suggested](https://github.com/WordPress/gutenberg/issues/10274#issuecomment-429936629) by @aduth:
- [x] Existing assigned tags are loaded and displayed on load
- [x] Request is made and subsequent results are shown upon input in the field