### PR TITLE
Block API: Normalize function arguments

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -6,7 +6,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - `wp.compose.remountOnPropChange` has been removed.
 - The following editor store actions have been removed: `createNotice`, `removeNotice`, `createSuccessNotice`, `createInfoNotice`, `createErrorNotice`, `createWarningNotice`. Use the equivalent actions by the same name from the `@wordpress/notices` module.
 - The id prop of wp.nux.DotTip has been removed. Please use the tipId prop instead.
-- `wp.blocks.isValidBlock` has been removed. Please use `wp.blocks.isBlockContentValid` instead.
+- `wp.blocks.isValidBlock` has been removed. Please use `wp.blocks.isValidBlockContent` instead but keep in mind that the order of params has changed.
 
 ## 4.3.0
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -6,6 +6,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - `wp.compose.remountOnPropChange` has been removed.
 - The following editor store actions have been removed: `createNotice`, `removeNotice`, `createSuccessNotice`, `createInfoNotice`, `createErrorNotice`, `createWarningNotice`. Use the equivalent actions by the same name from the `@wordpress/notices` module.
 - The id prop of wp.nux.DotTip has been removed. Please use the tipId prop instead.
+- `wp.blocks.isValidBlock` has been removed. Please use `wp.blocks.isBlockContentValid` instead.
 
 ## 4.3.0
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 5.1.0 (Unreleased)
+
+### New feature
+
+- `isBlockContentValid` function has been added ([#10891](https://github.com/WordPress/gutenberg/pull/10891)).
+
+### Deprecation
+
+- `isValidBlock` function has been deprecated ([#10891](https://github.com/WordPress/gutenberg/pull/10891)). Use `isBlockContentValid` instead.
+
 ## 5.0.0 (2018-10-29)
 
 ### Breaking Changes

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### New feature
 
-- `isBlockContentValid` function has been added ([#10891](https://github.com/WordPress/gutenberg/pull/10891)).
+- `isValidBlockContent` function has been added ([#10891](https://github.com/WordPress/gutenberg/pull/10891)).
 
 ### Deprecation
 
-- `isValidBlock` function has been deprecated ([#10891](https://github.com/WordPress/gutenberg/pull/10891)). Use `isBlockContentValid` instead.
+- `isValidBlock` function has been deprecated ([#10891](https://github.com/WordPress/gutenberg/pull/10891)). Use `isValidBlockContent` instead.
 
 ## 5.0.0 (2018-10-29)
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -29,20 +29,20 @@ import { getBlockType, getBlockTypes } from './registration';
 /**
  * Returns a block object given its type and attributes.
  *
- * @param {string} name            Block name.
- * @param {Object} blockAttributes Block attributes.
- * @param {?Array} innerBlocks     Nested blocks.
+ * @param {string} name        Block name.
+ * @param {Object} attributes  Block attributes.
+ * @param {?Array} innerBlocks Nested blocks.
  *
  * @return {Object} Block object.
  */
-export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
+export function createBlock( name, attributes = {}, innerBlocks = [] ) {
 	// Get the type definition associated with a registered block.
 	const blockType = getBlockType( name );
 
 	// Ensure attributes contains only values defined by block type, and merge
 	// default values for missing attributes.
-	const attributes = reduce( blockType.attributes, ( result, schema, key ) => {
-		const value = blockAttributes[ key ];
+	const sanitizedAttributes = reduce( blockType.attributes, ( result, schema, key ) => {
+		const value = attributes[ key ];
 
 		if ( undefined !== value ) {
 			result[ key ] = value;
@@ -75,7 +75,7 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
 		clientId,
 		name,
 		isValid: true,
-		attributes,
+		attributes: sanitizedAttributes,
 		innerBlocks,
 	};
 }
@@ -84,7 +84,7 @@ export function createBlock( name, blockAttributes = {}, innerBlocks = [] ) {
  * Given a block object, returns a copy of the block object, optionally merging
  * new attributes and/or replacing its inner blocks.
  *
- * @param {Object} block              Block object.
+ * @param {Object} block              Block instance.
  * @param {Object} mergeAttributes    Block attributes.
  * @param {?Array} newInnerBlocks     Nested blocks.
  *
@@ -112,7 +112,6 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
  * @param {Object} transform The transform object to validate.
  * @param {string} direction Is this a 'from' or 'to' transform.
  * @param {Array} blocks The blocks to transform from.
- * @param {boolean} isMultiBlock Have multiple blocks been selected?
  *
  * @return {boolean} Is the transform possible?
  */
@@ -157,7 +156,6 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
  * 'from' transforms on other blocks.
  *
  * @param {Array}  blocks  The blocks to transform from.
- * @param {boolean} isMultiBlock Have multiple blocks been selected?
  *
  * @return {Array} Block types that the blocks can be transformed into.
  */
@@ -189,7 +187,6 @@ const getBlockTypesForPossibleFromTransforms = ( blocks ) => {
  * the source block's own 'to' transforms.
  *
  * @param {Array} blocks The blocks to transform from.
- * @param {boolean} isMultiBlock Have multiple blocks been selected?
  *
  * @return {Array} Block types that the source can be transformed into.
  */

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -20,7 +20,7 @@ export {
 	getSaveElement,
 	getSaveContent,
 } from './serializer';
-export { isValidBlock } from './validation';
+export { isBlockContentValid, isValidBlock } from './validation';
 export {
 	getCategories,
 	setCategories,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -20,7 +20,7 @@ export {
 	getSaveElement,
 	getSaveContent,
 } from './serializer';
-export { isBlockContentValid, isValidBlock } from './validation';
+export { isValidBlockContent, isValidBlock } from './validation';
 export {
 	getCategories,
 	setCategories,

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -20,7 +20,7 @@ import {
 	getUnregisteredTypeHandlerName,
 } from './registration';
 import { createBlock } from './factory';
-import { isBlockContentValid } from './validation';
+import { isValidBlockContent } from './validation';
 import { getCommentDelimitedContent } from './serializer';
 import { attr, html, text, query, node, children, prop } from './matchers';
 
@@ -340,7 +340,7 @@ export function getMigratedBlock( block ) {
 		);
 
 		// Ignore the deprecation if it produces a block which is not valid.
-		const isValid = isBlockContentValid(
+		const isValid = isValidBlockContent(
 			deprecatedBlockType,
 			migratedAttributes,
 			originalContent
@@ -459,7 +459,7 @@ export function createBlockWithFallback( blockNode ) {
 	// provided source value with the serialized output before there are any modifications to
 	// the block. When both match, the block is marked as valid.
 	if ( ! isFallbackBlock ) {
-		block.isValid = isBlockContentValid( blockType, block.attributes, innerHTML );
+		block.isValid = isValidBlockContent( blockType, block.attributes, innerHTML );
 	}
 
 	// Preserve original content for future use in case the block is parsed as

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -20,7 +20,7 @@ import {
 	getUnregisteredTypeHandlerName,
 } from './registration';
 import { createBlock } from './factory';
-import { isValidBlock } from './validation';
+import { isBlockContentValid } from './validation';
 import { getCommentDelimitedContent } from './serializer';
 import { attr, html, text, query, node, children, prop } from './matchers';
 
@@ -283,7 +283,7 @@ export function getBlockAttribute( attributeKey, attributeSchema, innerHTML, com
  *
  * @return {Object} All block attributes.
  */
-export function getBlockAttributes( blockType, innerHTML, attributes ) {
+export function getBlockAttributes( blockType, innerHTML, attributes = {} ) {
 	const blockAttributes = mapValues( blockType.attributes, ( attributeSchema, attributeKey ) => {
 		return getBlockAttribute( attributeKey, attributeSchema, innerHTML, attributes );
 	} );
@@ -340,10 +340,10 @@ export function getMigratedBlock( block ) {
 		);
 
 		// Ignore the deprecation if it produces a block which is not valid.
-		const isValid = isValidBlock(
-			originalContent,
+		const isValid = isBlockContentValid(
 			deprecatedBlockType,
-			migratedAttributes
+			migratedAttributes,
+			originalContent
 		);
 
 		if ( ! isValid ) {
@@ -459,7 +459,7 @@ export function createBlockWithFallback( blockNode ) {
 	// provided source value with the serialized output before there are any modifications to
 	// the block. When both match, the block is marked as valid.
 	if ( ! isFallbackBlock ) {
-		block.isValid = isValidBlock( innerHTML, blockType, block.attributes );
+		block.isValid = isBlockContentValid( blockType, block.attributes, innerHTML );
 	}
 
 	// Preserve original content for future use in case the block is parsed as

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -174,10 +174,10 @@ export function unregisterBlockType( name ) {
 /**
  * Assigns name of block for handling non-block content.
  *
- * @param {string} name Block name.
+ * @param {string} blockName Block name.
  */
-export function setFreeformContentHandlerName( name ) {
-	dispatch( 'core/blocks' ).setFreeformFallbackBlockName( name );
+export function setFreeformContentHandlerName( blockName ) {
+	dispatch( 'core/blocks' ).setFreeformFallbackBlockName( blockName );
 }
 
 /**
@@ -193,10 +193,10 @@ export function getFreeformContentHandlerName() {
 /**
  * Assigns name of block handling unregistered block types.
  *
- * @param {string} name Block name.
+ * @param {string} blockName Block name.
  */
-export function setUnregisteredTypeHandlerName( name ) {
-	dispatch( 'core/blocks' ).setUnregisteredFallbackBlockName( name );
+export function setUnregisteredTypeHandlerName( blockName ) {
+	dispatch( 'core/blocks' ).setUnregisteredFallbackBlockName( blockName );
 }
 
 /**

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -134,14 +134,14 @@ export function getSaveContent( blockType, attributes, innerBlocks ) {
  * This function returns only those attributes which are needed to persist and
  * which cannot be matched from the block content.
  *
- * @param {Object<string,*>} allAttributes Attributes from in-memory block data.
  * @param {Object<string,*>} blockType     Block type.
+ * @param {Object<string,*>} attributes Attributes from in-memory block data.
  *
  * @return {Object<string,*>} Subset of attributes for comment serialization.
  */
-export function getCommentAttributes( allAttributes, blockType ) {
-	const attributes = reduce( blockType.attributes, ( result, attributeSchema, key ) => {
-		const value = allAttributes[ key ];
+export function getCommentAttributes( blockType, attributes ) {
+	return reduce( blockType.attributes, ( result, attributeSchema, key ) => {
+		const value = attributes[ key ];
 
 		// Ignore undefined values.
 		if ( undefined === value ) {
@@ -163,8 +163,6 @@ export function getCommentAttributes( allAttributes, blockType ) {
 		result[ key ] = value;
 		return result;
 	}, {} );
-
-	return attributes;
 }
 
 /**
@@ -195,7 +193,7 @@ export function serializeAttributes( attributes ) {
 /**
  * Given a block object, returns the Block's Inner HTML markup.
  *
- * @param {Object} block Block Object.
+ * @param {Object} block Block instance.
  *
  * @return {string} HTML.
  */
@@ -262,7 +260,7 @@ export function serializeBlock( block ) {
 	const blockName = block.name;
 	const blockType = getBlockType( blockName );
 	const saveContent = getBlockContent( block );
-	const saveAttributes = getCommentAttributes( block.attributes, blockType );
+	const saveAttributes = getCommentAttributes( blockType, block.attributes );
 
 	switch ( blockName ) {
 		case getFreeformContentHandlerName():

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -79,22 +79,27 @@ describe( 'block serializer', () => {
 		} );
 
 		it( 'should only return attributes which are not matched from content', () => {
-			const attributes = getCommentAttributes( {
-				fruit: 'bananas',
-				category: 'food',
-				ripeness: 'ripe',
-			}, { attributes: {
-				fruit: {
-					type: 'string',
-					source: 'text',
+			const attributes = getCommentAttributes(
+				{
+					attributes: {
+						fruit: {
+							type: 'string',
+							source: 'text',
+						},
+						category: {
+							type: 'string',
+						},
+						ripeness: {
+							type: 'string',
+						},
+					},
 				},
-				category: {
-					type: 'string',
-				},
-				ripeness: {
-					type: 'string',
-				},
-			} } );
+				{
+					fruit: 'bananas',
+					category: 'food',
+					ripeness: 'ripe',
+				}
+			);
 
 			expect( attributes ).toEqual( {
 				category: 'food',
@@ -103,17 +108,22 @@ describe( 'block serializer', () => {
 		} );
 
 		it( 'should skip attributes whose values are undefined', () => {
-			const attributes = getCommentAttributes( {
-				fruit: 'bananas',
-				ripeness: undefined,
-			}, { attributes: {
-				fruit: {
-					type: 'string',
+			const attributes = getCommentAttributes(
+				{
+					attributes: {
+						fruit: {
+							type: 'string',
+						},
+						ripeness: {
+							type: 'string',
+						},
+					},
 				},
-				ripeness: {
-					type: 'string',
-				},
-			} } );
+				{
+					fruit: 'bananas',
+					ripeness: undefined,
+				}
+			);
 
 			expect( attributes ).toEqual( { fruit: 'bananas' } );
 		} );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -13,7 +13,7 @@ import {
 	isEqualTokensOfType,
 	getNextNonWhitespaceToken,
 	isEquivalentHTML,
-	isValidBlock,
+	isBlockContentValid,
 	isClosedByToken,
 } from '../validation';
 import {
@@ -553,14 +553,14 @@ describe( 'validation', () => {
 		} );
 	} );
 
-	describe( 'isValidBlock()', () => {
+	describe( 'isBlockContentValid()', () => {
 		it( 'returns false if block is not valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
-			const isValid = isValidBlock(
-				'Apples',
+			const isValid = isBlockContentValid(
 				getBlockType( 'core/test-block' ),
-				{ fruit: 'Bananas' }
+				{ fruit: 'Bananas' },
+				'Apples'
 			);
 
 			expect( console ).toHaveWarned();
@@ -576,10 +576,10 @@ describe( 'validation', () => {
 				},
 			} );
 
-			const isValid = isValidBlock(
-				'Bananas',
+			const isValid = isBlockContentValid(
 				getBlockType( 'core/test-block' ),
-				{ fruit: 'Bananas' }
+				{ fruit: 'Bananas' },
+				'Bananas'
 			);
 
 			expect( console ).toHaveErrored();
@@ -589,10 +589,10 @@ describe( 'validation', () => {
 		it( 'returns true is block is valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
-			const isValid = isValidBlock(
-				'Bananas',
+			const isValid = isBlockContentValid(
 				getBlockType( 'core/test-block' ),
-				{ fruit: 'Bananas' }
+				{ fruit: 'Bananas' },
+				'Bananas'
 			);
 
 			expect( isValid ).toBe( true );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -13,7 +13,7 @@ import {
 	isEqualTokensOfType,
 	getNextNonWhitespaceToken,
 	isEquivalentHTML,
-	isBlockContentValid,
+	isValidBlockContent,
 	isClosedByToken,
 } from '../validation';
 import {
@@ -553,11 +553,11 @@ describe( 'validation', () => {
 		} );
 	} );
 
-	describe( 'isBlockContentValid()', () => {
+	describe( 'isValidBlockContent()', () => {
 		it( 'returns false if block is not valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
-			const isValid = isBlockContentValid(
+			const isValid = isValidBlockContent(
 				getBlockType( 'core/test-block' ),
 				{ fruit: 'Bananas' },
 				'Apples'
@@ -576,7 +576,7 @@ describe( 'validation', () => {
 				},
 			} );
 
-			const isValid = isBlockContentValid(
+			const isValid = isValidBlockContent(
 				getBlockType( 'core/test-block' ),
 				{ fruit: 'Bananas' },
 				'Bananas'
@@ -589,7 +589,7 @@ describe( 'validation', () => {
 		it( 'returns true is block is valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
-			const isValid = isBlockContentValid(
+			const isValid = isValidBlockContent(
 				getBlockType( 'core/test-block' ),
 				{ fruit: 'Bananas' },
 				'Bananas'

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -493,11 +493,12 @@ export function isEquivalentHTML( actual, expected ) {
 export function isValidBlock( innerHTML, blockType, attributes ) {
 	deprecated( 'isValidBlock', {
 		plugin: 'Gutenberg',
-		version: '4.3',
-		alternative: 'isBlockContentValid',
+		version: '4.4',
+		alternative: 'isValidBlockContent',
+		hint: 'The order of params has changed.',
 	} );
 
-	return isBlockContentValid( blockType, attributes, innerHTML );
+	return isValidBlockContent( blockType, attributes, innerHTML );
 }
 
 /**
@@ -513,7 +514,7 @@ export function isValidBlock( innerHTML, blockType, attributes ) {
  *
  * @return {boolean} Whether block is valid.
  */
-export function isBlockContentValid( blockType, attributes, innerHTML ) {
+export function isValidBlockContent( blockType, attributes, innerHTML ) {
 	let saveContent;
 	try {
 		saveContent = getSaveContent( blockType, attributes );

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -5,6 +5,11 @@ import { tokenize } from 'simple-html-tokenizer';
 import { xor, fromPairs, isEqual, includes, stubTrue } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import { getSaveContent } from './serializer';
@@ -485,6 +490,16 @@ export function isEquivalentHTML( actual, expected ) {
 	return true;
 }
 
+export function isValidBlock( innerHTML, blockType, attributes ) {
+	deprecated( 'isValidBlock', {
+		plugin: 'Gutenberg',
+		version: '4.3',
+		alternative: 'isBlockContentValid',
+	} );
+
+	return isBlockContentValid( blockType, attributes, innerHTML );
+}
+
 /**
  * Returns true if the parsed block is valid given the input content. A block
  * is considered valid if, when serialized with assumed attributes, the content
@@ -492,13 +507,13 @@ export function isEquivalentHTML( actual, expected ) {
  *
  * Logs to console in development environments when invalid.
  *
- * @param {string} innerHTML  Original block content.
  * @param {string} blockType  Block type.
  * @param {Object} attributes Parsed block attributes.
+ * @param {string} innerHTML  Original block content.
  *
  * @return {boolean} Whether block is valid.
  */
-export function isValidBlock( innerHTML, blockType, attributes ) {
+export function isBlockContentValid( blockType, attributes, innerHTML ) {
 	let saveContent;
 	try {
 		saveContent = getSaveContent( blockType, attributes );

--- a/packages/editor/src/components/block-list/block-html.js
+++ b/packages/editor/src/components/block-list/block-html.js
@@ -10,7 +10,7 @@ import { isEqual } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { getBlockAttributes, getBlockContent, getBlockType, isBlockContentValid, getSaveContent } from '@wordpress/blocks';
+import { getBlockAttributes, getBlockContent, getBlockType, isValidBlockContent, getSaveContent } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 export class BlockHTML extends Component {
@@ -38,7 +38,7 @@ export class BlockHTML extends Component {
 
 		// If html is empty  we reset the block to the default HTML and mark it as valid to avoid triggering an error
 		const content = html ? html : getSaveContent( blockType, attributes );
-		const isValid = html ? isBlockContentValid( blockType, attributes, content ) : true;
+		const isValid = html ? isValidBlockContent( blockType, attributes, content ) : true;
 
 		this.props.onChange( this.props.clientId, attributes, content, isValid );
 

--- a/packages/editor/src/components/block-list/block-html.js
+++ b/packages/editor/src/components/block-list/block-html.js
@@ -10,7 +10,7 @@ import { isEqual } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { getBlockAttributes, getBlockContent, getBlockType, isValidBlock, getSaveContent } from '@wordpress/blocks';
+import { getBlockAttributes, getBlockContent, getBlockType, isBlockContentValid, getSaveContent } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 export class BlockHTML extends Component {
@@ -38,7 +38,7 @@ export class BlockHTML extends Component {
 
 		// If html is empty  we reset the block to the default HTML and mark it as valid to avoid triggering an error
 		const content = html ? html : getSaveContent( blockType, attributes );
-		const isValid = html ? isValidBlock( content, blockType, attributes ) : true;
+		const isValid = html ? isBlockContentValid( blockType, attributes, content ) : true;
 
 		this.props.onChange( this.props.clientId, attributes, content, isValid );
 

--- a/test/integration/is-valid-block.spec.js
+++ b/test/integration/is-valid-block.spec.js
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-import { isBlockContentValid } from '@wordpress/blocks';
+import { isValidBlockContent } from '@wordpress/blocks';
 import { createElement } from '@wordpress/element';
 
-describe( 'isBlockContentValid', () => {
+describe( 'isValidBlockContent', () => {
 	beforeAll( () => {
 		// Load all hooks that modify blocks
 		require( '../../packages/editor/src/hooks' );
 	} );
 
 	it( 'should use the namespace in the classname for non-core blocks', () => {
-		const valid = isBlockContentValid(
+		const valid = isValidBlockContent(
 			{
 				save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 				name: 'myplugin/fruit',
@@ -24,7 +24,7 @@ describe( 'isBlockContentValid', () => {
 	} );
 
 	it( 'should include additional classes in block attributes', () => {
-		const valid = isBlockContentValid(
+		const valid = isValidBlockContent(
 			{
 				save: ( { attributes } ) => createElement( 'div', {
 					className: 'fruit',
@@ -42,7 +42,7 @@ describe( 'isBlockContentValid', () => {
 	} );
 
 	it( 'should not add a className if falsy', () => {
-		const valid = isBlockContentValid(
+		const valid = isValidBlockContent(
 			{
 				save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 				name: 'myplugin/fruit',

--- a/test/integration/is-valid-block.spec.js
+++ b/test/integration/is-valid-block.spec.js
@@ -1,31 +1,30 @@
 /**
  * External dependencies
  */
-import { isValidBlock } from '@wordpress/blocks';
+import { isBlockContentValid } from '@wordpress/blocks';
 import { createElement } from '@wordpress/element';
 
-describe( 'isValidBlock', () => {
+describe( 'isBlockContentValid', () => {
 	beforeAll( () => {
 		// Load all hooks that modify blocks
 		require( '../../packages/editor/src/hooks' );
 	} );
 
 	it( 'should use the namespace in the classname for non-core blocks', () => {
-		const valid = isValidBlock(
-			'<div class="wp-block-myplugin-fruit">Bananas</div>',
+		const valid = isBlockContentValid(
 			{
 				save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 				name: 'myplugin/fruit',
 			},
-			{ fruit: 'Bananas' }
+			{ fruit: 'Bananas' },
+			'<div class="wp-block-myplugin-fruit">Bananas</div>'
 		);
 
 		expect( valid ).toBe( true );
 	} );
 
 	it( 'should include additional classes in block attributes', () => {
-		const valid = isValidBlock(
-			'<div class="wp-block-myplugin-fruit fruit fresh">Bananas</div>',
+		const valid = isBlockContentValid(
 			{
 				save: ( { attributes } ) => createElement( 'div', {
 					className: 'fruit',
@@ -35,15 +34,15 @@ describe( 'isValidBlock', () => {
 			{
 				fruit: 'Bananas',
 				className: 'fresh',
-			}
+			},
+			'<div class="wp-block-myplugin-fruit fruit fresh">Bananas</div>'
 		);
 
 		expect( valid ).toBe( true );
 	} );
 
 	it( 'should not add a className if falsy', () => {
-		const valid = isValidBlock(
-			'<div>Bananas</div>',
+		const valid = isBlockContentValid(
 			{
 				save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 				name: 'myplugin/fruit',
@@ -51,7 +50,8 @@ describe( 'isValidBlock', () => {
 					className: false,
 				},
 			},
-			{ fruit: 'Bananas' }
+			{ fruit: 'Bananas' },
+			'<div>Bananas</div>'
 		);
 
 		expect( valid ).toBe( true );


### PR DESCRIPTION
## Description

Closes #5227.

Based on proposal from @matias:

> We have several functions that take arguments like `blockType`, `attributes`, `innerHtml`, but the order is not always consistent.
> 
> Since this is an often repeated pattern, we should consolidate usage.
> 
> Examples:
> 
> `isValidBlock — innerHTML, blockType, attributes.`
> `getBlockAttributes — blockType, innerHTML, attributes.`
> `getAttributesFromDeprecatedVersion — blockType, innerHTML, attributes.`
> `createBlock — name, attributes, innerBlocks.`
> `getSaveContent — blockType, attributes.`

I did the following refactorings:
- `isValidBlock( innerHTML, blockType, attributes )` renamed to `isBlockContentValid( blockType, attributes, innerHTML )`.
- `createBlock( name, blockAttributes = {}, innerBlocks = [] )` became `createBlock( name, attributes = {}, innerBlocks = [] )`.
- Added default value to the last param in `getBlockAttributes( blockType, innerHTML, attributes = {} )` - this one is tricky as it often is used with only 2 params. We should discuss if it really makes sense to swap two last params.
- `getCommentAttributes( allAttributes, blockType )` is now `getCommentAttributes( blockType, attributes )` - this is internal function.
- `getAttributesFromDeprecatedVersion` from the list above no longer exists - no action required.
- Did some code cleanup whenever I discovered something suspicious.

It still differs from @aduth shared which I wanted to follow initially:

> `isValidBlock( name, attributes, innerHTML )`
> `getBlockAttributes( name, attributes, innerHTML )`
> `getAttributesFromDeprecatedVersion( name, attributes, innerHTML )`
> `createBlock( name, attributes, innerBlocks )`
> `getSaveContent( name, attributes, innerBlocks )`

However after some time spent exploring the codebase, I find the fact that we use `blockType` very convinient in the context of unit tests. Should we allow using both `string` and `object` instead to leave the codebase unchanged but offer some more flexibility?

## How has this been tested?
`npm run test` & `npm run test-e2e`

## Types of changes
New deprecation is introduced.

Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
