### PR TITLE
Error in the deprecated-blocks documentation

### DIFF
--- a/docs/block-api/deprecated-blocks.md
+++ b/docs/block-api/deprecated-blocks.md
@@ -112,7 +112,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	},
 
 	save: function( props ) {
-		return el( 'div', {}, props.attributes.text );
+		return el( 'div', {}, props.attributes.content );
 	},
 
 	deprecated: [
@@ -153,7 +153,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	},
 
 	save( props ) {
-		return <div>{ props.attributes.text }</div>;
+		return <div>{ props.attributes.content }</div>;
 	},
 
 	deprecated: [


### PR DESCRIPTION
## Description
i changed a small error in the deprecated-blocks documentation

## How has this been tested?
I looked in my Github depot if the markdown file preview was ok


## Types of changes
Typo in documentation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
