### PR TITLE
Blocks: Fix More/Next dash line

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -5,7 +5,6 @@
 $z-layers: (
 	".editor-block-list__block-edit::before": 0,
 	".editor-block-switcher__arrow": 1,
-	".editor-block-list__block .wp-block-more::before": -1,
 	".editor-block-list__block {core/image aligned left or right}": 20,
 	".editor-block-list__block {core/image aligned wide or fullwide}": 20,
 	".block-library-classic__toolbar": 10,

--- a/packages/block-library/src/more/editor.scss
+++ b/packages/block-library/src/more/editor.scss
@@ -10,6 +10,7 @@
 
 	// Label
 	input[type="text"] {
+		position: relative;
 		font-size: $default-font-size;
 		text-transform: uppercase;
 		font-weight: 600;
@@ -38,6 +39,5 @@
 		left: 0;
 		right: 0;
 		border-top: 3px dashed $light-gray-700;
-		z-index: z-index(".editor-block-list__block .wp-block-more::before");
 	}
 }

--- a/packages/block-library/src/nextpage/editor.scss
+++ b/packages/block-library/src/nextpage/editor.scss
@@ -9,7 +9,6 @@
 
 	// Label
 	> span {
-		position: relative;
 		font-size: $default-font-size;
 		position: relative;
 		display: inline-block;

--- a/packages/block-library/src/nextpage/editor.scss
+++ b/packages/block-library/src/nextpage/editor.scss
@@ -9,6 +9,7 @@
 
 	// Label
 	> span {
+		position: relative;
 		font-size: $default-font-size;
 		position: relative;
 		display: inline-block;
@@ -30,6 +31,5 @@
 		left: 0;
 		right: 0;
 		border-top: 3px dashed $light-gray-700;
-		z-index: z-index(".editor-block-list__block .wp-block-more::before");
 	}
 }


### PR DESCRIPTION
Closes #10817

This pull request seeks to resolve an issue where the horizontal line intended to be shown with the More / Next blocks.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/47304998-2be68980-d5f6-11e8-85bc-77c8c4513c54.png)|![after](https://user-images.githubusercontent.com/1779930/47304959-140f0580-d5f6-11e8-8d15-6c20184e1a2c.png)

**Testing instructions:**

Verify a dashed line(s) is shown adjacent the input of the More / Next block.

Fixes #10817.