### PR TITLE
Add "custom" option in font size picker

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -181,7 +181,7 @@ class ParagraphBlock extends Component {
 					<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
 						<FontSizePicker
 							fallbackFontSize={ fallbackFontSize }
-							value={ fontSize.size }
+							value={ fontSize }
 							onChange={ setFontSize }
 						/>
 						<ToggleControl

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -231,7 +231,7 @@ class ParagraphBlock extends Component {
 					style={ {
 						backgroundColor: backgroundColor.color,
 						color: textColor.color,
-						fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
+						fontSize: ( fontSize.slug === 'custom' ) ? fontSize.size + 'px' : undefined,
 						textAlign: align,
 						direction,
 					} }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -109,24 +109,24 @@
 	color: #313131;
 }
 
-.has-small-font-size {
+.has-small-font-size.has-small-font-size {
 	font-size: 13px;
 }
 
 .has-regular-font-size, // not used now, kept because of backward compatibility.
-.has-normal-font-size {
+.has-normal-font-size.has-normal-font-size {
 	font-size: 16px;
 }
 
-.has-medium-font-size {
+.has-medium-font-size.has-medium-font-size {
 	font-size: 20px;
 }
 
-.has-large-font-size {
+.has-large-font-size.has-large-font-size {
 	font-size: 36px;
 }
 
 .has-larger-font-size, // not used now, kept because of backward compatibility.
-.has-huge-font-size, {
+.has-huge-font-size.has-huge-font-size, {
 	font-size: 42px;
 }

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -11,20 +11,22 @@ import { FontSizePicker } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
 
 const MyFontSizePicker = withState( {
-	fontSize: 16,
+	fontSize: 'large',
 } )( ( { fontSize, setState } ) => { 
 	const fontSizes = [
-		{ shortName: 'S', size: 12 },
-		{ shortName: 'M', size: 16 }
+		{ name: 'Small', size: 12, slug: 'small', },
+		{ name: 'Medium', size: 16, slug: 'medium', },
+		{ name: 'Large', size: 20, slug: 'large', },
 	];
+
 	const fallbackFontSize = 16;
 	
 	return ( 
 		<FontSizePicker 
-			fontSizes={ fontSizes } 
-			value={ fontSize }
 			fallbackFontSize={ fallbackFontSize }
+			fontSizes={ fontSizes } 
 			onChange={ fontSize => setState( { fontSize } ) } 
+			value={ fontSize }
 		/>
 	); 
 } );

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -20,6 +20,7 @@ import RangeControl from '../range-control';
 import { NavigableMenu } from '../navigable-container';
 
 function FontSizePicker( {
+	defaultFontSizeSlug,
 	fallbackFontSize,
 	fontSizes = [],
 	disableCustomFontSizes = false,
@@ -27,14 +28,7 @@ function FontSizePicker( {
 	value,
 	withSlider,
 } ) {
-	// Try to find the current font size in the set of preset font sizes.
-	const currentFont = fontSizes.find( ( font ) => {
-		return ( ( value === undefined ) ? 'normal' : value.slug ) === font.slug;
-	} );
-
-	// If the current font size is not one of the pre-defined sizes, we assume
-	// the custom option has been selected.
-	const isCustomFontSize = ! ( currentFont || value === undefined );
+	const isCustomFontSize = ( value.slug === 'custom' );
 
 	const onChangeCustomValue = ( event ) => {
 		const newValue = event.target.value;
@@ -60,9 +54,9 @@ function FontSizePicker( {
 							isLarge
 							onClick={ onToggle }
 							aria-expanded={ isOpen }
-							aria-label={ __( 'Custom font size' ) }
+							aria-label={ __( 'Choose font size' ) }
 						>
-							{ ( currentFont && currentFont.name ) || ( ! value && __( 'Normal' ) ) || _x( 'Custom', 'font size name' ) }
+							{ value && value.name }
 						</Button>
 					) }
 					renderContent={ () => (
@@ -70,7 +64,7 @@ function FontSizePicker( {
 							{ map( fontSizes, ( font ) => (
 								<Button
 									key={ font.slug }
-									onClick={ () => onChange( font.slug === 'normal' ? undefined : font ) }
+									onClick={ () => onChange( font ) }
 									className={ 'is-font-' + font.slug }
 									role="menuitem"
 								>
@@ -89,7 +83,7 @@ function FontSizePicker( {
 								>
 									{ isCustomFontSize && <Dashicon icon="saved" /> }
 									<span className="components-font-size-picker__dropdown-text-size">
-										{ __( 'Custom' ) }
+										{ _x( 'Custom', 'font size name' ) }
 									</span>
 								</Button>
 							}
@@ -108,7 +102,7 @@ function FontSizePicker( {
 				<Button
 					className="components-color-palette__clear"
 					type="button"
-					disabled={ value.slug === 'normal' }
+					disabled={ value.slug === defaultFontSizeSlug }
 					onClick={ onResetFontSize }
 					isSmall
 					isDefault

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, map } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -44,7 +44,7 @@ function FontSizePicker( {
 
 	// If the current font size is not one of the pre-defined sizes, we assume
 	// the custom option has been selected.
-	const isCustomFontSize = ! ( includes( map( fontSizes, 'size' ), value ) || value === undefined );
+	const isCustomFontSize = ! ( currentFont || value === undefined );
 
 	return (
 		<BaseControl label={ __( 'Font Size' ) }>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -100,7 +100,7 @@ function FontSizePicker( {
 					/>
 				}
 				<Button
-					className="components-color-palette__clear"
+					className="components-font-size-picker__clear"
 					type="button"
 					disabled={ value.slug === defaultFontSizeSlug }
 					onClick={ onResetFontSize }

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -31,10 +31,10 @@ function FontSizePicker( {
 	const isCustomFontSize = ( value.slug === 'custom' );
 
 	const onChangeCustomValue = ( event ) => {
-		const newValue = event.target.value;
-
 		// If the custom value is empty, use that. Otherwise, cast it to a Number.
-		onChange( newValue === '' ? '' : Number( newValue ) );
+		const newValue = ( event.target.value === '' ) ? '' : Number( event.target.value );
+
+		onChange( { slug: 'custom', size: newValue } );
 	};
 
 	const onResetFontSize = () => {
@@ -61,6 +61,19 @@ function FontSizePicker( {
 					) }
 					renderContent={ () => (
 						<NavigableMenu>
+							{ ( ! disableCustomFontSizes || isCustomFontSize ) &&
+								<Button
+									key={ 'custom' }
+									onClick={ () => onChange( { slug: 'custom', size: '' } ) }
+									className={ 'is-font-custom' }
+									role="menuitem"
+								>
+									{ isCustomFontSize && <Dashicon icon="saved" /> }
+									<span className="components-font-size-picker__dropdown-text-size">
+										{ _x( 'Custom', 'font size name' ) }
+									</span>
+								</Button>
+							}
 							{ map( fontSizes, ( font ) => (
 								<Button
 									key={ font.slug }
@@ -74,19 +87,6 @@ function FontSizePicker( {
 									</span>
 								</Button>
 							) ) }
-							{ ( ! disableCustomFontSizes || isCustomFontSize ) &&
-								<Button
-									key={ 'custom' }
-									onClick={ () => onChange( '' ) }
-									className={ 'is-font-custom' }
-									role="menuitem"
-								>
-									{ isCustomFontSize && <Dashicon icon="saved" /> }
-									<span className="components-font-size-picker__dropdown-text-size">
-										{ _x( 'Custom', 'font size name' ) }
-									</span>
-								</Button>
-							}
 						</NavigableMenu>
 					) }
 				/>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+import { includes, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -29,14 +29,22 @@ function FontSizePicker( {
 } ) {
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;
+
+		// If the typed value is empty, we mark that as "custom" so the user
+		// can type in a new value without it reverting to the "Normal" size.
 		if ( newValue === '' ) {
-			onChange( undefined );
+			onChange( 'custom' );
 			return;
 		}
+
 		onChange( Number( newValue ) );
 	};
 
 	const currentFont = fontSizes.find( ( font ) => font.size === value );
+
+	// If the current font size is not one of the pre-defined sizes, we assume
+	// the custom option has been selected.
+	const isCustomFontSize = ! ( includes( map( fontSizes, 'size' ), value ) || value === undefined );
 
 	return (
 		<BaseControl label={ __( 'Font Size' ) }>
@@ -71,10 +79,23 @@ function FontSizePicker( {
 									</span>
 								</Button>
 							) ) }
+							{ ( ! disableCustomFontSizes || isCustomFontSize ) &&
+								<Button
+									key={ 'custom' }
+									onClick={ () => onChange( 'custom' ) }
+									className={ 'is-font-custom' }
+									role="menuitem"
+								>
+									{ isCustomFontSize && <Dashicon icon="saved" /> }
+									<span className="components-font-size-picker__dropdown-text-size">
+										{ __( 'Custom' ) }
+									</span>
+								</Button>
+							}
 						</NavigableMenu>
 					) }
 				/>
-				{ ( ! withSlider && ! disableCustomFontSizes ) &&
+				{ ( ! withSlider && isCustomFontSize ) &&
 					<input
 						className="components-range-control__number"
 						type="number"
@@ -95,7 +116,7 @@ function FontSizePicker( {
 					{ __( 'Reset' ) }
 				</Button>
 			</div>
-			{ withSlider &&
+			{ ( withSlider && isCustomFontSize ) &&
 				<RangeControl
 					className="components-font-size-picker__custom-input"
 					label={ __( 'Custom Size' ) }

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -28,7 +28,9 @@ function FontSizePicker( {
 	withSlider,
 } ) {
 	// Try to find the current font size in the set of preset font sizes.
-	const currentFont = fontSizes.find( ( font ) => font.slug === value.slug );
+	const currentFont = fontSizes.find( ( font ) => {
+		return ( ( value === undefined ) ? 'normal' : value.slug ) === font.slug;
+	} );
 
 	// If the current font size is not one of the pre-defined sizes, we assume
 	// the custom option has been selected.

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -27,24 +27,23 @@ function FontSizePicker( {
 	value,
 	withSlider,
 } ) {
-	const onChangeValue = ( event ) => {
-		const newValue = event.target.value;
-
-		// If the typed value is empty, we mark that as "custom" so the user
-		// can type in a new value without it reverting to the "Normal" size.
-		if ( newValue === '' ) {
-			onChange( 'custom' );
-			return;
-		}
-
-		onChange( Number( newValue ) );
-	};
-
-	const currentFont = fontSizes.find( ( font ) => font.size === value );
+	// Try to find the current font size in the set of preset font sizes.
+	const currentFont = fontSizes.find( ( font ) => font.slug === value.slug );
 
 	// If the current font size is not one of the pre-defined sizes, we assume
 	// the custom option has been selected.
 	const isCustomFontSize = ! ( currentFont || value === undefined );
+
+	const onChangeCustomValue = ( event ) => {
+		const newValue = event.target.value;
+
+		// If the custom value is empty, use that. Otherwise, cast it to a Number.
+		onChange( newValue === '' ? '' : Number( newValue ) );
+	};
+
+	const onResetFontSize = () => {
+		onChange( undefined );
+	};
 
 	return (
 		<BaseControl label={ __( 'Font Size' ) }>
@@ -66,23 +65,23 @@ function FontSizePicker( {
 					) }
 					renderContent={ () => (
 						<NavigableMenu>
-							{ map( fontSizes, ( { name, size, slug } ) => (
+							{ map( fontSizes, ( font ) => (
 								<Button
-									key={ slug }
-									onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
-									className={ 'is-font-' + slug }
+									key={ font.slug }
+									onClick={ () => onChange( font.slug === 'normal' ? undefined : font ) }
+									className={ 'is-font-' + font.slug }
 									role="menuitem"
 								>
-									{ ( value === size || ( ! value && slug === 'normal' ) ) &&	<Dashicon icon="saved" /> }
-									<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: size } }>
-										{ name }
+									{ font.slug === value.slug && <Dashicon icon="saved" /> }
+									<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: font.size } }>
+										{ font.name }
 									</span>
 								</Button>
 							) ) }
 							{ ( ! disableCustomFontSizes || isCustomFontSize ) &&
 								<Button
 									key={ 'custom' }
-									onClick={ () => onChange( 'custom' ) }
+									onClick={ () => onChange( '' ) }
 									className={ 'is-font-custom' }
 									role="menuitem"
 								>
@@ -99,16 +98,16 @@ function FontSizePicker( {
 					<input
 						className="components-range-control__number"
 						type="number"
-						onChange={ onChangeValue }
+						onChange={ onChangeCustomValue }
 						aria-label={ __( 'Custom font size' ) }
-						value={ value || '' }
+						value={ value.size || '' }
 					/>
 				}
 				<Button
 					className="components-color-palette__clear"
 					type="button"
-					disabled={ value === undefined }
-					onClick={ () => onChange( undefined ) }
+					disabled={ value.slug === 'normal' }
+					onClick={ onResetFontSize }
 					isSmall
 					isDefault
 					aria-label={ __( 'Reset font size' ) }
@@ -120,9 +119,9 @@ function FontSizePicker( {
 				<RangeControl
 					className="components-font-size-picker__custom-input"
 					label={ __( 'Custom Size' ) }
-					value={ value || '' }
+					value={ value.size || '' }
 					initialPosition={ fallbackFontSize }
-					onChange={ onChange }
+					onChange={ onChangeCustomValue }
 					min={ 12 }
 					max={ 100 }
 					beforeIcon="editor-textcolor"

--- a/packages/editor/src/components/font-sizes/utils.js
+++ b/packages/editor/src/components/font-sizes/utils.js
@@ -16,21 +16,23 @@ import { __ } from '@wordpress/i18n';
  * @param {?string} fontSizeAttribute       Content of the font size attribute (slug).
  * @param {?number} customFontSizeAttribute Contents of the custom font size attribute (value).
  *
- * @return {?string} If fontSizeAttribute is set and an equal slug is found in fontSizes it returns the font size object for that slug.
- * 					 Otherwise, an object with just the size value based on customFontSize is returned.
+ * @return {?string} If a customFontSizeAttribute is set, return an object with the custom size value.
+ * 					 Otherwise, return one of the pre-defined fonts, falling back on the size with the slug "normal".
  */
 export const getFontSize = ( fontSizes, fontSizeAttribute, customFontSizeAttribute ) => {
-	if ( fontSizeAttribute ) {
-		const fontSizeObject = find( fontSizes, { slug: fontSizeAttribute } );
-		if ( fontSizeObject ) {
-			return fontSizeObject;
-		}
+	if ( customFontSizeAttribute !== undefined ) {
+		return {
+			name: __( 'Custom' ),
+			slug: 'custom',
+			size: customFontSizeAttribute,
+		};
 	}
-	return {
-		name: __( 'Custom' ),
-		slug: 'custom',
-		size: customFontSizeAttribute,
-	};
+
+	const fontSizeObject = find( fontSizes, { slug: ( fontSizeAttribute === undefined ? 'normal' : fontSizeAttribute ) } );
+
+	if ( fontSizeObject ) {
+		return fontSizeObject;
+	}
 };
 
 /**

--- a/packages/editor/src/components/font-sizes/utils.js
+++ b/packages/editor/src/components/font-sizes/utils.js
@@ -4,11 +4,6 @@
 import { find, kebabCase } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import { _x } from '@wordpress/i18n';
-
-/**
  * Returns the default font size slug.
  */
 export const getDefaultFontSizeSlug = 'normal';
@@ -27,7 +22,6 @@ export const getDefaultFontSizeSlug = 'normal';
 export const getFontSize = ( fontSizes, fontSizeAttribute, customFontSizeAttribute ) => {
 	if ( customFontSizeAttribute !== undefined ) {
 		return {
-			name: _x( 'Custom', 'font size name' ),
 			slug: 'custom',
 			size: customFontSizeAttribute,
 		};

--- a/packages/editor/src/components/font-sizes/utils.js
+++ b/packages/editor/src/components/font-sizes/utils.js
@@ -4,6 +4,11 @@
 import { find, kebabCase } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  *  Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values.
  * 	If namedFontSize is undefined or not found in fontSizes an object with just the size value based on customFontSize is returned.
  *
@@ -22,6 +27,8 @@ export const getFontSize = ( fontSizes, fontSizeAttribute, customFontSizeAttribu
 		}
 	}
 	return {
+		name: __( 'Custom' ),
+		slug: 'custom',
 		size: customFontSizeAttribute,
 	};
 };

--- a/packages/editor/src/components/font-sizes/utils.js
+++ b/packages/editor/src/components/font-sizes/utils.js
@@ -6,7 +6,12 @@ import { find, kebabCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
+
+/**
+ * Returns the default font size slug.
+ */
+export const getDefaultFontSizeSlug = 'normal';
 
 /**
  *  Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values.
@@ -22,13 +27,13 @@ import { __ } from '@wordpress/i18n';
 export const getFontSize = ( fontSizes, fontSizeAttribute, customFontSizeAttribute ) => {
 	if ( customFontSizeAttribute !== undefined ) {
 		return {
-			name: __( 'Custom' ),
+			name: _x( 'Custom', 'font size name' ),
 			slug: 'custom',
 			size: customFontSizeAttribute,
 		};
 	}
 
-	const fontSizeObject = find( fontSizes, { slug: ( fontSizeAttribute === undefined ? 'normal' : fontSizeAttribute ) } );
+	const fontSizeObject = find( fontSizes, { slug: ( fontSizeAttribute === undefined ? getDefaultFontSizeSlug : fontSizeAttribute ) } );
 
 	if ( fontSizeObject ) {
 		return fontSizeObject;

--- a/packages/editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/editor/src/components/font-sizes/with-font-sizes.js
@@ -13,7 +13,11 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getFontSize, getFontSizeClass } from './utils';
+import {
+	getDefaultFontSizeSlug,
+	getFontSize,
+	getFontSizeClass,
+} from './utils';
 
 /**
  * Higher-order component, which handles font size logic for class generation,
@@ -63,12 +67,15 @@ export default ( ...fontSizeNames ) => {
 					}
 
 					createSetFontSize( fontSizeAttributeName, customFontSizeAttributeName ) {
-						return ( fontSizeValue ) => {
-							const fontSizeObject = find( this.props.fontSizes, { slug: ( fontSizeValue === undefined ? 'normal' : fontSizeValue.slug ) } );
+						return ( font ) => {
+							// Ensure that "undefined" (aka a reset) or choosing the pre-defined
+							// default font size result in an undefined fontSizeObject.
+							const fontSizeObject = ( font === undefined || font.slug === getDefaultFontSizeSlug ) ?
+								null : find( this.props.fontSizes, { slug: ( font.slug ) } );
 
 							this.props.setAttributes( {
 								[ fontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? fontSizeObject.slug : undefined,
-								[ customFontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? undefined : fontSizeValue,
+								[ customFontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? undefined : font,
 							} );
 						};
 					}

--- a/packages/editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/editor/src/components/font-sizes/with-font-sizes.js
@@ -64,7 +64,8 @@ export default ( ...fontSizeNames ) => {
 
 					createSetFontSize( fontSizeAttributeName, customFontSizeAttributeName ) {
 						return ( fontSizeValue ) => {
-							const fontSizeObject = find( this.props.fontSizes, { size: fontSizeValue } );
+							const fontSizeObject = find( this.props.fontSizes, { slug: ( fontSizeValue === undefined ? 'normal' : fontSizeValue.slug ) } );
+
 							this.props.setAttributes( {
 								[ fontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? fontSizeObject.slug : undefined,
 								[ customFontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? undefined : fontSizeValue,

--- a/packages/editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/editor/src/components/font-sizes/with-font-sizes.js
@@ -71,11 +71,11 @@ export default ( ...fontSizeNames ) => {
 							// Ensure that "undefined" (aka a reset) or choosing the pre-defined
 							// default font size result in an undefined fontSizeObject.
 							const fontSizeObject = ( font === undefined || font.slug === getDefaultFontSizeSlug ) ?
-								null : find( this.props.fontSizes, { slug: ( font.slug ) } );
+								undefined : find( this.props.fontSizes, { slug: ( font.slug ) } );
 
 							this.props.setAttributes( {
-								[ fontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? fontSizeObject.slug : undefined,
-								[ customFontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? undefined : font,
+								[ fontSizeAttributeName ]: ( fontSizeObject && fontSizeObject.slug ) ? fontSizeObject.slug : undefined,
+								[ customFontSizeAttributeName ]: ( font && font.slug === 'custom' ) ? font.size : undefined,
 							} );
 						};
 					}

--- a/packages/editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/editor/src/components/font-sizes/with-font-sizes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, pickBy, reduce, some, upperFirst } from 'lodash';
+import { isNumber, pickBy, reduce, some, upperFirst } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -67,15 +67,11 @@ export default ( ...fontSizeNames ) => {
 					}
 
 					createSetFontSize( fontSizeAttributeName, customFontSizeAttributeName ) {
-						return ( font ) => {
-							// Ensure that "undefined" (aka a reset) or choosing the pre-defined
-							// default font size result in an undefined fontSizeObject.
-							const fontSizeObject = ( font === undefined || font.slug === getDefaultFontSizeSlug ) ?
-								undefined : find( this.props.fontSizes, { slug: ( font.slug ) } );
-
+						return ( value ) => {
+							// Conditionally set the slug or numeric size.
 							this.props.setAttributes( {
-								[ fontSizeAttributeName ]: ( fontSizeObject && fontSizeObject.slug ) ? fontSizeObject.slug : undefined,
-								[ customFontSizeAttributeName ]: ( font && font.slug === 'custom' ) ? font.size : undefined,
+								[ fontSizeAttributeName ]: ( value === getDefaultFontSizeSlug || isNumber( value ) ) ? undefined : value,
+								[ customFontSizeAttributeName ]: isNumber( value ) ? value : undefined,
 							} );
 						};
 					}
@@ -83,13 +79,15 @@ export default ( ...fontSizeNames ) => {
 					static getDerivedStateFromProps( { attributes, fontSizes }, previousState ) {
 						const didAttributesChange = ( customFontSizeAttributeName, fontSizeAttributeName ) => {
 							if ( previousState[ fontSizeAttributeName ] ) {
-								// if new font size is name compare with the previous slug
+								// If the new font size is a slug, compare with the previous slug.
 								if ( attributes[ fontSizeAttributeName ] ) {
-									return attributes[ fontSizeAttributeName ] !== previousState[ fontSizeAttributeName ].slug;
+									return attributes[ fontSizeAttributeName ] !== previousState[ fontSizeAttributeName ];
 								}
-								// if font size is not named, update when the font size value changes.
-								return previousState[ fontSizeAttributeName ].size !== attributes[ customFontSizeAttributeName ];
+
+								// If the font size is not named, update when the font size value changes.
+								return true;
 							}
+
 							// in this case we need to build the font size object
 							return true;
 						};

--- a/packages/editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/editor/src/components/font-sizes/with-font-sizes.js
@@ -71,7 +71,7 @@ export default ( ...fontSizeNames ) => {
 							// Conditionally set the slug or numeric size.
 							this.props.setAttributes( {
 								[ fontSizeAttributeName ]: ( value === getDefaultFontSizeSlug || isNumber( value ) ) ? undefined : value,
-								[ customFontSizeAttributeName ]: isNumber( value ) ? value : undefined,
+								[ customFontSizeAttributeName ]: ( isNumber( value ) || value === '' ) ? value : undefined,
 							} );
 						};
 					}
@@ -100,15 +100,18 @@ export default ( ...fontSizeNames ) => {
 							pickBy( fontSizeAttributeNames, didAttributesChange ),
 							( newStateAccumulator, customFontSizeAttributeName, fontSizeAttributeName ) => {
 								const fontSizeAttributeValue = attributes[ fontSizeAttributeName ];
+
 								const fontSizeObject = getFontSize(
 									fontSizes,
 									fontSizeAttributeValue,
 									attributes[ customFontSizeAttributeName ]
 								);
+
 								newStateAccumulator[ fontSizeAttributeName ] = {
 									...fontSizeObject,
 									class: getFontSizeClass( fontSizeAttributeValue ),
 								};
+
 								return newStateAccumulator;
 							},
 							{}

--- a/test/e2e/specs/__snapshots__/font-size-picker.test.js.snap
+++ b/test/e2e/specs/__snapshots__/font-size-picker.test.js.snap
@@ -1,37 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Font Size Picker should apply a custom font size using the font size input 1`] = `
-"<!-- wp:paragraph {\\"customFontSize\\":23} -->
-<p style=\\"font-size:23px\\">Paragraph to be made \\"small\\"</p>
-<!-- /wp:paragraph -->"
-`;
-
 exports[`Font Size Picker should apply a named font size using the font size buttons 1`] = `
 "<!-- wp:paragraph {\\"fontSize\\":\\"large\\"} -->
 <p class=\\"has-large-font-size\\">Paragraph to be made \\"large\\"</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Font Size Picker should apply a named font size using the font size input 1`] = `
-"<!-- wp:paragraph {\\"fontSize\\":\\"small\\"} -->
-<p class=\\"has-small-font-size\\">Paragraph to be made \\"small\\"</p>
-<!-- /wp:paragraph -->"
-`;
-
-exports[`Font Size Picker should reset a custom font size using input field 1`] = `
-"<!-- wp:paragraph -->
-<p>Paragraph to be made \\"small\\"</p>
-<!-- /wp:paragraph -->"
-`;
-
-exports[`Font Size Picker should reset a named font size using input field 1`] = `
-"<!-- wp:paragraph -->
-<p>Paragraph with font size reset using input field</p>
+exports[`Font Size Picker should apply a custom font size using the font size input 1`] = `
+"<!-- wp:paragraph {\\"customFontSize\\":23} -->
+<p style=\\"font-size:23px\\">Paragraph to be made \\"custom\\"</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`Font Size Picker should reset a named font size using the reset button 1`] = `
 "<!-- wp:paragraph -->
-<p>Paragraph with font size reset using button</p>
+<p>Paragraph with named font size reset using button</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Font Size Picker should reset a custom font size using the reset button 1`] = `
+"<!-- wp:paragraph -->
+<p>Paragraph with custom font size reset using button</p>
 <!-- /wp:paragraph -->"
 `;

--- a/test/e2e/specs/font-size-picker.test.js
+++ b/test/e2e/specs/font-size-picker.test.js
@@ -36,6 +36,8 @@ describe( 'Font Size Picker', () => {
 		await changeSizeButton.click();
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( '23' );
 
 		// Ensure content matches snapshot.
@@ -73,6 +75,8 @@ describe( 'Font Size Picker', () => {
 		await changeSizeButton.click();
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( '23' );
 
 		// Blur the range control

--- a/test/e2e/specs/font-size-picker.test.js
+++ b/test/e2e/specs/font-size-picker.test.js
@@ -26,23 +26,14 @@ describe( 'Font Size Picker', () => {
 		expect( content ).toMatchSnapshot();
 	} );
 
-	it( 'should apply a named font size using the font size input', async () => {
-		// Create a paragraph block with some content.
-		await clickBlockAppender();
-		await page.keyboard.type( 'Paragraph to be made "small"' );
-
-		await page.click( '.blocks-font-size .components-range-control__number' );
-		await page.keyboard.type( '13' );
-
-		// Ensure content matches snapshot.
-		const content = await getEditedPostContent();
-		expect( content ).toMatchSnapshot();
-	} );
-
 	it( 'should apply a custom font size using the font size input', async () => {
 		// Create a paragraph block with some content.
 		await clickBlockAppender();
-		await page.keyboard.type( 'Paragraph to be made "small"' );
+		await page.keyboard.type( 'Paragraph to be made "custom"' );
+
+		await page.click( '.components-font-size-picker__selector' );
+		const changeSizeButton = await page.waitForSelector( '.components-button.is-font-custom' );
+		await changeSizeButton.click();
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
 		await page.keyboard.type( '23' );
@@ -55,10 +46,11 @@ describe( 'Font Size Picker', () => {
 	it( 'should reset a named font size using the reset button', async () => {
 		// Create a paragraph block with some content.
 		await clickBlockAppender();
-		await page.keyboard.type( 'Paragraph with font size reset using button' );
+		await page.keyboard.type( 'Paragraph with named font size reset using button' );
 
-		await page.click( '.blocks-font-size .components-range-control__number' );
-		await page.keyboard.type( '13' );
+		await page.click( '.components-font-size-picker__selector' );
+		const changeSizeButton = await page.waitForSelector( '.components-button.is-font-small' );
+		await changeSizeButton.click();
 
 		// Blur the range control
 		await page.click( '.components-base-control__label' );
@@ -71,37 +63,23 @@ describe( 'Font Size Picker', () => {
 		expect( content ).toMatchSnapshot();
 	} );
 
-	it( 'should reset a named font size using input field', async () => {
+	it( 'should reset a custom font size using the reset button', async () => {
 		// Create a paragraph block with some content.
 		await clickBlockAppender();
-		await page.keyboard.type( 'Paragraph with font size reset using input field' );
+		await page.keyboard.type( 'Paragraph with custom font size reset using button' );
 
 		await page.click( '.components-font-size-picker__selector' );
-		const changeSizeButton = await page.waitForSelector( '.components-button.is-font-large' );
+		const changeSizeButton = await page.waitForSelector( '.components-button.is-font-custom' );
 		await changeSizeButton.click();
-
-		await page.click( '.blocks-font-size .components-range-control__number' );
-		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.press( 'Backspace' );
-
-		// Ensure content matches snapshot.
-		const content = await getEditedPostContent();
-		expect( content ).toMatchSnapshot();
-	} );
-
-	it( 'should reset a custom font size using input field', async () => {
-		// Create a paragraph block with some content.
-		await clickBlockAppender();
-		await page.keyboard.type( 'Paragraph to be made "small"' );
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
 		await page.keyboard.type( '23' );
 
-		await page.keyboard.press( 'Backspace' );
+		// Blur the range control
+		await page.click( '.components-base-control__label' );
 
-		await page.click( '.blocks-font-size .components-range-control__number' );
-		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.press( 'Backspace' );
+		const resetButton = ( await page.$x( '//*[contains(concat(" ", @class, " "), " components-font-size-picker__buttons ")]//*[text()=\'Reset\']' ) )[ 0 ];
+		await resetButton.click();
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();


### PR DESCRIPTION
This PR adds "Custom" as a selectable option in the font size picker and hides the font size text input unless Custom is selected.

The intent here is to disconnect the font size names from pixel values. The pixel values are only used in generating the preview in the Dropdown, and may not map to the actual size applied via CSS, as users may use relative units (em, rem, etc.) in their stylesheet.

When "Custom" is selected the user can enter any numeric value, as before and it will map to an inline `style` attribute.

## Screenshots

![font-sizes](https://user-images.githubusercontent.com/1231306/47087621-79c05380-d1ea-11e8-9e5f-28caa4b59b15.gif)

## Caveats

The only caveat right now is that if you type in a number that corresponds to a pre-defined font size (e.g. `16` or `20`), it reverts to use the corresponding pre-defined font size in the Dropdown. I think this is okay — it's still a better experience than before — but a follow up to this (as part of the API freeze, I think) would be to determine the selected font size via slug matching, not value matching.

Relates to #7761, #9549, #8689, and some others.