### PR TITLE
 Delay TinyMCE initialisation to focus

### DIFF
--- a/packages/block-library/src/button/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/button/test/__snapshots__/index.js.snap
@@ -23,7 +23,11 @@ exports[`core/button block edit matches snapshot 1`] = `
               contenteditable="true"
               data-is-placeholder-visible="true"
               role="textbox"
-            />
+            >
+              <br
+                data-mce-bogus="1"
+              />
+            </div>
             <div
               class="editor-rich-text__tinymce wp-block-button__link"
             >

--- a/packages/block-library/src/heading/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/heading/test/__snapshots__/index.js.snap
@@ -18,7 +18,11 @@ exports[`core/heading block edit matches snapshot 1`] = `
           contenteditable="true"
           data-is-placeholder-visible="true"
           role="textbox"
-        />
+        >
+          <br
+            data-mce-bogus="1"
+          />
+        </h2>
         <h2
           class="editor-rich-text__tinymce"
         >

--- a/packages/block-library/src/list/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/list/test/__snapshots__/index.js.snap
@@ -18,7 +18,11 @@ exports[`core/list block edit matches snapshot 1`] = `
           contenteditable="true"
           data-is-placeholder-visible="true"
           role="textbox"
-        />
+        >
+          <br
+            data-mce-bogus="1"
+          />
+        </ul>
         <ul
           class="editor-rich-text__tinymce"
         >

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -20,7 +20,11 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
             contenteditable="true"
             data-is-placeholder-visible="true"
             role="textbox"
-          />
+          >
+            <br
+              data-mce-bogus="1"
+            />
+          </p>
           <p
             class="editor-rich-text__tinymce wp-block-paragraph"
           >

--- a/packages/block-library/src/preformatted/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/preformatted/test/__snapshots__/index.js.snap
@@ -18,7 +18,11 @@ exports[`core/preformatted block edit matches snapshot 1`] = `
           contenteditable="true"
           data-is-placeholder-visible="true"
           role="textbox"
-        />
+        >
+          <br
+            data-mce-bogus="1"
+          />
+        </pre>
         <pre
           class="editor-rich-text__tinymce"
         >

--- a/packages/block-library/src/pullquote/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/pullquote/test/__snapshots__/index.js.snap
@@ -22,7 +22,11 @@ exports[`core/pullquote block edit matches snapshot 1`] = `
               contenteditable="true"
               data-is-placeholder-visible="true"
               role="textbox"
-            />
+            >
+              <br
+                data-mce-bogus="1"
+              />
+            </div>
             <div
               class="editor-rich-text__tinymce"
             >

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -115,7 +115,7 @@ export const settings = {
 				blocks: [ 'core/paragraph' ],
 				transform: ( { value, citation } ) => {
 					const paragraphs = [];
-					if ( value ) {
+					if ( value && value !== '<p></p>' ) {
 						paragraphs.push(
 							...split( create( { html: value, multilineTag: 'p' } ), '\u2028' )
 								.map( ( piece ) =>
@@ -125,7 +125,7 @@ export const settings = {
 								)
 						);
 					}
-					if ( citation ) {
+					if ( citation && citation !== '<p></p>' ) {
 						paragraphs.push(
 							createBlock( 'core/paragraph', {
 								content: citation,
@@ -189,7 +189,6 @@ export const settings = {
 
 	edit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
 		const { align, value, citation } = attributes;
-
 		return (
 			<Fragment>
 				<BlockControls>

--- a/packages/block-library/src/quote/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/quote/test/__snapshots__/index.js.snap
@@ -21,7 +21,11 @@ exports[`core/quote block edit matches snapshot 1`] = `
             contenteditable="true"
             data-is-placeholder-visible="true"
             role="textbox"
-          />
+          >
+            <br
+              data-mce-bogus="1"
+            />
+          </div>
           <div
             class="editor-rich-text__tinymce"
           >

