### PR TITLE
Use `currentcolor` as border-color for outline button style

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -35,6 +35,7 @@ $blocks-button__line-height: $big-font-size + 6px;
 
 .wp-block-button__link:not(.has-background) {
 	background-color: $dark-gray-700;
+
 	&:hover,
 	&:focus,
 	&:active {
@@ -51,13 +52,6 @@ $blocks-button__line-height: $big-font-size + 6px;
 		&:focus,
 		&:active {
 			border-color: currentcolor;
-		}
-
-		// If a background color is set, always ignore it for the
-		// outline button style. (`!important` is necessary to
-		// override an inline "style" attribute, if one is set.)
-		&.has-background {
-			background: transparent !important;
 		}
 	}
 

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -45,64 +45,25 @@ $blocks-button__line-height: $big-font-size + 6px;
 .wp-block-button.is-style-outline {
 	.wp-block-button__link {
 		background: transparent;
-		border: 2px solid transparent;
+		border: 2px solid currentcolor;
 
-		&.has-pale-pink-background-color {
-			border-color: #f78da7;
-		}
-
-		&.has-vivid-red-background-color {
-			border-color: #cf2e2e;
-		}
-
-		&.has-luminous-vivid-orange-background-color {
-			border-color: #ff6900;
-		}
-
-		&.has-luminous-vivid-amber-background-color {
-			border-color: #fcb900;
-		}
-
-		&.has-light-green-cyan-background-color {
-			border-color: #7bdcb5;
-		}
-
-		&.has-vivid-green-cyan-background-color {
-			border-color: #00d084;
-		}
-
-		&.has-pale-cyan-blue-background-color {
-			border-color: #8ed1fc;
-		}
-
-		&.has-vivid-cyan-blue-background-color {
-			border-color: #0693e3;
-		}
-
-		&.has-very-light-gray-background-color {
-			border-color: #eee;
-		}
-
-		&.has-cyan-bluish-gray-background-color {
-			border-color: #abb8c3;
-		}
-
-		&.has-very-dark-gray-background-color {
-			border-color: #313131;
-		}
-	}
-
-	.wp-block-button__link:not(.has-background) {
-		border-color: $dark-gray-700;
 		&:hover,
 		&:focus,
 		&:active {
-			border-color: $dark-gray-700;
+			border-color: currentcolor;
+		}
+
+		// If a background color is set, always ignore it for the
+		// outline button style. (`!important` is necessary to
+		// override an inline "style" attribute, if one is set.)
+		&.has-background {
+			background: transparent !important;
 		}
 	}
 
 	.wp-block-button__link:not(.has-text-color) {
 		color: $dark-gray-700;
+
 		&:hover,
 		&:focus,
 		&:active {
@@ -113,6 +74,7 @@ $blocks-button__line-height: $big-font-size + 6px;
 
 .wp-block-button__link:not(.has-text-color) {
 	color: $white;
+
 	&:hover,
 	&:focus,
 	&:active {


### PR DESCRIPTION
This updates the "Outline" button style to use `currentcolor`—aka the current text color—as the border color, per a @mtias [comment in Slack](https://wordpress.slack.com/archives/C02QB2JS7/p1539699415000100?thread_ts=1539697773.000100&cid=C02QB2JS7) (I'm considering that comment "design feedback" but I'm also happy to request additional feedback if desired.)

To override a potential inline `style` attribute, an `!important` is unfortunately required. I think this is acceptable in this case but I'm also open to other ideas!

## Screenshot

![edit_page_ _tomodomo_ _wordpress](https://user-images.githubusercontent.com/1231306/47037567-36fc6e00-d14d-11e8-9bc3-a54fc21d3373.png)