### PR TITLE
Fix importing react-dates styles into the components package stylesheet

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -1,5 +1,5 @@
 // We can't reference this package with ~ because of how Lerna handles packages. 😩
-@import "../../node_modules/react-dates/lib/css/_datepicker.css";
+@import "node_modules/react-dates/lib/css/_datepicker";
 
 .components-datetime {
 	.components-datetime__calendar-help {


### PR DESCRIPTION
closes #10825 

Importing css files from Sass don't include them into the bundled CSS file but just keep importing them as external css files which won't work in prod because we don't ship the node_modules in prod :)

The trick is to remove the "css" extension from the import to bundle the CSS file.

This is a quick fix though because it seems that this method is deprecated

<img width="894" alt="screen shot 2018-10-20 at 13 08 25" src="https://user-images.githubusercontent.com/272444/47255449-45a69600-d469-11e8-8701-1a2bafce347e.png">
