### PR TITLE
Adds Featured Image media frame to fix 8748

### DIFF
--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -94,7 +94,7 @@ class MediaUpload extends Component {
 		allowedTypes,
 		multiple = false,
 		gallery = false,
-		showAuthorFilters = false,
+		unstableFeaturedImageFlow = false,
 		title = __( 'Select or Upload Media' ),
 		modalClass,
 		value,
@@ -137,7 +137,7 @@ class MediaUpload extends Component {
 			this.frame = wp.media( frameConfig );
 		}
 
-		if ( showAuthorFilters ) {
+		if ( unstableFeaturedImageFlow ) {
 			const featuredImageFrame = getFeaturedImageMediaFrame();
 			const attachments = getAttachmentsCollection( value );
 			const selection = new wp.media.model.Selection( attachments.models, {

--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -9,6 +9,22 @@ import { castArray, pick } from 'lodash';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+const getFeaturedImageMediaFrame = () => {
+	return wp.media.view.MediaFrame.Post.extend( {
+
+		/**
+		 * Create the default states.
+		 *
+		 * @return {void}
+		 */
+		createStates: function createStates() {
+			this.states.add( [
+				new wp.media.controller.FeaturedImage(),
+			] );
+		},
+	} );
+};
+
 // Getter for the sake of unit tests.
 const getGalleryDetailsMediaFrame = () => {
 	/**
@@ -78,6 +94,7 @@ class MediaUpload extends Component {
 		allowedTypes,
 		multiple = false,
 		gallery = false,
+		showAuthorFilters = false,
 		title = __( 'Select or Upload Media' ),
 		modalClass,
 		value,
@@ -118,6 +135,22 @@ class MediaUpload extends Component {
 			}
 
 			this.frame = wp.media( frameConfig );
+		}
+
+		if ( showAuthorFilters ) {
+			const featuredImageFrame = getFeaturedImageMediaFrame();
+			const attachments = getAttachmentsCollection( value );
+			const selection = new wp.media.model.Selection( attachments.models, {
+				props: attachments.props.toJSON(),
+			} );
+			this.frame = new featuredImageFrame( {
+				mimeType: allowedTypes,
+				state: 'featured-image',
+				multiple,
+				selection,
+				editing: ( value ) ? true : false,
+			} );
+			wp.media.frame = this.frame;
 		}
 
 		if ( modalClass ) {

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -94,6 +94,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 							<MediaUpload
 								title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 								onSelect={ onUpdateImage }
+								unstableFeaturedImageFlow
 								allowedTypes={ ALLOWED_MEDIA_TYPES }
 								modalClass="editor-post-featured-image__media-modal"
 								render={ ( { open } ) => (

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -52,6 +52,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 						<MediaUpload
 							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
+							showAuthorFilters
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
@@ -76,6 +77,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 						<MediaUpload
 							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
+							showAuthorFilters
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -52,7 +52,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 						<MediaUpload
 							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
-							showAuthorFilters
+							unstableFeaturedImageFlow
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
@@ -77,7 +77,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 						<MediaUpload
 							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
-							showAuthorFilters
+							unstableFeaturedImageFlow
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (


### PR DESCRIPTION
## Description
This is to match the backbone featured image frames expected in the editor.  This allows a user to select images with filters of `mine` and `uploaded to post` which was previously missing in the existing Gutenberg featured image frame.


## How has this been tested?

1) Create post
2) upload image to post
3) click `set featured image`
4) notice new filters for selecting media
5) select `uploaded` option in the drop down
3) notice the image uploaded to the post is available

## Types of changes
This adds a condition of `featuredImage` to the `MediaUpload` component.

Issue this fixes:
https://github.com/WordPress/gutenberg/issues/8748