### PR TITLE
MediaUpload: Fix insesrting images with captions

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -24,7 +24,6 @@ import {
 	mediaUpload,
 } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
-import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -81,7 +80,7 @@ class FileEdit extends Component {
 			this.setState( { hasError: false } );
 			this.props.setAttributes( {
 				href: media.url,
-				fileName: create( { text: media.title } ),
+				fileName: media.title,
 				textLinkHref: media.url,
 				id: media.id,
 			} );

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -26,7 +26,6 @@ import {
 	InspectorControls,
 	mediaUpload,
 } from '@wordpress/editor';
-import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -46,15 +45,8 @@ export function defaultColumnsNumber( attributes ) {
 }
 
 export const pickRelevantMediaFiles = ( image ) => {
-	let { caption } = image;
-
-	if ( typeof caption !== 'object' ) {
-		caption = create( { html: caption } );
-	}
-
 	return {
-		...pick( image, [ 'alt', 'id', 'link', 'url' ] ),
-		caption,
+		...pick( image, [ 'alt', 'id', 'link', 'url', 'caption' ] ),
 	};
 };
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -40,7 +40,6 @@ import {
 } from '@wordpress/editor';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose } from '@wordpress/compose';
-import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -58,15 +57,8 @@ const LINK_DESTINATION_CUSTOM = 'custom';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 export const pickRelevantMediaFiles = ( image ) => {
-	let { caption } = image;
-
-	if ( typeof caption !== 'object' ) {
-		caption = create( { html: caption } );
-	}
-
 	return {
-		...pick( image, [ 'alt', 'id', 'link', 'url' ] ),
-		caption,
+		...pick( image, [ 'alt', 'id', 'link', 'url', 'caption' ] ),
 	};
 };
 
@@ -130,7 +122,7 @@ class ImageEdit extends Component {
 				url: undefined,
 				alt: undefined,
 				id: undefined,
-				caption: create(),
+				caption: '',
 			} );
 			return;
 		}

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -17,7 +17,6 @@ import {
 	RichText,
 } from '@wordpress/editor';
 import deprecated from '@wordpress/deprecated';
-import { create } from '@wordpress/rich-text';
 
 export const name = 'core/text-columns';
 
@@ -47,10 +46,10 @@ export const settings = {
 			},
 			default: [
 				{
-					children: create(),
+					children: '',
 				},
 				{
-					children: create(),
+					children: '',
 				},
 			],
 		},

--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -6,7 +6,6 @@ import { castArray, pick } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { parseWithAttributeSchema } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import deprecated from '@wordpress/deprecated';
@@ -91,7 +90,6 @@ class MediaUpload extends Component {
 		this.onSelect = this.onSelect.bind( this );
 		this.onUpdate = this.onUpdate.bind( this );
 		this.onClose = this.onClose.bind( this );
-		this.processMediaCaption = this.processMediaCaption.bind( this );
 
 		let allowedTypesToUse = allowedTypes;
 		if ( ! allowedTypes && deprecatedType ) {
@@ -162,9 +160,9 @@ class MediaUpload extends Component {
 		}
 
 		if ( multiple ) {
-			onSelect( selectedImages.models.map( ( model ) => this.processMediaCaption( slimImageObject( model.toJSON() ) ) ) );
+			onSelect( selectedImages.models.map( ( model ) => slimImageObject( model.toJSON() ) ) );
 		} else {
-			onSelect( this.processMediaCaption( slimImageObject( ( selectedImages.models[ 0 ].toJSON() ) ) ) );
+			onSelect( slimImageObject( ( selectedImages.models[ 0 ].toJSON() ) ) );
 		}
 	}
 
@@ -172,11 +170,7 @@ class MediaUpload extends Component {
 		const { onSelect, multiple = false } = this.props;
 		// Get media attachment details from the frame state
 		const attachment = this.frame.state().get( 'selection' ).toJSON();
-		onSelect(
-			multiple ?
-				attachment.map( this.processMediaCaption ) :
-				this.processMediaCaption( attachment[ 0 ] )
-		);
+		onSelect( multiple ? attachment : attachment[ 0 ] );
 	}
 
 	onOpen() {
@@ -203,14 +197,6 @@ class MediaUpload extends Component {
 
 	openModal() {
 		this.frame.open();
-	}
-
-	processMediaCaption( mediaObject ) {
-		return ! mediaObject.caption ?
-			mediaObject :
-			{ ...mediaObject, caption: parseWithAttributeSchema( mediaObject.caption, {
-				source: 'rich-text',
-			} ) };
 	}
 
 	render() {


### PR DESCRIPTION
closes #10597

This PR removes all the specific "rich-text" format handling we were doing for media uploads. We just consider the caption of images as HTML strings.

This fixes inserting images with captions from the Media Library

**Testing instructions**

 - Repeat instructions from #10597