### PR TITLE
Change Block Renderer Endpoint

### DIFF
--- a/lib/class-wp-rest-block-renderer-controller.php
+++ b/lib/class-wp-rest-block-renderer-controller.php
@@ -21,7 +21,7 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 	 * @access public
 	 */
 	public function __construct() {
-		$this->namespace = 'gutenberg/v1';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-renderer';
 	}
 

--- a/packages/components/src/server-side-render/index.js
+++ b/packages/components/src/server-side-render/index.js
@@ -21,7 +21,7 @@ import Placeholder from '../placeholder';
 import Spinner from '../spinner';
 
 export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
-	return addQueryArgs( `/gutenberg/v1/block-renderer/${ block }`, {
+	return addQueryArgs( `/wp/v2/block-renderer/${ block }`, {
 		context: 'edit',
 		...( null !== attributes ? { attributes } : {} ),
 		...urlQueryArgs,

--- a/packages/components/src/server-side-render/test/index.js
+++ b/packages/components/src/server-side-render/test/index.js
@@ -2,8 +2,8 @@ import { rendererPath } from '../index';
 
 describe( 'rendererPath', function() {
 	test( 'should return an base path for empty input', function() {
-		expect( rendererPath( 'core/test-block', null ) ).toBe( '/gutenberg/v1/block-renderer/core/test-block?context=edit' );
-		expect( rendererPath( 'core/test-block' ) ).toBe( '/gutenberg/v1/block-renderer/core/test-block?context=edit' );
+		expect( rendererPath( 'core/test-block', null ) ).toBe( '/wp/v2/block-renderer/core/test-block?context=edit' );
+		expect( rendererPath( 'core/test-block' ) ).toBe( '/wp/v2/block-renderer/core/test-block?context=edit' );
 	} );
 
 	test( 'should format basic url params ', function() {
@@ -15,7 +15,7 @@ describe( 'rendererPath', function() {
 				numberArg: 123,
 			} )
 		).toBe(
-			'/gutenberg/v1/block-renderer/core/test-block?context=edit&attributes%5BstringArg%5D=test&attributes%5BnullArg%5D=&attributes%5BemptyArg%5D=&attributes%5BnumberArg%5D=123',
+			'/wp/v2/block-renderer/core/test-block?context=edit&attributes%5BstringArg%5D=test&attributes%5BnullArg%5D=&attributes%5BemptyArg%5D=&attributes%5BnumberArg%5D=123',
 		);
 	} );
 
@@ -28,7 +28,7 @@ describe( 'rendererPath', function() {
 				},
 			} )
 		).toBe(
-			'/gutenberg/v1/block-renderer/core/test-block?context=edit&attributes%5BobjectArg%5D%5BstringProp%5D=test&attributes%5BobjectArg%5D%5BnumberProp%5D=123',
+			'/wp/v2/block-renderer/core/test-block?context=edit&attributes%5BobjectArg%5D%5BstringProp%5D=test&attributes%5BobjectArg%5D%5BnumberProp%5D=123',
 		);
 	} );
 
@@ -49,7 +49,7 @@ describe( 'rendererPath', function() {
 				],
 			} )
 		).toBe(
-			'/gutenberg/v1/block-renderer/core/test-block?context=edit&attributes%5Bchildren%5D%5B0%5D%5Bname%5D=bobby&attributes%5Bchildren%5D%5B0%5D%5Bage%5D=12&attributes%5Bchildren%5D%5B0%5D%5Bsex%5D=M&attributes%5Bchildren%5D%5B1%5D%5Bname%5D=sally&attributes%5Bchildren%5D%5B1%5D%5Bage%5D=8&attributes%5Bchildren%5D%5B1%5D%5Bsex%5D=F',
+			'/wp/v2/block-renderer/core/test-block?context=edit&attributes%5Bchildren%5D%5B0%5D%5Bname%5D=bobby&attributes%5Bchildren%5D%5B0%5D%5Bage%5D=12&attributes%5Bchildren%5D%5B0%5D%5Bsex%5D=M&attributes%5Bchildren%5D%5B1%5D%5Bname%5D=sally&attributes%5Bchildren%5D%5B1%5D%5Bage%5D=8&attributes%5Bchildren%5D%5B1%5D%5Bsex%5D=F',
 		);
 	} );
 
@@ -64,7 +64,7 @@ describe( 'rendererPath', function() {
 				}
 			)
 		).toBe(
-			'/gutenberg/v1/block-renderer/core/test-block?context=edit&attributes%5BstringArg%5D=test&id=1234',
+			'/wp/v2/block-renderer/core/test-block?context=edit&attributes%5BstringArg%5D=test&id=1234',
 		);
 	} );
 } );

