### PR TITLE
Categories block: use supports flag for alignment + wide alignment support

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -6,16 +6,12 @@ import { times, unescape } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
 import { PanelBody, Placeholder, Spinner, ToggleControl } from '@wordpress/components';
+import { compose, withInstanceId } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
+import { InspectorControls } from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { withInstanceId, compose } from '@wordpress/compose';
-import {
-	InspectorControls,
-	BlockControls,
-	BlockAlignmentToolbar,
-} from '@wordpress/editor';
 
 class CategoriesEdit extends Component {
 	constructor() {
@@ -149,8 +145,8 @@ class CategoriesEdit extends Component {
 	}
 
 	render() {
-		const { attributes, setAttributes, isRequesting } = this.props;
-		const { align, displayAsDropdown, showHierarchy, showPostCounts } = attributes;
+		const { attributes, isRequesting } = this.props;
+		const { displayAsDropdown, showHierarchy, showPostCounts } = attributes;
 
 		const inspectorControls = (
 			<InspectorControls>
@@ -191,15 +187,6 @@ class CategoriesEdit extends Component {
 		return (
 			<Fragment>
 				{ inspectorControls }
-				<BlockControls>
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-						controls={ [ 'left', 'center', 'right', 'full' ] }
-					/>
-				</BlockControls>
 				<div className={ this.props.className }>
 					{
 						displayAsDropdown ?

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -21,9 +21,6 @@ export const settings = {
 	category: 'widgets',
 
 	attributes: {
-		align: {
-			type: 'string',
-		},
 		displayAsDropdown: {
 			type: 'boolean',
 			default: false,
@@ -39,14 +36,8 @@ export const settings = {
 	},
 
 	supports: {
+		align: [ 'left', 'center', 'right', 'wide', 'full' ],
 		html: false,
-	},
-
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( [ 'left', 'center', 'right', 'full' ].includes( align ) ) {
-			return { 'data-align': align };
-		}
 	},
 
 	edit,


### PR DESCRIPTION
## Description
Previously #10635.

This PR changes the code for the Categories block to use the `supports` flag. It also adds support for the `wide` alignment to the Categories block, which strangely was lacking support for it despite already supporting the `full` alignment.

## How has this been tested?
I opened a post with an existing Categories block and checked to make sure setting alignments worked and applied the right classes in the editor and front-end.

## Types of changes
- The block now uses `supports: { align: true }` to add block alignment support. Note that the `align` attribute is still defined in PHP, as this is necessary for the alignments to work on the front-end.
- Added support for the `wide` alignment. (The block already supported the `full` alignment.)