### PR TITLE
Convert quote to / from pullquote

### DIFF
--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -71,6 +71,14 @@ export const settings = {
 				},
 			},
 			{
+				type: 'block',
+				blocks: [ 'core/pullquote' ],
+				transform: ( { value, citation } ) => createBlock( 'core/quote', {
+					value,
+					citation,
+				} ),
+			},
+			{
 				type: 'pattern',
 				regExp: /^>\s/,
 				transform: ( { content } ) => {
@@ -132,6 +140,17 @@ export const settings = {
 							value: toHTMLString( quotePieces.length ? join( pieces.slice( 1 ), '\u2028' ) : create(), 'p' ),
 						} ),
 					];
+				},
+			},
+
+			{
+				type: 'block',
+				blocks: [ 'core/pullquote' ],
+				transform: ( { value, citation } ) => {
+					return createBlock( 'core/pullquote', {
+						value,
+						citation,
+					} );
 				},
 			},
 		],

--- a/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Quote can be converted to a pullquote 1`] = `
+"<!-- wp:pullquote -->
+<figure class=\\"wp-block-pullquote\\"><blockquote><p>one</p><p>two</p><cite>cite</cite></blockquote></figure>
+<!-- /wp:pullquote -->"
+`;
+
 exports[`Quote can be converted to headings 1`] = `
 "<!-- wp:heading -->
 <h2>one</h2>

--- a/test/e2e/specs/blocks/quote.test.js
+++ b/test/e2e/specs/blocks/quote.test.js
@@ -103,6 +103,17 @@ describe( 'Quote', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'can be converted to a pullquote', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'cite' );
+		await convertBlock( 'Pullquote' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'can be merged into from a paragraph', async () => {
 		await insertBlock( 'Quote' );
 		await insertBlock( 'Paragraph' );


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/10548

Adds a transformation to convert `quote` to `pullquote` and viceversa.