### PR TITLE
Fix regressions and improve the insert link search field and suggestions list

### DIFF
--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -150,6 +150,8 @@ class URLInput extends Component {
 			return;
 		}
 
+		const post = this.state.posts[ this.state.selectedSuggestion ];
+
 		switch ( event.keyCode ) {
 			case UP: {
 				event.stopPropagation();
@@ -169,31 +171,34 @@ class URLInput extends Component {
 				} );
 				break;
 			}
-			case TAB:
+			case TAB: {
+				if ( this.state.selectedSuggestion !== null ) {
+					this.selectLink( post );
+					// Announce a link has been selected when tabbing away from the input field.
+					this.props.speak( __( 'Link selected' ) );
+				}
+				break;
+			}
 			case ENTER: {
 				if ( this.state.selectedSuggestion !== null ) {
 					event.stopPropagation();
-					const post = this.state.posts[ this.state.selectedSuggestion ];
-					this.selectLink( post, event );
+					this.selectLink( post );
 				}
 				break;
 			}
 		}
 	}
 
-	selectLink( post, event ) {
+	selectLink( post ) {
 		this.props.onChange( post.url, post );
 		this.setState( {
 			selectedSuggestion: null,
 			showSuggestions: false,
 		} );
+	}
 
-		// Announce a link has been selected when tabbing away from the input field.
-		if ( event.keyCode === TAB ) {
-			this.props.speak( __( 'Link selected' ) );
-			return;
-		}
-
+	handleOnClick( post ) {
+		this.selectLink( post );
 		// Move focus to the input field when a link suggestion is clicked.
 		this.inputRef.current.focus();
 	}
@@ -249,7 +254,7 @@ class URLInput extends Component {
 									className={ classnames( 'editor-url-input__suggestion', {
 										'is-selected': index === selectedSuggestion,
 									} ) }
-									onClick={ ( event ) => this.selectLink( post, event ) }
+									onClick={ () => this.handleOnClick( post ) }
 									aria-selected={ index === selectedSuggestion }
 								>
 									{ decodeEntities( post.title ) || __( '(no title)' ) }

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -22,15 +22,6 @@ import { addQueryArgs } from '@wordpress/url';
 // as being considered from the input.
 const stopEventPropagation = ( event ) => event.stopPropagation();
 
-function getAnchorRect( anchor ) {
-	/*
-	 * The default getAnchorRect() gets the parent node to calculate the popover
-	 * position. As the popover with the list of suggestions is now nested within
-	 * another popover, we need to get the gran parent node.
-	 */
-	return anchor.parentNode.parentNode.getBoundingClientRect();
-}
-
 class URLInput extends Component {
 	constructor( { autocompleteRef } ) {
 		super( ...arguments );
@@ -232,12 +223,7 @@ class URLInput extends Component {
 				</div>
 
 				{ showSuggestions && !! posts.length &&
-					<Popover
-						position="bottom center"
-						noArrow
-						focusOnMount={ false }
-						getAnchorRect={ getAnchorRect }
-					>
+					<Popover position="bottom" noArrow focusOnMount={ false }>
 						<div
 							className="editor-url-input__suggestions"
 							id={ `editor-url-input-suggestions-${ instanceId }` }

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -22,6 +22,15 @@ import { addQueryArgs } from '@wordpress/url';
 // as being considered from the input.
 const stopEventPropagation = ( event ) => event.stopPropagation();
 
+function getAnchorRect( anchor ) {
+	/*
+	 * The default getAnchorRect() gets the parent node to calculate the popover
+	 * position. As the popover with the list of suggestions is now nested within
+	 * another popover, we need to get the gran parent node.
+	 */
+	return anchor.parentNode.parentNode.getBoundingClientRect();
+}
+
 class URLInput extends Component {
 	constructor( { autocompleteRef } ) {
 		super( ...arguments );
@@ -218,7 +227,12 @@ class URLInput extends Component {
 				</div>
 
 				{ showSuggestions && !! posts.length &&
-					<Popover position="bottom" noArrow focusOnMount={ false }>
+					<Popover
+						position="bottom center"
+						noArrow
+						focusOnMount={ false }
+						getAnchorRect={ getAnchorRect }
+					>
 						<div
 							className="editor-url-input__suggestions"
 							id={ `editor-url-input-suggestions-${ instanceId }` }

--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -5,7 +5,6 @@ $input-size: 300px;
 .editor-block-list__block .editor-url-input,
 .components-popover .editor-url-input,
 .editor-url-input {
-	width: 100%;
 	flex-grow: 1;
 	position: relative;
 	padding: 1px;
@@ -38,9 +37,9 @@ $input-size: 300px;
 .editor-url-input__suggestions {
 	max-height: 200px;
 	transition: all 0.15s ease-in-out;
-	list-style: none;
 	padding: 4px 0;
-	width: $input-size + 2 * $icon-button-size;
+	// To match the url-input width: input width + padding + 2 buttons.
+	width: $input-size + 2 + 2 * $icon-button-size;
 	overflow-y: auto;
 }
 

--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -1,5 +1,5 @@
 // Link input
-$input-padding: 9px 8px;
+$input-padding: 8px;
 $input-size: 300px;
 
 .editor-block-list__block .editor-url-input,
@@ -28,8 +28,8 @@ $input-size: 300px;
 
 	.components-spinner {
 		position: absolute;
-		right: 0;
-		top: $input-padding;
+		right: $input-padding;
+		top: $input-padding + 1;
 		margin: 0;
 	}
 }
@@ -41,6 +41,7 @@ $input-size: 300px;
 	list-style: none;
 	padding: 4px 0;
 	width: $input-size + 2 * $icon-button-size;
+	overflow-y: auto;
 }
 
 // Hide suggestions on mobile until we @todo find a better way to show them
@@ -53,7 +54,7 @@ $input-size: 300px;
 }
 
 .editor-url-input__suggestion {
-	padding: 4px #{ $icon-button-size + $input-padding } 4px $input-padding;
+	padding: 4px $input-padding;
 	color: $dark-gray-300; // lightest we can use for contrast
 	display: block;
 	font-size: $default-font-size;

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -179,9 +179,9 @@ class InlineLinkUI extends Component {
 		this.resetState();
 
 		if ( isActive ) {
-			speak( __( 'Link edited.' ), 'assertive' );
+			speak( __( 'Link edited' ), 'assertive' );
 		} else {
-			speak( __( 'Link added.' ), 'assertive' );
+			speak( __( 'Link inserted' ), 'assertive' );
 		}
 	}
 


### PR DESCRIPTION
Fixes #10820 

Additionally fixes a few CSS regressions and improves the interaction with the insert link search field and suggestions list.

First commit:
- regression: makes the list of suggestions scrollable again when using a keyboard and the list is longer than the max-height (it worked in 2.9.0)
- regression: fixes the input padding after https://github.com/WordPress/gutenberg/commit/38378c88a0fe73c6413dd13c16a3830a433ae0bf which broke the usage of the variable in the padding calculation
- regression: fixes the spinner position for the same reason

Worth noting:
- I couldn't reproduce the original issue mentioned in #8646 because there's now a 1 pixel padding that makes the focus style visible so I just reverted the variable to `8px`
- re: the padding on the right: seems to me there's nothing to display in that space so I'm not sure why the padding was meant to be `44px`; changed to `8px`

Second commit:
- makes the `TAB` key populate the search field with the highlighted link URL
- this allows keyboard users to select the link (not submit yet) and tab to the Link Settings button; matches the current interaction in the Classic Editor
- adds a speak message to announce the link has been selected, matches the current interaction in the Classic Editor
- when clicking on a suggested link, moves focus to the search field: matches the current interaction in the Classic Editor and clarifies a further action (submit) is needed
- changes the `Link added.` message to `Link inserted` to match the Classic Editor message

Third commit:
- ~~regression: fixes the position of the suggestions popover after #10495~~ 
- the suggestions popover is now nested within another popover (the `URLPopover` introduced in #10495)
- this broke the position calculation, on current master the position looks like in the screenshot below:

<img width="711" alt="screen shot 2018-10-20 at 00 32 52" src="https://user-images.githubusercontent.com/1682452/47246892-99c96000-d400-11e8-99ce-54856e0297ed.png">

Basically, this happens because the "Link Settings" button is now placed outside of the first popover:
<img width="538" alt="screen shot 2018-10-20 at 17 12 26" src="https://user-images.githubusercontent.com/1682452/47258899-a1414580-d4a2-11e8-9909-bbc272bde813.png">

Thus, the calculation of the suggestions popover is based on the search field _form_ without the settings button. I can think of two ways to fix this:
- either move back the "Link Settings" button within the form (not sure if this is possible / desirable)
- or use a custom `getAnchorRect` function to get the grand parent node

I've opted for the latter, even if a better solution would probably be making the popover component handle these nesting cases. I'd appreciate some eyes form @aduth and @talldan. If there's the need for adjustments / refinements / improvements glad if you can take this PR and make it better.

- adds 2 pixels to the suggestions list width to match the search field popover width (it has now an additional 1 pixel padding)
- removes `width: 100%;` from the search field because it made the following "Apply" button smaller than it's supposed to be (the correct width is 36 pixels)
- removes a stray `list-style: none;` applied on a div

Re: the popover position when a popover is nested within another popover, I guess this relates also to #8468.

