### PR TITLE
Blocks: Add direction attribute / LTR button to paragraph block

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	Component,
 	Fragment,
@@ -14,6 +14,7 @@ import {
 import {
 	PanelBody,
 	ToggleControl,
+	Toolbar,
 	withFallbackStyles,
 } from '@wordpress/components';
 import {
@@ -29,6 +30,7 @@ import {
 } from '@wordpress/editor';
 import { createBlock } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 
 const { getComputedStyle } = window;
 
@@ -137,6 +139,7 @@ class ParagraphBlock extends Component {
 			fallbackFontSize,
 			fontSize,
 			setFontSize,
+			isRTL,
 		} = this.props;
 
 		const {
@@ -144,6 +147,7 @@ class ParagraphBlock extends Component {
 			content,
 			dropCap,
 			placeholder,
+			direction,
 		} = attributes;
 
 		return (
@@ -155,6 +159,23 @@ class ParagraphBlock extends Component {
 							setAttributes( { align: nextAlign } );
 						} }
 					/>
+					{ isRTL && (
+						<Toolbar
+							controls={ [
+								{
+									icon: 'editor-ltr',
+									title: _x( 'Left to right', 'editor button' ),
+									isActive: direction === 'ltr',
+									onClick() {
+										const nextDirection = direction === 'ltr' ? undefined : 'ltr';
+										setAttributes( {
+											direction: nextDirection,
+										} );
+									},
+								},
+							] }
+						/>
+					) }
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
@@ -212,6 +233,7 @@ class ParagraphBlock extends Component {
 						color: textColor.color,
 						fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 						textAlign: align,
+						direction,
 					} }
 					value={ content }
 					onChange={ ( nextContent ) => {
@@ -234,6 +256,13 @@ const ParagraphEdit = compose( [
 	withColors( 'backgroundColor', { textColor: 'color' } ),
 	withFontSizes( 'fontSize' ),
 	applyFallbackStyles,
+	withSelect( ( select ) => {
+		const { getEditorSettings } = select( 'core/editor' );
+
+		return {
+			isRTL: getEditorSettings().isRTL,
+		};
+	} ),
 ] )( ParagraphBlock );
 
 export default ParagraphEdit;

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -65,6 +65,10 @@ const schema = {
 	customFontSize: {
 		type: 'number',
 	},
+	direction: {
+		type: 'string',
+		enum: [ 'ltr', 'rtl' ],
+	},
 };
 
 export const name = 'core/paragraph';
@@ -230,6 +234,7 @@ export const settings = {
 			customTextColor,
 			fontSize,
 			customFontSize,
+			direction,
 		} = attributes;
 
 		const textClass = getColorClassName( 'color', textColor );
@@ -258,6 +263,7 @@ export const settings = {
 				style={ styles }
 				className={ className ? className : undefined }
 				value={ content }
+				dir={ direction }
 			/>
 		);
 	},


### PR DESCRIPTION
Closes #138

This pull request seeks to add an LTR toggle button to the paragraph block toolbar when an RTL locale is active.

![image](https://user-images.githubusercontent.com/1779930/47042647-d7f12600-d159-11e8-9b1d-5bdfb57192b1.png)

It adds a new `direction` block to the paragraph block. As implemented, the value will only ever be `ltr` or `undefined`, given current UI behavior as toggle only shown when the editor is configured as RTL. When non-undefined, it assigns a `dir` attribute to the saved markup. This should be entirely backward-compatible with existing paragraph blocks.

Future compatibility notes:

- Directionality could be abstracted as a common blocks feature, similar to align, color, etc.

**Testing Instructions:**

Verify there's no LTR button when an LTR locale is active.

Verify that an LTR button is active and serves as a toggle for paragraph block when an RTL locale is active.

cc @yoavf @aahani