### PR TITLE
Writing Flow: Unset typing flag if Escape pressed

### DIFF
--- a/packages/editor/src/components/observe-typing/index.js
+++ b/packages/editor/src/components/observe-typing/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
+import { over, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -9,7 +9,15 @@ import { includes } from 'lodash';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { isTextField } from '@wordpress/dom';
-import { UP, RIGHT, DOWN, LEFT, ENTER, BACKSPACE } from '@wordpress/keycodes';
+import {
+	UP,
+	RIGHT,
+	DOWN,
+	LEFT,
+	ENTER,
+	BACKSPACE,
+	ESCAPE,
+} from '@wordpress/keycodes';
 import { withSafeTimeout, compose } from '@wordpress/compose';
 
 /**
@@ -41,6 +49,12 @@ class ObserveTyping extends Component {
 		this.stopTypingOnMouseMove = this.stopTypingOnMouseMove.bind( this );
 		this.startTypingInTextField = this.startTypingInTextField.bind( this );
 		this.stopTypingOnNonTextField = this.stopTypingOnNonTextField.bind( this );
+		this.stopTypingOnEscapeKey = this.stopTypingOnEscapeKey.bind( this );
+
+		this.onKeyDown = over( [
+			this.startTypingInTextField,
+			this.stopTypingOnEscapeKey,
+		] );
 
 		this.lastMouseMove = null;
 	}
@@ -109,6 +123,17 @@ class ObserveTyping extends Component {
 	}
 
 	/**
+	 * Unsets typing flag if user presses Escape while typing flag is active.
+	 *
+	 * @param {KeyboardEvent} event Keypress or keydown event to interpret.
+	 */
+	stopTypingOnEscapeKey( event ) {
+		if ( this.props.isTyping && event.keyCode === ESCAPE ) {
+			this.props.onStopTyping();
+		}
+	}
+
+	/**
 	 * Handles a keypress or keydown event to infer intention to start typing.
 	 *
 	 * @param {KeyboardEvent} event Keypress or keydown event to interpret.
@@ -165,7 +190,7 @@ class ObserveTyping extends Component {
 			<div
 				onFocus={ this.stopTypingOnNonTextField }
 				onKeyPress={ this.startTypingInTextField }
-				onKeyDown={ this.startTypingInTextField }
+				onKeyDown={ this.onKeyDown }
 			>
 				{ children }
 			</div>

--- a/test/e2e/specs/navigable-toolbar.test.js
+++ b/test/e2e/specs/navigable-toolbar.test.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { newPost, pressWithModifier } from '../support/utils';
+
+describe( 'block toolbar', () => {
+	forEach( {
+		unified: true,
+		contextual: false,
+	}, ( isUnifiedToolbar, label ) => {
+		beforeEach( async () => {
+			await newPost();
+
+			await page.evaluate( ( _isUnifiedToolbar ) => {
+				const { select, dispatch } = wp.data;
+				const isCurrentlyUnified = select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' );
+				if ( isCurrentlyUnified !== _isUnifiedToolbar ) {
+					dispatch( 'core/edit-post' ).toggleFeature( 'fixedToolbar' );
+				}
+			}, isUnifiedToolbar );
+		} );
+
+		const isInRichTextEditable = () => page.evaluate( () => (
+			document.activeElement.classList.contains( 'editor-rich-text__tinymce' )
+		) );
+
+		const isInBlockToolbar = () => page.evaluate( () => (
+			!! document.activeElement.closest( '.editor-block-toolbar' )
+		) );
+
+		describe( label, () => {
+			it( 'navigates in and out of toolbar by keyboard (Alt+F10, Escape)', async () => {
+				// Assumes new post focus starts in title. Create first new
+				// block by ArrowDown.
+				await page.keyboard.press( 'ArrowDown' );
+
+				// [TEMPORARY]: A new paragraph is not technically a block yet
+				// until starting to type within it.
+				await page.keyboard.type( 'Example' );
+
+				// [TEMPORARY]: With non-unified toolbar, the toolbar will not
+				// be visible since the user has entered a "typing" mode.
+				// Future iterations should ensure Alt+F10 works in a block
+				// to focus the toolbar regardless of whether it is presently
+				// visible.
+				await page.keyboard.press( 'Escape' );
+
+				// Upward
+				await pressWithModifier( 'Alt', 'F10' );
+				expect( await isInBlockToolbar() ).toBe( true );
+
+				// Downward
+				await page.keyboard.press( 'Escape' );
+				expect( await isInRichTextEditable() ).toBe( true );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
Extracted from #10699

This pull request seeks to resolve an issue where the contextual block toolbar is not accessible by keyboard when typing, except by artificially creating a selection for the mere purpose of deactivating the "is typing" application state flag. It does so by canceling the typing mode when the user presses Escape.

**Implementation notes:**

There are still some undesirable behaviors, of which this is not intended to cover, though I will create issues for:

- There is special handling of a new paragraph block to consider it as "not yet a paragraph block", thus requiring some typing to occur before Escape will work. Ideally the behavior is made consistent so that Escape will always activate the toolbar.
   - Related: #7177, #10519, #7271, #5054, #8363
- Alt+F10 should navigate into the block toolbar regardless whether it is currently visible.
   - Tracked at #10907

**Testing instructions:**

Verify that, after typing in a paragraph block, pressing Escape causes the toolbar to be shown.