### PR TITLE
Try: Fix Safari issue where hover outlines sometimes lingered

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -124,6 +124,9 @@
 			transition: outline 0.1s linear;
 			pointer-events: none;
 
+			// This fixes an issue in Safari where outlines wouldn't completely fade out.
+			will-change: transform;
+
 			// Go edge-to-edge on mobile.
 			right: -$block-padding;
 			left: -$block-padding;


### PR DESCRIPTION
Hopefully fixes #10741.

Safari could leave some hover outline "residue" when fading out the outlines of a block that got deselected. This PR appears to fix this.

I note "appears", because I would like other Safari users to verify this is the case.

The `will-change: transform;` property essentially says: paint this animation using the GPU, which very often solves animation related issues like this. But it sometimes causes glitches elsewhere, notably around fixed positioning, overflow, that sort of thing. In my testing, everything is fine, but please verify.
