### PR TITLE
Take into account citation when transform a quote to paragraph

### DIFF
--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -116,6 +116,12 @@ export const settings = {
 							} )
 						);
 					}
+
+					if ( paragraphs.length === 0 ) {
+						return createBlock( 'core/paragraph', {
+							content: '',
+						} );
+					}
 					return paragraphs;
 				},
 			},

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -97,13 +97,27 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/paragraph' ],
-				transform: ( { value, citation } ) =>
-					split( create( { html: value + `<p>${ citation }</p>`, multilineTag: 'p' } ), '\u2028' )
-						.map( ( piece ) =>
+				transform: ( { value, citation } ) => {
+					const paragraphs = [];
+					if ( value ) {
+						paragraphs.push(
+							...split( create( { html: value, multilineTag: 'p' } ), '\u2028' )
+								.map( ( piece ) =>
+									createBlock( 'core/paragraph', {
+										content: toHTMLString( piece ),
+									} )
+								)
+						);
+					}
+					if ( citation ) {
+						paragraphs.push(
 							createBlock( 'core/paragraph', {
-								content: toHTMLString( piece ),
+								content: citation,
 							} )
-						),
+						);
+					}
+					return paragraphs;
+				},
 			},
 
 			{

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -97,8 +97,8 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/paragraph' ],
-				transform: ( { value } ) =>
-					split( create( { html: value, multilineTag: 'p' } ), '\u2028' )
+				transform: ( { value, citation } ) =>
+					split( create( { html: value + `<p>${ citation }</p>`, multilineTag: 'p' } ), '\u2028' )
 						.map( ( piece ) =>
 							createBlock( 'core/paragraph', {
 								content: toHTMLString( piece ),

--- a/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
@@ -38,13 +38,35 @@ exports[`Quote can be converted to headings 3`] = `
 <!-- /wp:heading -->"
 `;
 
-exports[`Quote can be converted to paragraphs 1`] = `
+exports[`Quote can be converted to paragraphs and renders a paragraph for the cite, if it exists 1`] = `
 "<!-- wp:paragraph -->
 <p>one</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>two</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>cite</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Quote can be converted to paragraphs and renders a void paragraph if both the cite and quote are void 1`] = `""`;
+
+exports[`Quote can be converted to paragraphs and renders one paragraph block per <p> within quote 1`] = `
+"<!-- wp:paragraph -->
+<p>one</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>two</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Quote can be converted to paragraphs and renders only one paragraph for the cite, if the quote is void 1`] = `
+"<!-- wp:paragraph -->
+<p>cite</p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/test/e2e/specs/blocks/quote.test.js
+++ b/test/e2e/specs/blocks/quote.test.js
@@ -68,14 +68,44 @@ describe( 'Quote', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'can be converted to paragraphs', async () => {
-		await insertBlock( 'Quote' );
-		await page.keyboard.type( 'one' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'two' );
-		await convertBlock( 'Paragraph' );
+	describe( 'can be converted to paragraphs', async () => {
+		it( 'and renders one paragraph block per <p> within quote', async () => {
+			await insertBlock( 'Quote' );
+			await page.keyboard.type( 'one' );
+			await page.keyboard.press( 'Enter' );
+			await page.keyboard.type( 'two' );
+			await convertBlock( 'Paragraph' );
 
-		expect( await getEditedPostContent() ).toMatchSnapshot();
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'and renders a paragraph for the cite, if it exists', async () => {
+			await insertBlock( 'Quote' );
+			await page.keyboard.type( 'one' );
+			await page.keyboard.press( 'Enter' );
+			await page.keyboard.type( 'two' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.type( 'cite' );
+			await convertBlock( 'Paragraph' );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'and renders only one paragraph for the cite, if the quote is void', async () => {
+			await insertBlock( 'Quote' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.type( 'cite' );
+			await convertBlock( 'Paragraph' );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'and renders a void paragraph if both the cite and quote are void', async () => {
+			await insertBlock( 'Quote' );
+			await convertBlock( 'Paragraph' );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
 	} );
 
 	it( 'can be created by converting a heading', async () => {


### PR DESCRIPTION
When transforming a quote to a paragraph the citation was left out. This PR makes the citation a new paragraph.