### PR TITLE
Fix multi-selected warning block highlight

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -232,6 +232,11 @@
 		left: -$block-padding;
 	}
 
+	// Avoid conflict with the multi-selection highlight color.
+	&.has-warning.is-multi-selected .editor-block-list__block-edit::after {
+		background-color: transparent;
+	}
+
 	&.has-warning.is-selected .editor-block-list__block-edit::after {
 		bottom: ( $block-toolbar-height - $block-padding - $border-width );
 

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -8,6 +8,11 @@
 	text-align: left;
 	padding: 20px;
 
+	// Avoid conflict with the multi-selection highlight color.
+	.has-warning.is-multi-selected & {
+		background-color: transparent;
+	}
+
 	.editor-warning__message {
 		line-height: $default-line-height;
 		font-family: $default-font;


### PR DESCRIPTION
## Description
This PR fixes #10712 which describes how multi-selected blocks containing warnings aren't properly highlighted.

## How has this been tested?
Loaded an editor containing regular blocks and blocks with an unregistered-block warning. Noted that unselected block warnings look as expected and that multi-selected block warnings are now highlighted with the rest of the block.

## Screenshots <!-- if applicable -->
![block-warning-selection-highlight](https://user-images.githubusercontent.com/530877/47244516-92776780-d3aa-11e8-947a-c47d1cff0b39.gif)