### PR TITLE
Make the color picker saturation control work with windows screen readers

### DIFF
--- a/packages/components/src/color-picker/saturation.js
+++ b/packages/components/src/color-picker/saturation.js
@@ -150,7 +150,7 @@ export class Saturation extends Component {
 			home: () => this.saturate( -1 ),
 		};
 
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions */
 		return (
 			<KeyboardShortcuts shortcuts={ shortcuts }>
 				<div
@@ -159,7 +159,9 @@ export class Saturation extends Component {
 					ref={ this.container }
 					onMouseDown={ this.handleMouseDown }
 					onTouchMove={ this.handleChange }
-					onTouchStart={ this.handleChange }>
+					onTouchStart={ this.handleChange }
+					role="application"
+				>
 					<div className="components-color-picker__saturation-white" />
 					<div className="components-color-picker__saturation-black" />
 					<button
@@ -179,7 +181,7 @@ export class Saturation extends Component {
 				</div>
 			</KeyboardShortcuts>
 		);
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions */
 	}
 }
 


### PR DESCRIPTION
Splitting this out from https://github.com/WordPress/gutenberg/pull/10564

## Description
Screen readers on Windows need to switch to "forms mode" on the saturation control to stop intercepting keystrokes and make the control work.

Adding a `role="application"` to the saturation control wrapper fixes it. Please consider `role="application"` must be used with caution and very sparingly, as it resets any native semantics and has other serious drawbacks; please always ask to the a11y team before using it. 

Thinking better at what proposed in https://github.com/WordPress/gutenberg/pull/10564#issuecomment-431299020 I now think there's no need for an `aria-label` on the div with role application, as it's not focusable and focus goes to the button instead.

## How has this been tested?
I've tested on Windows _without_ and _with_ a screen reader running.  Combos:
- NVDA Firefox
- NVDA IE11
- JAWS Chrome
- JAWS Firefox
- JAWS IE11

Recommended: test on a real Windows machine, not on a VM running Windows, see https://github.com/WordPress/gutenberg/pull/10564#issuecomment-431410395