### PR TITLE
Add space above code editor toolbar

### DIFF
--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -67,7 +67,7 @@
 	// Exit Code Editor toolbar.
 	.edit-post-text-editor__toolbar {
 		position: absolute;
-		top: 0;
+		top: $grid-size;
 		left: 0;
 		right: 0;
 		height: $block-controls-height;


### PR DESCRIPTION
The code editor toolbar previously had no space above it, so the hover state of the "Exit Code Editor" button bumped up against the top toolbar. This PR resolves that!

**Before**
![edit_page_ _tomodomo_ _wordpress](https://user-images.githubusercontent.com/1231306/47296308-e323d600-d5df-11e8-9a32-537e520a0f5b.png)

**After**
![edit_page_ _tomodomo_ _wordpress](https://user-images.githubusercontent.com/1231306/47296207-8fb18800-d5df-11e8-861c-054c84f78209.png)
