### PR TITLE
Restore the order of actions usually fired in edit-form-advanced.php

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -211,6 +211,7 @@ function gutenberg_init( $return, $post ) {
 	 * includes/meta-boxes is typically loaded from edit-form-advanced.php.
 	 */
 	require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
+	gutenberg_collect_meta_box_data();
 
 	require_once ABSPATH . 'wp-admin/admin-header.php';
 	the_gutenberg_project();

--- a/lib/register.php
+++ b/lib/register.php
@@ -10,26 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Set up global variables so that plugins will add meta boxes as if we were
- * using the main editor.
- *
- * @since 1.5.0
- */
-function gutenberg_trick_plugins_into_registering_meta_boxes() {
-	global $pagenow;
-
-	if ( in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) && ! isset( $_REQUEST['classic-editor'] ) ) {
-		// As early as possible, but after any plugins ( ACF ) that adds meta boxes.
-		add_action( 'admin_head', 'gutenberg_collect_meta_box_data', 99 );
-	}
-}
-// As late as possible, but before any logic that adds meta boxes.
-add_action(
-	'plugins_loaded',
-	'gutenberg_trick_plugins_into_registering_meta_boxes'
-);
-
-/**
  * Collect information about meta_boxes registered for the current post.
  *
  * Redirects to classic editor if a meta box is incompatible.


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
As described in #4929, the actions usually in edit-form-advanced.php are delayed by Gutenberg. This PR  aims to restore the same order as in WordPress 4.9. Thus:
`dbx_post_advanced`
`add_meta_boxes`
`add_meta_boxes_{$post_type}`
`do_meta_boxes`
`edit_form_advanced`
 are fired before `admin_enqueue_scripts` instead of after `admin_head`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I aimed to test the changes with a few plugins adding metaboxes:
* ACF 5.7.7
* CMB2 2.4.2
* Metabox 4.15.5
* Polylang 2.3.11

Note: ACF seems to be broken in the current development version of Gutenberg (Updating the post does not save the ACF values). This PR does change the result. ACF was working correctly with Gutenberg 3.9. So I assume that the current version of Gutenberg breaks ACF in a way which not related to this issue.

All metaboxes of other plugins seem to work correctly before and after applying this PR . I can correctly change values and changes are applied when saving the post.

A broken functionality of Polylang is restored by this PR (importing taxonomies and metas from an original post when creating a new translations). This functionnality is not related to the visible aspect of metaboxes but uses the `add_meta_boxes` action to work. 

Fixes #4929

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
