### PR TITLE
Copy reference type default attributes when creating a new block

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -47,7 +47,18 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
 		if ( undefined !== value ) {
 			result[ key ] = value;
 		} else if ( schema.hasOwnProperty( 'default' ) ) {
-			result[ key ] = schema.default;
+			let defaultValue = schema.default;
+
+			// If the type of the attribute's default is a reference type,
+			// make a copy so that implementors cannot easily mutate the
+			// block type's default attributes.
+			if ( Array.isArray( defaultValue ) ) {
+				defaultValue = defaultValue.slice();
+			} else if ( typeof defaultValue === 'object' ) {
+				defaultValue = Object.assign( {}, defaultValue );
+			}
+
+			result[ key ] = defaultValue;
 		}
 
 		if ( schema.source === 'html' && typeof result[ key ] !== 'string' ) {

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -134,6 +134,39 @@ describe( 'block factory', () => {
 			} );
 		} );
 
+		it( 'copies attribute defaults if their type is a reference type', () => {
+			const arrayDefault = [];
+			const objectDefault = {};
+
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					content: {
+						type: 'array',
+						source: 'children',
+						default: arrayDefault,
+					},
+					properties: {
+						type: 'object',
+						source: 'children',
+						default: objectDefault,
+					},
+				},
+			} );
+
+			const block = createBlock( 'core/test-block' );
+
+			// Mutate the array attribute and assert the original
+			// default wasn't also mutated.
+			block.attributes.content[ 0 ] = 'test';
+			expect( block.attributes.content ).not.toEqual( arrayDefault );
+
+			// Mutate the object attribute and assert the original
+			// default wasn't also mutated.
+			block.attributes.properties[ test ] = 'test';
+			expect( block.attributes.properties ).not.toEqual( objectDefault );
+		} );
+
 		it( 'should cast rich-text source attributes', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,


### PR DESCRIPTION
## Description
This is a small fix to make sure that the default attributes for a block type cannot be mutated within a block instance's edit method.

This issue originated from a message in the #core-editor channel in slack: https://wordpress.slack.com/archives/C02QB2JS7/p1540130491000100

After some investigation I discovered that createBlock passes default objects and arrays by reference instead of copying/cloning them when createBlock is called, leading to unexpected results if those references are mutated. To make things easier for block implementors, the solution in this PR is to copy those defaults in `createBlock`.

## How has this been tested?
- Added unit tests
- Manual testing using a custom block that mutates its attribute (there's a fuller example in the slack chat). ie:
```
onClick={ () => {
  testAttribute.newProperty = 'test';
  setAttribute( { testAttribute } );
} }
```

Then to test this custom block:
1. Add a new block of the custom type
2. Trigger the mutation of the attribute
3. Add another new block of the custom type
4. Observe that in the second block the default should not have been mutated

## Screenshots <!-- if applicable -->
This issue can result in the behaviour where the default attribute is mutated in the first block, and then successive new blocks when added also use the mutated default:
![2018-10-21 14 20 11](https://user-images.githubusercontent.com/677833/47329817-a2dc5a80-d6a8-11e8-90db-2492df8bf461.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
