### PR TITLE
Fix pre-publish panel overflow

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -4,6 +4,7 @@
 }
 
 .editor-post-publish-panel__content {
+	min-height: calc(100% - #{ $header-height + 60px }); // account for header and footer
 	.components-spinner {
 		display: block;
 		float: none;
@@ -35,8 +36,6 @@
 
 .editor-post-publish-panel__footer {
 	padding: 16px;
-	position: absolute;
-	bottom: 0;
 }
 
 .components-button.editor-post-publish-panel__toggle.is-primary {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -4,7 +4,9 @@
 }
 
 .editor-post-publish-panel__content {
-	min-height: calc(100% - #{ $header-height + 60px }); // account for header and footer
+	// Ensure the post-publish panel accounts for the header and footer height.
+	min-height: calc(100% - #{ $header-height + 60px });
+
 	.components-spinner {
 		display: block;
 		float: none;

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -5,7 +5,7 @@
 
 .editor-post-publish-panel__content {
 	// Ensure the post-publish panel accounts for the header and footer height.
-	min-height: calc(100% - #{ $header-height + 60px });
+	min-height: calc(100% - #{ $header-height + 84px });
 
 	.components-spinner {
 		display: block;


### PR DESCRIPTION
An alternative approach to fix the bug reported at https://github.com/WordPress/gutenberg/pull/10589

Make the pre-publish checkbox stick to the bottom and flow as the parent grows.
