### PR TITLE
Address further review of unregistered type handler

### DIFF
--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -37,9 +37,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 			<Warning actions={ actions }>
 				{ messageHTML }
 			</Warning>
-			<div>
-				<RawHTML>{ originalUndelimitedContent }</RawHTML>
-			</div>
+			<RawHTML>{ originalUndelimitedContent }</RawHTML>
 		</Fragment>
 	);
 }

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -410,7 +410,7 @@ export function createBlockWithFallback( blockNode ) {
 	attributes = attributes || {};
 
 	// Trim content to avoid creation of intermediary freeform segments.
-	const originalUndelimitedContent = innerHTML = innerHTML.trim();
+	innerHTML = innerHTML.trim();
 
 	// Use type from block content if available. Otherwise, default to the
 	// freeform content fallback.
@@ -437,6 +437,9 @@ export function createBlockWithFallback( blockNode ) {
 	let blockType = getBlockType( name );
 
 	if ( ! blockType ) {
+		// Preserve undelimited content for use by the unregistered type handler.
+		const originalUndelimitedContent = innerHTML;
+
 		// If detected as a block which is not registered, preserve comment
 		// delimiters in content of unregistered type handler.
 		if ( name ) {


### PR DESCRIPTION
## Description
This PR follows up on post-merge review comments for #8274 (added unregistered type handler).
https://github.com/WordPress/gutenberg/pull/8274#discussion_r225259189
https://github.com/WordPress/gutenberg/pull/8274#discussion_r225260135

## How has this been tested?
Ran automated tests. Manually tested by changing and saving content around unregistered blocks, re-enabling a plugin that registers the missing blocks, and reloading to observe that the content was preserved.