### PR TITLE
Fix:  Show resizer on "Media & Text" block on unified toolbar mode

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -104,6 +104,7 @@ class MediaTextEdit extends Component {
 			attributes,
 			className,
 			backgroundColor,
+			isSelected,
 			setAttributes,
 			setBackgroundColor,
 		} = this.props;
@@ -111,6 +112,7 @@ class MediaTextEdit extends Component {
 		const temporaryMediaWidth = this.state.mediaWidth;
 		const classNames = classnames( className, {
 			'has-media-on-the-right': 'right' === mediaPosition,
+			'is-selected': isSelected,
 			[ backgroundColor.class ]: backgroundColor.class,
 		} );
 		const widthString = `${ temporaryMediaWidth || mediaWidth }%`;

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -51,8 +51,7 @@ figure.block-library-media-text__media-container {
 	display: none;
 }
 
-.editor-block-list__block.is-selected,
-.editor-block-list__block.is-focused {
+.wp-block-media-text.is-selected {
 	.editor-media-container__resizer .components-resizable-box__handle {
 		display: block;
 	}


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/10895
On unified toolbar mode it was not possible to resize the media on Media & Text block.
During the elaboration of https://github.com/WordPress/gutenberg/pull/9416 this bug was addressed but I think during subsequent rebases and changes more concretely the usage of our abstracted Resizable box we had a regression.

This PR applies exactly the same fix that was applied in spacer block to the Media & Text block.


## How has this been tested?
I checked it is possible to resize the media in Media & Text block in all mode including the unified toolbar.
