### PR TITLE
Avoid PHP notices due to non-available meta boxes

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -318,9 +318,13 @@ function the_gutenberg_metaboxes() {
 	foreach ( $locations as $location ) {
 		$meta_boxes_per_location[ $location ] = array();
 		foreach ( $priorities as $priority ) {
-			$meta_boxes = (array) $wp_meta_boxes[ $current_screen->id ][ $location ][ $priority ];
-			foreach ( $meta_boxes as $meta_box ) {
-				if ( ! empty( $meta_box['title'] ) ) {
+			if ( isset( $wp_meta_boxes[ $current_screen->id ][ $location ][ $priority ] ) ) {
+				$meta_boxes = (array) $wp_meta_boxes[ $current_screen->id ][ $location ][ $priority ];
+				foreach ( $meta_boxes as $meta_box ) {
+					if ( false == $meta_box || ! $meta_box['title'] ) {
+						continue;
+					}
+
 					$meta_boxes_per_location[ $location ][] = array(
 						'id'    => $meta_box['id'],
 						'title' => $meta_box['title'],


### PR DESCRIPTION
## Description
Since #10676 there are few PHP notices if no box is registered for a priority.

## How has this been tested?
Open the editor before and after applying the change. The second time there should be no notices.


## Screenshots <!-- if applicable -->
<img width="1298" alt="notices" src="https://user-images.githubusercontent.com/617637/47265617-e6a95580-d52a-11e8-855f-5d1d2acf7059.png">


## Types of changes
Use the same checks as in `do_meta_boxes()`.