### PR TITLE
Add lodash deburr to autocomplete so that is works with diacritics

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { escapeRegExp, find, map, debounce } from 'lodash';
+import { escapeRegExp, find, map, debounce, deburr } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -382,8 +382,8 @@ export class Autocomplete extends Component {
 		}
 
 		if ( isCollapsed( record ) ) {
-			const text = getTextContent( slice( record, 0 ) );
-			const prevText = getTextContent( slice( prevRecord, 0 ) );
+			const text = deburr( getTextContent( slice( record, 0 ) ) );
+			const prevText = deburr( getTextContent( slice( prevRecord, 0 ) ) );
 
 			if ( text !== prevText ) {
 				const textAfterSelection = getTextContent( slice( record, undefined, getTextContent( record ).length ) );

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -122,7 +122,7 @@ function filterOptions( search, options = [], maxResults = 10 ) {
 			keywords = [ ...keywords, option.label ];
 		}
 
-		const isMatch = keywords.some( ( keyword ) => search.test( keyword ) );
+		const isMatch = keywords.some( ( keyword ) => search.test( deburr( keyword ) ) );
 		if ( ! isMatch ) {
 			continue;
 		}


### PR DESCRIPTION

## Description
Added lodash's deburr function to the autocomplete so that when searching in a language that has diacritics it will find them both with and without the diacrytic. For example now both "/U" and "/Ü" will find the "Überschrift" block in the German language. 


## How has this been tested?
Type /U and /Ü and verify that they both return the expected result block in the German Language. FIxes #10489

## Screenshots
![beitrag_bearbeiten_ _gutenberg_dev_ _wordpress](https://user-images.githubusercontent.com/6653970/47195365-931be980-d329-11e8-9c47-75eb29fbea5b.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
