### PR TITLE
Remove closing </li> tag from i18n string

### DIFF
--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -78,7 +78,7 @@ export class DateTimePicker extends Component {
 								<li>
 									<abbr aria-label={ __( 'Up and Down Arrows' ) }>↑/↓</abbr>
 									{ ' ' /* JSX removes whitespace, but a space is required for screen readers. */ }
-									{ __( 'Move backward (up) and forward (down) by one week.</li>' ) }
+									{ __( 'Move backward (up) and forward (down) by one week.' ) }
 								</li>
 								<li>
 									<abbr aria-label={ __( 'Page Up and Page Down' ) }>{ __( 'PgUp/PgDn' ) }</abbr>


### PR DESCRIPTION
## Description
Fixes #10841 
The closing `</li>` HTML tag should be removed from https://plugins.trac.wordpress.org/browser/gutenberg/trunk/languages/gutenberg-translations.php#L978 

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Cheers,
Jb