### PR TITLE
Update REST Search controller to use 'wp/v2' namespace

### DIFF
--- a/lib/class-wp-rest-search-controller.php
+++ b/lib/class-wp-rest-search-controller.php
@@ -62,7 +62,7 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 	 *                               handler instance must extend the `WP_REST_Search_Handler` class.
 	 */
 	public function __construct( array $search_handlers ) {
-		$this->namespace = 'gutenberg/v1';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'search';
 
 		foreach ( $search_handlers as $search_handler ) {

--- a/packages/components/src/server-side-render/README.md
+++ b/packages/components/src/server-side-render/README.md
@@ -32,5 +32,5 @@ Output uses the block's `render_callback` function, set when defining the block.
 
 ## API Endpoint
 
-The API endpoint for getting the output for ServerSideRender is `/gutenberg/v1/block-renderer/:block`. It accepts any params, which are used as `attributes` for the block's `render_callback` method.
+The API endpoint for getting the output for ServerSideRender is `/wp/v2/block-renderer/:block`. It accepts any params, which are used as `attributes` for the block's `render_callback` method.
 

--- a/packages/editor/src/components/url-input/README.md
+++ b/packages/editor/src/components/url-input/README.md
@@ -22,7 +22,7 @@ Render a URL input button that pops up an input to search for and select a post 
   "_links": {
     "self": [ { "embeddable": true, "href": "https://example.com/wp-json/wp/v2/pages/1" } ],
     "about": [ { "href": "https://example.com/wp-json/wp/v2/types/page" } ],
-    "collection": [ { "href": "https://example.com/wp-json/gutenberg/v1/search" } ]
+    "collection": [ { "href": "https://example.com/wp-json/wp/v2/search" } ]
   }
 }
 ```
@@ -120,7 +120,7 @@ Renders the URL input field used by the `URLInputButton` component. It can be us
   "_links": {
     "self": [ { "embeddable": true, "href": "https://example.com/wp-json/wp/v2/pages/1" } ],
     "about": [ { "href": "https://example.com/wp-json/wp/v2/types/page" } ],
-    "collection": [ { "href": "https://example.com/wp-json/gutenberg/v1/search" } ]
+    "collection": [ { "href": "https://example.com/wp-json/wp/v2/search" } ]
   }
 }
 ```

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -90,7 +90,7 @@ class URLInput extends Component {
 		} );
 
 		const request = apiFetch( {
-			path: addQueryArgs( '/gutenberg/v1/search', {
+			path: addQueryArgs( '/wp/v2/search', {
 				search: value,
 				per_page: 20,
 				type: 'post',

--- a/phpunit/class-rest-search-controller-test.php
+++ b/phpunit/class-rest-search-controller-test.php
@@ -82,8 +82,8 @@ class REST_Search_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 
-		$this->assertArrayHasKey( '/gutenberg/v1/search', $routes );
-		$this->assertCount( 1, $routes['/gutenberg/v1/search'] );
+		$this->assertArrayHasKey( '/wp/v2/search', $routes );
+		$this->assertCount( 1, $routes['/wp/v2/search'] );
 	}
 
 	/**
@@ -291,7 +291,7 @@ class REST_Search_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_item() {
 		/** The search controller does not allow getting individual item content */
-		$request  = new WP_REST_Request( 'GET', '/gutenberg/v1/search' . self::$my_title_post_ids[0] );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/search' . self::$my_title_post_ids[0] );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -301,7 +301,7 @@ class REST_Search_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_create_item() {
 		/** The search controller does not allow creating content */
-		$request  = new WP_REST_Request( 'POST', '/gutenberg/v1/search' );
+		$request  = new WP_REST_Request( 'POST', '/wp/v2/search' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -311,7 +311,7 @@ class REST_Search_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_update_item() {
 		/** The search controller does not allow upading content */
-		$request  = new WP_REST_Request( 'POST', '/gutenberg/v1/search' . self::$my_title_post_ids[0] );
+		$request  = new WP_REST_Request( 'POST', '/wp/v2/search' . self::$my_title_post_ids[0] );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -321,7 +321,7 @@ class REST_Search_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_delete_item() {
 		/** The search controller does not allow deleting content */
-		$request  = new WP_REST_Request( 'DELETE', '/gutenberg/v1/search' . self::$my_title_post_ids[0] );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/search' . self::$my_title_post_ids[0] );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -377,7 +377,7 @@ class REST_Search_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * Tests the item schema is correct.
 	 */
 	public function test_get_item_schema() {
-		$request    = new WP_REST_Request( 'OPTIONS', '/gutenberg/v1/search' );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/search' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
@@ -510,7 +510,7 @@ class REST_Search_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * Get a REST request object for given parameters.
 	 */
 	private function get_request( $params = array(), $method = 'GET' ) {
-		$request = new WP_REST_Request( $method, '/gutenberg/v1/search' );
+		$request = new WP_REST_Request( $method, '/wp/v2/search' );
 
 		foreach ( $params as $param => $value ) {
 			$request->set_param( $param, $value );


### PR DESCRIPTION
Similar to #10662

In preparation for https://core.trac.wordpress.org/ticket/39965