### PR TITLE
Reset TinyMCE state in live DOM after blur

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -103,6 +103,7 @@ export class RichText extends Component {
 		this.valueToFormat = this.valueToFormat.bind( this );
 		this.setRef = this.setRef.bind( this );
 		this.isActive = this.isActive.bind( this );
+		this.onBlur = this.onBlur.bind( this );
 
 		this.formatToValue = memize( this.formatToValue.bind( this ), { size: 1 } );
 
@@ -403,6 +404,10 @@ export class RichText extends Component {
 		if ( unstableOnFocus ) {
 			unstableOnFocus();
 		}
+	}
+
+	onBlur() {
+		this.applyRecord( this.formatToValue( this.savedContent ) );
 	}
 
 	/**
@@ -921,6 +926,7 @@ export class RichText extends Component {
 								key={ key }
 								onPaste={ this.onPaste }
 								onInput={ this.onInput }
+								onBlur={ this.onBlur }
 								multilineTag={ this.multilineTag }
 								setRef={ this.setRef }
 							/>

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -203,6 +203,7 @@ export default class TinyMCE extends Component {
 			isPlaceholderVisible,
 			onPaste,
 			onInput,
+			onBlur,
 			multilineTag,
 		} = this.props;
 
@@ -243,6 +244,7 @@ export default class TinyMCE extends Component {
 			dangerouslySetInnerHTML: { __html: initialHTML },
 			onPaste,
 			onInput,
+			onBlur,
 		} );
 	}
 }


### PR DESCRIPTION
## Description

Fixes #8877.

This is an alternative approach to #8879. With the new RichText value, we can simply overwrite the live DOM on blur so that any TinyMCE is removed.

## How has this been tested?
See #8877.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->