### PR TITLE
Speak: Add/complete audible feedback for link editing

### DIFF
--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Toolbar } from '@wordpress/components';
+import {
+	Toolbar,
+	withSpokenMessages,
+} from '@wordpress/components';
 import { rawShortcut } from '@wordpress/keycodes';
 import { Component } from '@wordpress/element';
 import {
@@ -48,6 +51,7 @@ class FormatToolbar extends Component {
 
 	removeLink() {
 		this.removeFormat( 'a' );
+		this.props.speak( __( 'Link removed.' ), 'assertive' );
 	}
 
 	addLink() {
@@ -155,4 +159,4 @@ class FormatToolbar extends Component {
 	}
 }
 
-export default FormatToolbar;
+export default withSpokenMessages( FormatToolbar );

--- a/packages/editor/src/components/rich-text/format-toolbar/link-container.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/link-container.js
@@ -167,6 +167,10 @@ class LinkContainer extends Component {
 			this.props.applyFormat( format );
 		}
 
+		if ( this.state.editLink ) {
+			this.props.speak( __( 'Link edited.' ), 'assertive' );
+		}
+
 		this.resetState();
 
 		if ( ! link ) {


### PR DESCRIPTION
## Description
When users complete an action adding, editing or removing a link announce those action completions to assistive screen readers.

Fixes https://github.com/WordPress/gutenberg/issues/1867

## How has this been tested?
Adding and removing links in chrome with mac voice over enabled - the actions were properly announced.

## Types of changes
* Speak ‘link removed’ when a link is removed
* Speak ‘link edited’ when a link is edited

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
