### PR TITLE
Fix: Inserter Search Results Not Announcing 

### DIFF
--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -162,7 +162,7 @@ export class InserterMenu extends Component {
 	}
 
 	filter( filterValue = '' ) {
-		const { items, rootChildBlocks, debouncedSpeak } = this.props;
+		const { debouncedSpeak, items, rootChildBlocks } = this.props;
 		const filteredItems = searchItems( items, filterValue );
 
 		const childItems = filter( filteredItems, ( { name } ) => includes( rootChildBlocks, name ) );

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -206,7 +206,9 @@ export class InserterMenu extends Component {
 			openPanels,
 		} );
 
-		const resultCount = Object.keys( itemsPerCategory ).reduce( ( memo, curr ) => memo + itemsPerCategory[ curr ].length, 0 );
+		const resultCount = Object.keys( itemsPerCategory ).reduce( ( accumulator, currentCategorySlug ) => {
+			return accumulator + itemsPerCategory[ currentCategorySlug ].length;
+		}, 0 );
 
 		const resultsFoundMessage = sprintf(
 			_n( '%d result found.', '%d results found.', resultCount ),

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -20,7 +20,7 @@ import scrollIntoView from 'dom-scroll-into-view';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component, findDOMNode, createRef } from '@wordpress/element';
 import { withSpokenMessages, PanelBody } from '@wordpress/components';
 import { getCategories, isReusableBlock } from '@wordpress/blocks';
@@ -162,7 +162,7 @@ export class InserterMenu extends Component {
 	}
 
 	filter( filterValue = '' ) {
-		const { items, rootChildBlocks } = this.props;
+		const { items, rootChildBlocks, debouncedSpeak } = this.props;
 		const filteredItems = searchItems( items, filterValue );
 
 		const childItems = filter( filteredItems, ( { name } ) => includes( rootChildBlocks, name ) );
@@ -205,6 +205,15 @@ export class InserterMenu extends Component {
 			itemsPerCategory,
 			openPanels,
 		} );
+
+		const resultCount = Object.keys( itemsPerCategory ).reduce( ( memo, curr ) => memo + itemsPerCategory[ curr ].length, 0 );
+
+		const resultsFoundMessage = sprintf(
+			_n( '%d result found.', '%d results found.', resultCount ),
+			resultCount
+		);
+
+		debouncedSpeak( resultsFoundMessage, 'assertive' );
 	}
 
 	render() {


### PR DESCRIPTION

## Description
The inserter search results do not announce to screen readers the current number of filtered results. This implements some logic to calculate that number and announce to the user how many results have been found. 

## How has this been tested?
First and foremost, I typed in various strings of text to change the number of results. Then I made sure the text in the live region calculated the correct number and matched up with the actual count. 

Then I used VoiceOver and Safari (there is a bug in other browsers where aria-live doesn't work) to test that the value of the aria-live region is read to a screen reader. At least from my initial testing everything seemed to work correctly. 

## Screenshots

<img width="687" alt="screen shot 2018-10-18 at 3 58 31 pm" src="https://user-images.githubusercontent.com/3654512/47180780-5e8b3c00-d2ef-11e8-8f36-8b0df84b0a7e.png">

![screen shot 2018-10-18 at 3 59 26 pm](https://user-images.githubusercontent.com/3654512/47180856-7e226480-d2ef-11e8-9ea4-7a0d57208dbf.png)


<img width="608" alt="screen shot 2018-10-18 at 3 59 16 pm" src="https://user-images.githubusercontent.com/3654512/47180846-78c51a00-d2ef-11e8-8194-2d672577f7d4.png">

![screen shot 2018-10-18 at 3 59 22 pm](https://user-images.githubusercontent.com/3654512/47180872-8aa6bd00-d2ef-11e8-8922-a8fc7044cf7d.png)


<img width="197" alt="screen shot 2018-10-18 at 3 58 04 pm" src="https://user-images.githubusercontent.com/3654512/47180895-985c4280-d2ef-11e8-9453-2ffa398da81e.png">


## Types of changes

Makes the inserter more accessible by fixing this issue: https://github.com/WordPress/gutenberg/issues/10583

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
