### PR TITLE
Handle blocks passing null as RichText value

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -221,8 +221,12 @@ export default class TinyMCE extends Component {
 		// us to show and focus the content before it's truly ready to edit.
 		let initialHTML = defaultValue;
 
+		// Guard for blocks passing `null` in onSplit callbacks. May be removed
+		// if onSplit is revised to not pass a `null` value.
+		if ( defaultValue === null ) {
+			initialHTML = '';
 		// Handle deprecated `children` and `node` sources.
-		if ( Array.isArray( defaultValue ) ) {
+		} else if ( Array.isArray( defaultValue ) ) {
 			initialHTML = children.toHTML( defaultValue );
 		} else if ( typeof defaultValue !== 'string' ) {
 			initialHTML = toHTMLString( defaultValue, multilineTag );


### PR DESCRIPTION
## Description

Fix for bug reported by @mcsf to me.

Steps to reproduce:

* Copy some text that is more than one line (e.g. a few paragraphs).
* Create a list in Gutenberg, or a heading and type something.
* Paste you clipboard contents at the very start of very end of the rich text area.

Inside RichText, this will cause `onSplit` to be called with `null` as the first or second argument. Some blocks are passing this value directly to `setAttributes` which is then put into `RichText`. The fix would be to detect `null` and use an empty string. We already do this inside `RichText`, but not for the initial value in the nested `TinyMCE` component.

https://github.com/WordPress/gutenberg/blob/0c4196574bfba740dbc8e6f212f28d2f2ac28531/packages/editor/src/components/rich-text/index.js#L817-L821

## How has this been tested?
See above.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->