### PR TITLE
Clean-up: rm unused variable fallbacks in RichText

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import {
 	defer,
 	find,
-	identity,
 	isNil,
 	noop,
 	isEqual,
@@ -968,7 +967,7 @@ const RichTextContainer = compose( [
 		};
 	} ),
 	withSelect( ( select ) => {
-		const { isViewportMatch = identity } = select( 'core/viewport' ) || {};
+		const { isViewportMatch } = select( 'core/viewport' );
 		const { canUserUseUnfilteredHTML } = select( 'core/editor' );
 
 		return {


### PR DESCRIPTION
## Description
Addresses https://github.com/WordPress/gutenberg/pull/5769#discussion_r201446542

Should have no effect whatsoever.

## How has this been tested?

Try operating a RichText component, try switching to and from mobile view with the browser's Response Mode, make sure no errors arise.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
