### PR TITLE
Block API: Remove HTML source string normalization

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -158,6 +158,7 @@ attributes: {
 		attribute: 'src',
 	},
 	author: {
+		type: 'string',
 		source: 'html',
 		selector: '.book-author',
 	},

--- a/docs/block-api/attributes.md
+++ b/docs/block-api/attributes.md
@@ -19,6 +19,7 @@ _Example_: Extract the `src` attribute from an image found in the block's markup
 ```js
 {
 	url: {
+		type: 'string',
 		source: 'attribute',
 		selector: 'img',
 		attribute: 'src',
@@ -34,6 +35,7 @@ Use `text` to extract the inner text from markup.
 ```js
 {
 	content: {
+		type: 'string',
 		source: 'text',
 		selector: 'figcaption',
 	}
@@ -48,6 +50,7 @@ Use `html` to extract the inner HTML from markup.
 ```js
 {
 	content: {
+		type: 'string',
 		source: 'html',
 		selector: 'figcaption',
 	}
@@ -60,6 +63,7 @@ Use the `multiline` property to extract the inner HTML of matching tag names for
 ```js
 {
 	content: {
+		type: 'string',
 		source: 'html',
 		multiline: 'p',
 		selector: 'blockquote',
@@ -77,11 +81,20 @@ _Example_: Extract `src` and `alt` from each image element in the block's markup
 ```js
 {
 	images: {
+		type: 'array',
 		source: 'query'
 		selector: 'img',
 		query: {
-			url: { source: 'attribute', attribute: 'src' },
-			alt: { source: 'attribute', attribute: 'alt' },
+			url: {
+				type: 'string',
+				source: 'attribute',
+				attribute: 'src',
+			},
+			alt: {
+				type: 'string',
+				source: 'attribute',
+				attribute: 'alt',
+			},
 		}
 	}
 }

--- a/docs/block-api/deprecated-blocks.md
+++ b/docs/block-api/deprecated-blocks.md
@@ -204,6 +204,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 		{
 			attributes: {
 				title: {
+					type: 'string',
 					source: 'html',
 					selector: 'p',
 				},
@@ -244,6 +245,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 		{
 			attributes: {
 				title: {
+					type: 'string',
 					source: 'html',
 					selector: 'p',
 				},

--- a/docs/blocks/block-controls-toolbars-and-inspector.md
+++ b/docs/blocks/block-controls-toolbars-and-inspector.md
@@ -29,6 +29,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 
 	attributes: {
 		content: {
+			type: 'string',
 			source: 'html',
 			selector: 'p',
 		},
@@ -111,6 +112,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 
 	attributes: {
 		content: {
+			type: 'string',
 			source: 'html',
 			selector: 'p',
 		},

--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -24,6 +24,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 
 	attributes: {
 		content: {
+			type: 'string',
 			source: 'html',
 			selector: 'p',
 		}
@@ -72,6 +73,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 
 	attributes: {
 		content: {
+			type: 'string',
 			source: 'html',
 			selector: 'p',
 		},

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -31,6 +31,7 @@ export const settings = {
 			attribute: 'src',
 		},
 		caption: {
+			type: 'string',
 			source: 'html',
 			selector: 'figcaption',
 		},

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -33,6 +33,7 @@ const blockAttributes = {
 		attribute: 'title',
 	},
 	text: {
+		type: 'string',
 		source: 'html',
 		selector: 'a',
 	},

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -37,6 +37,7 @@ const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
 
 const blockAttributes = {
 	title: {
+		type: 'string',
 		source: 'html',
 		selector: 'p',
 	},
@@ -463,6 +464,7 @@ export const settings = {
 		attributes: {
 			...blockAttributes,
 			title: {
+				type: 'string',
 				source: 'html',
 				selector: 'h2',
 			},

--- a/packages/block-library/src/embed/settings.js
+++ b/packages/block-library/src/embed/settings.js
@@ -21,6 +21,7 @@ const embedAttributes = {
 		type: 'string',
 	},
 	caption: {
+		type: 'string',
 		source: 'html',
 		selector: 'figcaption',
 	},

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -39,6 +39,7 @@ export const settings = {
 			type: 'string',
 		},
 		fileName: {
+			type: 'string',
 			source: 'html',
 			selector: 'a:not([download])',
 		},
@@ -61,6 +62,7 @@ export const settings = {
 			default: true,
 		},
 		downloadButtonText: {
+			type: 'string',
 			source: 'html',
 			selector: 'a[download]',
 			default: _x( 'Download', 'button label' ),

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -46,6 +46,7 @@ const blockAttributes = {
 				attribute: 'data-id',
 			},
 			caption: {
+				type: 'string',
 				source: 'html',
 				selector: 'figcaption',
 			},

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -42,8 +42,10 @@ const supports = {
 
 const schema = {
 	content: {
+		type: 'string',
 		source: 'html',
 		selector: 'h1,h2,h3,h4,h5,h6',
+		default: '',
 	},
 	level: {
 		type: 'number',

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -43,6 +43,7 @@ const blockAttributes = {
 		default: '',
 	},
 	caption: {
+		type: 'string',
 		source: 'html',
 		selector: 'figcaption',
 	},

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -48,9 +48,11 @@ const schema = {
 		default: false,
 	},
 	values: {
+		type: 'string',
 		source: 'html',
 		selector: 'ol,ul',
 		multiline: 'li',
+		default: '',
 	},
 };
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -33,6 +33,7 @@ const supports = {
 
 const schema = {
 	content: {
+		type: 'string',
 		source: 'html',
 		selector: 'p',
 		default: '',
@@ -197,6 +198,7 @@ export const settings = {
 				content: {
 					type: 'string',
 					source: 'html',
+					default: '',
 				},
 			},
 			save( { attributes } ) {

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -19,8 +19,10 @@ export const settings = {
 
 	attributes: {
 		content: {
+			type: 'string',
 			source: 'html',
 			selector: 'pre',
+			default: '',
 		},
 	},
 

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -26,13 +26,16 @@ import {
 
 const blockAttributes = {
 	value: {
+		type: 'string',
 		source: 'html',
 		selector: 'blockquote',
 		multiline: 'p',
 	},
 	citation: {
+		type: 'string',
 		source: 'html',
 		selector: 'cite',
+		default: '',
 	},
 	mainColor: {
 		type: 'string',
@@ -133,6 +136,7 @@ export const settings = {
 		attributes: {
 			...blockAttributes,
 			citation: {
+				type: 'string',
 				source: 'html',
 				selector: 'footer',
 			},

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -19,13 +19,17 @@ import { G, Path, SVG } from '@wordpress/components';
 
 const blockAttributes = {
 	value: {
+		type: 'string',
 		source: 'html',
 		selector: 'blockquote',
 		multiline: 'p',
+		default: '',
 	},
 	citation: {
+		type: 'string',
 		source: 'html',
 		selector: 'cite',
+		default: '',
 	},
 	align: {
 		type: 'string',
@@ -292,8 +296,10 @@ export const settings = {
 			attributes: {
 				...blockAttributes,
 				citation: {
+					type: 'string',
 					source: 'html',
 					selector: 'footer',
+					default: '',
 				},
 				style: {
 					type: 'number',

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -31,6 +31,7 @@ export const settings = {
 
 	attributes: {
 		content: {
+			type: 'string',
 			source: 'html',
 			selector: 'p',
 		},

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -59,6 +59,7 @@ function getTableSectionAttributeSchema( section ) {
 				selector: 'td,th',
 				query: {
 					content: {
+						type: 'string',
 						source: 'html',
 					},
 					tag: {

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -41,6 +41,7 @@ export const settings = {
 			selector: 'p',
 			query: {
 				children: {
+					type: 'string',
 					source: 'html',
 				},
 			},

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -26,8 +26,10 @@ export const settings = {
 
 	attributes: {
 		content: {
+			type: 'string',
 			source: 'html',
 			selector: 'pre',
+			default: '',
 		},
 		textAlign: {
 			type: 'string',

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -33,6 +33,7 @@ export const settings = {
 			attribute: 'autoplay',
 		},
 		caption: {
+			type: 'string',
 			source: 'html',
 			selector: 'figcaption',
 		},

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -50,10 +50,6 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
 			result[ key ] = schema.default;
 		}
 
-		if ( schema.source === 'html' && typeof result[ key ] !== 'string' ) {
-			result[ key ] = '';
-		}
-
 		if ( [ 'node', 'children' ].indexOf( schema.source ) !== -1 ) {
 			// Ensure value passed is always an array, which we're expecting in
 			// the RichText component to handle the deprecated value.


### PR DESCRIPTION
Related: #10678 (specifically https://github.com/WordPress/gutenberg/pull/10678/files#r225838572)

This pull request seeks to remove string normalization in the block factory method, which had been added in #10678 as a tolerance to avoid issues where an `undefined` value would not concatenate, relevant largely in merging the RichText values of two blocks.

The argument made is that while this provides some convenience, it does so inconsistently from the behavior of any other attribute source/type, where the block developer is otherwise responsible for assuring its specific value form before operating on it.

**Implementation notes:**

The process here was in auditing each block using a `source: 'html'` for any operations which assume a string shape (like the quote merge concatenation in #10678), ensuring the default value. This does not mean a `default` is provided for every occurrence of `source: 'html'`, and as such no guarantee is made for safety of concatenating attributes of `source: 'html'`.

Changes also include adding the missing `type` for HTML-sourced attributes. I expect this may be a remnant of when the attribute was of the un-typed abstracted `rich-text` source.

**Testing instructions:**

Repeat testing instructions from #10678