### PR TITLE
Make sure autocomplete triggers are regex safe

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -407,7 +407,8 @@ export class Autocomplete extends Component {
 					return;
 				}
 
-				const match = text.match( new RegExp( `${ open.triggerPrefix }(\\w*)$` ) );
+				const safeTrigger = escapeRegExp( open.triggerPrefix );
+				const match = text.match( new RegExp( `${ safeTrigger }(\\w*)$` ) );
 				const query = match && match[ 1 ];
 				const { open: wasOpen, suppress: wasSuppress, query: wasQuery } = this.state;
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/WordPress/gutenberg/issues/10781

Make sure autocomplete triggers are made safe for use in regex.

## How has this been tested?

Install and test the autocomplete example from https://github.com/WordPress/gutenberg/issues/10781

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
