### PR TITLE
Editor: Add KeybindScope complement to NavigableToolbar

### DIFF
--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -1,24 +1,13 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
-import NavigableToolbar from '../navigable-toolbar';
 import { BlockToolbar } from '../';
 
 function BlockContextualToolbar( { focusOnMount } ) {
 	return (
-		<NavigableToolbar
-			focusOnMount={ focusOnMount }
-			className="editor-block-contextual-toolbar"
-			/* translators: accessibility text for the block toolbar */
-			aria-label={ __( 'Block tools' ) }
-		>
-			<BlockToolbar />
-		</NavigableToolbar>
+		<div className="editor-block-contextual-toolbar">
+			<BlockToolbar focusOnMount={ focusOnMount } />
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -22,7 +22,7 @@ import {
 	isUnmodifiedDefaultBlock,
 	getUnregisteredTypeHandlerName,
 } from '@wordpress/blocks';
-import { KeyboardShortcuts, withFilters } from '@wordpress/components';
+import { withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -569,25 +569,22 @@ export class BlockListBlock extends Component {
 										focusOnMount={ this.isForcingContextualToolbar }
 									/>
 								) }
-								{ ! shouldShowContextualToolbar &&
-									isSelected &&
-									! hasFixedToolbar &&
-									! isEmptyDefaultBlock && (
-									<KeyboardShortcuts
-										bindGlobal
-										eventName="keydown"
-										shortcuts={ {
-											'alt+f10': this.forceFocusedContextualToolbar,
-										} }
-									/>
-								) }
 								<IgnoreNestedEvents
 									ref={ this.bindBlockNode }
 									onDragStart={ this.preventDrag }
 									onMouseDown={ this.onPointerDown }
 									data-block={ clientId }
 								>
-									<NavigableToolbar.KeybindScope scopeId={ 'block-' + clientId }>
+									<NavigableToolbar.KeybindScope
+										onFocusToolbar={
+											! shouldShowContextualToolbar &&
+											isSelected &&
+											! hasFixedToolbar &&
+											! isEmptyDefaultBlock &&
+											this.forceFocusedContextualToolbar
+										}
+										scopeId={ 'block-' + clientId }
+									>
 										<BlockCrashBoundary onError={ this.onBlockError }>
 											{ isValid && blockEdit }
 											{ isValid && mode === 'html' && (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -3,6 +3,7 @@
  */
 import { withSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,32 +13,41 @@ import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 import BlockSettingsMenu from '../block-settings-menu';
+import NavigableToolbar from '../navigable-toolbar';
 
-function BlockToolbar( { blockClientIds, isValid, mode } ) {
+function BlockToolbar( { blockClientIds, isValid, mode, focusOnMount } ) {
 	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
 
-	if ( blockClientIds.length > 1 ) {
-		return (
-			<div className="editor-block-toolbar">
-				<MultiBlocksSwitcher />
-				<BlockSettingsMenu clientIds={ blockClientIds } />
-			</div>
+	const hasMultiSelection = blockClientIds.length > 1;
+
+	let controls;
+	if ( hasMultiSelection ) {
+		controls = (
+			<MultiBlocksSwitcher />
+		);
+	} else if ( mode === 'visual' && isValid ) {
+		controls = (
+			<Fragment>
+				<BlockSwitcher clientIds={ blockClientIds } />
+				<BlockControls.Slot />
+				<BlockFormatControls.Slot />
+			</Fragment>
 		);
 	}
 
 	return (
-		<div className="editor-block-toolbar">
-			{ mode === 'visual' && isValid && (
-				<Fragment>
-					<BlockSwitcher clientIds={ blockClientIds } />
-					<BlockControls.Slot />
-					<BlockFormatControls.Slot />
-				</Fragment>
-			) }
+		<NavigableToolbar
+			focusOnMount={ focusOnMount }
+			className="editor-block-toolbar"
+			/* translators: accessibility text for the block toolbar */
+			aria-label={ __( 'Block Toolbar' ) }
+			scopeId={ 'block-' + blockClientIds[ 0 ] }
+		>
+			{ controls }
 			<BlockSettingsMenu clientIds={ blockClientIds } />
-		</div>
+		</NavigableToolbar>
 	);
 }
 

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -11,53 +11,50 @@ import { Component, createRef } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
 
-/**
- * Browser dependencies
- */
-
-const { Node, getSelection } = window;
-
 class NavigableToolbar extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.focusToolbar = this.focusToolbar.bind( this );
-		this.focusSelection = this.focusSelection.bind( this );
+		this.restoreFocus = this.restoreFocus.bind( this );
 
 		this.switchOnKeyDown = cond( [
-			[ matchesProperty( [ 'keyCode' ], ESCAPE ), this.focusSelection ],
+			[ matchesProperty( [ 'keyCode' ], ESCAPE ), this.restoreFocus ],
 		] );
 		this.toolbar = createRef();
 	}
 
+	/**
+	 * Shifts focus to the first tabbable element within the toolbar container,
+	 * if one exists.
+	 */
 	focusToolbar() {
 		const tabbables = focus.tabbable.find( this.toolbar.current );
-		if ( tabbables.length ) {
-			tabbables[ 0 ].focus();
-		}
-	}
-
-	/**
-	 * Programmatically shifts focus to the element where the current selection
-	 * exists, if there is a selection.
-	 */
-	focusSelection() {
-		// Ensure that a selection exists.
-		const selection = getSelection();
-		if ( ! selection ) {
+		if ( ! tabbables.length ) {
 			return;
 		}
 
-		// Focus node may be a text node, which cannot be focused directly.
-		// Find its parent element instead.
-		const { focusNode } = selection;
-		let focusElement = focusNode;
-		if ( focusElement.nodeType !== Node.ELEMENT_NODE ) {
-			focusElement = focusElement.parentElement;
-		}
+		// Track the original active element prior to shifting focus, so that
+		// focus can be returned if the user presses Escape while in toolbar.
+		//
+		// [TODO]: Currently, to support "stepping down" through multiple
+		// navigable toolbars, the assigned value is only cleared after
+		// pressing Escape. If the user manually shifts focus away and later
+		// returns to press Escape, it will still (wrongly) use the earlier-
+		// assigned value.
+		this.activeElementBeforeFocus = document.activeElement;
 
-		if ( focusElement ) {
-			focusElement.focus();
+		tabbables[ 0 ].focus();
+	}
+
+	/**
+	 * Restores focus to the active element at the time focus was
+	 * programattically shifted to the toolbar, if one exists.
+	 */
+	restoreFocus() {
+		if ( this.activeElementBeforeFocus ) {
+			this.activeElementBeforeFocus.focus();
+			delete this.activeElementBeforeFocus;
 		}
 	}
 

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -116,6 +116,10 @@ NavigableToolbar.KeybindScope = class extends Component {
 		if ( toolbar ) {
 			toolbar.focusToolbar();
 		}
+
+		if ( this.props.onFocusToolbar ) {
+			this.props.onFocusToolbar();
+		}
 	}
 
 	render() {

--- a/packages/block-editor/src/components/navigable-toolbar/navigable-toolbar/README.md
+++ b/packages/block-editor/src/components/navigable-toolbar/navigable-toolbar/README.md
@@ -1,0 +1,29 @@
+NavigableToolbar
+================
+
+NavigableToolbar is a set of components which renders a toolbar menu and coordinates focus to and from the toolbar by contextual keyboard shortcuts.
+
+While focused within the scope of a `NavigableToolbar.KeybindScope` component, pressing <kbd>Alt + F10</kbd> will direct focus to the corresponding toolbar by scope identifier. Pressing <kbd>Escape</kbd> while in a toolbar will return focus to the element which had focus at the time of the <kbd>Alt + F10</kbd> key combination, if applicable.
+
+## Usage
+
+Render a `NavigableToolbar` with an assigned scopeId. Elsewhere, render one or more `NavigableToolbar.KeybindScope` wrapping the context(s) in which the toolbar's keyboard shortcut should be observed.
+
+```jsx
+import { NavigableToolbar } from '@wordpress/editor';
+import { Toolbar } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+
+function MyNavigableToolbar() {
+	return (
+		<Fragment>
+			<NavigableToolbar scopeId="my-toolbar">
+				<Toolbar controls={ [ /* ... */ ] } />
+			</NavigableToolbar>
+			<NavigableToolbar.KeybindScope scopeId="my-toolbar">
+				<textarea />
+			</NavigableToolbar.KeybindScope>
+		</Fragment>
+	);
+}
+```

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -11,9 +11,18 @@ import { orderBy } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Toolbar, Slot, DropdownMenu } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+
+import NavigableToolbar from '../../navigable-toolbar';
+
 const FormatToolbar = ( { controls } ) => {
 	return (
-		<div className="editor-format-toolbar">
+		<NavigableToolbar
+			scopeId="block-editor-format-toolbar"
+			className="editor-format-toolbar"
+		>
 			<Toolbar>
 				{ controls.map( ( format ) =>
 					<Slot name={ `RichText.ToolbarControls.${ format }` } key={ format } />
@@ -29,7 +38,7 @@ const FormatToolbar = ( { controls } ) => {
 					}
 				</Slot>
 			</Toolbar>
-		</div>
+		</NavigableToolbar>
 	);
 };
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -55,6 +55,7 @@ import deprecated from '@wordpress/deprecated';
 import Autocomplete from '../autocomplete';
 import BlockFormatControls from '../block-format-controls';
 import FormatEdit from './format-edit';
+import NavigableToolbar from '../navigable-toolbar';
 import FormatToolbar from './format-toolbar';
 import Editable from './editable';
 import { pickAriaProps } from './aria';
@@ -1044,8 +1045,8 @@ export class RichText extends Component {
 					record={ record }
 					onChange={ this.onChange }
 				>
-					{ ( { listBoxId, activeId } ) => (
-						<Fragment>
+					{ ( { listBoxId, activeId } ) => {
+						let field = (
 							<Editable
 								tagName={ Tagname }
 								style={ style }
@@ -1071,17 +1072,36 @@ export class RichText extends Component {
 								multilineWrapperTags={ this.multilineWrapperTags }
 								setRef={ this.setRef }
 							/>
-							{ isPlaceholderVisible &&
-								<Tagname
-									className={ classnames( 'editor-rich-text__editable', className ) }
-									style={ style }
-								>
-									{ MultilineTag ? <MultilineTag>{ placeholder }</MultilineTag> : placeholder }
-								</Tagname>
-							}
-							{ isSelected && <FormatEdit value={ record } onChange={ this.onChange } /> }
-						</Fragment>
-					) }
+						);
+
+						if ( isSelected && inlineToolbar ) {
+							field = (
+								<NavigableToolbar.KeybindScope scopeId="block-editor-format-toolbar">
+									{ field }
+								</NavigableToolbar.KeybindScope>
+							);
+						}
+
+						return (
+							<Fragment>
+								{ field }
+								{ isPlaceholderVisible &&
+									<Tagname
+										className={ classnames( 'editor-rich-text__editable', className ) }
+										style={ style }
+									>
+										{ MultilineTag ? <MultilineTag>{ placeholder }</MultilineTag> : placeholder }
+									</Tagname>
+								}
+								{ isSelected && (
+									<FormatEdit
+										value={ record }
+										onChange={ this.onChange }
+									/>
+								) }
+							</Fragment>
+						);
+					} }
 				</Autocomplete>
 				{ isSelected && <RemoveBrowserShortcuts /> }
 			</div>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -105,6 +105,10 @@
 
 - `IconButton` correctly respects a passed `aria-label` prop.
 
+### New Feature
+
+- Added new prop `ignoreChildHandled` to the `KeyboardShortcuts` component.
+
 ### Deprecation
 
 - `PanelColor` has been deprecated in favor of `wp.editor.PanelColorSettings`.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -108,6 +108,7 @@
 ### New Feature
 
 - Added new prop `ignoreChildHandled` to the `KeyboardShortcuts` component.
+- `KeyboardShortcuts` now passes through extra props to its rendered element when wrapping children.
 
 ### Deprecation
 

--- a/packages/components/src/keyboard-shortcuts/README.md
+++ b/packages/components/src/keyboard-shortcuts/README.md
@@ -34,7 +34,7 @@ const MyKeyboardShortcuts = withState( {
 
 ## Props
 
-The component accepts the following props:
+The component accepts the following props. Any other props are passed to the rendered wrapping element, if passed with `children`.
 
 ### children
 

--- a/packages/components/src/keyboard-shortcuts/README.md
+++ b/packages/components/src/keyboard-shortcuts/README.md
@@ -70,6 +70,12 @@ By default, a callback is invoked in response to the `keydown` event. To overrid
 - Type: `String`
 - Required: No
 
+## ignoreChildHandled
+
+Pass as `true` to avoid calling the callback handler when the shortcut has already been handled by a descendant `KeyboardShortcuts`.
+
+This behaves similarly to [`Event#stopPropagation`](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation) but impacts only the behavior of `KeyboardShortcuts`, not otherwise stopping propagation of the event.
+
 ## References
 
 - [Mousetrap documentation](https://craig.is/killing/mice)

--- a/packages/components/src/keyboard-shortcuts/index.js
+++ b/packages/components/src/keyboard-shortcuts/index.js
@@ -3,7 +3,7 @@
  */
 import Mousetrap from 'mousetrap';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
-import { forEach } from 'lodash';
+import { forEach, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -70,7 +70,17 @@ class KeyboardShortcuts extends Component {
 			return null;
 		}
 
-		return <div ref={ this.bindKeyTarget }>{ children }</div>;
+		return (
+			<div
+				ref={ this.bindKeyTarget }
+				{ ...omit( this.props, [
+					'shortcuts',
+					'bindGlobal',
+					'eventName',
+					'ignoreChildHandled',
+				] ) }
+			/>
+		);
 	}
 }
 

--- a/packages/components/src/keyboard-shortcuts/test/__snapshots__/index.js.snap
+++ b/packages/components/src/keyboard-shortcuts/test/__snapshots__/index.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KeyboardShortcuts should passes through props to children wrapper 1`] = `"<div class=\\"is-ok\\"><textarea></textarea></div>"`;

--- a/packages/components/src/keyboard-shortcuts/test/index.js
+++ b/packages/components/src/keyboard-shortcuts/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { noop } from 'lodash';
 import { mount } from 'enzyme';
 
 /**
@@ -109,6 +110,119 @@ describe( 'KeyboardShortcuts', () => {
 		expect( spy ).not.toHaveBeenCalled();
 
 		// Inside scope
+		keyPress( 68, textareas.at( 0 ).getDOMNode() );
+		expect( spy ).toHaveBeenCalled();
+	} );
+
+	it( 'should continue to bubble to ancestors', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<KeyboardShortcuts
+				shortcuts={ {
+					d: spy,
+				} }
+			>
+				<KeyboardShortcuts
+					shortcuts={ {
+						d: noop,
+					} }
+				>
+					<textarea></textarea>
+				</KeyboardShortcuts>
+			</KeyboardShortcuts>,
+			{ attachTo: attachNode }
+		);
+
+		const textareas = wrapper.find( 'textarea' );
+
+		keyPress( 68, textareas.at( 0 ).getDOMNode() );
+		expect( spy ).toHaveBeenCalled();
+	} );
+
+	it( 'should ignore events on child handled', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<KeyboardShortcuts
+				ignoreChildHandled
+				shortcuts={ {
+					d: spy,
+				} }
+			>
+				<KeyboardShortcuts
+					shortcuts={ {
+						d: noop,
+					} }
+				>
+					<textarea></textarea>
+				</KeyboardShortcuts>
+			</KeyboardShortcuts>,
+			{ attachTo: attachNode }
+		);
+
+		const textareas = wrapper.find( 'textarea' );
+
+		keyPress( 68, textareas.at( 0 ).getDOMNode() );
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should propagate events on child handled', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		const wrapper = mount(
+			<div onKeyDown={ spy }>
+				<KeyboardShortcuts
+					ignoreChildHandled
+					shortcuts={ {
+						d: noop,
+					} }
+				>
+					<KeyboardShortcuts
+						shortcuts={ {
+							d: noop,
+						} }
+					>
+						<textarea></textarea>
+					</KeyboardShortcuts>
+				</KeyboardShortcuts>
+			</div>,
+			{ attachTo: attachNode }
+		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
+
+		const textareas = wrapper.find( 'textarea' );
+
+		keyPress( 68, textareas.at( 0 ).getDOMNode() );
+		expect( spy ).toHaveBeenCalled();
+	} );
+
+	it( 'should handle if ignoreChildHandled but not handled by child', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<KeyboardShortcuts
+				ignoreChildHandled
+				shortcuts={ {
+					d: spy,
+				} }
+			>
+				<textarea></textarea>
+			</KeyboardShortcuts>,
+			{ attachTo: attachNode }
+		);
+
+		const textareas = wrapper.find( 'textarea' );
+
 		keyPress( 68, textareas.at( 0 ).getDOMNode() );
 		expect( spy ).toHaveBeenCalled();
 	} );

--- a/packages/components/src/keyboard-shortcuts/test/index.js
+++ b/packages/components/src/keyboard-shortcuts/test/index.js
@@ -226,4 +226,22 @@ describe( 'KeyboardShortcuts', () => {
 		keyPress( 68, textareas.at( 0 ).getDOMNode() );
 		expect( spy ).toHaveBeenCalled();
 	} );
+
+	it( 'should passes through props to children wrapper', () => {
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<KeyboardShortcuts
+				ignoreChildHandled
+				shortcuts={ {} }
+				className="is-ok"
+			>
+				<textarea></textarea>
+			</KeyboardShortcuts>,
+			{ attachTo: attachNode }
+		);
+
+		expect( wrapper.getDOMNode().outerHTML ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/navigable-toolbar.test.js
@@ -33,6 +33,12 @@ describe( 'block toolbar', () => {
 			!! document.activeElement.closest( '.editor-block-toolbar' )
 		) );
 
+		const isInHeaderToolbar = () => page.evaluate( () => (
+			// Test the precise element since in Unified mode, the block
+			// toolbar is technically a child of the header toolbar.
+			document.activeElement.classList.contains( 'editor-inserter__toggle' )
+		) );
+
 		describe( label, () => {
 			it( 'navigates in and out of toolbar by keyboard (Alt+F10, Escape)', async () => {
 				// Assumes new post focus starts in title. Create first new
@@ -43,11 +49,21 @@ describe( 'block toolbar', () => {
 				// until starting to type within it.
 				await page.keyboard.type( 'Example' );
 
+				// At this point, we should have two levels of toolbar to
+				// step into and out of:
+				//
+				// 1. Block
+				// 2. Header
+
 				// Upward
 				await pressKeyWithModifier( 'alt', 'F10' );
 				expect( await isInBlockToolbar() ).toBe( true );
+				await pressKeyWithModifier( 'alt', 'F10' );
+				expect( await isInHeaderToolbar() ).toBe( true );
 
 				// Downward
+				await page.keyboard.press( 'Escape' );
+				expect( await isInBlockToolbar() ).toBe( true );
 				await page.keyboard.press( 'Escape' );
 				expect( await isInRichTextEditable() ).toBe( true );
 			} );

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -34,6 +34,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isText
 		<NavigableToolbar
 			className="edit-post-header-toolbar"
 			aria-label={ toolbarAriaLabel }
+			scopeId="edit-post-header"
 		>
 			<FullscreenModeClose />
 			<div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -8,7 +8,10 @@ import classnames from 'classnames';
  */
 import { Button, Popover, ScrollLock, navigateRegions } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { PreserveScrollInReorder } from '@wordpress/block-editor';
+import {
+	PreserveScrollInReorder,
+	NavigableToolbar,
+} from '@wordpress/block-editor';
 import {
 	AutosaveMonitor,
 	UnsavedChangesWarning,
@@ -71,57 +74,62 @@ function Layout( {
 			<UnsavedChangesWarning />
 			<AutosaveMonitor />
 			<Header />
-			<div
-				className="edit-post-layout__content"
-				role="region"
-				/* translators: accessibility text for the content landmark region. */
-				aria-label={ __( 'Editor content' ) }
-				tabIndex="-1"
+			<NavigableToolbar.KeybindScope
+				scopeId="edit-post-header"
+				className="edit-post-layout__navigable-toolbar-scope"
 			>
-				<EditorNotices dismissible={ false } className="is-pinned" />
-				<EditorNotices dismissible={ true } />
-				<PreserveScrollInReorder />
-				<EditorModeKeyboardShortcuts />
-				<KeyboardShortcutHelpModal />
-				<OptionsModal />
-				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
-				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
-				<div className="edit-post-layout__metaboxes">
-					<MetaBoxes location="normal" />
-				</div>
-				<div className="edit-post-layout__metaboxes">
-					<MetaBoxes location="advanced" />
-				</div>
-			</div>
-			{ publishSidebarOpened ? (
-				<PostPublishPanel
-					{ ...publishLandmarkProps }
-					onClose={ closePublishSidebar }
-					forceIsDirty={ hasActiveMetaboxes }
-					forceIsSaving={ isSaving }
-					PrePublishExtension={ PluginPrePublishPanel.Slot }
-					PostPublishExtension={ PluginPostPublishPanel.Slot }
-				/>
-			) : (
-				<Fragment>
-					<div className="edit-post-toggle-publish-panel" { ...publishLandmarkProps }>
-						<Button
-							isDefault
-							type="button"
-							className="edit-post-toggle-publish-panel__button"
-							onClick={ togglePublishSidebar }
-							aria-expanded={ false }
-						>
-							{ __( 'Open publish panel' ) }
-						</Button>
+				<div
+					className="edit-post-layout__content"
+					role="region"
+					/* translators: accessibility text for the content landmark region. */
+					aria-label={ __( 'Editor content' ) }
+					tabIndex="-1"
+				>
+					<EditorNotices dismissible={ false } className="is-pinned" />
+					<EditorNotices dismissible={ true } />
+					<PreserveScrollInReorder />
+					<EditorModeKeyboardShortcuts />
+					<KeyboardShortcutHelpModal />
+					<OptionsModal />
+					{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
+					{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
+					<div className="edit-post-layout__metaboxes">
+						<MetaBoxes location="normal" />
 					</div>
-					<SettingsSidebar />
-					<Sidebar.Slot />
-					{
-						isMobileViewport && sidebarIsOpened && <ScrollLock />
-					}
-				</Fragment>
-			) }
+					<div className="edit-post-layout__metaboxes">
+						<MetaBoxes location="advanced" />
+					</div>
+				</div>
+				{ publishSidebarOpened ? (
+					<PostPublishPanel
+						{ ...publishLandmarkProps }
+						onClose={ closePublishSidebar }
+						forceIsDirty={ hasActiveMetaboxes }
+						forceIsSaving={ isSaving }
+						PrePublishExtension={ PluginPrePublishPanel.Slot }
+						PostPublishExtension={ PluginPostPublishPanel.Slot }
+					/>
+				) : (
+					<Fragment>
+						<div className="edit-post-toggle-publish-panel" { ...publishLandmarkProps }>
+							<Button
+								isDefault
+								type="button"
+								className="edit-post-toggle-publish-panel__button"
+								onClick={ togglePublishSidebar }
+								aria-expanded={ false }
+							>
+								{ __( 'Open publish panel' ) }
+							</Button>
+						</div>
+						<SettingsSidebar />
+						<Sidebar.Slot />
+						{
+							isMobileViewport && sidebarIsOpened && <ScrollLock />
+						}
+					</Fragment>
+				) }
+			</NavigableToolbar.KeybindScope>
 			<Popover.Slot />
 			<PluginArea />
 		</div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -73,11 +73,11 @@ function Layout( {
 			<BrowserURL />
 			<UnsavedChangesWarning />
 			<AutosaveMonitor />
-			<Header />
 			<NavigableToolbar.KeybindScope
 				scopeId="edit-post-header"
 				className="edit-post-layout__navigable-toolbar-scope"
 			>
+				<Header />
 				<div
 					className="edit-post-layout__content"
 					role="region"

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,5 +1,6 @@
 .edit-post-layout,
-.edit-post-layout__content {
+.edit-post-layout__content,
+.edit-post-layout__navigable-toolbar-scope {
 	height: 100%;
 }
 


### PR DESCRIPTION
Supersedes #10529
Fixes #6165

This pull request seeks to revise the behavior of `NavigableToolbar` from implementing a global keybind to instead observe key combinations within a specific scope. Further, in restoring focus after an Escape press from the toolbar, it considers the element which had focus before focus had shifted to the toolbar programmatically. The scoping also allows for "stepping" behavior, where <kbd>Alt+F10</kbd>/<kbd>Escape</kbd> respectively work their way up/down to/from the nearest navigable toolbar scope.

![toolbars](https://user-images.githubusercontent.com/1779930/47106878-bc4b5580-d215-11e8-8908-d4484c702de1.gif)

**Implementation notes:**

- To accommodate the lack of a visible toolbar while "typing", the typing observer now interprets the Escape key press as intent to cancel typing (thus displaying toolbar).
   - I had also considered refactoring ObserveTyping to always toggle the typing flag on/off if a key pressed is not a "typing start". This turned out to have too many edge cases to consider here.
- Most of the included commits can (should?) be split out to their own pull requests in order to ease review

**Remaining tasks:**

- End-to-end case(s)

**Testing instructions**

Verify that, with toolbars present, Alt+F10 sequentially steps upward to the "closest" toolbar. Conversely, Escape steps back down.