### PR TITLE
Fix autocomplete keyboard nav in link popover

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -99,6 +99,7 @@ class LinkContainer extends Component {
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onChangeInputValue = this.onChangeInputValue.bind( this );
 		this.setLinkTarget = this.setLinkTarget.bind( this );
+		this.onClickOutside = this.onClickOutside.bind( this );
 		this.resetState = this.resetState.bind( this );
 		this.autocompleteRef = createRef();
 
@@ -175,15 +176,20 @@ class LinkContainer extends Component {
 		event.preventDefault();
 	}
 
-	resetState( event ) {
+	onClickOutside( event ) {
 		// The autocomplete suggestions list renders in a separate popover (in a portal),
 		// so onClickOutside fails to detect that a click on a suggestion occured in the
 		// LinkContainer. Detect clicks on autocomplete suggestions using a ref here, and
-		// return early if so.
-		if ( this.autocompleteRef.current && this.autocompleteRef.current.contains( event.target ) ) {
+		// return to avoid the popover being closed.
+		const autocompleteElement = this.autocompleteRef.current;
+		if ( autocompleteElement && autocompleteElement.contains( event.target ) ) {
 			return;
 		}
 
+		this.resetState();
+	}
+
+	resetState() {
 		this.props.stopAddingLink();
 		this.setState( { editLink: false } );
 	}
@@ -205,7 +211,7 @@ class LinkContainer extends Component {
 					key={ `${ record.start }${ record.end }` /* Used to force rerender on selection change */ }
 				>
 					<URLPopover
-						onClickOutside={ this.resetState }
+						onClickOutside={ this.onClickOutside }
 						focusOnMount={ showInput ? 'firstElement' : false }
 						renderSettings={ () => (
 							<ToggleControl

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -46,7 +46,7 @@ class URLInput extends Component {
 		// when already expanded
 		if ( showSuggestions && selectedSuggestion !== null && ! this.scrollingIntoView ) {
 			this.scrollingIntoView = true;
-			scrollIntoView( this.suggestionNodes[ selectedSuggestion ], this.autocompleteRef, {
+			scrollIntoView( this.suggestionNodes[ selectedSuggestion ], this.autocompleteRef.current, {
 				onlyScrollIfNeeded: true,
 			} );
 

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -257,11 +257,8 @@ describe( 'Links', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	// Test for regressions of https://github.com/WordPress/gutenberg/issues/10496.
-	it( 'allows autocomplete suggestions to be selected with the mouse', async () => {
-		const titleText = 'Unique post title';
-
-		// First create a post that we can search for using the link autocompletion.
+	const createPostWithTitle = async ( titleText ) => {
+		await newPost();
 		await page.type( '.editor-post-title__input', titleText );
 		await page.click( '.editor-post-publish-panel__toggle' );
 
@@ -273,8 +270,16 @@ describe( 'Links', () => {
 		// Publish the post
 		await page.click( '.editor-post-publish-button' );
 
+		// Return the URL of the new post
 		await page.waitForSelector( '.post-publish-panel__postpublish-post-address input' );
-		const postURL = await page.evaluate( () => document.querySelector( '.post-publish-panel__postpublish-post-address input' ).value );
+		return page.evaluate( () => document.querySelector( '.post-publish-panel__postpublish-post-address input' ).value );
+	};
+
+	// Test for regressions of https://github.com/WordPress/gutenberg/issues/10496.
+	it( 'allows autocomplete suggestions to be selected with the mouse', async () => {
+		// First create a post that we can search for using the link autocompletion.
+		const titleText = 'Test post mouse';
+		const postURL = await createPostWithTitle( titleText );
 
 		// Now create a new post and try to select the post created previously
 		// from the autocomplete suggestions.
@@ -297,11 +302,10 @@ describe( 'Links', () => {
 		const firstSuggestion = autocompleteSuggestions[ 0 ];
 
 		// Expect that clicking on the autocomplete suggestion doesn't dismiss the link popover.
-		// and that the url input has a value.
 		await firstSuggestion.click();
 		expect( await page.$( '.editor-url-popover' ) ).not.toBeNull();
 
-		// Expect the url input value to have been updated with the post url
+		// Expect the url input value to have been updated with the post url.
 		const inputValue = await page.evaluate( () => document.querySelector( '.editor-url-input input[aria-label="URL"]' ).value );
 		expect( inputValue ).toEqual( postURL );
 
@@ -310,5 +314,81 @@ describe( 'Links', () => {
 		await page.click( 'button[aria-label="Apply"]' );
 		const linkHref = await page.evaluate( () => document.querySelector( '.editor-format-toolbar__link-container-value' ).href );
 		expect( linkHref ).toEqual( postURL );
+	} );
+
+	// Test for regressions of https://github.com/WordPress/gutenberg/issues/10496.
+	it( 'allows autocomplete suggestions to be navigated with the keyboard', async () => {
+		const titleText = 'Test post keyboard';
+		const postURL = await createPostWithTitle( titleText );
+
+		await newPost();
+		await clickBlockAppender();
+
+		// Now in a new post and try to create a link from an autocomplete suggestion using the keyboard.
+		await page.keyboard.type( 'This is Gutenberg' );
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+
+		// Press Cmd+K to insert a link
+		await pressWithModifier( META_KEY, 'K' );
+
+		// Wait for the URL field to auto-focus
+		await waitForAutoFocus();
+
+		await page.keyboard.type( titleText );
+		await page.waitForSelector( '.editor-url-input__suggestion' );
+		const autocompleteSuggestions = await page.$x( `//*[contains(@class, "editor-url-input__suggestion")]//button[contains(text(), '${ titleText }')]` );
+
+		// Expect there to be some autocomplete suggestions.
+		expect( autocompleteSuggestions.length ).toBeGreaterThan( 0 );
+
+		// Expect the the first suggestion to be selected when pressing the down arrow.
+		await page.keyboard.press( 'ArrowDown' );
+		const isSelected = await page.evaluate( () => document.querySelector( '.editor-url-input__suggestion' ).getAttribute( 'aria-selected' ) );
+		expect( isSelected ).toBe( 'true' );
+
+		// Expect the link to apply correctly when pressing Enter.
+		// Note - have avoided using snapshots here since the link url can't be determined ahead of time.
+		await page.keyboard.press( 'Enter' );
+		const linkHref = await page.evaluate( () => document.querySelector( '.editor-format-toolbar__link-container-value' ).href );
+		expect( linkHref ).toEqual( postURL );
+	} );
+
+	it( 'allows use of escape key to dismiss the url popover', async () => {
+		const titleText = 'Test post escape';
+		await createPostWithTitle( titleText );
+
+		await newPost();
+		await clickBlockAppender();
+
+		// Now in a new post and try to create a link from an autocomplete suggestion using the keyboard.
+		await page.keyboard.type( 'This is Gutenberg' );
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+
+		// Press Cmd+K to insert a link
+		await pressWithModifier( META_KEY, 'K' );
+
+		// Wait for the URL field to auto-focus
+		await waitForAutoFocus();
+		expect( await page.$( '.editor-url-popover' ) ).not.toBeNull();
+
+		// Trigger the autocomplete suggestion list and select the first suggestion.
+		await page.keyboard.type( titleText );
+		await page.waitForSelector( '.editor-url-input__suggestion' );
+		await page.keyboard.press( 'ArrowDown' );
+
+		// Expect the the escape key to dismiss the popover when the autocomplete suggestion list is open.
+		await page.keyboard.press( 'Escape' );
+		expect( await page.$( '.editor-url-popover' ) ).toBeNull();
+
+		// Press Cmd+K to insert a link
+		await pressWithModifier( META_KEY, 'K' );
+
+		// Wait for the URL field to auto-focus
+		await waitForAutoFocus();
+		expect( await page.$( '.editor-url-popover' ) ).not.toBeNull();
+
+		// Expect the the escape key to dismiss the popover normally.
+		await page.keyboard.press( 'Escape' );
+		expect( await page.$( '.editor-url-popover' ) ).toBeNull();
 	} );
 } );


### PR DESCRIPTION
## Description
Fixes #10689

Resolves a regression caused by #10500:
- #10500 changed the type of ref in the URLInput to a `createRef`. To access the underlying element with a createRef, `ref.current` must be used, but an instance of this was missed in that change, causing `scrollIntoView` to throw an error:
https://github.com/WordPress/gutenberg/compare/fix/autocomplete-keyboard-nav-in-link?expand=1#diff-95b4cd296d28092a0710c1d98aee45d8R49

- On further testing, there was also an issue with using the escape key not closing the url input. This was caused by `event` being undefined in the `resetState` method when called from a couple of callsites. The fix for this was to extract a separate onClickOutside handler:
https://github.com/WordPress/gutenberg/compare/fix/autocomplete-keyboard-nav-in-link?expand=1#diff-3fc799f44a8120d79cc3867b1d703822R179

## How has this been tested?
- Manual Testing
- e2e tests added for both issues

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
