### PR TITLE
[Fix] Make disabled state of 'Pre-publish checks' affect desktop viewport only

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -10,6 +10,7 @@ import {
 	PostPublishButton,
 } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { withViewportMatch } from '@wordpress/viewport';
 import { compose } from '@wordpress/compose';
 import { DotTip } from '@wordpress/nux';
 
@@ -30,6 +31,7 @@ function Header( {
 	togglePublishSidebar,
 	hasActiveMetaboxes,
 	isSaving,
+	isMobileViewport,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
@@ -49,7 +51,7 @@ function Header( {
 						forceIsSaving={ isSaving }
 					/>
 					<PostPreviewButton />
-					{ isPublishSidebarEnabled ? (
+					{ isPublishSidebarEnabled || isMobileViewport ? (
 						<PostPublishPanelToggle
 							isOpen={ isPublishSidebarOpened }
 							onToggle={ togglePublishSidebar }
@@ -102,4 +104,5 @@ export default compose(
 			hasBlockSelection: undefined,
 		};
 	} ),
+	withViewportMatch( { isMobileViewport: '< small' } ),
 )( Header );


### PR DESCRIPTION
## Description
This PR closes #10475 which reports the Editor Bar to not fit on mobile devices (notably iPhone 5 size screens in German) if Pre-publish checks are disabled. As suggested in the issue, this PR just makes the disabled state of 'Pre-publish checks' not affect mobile viewport.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Disabled "Pre-publish checks" by unchecking "Enable Pre-publish Checks" in More->Options.
2. Started a new post on a mobile device as a user with the contributor role.
3. Made sure the Pre-publish check shows up, even though they are disabled.

## Types of changes
This PR just imports `withViewportMatch` and creates `isMobileViewport` associated with it. `isMobileViewport` is then used as a conditional for pre-publish checks to be visible in mobile devices even if they are turned off.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
