### PR TITLE
Table Block: Avoid redirecting when creating a new table block

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -77,8 +77,12 @@ export default class TableEdit extends Component {
 
 	/**
 	 * Creates a table based on dimensions in local state.
+	 *
+	 * @param {Object} event Form submit event.
 	 */
-	onCreateTable() {
+	onCreateTable( event ) {
+		event.preventDefault();
+
 		const { setAttributes } = this.props;
 		let { initialRowCount, initialColumnCount } = this.state;
 


### PR DESCRIPTION
closes #10254

**Testing instructions**

 - Repeat testing instructions from #10254  in Safari.