### PR TITLE
Fix/categories block label missing

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -110,12 +110,13 @@ class CategoriesEdit extends Component {
 		const { showHierarchy, instanceId, className } = this.props;
 		const parentId = showHierarchy ? 0 : null;
 		const categories = this.getCategories( parentId );
+		const selectId = `${ className }-${ instanceId }`;
 		return (
 			<Fragment>
-				<label htmlFor={ `${ className }-${ instanceId }` } className="screen-reader-text">
+				<label htmlFor={ selectId } className="screen-reader-text">
 					{ __( 'Categories' ) }
 				</label>
-				<select id={ `${ className }-${ instanceId }` } className={ `${ className }__dropdown` }>
+				<select id={ selectId } className={ `${ className }__dropdown` }>
 					{ categories.map( ( category ) => this.renderCategoryDropdownItem( category, 0 ) ) }
 				</select>
 			</Fragment>

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { times, unescape } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
@@ -11,7 +16,6 @@ import {
 	BlockControls,
 	BlockAlignmentToolbar,
 } from '@wordpress/editor';
-import { times, unescape } from 'lodash';
 
 class CategoriesEdit extends Component {
 	constructor() {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -5,12 +5,13 @@ import { Component, Fragment } from '@wordpress/element';
 import { PanelBody, Placeholder, Spinner, ToggleControl } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { times, unescape } from 'lodash';
+import { withInstanceId, compose } from '@wordpress/compose';
 import {
 	InspectorControls,
 	BlockControls,
 	BlockAlignmentToolbar,
 } from '@wordpress/editor';
+import { times, unescape } from 'lodash';
 
 class CategoriesEdit extends Component {
 	constructor() {
@@ -106,14 +107,18 @@ class CategoriesEdit extends Component {
 	}
 
 	renderCategoryDropdown() {
-		const { showHierarchy } = this.props.attributes;
+		const { showHierarchy, instanceId, className } = this.props;
 		const parentId = showHierarchy ? 0 : null;
 		const categories = this.getCategories( parentId );
-
 		return (
-			<select className={ `${ this.props.className }__dropdown` }>
-				{ categories.map( ( category ) => this.renderCategoryDropdownItem( category, 0 ) ) }
-			</select>
+			<Fragment>
+				<label htmlFor={ `${ className }-${ instanceId }` } className="screen-reader-text">
+					{ __( 'Categories' ) }
+				</label>
+				<select name={ `${ className }-${ instanceId }` } className={ `${ className }__dropdown` }>
+					{ categories.map( ( category ) => this.renderCategoryDropdownItem( category, 0 ) ) }
+				</select>
+			</Fragment>
 		);
 	}
 
@@ -201,14 +206,16 @@ class CategoriesEdit extends Component {
 		);
 	}
 }
+export default compose(
+	withSelect( ( select ) => {
+		const { getEntityRecords } = select( 'core' );
+		const { isResolving } = select( 'core/data' );
+		const query = { per_page: -1 };
 
-export default withSelect( ( select ) => {
-	const { getEntityRecords } = select( 'core' );
-	const { isResolving } = select( 'core/data' );
-	const query = { per_page: -1 };
-
-	return {
-		categories: getEntityRecords( 'taxonomy', 'category', query ),
-		isRequesting: isResolving( 'core', 'getEntityRecords', [ 'taxonomy', 'category', query ] ),
-	};
-} )( CategoriesEdit );
+		return {
+			categories: getEntityRecords( 'taxonomy', 'category', query ),
+			isRequesting: isResolving( 'core', 'getEntityRecords', [ 'taxonomy', 'category', query ] ),
+		};
+	} ),
+	withInstanceId
+)( CategoriesEdit );

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -114,7 +114,7 @@ class CategoriesEdit extends Component {
 		const { showHierarchy, instanceId, className } = this.props;
 		const parentId = showHierarchy ? 0 : null;
 		const categories = this.getCategories( parentId );
-		const selectId = `${ className }-${ instanceId }`;
+		const selectId = `blocks-category-select-${ instanceId }`;
 		return (
 			<Fragment>
 				<label htmlFor={ selectId } className="screen-reader-text">

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -115,7 +115,7 @@ class CategoriesEdit extends Component {
 				<label htmlFor={ `${ className }-${ instanceId }` } className="screen-reader-text">
 					{ __( 'Categories' ) }
 				</label>
-				<select name={ `${ className }-${ instanceId }` } className={ `${ className }__dropdown` }>
+				<select id={ `${ className }-${ instanceId }` } className={ `${ className }__dropdown` }>
 					{ categories.map( ( category ) => this.renderCategoryDropdownItem( category, 0 ) ) }
 				</select>
 			</Fragment>


### PR DESCRIPTION
## Description

The categories block does not have a label when it is set to "Display as dropdown" as mentioned in #10871. This updates the markup in the admin to render a visually hidden label for assistive technology to provide context to the dropdown. 

Also mentioned in the related issue above is that the labels should possibly be visual by default. Once merged, another PR can be opened to address that.

One thing to note is that various screen readers will respond differently to select dropdowns based on the type of label used (implicit vs explicit) so even though in my testing it never read the label because I was using VoiceOver and Safari, other browsers/screen readers will respond differently
(http://www.davidmacd.com/blog/select-box-label.html)

## How has this been tested?
Tested on OSX in Chrome, Safari, Firefox, Edge,  and IE11 using Browserstack. I used Voice Over + Safari to test that the label is properly read. 

## Screenshots <!-- if applicable -->
![screen shot 2018-10-22 at 2 22 38 pm](https://user-images.githubusercontent.com/3654512/47310734-f8136000-d605-11e8-97eb-9cf890da0a25.png)

<img width="300" alt="screen shot 2018-10-22 at 2 24 40 pm" src="https://user-images.githubusercontent.com/3654512/47310858-4294dc80-d606-11e8-83b8-b7de08f6ca68.png">

(My category name was test, which I now realize should probably be something a little more contextual)


## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
