### PR TITLE
Fix two more instances of old rich text value source

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -24,7 +24,6 @@ import {
 	mediaUpload,
 } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
-import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -81,7 +80,7 @@ class FileEdit extends Component {
 			this.setState( { hasError: false } );
 			this.props.setAttributes( {
 				href: media.url,
-				fileName: create( { text: media.title } ),
+				fileName: media.title,
 				textLinkHref: media.url,
 				id: media.id,
 			} );

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -17,7 +17,6 @@ import {
 	RichText,
 } from '@wordpress/editor';
 import deprecated from '@wordpress/deprecated';
-import { create } from '@wordpress/rich-text';
 
 export const name = 'core/text-columns';
 
@@ -45,14 +44,7 @@ export const settings = {
 					source: 'html',
 				},
 			},
-			default: [
-				{
-					children: create(),
-				},
-				{
-					children: create(),
-				},
-			],
+			default: [ {}, {} ],
 		},
 		columns: {
 			type: 'number',


### PR DESCRIPTION
## Description

There's two more instances (file and text column blocks) where rich text value are created inside blocks and passed to RichText.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
