### PR TITLE
Add i18n context for resolving invalid blocks

### DIFF
--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Button, Modal } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import {
@@ -45,7 +45,7 @@ export class BlockInvalidWarning extends Component {
 		if ( compare ) {
 			return (
 				<Modal
-					title={ __( 'Resolve Block' ) }
+					title={ _x( 'Resolve Block', 'title for ways to fix an invalid block' ) }
 					onRequestClose={ this.onCompareClose }
 					className="editor-block-compare"
 				>
@@ -64,7 +64,7 @@ export class BlockInvalidWarning extends Component {
 			<Warning
 				actions={ [
 					<Button key="convert" onClick={ this.onCompare } isLarge isPrimary={ ! hasHTMLBlock }>
-						{ __( 'Resolve' ) }
+						{ _x( 'Resolve', 'imperative verb: show ways to fix an invalid block' ) }
 					</Button>,
 					hasHTMLBlock && (
 						<Button key="edit" onClick={ convertToHTML } isLarge isPrimary>

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -45,7 +45,10 @@ export class BlockInvalidWarning extends Component {
 		if ( compare ) {
 			return (
 				<Modal
-					title={ _x( 'Resolve Block', 'title for ways to fix an invalid block' ) }
+					title={
+						// translators: Dialog title to fix block content
+						__( 'Resolve Block' )
+					}
 					onRequestClose={ this.onCompareClose }
 					className="editor-block-compare"
 				>
@@ -64,7 +67,10 @@ export class BlockInvalidWarning extends Component {
 			<Warning
 				actions={ [
 					<Button key="convert" onClick={ this.onCompare } isLarge isPrimary={ ! hasHTMLBlock }>
-						{ _x( 'Resolve', 'imperative verb: show ways to fix an invalid block' ) }
+						{
+							// translators: Button to fix block content
+							_x( 'Resolve', 'imperative verb' )
+						}
 					</Button>,
 					hasHTMLBlock && (
 						<Button key="edit" onClick={ convertToHTML } isLarge isPrimary>


### PR DESCRIPTION
## Description
This is a simple PR to add i18n context for "Resolve" and "Resolve Block" strings to resolve translation concerns from [this comment](https://github.com/WordPress/gutenberg/pull/8274#issuecomment-431014989).

@gAllegr, does this address your issue with the strings?

## Screenshots

<img width="656" alt="screen shot 2018-10-19 at 12 18 12 am" src="https://user-images.githubusercontent.com/530877/47203314-b730f800-d334-11e8-90c9-3f61d43b0344.png">
<img width="444" alt="screen shot 2018-10-19 at 12 18 20 am" src="https://user-images.githubusercontent.com/530877/47203321-b9935200-d334-11e8-800d-299b232e1e51.png">