--- a/packages/block-library/src/text-columns/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/text-columns/test/__snapshots__/index.js.snap
@@ -24,7 +24,11 @@ exports[`core/text-columns block edit matches snapshot 1`] = `
               contenteditable="true"
               data-is-placeholder-visible="true"
               role="textbox"
-            />
+            >
+              <br
+                data-mce-bogus="1"
+              />
+            </p>
             <p
               class="editor-rich-text__tinymce"
             >
@@ -55,7 +59,11 @@ exports[`core/text-columns block edit matches snapshot 1`] = `
               contenteditable="true"
               data-is-placeholder-visible="true"
               role="textbox"
-            />
+            >
+              <br
+                data-mce-bogus="1"
+              />
+            </p>
             <p
               class="editor-rich-text__tinymce"
             >

--- a/packages/block-library/src/verse/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/verse/test/__snapshots__/index.js.snap
@@ -18,7 +18,11 @@ exports[`core/verse block edit matches snapshot 1`] = `
           contenteditable="true"
           data-is-placeholder-visible="true"
           role="textbox"
-        />
+        >
+          <br
+            data-mce-bogus="1"
+          />
+        </pre>
         <pre
           class="editor-rich-text__tinymce"
         >

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -197,11 +197,6 @@ export default class TinyMCE extends Component {
 					} );
 
 					editor.dom.setHTML = setHTML;
-					tinymce.DOM.addClass( editor.getBody(), 'mce-initialised' );
-				} );
-
-				editor.on( 'remove', () => {
-					tinymce.DOM.removeClass( editor.getBody(), 'mce-initialised' );
 				} );
 			},
 		} );

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -101,9 +101,10 @@ export default class TinyMCE extends Component {
 	constructor() {
 		super();
 		this.bindEditorNode = this.bindEditorNode.bind( this );
+		this.onFocus = this.onFocus.bind( this );
 	}
 
-	componentDidMount() {
+	onFocus() {
 		this.initialize();
 	}
 
@@ -258,6 +259,7 @@ export default class TinyMCE extends Component {
 			dangerouslySetInnerHTML: { __html: initialHTML },
 			onPaste,
 			onInput,
+			onFocus: this.onFocus,
 		} );
 	}
 }

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -159,6 +159,7 @@ export default class TinyMCE extends Component {
 			browser_spellcheck: true,
 			entity_encoding: 'raw',
 			convert_urls: false,
+			verify_html: false,
 			inline_boundaries_selector: 'a[href],code,b,i,strong,em,del,ins,sup,sub',
 			plugins: [],
 		} );
@@ -260,6 +261,10 @@ export default class TinyMCE extends Component {
 				multilineTag,
 				multilineWrapperTags,
 			} );
+		}
+
+		if ( initialHTML === '' ) {
+			initialHTML = '<br data-mce-bogus="1">';
 		}
 
 		return createElement( tagName, {

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -179,6 +179,20 @@ export default class TinyMCE extends Component {
 						editor.shortcuts.remove( `access+${ number }` );
 					} );
 				} );
+
+				// TinyMCE resets the element content on initialization, even
+				// when it's already identical to what exists currently. This
+				// behavior clobbers a selection which exists at the time of
+				// initialization, thus breaking writing flow navigation. The
+				// hack here neutralizes setHTML during initialization.
+				let setHTML;
+				editor.on( 'PreInit', () => {
+					setHTML = editor.dom.setHTML;
+					editor.dom.setHTML = () => {};
+				} );
+				editor.on( 'Init', () => {
+					editor.dom.setHTML = setHTML;
+				} );
 			},
 		} );
 	}

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -7,6 +7,7 @@ import {
 	newPost,
 	pressWithModifier,
 	ACCESS_MODIFIER_KEYS,
+	waitForRichTextInitialization,
 } from '../support/utils';
 
 const addThreeParagraphsToNewPost = async () => {
@@ -16,8 +17,10 @@ const addThreeParagraphsToNewPost = async () => {
 	await clickBlockAppender();
 	await page.keyboard.type( 'First paragraph' );
 	await page.keyboard.press( 'Enter' );
+	await waitForRichTextInitialization();
 	await page.keyboard.type( 'Second paragraph' );
 	await page.keyboard.press( 'Enter' );
+	await waitForRichTextInitialization();
 };
 
 const clickOnBlockSettingsMenuItem = async ( buttonLabel ) => {
@@ -96,6 +99,7 @@ describe( 'block deletion -', () => {
 			// Add a third paragraph for this test.
 			await page.keyboard.type( 'Third paragraph' );
 			await page.keyboard.press( 'Enter' );
+			await waitForRichTextInitialization();
 
 			// Press the up arrow once to select the third and fourth blocks.
 			await pressWithModifier( 'Shift', 'ArrowUp' );

--- a/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/quote.test.js.snap
@@ -58,7 +58,11 @@ exports[`Quote can be converted to paragraphs and renders a paragraph for the ci
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Quote can be converted to paragraphs and renders a void paragraph if both the cite and quote are void 1`] = `""`;
+exports[`Quote can be converted to paragraphs and renders a void paragraph if both the cite and quote are void 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
 
 exports[`Quote can be converted to paragraphs and renders one paragraph block per <p> within quote 1`] = `
 "<!-- wp:paragraph -->

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -8,6 +8,7 @@ import {
 	pressTimes,
 	pressWithModifier,
 	META_KEY,
+	waitForRichTextInitialization,
 } from '../support/utils';
 
 describe( 'splitting and merging blocks', () => {
@@ -132,7 +133,9 @@ describe( 'splitting and merging blocks', () => {
 		await pressWithModifier( META_KEY, 'b' );
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Enter' );
+		await waitForRichTextInitialization();
 		await page.keyboard.press( 'Enter' );
+		await waitForRichTextInitialization();
 
 		await page.keyboard.press( 'Backspace' );
 
@@ -172,8 +175,11 @@ describe( 'splitting and merging blocks', () => {
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'First' );
 		await page.keyboard.press( 'Enter' );
+		await waitForRichTextInitialization();
 		await page.keyboard.press( 'Enter' );
+		await waitForRichTextInitialization();
 		await page.keyboard.press( 'Enter' );
+		await waitForRichTextInitialization();
 		await page.keyboard.type( 'Second' );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -110,7 +110,7 @@ async function waitForRichTextInitialization() {
 	}
 
 	return page.waitForFunction( () => {
-		return !! document.activeElement.closest( '.mce-content-body' );
+		return !! document.activeElement.closest( '.mce-initialised' );
 	} );
 }
 

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -102,7 +102,7 @@ async function login() {
  */
 async function waitForRichTextInitialization() {
 	const isInRichText = await page.evaluate( () => {
-		return !! document.activeElement.closest( '.editor-rich-text__tinymce' );
+		return document.activeElement.contentEditable === 'true';
 	} );
 
 	if ( ! isInRichText ) {

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -100,9 +100,9 @@ async function login() {
  * @return {Promise} Promise resolving once RichText is initialized, or is
  *                   determined to not be a container of the active element.
  */
-async function waitForRichTextInitialization() {
+export async function waitForRichTextInitialization() {
 	const isInRichText = await page.evaluate( () => {
-		return document.activeElement.contentEditable === 'true';
+		return !! document.activeElement.closest( '.editor-rich-text__tinymce' );
 	} );
 
 	if ( ! isInRichText ) {
@@ -110,7 +110,7 @@ async function waitForRichTextInitialization() {
 	}
 
 	return page.waitForFunction( () => {
-		return !! document.activeElement.closest( '.mce-initialised' );
+		return !! document.activeElement.closest( '.mce-content-body' );
 	} );
 }
 


### PR DESCRIPTION
## Description
This PR is similar to #9040, with the difference that it does not destroy TinyMCE on blur. It merely delays TinyMCE initialisation to the point where the user focuses the field.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->