### PR TITLE
File Block: Remove the download attribute

### DIFF
--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -11,7 +11,6 @@ import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { RichText } from '@wordpress/editor';
-import { create, getTextContent } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -40,20 +39,20 @@ export const settings = {
 		},
 		fileName: {
 			source: 'html',
-			selector: 'a:not([download])',
+			selector: '.wp-block-file__link',
 		},
 		// Differs to the href when the block is configured to link to the attachment page
 		textLinkHref: {
 			type: 'string',
 			source: 'attribute',
-			selector: 'a:not([download])',
+			selector: '.wp-block-file__link',
 			attribute: 'href',
 		},
 		// e.g. `_blank` when the block is configured to open in a new window
 		textLinkTarget: {
 			type: 'string',
 			source: 'attribute',
-			selector: 'a:not([download])',
+			selector: '.wp-block-file__link',
 			attribute: 'target',
 		},
 		showDownloadButton: {
@@ -62,7 +61,7 @@ export const settings = {
 		},
 		downloadButtonText: {
 			source: 'html',
-			selector: 'a[download]',
+			selector: '.wp-block-file__button',
 			default: __( 'Download' ),
 		},
 	},
@@ -208,6 +207,7 @@ export const settings = {
 						href={ textLinkHref }
 						target={ textLinkTarget }
 						rel={ textLinkTarget ? 'noreferrer noopener' : false }
+						className="wp-block-file__link"
 					>
 						<RichText.Content
 							value={ fileName }
@@ -218,10 +218,6 @@ export const settings = {
 					<a
 						href={ href }
 						className="wp-block-file__button"
-						// ensure download attribute is still set when fileName
-						// is undefined. Using '' here as `true` still leaves
-						// the attribute unset.
-						download={ getTextContent( create( { html: fileName } ) ) }
 					>
 						<RichText.Content
 							value={ downloadButtonText }


### PR DESCRIPTION
## Description

Remove the `download` attribute from the File block's "Download" button.

The addition of the `download` attribute for `a` tags to the `wp_kses` whitelist has been [recently blocked](https://core.trac.wordpress.org/ticket/44724#comment:11) (cc @pento):

> The `download` attribute doesn't work on cross-origin links (eg, any site that uses a CDN for hosting uploads). I don't know that we necessarily need to account for this, but it is something to consider.
>
> It's also a risk to allow the download filename to be set: for example, an author could upload `my_definitely_not_suspicious_file.txt`, but then set the download attribute to be `CLICK_ME.bat`, which isn't great. If we do allow the `download` attribute, it should only be allowed with no value.

It makes sense to me to just remove the attribute altogether from the File block, and leave to the user the decision of saving the file instead of navigating to it.

## How has this been tested?
Manually on a local environment, checking for regressions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
