### PR TITLE
[ReactNative] Refactor block splitting code on paragraph and heading blocks

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -24,28 +24,11 @@ import './editor.scss';
 const minHeight = 50;
 
 class HeadingEdit extends Component {
-	constructor() {
-		super( ...arguments );
-		this.splitBlock = this.splitBlock.bind( this );
-	}
-
-	// eslint-disable-next-line no-unused-vars
-	splitBlock( htmlText, start, end ) {
-		const {
-			insertBlocksAfter,
-		} = this.props;
-
-		if ( insertBlocksAfter ) {
-			const blocks = [];
-			blocks.push( createBlock( 'core/paragraph', { content: 'Test' } ) );
-			insertBlocksAfter( blocks );
-		}
-	}
-
 	render() {
 		const {
 			attributes,
 			setAttributes,
+			insertBlocksAfter,
 		} = this.props;
 
 		const {
@@ -73,7 +56,17 @@ class HeadingEdit extends Component {
 							content: newParaBlock.attributes.content,
 						} );
 					} }
-					onSplit={ this.splitBlock }
+					onSplit={
+						insertBlocksAfter ?
+							( before, after, ...blocks ) => {
+								setAttributes( { content: before } );
+								insertBlocksAfter( [
+									...blocks,
+									createBlock( 'core/paragraph', { content: after } ),
+								] );
+							} :
+							undefined
+					}
 					onContentSizeChange={ ( event ) => {
 						setAttributes( { aztecHeight: event.aztecHeight } );
 					} }

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -13,22 +13,54 @@ import { RichText } from '@wordpress/editor';
 
 const minHeight = 50;
 
+const name = 'core/paragraph';
+
 class ParagraphEdit extends Component {
 	constructor() {
 		super( ...arguments );
 		this.splitBlock = this.splitBlock.bind( this );
 	}
 
-	// eslint-disable-next-line no-unused-vars
-	splitBlock( htmlText, start, end ) {
+	/**
+	 * Split handler for RichText value, namely when content is pasted or the
+	 * user presses the Enter key.
+	 *
+	 * @param {?Array}     before Optional before value, to be used as content
+	 *                            in place of what exists currently for the
+	 *                            block. If undefined, the block is deleted.
+	 * @param {?Array}     after  Optional after value, to be appended in a new
+	 *                            paragraph block to the set of blocks passed
+	 *                            as spread.
+	 * @param {...WPBlock} blocks Optional blocks inserted between the before
+	 *                            and after value blocks.
+	 */
+	splitBlock( before, after, ...blocks ) {
 		const {
+			attributes,
 			insertBlocksAfter,
+			setAttributes,
 		} = this.props;
 
-		if ( insertBlocksAfter ) {
-			const blocks = [];
-			blocks.push( createBlock( 'core/paragraph', { content: 'Test' } ) );
+		if ( after !== null ) {
+			// Append "After" content as a new paragraph block to the end of
+			// any other blocks being inserted after the current paragraph.
+			const newBlock = createBlock( name, { content: after } );
+			blocks.push( newBlock );
+		}
+
+		if ( blocks.length && insertBlocksAfter ) {
 			insertBlocksAfter( blocks );
+		}
+
+		const { content } = attributes;
+		if ( before === null ) {
+			// TODO : If before content is omitted, treat as intent to delete block.
+			// onReplace( [] );
+		} else if ( content !== before ) {
+			// Only update content if it has in-fact changed. In case that user
+			// has created a new paragraph at end of an existing one, the value
+			// of before will be strictly equal to the current content.
+			setAttributes( { content: before } );
 		}
 	}
 


### PR DESCRIPTION
In this PR I started the refactor of the code that handles block splitting (for Paragraph and Heading blocks) on Enter.KEY and tried to stay closer to the web implementation.

@diegoreymendez  this is just a working in progress, but worth to get this merged since it will probably affect the Native wrapper around Aztec. See the [hack](https://github.com/WordPress/gutenberg/compare/rnmobile/split-para-heading-blocks-on-enter-step2?expand=1#diff-ed195425f515f40db41c23d586760ef9R90) here. 

Internally there is a conversion from HTML to RichText format, and the position of the cursor  obviously doesn't match. Consequence of this, the code that actually does the split uses a wrong index and split at "arbitrary" position.
Maybe just returning the "geographical" position of the cursor in Aztec will fix this issue. We need to investiga that better, so having this merged will help.
