### PR TITLE
Focal Point Picker

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -912,6 +912,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "FocalPointPicker",
+		"slug": "focal-point-picker",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/focal-point-picker/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "FocusableIframe",
 		"slug": "focusable-iframe",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/focusable-iframe/README.md",

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -71,9 +71,6 @@ const blockAttributes = {
 	focalPoint: {
 		type: 'object',
 	},
-	dimensions: {
-		type: 'object',
-	},
 };
 
 export const name = 'core/cover';
@@ -182,7 +179,6 @@ export const settings = {
 				backgroundType,
 				contentAlign,
 				dimRatio,
-				dimensions,
 				focalPoint,
 				hasParallax,
 				id,
@@ -218,10 +214,6 @@ export const settings = {
 					url: media.url,
 					id: media.id,
 					backgroundType: mediaType,
-					dimensions: {
-						height: media.height,
-						width: media.width,
-					},
 				} );
 			};
 			const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
@@ -286,7 +278,6 @@ export const settings = {
 									<FocalPointPicker
 										label={ __( 'Focal Point Picker' ) }
 										url={ url }
-										dimensions={ dimensions }
 										value={ focalPoint }
 										onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
 									/>

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -33,6 +33,7 @@ import {
 	withColors,
 	getColorClassName,
 } from '@wordpress/editor';
+import { has } from 'lodash';
 
 const blockAttributes = {
 	title: {
@@ -237,7 +238,7 @@ export const settings = {
 				backgroundColor: overlayColor.color,
 			};
 
-			if ( focalPoint ) {
+			if ( ! hasParallax && validFocalPoint( focalPoint ) ) {
 				style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 			}
 
@@ -291,7 +292,7 @@ export const settings = {
 										onChange={ toggleParallax }
 									/>
 								) }
-								{ IMAGE_BACKGROUND_TYPE === backgroundType && ! hasParallax && (
+								{ IMAGE_BACKGROUND_TYPE === backgroundType && ! hasParallax && validDimensions( dimensions ) && (
 									<FocalPointPicker
 										label={ __( 'Focal Point Picker' ) }
 										url={ url }
@@ -418,7 +419,7 @@ export const settings = {
 		if ( ! overlayColorClass ) {
 			style.backgroundColor = customOverlayColor;
 		}
-		if ( focalPoint && ! hasParallax ) {
+		if ( ! hasParallax && validFocalPoint( focalPoint ) ) {
 			style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 		}
 
@@ -532,4 +533,12 @@ function backgroundImageStyles( url ) {
 	return url ?
 		{ backgroundImage: `url(${ url })` } :
 		{};
+}
+
+function validFocalPoint( focalPoint ) {
+	return ( focalPoint && has( focalPoint, [ 'x' ] ) && has( focalPoint, [ 'y' ] ) );
+}
+
+function validDimensions( dimensions ) {
+	return ( dimensions && has( dimensions, [ 'height' ] ) && has( dimensions, [ 'width' ] ) );
 }

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
+	FocalPointPicker,
 	IconButton,
 	PanelBody,
 	RangeControl,
@@ -66,6 +67,12 @@ const blockAttributes = {
 	backgroundType: {
 		type: 'string',
 		default: 'image',
+	},
+	focalPoint: {
+		type: 'object',
+	},
+	dimensions: {
+		type: 'object',
 	},
 };
 
@@ -175,6 +182,8 @@ export const settings = {
 				backgroundType,
 				contentAlign,
 				dimRatio,
+				dimensions,
+				focalPoint,
 				hasParallax,
 				id,
 				title,
@@ -209,6 +218,10 @@ export const settings = {
 					url: media.url,
 					id: media.id,
 					backgroundType: mediaType,
+					dimensions: {
+						height: media.height,
+						width: media.width,
+					},
 				} );
 			};
 			const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
@@ -224,6 +237,19 @@ export const settings = {
 				backgroundColor: overlayColor.color,
 			};
 
+			if ( focalPoint ) {
+				style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
+			}
+
+			const classes = classnames(
+				className,
+				contentAlign !== 'center' && `has-${ contentAlign }-content`,
+				dimRatioToClass( dimRatio ),
+				{
+					'has-background-dim': dimRatio !== 0,
+					'has-parallax': hasParallax,
+				}
+			);
 			const controls = (
 				<Fragment>
 					<BlockControls>
@@ -263,6 +289,15 @@ export const settings = {
 										label={ __( 'Fixed Background' ) }
 										checked={ hasParallax }
 										onChange={ toggleParallax }
+									/>
+								) }
+								{ IMAGE_BACKGROUND_TYPE === backgroundType && ! hasParallax && (
+									<FocalPointPicker
+										label={ __( 'Focal Point Picker' ) }
+										url={ url }
+										dimensions={ dimensions }
+										value={ focalPoint }
+										onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
 									/>
 								) }
 								<PanelColorSettings
@@ -370,6 +405,7 @@ export const settings = {
 			contentAlign,
 			customOverlayColor,
 			dimRatio,
+			focalPoint,
 			hasParallax,
 			overlayColor,
 			title,
@@ -381,6 +417,9 @@ export const settings = {
 			{};
 		if ( ! overlayColorClass ) {
 			style.backgroundColor = customOverlayColor;
+		}
+		if ( focalPoint && ! hasParallax ) {
+			style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 		}
 
 		const classes = classnames(

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -33,7 +33,6 @@ import {
 	withColors,
 	getColorClassName,
 } from '@wordpress/editor';
-import { has } from 'lodash';
 
 const blockAttributes = {
 	title: {
@@ -238,19 +237,10 @@ export const settings = {
 				backgroundColor: overlayColor.color,
 			};
 
-			if ( ! hasParallax && validFocalPoint( focalPoint ) ) {
+			if ( focalPoint ) {
 				style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 			}
 
-			const classes = classnames(
-				className,
-				contentAlign !== 'center' && `has-${ contentAlign }-content`,
-				dimRatioToClass( dimRatio ),
-				{
-					'has-background-dim': dimRatio !== 0,
-					'has-parallax': hasParallax,
-				}
-			);
 			const controls = (
 				<Fragment>
 					<BlockControls>
@@ -292,7 +282,7 @@ export const settings = {
 										onChange={ toggleParallax }
 									/>
 								) }
-								{ IMAGE_BACKGROUND_TYPE === backgroundType && ! hasParallax && validDimensions( dimensions ) && (
+								{ IMAGE_BACKGROUND_TYPE === backgroundType && ! hasParallax && (
 									<FocalPointPicker
 										label={ __( 'Focal Point Picker' ) }
 										url={ url }
@@ -419,7 +409,7 @@ export const settings = {
 		if ( ! overlayColorClass ) {
 			style.backgroundColor = customOverlayColor;
 		}
-		if ( ! hasParallax && validFocalPoint( focalPoint ) ) {
+		if ( focalPoint && ! hasParallax ) {
 			style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 		}
 
@@ -533,12 +523,4 @@ function backgroundImageStyles( url ) {
 	return url ?
 		{ backgroundImage: `url(${ url })` } :
 		{};
-}
-
-function validFocalPoint( focalPoint ) {
-	return ( focalPoint && has( focalPoint, [ 'x' ] ) && has( focalPoint, [ 'y' ] ) );
-}
-
-function validDimensions( dimensions ) {
-	return ( dimensions && has( dimensions, [ 'height' ] ) && has( dimensions, [ 'width' ] ) );
 }

--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -12,7 +12,7 @@ const MyFocalPointPicker = withState( {
 		x: 0.5,
 		y: 0.5
 	},
-} )( ( { dimensions={ dimensions }, setState } ) => { 
+} )( ( { focalPoint, setState } ) => { 
 	const url = '/path/to/image';
 	const dimensions = {
 		width: 400,

--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -1,6 +1,9 @@
 # Focal Point Picker
 
-Focal Point Picker is a component which creates a UI for identifying the most visually important point on an image, which can be used to ensure that the image is cropped appropriately. The component is useful for background images which may be cropped in undesirable ways on small and irregular viewports. The selected point is returned as an object containing `x` and `y` values between 0-1, which can be converted to percentages and applied as the image container's `background-position` attribute.
+Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image. This component addresses a specific problem: with large background images it is common to see undesirable crops, especially when viewing on smaller viewports such as mobile phones. This component allows the selection of the point with the most important visual information and returns it as a pair of numbers between 0 and 1. This value can be easily converted into the CSS `background-position` attribute, and will ensure that the focal point is never cropped out, regardless of viewport.
+
+Example focal point picker value: `{ x: 0.5, y: 0.1 }`
+Corresponding CSS: `background-position: 50% 10%;`
 
 ## Usage
 
@@ -18,11 +21,6 @@ const MyFocalPointPicker = withState( {
 		width: 400,
 		height: 100
 	};
-	const style = {
-		backgroundImage: `url(${ url })` ,
-		backgroundPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`
-	}
-	const imageContainer = <div style={ style } />;
 	return ( 
 		<FocalPointPicker 
 			url={ url }
@@ -32,6 +30,15 @@ const MyFocalPointPicker = withState( {
 		/>
 	) 
 } );
+
+/* Example function to render the CSS styles based on Focal Point Picker value */
+const renderImageContainerWithFocalPoint = ( url, focalPoint ) => {
+	const style = {
+		backgroundImage: `url(${ url })` ,
+		backgroundPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`
+	}
+	return <div style={ style } />;
+};
 ```
 
 ## Props
@@ -51,11 +58,11 @@ const MyFocalPointPicker = withState( {
 ### `value`
 
 - Type: `Object`
-- Required: No
+- Required: Yes
 - Description: The focal point. Should be an object containing `x` and `y` params.
 
 ### `onChange`
 
 - Type: `Function`
-- Required: No
+- Required: Yes
 - Description: Callback which is called when the focal point changes. 

--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -1,0 +1,61 @@
+# Focal Point Picker
+
+Focal Point Picker is a component which creates a UI for identifying the most visually important point on an image, which can be used to ensure that the image is cropped appropriately. The component is useful for background images which may be cropped in undesirable ways on small and irregular viewports. The selected point is returned as an object containing `x` and `y` values between 0-1, which can be converted to percentages and applied as the image container's `background-position` attribute.
+
+## Usage
+
+```jsx
+import { FocalPointPicker } from '@wordpress/components';
+
+const MyFocalPointPicker = withState( {
+	focalPoint: {
+		x: 0.5,
+		y: 0.5
+	},
+} )( ( { dimensions={ dimensions }, setState } ) => { 
+	const url = '/path/to/image';
+	const dimensions = {
+		width: 400,
+		height: 100
+	};
+	const style = {
+		backgroundImage: `url(${ url })` ,
+		backgroundPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`
+	}
+	const imageContainer = <div style={ style } />;
+	return ( 
+		<FocalPointPicker 
+			url={ url }
+			dimensions={ dimensions }
+			value={ focalPoint }
+			onChange={ ( focalPoint ) => setState( { focalPoint } ) } 
+		/>
+	) 
+} );
+```
+
+## Props
+
+### `url`
+
+- Type: `Text`
+- Required: Yes
+- Description: URL of the image to be displayed
+
+### `dimensions`
+
+- Type: `Object`
+- Required: Yes
+- Description: An object describing the height and width of the image. Requires two paramaters: `height`, `width`.
+
+### `value`
+
+- Type: `Object`
+- Required: No
+- Description: The focal point. Should be an object containing `x` and `y` params.
+
+### `onChange`
+
+- Type: `Function`
+- Required: No
+- Description: Callback which is called when the focal point changes. 

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -1,0 +1,165 @@
+/**
+ * External dependencies
+ */
+
+import { Component, createRef } from '@wordpress/element';
+import { withInstanceId, compose } from '@wordpress/compose';
+import BaseControl from '../base-control/';
+import withFocusOutside from '../higher-order/with-focus-outside';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+
+import './style.scss';
+
+export class FocalPointPicker extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onMouseMove = this.onMouseMove.bind( this );
+		this.state = {
+			isDragging: false,
+			bounds: {},
+		};
+		this.containerRef = createRef();
+	}
+	componentDidMount() {
+		this.setState( { bounds: this.calculateBounds() } );
+	}
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.dimensions !== this.props.dimensions || prevProps.url !== this.props.url ) {
+			this.setState( {
+				bounds: this.calculateBounds(),
+				isDragging: false,
+			} );
+		}
+	}
+	calculateBounds() {
+		const { dimensions } = this.props;
+		const pickerDimensions = this.pickerDimensions();
+		const bounds = {
+			top: 0,
+			left: 0,
+			bottom: 0,
+			right: 0,
+			width: 0,
+			height: 0,
+		};
+		const widthRatio = pickerDimensions.width / dimensions.width;
+		const heightRatio = pickerDimensions.height / dimensions.height;
+		if ( heightRatio >= widthRatio ) {
+			bounds.width = bounds.right = pickerDimensions.width;
+			bounds.height = dimensions.height * widthRatio;
+			bounds.top = ( pickerDimensions.height - bounds.height ) / 2;
+			bounds.bottom = bounds.top + bounds.height;
+		} else {
+			bounds.height = bounds.bottom = pickerDimensions.height;
+			bounds.width = dimensions.width * heightRatio;
+			bounds.left = ( pickerDimensions.width - bounds.width ) / 2;
+			bounds.right = bounds.left + bounds.width;
+		}
+		return bounds;
+	}
+	onMouseMove( event ) {
+		const { isDragging, bounds } = this.state;
+		const { onChange } = this.props;
+
+		if ( isDragging ) {
+			const pickerDimensions = this.pickerDimensions();
+			const cursorPosition = {
+				left: event.pageX - pickerDimensions.left,
+				top: event.pageY - pickerDimensions.top,
+			};
+			const left = Math.max(
+				bounds.left, Math.min(
+					cursorPosition.left, bounds.right
+				)
+			);
+			const top = Math.max(
+				bounds.top, Math.min(
+					cursorPosition.top, bounds.bottom
+				)
+			);
+			onChange( {
+				x: left / pickerDimensions.width,
+				y: top / pickerDimensions.height,
+			} );
+		}
+	}
+	pickerDimensions() {
+		if ( this.containerRef.current ) {
+			return {
+				width: this.containerRef.current.clientWidth,
+				height: this.containerRef.current.clientHeight,
+				top: this.containerRef.current.getBoundingClientRect().top + document.body.scrollTop,
+				left: this.containerRef.current.getBoundingClientRect().left,
+			};
+		}
+		return {
+			width: 0,
+			height: 0,
+			left: 0,
+			top: 0,
+		};
+	}
+	render() {
+		const { instanceId, url, value, label, help, className } = this.props;
+		const { isDragging } = this.state;
+		const pickerDimensions = this.pickerDimensions();
+		const containerStyle = { backgroundImage: `url(${ url })` };
+		const iconContainerStyle = {
+			left: `${ value.x * pickerDimensions.width }px`,
+			top: `${ value.y * pickerDimensions.height }px`,
+		};
+		const iconContainerClasses = classnames(
+			'component-focal-point-picker__icon_container',
+			isDragging ? 'is-dragging' : null
+		);
+		const id = `inspector-focal-point-picker-control-${ instanceId }`;
+		return (
+			<BaseControl label={ label } id={ id } help={ help } className={ className }>
+				<div
+					className="component-focal-point-picker"
+					style={ containerStyle }
+					onMouseDown={ () => this.setState( { isDragging: true } ) }
+					onDragStart={ () => this.setState( { isDragging: true } ) }
+					onMouseUp={ () => this.setState( { isDragging: false } ) }
+					onDrop={ () => this.setState( { isDragging: false } ) }
+					onMouseMove={ this.onMouseMove }
+					ref={ this.containerRef }
+					role="button"
+					tabIndex="0"
+				>
+					<div className={ iconContainerClasses } style={ iconContainerStyle }>
+						<i className="component-focal-point-picker__icon"></i>
+					</div>
+				</div>
+			</BaseControl>
+		);
+	}
+	handleFocusOutside() {
+		this.setState( {
+			isDragging: false,
+		} );
+	}
+}
+
+FocalPointPicker.defaultProps = {
+	url: null,
+	dimensions: {
+		height: 0,
+		width: 0,
+	},
+	value: {
+		x: 0.5,
+		y: 0.5,
+	},
+	onChange: () => {},
+};
+
+export default compose( [
+	withInstanceId,
+	withFocusOutside,
+] )( FocalPointPicker );
+

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -14,7 +14,6 @@ import { withInstanceId, compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import BaseControl from '../base-control';
-import TextControl from '../text-control';
 import withFocusOutside from '../higher-order/with-focus-outside';
 
 const TEXTCONTROL_MIN = 0;
@@ -121,11 +120,11 @@ export class FocalPointPicker extends Component {
 	fractionToPercentage( fraction ) {
 		return Math.round( fraction * 100 );
 	}
-	horizontalPositionChanged( value ) {
-		this.positionChangeFromTextControl( 'x', value );
+	horizontalPositionChanged( event ) {
+		this.positionChangeFromTextControl( 'x', event.target.value );
 	}
-	verticalPositionChanged( value ) {
-		this.positionChangeFromTextControl( 'y', value );
+	verticalPositionChanged( event ) {
+		this.positionChangeFromTextControl( 'y', event.target.value );
 	}
 	positionChangeFromTextControl( axis, value ) {
 		const { onChange } = this.props;
@@ -172,6 +171,8 @@ export class FocalPointPicker extends Component {
 			isDragging ? 'is-dragging' : null
 		);
 		const id = `inspector-focal-point-picker-control-${ instanceId }`;
+		const horizontalPositionId = `inspector-focal-point-picker-control-horizontal-position-${ instanceId }`;
+		const verticalPositionId = `inspector-focal-point-picker-control-horizontal-position-${ instanceId }`;
 		return (
 			<BaseControl label={ label } id={ id } help={ help } className={ className }>
 				<div
@@ -196,22 +197,30 @@ export class FocalPointPicker extends Component {
 					</div>
 				</div>
 				<div className="component-focal-point-picker_position-display-container">
-					<TextControl
-						label={ __( 'Horizontal Pos.' ) }
-						max={ TEXTCONTROL_MAX }
-						min={ TEXTCONTROL_MIN }
-						onChange={ this.horizontalPositionChanged }
-						type="number"
-						value={ this.fractionToPercentage( percentages.x ) }
-					/>
-					<TextControl
-						label={ __( 'Vertical Pos.' ) }
-						max={ TEXTCONTROL_MAX }
-						min={ TEXTCONTROL_MIN }
-						onChange={ this.verticalPositionChanged }
-						type="number"
-						value={ this.fractionToPercentage( percentages.y ) }
-					/>
+					<BaseControl label={ __( 'Horizontal Pos.' ) }>
+						<input
+							className="components-text-control__input"
+							id={ horizontalPositionId }
+							max={ TEXTCONTROL_MAX }
+							min={ TEXTCONTROL_MIN }
+							onChange={ this.horizontalPositionChanged }
+							type="number"
+							value={ this.fractionToPercentage( percentages.x ) }
+						/>
+						<span>%</span>
+					</BaseControl>
+					<BaseControl label={ __( 'Vertical Pos.' ) }>
+						<input
+							className="components-text-control__input"
+							id={ verticalPositionId }
+							max={ TEXTCONTROL_MAX }
+							min={ TEXTCONTROL_MIN }
+							onChange={ this.verticalPositionChanged }
+							type="number"
+							value={ this.fractionToPercentage( percentages.y ) }
+						/>
+						<span>%</span>
+					</BaseControl>
 				</div>
 			</BaseControl>
 		);

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -33,29 +33,21 @@ export class FocalPointPicker extends Component {
 		this.imageRef = createRef();
 		this.horizontalPositionChanged = this.horizontalPositionChanged.bind( this );
 		this.verticalPositionChanged = this.verticalPositionChanged.bind( this );
+		this.onLoad = this.onLoad.bind( this );
 	}
 	componentDidMount() {
-		setTimeout( () => {
-			this.setState( {
-				bounds: this.calculateBounds(),
-				percentages: this.props.value,
-			} );
-		}, 1 );
+		this.setState( {
+			percentages: this.props.value,
+		} );
 	}
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.url !== this.props.url ) {
 			this.setState( {
-				bounds: this.calculateBounds(),
 				isDragging: false,
 			} );
 		}
 	}
 	calculateBounds() {
-		const dimensions = {
-			width: this.imageRef.current.clientWidth,
-			height: this.imageRef.current.clientHeight,
-		};
-		const pickerDimensions = this.pickerDimensions();
 		const bounds = {
 			top: 0,
 			left: 0,
@@ -64,6 +56,14 @@ export class FocalPointPicker extends Component {
 			width: 0,
 			height: 0,
 		};
+		if ( ! this.imageRef.current ) {
+			return bounds;
+		}
+		const dimensions = {
+			width: this.imageRef.current.clientWidth,
+			height: this.imageRef.current.clientHeight,
+		};
+		const pickerDimensions = this.pickerDimensions();
 		const widthRatio = pickerDimensions.width / dimensions.width;
 		const heightRatio = pickerDimensions.height / dimensions.height;
 		if ( heightRatio >= widthRatio ) {
@@ -78,6 +78,11 @@ export class FocalPointPicker extends Component {
 			bounds.right = bounds.left + bounds.width;
 		}
 		return bounds;
+	}
+	onLoad() {
+		this.setState( {
+			bounds: this.calculateBounds(),
+		} );
 	}
 	onMouseMove( event ) {
 		const { isDragging, bounds } = this.state;
@@ -180,7 +185,12 @@ export class FocalPointPicker extends Component {
 					role="button"
 					tabIndex="0"
 				>
-					<img src={ url } ref={ this.imageRef } alt="Dimensions helper" />
+					<img
+						alt="Dimensions helper"
+						onLoad={ this.onLoad }
+						ref={ this.imageRef }
+						src={ url }
+					/>
 					<div className={ iconContainerClasses } style={ iconContainerStyle }>
 						<i className="component-focal-point-picker__icon" />
 					</div>

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -27,12 +27,13 @@ export class FocalPointPicker extends Component {
 			percentages: {},
 		};
 		this.containerRef = createRef();
+		this.imageRef = createRef();
 	}
 	componentDidMount() {
 		this.setState( { bounds: this.calculateBounds() } );
 	}
 	componentDidUpdate( prevProps ) {
-		if ( prevProps.dimensions !== this.props.dimensions || prevProps.url !== this.props.url ) {
+		if ( prevProps.url !== this.props.url ) {
 			this.setState( {
 				bounds: this.calculateBounds(),
 				isDragging: false,
@@ -40,7 +41,10 @@ export class FocalPointPicker extends Component {
 		}
 	}
 	calculateBounds() {
-		const { dimensions } = this.props;
+		const dimensions = {
+			width: this.imageRef.current.clientWidth,
+			height: this.imageRef.current.clientHeight,
+		};
 		const pickerDimensions = this.pickerDimensions();
 		const bounds = {
 			top: 0,
@@ -150,6 +154,7 @@ export class FocalPointPicker extends Component {
 					role="button"
 					tabIndex="0"
 				>
+					<img src={ url } ref={ this.imageRef } alt="Dimensions helper" />
 					<div className={ iconContainerClasses } style={ iconContainerStyle }>
 						<i className="component-focal-point-picker__icon" />
 					</div>
@@ -176,10 +181,6 @@ export class FocalPointPicker extends Component {
 
 FocalPointPicker.defaultProps = {
 	url: null,
-	dimensions: {
-		height: 0,
-		width: 0,
-	},
 	value: {
 		x: 0.5,
 		y: 0.5,

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -155,6 +155,11 @@ export class FocalPointPicker extends Component {
 			top: 0,
 		};
 	}
+	handleFocusOutside() {
+		this.setState( {
+			isDragging: false,
+		} );
+	}
 	render() {
 		const { instanceId, url, value, label, help, className } = this.props;
 		const { bounds, isDragging, percentages } = this.state;
@@ -168,7 +173,7 @@ export class FocalPointPicker extends Component {
 			top: `${ iconCoordinates.top }px`,
 		};
 		const iconContainerClasses = classnames(
-			'component-focal-point-picker__icon_container',
+			'components-focal-point-picker__icon_container',
 			isDragging ? 'is-dragging' : null
 		);
 		const id = `inspector-focal-point-picker-control-${ instanceId }`;
@@ -176,9 +181,9 @@ export class FocalPointPicker extends Component {
 		const verticalPositionId = `inspector-focal-point-picker-control-horizontal-position-${ instanceId }`;
 		return (
 			<BaseControl label={ label } id={ id } help={ help } className={ className }>
-				<div className="component-focal-point-picker-wrapper">
+				<div className="components-focal-point-picker-wrapper">
 					<div
-						className="component-focal-point-picker"
+						className="components-focal-point-picker"
 						onMouseDown={ () => this.setState( { isDragging: true } ) }
 						onDragStart={ () => this.setState( { isDragging: true } ) }
 						onMouseUp={ () => this.setState( { isDragging: false } ) }
@@ -196,14 +201,14 @@ export class FocalPointPicker extends Component {
 							draggable="false"
 						/>
 						<div className={ iconContainerClasses } style={ iconContainerStyle }>
-							<SVG className="component-focal-point-picker__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
-								<Path className="component-focal-point-picker__icon-outline" d="M15 1C7.3 1 1 7.3 1 15s6.3 14 14 14 14-6.3 14-14S22.7 1 15 1zm0 22c-4.4 0-8-3.6-8-8s3.6-8 8-8 8 3.6 8 8-3.6 8-8 8z" />
-								<Path className="component-focal-point-picker__icon-fill" d="M15 3C8.4 3 3 8.4 3 15s5.4 12 12 12 12-5.4 12-12S21.6 3 15 3zm0 22C9.5 25 5 20.5 5 15S9.5 5 15 5s10 4.5 10 10-4.5 10-10 10z" />
+							<SVG className="components-focal-point-picker__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+								<Path className="components-focal-point-picker__icon-outline" d="M15 1C7.3 1 1 7.3 1 15s6.3 14 14 14 14-6.3 14-14S22.7 1 15 1zm0 22c-4.4 0-8-3.6-8-8s3.6-8 8-8 8 3.6 8 8-3.6 8-8 8z" />
+								<Path className="components-focal-point-picker__icon-fill" d="M15 3C8.4 3 3 8.4 3 15s5.4 12 12 12 12-5.4 12-12S21.6 3 15 3zm0 22C9.5 25 5 20.5 5 15S9.5 5 15 5s10 4.5 10 10-4.5 10-10 10z" />
 							</SVG>
 						</div>
 					</div>
 				</div>
-				<div className="component-focal-point-picker_position-display-container">
+				<div className="components-focal-point-picker_position-display-container">
 					<BaseControl label={ __( 'Horizontal Pos.' ) }>
 						<input
 							className="components-text-control__input"
@@ -231,11 +236,6 @@ export class FocalPointPicker extends Component {
 				</div>
 			</BaseControl>
 		);
-	}
-	handleFocusOutside() {
-		this.setState( {
-			isDragging: false,
-		} );
 	}
 }
 

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { withInstanceId, compose } from '@wordpress/compose';
 
@@ -13,6 +14,7 @@ import { withInstanceId, compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import BaseControl from '../base-control';
+import TextControl from '../text-control';
 import withFocusOutside from '../higher-order/with-focus-outside';
 
 export class FocalPointPicker extends Component {
@@ -22,6 +24,7 @@ export class FocalPointPicker extends Component {
 		this.state = {
 			isDragging: false,
 			bounds: {},
+			percentages: {},
 		};
 		this.containerRef = createRef();
 	}
@@ -73,20 +76,31 @@ export class FocalPointPicker extends Component {
 				top: event.pageY - pickerDimensions.top,
 			};
 			const left = Math.max(
-				bounds.left, Math.min(
+				bounds.left,
+				Math.min(
 					cursorPosition.left, bounds.right
 				)
 			);
 			const top = Math.max(
-				bounds.top, Math.min(
+				bounds.top,
+				Math.min(
 					cursorPosition.top, bounds.bottom
 				)
 			);
-			onChange( {
-				x: left / pickerDimensions.width,
-				y: top / pickerDimensions.height,
+			const percentages = {
+				x: ( left - bounds.left ) / ( pickerDimensions.width - ( bounds.left * 2 ) ),
+				y: ( top - bounds.top ) / ( pickerDimensions.height - ( bounds.top * 2 ) ),
+			};
+			this.setState( { percentages }, function() {
+				onChange( {
+					x: this.state.percentages.x,
+					y: this.state.percentages.y,
+				} );
 			} );
 		}
+	}
+	fractionToPercentage( fraction ) {
+		return Math.round( fraction * 100 ) + '%';
 	}
 	pickerDimensions() {
 		if ( this.containerRef.current ) {
@@ -106,12 +120,16 @@ export class FocalPointPicker extends Component {
 	}
 	render() {
 		const { instanceId, url, value, label, help, className } = this.props;
-		const { isDragging } = this.state;
+		const { bounds, isDragging, percentages } = this.state;
 		const pickerDimensions = this.pickerDimensions();
 		const containerStyle = { backgroundImage: `url(${ url })` };
+		const iconCoordinates = {
+			left: ( value.x * ( pickerDimensions.width - ( bounds.left * 2 ) ) ) + bounds.left,
+			top: ( value.y * ( pickerDimensions.height - ( bounds.top * 2 ) ) ) + bounds.top,
+		};
 		const iconContainerStyle = {
-			left: `${ value.x * pickerDimensions.width }px`,
-			top: `${ value.y * pickerDimensions.height }px`,
+			left: `${ iconCoordinates.left }px`,
+			top: `${ iconCoordinates.top }px`,
 		};
 		const iconContainerClasses = classnames(
 			'component-focal-point-picker__icon_container',
@@ -133,8 +151,18 @@ export class FocalPointPicker extends Component {
 					tabIndex="0"
 				>
 					<div className={ iconContainerClasses } style={ iconContainerStyle }>
-						<i className="component-focal-point-picker__icon"></i>
+						<i className="component-focal-point-picker__icon" />
 					</div>
+				</div>
+				<div className="component-focal-point-picker_position-display-container">
+					<TextControl
+						label={ __( 'Horizontal Pos.' ) }
+						value={ this.fractionToPercentage( percentages.x ) }
+					/>
+					<TextControl
+						label={ __( 'Vertical Pos.' ) }
+						value={ this.fractionToPercentage( percentages.y ) }
+					/>
 				</div>
 			</BaseControl>
 		);
@@ -159,8 +187,4 @@ FocalPointPicker.defaultProps = {
 	onChange: () => {},
 };
 
-export default compose( [
-	withInstanceId,
-	withFocusOutside,
-] )( FocalPointPicker );
-
+export default compose( [ withInstanceId, withFocusOutside ] )( FocalPointPicker );

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -185,7 +185,7 @@ export class FocalPointPicker extends Component {
 						onMouseMove={ this.onMouseMove }
 						ref={ this.containerRef }
 						role="button"
-						tabIndex="0"
+						tabIndex="-1"
 					>
 						<img
 							alt="Dimensions helper"

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -17,6 +17,9 @@ import BaseControl from '../base-control';
 import TextControl from '../text-control';
 import withFocusOutside from '../higher-order/with-focus-outside';
 
+const TEXTCONTROL_MIN = 0;
+const TEXTCONTROL_MAX = 100;
+
 export class FocalPointPicker extends Component {
 	constructor() {
 		super( ...arguments );
@@ -28,6 +31,8 @@ export class FocalPointPicker extends Component {
 		};
 		this.containerRef = createRef();
 		this.imageRef = createRef();
+		this.horizontalPositionChanged = this.horizontalPositionChanged.bind( this );
+		this.verticalPositionChanged = this.verticalPositionChanged.bind( this );
 	}
 	componentDidMount() {
 		setTimeout( () => {
@@ -109,7 +114,25 @@ export class FocalPointPicker extends Component {
 		}
 	}
 	fractionToPercentage( fraction ) {
-		return Math.round( fraction * 100 ) + '%';
+		return Math.round( fraction * 100 );
+	}
+	horizontalPositionChanged( value ) {
+		this.positionChangeFromTextControl( 'x', value );
+	}
+	verticalPositionChanged( value ) {
+		this.positionChangeFromTextControl( 'y', value );
+	}
+	positionChangeFromTextControl( axis, value ) {
+		const { onChange } = this.props;
+		const { percentages } = this.state;
+		const cleanValue = Math.max( Math.min( parseInt( value ), 100 ), 0 );
+		percentages[ axis ] = cleanValue ? cleanValue / 100 : 0;
+		this.setState( { percentages }, function() {
+			onChange( {
+				x: this.state.percentages.x,
+				y: this.state.percentages.y,
+			} );
+		} );
 	}
 	pickerDimensions() {
 		if ( this.containerRef.current ) {
@@ -167,10 +190,18 @@ export class FocalPointPicker extends Component {
 				<div className="component-focal-point-picker_position-display-container">
 					<TextControl
 						label={ __( 'Horizontal Pos.' ) }
+						max={ TEXTCONTROL_MAX }
+						min={ TEXTCONTROL_MIN }
+						onChange={ this.horizontalPositionChanged }
+						type="number"
 						value={ this.fractionToPercentage( percentages.x ) }
 					/>
 					<TextControl
 						label={ __( 'Vertical Pos.' ) }
+						max={ TEXTCONTROL_MAX }
+						min={ TEXTCONTROL_MIN }
+						onChange={ this.verticalPositionChanged }
+						type="number"
 						value={ this.fractionToPercentage( percentages.y ) }
 					/>
 				</div>

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -1,12 +1,19 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 
+/**
+ * WordPress dependencies
+ */
 import { Component, createRef } from '@wordpress/element';
 import { withInstanceId, compose } from '@wordpress/compose';
-import BaseControl from '../base-control/';
+
+/**
+ * Internal dependencies
+ */
+import BaseControl from '../base-control';
 import withFocusOutside from '../higher-order/with-focus-outside';
-import classnames from 'classnames';
 
 export class FocalPointPicker extends Component {
 	constructor() {

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -175,25 +175,27 @@ export class FocalPointPicker extends Component {
 		const verticalPositionId = `inspector-focal-point-picker-control-horizontal-position-${ instanceId }`;
 		return (
 			<BaseControl label={ label } id={ id } help={ help } className={ className }>
-				<div
-					className="component-focal-point-picker"
-					onMouseDown={ () => this.setState( { isDragging: true } ) }
-					onDragStart={ () => this.setState( { isDragging: true } ) }
-					onMouseUp={ () => this.setState( { isDragging: false } ) }
-					onDrop={ () => this.setState( { isDragging: false } ) }
-					onMouseMove={ this.onMouseMove }
-					ref={ this.containerRef }
-					role="button"
-					tabIndex="0"
-				>
-					<img
-						alt="Dimensions helper"
-						onLoad={ this.onLoad }
-						ref={ this.imageRef }
-						src={ url }
-					/>
-					<div className={ iconContainerClasses } style={ iconContainerStyle }>
-						<i className="component-focal-point-picker__icon" />
+				<div className="component-focal-point-picker-wrapper">
+					<div
+						className="component-focal-point-picker"
+						onMouseDown={ () => this.setState( { isDragging: true } ) }
+						onDragStart={ () => this.setState( { isDragging: true } ) }
+						onMouseUp={ () => this.setState( { isDragging: false } ) }
+						onDrop={ () => this.setState( { isDragging: false } ) }
+						onMouseMove={ this.onMouseMove }
+						ref={ this.containerRef }
+						role="button"
+						tabIndex="0"
+					>
+						<img
+							alt="Dimensions helper"
+							onLoad={ this.onLoad }
+							ref={ this.imageRef }
+							src={ url }
+						/>
+						<div className={ iconContainerClasses } style={ iconContainerStyle }>
+							<i className="component-focal-point-picker__icon" />
+						</div>
 					</div>
 				</div>
 				<div className="component-focal-point-picker_position-display-container">

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -30,7 +30,12 @@ export class FocalPointPicker extends Component {
 		this.imageRef = createRef();
 	}
 	componentDidMount() {
-		this.setState( { bounds: this.calculateBounds() } );
+		setTimeout( () => {
+			this.setState( {
+				bounds: this.calculateBounds(),
+				percentages: this.props.value,
+			} );
+		}, 1 );
 	}
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.url !== this.props.url ) {

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -15,6 +15,7 @@ import { withInstanceId, compose } from '@wordpress/compose';
  */
 import BaseControl from '../base-control';
 import withFocusOutside from '../higher-order/with-focus-outside';
+import { Path, SVG } from '../primitives';
 
 const TEXTCONTROL_MIN = 0;
 const TEXTCONTROL_MAX = 100;
@@ -192,9 +193,13 @@ export class FocalPointPicker extends Component {
 							onLoad={ this.onLoad }
 							ref={ this.imageRef }
 							src={ url }
+							draggable="false"
 						/>
 						<div className={ iconContainerClasses } style={ iconContainerStyle }>
-							<i className="component-focal-point-picker__icon" />
+							<SVG className="component-focal-point-picker__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+								<Path className="component-focal-point-picker__icon-outline" d="M15 1C7.3 1 1 7.3 1 15s6.3 14 14 14 14-6.3 14-14S22.7 1 15 1zm0 22c-4.4 0-8-3.6-8-8s3.6-8 8-8 8 3.6 8 8-3.6 8-8 8z" />
+								<Path className="component-focal-point-picker__icon-fill" d="M15 3C8.4 3 3 8.4 3 15s5.4 12 12 12 12-5.4 12-12S21.6 3 15 3zm0 22C9.5 25 5 20.5 5 15S9.5 5 15 5s10 4.5 10 10-4.5 10-10 10z" />
+							</SVG>
 						</div>
 					</div>
 				</div>

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -8,12 +8,6 @@ import BaseControl from '../base-control/';
 import withFocusOutside from '../higher-order/with-focus-outside';
 import classnames from 'classnames';
 
-/**
- * Internal dependencies
- */
-
-import './style.scss';
-
 export class FocalPointPicker extends Component {
 	constructor() {
 		super( ...arguments );

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -154,7 +154,6 @@ export class FocalPointPicker extends Component {
 		const { instanceId, url, value, label, help, className } = this.props;
 		const { bounds, isDragging, percentages } = this.state;
 		const pickerDimensions = this.pickerDimensions();
-		const containerStyle = { backgroundImage: `url(${ url })` };
 		const iconCoordinates = {
 			left: ( value.x * ( pickerDimensions.width - ( bounds.left * 2 ) ) ) + bounds.left,
 			top: ( value.y * ( pickerDimensions.height - ( bounds.top * 2 ) ) ) + bounds.top,
@@ -172,7 +171,6 @@ export class FocalPointPicker extends Component {
 			<BaseControl label={ label } id={ id } help={ help } className={ className }>
 				<div
 					className="component-focal-point-picker"
-					style={ containerStyle }
 					onMouseDown={ () => this.setState( { isDragging: true } ) }
 					onDragStart={ () => this.setState( { isDragging: true } ) }
 					onMouseUp={ () => this.setState( { isDragging: false } ) }

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -1,0 +1,39 @@
+$focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform='translate(1 1)' stroke='%23000' strokeWidth='2' fill='none' fillRule='evenodd'%3E%3Cellipse fill='%23fff' cx='11' cy='11.129' rx='9.533' ry='9.645' /%3E%3Cpath d='M0 11.13h22M10.945 22.347V.09' strokeLinecap='square' /%3E%3C/g%3E%3C/svg%3E";
+
+.component-focal-point-picker {
+	background-color: transparent;
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+	border: 1px solid $light-gray-500;
+	cursor: pointer;
+	display: block;
+	height: 200px;
+	position: relative;
+	width: 100%;
+}
+
+.component-focal-point-picker__icon_container {
+	background-color: transparent;
+	cursor: -webkit-grab;
+	height: 30px;
+	opacity: 0.5;
+	position: absolute;
+	width: 30px;
+	z-index: 10000;
+
+	&.is-dragging {
+		cursor: -webkit-grabbing;
+	}
+}
+
+.component-focal-point-picker__icon {
+	background-image: url($focalPointPickerSVG);
+	background-size: 100%;
+	display: block;
+	height: 100%;
+	left: -15px;
+	position: absolute;
+	top: -15px;
+	width: 100%;
+}

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -1,5 +1,3 @@
-$focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform='translate(1 1)' stroke='%23000' strokeWidth='2' fill='none' fillRule='evenodd'%3E%3Cellipse fill='%23fff' cx='11' cy='11.129' rx='9.533' ry='9.645' /%3E%3Cpath d='M0 11.13h22M10.945 22.347V.09' strokeLinecap='square' /%3E%3C/g%3E%3C/svg%3E";
-
 .component-focal-point-picker-wrapper {
 	background-color: transparent;
 	border: 1px solid $light-gray-500;
@@ -28,27 +26,33 @@ $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height=
 
 .component-focal-point-picker__icon_container {
 	background-color: transparent;
-	cursor: -webkit-grab;
+	cursor: grab;
 	height: 30px;
-	opacity: 0.5;
+	opacity: 0.8;
 	position: absolute;
 	width: 30px;
 	z-index: 10000;
 
 	&.is-dragging {
-		cursor: -webkit-grabbing;
+		cursor: grabbing;
 	}
 }
 
 .component-focal-point-picker__icon {
-	background-image: url($focalPointPickerSVG);
-	background-size: 100%;
 	display: block;
 	height: 100%;
 	left: -15px;
 	position: absolute;
 	top: -15px;
 	width: 100%;
+
+	.component-focal-point-picker__icon-outline {
+		fill: $white;
+	}
+
+	.component-focal-point-picker__icon-fill {
+		fill: theme(primary);
+	}
 }
 
 .component-focal-point-picker_position-display-container {

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -12,7 +12,11 @@ $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height=
 	position: relative;
 	width: 100%;
 	img {
-		opacity: 0;
+		height: auto;
+		max-height: 100%;
+		max-width: 100%;
+		opacity: 0.1;
+		width: auto;
 	}
 }
 

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -7,6 +7,7 @@ $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height=
 	width: 100%;
 	padding: 14px;
 }
+
 .component-focal-point-picker {
 	align-items: center;
 	cursor: pointer;
@@ -15,6 +16,7 @@ $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height=
 	justify-content: center;
 	position: relative;
 	width: 100%;
+
 	img {
 		height: auto;
 		max-height: 100%;
@@ -52,12 +54,16 @@ $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height=
 .component-focal-point-picker_position-display-container {
 	margin: 1em 0;
 	display: flex;
+
 	.components-base-control__field {
 		margin: 0 1em 0 0;
 	}
-	input {
+
+	input[type="number"].components-text-control__input { // Needs specificity to override padding.
 		max-width: 4em;
+		padding: 6px 4px;
 	}
+
 	span {
 		margin: 0 0 0 0.2em;
 	}

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -11,6 +11,9 @@ $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height=
 	height: 200px;
 	position: relative;
 	width: 100%;
+	img {
+		opacity: 0;
+	}
 }
 
 .component-focal-point-picker__icon_container {

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -53,4 +53,7 @@ $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height=
 	input {
 		max-width: 4em;
 	}
+	span {
+		margin: 0 0 0 0.2em;
+	}
 }

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -37,3 +37,14 @@ $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height=
 	top: -15px;
 	width: 100%;
 }
+
+.component-focal-point-picker_position-display-container {
+	margin: 1em 0;
+	display: flex;
+	.components-base-control__field {
+		margin: 0 1em 0 0;
+	}
+	input {
+		max-width: 4em;
+	}
+}

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -30,6 +30,7 @@
 	height: 30px;
 	opacity: 0.8;
 	position: absolute;
+	will-change: transform;
 	width: 30px;
 	z-index: 10000;
 

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -1,12 +1,17 @@
 $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform='translate(1 1)' stroke='%23000' strokeWidth='2' fill='none' fillRule='evenodd'%3E%3Cellipse fill='%23fff' cx='11' cy='11.129' rx='9.533' ry='9.645' /%3E%3Cpath d='M0 11.13h22M10.945 22.347V.09' strokeLinecap='square' /%3E%3C/g%3E%3C/svg%3E";
 
-.component-focal-point-picker {
-	align-items: center;
+.component-focal-point-picker-wrapper {
 	background-color: transparent;
 	border: 1px solid $light-gray-500;
+	height: 200px;
+	width: 100%;
+	padding: 14px;
+}
+.component-focal-point-picker {
+	align-items: center;
 	cursor: pointer;
 	display: flex;
-	height: 200px;
+	height: 100%;
 	justify-content: center;
 	position: relative;
 	width: 100%;

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -1,4 +1,4 @@
-.component-focal-point-picker-wrapper {
+.components-focal-point-picker-wrapper {
 	background-color: transparent;
 	border: 1px solid $light-gray-500;
 	height: 200px;
@@ -6,7 +6,7 @@
 	padding: 14px;
 }
 
-.component-focal-point-picker {
+.components-focal-point-picker {
 	align-items: center;
 	cursor: pointer;
 	display: flex;
@@ -24,7 +24,7 @@
 	}
 }
 
-.component-focal-point-picker__icon_container {
+.components-focal-point-picker__icon_container {
 	background-color: transparent;
 	cursor: grab;
 	height: 30px;
@@ -39,7 +39,7 @@
 	}
 }
 
-.component-focal-point-picker__icon {
+.components-focal-point-picker__icon {
 	display: block;
 	height: 100%;
 	left: -15px;
@@ -47,16 +47,16 @@
 	top: -15px;
 	width: 100%;
 
-	.component-focal-point-picker__icon-outline {
+	.components-focal-point-picker__icon-outline {
 		fill: $white;
 	}
 
-	.component-focal-point-picker__icon-fill {
+	.components-focal-point-picker__icon-fill {
 		fill: theme(primary);
 	}
 }
 
-.component-focal-point-picker_position-display-container {
+.components-focal-point-picker_position-display-container {
 	margin: 1em 0;
 	display: flex;
 

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -1,22 +1,21 @@
 $focalPointPickerSVG: "data:image/svg+xml;charset=utf8,%3Csvg width='24' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform='translate(1 1)' stroke='%23000' strokeWidth='2' fill='none' fillRule='evenodd'%3E%3Cellipse fill='%23fff' cx='11' cy='11.129' rx='9.533' ry='9.645' /%3E%3Cpath d='M0 11.13h22M10.945 22.347V.09' strokeLinecap='square' /%3E%3C/g%3E%3C/svg%3E";
 
 .component-focal-point-picker {
+	align-items: center;
 	background-color: transparent;
-	background-position: center;
-	background-repeat: no-repeat;
-	background-size: contain;
 	border: 1px solid $light-gray-500;
 	cursor: pointer;
-	display: block;
+	display: flex;
 	height: 200px;
+	justify-content: center;
 	position: relative;
 	width: 100%;
 	img {
 		height: auto;
 		max-height: 100%;
 		max-width: 100%;
-		opacity: 0.1;
 		width: auto;
+		user-select: none;
 	}
 }
 

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -19,6 +19,7 @@ export { default as DropZoneProvider } from './drop-zone/provider';
 export { default as Dropdown } from './dropdown';
 export { default as DropdownMenu } from './dropdown-menu';
 export { default as ExternalLink } from './external-link';
+export { default as FocalPointPicker } from './focal-point-picker';
 export { default as FocusableIframe } from './focusable-iframe';
 export { default as FontSizePicker } from './font-size-picker';
 export { default as FormFileUpload } from './form-file-upload';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -13,6 +13,7 @@
 @import "./drop-zone/style.scss";
 @import "./dropdown-menu/style.scss";
 @import "./external-link/style.scss";
+@import "./focal-point-picker/style.scss";
 @import "./font-size-picker/style.scss";
 @import "./form-file-upload/style.scss";
 @import "./form-toggle/style.scss";


### PR DESCRIPTION
## Description
This PR creates a Focal Point Picker component and implements it in the `Cover` block. Here is the rationale for this functionality: when dealing with large background images like the ones used in `Cover`, it's common to see undesirable crops, especially on smaller viewports. If the primary subject of an image happens to be dead center then it will display perfectly everywhere, but if it is off-center by even a little, key visual information can be cropped out.

The Focal Point Picker component allows the user to visually select the ideal center point, which is then returned as a pair of percentage-like coordinates (e.g. `{ x: 0.1, y: 0.9 }`) which can easily be converted into `background-position` attributes and applied to the element with the background image. 

### Video and Parallax

The Focal Point Picker only works if an image is being used, and if `Fixed Background` is disabled. For now, the same approach won't be applied to videos, and Parallaxed images don't really require a focal point since their crop changes as the user scrolls.

### Legacy Content

As part of this branch, `Cover` block saves the dimensions of images when selected, which is needed by the component. For instances of `Cover` block that pre-date this branch there will be no dimensions data, and therefore the focal point picker is suppressed. Because of this approach there was no need to add a Gutenberg deprecation definition.

## How has this been tested?

- Spin up local Gutenberg instance following instructions here: https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md
- Switch branch to `try/focal-point-picker`
- Create new post
- Add `Cover` block to post.
- Upload or select a large image, ideally one where the central focus is not off center - the further the better.
- Click on block, then show block settings. In the sidebar, click and drag the picker icon to the 
focal point of the image. Depending on the dimensions, you will probably see the image move around a little in the editor. 
- Save the post and preview. 

## Screenshots <!-- if applicable -->

Here are two screen captures demonstrating the use of the focal point picker:

https://cloudup.com/cIIvWAafA20

https://cloudup.com/cnL3p-eZvSq

## Types of changes

The Focal Point Picker is a new feature, which shouldn't affect anything, however the implementation in `Cover` could possibly break the block and should be tested thoroughly. Another important testing flow is to create a `Cover` block while on `master`, then branch switch to `try/focal-point-picker`. The block should remain exact as it was, with no focal point picker visible.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
