### PR TITLE
Use post type labels in PostFeaturedImage component

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -21,6 +21,7 @@ import MediaUpload from '../media-upload';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 // Used when labels from post type were not yet loaded or when they are not present.
+const DEFAULT_FEATURE_IMAGE_LABEL = __( 'Featured Image' );
 const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
 const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
 
@@ -46,7 +47,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 			<div className="editor-post-featured-image">
 				{ !! featuredImageId &&
 					<MediaUpload
-						title={ __( 'Set featured image' ) }
+						title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 						onSelect={ onUpdateImage }
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						modalClass="editor-post-featured-image__media-modal"
@@ -57,7 +58,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 										naturalWidth={ mediaWidth }
 										naturalHeight={ mediaHeight }
 									>
-										<img src={ mediaSourceUrl } alt={ __( 'Featured image' ) } />
+										<img src={ mediaSourceUrl } alt={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL } />
 									</ResponsiveWrapper>
 								}
 								{ ! media && <Spinner /> }
@@ -68,7 +69,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 				}
 				{ !! featuredImageId && media && ! media.isLoading &&
 				<MediaUpload
-					title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+					title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 					onSelect={ onUpdateImage }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					modalClass="editor-post-featured-image__media-modal"
@@ -82,13 +83,13 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 				{ ! featuredImageId &&
 					<div>
 						<MediaUpload
-							title={ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button className="editor-post-featured-image__toggle" onClick={ open }>
-									{ __( 'Set featured image' ) }
+									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
 								</Button>
 							) }
 						/>


### PR DESCRIPTION
## Description
A post type can register custom labels for featured image support. The current `PostFeaturedImage` component didn't handle this consistently.

## How has this been tested?
A new CPT with custom labels for the featured image :

```php
add_action( 'init', function() {
	register_post_type( 'my-foo', [
		'public'       => true,
		'show_in_rest' => true,
		'supports'     => [ 'title', 'editor', 'thumbnail' ],
		'labels'       => [
			'name'                  => _x( 'Team', 'post type general name', 'my-foo' ),
			'singular_name'         => _x( 'Person', 'post type singular name', 'my-foo' ),
			'featured_image'        => __( 'Photo', 'my-foo' ),
			'set_featured_image'    => __( 'Set photo', 'my-foo' ),
			'remove_featured_image' => __( 'Remove photo', 'my-foo' ),
			'use_featured_image'    => __( 'Use as photo', 'my-foo' ),
		],
	] );
} );
```
Instead of "Set featured image" the component now prints "Set photo". The title of the media modal now also reflects the `featured_image` label.
