### PR TITLE
Update the styles of the read more and page break blocks

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -47,7 +47,7 @@ export default class MoreEdit extends Component {
 		const toggleNoTeaser = () => setAttributes( { noTeaser: ! noTeaser } );
 		const { defaultText } = this.state;
 		const value = customText !== undefined ? customText : defaultText;
-		const inputLength = value.length + 1;
+		const inputLength = value.length + 2;
 
 		return (
 			<Fragment>

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -17,7 +17,7 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
     <input
       onChange={[Function]}
       onKeyDown={[Function]}
-      size={1}
+      size={2}
       type="text"
       value=""
     />
@@ -42,7 +42,7 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
     <input
       onChange={[Function]}
       onKeyDown={[Function]}
-      size={1}
+      size={2}
       type="text"
       value=""
     />

--- a/packages/block-library/src/more/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`core/more block edit matches snapshot 1`] = `
   class="wp-block-more"
 >
   <input
-    size="10"
+    size="11"
     type="text"
     value="Read more"
   />

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -76,6 +76,7 @@
 	position: relative;
 	padding-left: $block-padding;
 	padding-right: $block-padding;
+	z-index: 0;
 
 	// Break long strings of text without spaces so they don't overflow the block.
 	overflow-wrap: break-word;


### PR DESCRIPTION
## Description
Update the z-index of .editor-block-list__layout .editor-block-list__block to make the dotted lined border that appear for the read more and page break blocks. Also, increase the length that is added to the read more block so that is doesn't truncate the default text when it has focus with the cursor at the end of the value. Fixes #10817 

It made sense to me to apply the z-index here, but I'm new to working on Gutenberg so if this style is better applies somewhere else I'm happy to update.

Also, might be a good idea to add an e2e test to check that those lines are visible? I don't have any experience with writing tests for Gutenberg but can take a shot this week if anyone thinks that would be a good idea?

## How has this been tested?
Edit a page.
Add a read more block
See that the dotted line is visible and the default text is no cut off when it had the cursor at the end of the line.
Add a page break block
See that the dotted line is visible 
Also dragged both the more block and the other elements on the page to see that the z-index change didn't behave oddly in the dragging state and it looked okay.

## Screenshots
<img width="741" alt="edit_post_ _gutenberg_dev_ _wordpress" src="https://user-images.githubusercontent.com/6653970/47270883-2c244d80-d540-11e8-9039-29dad8003b87.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
