### PR TITLE
Add has-dates class to Latest Posts block if applicable

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -134,6 +134,7 @@ class LatestPostsEdit extends Component {
 				<ul
 					className={ classnames( this.props.className, {
 						'is-grid': postLayout === 'grid',
+						'has-dates': displayPostDate,
 						[ `columns-${ columns }` ]: postLayout === 'grid',
 					} ) }
 				>

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -62,6 +62,10 @@ function render_block_core_latest_posts( $attributes ) {
 		$class .= ' columns-' . $attributes['columns'];
 	}
 
+	if ( isset( $attributes['displayPostDate'] ) && $attributes['displayPostDate'] ) {
+		$class .= ' has-dates';
+	}
+
 	if ( isset( $attributes['className'] ) ) {
 		$class .= ' ' . $attributes['className'];
 	}


### PR DESCRIPTION
## Description

This changes the Latest Posts block to add a `has-dates` class when the `Display post date
` option is set. The class is added both in the editor and on the front end.

## How has this been tested?

Tested this using the local Docker environment by adding a Latest Posts block and toggling that option.

## Screenshots

Editor:

<img width="1478" alt="screenshot 2018-10-18 at 12 11 35" src="https://user-images.githubusercontent.com/841956/47147747-2ffd6900-d2cf-11e8-9afb-ef7d3a258ccb.png">

Front end:

<img width="1578" alt="screenshot 2018-10-18 at 12 11 44" src="https://user-images.githubusercontent.com/841956/47147752-32f85980-d2cf-11e8-9198-b044b4c5e015.png">


## Types of changes

This adds a new `has-dates` class, as is already the case with the "Latest Comments" block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Fixes #10691.