### PR TITLE
RichText: own undo signalling

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -418,14 +418,13 @@ export class RichText extends Component {
 	 * Sync the value to global state. The node tree and selection will also be
 	 * updated if differences are found.
 	 *
-	 * @param {Object}  record        The record to sync and apply.
-	 * @param {boolean} _withoutApply If true, the record won't be applied to
-	 *                                the live DOM.
+	 * @param {Object}  record            The record to sync and apply.
+	 * @param {Object}  $2                Named options.
+	 * @param {boolean} $2.withoutHistory If true, no undo level will be
+	 *                                    created.
 	 */
-	onChange( record, { withoutHistory, _withoutApply } = {} ) {
-		if ( ! _withoutApply ) {
-			this.applyRecord( record );
-		}
+	onChange( record, { withoutHistory } = {} ) {
+		this.applyRecord( record );
 
 		const { start, end } = record;
 
@@ -604,7 +603,7 @@ export class RichText extends Component {
 		// The input event does not fire when the whole field is selected and
 		// BACKSPACE is pressed.
 		if ( keyCode === BACKSPACE ) {
-			this.onChange( this.createRecord(), true );
+			this.onChange( this.createRecord() );
 		}
 
 		// `scrollToRect` is called on `nodechange`, whereas calling it on

--- a/packages/editor/src/components/rich-text/remove-browser-shortcuts.js
+++ b/packages/editor/src/components/rich-text/remove-browser-shortcuts.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { fromPairs } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { rawShortcut } from '@wordpress/keycodes';
+import { KeyboardShortcuts } from '@wordpress/components';
+
+/**
+ * Set of keyboard shortcuts handled internally by RichText.
+ *
+ * @type {Array}
+ */
+const HANDLED_SHORTCUTS = [
+	rawShortcut.primary( 'z' ),
+	rawShortcut.primaryShift( 'z' ),
+	rawShortcut.primary( 'y' ),
+];
+
+/**
+ * An instance of a KeyboardShortcuts element pre-bound for the handled
+ * shortcuts. Since shortcuts never change, the element can be considered
+ * static, and can be skipped in reconciliation.
+ *
+ * @type {WPElement}
+ */
+const SHORTCUTS_ELEMENT = (
+	<KeyboardShortcuts
+		bindGlobal
+		shortcuts={ fromPairs( HANDLED_SHORTCUTS.map( ( shortcut ) => {
+			return [ shortcut, ( event ) => event.preventDefault() ];
+		} ) ) }
+	/>
+);
+
+/**
+ * Component which registered keyboard event handlers to prevent default
+ * behaviors for key combinations otherwise handled internally by RichText.
+ *
+ * @return {WPElement} WordPress element.
+ */
+export const RemoveBrowserShortcuts = () => SHORTCUTS_ELEMENT;

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -221,7 +221,18 @@ export default class TinyMCE extends Component {
 				} );
 
 				editor.on( 'init', () => {
-					// See https://github.com/tinymce/tinymce/blob/master/src/core/main/ts/keyboard/FormatShortcuts.ts
+					// History is handled internally by RichText.
+					//
+					// See: https://github.com/tinymce/tinymce/blob/master/src/core/main/ts/api/UndoManager.ts
+					[ 'z', 'y' ].forEach( ( character ) => {
+						editor.shortcuts.remove( `meta+${ character }` );
+					} );
+					editor.shortcuts.remove( 'meta+shift+z' );
+
+					// Reset TinyMCE's default formatting shortcuts, since
+					// RichText supports only registered formats.
+					//
+					// See: https://github.com/tinymce/tinymce/blob/master/src/core/main/ts/keyboard/FormatShortcuts.ts
 					[ 'b', 'i', 'u' ].forEach( ( character ) => {
 						editor.shortcuts.remove( `meta+${ character }` );
 					} );
@@ -229,6 +240,7 @@ export default class TinyMCE extends Component {
 						editor.shortcuts.remove( `access+${ number }` );
 					} );
 
+					// Restore the original `setHTML` once initialized.
 					editor.dom.setHTML = setHTML;
 				} );
 

--- a/test/e2e/specs/__snapshots__/undo.test.js.snap
+++ b/test/e2e/specs/__snapshots__/undo.test.js.snap
@@ -16,7 +16,7 @@ exports[`undo Should undo to expected level intervals 1`] = `
 
 exports[`undo should undo typing after arrow navigation 1`] = `
 "<!-- wp:paragraph -->
-<p>before keyboar after keyboardd</p>
+<p>before keyboard after keyboard</p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/test/e2e/specs/__snapshots__/undo.test.js.snap
+++ b/test/e2e/specs/__snapshots__/undo.test.js.snap
@@ -13,3 +13,39 @@ exports[`undo Should undo to expected level intervals 1`] = `
 <p>test</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`undo should undo typing after arrow navigation 1`] = `
+"<!-- wp:paragraph -->
+<p>before keyboar after keyboardd</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`undo should undo typing after arrow navigation 2`] = `
+"<!-- wp:paragraph -->
+<p>before keyboard</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`undo should undo typing after mouse move 1`] = `
+"<!-- wp:paragraph -->
+<p>before move after move</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`undo should undo typing after mouse move 2`] = `
+"<!-- wp:paragraph -->
+<p>before move</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`undo should undo typing after non input change 1`] = `
+"<!-- wp:paragraph -->
+<p>before keyboard <strong>after keyboard</strong></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`undo should undo typing after non input change 2`] = `
+"<!-- wp:paragraph -->
+<p>before keyboard </p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/__snapshots__/undo.test.js.snap
+++ b/test/e2e/specs/__snapshots__/undo.test.js.snap
@@ -14,27 +14,15 @@ exports[`undo Should undo to expected level intervals 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`undo should undo typing after arrow navigation 1`] = `
+exports[`undo should undo typing after a pause 1`] = `
 "<!-- wp:paragraph -->
