### PR TITLE
Transform pullquote to/from paragraph

### DIFF
--- a/test/e2e/specs/blocks/__snapshots__/pullquote.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/pullquote.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pullquote can be converted to a quote 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>one</p><p>two</p><cite>cite</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Pullquote can be converted to paragraphs and renders a paragraph for the cite, if it exists 1`] = `
+"<!-- wp:paragraph -->
+<p>one</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>two</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>cite</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Pullquote can be converted to paragraphs and renders a void paragraph if both the cite and quote are void 1`] = `""`;
+
+exports[`Pullquote can be converted to paragraphs and renders one paragraph block per <p> within the quote 1`] = `
+"<!-- wp:paragraph -->
+<p>one</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>two</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Pullquote can be converted to paragraphs and renders only one paragraph for the cite, if the quote is void 1`] = `
+"<!-- wp:paragraph -->
+<p>cite</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Pullquote can be created by converting a paragraph 1`] = `
+"<!-- wp:pullquote -->
+<figure class=\\"wp-block-pullquote\\"><blockquote><p>test</p></blockquote></figure>
+<!-- /wp:pullquote -->"
+`;
+
+exports[`Pullquote can be created by converting multiple paragraphs 1`] = `
+"<!-- wp:pullquote -->
+<figure class=\\"wp-block-pullquote\\"><blockquote><p>one</p><p>two</p></blockquote></figure>
+<!-- /wp:pullquote -->"
+`;
+
+exports[`Pullquote can be created by typing "/pullquote" 1`] = `
+"<!-- wp:pullquote -->
+<figure class=\\"wp-block-pullquote\\"><blockquote><p>I’m a pullquote</p></blockquote></figure>
+<!-- /wp:pullquote -->"
+`;

--- a/test/e2e/specs/blocks/pullquote.test.js
+++ b/test/e2e/specs/blocks/pullquote.test.js
@@ -1,0 +1,98 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	newPost,
+	convertBlock,
+	insertBlock,
+} from '../../support/utils';
+
+describe( 'Pullquote', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'can be created by typing "/pullquote"', async () => {
+		// Create a list with the slash block shortcut.
+		await clickBlockAppender();
+		await page.keyboard.type( '/pullquote' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'I’m a pullquote' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting a paragraph', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'test' );
+		await convertBlock( 'Pullquote' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by converting multiple paragraphs', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.down( 'Shift' );
+		await page.click( '[data-type="core/paragraph"]' );
+		await page.keyboard.up( 'Shift' );
+		await convertBlock( 'Pullquote' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	describe( 'can be converted to paragraphs', async () => {
+		it( 'and renders one paragraph block per <p> within the quote', async () => {
+			await insertBlock( 'Pullquote' );
+			await page.keyboard.type( 'one' );
+			await page.keyboard.press( 'Enter' );
+			await page.keyboard.type( 'two' );
+			await convertBlock( 'Paragraph' );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'and renders a paragraph for the cite, if it exists', async () => {
+			await insertBlock( 'Pullquote' );
+			await page.keyboard.type( 'one' );
+			await page.keyboard.press( 'Enter' );
+			await page.keyboard.type( 'two' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.type( 'cite' );
+			await convertBlock( 'Paragraph' );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'and renders only one paragraph for the cite, if the quote is void', async () => {
+			await insertBlock( 'Pullquote' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.type( 'cite' );
+			await convertBlock( 'Paragraph' );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'and renders a void paragraph if both the cite and quote are void', async () => {
+			await insertBlock( 'Pullquote' );
+			await convertBlock( 'Paragraph' );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
+
+	it( 'can be converted to a quote', async () => {
+		await insertBlock( 'Pullquote' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'cite' );
+		await convertBlock( 'Quote' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This PR adds the ability to transform a pullquote block to and from a paragraph.

It also adds missing e2e tests.

## Test 

Pullquote to paragraph. Test pullquotes containing:

* many paragraphs in the quote and a cite: transforms to as many paragraphs as there are in the quote plus another one for the cite.
* only the quote: transforms to as many paragraphs as there are in the quote.
* only the cite: transforms to a single paragraph with the cite.
* no quote or cite: transforms to a void paragraph.

Paragraph to pullquote:

* single paragraph: a pullquote with the single paragraph as the quote is created.
* multiple paragraphs selected: a pullquote with as many paragraphs as selected as the quote.
