### PR TITLE
Try: Ensure compatibility with WordPress 5.0

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -9,54 +9,54 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-/**
- * Registers a block type.
- *
- * @since 0.1.0
- * @since 0.6.0 Now also accepts a WP_Block_Type instance as first parameter.
- *
- * @param string|WP_Block_Type $name Block type name including namespace, or alternatively a
- *                                   complete WP_Block_Type instance. In case a WP_Block_Type
- *                                   is provided, the $args parameter will be ignored.
- * @param array                $args {
- *     Optional. Array of block type arguments. Any arguments may be defined, however the
- *     ones described below are supported by default. Default empty array.
- *
- *     @type callable $render_callback Callback used to render blocks of this block type.
- * }
- * @return WP_Block_Type|false The registered block type on success, or false on failure.
- */
 if ( ! function_exists( 'register_block_type' ) ) {
+	/**
+	 * Registers a block type.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.0 Now also accepts a WP_Block_Type instance as first parameter.
+	 *
+	 * @param string|WP_Block_Type $name Block type name including namespace, or alternatively a
+	 *                                   complete WP_Block_Type instance. In case a WP_Block_Type
+	 *                                   is provided, the $args parameter will be ignored.
+	 * @param array                $args {
+	 *     Optional. Array of block type arguments. Any arguments may be defined, however the
+	 *     ones described below are supported by default. Default empty array.
+	 *
+	 *     @type callable $render_callback Callback used to render blocks of this block type.
+	 * }
+	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
+	 */
 	function register_block_type( $name, $args = array() ) {
 		return WP_Block_Type_Registry::get_instance()->register( $name, $args );
 	}
 }
 
-/**
- * Unregisters a block type.
- *
- * @since 0.1.0
- * @since 0.6.0 Now also accepts a WP_Block_Type instance as first parameter.
- *
- * @param string|WP_Block_Type $name Block type name including namespace, or alternatively a
- *                                   complete WP_Block_Type instance.
- * @return WP_Block_Type|false The unregistered block type on success, or false on failure.
- */
 if ( ! function_exists( 'unregister_block_type' ) ) {
+	/**
+	 * Unregisters a block type.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.0 Now also accepts a WP_Block_Type instance as first parameter.
+	 *
+	 * @param string|WP_Block_Type $name Block type name including namespace, or alternatively a
+	 *                                   complete WP_Block_Type instance.
+	 * @return WP_Block_Type|false The unregistered block type on success, or false on failure.
+	 */
 	function unregister_block_type( $name ) {
 		return WP_Block_Type_Registry::get_instance()->unregister( $name );
 	}
 }
 
