### PR TITLE
Use mock response for demo test if Vimeo is down

### DIFF
--- a/test/e2e/specs/demo.test.js
+++ b/test/e2e/specs/demo.test.js
@@ -8,6 +8,15 @@ import fetch from 'node-fetch';
  */
 import { visitAdmin } from '../support/utils';
 
+const MOCK_VIMEO_RESPONSE = {
+	url: 'https://vimeo.com/22439234',
+	html: '<iframe width="16" height="9"></iframe>',
+	type: 'video',
+	provider_name: 'Vimeo',
+	provider_url: 'https://vimeo.com',
+	version: '1.0',
+};
+
 describe( 'new editor state', () => {
 	beforeAll( async () => {
 		// Intercept embed requests so that scripts loaded from third parties
@@ -27,13 +36,22 @@ describe( 'new editor state', () => {
 					}
 				);
 				const preview = await response.json();
-				// Remove the first src attribute. This stops the Vimeo iframe loading the actual
-				// embedded content, but the height and width are preserved so layout related
-				// attributes, like aspect ratio CSS classes, remain the same.
-				preview.html = preview.html.replace( /src=[^\s]+/, '' );
+				let responseBody;
+				if ( 'Embed Handler' === preview.provider_name ) {
+					// If Vimeo is down, that would make this test fail. So if we get a
+					// response from 'Embed Handler' instead of 'Vimeo', respond with a mock
+					// response, so we don't hold up development while Vimeo is down.
+					responseBody = MOCK_VIMEO_RESPONSE;
+				} else {
+					// Remove the first src attribute. This stops the Vimeo iframe loading the actual
+					// embedded content, but the height and width are preserved so layout related
+					// attributes, like aspect ratio CSS classes, remain the same.
+					preview.html = preview.html.replace( /src=[^\s]+/, '' );
+					responseBody = preview;
+				}
 				request.respond( {
 					content: 'application/json',
-					body: JSON.stringify( preview ),
+					body: JSON.stringify( responseBody ),
 				} );
 			} else {
 				request.continue();


### PR DESCRIPTION
## Description

This makes the demo test more resilient if Vimeo is having problems.

We want at least one test that does a full e2e test with a working embed provider,
but if that provider is down or having problems, we don't want to hold up development.

This PR checks if the embed response has been successful or not, and if it has not
a mock response is used.

## How has this been tested?

Run the e2e tests, they should pass.
Edit your hosts file and set `vimeo.com` to `127.0.1.1` and run the e2e tests again. They should still pass.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
