### PR TITLE
Ensure cite is string when merging quote

### DIFF
--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -197,7 +197,7 @@ export const settings = {
 		);
 	},
 
-	merge( attributes, { value, citation = '' } ) {
+	merge( attributes, { value, citation } ) {
 		return {
 			...attributes,
 			value: attributes.value + value,

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -198,6 +198,13 @@ export const settings = {
 	},
 
 	merge( attributes, { value, citation } ) {
+		if ( ! value || value === '<p></p>' ) {
+			return {
+				...attributes,
+				citation: attributes.citation + citation,
+			};
+		}
+
 		return {
 			...attributes,
 			value: attributes.value + value,

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -197,11 +197,11 @@ export const settings = {
 		);
 	},
 
-	merge( attributes, attributesToMerge ) {
+	merge( attributes, { value, citation = '' } ) {
 		return {
 			...attributes,
-			value: attributes.value + attributesToMerge.value,
-			citation: attributes.citation + attributesToMerge.citation,
+			value: attributes.value + value,
+			citation: attributes.citation + citation,
 		};
 	},
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -50,6 +50,10 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
 			result[ key ] = schema.default;
 		}
 
+		if ( schema.source === 'html' && typeof result[ key ] !== 'string' ) {
+			result[ key ] = '';
+		}
+
 		if ( [ 'node', 'children' ].indexOf( schema.source ) !== -1 ) {
 			// Ensure value passed is always an array, which we're expecting in
 			// the RichText component to handle the deprecated value.

--- a/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
@@ -83,3 +83,9 @@ exports[`Quote can be created by using > at the start of a paragraph block 1`] =
 <blockquote class=\\"wp-block-quote\\"><p>A quote</p><p>Another paragraph</p></blockquote>
 <!-- /wp:quote -->"
 `;
+
+exports[`Quote can be merged into from a paragraph 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>test</p></blockquote>
+<!-- /wp:quote -->"
+`;

--- a/test/e2e/specs/blocks/quote.test.js
+++ b/test/e2e/specs/blocks/quote.test.js
@@ -102,4 +102,13 @@ describe( 'Quote', () => {
 		await convertBlock( 'Heading' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'can be merged into from a paragraph', async () => {
+		await insertBlock( 'Quote' );
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'test' );
+		await pressTimes( 'ArrowLeft', 'test'.length );
+		await page.keyboard.press( 'Backspace' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

When merging a paragraph with a quote, the citation is undefined and cast to a string.

<img width="329" alt="screen shot 2018-10-17 at 10 10 03" src="https://user-images.githubusercontent.com/4710635/47072239-f278dd00-d1f5-11e8-9a73-539b53baa310.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->