### PR TITLE
Testing: Stub all oEmbed requests as empty string

### DIFF
--- a/test/e2e/specs/demo-content-with-keyboard.test.js
+++ b/test/e2e/specs/demo-content-with-keyboard.test.js
@@ -358,10 +358,11 @@ describe( 'Demo content post', () => {
 
 		const postContent = await getEditedPostContent();
 
-		// Some random asserters to ensure blocks have been inserted and the navigation went well
+		// TODO: A snapshot test should be used, but content must be normalized
+		// to account for differences in (a) upload path and (b) media IDs.
 		expect( postContent ).toMatch( `<p style="text-align:center">Thanks for testing Gutenberg!</p>` );
 		expect( postContent ).toMatch( `<div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>` );
 		expect( postContent ).toMatch( `<p style="text-align:center"><em>If you want to learn more about how to build additional blocks, or if you are interested in helping with the project, head over to the <a href="https://github.com/WordPress/gutenberg">GitHub repository</a>.</em></p>` );
-		expect( postContent ).toMatch( new RegExp( `<figure class=\\"wp-block-embed-vimeo wp-block-embed is-type-video is-provider-vimeo wp-embed-aspect-16-9 wp-has-aspect-ratio\\"><div class=\\"wp-block-embed__wrapper\\">\\s*https://vimeo.com/22439234\\s*</div></figure>` ) );
+		expect( postContent ).toMatch( new RegExp( `<figure class=\\"wp-block-embed-vimeo wp-block-embed\\"><div class=\\"wp-block-embed__wrapper\\">\\s*https://vimeo.com/22439234\\s*</div></figure>` ) );
 	} );
 } );

--- a/test/e2e/specs/demo.test.js
+++ b/test/e2e/specs/demo.test.js
@@ -1,45 +1,10 @@
 /**
- * External dependencies
- */
-import fetch from 'node-fetch';
-
-/**
  * Internal dependencies
  */
 import { visitAdmin } from '../support/utils';
 
 describe( 'new editor state', () => {
 	beforeAll( async () => {
-		// Intercept embed requests so that scripts loaded from third parties
-		// cannot leave errors in the console and cause the test to fail.
-		await page.setRequestInterception( true );
-		page.on( 'request', async ( request ) => {
-			if ( request.url().indexOf( 'oembed/1.0/proxy' ) !== -1 ) {
-				// Because we can't get the responses to requests and modify them on the fly,
-				// we have to make our own request, get the response, modify it, then use the
-				// modified values to respond to the request.
-				const response = await fetch(
-					request.url(),
-					{
-						headers: request.headers(),
-						method: request.method(),
-						body: request.postData(),
-					}
-				);
-				const preview = await response.json();
-				// Remove the first src attribute. This stops the Vimeo iframe loading the actual
-				// embedded content, but the height and width are preserved so layout related
-				// attributes, like aspect ratio CSS classes, remain the same.
-				preview.html = preview.html.replace( /src=[^\s]+/, '' );
-				request.respond( {
-					content: 'application/json',
-					body: JSON.stringify( preview ),
-				} );
-			} else {
-				request.continue();
-			}
-		} );
-
 		await visitAdmin( 'post-new.php', 'gutenberg-demo' );
 	} );
 

--- a/test/e2e/test-mu-plugins/stub-embeds.php
+++ b/test/e2e/test-mu-plugins/stub-embeds.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Plugin Name: Gutenberg Test Plugin, Stub Embeds
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-stub-embeds
+ */
+
+/*
+ * NOTE: Currently, this only overrides the `html` return value of the embed
+ * request, but does not (yet) otherwise stub the request to the provider's
+ * oEmbed endpoint.
+ */
+
+add_filter( 'pre_oembed_result', '__return_empty_string' );


### PR DESCRIPTION
Related: #10682

This pull request seeks to improve end-to-end tests to stub an empty HTML response for all oEmbeds.

**Testing Instructions:**

Ensure end-to-end tests pass:

```
npm run test-e2e
```