### PR TITLE
Fix: Font size default classes.

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -113,7 +113,12 @@
 	font-size: 13px;
 }
 
-.has-regular-font-size {
+.has-regular-font-size, // not used now, kept because of backward compatibility.
+.has-normal-font-size {
+	font-size: 16px;
+}
+
+.has-medium-font-size {
 	font-size: 20px;
 }
 
@@ -121,6 +126,7 @@
 	font-size: 36px;
 }
 
-.has-larger-font-size {
+.has-larger-font-size, // not used now, kept because of backward compatibility.
+.has-huge-font-size, {
 	font-size: 42px;
 }


### PR DESCRIPTION
## Description
Regressed in: https://github.com/WordPress/gutenberg/pull/9802

In PR https://github.com/WordPress/gutenberg/pull/9802 we added two new slugs, medium, and huge, but the corresponding classes were not added has-medium-font-size and has-huge-font-size.
This PR adds the missing classes.

## How has this been tested?
I created a paragraph for each named font size and verified a corresponding class exists on the front end.
