### PR TITLE
Improve the Toggle Control DOM order for better accessibility

### DIFF
--- a/packages/components/src/toggle-control/index.js
+++ b/packages/components/src/toggle-control/index.js
@@ -13,7 +13,7 @@ import { withInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import FormToggle from '../form-toggle';
-import BaseControl from './../base-control';
+import BaseControl from '../base-control';
 
 class ToggleControl extends Component {
 	constructor() {
@@ -40,7 +40,6 @@ class ToggleControl extends Component {
 
 		return (
 			<BaseControl
-				label={ label }
 				id={ id }
 				help={ helpLabel }
 				className="components-toggle-control"
@@ -51,6 +50,12 @@ class ToggleControl extends Component {
 					onChange={ this.onChange }
 					aria-describedby={ describedBy }
 				/>
+				<label
+					htmlFor={ id }
+					className="components-toggle-control__label"
+				>
+					{ label }
+				</label>
 			</BaseControl>
 		);
 	}

--- a/packages/components/src/toggle-control/style.scss
+++ b/packages/components/src/toggle-control/style.scss
@@ -2,11 +2,12 @@
 	display: flex;
 	margin-bottom: $grid-size-small * 3;
 
-	.components-base-control__label {
-		order: 1;
-	}
-
 	.components-form-toggle {
 		margin-right: $grid-size-large;
+	}
+
+	.components-toggle-control__label {
+		display: block;
+		margin-bottom: 4px;
 	}
 }


### PR DESCRIPTION
## Description

After the change in #10552 it's now possible to make the Toggle control checkbox and label DOM order match the visual order.

Checkboxes should always come first and be followed by their labels in the DOM order. Rather than using the flexbox `order` property, I'd like to propose to change the actual order in the DOM.

This PR avoids to use the `BaseControl` label and instead uses a specific `<label>` element placed _after_ the checkbox, like Gutenberg already does for the `RadioControl` component.

There are no visual changes, see the Drop Cap toggle as an example:

Before:

<img width="289" alt="screen shot 2018-10-21 at 12 17 17" src="https://user-images.githubusercontent.com/1682452/47268112-eb7f0100-d54c-11e8-9532-d20983b6c459.png">

After:

<img width="293" alt="screen shot 2018-10-21 at 13 22 06" src="https://user-images.githubusercontent.com/1682452/47268113-f043b500-d54c-11e8-9d90-8dedb1ee5c47.png">

Fixes #10868 