### PR TITLE
chore: Release 4.0

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 4.0.0-rc.1
+ * Version: 4.0.0
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "4.0.0-rc.1",
+	"version": "4.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "4.0.0-rc.1",
+	"version": "4.0.0",
 	"private": true,
 	"description": "A new WordPress editor experience",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
This bumps the version to 4.0. I'll cherry-pick it, along with everything in https://github.com/WordPress/gutenberg/pulls?utf8=✓&q=is%3Apr+milestone%3A4.0+is%3Aclosed+merged%3A%3E2018-10-10, for the 4.0 release.