### PR TITLE
Fix doc in the Block api supports section

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -416,7 +416,7 @@ When supports align is used the block attributes definition is extended to inclu
 By default, no alignment is assigned to the block.
 The block can apply a default alignment by specifying its own align attribute with a default e.g.:
 ```
-attributes: {
+supports: {
 	...
 	align: {
 		type: 'string',


### PR DESCRIPTION
## Description
I changed a small error in the Block api supports section documentation

## How has this been tested?
I looked in my Github depot if the markdown file preview was ok

## Types of changes
Typo in the documentation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
