### PR TITLE
Datepicker: Consistent help text

### DIFF
--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -59,7 +59,7 @@ export class DateTimePicker extends Component {
 						<div className="components-datetime__calendar-help">
 							<h4>{ __( 'Click to Select' ) }</h4>
 							<ul>
-								<li>{ __( 'Click the right and left arrows to select other months in the past or the future.' ) }</li>
+								<li>{ __( 'Click the right or left arrows to select other months in the past or the future.' ) }</li>
 								<li>{ __( 'Click the desired day to select it.' ) }</li>
 							</ul>
 
@@ -73,12 +73,12 @@ export class DateTimePicker extends Component {
 								<li>
 									<abbr aria-label={ __( 'Left and Right Arrows' ) }>←/→</abbr>
 									{ ' ' /* JSX removes whitespace, but a space is required for screen readers. */ }
-									{ __( 'Move backward (left) and forward (right) by one day.' ) }
+									{ __( 'Move backward (left) or forward (right) by one day.' ) }
 								</li>
 								<li>
 									<abbr aria-label={ __( 'Up and Down Arrows' ) }>↑/↓</abbr>
 									{ ' ' /* JSX removes whitespace, but a space is required for screen readers. */ }
-									{ __( 'Move backward (up) and forward (down) by one week.' ) }
+									{ __( 'Move backward (up) or forward (down) by one week.' ) }
 								</li>
 								<li>
 									<abbr aria-label={ __( 'Page Up and Page Down' ) }>{ __( 'PgUp/PgDn' ) }</abbr>


### PR DESCRIPTION
## Description
Fixes: #10920
To become more consistent and precise we should use `or` because you have to select the one `or` the other option.