--- a/phpunit/class-rest-block-renderer-controller-test.php
+++ b/phpunit/class-rest-block-renderer-controller-test.php
@@ -13,6 +13,13 @@
 class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 	/**
+	 * The REST API route for the block renderer.
+	 *
+	 * @var string
+	 */
+	protected static $rest_api_route = '/wp/v2/block-renderer/';
+
+	/**
 	 * Test block's name.
 	 *
 	 * @var string
@@ -169,7 +176,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 
 		$routes = rest_get_server()->get_routes();
 		foreach ( $dynamic_block_names as $dynamic_block_name ) {
-			$this->assertArrayHasKey( "/gutenberg/v1/block-renderer/(?P<name>$dynamic_block_name)", $routes );
+			$this->assertArrayHasKey( self::$rest_api_route . "(?P<name>$dynamic_block_name)", $routes );
 		}
 	}
 
@@ -181,7 +188,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_get_item_without_permissions() {
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$block_name );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );
 		$request->set_param( 'context', 'edit' );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -195,7 +202,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_get_item_with_invalid_context() {
 		wp_set_current_user( self::$user_id );
 
-		$request  = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$block_name );
+		$request  = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
@@ -208,7 +215,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	 */
 	public function test_get_item_invalid_block_name() {
 		wp_set_current_user( self::$user_id );
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/core/123' );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . 'core/123' );
 
 		$request->set_param( 'context', 'edit' );
 		$response = rest_get_server()->dispatch( $request );
@@ -223,7 +230,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	 */
 	public function test_get_item_invalid_attribute() {
 		wp_set_current_user( self::$user_id );
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$block_name );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );
 		$request->set_param( 'context', 'edit' );
 		$request->set_param(
 			'attributes',
@@ -242,7 +249,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	 */
 	public function test_get_item_unrecognized_attribute() {
 		wp_set_current_user( self::$user_id );
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$block_name );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );
 		$request->set_param( 'context', 'edit' );
 		$request->set_param(
 			'attributes',
@@ -268,7 +275,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 			$defaults[ $key ] = isset( $attribute['default'] ) ? $attribute['default'] : null;
 		}
 
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$block_name );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );
 		$request->set_param( 'context', 'edit' );
 		$request->set_param( 'attributes', array() );
 		$response = rest_get_server()->dispatch( $request );
@@ -301,7 +308,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$expected_attributes['some_int']   = (int) $expected_attributes['some_int'];
 		$expected_attributes['some_array'] = array_map( 'intval', $expected_attributes['some_array'] );
 
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$block_name );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );
 		$request->set_param( 'context', 'edit' );
 		$request->set_param( 'attributes', $attributes );
 		$response = rest_get_server()->dispatch( $request );
@@ -327,7 +334,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 			'layout' => 'foo',
 		);
 
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$block_name );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );
 		$request->set_param( 'context', 'edit' );
 		$request->set_param( 'attributes', $attributes );
 		$response = rest_get_server()->dispatch( $request );
@@ -341,7 +348,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		wp_set_current_user( self::$user_id );
 
 		$expected_title = 'Test Post';
-		$request        = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$context_block_name );
+		$request        = new WP_REST_Request( 'GET', self::$rest_api_route . self::$context_block_name );
 		$request->set_param( 'context', 'edit' );
 
 		// Test without post ID.
@@ -368,7 +375,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_get_item_without_permissions_invalid_post() {
 		wp_set_current_user( self::$user_id );
 
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$context_block_name );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$context_block_name );
 		$request->set_param( 'context', 'edit' );
 
 		// Test with invalid post ID.
@@ -384,7 +391,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_get_item_without_permissions_cannot_edit_post() {
 		wp_set_current_user( self::$author_id );
 
-		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/block-renderer/' . self::$context_block_name );
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$context_block_name );
 		$request->set_param( 'context', 'edit' );
 
 		// Test with private post ID.
@@ -400,7 +407,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	 * @covers WP_REST_Block_Renderer_Controller::get_item_schema()
 	 */
 	public function test_get_item_schema() {
-		$request  = new WP_REST_Request( 'OPTIONS', '/gutenberg/v1/block-renderer/' . self::$block_name );
+		$request  = new WP_REST_Request( 'OPTIONS', self::$rest_api_route . self::$block_name );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION
Change the block renderer controller endpoint from `/gutenberg/v1/block-renderer/` to `/wp/v2/block-renderer/`. This will allow the controller to be merged into WordPress core.

Also, prevent the endpoint being written out in full for each test by adding a static property to the `REST_Block_Renderer_Controller_Test` class.

This is a blocker for https://core.trac.wordpress.org/ticket/45098.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Fixes #10655.