### PR TITLE
Color Picker: Fix width of popover

### DIFF
--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -145,11 +145,6 @@ $color-palette-circle-spacing: 14px;
 	background-clip: content-box, content-box, content-box, content-box, content-box, content-box, padding-box, padding-box, padding-box, padding-box, padding-box, padding-box;
 }
 
-.components-color-palette__picker:not(.is-mobile).components-popover .components-popover__content {
-	// ChromePicker has a hardcoded width, so we need to override the popover min-width.
-	min-width: unset;
-}
-
 .block-editor__container .components-popover.components-color-palette__picker.is-bottom {
 	z-index: z-index(".block-editor__container .components-popover.components-color-palette__picker.is-bottom");
 }


### PR DESCRIPTION
Looks like a bit of CSS was lost in the merge of #10564 – we need to remove the `min-width: unset` on the popover, because the new color picker does _not_ set its own min-width. Removing this CSS allows the popover to be the default size.

Before:
<img width="290" alt="screen shot 2018-10-19 at 12 24 15 pm" src="https://user-images.githubusercontent.com/541093/47231102-fe9d9f80-d399-11e8-8197-ee01ce876088.png">

After:
<img width="291" alt="screen shot 2018-10-19 at 12 23 48 pm" src="https://user-images.githubusercontent.com/541093/47231100-fe9d9f80-d399-11e8-87ad-1d5438222ba2.png">

cc @tofumatt & @afercia for reporting