### PR TITLE
Components: Optimize SlotFill rendering to avoid props destructuring

### DIFF
--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -10,18 +10,10 @@ export { Fill };
 export { Provider };
 
 export function createSlotFill( name ) {
-	const FillComponent = ( { children, ...props } ) => (
-		<Fill name={ name } { ...props }>
-			{ children }
-		</Fill>
-	);
+	const FillComponent = ( props ) => <Fill name={ name } { ...props } />;
 	FillComponent.displayName = name + 'Fill';
 
-	const SlotComponent = ( { children, ...props } ) => (
-		<Slot name={ name } { ...props }>
-			{ children }
-		</Slot>
-	);
+	const SlotComponent = ( props ) => <Slot name={ name } { ...props } />;
 	SlotComponent.displayName = name + 'Slot';
 
 	return {


### PR DESCRIPTION
Related: #5952

This pull request seeks to optimize the rendering of components created through `createSlotFill` to avoid an unnecessary props destructuring. These components are considered to be hot code paths, being called upwards of thousands of times in the authoring of one or few paragraphs of text (itself an issue worth exploring).

The change is simple; since React considers `children` as a prop (and, in fact, always [normalizes back to a prop anyways](https://github.com/facebook/react/blob/04c4f2fcea0ba1496b5b20d0fca8d8d48d6ecf64/packages/react/src/ReactElement.js#L203-L219)), there's no need to extract it separately, and it can be included in the default spread of props.

The issue boils down to the effective transpiled output of a destructuring:

- [With `children` treated separately](https://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=KYDwDg9gTgLgBAMwK4DsDGMCWEVzVYAQxmAGUAbCGAMU3PIAo4VCBbYOASjgG8AoAJBocAZ3i16AYQitIKYCngBeOEx54AFnQAmBFABo4AOhNgoEMCLgBfLnCUA-VYIEAeCeWZtgS9S3Y2vMam5pY2Di4C6mha5LoKNi6uAPQeEQKcANx81nxAA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2&prettier=false&targets=&version=6.26.0&envVersion=)
- [With `children` included in `...props` spread](https://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=KYDwDg9gTgLgBAMwK4DsDGMCWEVzVYAQxmAGUAbCGAMU3PIAo4VCBbYOASjgG8AoAJBocAZ3i16AYQitIKYCngBeOEzBQIYEVzhKAfKsECAPBPLM2wJTwvs4AX15wAdK_WbtjgPR7BnANx89nxAA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2&prettier=false&targets=&version=6.26.0&envVersion=)

Note in above the iteration which would occur through `_objectWithoutProperties` in the separate treatment, which is avoided altogether in the implementation proposed here.

**Testing instructions:**

There should be no effective difference in behavior.

Ensure Slot/Fill works as expected (sidebar, toolbars, plugins).