### PR TITLE
Only silence REST errors if the REST server is added

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -164,7 +164,7 @@ function gutenberg_pre_init() {
 
 	require_once dirname( __FILE__ ) . '/lib/load.php';
 
-	if ( class_exists( 'WP_REST_Controller' ) ) {
+	if ( function_exists( 'gutenberg_silence_rest_errors' ) ) {
 		gutenberg_silence_rest_errors();
 	}
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -164,7 +164,9 @@ function gutenberg_pre_init() {
 
 	require_once dirname( __FILE__ ) . '/lib/load.php';
 
-	gutenberg_silence_rest_errors();
+	if ( class_exists( 'WP_REST_Controller' ) ) {
+		gutenberg_silence_rest_errors();
+	}
 
 	add_filter( 'replace_editor', 'gutenberg_init', 10, 2 );
 }


### PR DESCRIPTION
## Description

If the REST server is not available in a code run, Gutenberg will fatal with `Fatal error: Uncaught Error: Call to undefined function gutenberg_silence_rest_errors()`

## How has this been tested?

Tested with the 4.1-RC1 plugin on an environment that only loads the REST server for REST requests. Tested by going to `/wp-admin` and confirming that the page loads without a fatal error.

## Types of changes

`gutenberg_silence_rest_errors()` is called in `gutenberg.php` in `gutenberg_pre_init`. The function is defined in `lib/rest-api.php`, which is only loaded in `load.php` if `class_exists( 'WP_REST_Controller' )`.

This PR adds the same `class_exists()` test to the call to `gutenberg_silence_rest_errors()` in `gutenberg.php`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
