### PR TITLE
Add withPropsChange hoc; Add Mechanism to use custom colors on withColors

### DIFF
--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -9,6 +9,7 @@ export { default as pure } from './pure';
 export { default as remountOnPropChange } from './remount-on-prop-change';
 export { default as withGlobalEvents } from './with-global-events';
 export { default as withInstanceId } from './with-instance-id';
+export { default as withPropsChange } from './with-props-change';
 export { default as withSafeTimeout } from './with-safe-timeout';
 export { default as withState } from './with-state';
 

--- a/packages/compose/src/with-props-change/README.md
+++ b/packages/compose/src/with-props-change/README.md
@@ -1,0 +1,30 @@
+withPropsChange
+==============
+
+Sometimes it may be useful to overwrite the props a component receives.
+E.g: to force a prop to contain some static prop or to in a specific context,
+compute one property as a function of other.
+
+withPropsChange receives a function that given the props of a component,
+should return the new props.
+
+## Usage
+
+```jsx
+/**
+ * WordPress dependencies
+ */
+import { withInstanceId } from '@wordpress/compose';
+
+const ShowGreeting = ( { greeting, name } ) => {
+	return (
+		<div>
+			{ greeting } { name }
+		</div>
+	);
+};
+
+const ShowWordPressGreeting = withPropsChange(
+	( props ) => ( { ...props, greeting: 'Howdy' } )
+)( ShowGreeting );
+```

--- a/packages/compose/src/with-props-change/index.js
+++ b/packages/compose/src/with-props-change/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createHigherOrderComponent from '../create-higher-order-component';
+
+/**
+ * A Higher Order Component used to change props passed to a component.
+ *
+ * @param {?function} propsMutationFunction Function that changes the props.
+ *
+ * @return {Component} Wrapped component.
+ */
+export default function withPropsChange( propsMutationFunction = noop ) {
+	return createHigherOrderComponent( ( OriginalComponent ) => {
+		return ( props ) => {
+			return (
+				<OriginalComponent
+					{ ...propsMutationFunction( props ) }
+				/>
+			);
+		};
+	} );
+}

--- a/packages/compose/src/with-props-change/test/index.js
+++ b/packages/compose/src/with-props-change/test/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { render } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import withPropsChange from '../';
+
+describe( 'withPropsChange', () => {
+	const InnerComponent = ( { myProp } ) => {
+		return myProp ? ( <div>{ myProp }</div> ) : '';
+	};
+	it( 'should be able to add props', () => {
+		const Component = withPropsChange(
+			( props ) => ( { ...props, myProp: 'myPropValue' } )
+		)( InnerComponent );
+		expect( render( <InnerComponent /> ).text() ).toBe( '' );
+		expect( render( <Component /> ).text() ).toBe( 'myPropValue' );
+	} );
+
+	it( 'should be able to remove props', () => {
+		const Component = withPropsChange(
+			( props ) => ( { ...props, myProp: undefined } )
+		)( InnerComponent );
+		expect( render( <InnerComponent myProp="myPropValue" /> ).text() ).toBe( 'myPropValue' );
+		expect( render( <Component myProp="myPropValue" /> ).text() ).toBe( '' );
+	} );
+
+	it( 'should be able to change props', () => {
+		const Component = withPropsChange(
+			( props ) => ( { ...props, myProp: 'myPropValueChanged' } )
+		)( InnerComponent );
+		expect( render( <InnerComponent myProp="myPropValue" /> ).text() ).toBe( 'myPropValue' );
+		expect( render( <Component myProp="myPropValue" /> ).text() ).toBe( 'myPropValueChanged' );
+	} );
+
+	it( 'should not change props if no mutation function is passed', () => {
+		const Component = withPropsChange()( InnerComponent );
+		expect( render( <InnerComponent myProp="myPropValue" /> ).text() ).toBe( 'myPropValue' );
+		expect( render( <Component myProp="myPropValue" /> ).text() ).toBe( 'myPropValue' );
+	} );
+} );

--- a/packages/editor/src/components/colors/with-colors.js
+++ b/packages/editor/src/components/colors/with-colors.js
@@ -42,7 +42,10 @@ export default ( ...args ) => {
 
 	return createHigherOrderComponent(
 		compose( [
-			withSelect( ( select ) => {
+			withSelect( ( select, { colors } ) => {
+				if ( colors ) {
+					return {};
+				}
 				const settings = select( 'core/editor' ).getEditorSettings();
 				return {
 					colors: get( settings, [ 'colors' ], DEFAULT_COLORS ),


### PR DESCRIPTION
## Description
This PR  adds a very simple HOC that allows us to mutate the props a component receives (change props, remove props, or add props).

This PR change withColors to allow the component to receive colors passed to it instead of the using the ones available in the state.


Joining withProps + withColors blocks can easily have a set of static colors but take advantage of all the logic withColors offers them.

```
 var COLORS = [ {
            slug: 'green',
            name: 'Green',
            color: '#00ff00'
        },{
            slug: 'yellow',
            name: 'Yellow',
            color: '#ffff00'
    } ];
...

compose( [ 
	withColors( 'backgroundColor', 'textColor' ),
	withPropsChange( function( props ){
            return Object.assign( props, {
                colors: COLORS
            } ),
	withColors( 'borderBottomColor', 'borderTopColor' )
] );
```

In the previous sample backgroundColor and textColor use the color palette provided by the editor/theme while borderBottomColor and borderTopColor use the static colors provided by the block.
The block is responsible for implementing the following classes: .has-green-border-top-color, has-yellow-border-top-color, has-green-border-bottom-color, .has-yellow-border-bottom-color;
This is useful in a context where there are no expectations themes should provide classes e.g: border colors, or if the block only makes sense with a given set of colors and we want to avoid inline styles.

This PR may be useful for https://github.com/WordPress/gutenberg/pull/10611.

## How has this been tested?
I added the test bock available in https://gist.github.com/jorgefilipecosta/27622e3036e91e0d03f9026ef65fc162.

I checked that for border colors we can choose between a specified set, and classes are used for border colors with the logic being handled by withColors.
I checked that background and text color still present the expected behavior.
I checked that existing blocks that use colors ( cover, paragraph, button etc...) still work as expected.