-<p>before keyboard after keyboard</p>
+<p>before pause after pause</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`undo should undo typing after arrow navigation 2`] = `
+exports[`undo should undo typing after a pause 2`] = `
 "<!-- wp:paragraph -->
-<p>before keyboard</p>
-<!-- /wp:paragraph -->"
-`;
-
-exports[`undo should undo typing after mouse move 1`] = `
-"<!-- wp:paragraph -->
-<p>before move after move</p>
-<!-- /wp:paragraph -->"
-`;
-
-exports[`undo should undo typing after mouse move 2`] = `
-"<!-- wp:paragraph -->
-<p>before move</p>
+<p>before pause</p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/test/e2e/specs/undo.test.js
+++ b/test/e2e/specs/undo.test.js
@@ -46,7 +46,7 @@ describe( 'undo', () => {
 		await clickBlockAppender();
 
 		await page.keyboard.type( 'before keyboard' );
-		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( ' after keyboard' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/test/e2e/specs/undo.test.js
+++ b/test/e2e/specs/undo.test.js
@@ -10,8 +10,50 @@ import {
 } from '../support/utils';
 
 describe( 'undo', () => {
-	beforeAll( async () => {
+	beforeEach( async () => {
 		await newPost();
+	} );
+
+	it( 'should undo typing after mouse move', async () => {
+		await clickBlockAppender();
+
+		await page.keyboard.type( 'before move' );
+		await page.mouse.down();
+		await page.keyboard.type( ' after move' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressWithModifier( META_KEY, 'z' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should undo typing after non input change', async () => {
+		await clickBlockAppender();
+
+		await page.keyboard.type( 'before keyboard ' );
+		await pressWithModifier( META_KEY, 'b' );
+		await page.keyboard.type( 'after keyboard' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressWithModifier( META_KEY, 'z' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should undo typing after arrow navigation', async () => {
+		await clickBlockAppender();
+
+		await page.keyboard.type( 'before keyboard' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.type( ' after keyboard' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressWithModifier( META_KEY, 'z' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	it( 'Should undo to expected level intervals', async () => {

--- a/test/e2e/specs/undo.test.js
+++ b/test/e2e/specs/undo.test.js
@@ -14,12 +14,12 @@ describe( 'undo', () => {
 		await newPost();
 	} );
 
-	it( 'should undo typing after mouse move', async () => {
+	it( 'should undo typing after a pause', async () => {
 		await clickBlockAppender();
 
-		await page.keyboard.type( 'before move' );
-		await page.mouse.down();
-		await page.keyboard.type( ' after move' );
+		await page.keyboard.type( 'before pause' );
+		await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+		await page.keyboard.type( ' after pause' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
@@ -34,20 +34,6 @@ describe( 'undo', () => {
 		await page.keyboard.type( 'before keyboard ' );
 		await pressWithModifier( META_KEY, 'b' );
 		await page.keyboard.type( 'after keyboard' );
-
-		expect( await getEditedPostContent() ).toMatchSnapshot();
-
-		await pressWithModifier( META_KEY, 'z' );
-
-		expect( await getEditedPostContent() ).toMatchSnapshot();
-	} );
-
-	it( 'should undo typing after arrow navigation', async () => {
-		await clickBlockAppender();
-
-		await page.keyboard.type( 'before keyboard' );
-		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.type( ' after keyboard' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 


### PR DESCRIPTION
## Description

This is a proposal for the `RichText` component to handle undo signalling in favour of listening to the TinyMCE `change` event.

`RichText` will signal that an undo level should be created:

* When the user changes the value, except when it comes from the `input` event (typing).
* When there is over a second pause between input events (typing).

Why?

It's not always clear when the `change` event exactly triggers and we do not always want it to create an undo level. The `change` event also no longer accounts for formatting changes, as these are no longer done by TinyMCE. It's easier to just do it ourselves so we can fine-tune and not rely on the TinyMCE event.

## How has this been tested?
Test undoing and redoing changes from `RichText` components.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->