### PR TITLE
Update creating-dynamic-blocks.md

### DIFF
--- a/docs/blocks/creating-dynamic-blocks.md
+++ b/docs/blocks/creating-dynamic-blocks.md
@@ -23,7 +23,10 @@ registerBlockType( 'my-plugin/latest-post', {
 			posts: select( 'core' ).getEntityRecords( 'postType', 'post' )
 		};
 	} )( function( props ) {
-		if ( props.posts && props.posts.length === 0 ) {
+		if ( ! props.posts ) {
+			return "Loading...";
+		}
+		if ( props.posts.length === 0 ) {
 			return "No posts";
 		}
 		var className = props.className;
@@ -59,10 +62,13 @@ registerBlockType( 'my-plugin/latest-post', {
 			posts: select( 'core' ).getEntityRecords( 'postType', 'post' )
 		};
 	} )( ( { posts, className } ) => {
+		if ( ! posts ) {
+			return "Loading...";
+		}
 		if ( posts && posts.length === 0 ) {
 			return "No posts";
 		}
-		var post = posts[ 0 ];
+		let post = posts[ 0 ];
 
 		return <a className={ className } href={ post.link }>
 			{ post.title.rendered }

--- a/docs/blocks/creating-dynamic-blocks.md
+++ b/docs/blocks/creating-dynamic-blocks.md
@@ -23,9 +23,11 @@ registerBlockType( 'my-plugin/latest-post', {
 			posts: select( 'core' ).getEntityRecords( 'postType', 'post' )
 		};
 	} )( function( props ) {
+		
 		if ( ! props.posts ) {
 			return "Loading...";
 		}
+
 		if ( props.posts.length === 0 ) {
 			return "No posts";
 		}
@@ -62,12 +64,15 @@ registerBlockType( 'my-plugin/latest-post', {
 			posts: select( 'core' ).getEntityRecords( 'postType', 'post' )
 		};
 	} )( ( { posts, className } ) => {
+
 		if ( ! posts ) {
 			return "Loading...";
 		}
+
 		if ( posts && posts.length === 0 ) {
 			return "No posts";
 		}
+
 		let post = posts[ 0 ];
 
 		return <a className={ className } href={ post.link }>


### PR DESCRIPTION
## Description
While posts are loading inside the edit method the `posts` variable is null, attempting to access `post[0]` causes an error 

"TypeError: Cannot read property '0' of null" and the block displays "This block has encountered an error and cannot be previewed." 

checking that posts has a value resolves this.

## How has this been tested?
I have tested these changes in browser.

## Types of changes
Bug fix in creating your first block docs