-/**
- * Parses blocks out of a content string.
- *
- * @since 0.5.0
- *
- * @param  string $content Post content.
- * @return array  Array of parsed block objects.
- */
 if ( ! function_exists( 'gutenberg_parse_blocks' ) ) {
+	/**
+	 * Parses blocks out of a content string.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param  string $content Post content.
+	 * @return array  Array of parsed block objects.
+	 */
 	function gutenberg_parse_blocks( $content ) {
 		/*
 		 * If there are no blocks in the content, return a single block, rather
@@ -90,12 +90,12 @@ if ( ! function_exists( 'gutenberg_parse_blocks' ) ) {
 	}
 }
 
-/**
- * Returns an array of the names of all registered dynamic block types.
- *
- * @return array Array of dynamic block names.
- */
 if ( ! function_exists( 'get_dynamic_block_names' ) ) {
+	/**
+	 * Returns an array of the names of all registered dynamic block types.
+	 *
+	 * @return array Array of dynamic block names.
+	 */
 	function get_dynamic_block_names() {
 		$dynamic_block_names = array();
 
@@ -110,14 +110,14 @@ if ( ! function_exists( 'get_dynamic_block_names' ) ) {
 	}
 }
 
-/**
- * Retrieve the dynamic blocks regular expression for searching.
- *
- * @since 3.6.0
- *
- * @return string
- */
 if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
+	/**
+	 * Retrieve the dynamic blocks regular expression for searching.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return string
+	 */
 	function get_dynamic_blocks_regex() {
 		$dynamic_block_names   = get_dynamic_block_names();
 		$dynamic_block_pattern = (
@@ -171,16 +171,16 @@ function gutenberg_render_block( $block ) {
 	return '';
 }
 
-/**
- * Parses dynamic blocks out of `post_content` and re-renders them.
- *
- * @since 0.1.0
- * @global WP_Post $post The post to edit.
- *
- * @param  string $content Post content.
- * @return string          Updated post content.
- */
 if ( ! function_exists( 'do_blocks' ) ) {
+	/**
+	 * Parses dynamic blocks out of `post_content` and re-renders them.
+	 *
+	 * @since 0.1.0
+	 * @global WP_Post $post The post to edit.
+	 *
+	 * @param  string $content Post content.
+	 * @return string          Updated post content.
+	 */
 	function do_blocks( $content ) {
 		global $post;
 
@@ -265,32 +265,32 @@ if ( ! function_exists( 'do_blocks' ) ) {
 	add_filter( 'the_content', 'do_blocks', 7 ); // BEFORE do_shortcode() and oembed.
 }
 
-/**
- * Remove all dynamic blocks from the given content.
- *
- * @since 3.6.0
- *
- * @param string $content Content of the current post.
- * @return string
- */
 if ( ! function_exists( 'strip_dynamic_blocks' ) ) {
+	/**
+	 * Remove all dynamic blocks from the given content.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param string $content Content of the current post.
+	 * @return string
+	 */
 	function strip_dynamic_blocks( $content ) {
 		return preg_replace( get_dynamic_blocks_regex(), '', $content );
 	}
 }
 
-/**
- * Adds the content filter to strip dynamic blocks from excerpts.
- *
- * It's a bit hacky for now, but once this gets merged into core the function
- * can just be called in `wp_trim_excerpt()`.
- *
- * @since 3.6.0
- *
- * @param string $text Excerpt.
- * @return string
- */
 if ( ! function_exists( 'strip_dynamic_blocks_add_filter' ) ) {
+	/**
+	 * Adds the content filter to strip dynamic blocks from excerpts.
+	 *
+	 * It's a bit hacky for now, but once this gets merged into core the function
+	 * can just be called in `wp_trim_excerpt()`.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param string $text Excerpt.
+	 * @return string
+	 */
 	function strip_dynamic_blocks_add_filter( $text ) {
 		add_filter( 'the_content', 'strip_dynamic_blocks', 6 ); // Before do_blocks().
 
@@ -299,18 +299,18 @@ if ( ! function_exists( 'strip_dynamic_blocks_add_filter' ) ) {
 	add_filter( 'get_the_excerpt', 'strip_dynamic_blocks_add_filter', 9 ); // Before wp_trim_excerpt().
 }
 
-/**
- * Removes the content filter to strip dynamic blocks from excerpts.
- *
- * It's a bit hacky for now, but once this gets merged into core the function
- * can just be called in `wp_trim_excerpt()`.
- *
- * @since 3.6.0
- *
- * @param string $text Excerpt.
- * @return string
- */
 if ( ! function_exists( 'strip_dynamic_blocks_remove_filter' ) ) {
+	/**
+	 * Removes the content filter to strip dynamic blocks from excerpts.
+	 *
+	 * It's a bit hacky for now, but once this gets merged into core the function
+	 * can just be called in `wp_trim_excerpt()`.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param string $text Excerpt.
+	 * @return string
+	 */
 	function strip_dynamic_blocks_remove_filter( $text ) {
 		remove_filter( 'the_content', 'strip_dynamic_blocks', 8 );
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -26,8 +26,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * }
  * @return WP_Block_Type|false The registered block type on success, or false on failure.
  */
-function register_block_type( $name, $args = array() ) {
-	return WP_Block_Type_Registry::get_instance()->register( $name, $args );
+if ( ! function_exists( 'register_block_type' ) ) {
+	function register_block_type( $name, $args = array() ) {
+		return WP_Block_Type_Registry::get_instance()->register( $name, $args );
+	}
 }
 
 /**
@@ -40,8 +42,10 @@ function register_block_type( $name, $args = array() ) {
  *                                   complete WP_Block_Type instance.
  * @return WP_Block_Type|false The unregistered block type on success, or false on failure.
  */
-function unregister_block_type( $name ) {
-	return WP_Block_Type_Registry::get_instance()->unregister( $name );
+if ( ! function_exists( 'unregister_block_type' ) ) {
+	function unregister_block_type( $name ) {
+		return WP_Block_Type_Registry::get_instance()->unregister( $name );
+	}
 }
 
 /**
@@ -52,36 +56,38 @@ function unregister_block_type( $name ) {
  * @param  string $content Post content.
  * @return array  Array of parsed block objects.
  */
-function gutenberg_parse_blocks( $content ) {
-	/*
-	 * If there are no blocks in the content, return a single block, rather
-	 * than wasting time trying to parse the string.
-	 */
-	if ( ! has_blocks( $content ) ) {
-		return array(
-			array(
-				'blockName'   => null,
-				'attrs'       => array(),
-				'innerBlocks' => array(),
-				'innerHTML'   => $content,
-			),
-		);
-	}
+if ( ! function_exists( 'gutenberg_parse_blocks' ) ) {
+	function gutenberg_parse_blocks( $content ) {
+		/*
+		 * If there are no blocks in the content, return a single block, rather
+		 * than wasting time trying to parse the string.
+		 */
+		if ( ! has_blocks( $content ) ) {
+			return array(
+				array(
+					'blockName'   => null,
+					'attrs'       => array(),
+					'innerBlocks' => array(),
+					'innerHTML'   => $content,
+				),
+			);
+		}
 
-	/**
-	 * Filter to allow plugins to replace the server-side block parser
-	 *
-	 * @since 3.8.0
-	 *
-	 * @param string $parser_class Name of block parser class
-	 */
-	$parser_class = apply_filters( 'block_parser_class', 'WP_Block_Parser' );
-	// Load default block parser for server-side parsing if the default parser class is being used.
-	if ( 'WP_Block_Parser' === $parser_class ) {
-		require_once dirname( __FILE__ ) . '/../packages/block-serialization-default-parser/parser.php';
+		/**
+		 * Filter to allow plugins to replace the server-side block parser
+		 *
+		 * @since 3.8.0
+		 *
+		 * @param string $parser_class Name of block parser class
+		 */
+		$parser_class = apply_filters( 'block_parser_class', 'WP_Block_Parser' );
+		// Load default block parser for server-side parsing if the default parser class is being used.
+		if ( 'WP_Block_Parser' === $parser_class ) {
+			require_once dirname( __FILE__ ) . '/../packages/block-serialization-default-parser/parser.php';
+		}
+		$parser = new $parser_class();
+		return $parser->parse( $content );
 	}
-	$parser = new $parser_class();
-	return $parser->parse( $content );
 }
 
 /**
@@ -89,17 +95,19 @@ function gutenberg_parse_blocks( $content ) {
  *
  * @return array Array of dynamic block names.
  */
-function get_dynamic_block_names() {
-	$dynamic_block_names = array();
+if ( ! function_exists( 'get_dynamic_block_names' ) ) {
+	function get_dynamic_block_names() {
+		$dynamic_block_names = array();
 
-	$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
-	foreach ( $block_types as $block_type ) {
-		if ( $block_type->is_dynamic() ) {
-			$dynamic_block_names[] = $block_type->name;
+		$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+		foreach ( $block_types as $block_type ) {
+			if ( $block_type->is_dynamic() ) {
+				$dynamic_block_names[] = $block_type->name;
+			}
 		}
-	}
 
-	return $dynamic_block_names;
+		return $dynamic_block_names;
+	}
 }
 
 /**
@@ -109,29 +117,31 @@ function get_dynamic_block_names() {
  *
  * @return string
  */
-function get_dynamic_blocks_regex() {
-	$dynamic_block_names   = get_dynamic_block_names();
-	$dynamic_block_pattern = (
-		'/<!--\s+wp:(' .
-		str_replace(
-			'/',
-			'\/',                 // Escape namespace, not handled by preg_quote.
+if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
+	function get_dynamic_blocks_regex() {
+		$dynamic_block_names   = get_dynamic_block_names();
+		$dynamic_block_pattern = (
+			'/<!--\s+wp:(' .
 			str_replace(
-				'core/',
-				'(?:core/)?', // Allow implicit core namespace, but don't capture.
-				implode(
-					'|',                   // Join block names into capture group alternation.
-					array_map(
-						'preg_quote',    // Escape block name for regular expression.
-						$dynamic_block_names
+				'/',
+				'\/',                 // Escape namespace, not handled by preg_quote.
+				str_replace(
+					'core/',
+					'(?:core/)?', // Allow implicit core namespace, but don't capture.
+					implode(
+						'|',                   // Join block names into capture group alternation.
+						array_map(
+							'preg_quote',    // Escape block name for regular expression.
+							$dynamic_block_names
+						)
 					)
 				)
-			)
-		) .
-		')(\s+(\{.*?\}))?\s+(\/)?-->/'
-	);
+			) .
+			')(\s+(\{.*?\}))?\s+(\/)?-->/'
+		);
 
-	return $dynamic_block_pattern;
+		return $dynamic_block_pattern;
+	}
 }
 
 /**
@@ -170,88 +180,90 @@ function gutenberg_render_block( $block ) {
  * @param  string $content Post content.
  * @return string          Updated post content.
  */
-function do_blocks( $content ) {
-	global $post;
+if ( ! function_exists( 'do_blocks' ) ) {
+	function do_blocks( $content ) {
+		global $post;
 
-	$rendered_content      = '';
-	$dynamic_block_pattern = get_dynamic_blocks_regex();
+		$rendered_content      = '';
+		$dynamic_block_pattern = get_dynamic_blocks_regex();
 
-	/*
-	 * Back up global post, to restore after render callback.
-	 * Allows callbacks to run new WP_Query instances without breaking the global post.
-	 */
-	$global_post = $post;
+		/*
+		 * Back up global post, to restore after render callback.
+		 * Allows callbacks to run new WP_Query instances without breaking the global post.
+		 */
+		$global_post = $post;
 
-	while ( preg_match( $dynamic_block_pattern, $content, $block_match, PREG_OFFSET_CAPTURE ) ) {
-		$opening_tag     = $block_match[0][0];
-		$offset          = $block_match[0][1];
-		$block_name      = $block_match[1][0];
-		$is_self_closing = isset( $block_match[4] );
+		while ( preg_match( $dynamic_block_pattern, $content, $block_match, PREG_OFFSET_CAPTURE ) ) {
+			$opening_tag     = $block_match[0][0];
+			$offset          = $block_match[0][1];
+			$block_name      = $block_match[1][0];
+			$is_self_closing = isset( $block_match[4] );
 
-		// Reset attributes JSON to prevent scope bleed from last iteration.
-		$block_attributes_json = null;
-		if ( isset( $block_match[3] ) ) {
-			$block_attributes_json = $block_match[3][0];
-		}
-
-		// Since content is a working copy since the last match, append to
-		// rendered content up to the matched offset...
-		$rendered_content .= substr( $content, 0, $offset );
-
-		// ...then update the working copy of content.
-		$content = substr( $content, $offset + strlen( $opening_tag ) );
-
-		// Make implicit core namespace explicit.
-		$is_implicit_core_namespace = ( false === strpos( $block_name, '/' ) );
-		$normalized_block_name      = $is_implicit_core_namespace ? 'core/' . $block_name : $block_name;
-
-		// Find registered block type. We can assume it exists since we use the
-		// `get_dynamic_block_names` function as a source for pattern matching.
-		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $normalized_block_name );
-
-		// Attempt to parse attributes JSON, if available.
-		$attributes = array();
-		if ( ! empty( $block_attributes_json ) ) {
-			$decoded_attributes = json_decode( $block_attributes_json, true );
-			if ( ! is_null( $decoded_attributes ) ) {
-				$attributes = $decoded_attributes;
-			}
-		}
-
-		$inner_content = '';
-
-		if ( ! $is_self_closing ) {
-			$end_tag_pattern = '/<!--\s+\/wp:' . str_replace( '/', '\/', preg_quote( $block_name ) ) . '\s+-->/';
-			if ( ! preg_match( $end_tag_pattern, $content, $block_match_end, PREG_OFFSET_CAPTURE ) ) {
-				// If no closing tag is found, abort all matching, and continue
-				// to append remainder of content to rendered output.
-				break;
+			// Reset attributes JSON to prevent scope bleed from last iteration.
+			$block_attributes_json = null;
+			if ( isset( $block_match[3] ) ) {
+				$block_attributes_json = $block_match[3][0];
 			}
 
-			// Update content to omit text up to and including closing tag.
-			$end_tag    = $block_match_end[0][0];
-			$end_offset = $block_match_end[0][1];
+			// Since content is a working copy since the last match, append to
+			// rendered content up to the matched offset...
+			$rendered_content .= substr( $content, 0, $offset );
 
-			$inner_content = substr( $content, 0, $end_offset );
-			$content       = substr( $content, $end_offset + strlen( $end_tag ) );
+			// ...then update the working copy of content.
+			$content = substr( $content, $offset + strlen( $opening_tag ) );
+
+			// Make implicit core namespace explicit.
+			$is_implicit_core_namespace = ( false === strpos( $block_name, '/' ) );
+			$normalized_block_name      = $is_implicit_core_namespace ? 'core/' . $block_name : $block_name;
+
+			// Find registered block type. We can assume it exists since we use the
+			// `get_dynamic_block_names` function as a source for pattern matching.
+			$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $normalized_block_name );
+
+			// Attempt to parse attributes JSON, if available.
+			$attributes = array();
+			if ( ! empty( $block_attributes_json ) ) {
+				$decoded_attributes = json_decode( $block_attributes_json, true );
+				if ( ! is_null( $decoded_attributes ) ) {
+					$attributes = $decoded_attributes;
+				}
+			}
+
+			$inner_content = '';
+
+			if ( ! $is_self_closing ) {
+				$end_tag_pattern = '/<!--\s+\/wp:' . str_replace( '/', '\/', preg_quote( $block_name ) ) . '\s+-->/';
+				if ( ! preg_match( $end_tag_pattern, $content, $block_match_end, PREG_OFFSET_CAPTURE ) ) {
+					// If no closing tag is found, abort all matching, and continue
+					// to append remainder of content to rendered output.
+					break;
+				}
+
+				// Update content to omit text up to and including closing tag.
+				$end_tag    = $block_match_end[0][0];
+				$end_offset = $block_match_end[0][1];
+
+				$inner_content = substr( $content, 0, $end_offset );
+				$content       = substr( $content, $end_offset + strlen( $end_tag ) );
+			}
+
+			// Replace dynamic block with server-rendered output.
+			$rendered_content .= $block_type->render( $attributes, $inner_content );
+
+			// Restore global $post.
+			$post = $global_post;
 		}
 
-		// Replace dynamic block with server-rendered output.
-		$rendered_content .= $block_type->render( $attributes, $inner_content );
+		// Append remaining unmatched content.
+		$rendered_content .= $content;
 
-		// Restore global $post.
-		$post = $global_post;
+		// Strip remaining block comment demarcations.
+		$rendered_content = preg_replace( '/<!--\s+\/?wp:.*?-->\r?\n?/m', '', $rendered_content );
+
+		return $rendered_content;
 	}
-
-	// Append remaining unmatched content.
-	$rendered_content .= $content;
-
-	// Strip remaining block comment demarcations.
-	$rendered_content = preg_replace( '/<!--\s+\/?wp:.*?-->\r?\n?/m', '', $rendered_content );
-
-	return $rendered_content;
+	add_filter( 'the_content', 'do_blocks', 7 ); // BEFORE do_shortcode() and oembed.
 }
-add_filter( 'the_content', 'do_blocks', 7 ); // BEFORE do_shortcode() and oembed.
 
 /**
  * Remove all dynamic blocks from the given content.
@@ -261,8 +273,10 @@ add_filter( 'the_content', 'do_blocks', 7 ); // BEFORE do_shortcode() and oembed
  * @param string $content Content of the current post.
  * @return string
  */
-function strip_dynamic_blocks( $content ) {
-	return preg_replace( get_dynamic_blocks_regex(), '', $content );
+if ( ! function_exists( 'strip_dynamic_blocks' ) ) {
+	function strip_dynamic_blocks( $content ) {
+		return preg_replace( get_dynamic_blocks_regex(), '', $content );
+	}
 }
 
 /**
@@ -276,12 +290,14 @@ function strip_dynamic_blocks( $content ) {
  * @param string $text Excerpt.
  * @return string
  */
-function strip_dynamic_blocks_add_filter( $text ) {
-	add_filter( 'the_content', 'strip_dynamic_blocks', 6 ); // Before do_blocks().
+if ( ! function_exists( 'strip_dynamic_blocks_add_filter' ) ) {
+	function strip_dynamic_blocks_add_filter( $text ) {
+		add_filter( 'the_content', 'strip_dynamic_blocks', 6 ); // Before do_blocks().
 
-	return $text;
+		return $text;
+	}
+	add_filter( 'get_the_excerpt', 'strip_dynamic_blocks_add_filter', 9 ); // Before wp_trim_excerpt().
 }
-add_filter( 'get_the_excerpt', 'strip_dynamic_blocks_add_filter', 9 ); // Before wp_trim_excerpt().
 
 /**
  * Removes the content filter to strip dynamic blocks from excerpts.
@@ -294,9 +310,11 @@ add_filter( 'get_the_excerpt', 'strip_dynamic_blocks_add_filter', 9 ); // Before
  * @param string $text Excerpt.
  * @return string
  */
-function strip_dynamic_blocks_remove_filter( $text ) {
-	remove_filter( 'the_content', 'strip_dynamic_blocks', 8 );
+if ( ! function_exists( 'strip_dynamic_blocks_remove_filter' ) ) {
+	function strip_dynamic_blocks_remove_filter( $text ) {
+		remove_filter( 'the_content', 'strip_dynamic_blocks', 8 );
 
-	return $text;
+		return $text;
+	}
+	add_filter( 'wp_trim_excerpt', 'strip_dynamic_blocks_remove_filter', 0 ); // Before all other.
 }
-add_filter( 'wp_trim_excerpt', 'strip_dynamic_blocks_remove_filter', 0 ); // Before all other.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -97,6 +97,10 @@ if ( ! function_exists( 'wp_register_tinymce_scripts' ) ) {
  * @since 0.1.0
  */
 function gutenberg_register_scripts_and_styles() {
+	if ( wp_script_is( 'wp-polyfill', 'registered' ) ) {
+		return;
+	}
+
 	gutenberg_register_vendor_scripts();
 
 	wp_register_tinymce_scripts();

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -69,22 +69,24 @@ function gutenberg_get_script_polyfill( $tests ) {
 /**
  * Registers the main TinyMCE scripts.
  */
-function register_tinymce_scripts() {
-	global $tinymce_version, $concatenate_scripts, $compress_scripts;
-	if ( ! isset( $concatenate_scripts ) ) {
-		script_concat_settings();
-	}
-	$suffix     = SCRIPT_DEBUG ? '' : '.min';
-	$compressed = $compress_scripts && $concatenate_scripts && isset( $_SERVER['HTTP_ACCEPT_ENCODING'] )
-		&& false !== stripos( $_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip' );
-	// Load tinymce.js when running from /src, otherwise load wp-tinymce.js.gz (in production) or
-	// tinymce.min.js (when SCRIPT_DEBUG is true).
-	$mce_suffix = false !== strpos( get_bloginfo( 'version' ), '-src' ) ? '' : '.min';
-	if ( $compressed ) {
-		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array(), $tinymce_version );
-	} else {
-		wp_register_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array(), $tinymce_version );
-		wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ), $tinymce_version );
+if ( ! function_exists( 'wp_register_tinymce_scripts' ) ) {
+	function wp_register_tinymce_scripts() {
+		global $tinymce_version, $concatenate_scripts, $compress_scripts;
+		if ( ! isset( $concatenate_scripts ) ) {
+			script_concat_settings();
+		}
+		$suffix     = SCRIPT_DEBUG ? '' : '.min';
+		$compressed = $compress_scripts && $concatenate_scripts && isset( $_SERVER['HTTP_ACCEPT_ENCODING'] )
+			&& false !== stripos( $_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip' );
+		// Load tinymce.js when running from /src, otherwise load wp-tinymce.js.gz (in production) or
+		// tinymce.min.js (when SCRIPT_DEBUG is true).
+		$mce_suffix = false !== strpos( get_bloginfo( 'version' ), '-src' ) ? '' : '.min';
+		if ( $compressed ) {
+			wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array(), $tinymce_version );
+		} else {
+			wp_register_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array(), $tinymce_version );
+			wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ), $tinymce_version );
+		}
 	}
 }
 
@@ -97,7 +99,7 @@ function register_tinymce_scripts() {
 function gutenberg_register_scripts_and_styles() {
 	gutenberg_register_vendor_scripts();
 
-	register_tinymce_scripts();
+	wp_register_tinymce_scripts();
 
 	wp_register_script(
 		'wp-polyfill',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -69,8 +69,8 @@ function gutenberg_get_script_polyfill( $tests ) {
 /**
  * Registers the main TinyMCE scripts.
  */
-if ( ! function_exists( 'wp_register_tinymce_scripts' ) ) {
-	function wp_register_tinymce_scripts() {
+if ( ! function_exists( 'register_tinymce_scripts' ) ) {
+	function register_tinymce_scripts() {
 		global $tinymce_version, $concatenate_scripts, $compress_scripts;
 		if ( ! isset( $concatenate_scripts ) ) {
 			script_concat_settings();
@@ -82,12 +82,17 @@ if ( ! function_exists( 'wp_register_tinymce_scripts' ) ) {
 		// tinymce.min.js (when SCRIPT_DEBUG is true).
 		$mce_suffix = false !== strpos( get_bloginfo( 'version' ), '-src' ) ? '' : '.min';
 		if ( $compressed ) {
-			wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array(), $tinymce_version );
+			gutenberg_override_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array(), $tinymce_version );
 		} else {
-			wp_register_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array(), $tinymce_version );
-			wp_register_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ), $tinymce_version );
+			gutenberg_override_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array(), $tinymce_version );
+			gutenberg_override_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ), $tinymce_version );
 		}
 	}
+}
+
+function gutenberg_override_script( $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
+	wp_deregister_script( $handle );
+	wp_register_script( $handle, $src, $deps, $ver, $in_footer );
 }
 
 /**
@@ -97,15 +102,11 @@ if ( ! function_exists( 'wp_register_tinymce_scripts' ) ) {
  * @since 0.1.0
  */
 function gutenberg_register_scripts_and_styles() {
-	if ( wp_script_is( 'wp-polyfill', 'registered' ) ) {
-		return;
-	}
-
 	gutenberg_register_vendor_scripts();
 
-	wp_register_tinymce_scripts();
+	register_tinymce_scripts();
 
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-polyfill',
 		null,
 		array(
@@ -124,63 +125,63 @@ function gutenberg_register_scripts_and_styles() {
 			)
 		)
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-url',
 		gutenberg_url( 'build/url/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/url/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-autop',
 		gutenberg_url( 'build/autop/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/autop/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-wordcount',
 		gutenberg_url( 'build/wordcount/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/wordcount/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-dom-ready',
 		gutenberg_url( 'build/dom-ready/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/dom-ready/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-a11y',
 		gutenberg_url( 'build/a11y/index.js' ),
 		array( 'wp-dom-ready', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/a11y/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-hooks',
 		gutenberg_url( 'build/hooks/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/hooks/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-i18n',
 		gutenberg_url( 'build/i18n/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/i18n/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-is-shallow-equal',
 		gutenberg_url( 'build/is-shallow-equal/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/is-shallow-equal/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-token-list',
 		gutenberg_url( 'build/token-list/index.js' ),
 		array( 'lodash', 'wp-polyfill' ),
@@ -189,7 +190,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 
 	// Editor Scripts.
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-api-fetch',
 		gutenberg_url( 'build/api-fetch/index.js' ),
 		array( 'wp-polyfill', 'wp-hooks', 'wp-i18n' ),
@@ -213,42 +214,42 @@ function gutenberg_register_scripts_and_styles() {
 		'after'
 	);
 
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-deprecated',
 		gutenberg_url( 'build/deprecated/index.js' ),
 		array( 'wp-polyfill', 'wp-hooks' ),
 		filemtime( gutenberg_dir_path() . 'build/deprecated/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-blob',
 		gutenberg_url( 'build/blob/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/blob/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-compose',
 		gutenberg_url( 'build/compose/index.js' ),
 		array( 'lodash', 'wp-element', 'wp-is-shallow-equal', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/compose/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-keycodes',
 		gutenberg_url( 'build/keycodes/index.js' ),
 		array( 'lodash', 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/keycodes/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-html-entities',
 		gutenberg_url( 'build/html-entities/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/html-entities/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-data',
 		gutenberg_url( 'build/data/index.js' ),
 		array(
@@ -279,49 +280,49 @@ function gutenberg_register_scripts_and_styles() {
 			)
 		)
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-core-data',
 		gutenberg_url( 'build/core-data/index.js' ),
 		array( 'wp-data', 'wp-api-fetch', 'wp-polyfill', 'wp-url', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/core-data/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-dom',
 		gutenberg_url( 'build/dom/index.js' ),
 		array( 'lodash', 'wp-polyfill', 'wp-tinymce' ),
 		filemtime( gutenberg_dir_path() . 'build/dom/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-block-serialization-default-parser',
 		gutenberg_url( 'build/block-serialization-default-parser/index.js' ),
 		array(),
 		filemtime( gutenberg_dir_path() . 'build/block-serialization-default-parser/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-block-serialization-spec-parser',
 		gutenberg_url( 'build/block-serialization-spec-parser/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/block-serialization-spec-parser/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-shortcode',
 		gutenberg_url( 'build/shortcode/index.js' ),
 		array( 'wp-polyfill', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/shortcode/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-redux-routine',
 		gutenberg_url( 'build/redux-routine/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/redux-routine/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-date',
 		gutenberg_url( 'build/date/index.js' ),
 		array( 'moment', 'wp-polyfill' ),
@@ -364,28 +365,28 @@ function gutenberg_register_scripts_and_styles() {
 		),
 		'after'
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-element',
 		gutenberg_url( 'build/element/index.js' ),
 		array( 'wp-polyfill', 'react', 'react-dom', 'lodash', 'wp-escape-html' ),
 		filemtime( gutenberg_dir_path() . 'build/element/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-escape-html',
 		gutenberg_url( 'build/escape-html/index.js' ),
 		array( 'wp-polyfill' ),
 		filemtime( gutenberg_dir_path() . 'build/element/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-rich-text',
 		gutenberg_url( 'build/rich-text/index.js' ),
 		array( 'wp-polyfill', 'wp-escape-html', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/rich-text/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-components',
 		gutenberg_url( 'build/components/index.js' ),
 		array(
@@ -413,7 +414,7 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-components',
 		sprintf( 'wp.components.unstable__setSiteURL(%s);', json_encode( site_url() ) )
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-blocks',
 		gutenberg_url( 'build/blocks/index.js' ),
 		array(
@@ -434,14 +435,14 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/blocks/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-viewport',
 		gutenberg_url( 'build/viewport/index.js' ),
 		array( 'wp-polyfill', 'wp-element', 'wp-data', 'wp-compose', 'lodash' ),
 		filemtime( gutenberg_dir_path() . 'build/viewport/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-block-library',
 		gutenberg_url( 'build/block-library/index.js' ),
 		array(
@@ -470,7 +471,7 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/block-library/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-nux',
 		gutenberg_url( 'build/nux/index.js' ),
 		array(
@@ -485,7 +486,7 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/nux/index.js' ),
 		true
 	);
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-plugins',
 		gutenberg_url( 'build/plugins/index.js' ),
 		array( 'lodash', 'wp-compose', 'wp-element', 'wp-hooks', 'wp-polyfill' ),
@@ -596,7 +597,7 @@ function gutenberg_register_scripts_and_styles() {
 		)
 	);
 
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-editor',
 		gutenberg_url( 'build/editor/index.js' ),
 		array(
@@ -632,7 +633,7 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/editor/index.js' )
 	);
 
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-edit-post',
 		gutenberg_url( 'build/edit-post/index.js' ),
 		array(
@@ -666,7 +667,7 @@ function gutenberg_register_scripts_and_styles() {
 		true
 	);
 
-	wp_register_script(
+	gutenberg_override_script(
 		'wp-list-reusable-blocks',
 		gutenberg_url( 'build/list-reusable-blocks/index.js' ),
 		array(
@@ -989,7 +990,7 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 		if ( ! $f ) {
 			// Failed to open the file for writing, probably due to server
 			// permissions.  Enqueue the script directly from the URL instead.
-			wp_register_script( $handle, $src, $deps, null );
+			gutenberg_override_script( $handle, $src, $deps, null );
 			return;
 		}
 		fclose( $f );
@@ -1002,12 +1003,12 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 			// The request failed. If the file is already cached, continue to
 			// use this file. If not, then unlink the 0 byte file, and enqueue
 			// the script directly from the URL.
-			wp_register_script( $handle, $src, $deps, null );
+			gutenberg_override_script( $handle, $src, $deps, null );
 			unlink( $full_path );
 			return;
 		}
 	}
-	wp_register_script(
+	gutenberg_override_script(
 		$handle,
 		gutenberg_url( 'vendor/' . $filename ),
 		$deps,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -66,10 +66,10 @@ function gutenberg_get_script_polyfill( $tests ) {
 	return $polyfill;
 }
 
-/**
- * Registers the main TinyMCE scripts.
- */
 if ( ! function_exists( 'register_tinymce_scripts' ) ) {
+	/**
+	 * Registers the main TinyMCE scripts.
+	 */
 	function register_tinymce_scripts() {
 		global $tinymce_version, $concatenate_scripts, $compress_scripts;
 		if ( ! isset( $concatenate_scripts ) ) {
@@ -90,11 +90,44 @@ if ( ! function_exists( 'register_tinymce_scripts' ) ) {
 	}
 }
 
+/**
+ * Registers a script according to `wp_register_script`. Honors this request by
+ * deregistering any script by the same handler before registration.
+ *
+ * @since 4.1.0
+ *
+ * @param string           $handle    Name of the script. Should be unique.
+ * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
+ * @param array            $deps      Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
+ *                                    as a query string for cache busting purposes. If version is set to false, a version
+ *                                    number is automatically added equal to current installed WordPress version.
+ *                                    If set to null, no version is added.
+ * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
+ *                                    Default 'false'.
+ */
 function gutenberg_override_script( $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
 	wp_deregister_script( $handle );
 	wp_register_script( $handle, $src, $deps, $ver, $in_footer );
 }
 
+/**
+ * Registers a style according to `wp_register_style`. Honors this request by
+ * deregistering any style by the same handler before registration.
+ *
+ * @since 4.1.0
+ *
+ * @param string           $handle Name of the stylesheet. Should be unique.
+ * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
+ * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
+ * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
+ *                                 as a query string for cache busting purposes. If version is set to false, a version
+ *                                 number is automatically added equal to current installed WordPress version.
+ *                                 If set to null, no version is added.
+ * @param string           $media  Optional. The media for which this stylesheet has been defined.
+ *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
+ *                                 '(orientation: portrait)' and '(max-width: 640px)'.
+ */
 function gutenberg_override_style( $handle, $src, $deps = array(), $ver = false, $media = 'all' ) {
 	wp_deregister_style( $handle );
 	wp_register_style( $handle, $src, $deps, $ver, $media );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -95,6 +95,11 @@ function gutenberg_override_script( $handle, $src, $deps = array(), $ver = false
 	wp_register_script( $handle, $src, $deps, $ver, $in_footer );
 }
 
+function gutenberg_override_style( $handle, $src, $deps = array(), $ver = false, $media = 'all' ) {
+	wp_deregister_style( $handle );
+	wp_register_style( $handle, $src, $deps, $ver, $media );
+}
+
 /**
  * Registers common scripts and styles to be used as dependencies of the editor
  * and plugins.
@@ -685,7 +690,7 @@ function gutenberg_register_scripts_and_styles() {
 
 	// Editor Styles.
 	// This empty stylesheet is defined to ensure backwards compatibility.
-	wp_register_style( 'wp-blocks', false );
+	gutenberg_override_style( 'wp-blocks', false );
 
 	$fonts_url = '';
 
@@ -701,14 +706,14 @@ function gutenberg_register_scripts_and_styles() {
 		$fonts_url = esc_url_raw( add_query_arg( $query_args, 'https://fonts.googleapis.com/css' ) );
 	}
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-editor-font',
 		$fonts_url,
 		array(),
 		null
 	);
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-editor',
 		gutenberg_url( 'build/editor/style.css' ),
 		array( 'wp-components', 'wp-editor-font', 'wp-nux' ),
@@ -716,7 +721,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_style_add_data( 'wp-editor', 'rtl', 'replace' );
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-edit-post',
 		gutenberg_url( 'build/edit-post/style.css' ),
 		array( 'wp-components', 'wp-editor', 'wp-edit-blocks', 'wp-block-library', 'wp-nux' ),
@@ -724,7 +729,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_style_add_data( 'wp-edit-post', 'rtl', 'replace' );
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-components',
 		gutenberg_url( 'build/components/style.css' ),
 		array(),
@@ -732,7 +737,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_style_add_data( 'wp-components', 'rtl', 'replace' );
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-block-library',
 		gutenberg_url( 'build/block-library/style.css' ),
 		current_theme_supports( 'wp-block-styles' ) ? array( 'wp-block-library-theme' ) : array(),
@@ -740,7 +745,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_style_add_data( 'wp-block-library', 'rtl', 'replace' );
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-edit-blocks',
 		gutenberg_url( 'build/block-library/editor.css' ),
 		array(
@@ -753,7 +758,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_style_add_data( 'wp-edit-blocks', 'rtl', 'replace' );
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-nux',
 		gutenberg_url( 'build/nux/style.css' ),
 		array( 'wp-components' ),
@@ -761,7 +766,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_style_add_data( 'wp-nux', 'rtl', 'replace' );
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-block-library-theme',
 		gutenberg_url( 'build/block-library/theme.css' ),
 		array(),
@@ -769,7 +774,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_style_add_data( 'wp-block-library-theme', 'rtl', 'replace' );
 
-	wp_register_style(
+	gutenberg_override_style(
 		'wp-list-reusable-blocks',
 		gutenberg_url( 'build/list-reusable-blocks/style.css' ),
 		array( 'wp-components' ),

--- a/lib/load.php
+++ b/lib/load.php
@@ -53,9 +53,24 @@ require dirname( __FILE__ ) . '/register.php';
 
 
 // Register server-side code for individual blocks.
-require dirname( __FILE__ ) . '/../packages/block-library/src/archives/index.php';
-require dirname( __FILE__ ) . '/../packages/block-library/src/block/index.php';
-require dirname( __FILE__ ) . '/../packages/block-library/src/categories/index.php';
-require dirname( __FILE__ ) . '/../packages/block-library/src/latest-comments/index.php';
-require dirname( __FILE__ ) . '/../packages/block-library/src/latest-posts/index.php';
-require dirname( __FILE__ ) . '/../packages/block-library/src/shortcode/index.php';
+if ( ! function_exists( 'render_block_core_archives' ) ) {
+	require dirname( __FILE__ ) . '/../packages/block-library/src/archives/index.php';
+}
+if ( ! function_exists( 'render_block_core_block' ) ) {
+	require dirname( __FILE__ ) . '/../packages/block-library/src/block/index.php';
+}
+if ( ! function_exists( 'render_block_core_categories' ) ) {
+	require dirname( __FILE__ ) . '/../packages/block-library/src/categories/index.php';
+}
+// Currently merged in core as `gutenberg_render_block_core_latest_comments`,
+// expected to change soon.
+if ( ! function_exists( 'render_block_core_latest_comments' )
+	&& ! function_exists( 'gutenberg_render_block_core_latest_comments' ) ) {
+	require dirname( __FILE__ ) . '/../packages/block-library/src/latest-comments/index.php';
+}
+if ( ! function_exists( 'render_block_core_latest_posts' ) ) {
+	require dirname( __FILE__ ) . '/../packages/block-library/src/latest-posts/index.php';
+}
+if ( ! function_exists( 'render_block_core_shortcode' ) ) {
+	require dirname( __FILE__ ) . '/../packages/block-library/src/shortcode/index.php';
+}

--- a/lib/register.php
+++ b/lib/register.php
@@ -323,15 +323,17 @@ function gutenberg_can_edit_post_type( $post_type ) {
  * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
  * @return bool Whether the post has blocks.
  */
-function has_blocks( $post = null ) {
-	if ( ! is_string( $post ) ) {
-		$wp_post = get_post( $post );
-		if ( $wp_post instanceof WP_Post ) {
-			$post = $wp_post->post_content;
+if ( ! function_exists( 'has_blocks' ) ) {
+	function has_blocks( $post = null ) {
+		if ( ! is_string( $post ) ) {
+			$wp_post = get_post( $post );
+			if ( $wp_post instanceof WP_Post ) {
+				$post = $wp_post->post_content;
+			}
 		}
-	}
 
-	return false !== strpos( (string) $post, '<!-- wp:' );
+		return false !== strpos( (string) $post, '<!-- wp:' );
+	}
 }
 
 /**
@@ -384,19 +386,21 @@ function gutenberg_content_has_blocks( $content ) {
  * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
  * @return bool Whether the post content contains the specified block.
  */
-function has_block( $block_type, $post = null ) {
-	if ( ! has_blocks( $post ) ) {
-		return false;
-	}
-
-	if ( ! is_string( $post ) ) {
-		$wp_post = get_post( $post );
-		if ( $wp_post instanceof WP_Post ) {
-			$post = $wp_post->post_content;
+if ( ! function_exists( 'has_block' ) ) {
+	function has_block( $block_type, $post = null ) {
+		if ( ! has_blocks( $post ) ) {
+			return false;
 		}
-	}
 
-	return false !== strpos( $post, '<!-- wp:' . $block_type . ' ' );
+		if ( ! is_string( $post ) ) {
+			$wp_post = get_post( $post );
+			if ( $wp_post instanceof WP_Post ) {
+				$post = $wp_post->post_content;
+			}
+		}
+
+		return false !== strpos( $post, '<!-- wp:' . $block_type . ' ' );
+	}
 }
 
 /**

--- a/lib/register.php
+++ b/lib/register.php
@@ -310,20 +310,20 @@ function gutenberg_can_edit_post_type( $post_type ) {
 	return apply_filters( 'gutenberg_can_edit_post_type', $can_edit, $post_type );
 }
 
-/**
- * Determine whether a post or content string has blocks.
- *
- * This test optimizes for performance rather than strict accuracy, detecting
- * the pattern of a block but not validating its structure. For strict accuracy
- * you should use the block parser on post content.
- *
- * @since 3.6.0
- * @see gutenberg_parse_blocks()
- *
- * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
- * @return bool Whether the post has blocks.
- */
 if ( ! function_exists( 'has_blocks' ) ) {
+	/**
+	 * Determine whether a post or content string has blocks.
+	 *
+	 * This test optimizes for performance rather than strict accuracy, detecting
+	 * the pattern of a block but not validating its structure. For strict accuracy
+	 * you should use the block parser on post content.
+	 *
+	 * @since 3.6.0
+	 * @see gutenberg_parse_blocks()
+	 *
+	 * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
+	 * @return bool Whether the post has blocks.
+	 */
 	function has_blocks( $post = null ) {
 		if ( ! is_string( $post ) ) {
 			$wp_post = get_post( $post );
@@ -374,19 +374,19 @@ function gutenberg_content_has_blocks( $content ) {
 	return has_blocks( $content );
 }
 
-/**
- * Determine whether a $post or a string contains a specific block type.
- * This test optimizes for performance rather than strict accuracy, detecting
- * the block type exists but not validating its structure.
- * For strict accuracy, you should use the block parser on post content.
- *
- * @since 3.6.0
- *
- * @param string                  $block_type Full Block type to look for.
- * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
- * @return bool Whether the post content contains the specified block.
- */
 if ( ! function_exists( 'has_block' ) ) {
+	/**
+	 * Determine whether a $post or a string contains a specific block type.
+	 * This test optimizes for performance rather than strict accuracy, detecting
+	 * the block type exists but not validating its structure.
+	 * For strict accuracy, you should use the block parser on post content.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param string                  $block_type Full Block type to look for.
+	 * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
+	 * @return bool Whether the post content contains the specified block.
+	 */
 	function has_block( $block_type, $post = null ) {
 		if ( ! has_blocks( $post ) ) {
 			return false;

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -25,12 +25,14 @@
  * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
  * @return string The post title if set; "(no title)" if no title is set.
  */
-function gutenberg_draft_or_post_title( $post = 0 ) {
-	$title = get_the_title( $post );
-	if ( empty( $title ) ) {
-		$title = __( '(no title)', 'gutenberg' );
+if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
+	function gutenberg_draft_or_post_title( $post = 0 ) {
+		$title = get_the_title( $post );
+		if ( empty( $title ) ) {
+			$title = __( '(no title)', 'gutenberg' );
+		}
+		return esc_html( $title );
 	}
-	return esc_html( $title );
 }
 
 /**

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -5,27 +5,27 @@
  * @package gutenberg
  */
 
-/**
- * Get the post title.
- *
- * The post title is fetched and if it is blank then a default string is
- * returned.
- *
- * Copied from `wp-admin/includes/template.php`, but we can't include that
- * file because:
- *
- * 1. It causes bugs with test fixture generation and strange Docker 255 error
- *    codes.
- * 2. It's in the admin; ideally we *shouldn't* be including files from the
- *    admin for a block's output. It's a very small/simple function as well,
- *    so duplicating it isn't too terrible.
- *
- * @since 3.3.0
- *
- * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
- * @return string The post title if set; "(no title)" if no title is set.
- */
 if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
+	/**
+	 * Get the post title.
+	 *
+	 * The post title is fetched and if it is blank then a default string is
+	 * returned.
+	 *
+	 * Copied from `wp-admin/includes/template.php`, but we can't include that
+	 * file because:
+	 *
+	 * 1. It causes bugs with test fixture generation and strange Docker 255 error
+	 *    codes.
+	 * 2. It's in the admin; ideally we *shouldn't* be including files from the
+	 *    admin for a block's output. It's a very small/simple function as well,
+	 *    so duplicating it isn't too terrible.
+	 *
+	 * @since 3.3.0
+	 *
+	 * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
+	 * @return string The post title if set; "(no title)" if no title is set.
+	 */
 	function gutenberg_draft_or_post_title( $post = 0 ) {
 		$title = get_the_title( $post );
 		if ( empty( $title ) ) {


### PR DESCRIPTION
This lets the plugin run alongside WP trunk and override core packages.

I recommend seeing the [diff without whitespace changes](https://github.com/WordPress/gutenberg/pull/10754/files?utf8=✓&diff=unified&w=1).

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->