### PR TITLE
Editor: Reshape editor state for optimized and accurate dirtiness detection

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -36,6 +36,18 @@ the post has been saved.
 
 Whether the post is new.
 
+### hasChangedContent
+
+Returns true if content includes unsaved changes, or false otherwise.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+Whether content includes unsaved changes.
+
 ### isEditedPostDirty
 
 Returns true if there are unsaved values for the current edit session, or

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -171,18 +171,8 @@ export const requestPostUpdate = async ( action, store ) => {
  * @param {Object} action  action object.
  * @param {Object} store   Redux Store.
  */
-export const requestPostUpdateSuccess = ( action, store ) => {
+export const requestPostUpdateSuccess = ( action ) => {
 	const { previousPost, post, isAutosave, postType } = action;
-	const { dispatch, getState } = store;
-
-	// TEMPORARY: If edits remain after a save completes, the user must be
-	// prompted about unsaved changes. This should be refactored as part of
-	// the `isEditedPostDirty` selector instead.
-	//
-	// See: https://github.com/WordPress/gutenberg/issues/7409
-	if ( Object.keys( getPostEdits( getState() ) ).length ) {
-		dispatch( { type: 'DIRTY_ARTIFICIALLY' } );
-	}
 
 	// Autosaves are neither shown a notice nor redirected.
 	if ( isAutosave ) {

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -257,9 +257,6 @@ export const editor = flow( [
 
 				return state;
 
-			case 'DIRTY_ARTIFICIALLY':
-				return { ...state };
-
 			case 'UPDATE_POST':
 			case 'RESET_POST':
 				const getCanonicalValue = action.type === 'UPDATE_POST' ?

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -236,13 +236,6 @@ export const editor = flow( [
 		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'UPDATE_POST' ],
 		shouldOverwriteState,
 	} ),
-
-	// Track whether changes exist, resetting at each post save. Relies on
-	// editor initialization firing post reset as an effect.
-	withChangeDetection( {
-		resetTypes: [ 'SETUP_EDITOR_STATE', 'REQUEST_POST_UPDATE_START' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'UPDATE_POST' ],
-	} ),
 ] )( {
 	edits( state = {}, action ) {
 		switch ( action.type ) {
@@ -287,7 +280,16 @@ export const editor = flow( [
 		return state;
 	},
 
-	blocks: combineReducers( {
+	blocks: flow( [
+		combineReducers,
+
+		// Track whether changes exist, resetting at each post save. Relies on
+		// editor initialization firing post reset as an effect.
+		withChangeDetection( {
+			resetTypes: [ 'SETUP_EDITOR_STATE', 'REQUEST_POST_UPDATE_START' ],
+			ignoreTypes: [ 'RECEIVE_BLOCKS', 'RESET_POST', 'UPDATE_POST' ],
+		} ),
+	] )( {
 		byClientId( state = {}, action ) {
 			switch ( action.type ) {
 				case 'RESET_BLOCKS':

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -487,9 +487,17 @@ export function isEditedPostAutosaveable( state ) {
 		return true;
 	}
 
+	// To avoid an expensive content serialization, use the content dirtiness
+	// flag in place of content field comparison against the known autosave.
+	// This is not strictly accurate, and relies on a tolerance toward autosave
+	// request failures for unnecessary saves.
+	if ( hasChangedContent( state ) ) {
+		return true;
+	}
+
 	// If the title, excerpt or content has changed, the post is autosaveable.
 	const autosave = getAutosave( state );
-	return [ 'title', 'excerpt', 'content' ].some( ( field ) => (
+	return [ 'title', 'excerpt' ].some( ( field ) => (
 		autosave[ field ] !== getEditedPostAttribute( state, field )
 	) );
 }

--- a/packages/editor/src/store/test/effects.js
+++ b/packages/editor/src/store/test/effects.js
@@ -25,7 +25,6 @@ import actions, {
 	resetBlocks,
 	selectBlock,
 	setTemplateValidity,
-	editPost,
 } from '../actions';
 import effects, { validateBlocksToTemplate } from '../effects';
 import { SAVE_POST_NOTICE_ID } from '../effects/posts';
@@ -222,16 +221,6 @@ describe( 'effects', () => {
 	describe( '.REQUEST_POST_UPDATE_SUCCESS', () => {
 		const handler = effects.REQUEST_POST_UPDATE_SUCCESS;
 
-		function createGetState( hasLingeringEdits = false ) {
-			let state = reducer( undefined, {} );
-			if ( hasLingeringEdits ) {
-				state = reducer( state, editPost( { edited: true } ) );
-			}
-
-			const getState = () => state;
-			return getState;
-		}
-
 		const defaultPost = {
 			id: 1,
 			title: {
@@ -259,14 +248,11 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should dispatch notices when publishing or scheduling a post', () => {
-			const dispatch = jest.fn();
-			const store = { dispatch, getState: createGetState() };
-
 			const previousPost = getDraftPost();
 			const post = getPublishedPost();
 			const postType = getPostType();
 
-			handler( { post, previousPost, postType }, store );
+			handler( { post, previousPost, postType } );
 
 			expect( dataDispatch( 'core/notices' ).createSuccessNotice ).toHaveBeenCalledWith(
 				'Post published.',
@@ -280,14 +266,11 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should dispatch notices when reverting a published post to a draft', () => {
-			const dispatch = jest.fn();
-			const store = { dispatch, getState: createGetState() };
-
 			const previousPost = getPublishedPost();
 			const post = getDraftPost();
 			const postType = getPostType();
 
-			handler( { post, previousPost, postType }, store );
+			handler( { post, previousPost, postType } );
 
 			expect( dataDispatch( 'core/notices' ).createSuccessNotice ).toHaveBeenCalledWith(
 				'Post reverted to draft.',
@@ -299,14 +282,11 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should dispatch notices when just updating a published post again', () => {
-			const dispatch = jest.fn();
-			const store = { dispatch, getState: createGetState() };
-
 			const previousPost = getPublishedPost();
 			const post = getPublishedPost();
 			const postType = getPostType();
 
-			handler( { post, previousPost, postType }, store );
+			handler( { post, previousPost, postType } );
 
 			expect( dataDispatch( 'core/notices' ).createSuccessNotice ).toHaveBeenCalledWith(
 				'Post updated.',
@@ -320,28 +300,12 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should do nothing if the updated post was autosaved', () => {
-			const dispatch = jest.fn();
-			const store = { dispatch, getState: createGetState() };
-
 			const previousPost = getPublishedPost();
 			const post = { ...getPublishedPost(), id: defaultPost.id + 1 };
 
-			handler( { post, previousPost, isAutosave: true }, store );
+			handler( { post, previousPost, isAutosave: true } );
 
 			expect( dataDispatch( 'core/notices' ).createSuccessNotice ).not.toHaveBeenCalled();
-		} );
-
-		it( 'should dispatch dirtying action if edits linger after autosave', () => {
-			const dispatch = jest.fn();
-			const store = { dispatch, getState: createGetState( true ) };
-
-			const previousPost = getPublishedPost();
-			const post = { ...getPublishedPost(), id: defaultPost.id + 1 };
-
-			handler( { post, previousPost, isAutosave: true }, store );
-
-			expect( dispatch ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( { type: 'DIRTY_ARTIFICIALLY' } );
 		} );
 	} );
 

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -279,7 +279,7 @@ describe( 'state', () => {
 			unregisterBlockType( 'core/test-block' );
 		} );
 
-		it( 'should return history (empty edits, blocks), dirty flag by default', () => {
+		it( 'should return history (empty edits, blocks) by default', () => {
 			const state = editor( undefined, {} );
 
 			expect( state.past ).toEqual( [] );
@@ -287,7 +287,7 @@ describe( 'state', () => {
 			expect( state.present.edits ).toEqual( {} );
 			expect( state.present.blocks.byClientId ).toEqual( {} );
 			expect( state.present.blocks.order ).toEqual( {} );
-			expect( state.isDirty ).toBe( false );
+			expect( state.present.blocks.isDirty ).toBe( false );
 		} );
 
 		it( 'should key by reset blocks clientId', () => {

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -28,6 +28,7 @@ const {
 	hasEditorUndo,
 	hasEditorRedo,
 	isEditedPostNew,
+	hasChangedContent,
 	isEditedPostDirty,
 	isCleanNewPost,
 	getCurrentPost,
@@ -271,14 +272,100 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isEditedPostDirty', () => {
-		it( 'should return true when post saved state dirty', () => {
+	describe( 'hasChangedContent', () => {
+		it( 'should return false if no dirty blocks nor content property edit', () => {
 			const state = {
 				editor: {
-					isDirty: true,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
-				saving: {
-					requesting: false,
+			};
+
+			expect( hasChangedContent( state ) ).toBe( false );
+		} );
+
+		it( 'should return true if dirty blocks', () => {
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							isDirty: true,
+						},
+						edits: {},
+					},
+				},
+			};
+
+			expect( hasChangedContent( state ) ).toBe( true );
+		} );
+
+		it( 'should return true if content property edit', () => {
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {
+							content: 'text mode edited',
+						},
+					},
+				},
+			};
+
+			expect( hasChangedContent( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isEditedPostDirty', () => {
+		it( 'should return false when blocks state not dirty nor edits exist', () => {
+			const state = {
+				optimist: [],
+				editor: {
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
+				},
+			};
+
+			expect( isEditedPostDirty( state ) ).toBe( false );
+		} );
+
+		it( 'should return true when blocks state dirty', () => {
+			const state = {
+				optimist: [],
+				editor: {
+					present: {
+						blocks: {
+							isDirty: true,
+						},
+						edits: {},
+					},
+				},
+			};
+
+			expect( isEditedPostDirty( state ) ).toBe( true );
+		} );
+
+		it( 'should return true when edits exist', () => {
+			const state = {
+				optimist: [],
+				editor: {
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {
+							excerpt: 'hello world',
+						},
+					},
 				},
 			};
 
@@ -291,30 +378,27 @@ describe( 'selectors', () => {
 					{
 						beforeState: {
 							editor: {
-								isDirty: true,
+								present: {
+									blocks: {
+										isDirty: true,
+									},
+									edits: {},
+								},
 							},
 						},
 					},
 				],
 				editor: {
-					isDirty: false,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( true );
-		} );
-
-		it( 'should return false when post saved state not dirty', () => {
-			const state = {
-				editor: {
-					isDirty: false,
-				},
-				saving: {
-					requesting: false,
-				},
-			};
-
-			expect( isEditedPostDirty( state ) ).toBe( false );
 		} );
 	} );
 
@@ -322,7 +406,12 @@ describe( 'selectors', () => {
 		it( 'should return true when the post is not dirty and has not been saved before', () => {
 			const state = {
 				editor: {
-					isDirty: false,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					id: 1,
@@ -339,7 +428,12 @@ describe( 'selectors', () => {
 		it( 'should return false when the post is not dirty but the post has been saved', () => {
 			const state = {
 				editor: {
-					isDirty: false,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					id: 1,
@@ -356,7 +450,12 @@ describe( 'selectors', () => {
 		it( 'should return false when the post is dirty but the post has not been saved', () => {
 			const state = {
 				editor: {
-					isDirty: true,
+					present: {
+						blocks: {
+							isDirty: true,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					id: 1,
@@ -851,7 +950,12 @@ describe( 'selectors', () => {
 		it( 'should return true for pending posts', () => {
 			const state = {
 				editor: {
-					isDirty: false,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					status: 'pending',
@@ -867,7 +971,12 @@ describe( 'selectors', () => {
 		it( 'should return true for draft posts', () => {
 			const state = {
 				editor: {
-					isDirty: false,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					status: 'draft',
@@ -883,7 +992,12 @@ describe( 'selectors', () => {
 		it( 'should return false for published posts', () => {
 			const state = {
 				editor: {
-					isDirty: false,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					status: 'publish',
@@ -899,7 +1013,12 @@ describe( 'selectors', () => {
 		it( 'should return true for published, dirty posts', () => {
 			const state = {
 				editor: {
-					isDirty: true,
+					present: {
+						blocks: {
+							isDirty: true,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					status: 'publish',
@@ -915,7 +1034,12 @@ describe( 'selectors', () => {
 		it( 'should return false for private posts', () => {
 			const state = {
 				editor: {
-					isDirty: false,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					status: 'private',
@@ -931,7 +1055,12 @@ describe( 'selectors', () => {
 		it( 'should return false for scheduled posts', () => {
 			const state = {
 				editor: {
-					isDirty: false,
+					present: {
+						blocks: {
+							isDirty: false,
+						},
+						edits: {},
+					},
 				},
 				currentPost: {
 					status: 'future',
@@ -950,7 +1079,12 @@ describe( 'selectors', () => {
 					status: 'private',
 				},
 				editor: {
-					isDirty: true,
+					present: {
+						blocks: {
+							isDirty: true,
+						},
+						edits: {},
+					},
 				},
 				saving: {
 					requesting: false,

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1348,24 +1348,19 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocks: {
-							byClientId: {},
-							order: {},
+							isDirty: false,
 						},
-						edits: {
-							content: 'foo',
-						},
+						edits: {},
 					},
 				},
 				initialEdits: {},
 				currentPost: {
 					title: 'foo',
-					content: 'foo',
 					excerpt: 'foo',
 				},
 				saving: {},
 				autosave: {
 					title: 'foo',
-					content: 'foo',
 					excerpt: 'foo',
 				},
 			};
@@ -1373,26 +1368,46 @@ describe( 'selectors', () => {
 			expect( isEditedPostAutosaveable( state ) ).toBe( false );
 		} );
 
-		it( 'should return true if title, excerpt, or content have changed', () => {
-			for ( const variantField of [ 'title', 'excerpt', 'content' ] ) {
-				for ( const constantField of without( [ 'title', 'excerpt', 'content' ], variantField ) ) {
+		it( 'should return true if content has changes', () => {
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							isDirty: true,
+						},
+						edits: {},
+					},
+				},
+				currentPost: {
+					title: 'foo',
+					excerpt: 'foo',
+				},
+				saving: {},
+				autosave: {
+					title: 'foo',
+					excerpt: 'foo',
+				},
+			};
+
+			expect( isEditedPostAutosaveable( state ) ).toBe( true );
+		} );
+
+		it( 'should return true if title or excerpt have changed', () => {
+			for ( const variantField of [ 'title', 'excerpt' ] ) {
+				for ( const constantField of without( [ 'title', 'excerpt' ], variantField ) ) {
 					const state = {
 						editor: {
 							present: {
 								blocks: {
-									byClientId: {},
-									order: {},
+									isDirty: false,
 								},
-								edits: {
-									content: 'foo',
-								},
+								edits: {},
 							},
 						},
 						initialEdits: {},
 						currentPost: {
 							title: 'foo',
 							content: 'foo',
-							excerpt: 'foo',
 						},
 						saving: {},
 						autosave: {


### PR DESCRIPTION
Closes #10427
Closes #7409

This pull request seeks to refactor editor state to to enable a more sensible, accurate, and performant dirty detection routine. Rather than representing `isDirty` as a reflection of the entirety of the `state.editor` state object, it's now been moved to only handle the new `state.editor.blocks`, which contains `byClientId` and `order` (previously `state.editor.blocksByClientId` and `state.editor.blockOrder`). Dirty detection for fields other than content are reflected by the presence of any keys in `state.editor.edits`.

This helps to support:

- Removal of an undesirable artificial dirtying, which was intended as a temporary solution
- Avoid expensive calls to content serialization, notably in `isEditedPostAutosaveable` (which, as noted in #10427, became very negatively impactful)

Previous attempts to implement this had been unsuccessful in that `withChangeDetection` adds a property to the combined reducer which was incompatible with Redux's `combineReducers` (logging an error to the console). To work around this, the `combineReducers` exported from `@wordpress/data` was swapped with an in-place-compatible, more-performant variation [`turbo-combine-reducers`](https://github.com/aduth/turbo-combine-reducers) (authored by yours truly).

**Testing Instructions:**

Verify that there is no regressions in the behavior of autosave, namely that it occurs after delay if and only if one of content, title, or excerpt is updated. 

Conversely, verify that if a field other than the three aforementioned is updated (e.g. categories added or removed), it is reflected by the UI as needing save ("Save Draft" becomes active). An autosave should not occur, but you should be prompted about unsaved changes if you attempt to leave the page before pressing "Save Draft".

Finally, verify that if changing _both_ one of content, title, excerpt _and_ another field, that the autosave does occur, and once completed, the editor is still in a "dirty" state ("Save Changes" present, after brief delay once save finishes). This is because autosaves do not include other fields.