### PR TITLE
Don’t auto-select a pullquote text colour for regular style

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -35,9 +35,10 @@ class PullQuoteEdit extends Component {
 	pullQuoteMainColorSetter( colorValue ) {
 		const { colorUtils, textColor, setTextColor, setMainColor, className } = this.props;
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+		const shouldSetTextColor = isSolidColorStyle && ! textColor.color && colorValue;
 
 		setMainColor( colorValue );
-		if ( ( isSolidColorStyle && ! textColor.color ) || this.wasTextColorAutomaticallyComputed ) {
+		if ( shouldSetTextColor || this.wasTextColorAutomaticallyComputed ) {
 			this.wasTextColorAutomaticallyComputed = true;
 			setTextColor( colorUtils.getMostReadableColor( colorValue ) );
 		}

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -35,10 +35,11 @@ class PullQuoteEdit extends Component {
 	pullQuoteMainColorSetter( colorValue ) {
 		const { colorUtils, textColor, setTextColor, setMainColor, className } = this.props;
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
-		const shouldSetTextColor = isSolidColorStyle && ! textColor.color && colorValue;
+		const needTextColor = ! textColor.color || this.wasTextColorAutomaticallyComputed;
+		const shouldSetTextColor = isSolidColorStyle && needTextColor && colorValue;
 
 		setMainColor( colorValue );
-		if ( shouldSetTextColor || this.wasTextColorAutomaticallyComputed ) {
+		if ( shouldSetTextColor ) {
 			this.wasTextColorAutomaticallyComputed = true;
 			setTextColor( colorUtils.getMostReadableColor( colorValue ) );
 		}

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -33,9 +33,11 @@ class PullQuoteEdit extends Component {
 	}
 
 	pullQuoteMainColorSetter( colorValue ) {
-		const { colorUtils, textColor, setTextColor, setMainColor } = this.props;
+		const { colorUtils, textColor, setTextColor, setMainColor, className } = this.props;
+		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+
 		setMainColor( colorValue );
-		if ( ! textColor.color || this.wasTextColorAutomaticallyComputed ) {
+		if ( ( isSolidColorStyle && ! textColor.color ) || this.wasTextColorAutomaticallyComputed ) {
 			this.wasTextColorAutomaticallyComputed = true;
 			setTextColor( colorUtils.getMostReadableColor( colorValue ) );
 		}


### PR DESCRIPTION
The pullquote block auto-selects an appropriate text colour based on the main colour. This is designed to give a good contrast. However it assumes the quote has a 'solid colour' style where the main colour is the background, with the text overlayed:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/47211137-a6ac6c00-d38c-11e8-98d8-df2183311608.jpg)

If the pullquote uses the 'regular colour' style the background is white (or whatever the theme uses), and the main colour changes the top and bottom border:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/47211237-e7a48080-d38c-11e8-87b7-d0b6c81156cb.jpg)

The colour calculated for the main colour background can often give a poor contrast ratio on this white background.

For example, if you create a pull quote with regular style and pick red as the main colour it sets the text colour to light grey (the calculated text colour for red). In the above solid colour quote this gives good contrast, but on a regular colour quote with white background it gives poor contrast:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/47211340-1e7a9680-d38d-11e8-92bb-333723afc407.jpg)

This PR restricts the auto-colour selection to the 'solid colour' style only. I'm not sure if this fits the intended purpose of the block, but it fixes the problem in this instance.

Also fixes the situation where clicking 'clear' on the main colour sets a text colour.

Fixes #10568

## How has this been tested?
1. Create a pull quote block
2. Open block settings
3. Set main colour to red
4. Confirm the text colour does not change
5. Clear the text colour
6. Clear the main colour and verify that the text colour is not set

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
